### PR TITLE
Allow editing a completed review in place in focus mode

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -307,19 +307,19 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
     expect(onSetStatus).not.toHaveBeenCalled();
   });
 
-  it('still offers Reopen as the explicit way to send a completed trace back to the to-do list', async () => {
+  it('still offers Move to Todo as the explicit way to send a completed trace back to the to-do list', async () => {
     const onSetStatus = jest.fn((_status: string) => Promise.resolve());
     renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { item: completeItem });
 
-    fireEvent.click(screen.getByText('Reopen'));
+    fireEvent.click(screen.getByText('Move to Todo'));
     await waitFor(() => expect(onSetStatus).toHaveBeenCalledWith('PENDING'));
   });
 
-  it('locks a declined trace and offers only Reopen (no save/submit)', () => {
+  it('locks a declined trace and offers only Move to Todo (no save/submit)', () => {
     const onSetStatus = jest.fn((_status: string) => Promise.resolve());
     renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { item: declinedItem });
 
-    expect(screen.getByText('Reopen')).toBeInTheDocument();
+    expect(screen.getByText('Move to Todo')).toBeInTheDocument();
     expect(screen.queryByText('Save changes')).not.toBeInTheDocument();
     expect(screen.queryByText('Submit')).not.toBeInTheDocument();
     // The lock is the inputs being disabled, not just the missing button.

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -51,26 +51,43 @@ const pendingItem: ReviewQueueItem = {
 const renderFocused = (
   schemas: LabelSchema[],
   onSetStatus: (status: string) => Promise<void>,
-  opts: { canReview?: boolean; onAssignSelf?: () => void } = {},
-) =>
-  render(
+  opts: {
+    canReview?: boolean;
+    onAssignSelf?: () => void;
+    item?: ReviewQueueItem;
+    onSelect?: () => void;
+    onBack?: () => void;
+  } = {},
+) => {
+  const item = opts.item ?? pendingItem;
+  return render(
     <IntlProvider locale="en">
       <DesignSystemProvider>
         <FocusedReview
-          item={pendingItem}
-          items={[pendingItem]}
+          item={item}
+          items={[item]}
           schemas={schemas}
           completedBy="tester"
           isSettingStatus={false}
           canReview={opts.canReview ?? true}
           onAssignSelf={opts.onAssignSelf}
-          onBack={jest.fn()}
-          onSelect={jest.fn()}
+          onBack={opts.onBack ?? jest.fn()}
+          onSelect={opts.onSelect ?? jest.fn()}
           onSetStatus={onSetStatus}
         />
       </DesignSystemProvider>
     </IntlProvider>,
   );
+};
+
+const completeItem: ReviewQueueItem = {
+  ...pendingItem,
+  status: 'COMPLETE',
+  completed_by: 'tester',
+  completed_time_ms: 1_780_000_001_000,
+};
+
+const declinedItem: ReviewQueueItem = { ...pendingItem, status: 'DECLINED' };
 
 describe('FocusedReview single Pass/Fail auto-submit', () => {
   beforeEach(() => {
@@ -215,5 +232,97 @@ describe('FocusedReview waits for prior answers to settle before submitting', ()
     fireEvent.click(screen.getByText('Pass'));
     expect(mockCreateAssessment).not.toHaveBeenCalled();
     expect(onSetStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('FocusedReview edit-in-place on a completed trace', () => {
+  beforeEach(() => {
+    mockCreateAssessment.mockReset();
+    mockCreateAssessment.mockImplementation(() => Promise.resolve());
+    // The completed trace prefills its prior answer (with its assessment id, so a
+    // re-save supersedes it rather than duplicating), so the form is pre-populated.
+    mockPriorAnswersResult = {
+      priorAnswers: [{ name: 'Looks good?', kind: 'feedback', value: true, valid: true, assessmentId: 'a-prior' }],
+      isLoading: false,
+      isFetching: false,
+    };
+  });
+  afterEach(() => {
+    mockPriorAnswersResult = { priorAnswers: [], isLoading: false, isFetching: false };
+  });
+
+  it('keeps a completed trace editable and re-saves (superseding the prior) without changing status or navigating', async () => {
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    const onSelect = jest.fn();
+    const onBack = jest.fn();
+    // Two questions so the explicit primary button renders (not the auto-submit case).
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, {
+      item: completeItem,
+      onSelect,
+      onBack,
+    });
+
+    // The primary action re-saves edits rather than completing afresh, and the
+    // inputs stay editable (not disabled like a declined trace). With no edit yet
+    // it's a no-op, so the button is disabled until the reviewer actually changes
+    // something — a passive prefill must not re-supersede identical assessments.
+    expect(screen.queryByText('Submit')).not.toBeInTheDocument();
+    expect(screen.getByText('Save changes').closest('button')).toBeDisabled();
+
+    // Edit the second question (the editable inputs are what "stays editable" means).
+    fireEvent.click(screen.getAllByText('Pass')[1]);
+    expect(screen.getByText('Save changes').closest('button')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Save changes'));
+
+    await waitFor(() => expect(mockCreateAssessment).toHaveBeenCalled());
+    // The prior answer is superseded via `overrides` (not duplicated), with the
+    // right value/source — the core edit-in-place contract.
+    expect(mockCreateAssessment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: 'tr-1',
+        name: 'Looks good?',
+        value: true,
+        sourceId: 'tester',
+        overrides: 'a-prior',
+      }),
+    );
+    // Re-saving rewrites the answers but must NOT flip the status or move the
+    // reviewer off the trace — it stays COMPLETE / off the to-do list.
+    expect(onSetStatus).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onBack).not.toHaveBeenCalled();
+    expect(await screen.findByText('Changes saved')).toBeInTheDocument();
+  });
+
+  it('shows the save error and suppresses the saved confirmation when an in-place re-save fails', async () => {
+    mockCreateAssessment.mockImplementation(() => Promise.reject(new Error('boom')));
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { item: completeItem });
+
+    fireEvent.click(screen.getAllByText('Pass')[1]);
+    fireEvent.click(screen.getByText('Save changes'));
+
+    expect(await screen.findByText(/could not save your review/i)).toBeInTheDocument();
+    expect(screen.queryByText('Changes saved')).not.toBeInTheDocument();
+    expect(onSetStatus).not.toHaveBeenCalled();
+  });
+
+  it('still offers Reopen as the explicit way to send a completed trace back to the to-do list', async () => {
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { item: completeItem });
+
+    fireEvent.click(screen.getByText('Reopen'));
+    await waitFor(() => expect(onSetStatus).toHaveBeenCalledWith('PENDING'));
+  });
+
+  it('locks a declined trace and offers only Reopen (no save/submit)', () => {
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { item: declinedItem });
+
+    expect(screen.getByText('Reopen')).toBeInTheDocument();
+    expect(screen.queryByText('Save changes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Submit')).not.toBeInTheDocument();
+    // The lock is the inputs being disabled, not just the missing button.
+    expect(screen.getAllByRole('radio', { name: 'Pass' })[0]).toBeDisabled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -105,14 +105,34 @@ export const FocusedReview = ({
   const [edited, setEdited] = useState<Record<string, LabelSchemaValue>>({});
   const [editedRationales, setEditedRationales] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // Confirmation shown after an in-place edit of a completed trace is saved;
+  // cleared as soon as the reviewer edits again.
+  const [editSaved, setEditSaved] = useState(false);
 
   const valueFor = (name: string): LabelSchemaValue => (name in edited ? edited[name] : prefilled[name]);
-  const setAnswer = (name: string, value: LabelSchemaValue) => setEdited((prev) => ({ ...prev, [name]: value }));
+  const setAnswer = (name: string, value: LabelSchemaValue) => {
+    setEditSaved(false);
+    setEdited((prev) => ({ ...prev, [name]: value }));
+  };
   const rationaleFor = (name: string): string =>
     name in editedRationales ? editedRationales[name] : (prefilledRationales[name] ?? '');
-  const setRationale = (name: string, value: string) => setEditedRationales((prev) => ({ ...prev, [name]: value }));
+  const setRationale = (name: string, value: string) => {
+    setEditSaved(false);
+    setEditedRationales((prev) => ({ ...prev, [name]: value }));
+  };
 
-  const isTerminal = item.status === 'COMPLETE' || item.status === 'DECLINED';
+  // A completed trace stays editable: the reviewer can revise their answers and
+  // re-save without the trace leaving the "done" bucket (mirrors the review app,
+  // where there is no reopen — you just edit a completed item). A declined trace
+  // has no answers to edit, so it stays locked; "Reopen" is the way back to it.
+  const isComplete = item.status === 'COMPLETE';
+  const isDeclined = item.status === 'DECLINED';
+  const isTerminal = isComplete || isDeclined;
+  // Whether the reviewer has touched any answer/rationale this session. The
+  // "Save changes" path on a completed trace only writes when there's an edit,
+  // so a no-op click doesn't re-supersede identical assessments. (A fresh submit
+  // doesn't need this — a reopened trace can be re-completed straight from prefill.)
+  const hasEdits = Object.keys(edited).length > 0 || Object.keys(editedRationales).length > 0;
   // A queue whose only question is a single Pass/Fail (no rationale) submits as
   // soon as the reviewer picks an answer — no Submit click needed.
   const autoSubmitSchema =
@@ -200,6 +220,14 @@ export const FocusedReview = ({
           }),
         ),
       );
+      // Editing an already-complete trace: the answers above are re-written
+      // (superseding the priors), but the trace stays COMPLETE and we keep the
+      // reviewer on it. Re-saving an edit must not flip it back to PENDING / the
+      // to-do list, and its `completed_by`/`completed_time_ms` attribution stands.
+      if (isComplete) {
+        setEditSaved(true);
+        return;
+      }
       await onSetStatus('COMPLETE');
       // Keep the reviewer moving: jump to the next still-pending trace, or
       // return to the queue list once everything has been reviewed.
@@ -424,7 +452,7 @@ export const FocusedReview = ({
                         submitAnswersAndComplete({ [schema.name]: value });
                       }
                     }}
-                    disabled={isTerminal || !canReview}
+                    disabled={isDeclined || !canReview}
                     componentId={`${CID}.question`}
                     label={schema.name}
                     instruction={schema.instruction}
@@ -435,7 +463,7 @@ export const FocusedReview = ({
                       rows={2}
                       value={rationaleFor(schema.name)}
                       onChange={(e) => setRationale(schema.name, e.target.value)}
-                      disabled={isTerminal || !canReview}
+                      disabled={isDeclined || !canReview}
                       placeholder={intl.formatMessage({
                         defaultMessage: 'Rationale (optional)',
                         description: 'Review focused view: free-form rationale placeholder',
@@ -486,6 +514,18 @@ export const FocusedReview = ({
                 )}
               </div>
             )}
+            {editSaved && !submitError && (
+              <Alert
+                componentId={`${CID}.edit-saved`}
+                type="success"
+                closable
+                onClose={() => setEditSaved(false)}
+                message={intl.formatMessage({
+                  defaultMessage: 'Changes saved',
+                  description: 'Review focused view: confirmation that edited answers were saved',
+                })}
+              />
+            )}
             {submitError && (
               <Alert
                 componentId={`${CID}.submit-error`}
@@ -519,25 +559,32 @@ export const FocusedReview = ({
                   <FormattedMessage defaultMessage="Decline" description="Review focused view: decline action" />
                 </Button>
               )}
-              {!hideSubmit && (
+              {!hideSubmit && !isDeclined && (
                 <Button
                   componentId={`${CID}.complete`}
                   type="primary"
                   disabled={
-                    isTerminal ||
                     isCreatingAssessment ||
                     isSettingStatus ||
                     !canReview ||
                     answeredCount === 0 ||
-                    priorAnswersFetching
+                    priorAnswersFetching ||
+                    (isComplete && !hasEdits)
                   }
                   loading={isCreatingAssessment || isSettingStatus}
                   onClick={() => submitAnswersAndComplete()}
                 >
-                  <FormattedMessage
-                    defaultMessage="Submit"
-                    description="Review focused view: submit answers and mark the trace complete"
-                  />
+                  {isComplete ? (
+                    <FormattedMessage
+                      defaultMessage="Save changes"
+                      description="Review focused view: re-save edited answers on an already-complete trace"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      defaultMessage="Submit"
+                      description="Review focused view: submit answers and mark the trace complete"
+                    />
+                  )}
                 </Button>
               )}
             </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -548,7 +548,10 @@ export const FocusedReview = ({
                   disabled={isSettingStatus || !canReview}
                   onClick={() => handleSetStatus('PENDING')}
                 >
-                  <FormattedMessage defaultMessage="Reopen" description="Review focused view: reopen action" />
+                  <FormattedMessage
+                    defaultMessage="Move to Todo"
+                    description="Review focused view: send a completed/declined trace back to the to-do list"
+                  />
                 </Button>
               ) : (
                 <Button

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1775,6 +1775,10 @@
     "defaultMessage": "Traces",
     "description": "Label for the traces mode on the registered prompt details page"
   },
+  "7N8Fqq": {
+    "defaultMessage": "Changes saved",
+    "description": "Review focused view: confirmation that edited answers were saved"
+  },
   "7NKkk1": {
     "defaultMessage": "Save",
     "description": "Modal button text to save the changes to rename the experiment run name"
@@ -2006,6 +2010,10 @@
   "8YmId5": {
     "defaultMessage": "Y axis",
     "description": "Label for Y axis in Contour chart configurator in compare runs chart config modal"
+  },
+  "8bgHT0": {
+    "defaultMessage": "Save changes",
+    "description": "Review focused view: re-save edited answers on an already-complete trace"
   },
   "8biXJJ": {
     "defaultMessage": "Select output type",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2807,6 +2807,10 @@
     "defaultMessage": "System Metrics",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > system metrics heading"
   },
+  "CKwhUr": {
+    "defaultMessage": "Move to Todo",
+    "description": "Review focused view: send a completed/declined trace back to the to-do list"
+  },
   "CO81il": {
     "defaultMessage": "No usage data available",
     "description": "Empty state title"
@@ -3218,10 +3222,6 @@
   "EjPmMR": {
     "defaultMessage": "Workspace Manager",
     "description": "Roles table column header for the workspace-admin marker (multi-tenant)"
-  },
-  "Ek+kWF": {
-    "defaultMessage": "Reopen",
-    "description": "Review focused view: reopen action"
   },
   "EkUD0b": {
     "defaultMessage": "No results",


### PR DESCRIPTION
### Related Issues/PRs

Relates to the OSS review-queue focus-mode work.

### What changes are proposed in this pull request?

Aligns OSS review-queue focus mode with the Databricks Review App's edit-in-place model.

Previously, once a review-queue item was `COMPLETE`, the focus-mode answer inputs were locked, so the only way to revise an answer was the explicit **Reopen** button, which flipped the status back to `PENDING` and put the trace back on the to-do list. The Review App has no reopen concept: a completed item stays editable, and re-saving an edit never sends it back to the to-do list.

This change brings the two closer together:

- A `COMPLETE` item's answer inputs stay editable, and the primary button becomes **Save changes**. Saving re-writes the assessments (superseding the priors through the existing `overrides` path) without calling `onSetStatus` and without navigating away, so the trace stays `COMPLETE`, off the to-do list, with its `completed_by` / `completed_time_ms` attribution intact. A small "Changes saved" confirmation is shown.
- **Save changes** is enabled only once the reviewer actually edits an answer/rationale, so a passive prefill never re-supersedes identical assessments with a no-op write.
- `DECLINED` items stay locked (there are no answers to edit), and the explicit **Reopen** action is kept as the deliberate way to send a trace back to the to-do pool.

The backend already supports every status transition and the assessment supersede, so this is a frontend-only change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Extended `FocusedReview.test.tsx`: a completed trace stays editable and re-saving supersedes the prior (asserting the `overrides`/value/source args) without changing status or navigating, and shows "Changes saved"; a failed in-place re-save surfaces the error and suppresses the saved confirmation; **Reopen** still sends a completed trace back to the to-do list; a declined trace keeps its inputs disabled and offers only **Reopen**. `yarn test FocusedReview` (13 passing), `yarn type-check`, `yarn lint`, `yarn prettier:check`, and `yarn i18n:check` all clean.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Reviewers can now edit a completed review in the review-queue focus mode and save the changes in place, without the trace being sent back to the to-do list.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.