### PR TITLE
Rerun approval check on `nailaopus[bot]` review approval

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -26,7 +26,7 @@ jobs:
       github.event.review.state == 'approved' &&
       (
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) ||
-        (github.event.review.user.type == 'Bot' && contains(fromJSON('["mlflow-app[bot]", "nailaopus[bot]"]'), github.event.review.user.login))
+        github.event.review.user.type == 'Bot'
       )
     steps:
       - name: Upload PR number

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -26,7 +26,7 @@ jobs:
       github.event.review.state == 'approved' &&
       (
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) ||
-        (github.event.review.user.login == 'mlflow-app[bot]' && github.event.review.user.type == 'Bot')
+        (github.event.review.user.type == 'Bot' && contains(fromJSON('["mlflow-app[bot]", "nailaopus[bot]"]'), github.event.review.user.login))
       )
     steps:
       - name: Upload PR number

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -26,7 +26,7 @@ jobs:
       github.event.review.state == 'approved' &&
       (
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association) ||
-        github.event.review.user.type == 'Bot'
+        (github.event.review.user.type == 'Bot' && contains(fromJSON('["mlflow-app[bot]", "nailaopus[bot]"]'), github.event.review.user.login))
       )
     steps:
       - name: Upload PR number


### PR DESCRIPTION
### Related Issues/PRs

Relates to the NaiLaOpus auto-reviewer workflow (`approval.js` / `rerun.yml`).

### What changes are proposed in this pull request?

`approval.yml`'s `check` job is a required status check that fails until a PR has a maintainer approval. It runs on `pull_request_target`, so after someone approves, the failed check has to be re-run to flip green. That re-run is driven by `rerun.yml` (on `pull_request_review`) which hands off to `rerun-workflow-run.yml`.

`rerun.yml`'s gate only fired for human `OWNER`/`MEMBER`/`COLLABORATOR` reviews and the hard-coded `mlflow-app[bot]`. A `nailaopus[bot]` approval comes through as `author_association: NONE` with login `nailaopus[bot]`, so neither branch matched and the rerun never happened. `approval.js` already lists `nailaopus[bot]` in its `APPROVED_BOTS` set, so the check *would* pass once re-run, but nothing re-ran it, leaving the approval check stuck red until an unrelated event (e.g. a new commit) re-triggered `approval.yml`.

This PR allows `nailaopus[bot]` in the bot clause of `rerun.yml` using a list that mirrors the `APPROVED_BOTS` set in `approval.js`:

```yaml
(github.event.review.user.type == 'Bot' && contains(fromJSON('["mlflow-app[bot]", "nailaopus[bot]"]'), github.event.review.user.login))
```

Note: the allowlist now lives in two places (this YAML list and the `APPROVED_BOTS` set in `approval.js`) and they must be kept in sync when adding another approving bot.

### How is this PR tested?

- [x] Manual tests

Verified against the live review payload on an actual NaiLaOpus approval (`mlflow/mlflow#23956`), which the API reports as `login: nailaopus[bot]`, `type: Bot`, `author_association: NONE` -- the exact values the new condition matches.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.