### PR TITLE
Set model provider in Anthropic autolog so LLM cost is computed

### DIFF
--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -132,6 +132,12 @@ class TracingSession:
                 self.span.record_exception(exc_val)
 
             set_span_model_attribute(self.span, self.inputs)
+            # Client-side cost computation (used for Databricks backends) resolves
+            # litellm pricing by provider; without it, Claude model names don't
+            # match and cost is silently dropped while token usage is still
+            # recorded. This autolog patches the Anthropic SDK, so the provider
+            # is always Anthropic.
+            self.span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, "anthropic")
             _set_token_usage_attribute(self.span, self.output)
             self.span.end(outputs=self.output)
 

--- a/tests/anthropic/test_anthropic_autolog.py
+++ b/tests/anthropic/test_anthropic_autolog.py
@@ -204,6 +204,7 @@ def test_messages_autolog(is_async, mock_litellm_cost):
         "total_tokens": 28,
     }
     assert span.model_name == "test_model"
+    assert span.get_attribute(SpanAttributeKey.MODEL_PROVIDER) == "anthropic"
     assert span.get_attribute(SpanAttributeKey.MESSAGE_FORMAT) == "anthropic"
 
     if not IS_TRACING_SDK_ONLY:
@@ -269,6 +270,7 @@ def test_messages_autolog_multi_modal(is_async):
         "total_tokens": 28,
     }
     assert span.model_name == "test_model"
+    assert span.get_attribute(SpanAttributeKey.MODEL_PROVIDER) == "anthropic"
     assert span.get_attribute(SpanAttributeKey.MESSAGE_FORMAT) == "anthropic"
 
     assert traces[0].info.token_usage == {
@@ -395,6 +397,7 @@ def test_messages_autolog_with_thinking(is_async, mock_litellm_cost):
         "total_tokens": 28,
     }
     assert span.model_name == "test_model"
+    assert span.get_attribute(SpanAttributeKey.MODEL_PROVIDER) == "anthropic"
     assert span.get_attribute(SpanAttributeKey.MESSAGE_FORMAT) == "anthropic"
 
     if not IS_TRACING_SDK_ONLY:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`mlflow.anthropic.autolog()` records the model name and token usage on each LLM span, but never sets the `mlflow.llm.provider` (`SpanAttributeKey.MODEL_PROVIDER`) attribute.

On Databricks backends, LLM cost is computed **client-side** (`should_compute_cost_client_side()` returns `True`), and `calculate_cost_by_model_and_token_usage` resolves litellm pricing. Without the provider hint, litellm cannot resolve Claude model names (e.g. `claude-sonnet-4-6`), so the per-span cost lookup returns `None` and trace-level cost is silently dropped -- while token usage is still recorded. The result: traces show token counts but no cost.

This sets the provider to `"anthropic"` in `TracingSession._exit_impl`, alongside the existing model attribute. Every other LLM autolog that supports cost (gemini, bedrock, langchain, dspy, autogen) already sets the provider; Anthropic was the only one missing it.

Verified end-to-end against a Databricks workspace: a span with model only yields `llm_cost = None`, while model + `provider="anthropic"` yields a populated cost.

> Note: the existing cost tests only passed because they mock `litellm.cost_per_token`, which ignores the provider argument and so masked this gap. This PR adds an explicit assertion that the provider attribute is set.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

`tests/anthropic/test_anthropic_autolog.py` now asserts `mlflow.llm.provider == "anthropic"` on the produced spans; all cases pass with `litellm` installed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Anthropic autolog now records the model provider, so LLM cost is computed and reported for Anthropic traces on Databricks backends (previously only token usage was recorded).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.