### PR TITLE
Bump pinned NaiLaOpus orchestrator SHA to enable tracing

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -141,7 +141,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: ee5492f55a011e67dfe9643f74b3f8fb3ae52d27
+          ref: d4ac1fd5e110dbbe3f00db09b65b53d06d022d66
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Relates to the NaiLaOpus auto-reviewer (`.github/workflows/nailaopus.yml`).

### What changes are proposed in this pull request?

`nailaopus.yml` pins the `mlflow/internal` orchestrator checkout to a specific SHA (so production reviews are reproducible and an orchestrator change can't silently alter the bot). That pin was `ee5492f5` (**May 19**), which predates the MLflow tracing support that was added to the orchestrator afterward (`mlflow/internal#52`, merged **May 27**, plus the trace-tag follow-up `#53`).

The effect: even though the tracing variables/secrets are now configured on this repo (`MLFLOW_ENABLE_TRACING`, `MLFLOW_TRACKING_URI=databricks`, `MLFLOW_EXPERIMENT_ID`, and the `DATABRICKS_*` service-principal credentials), the bot was running an orchestrator snapshot with **no tracing instrumentation at all**. No spans were created, so no traces were emitted -- the run logs show zero MLflow activity (not even the async-export flush line that appears whenever any span is queued).

This bumps the pin to current `mlflow/internal` main (`d4ac1fd5`), which contains the tracing code paths.

Note: per the pinning policy in the workflow comment, bumping the SHA pulls in **all** orchestrator changes since the old pin (May 19 -> June 12), not only the tracing PRs -- this is inherent to the SHA-pin model and the accompanying diff should be reviewed on `mlflow/internal`.

### How is this PR tested?

- [x] Manual tests

Reproduced the orchestrator's exact tracing pattern (`set_experiment(experiment_id=...)` + `mlflow.anthropic.autolog()` + `mlflow.tracing.context(...)` + `mlflow.start_span(...)`) as a short-lived process against a real Databricks workspace using `mlflow-tracing` 3.13. The trace exported end-to-end (parent `run_review` span with a nested tool span, `repo` tag intact) and flushed on process exit, confirming traces will appear once the orchestrator code is present.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.