### PR TITLE
fix: prevent duplicate table creation during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,7 +86,8 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    if not _all_tables_exist(engine):
+        _upgrade_db(engine)
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:


### PR DESCRIPTION
## What
Running `mlflow db upgrade` from 3.7.0 to 3.8.x fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")` because the new version of `_initialize_tables` first creates all tables via `InitialBase.metadata.create_all(engine)` and then attempts to run Alembic migrations (`_upgrade_db`) that try to create the same tables again.

## Fix
Added a check in `_initialize_tables` to only run `_upgrade_db` if not all expected tables exist already. This way, when upgrading from a previous version, the initial table creation via `create_all` is skipped for existing tables, and migrations are only run when necessary.

Closes #19943