### PR TITLE
fix: keep agent sync handlers off the event loop

### DIFF
--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -1,10 +1,13 @@
 import argparse
+import asyncio
+import contextvars
 import functools
 import inspect
 import json
 import logging
 import os
 import posixpath
+import threading
 from typing import Any, AsyncGenerator, Callable, Literal, ParamSpec, TypeVar
 
 import httpx
@@ -29,6 +32,7 @@ _R = TypeVar("_R")
 
 _invoke_function: Callable[..., Any] | None = None
 _stream_function: Callable[..., Any] | None = None
+_STREAM_DONE = object()
 
 
 def get_invoke_function():
@@ -37,6 +41,52 @@ def get_invoke_function():
 
 def get_stream_function():
     return _stream_function
+
+
+async def _iterate_sync_stream(
+    func: Callable[[dict[str, Any]], Any],
+    request: dict[str, Any],
+    context: contextvars.Context,
+) -> AsyncGenerator[Any, None]:
+    loop = asyncio.get_running_loop()
+    queue = asyncio.Queue()
+    stop = threading.Event()
+    iterator = None
+
+    def put(item: Any) -> None:
+        asyncio.run_coroutine_threadsafe(queue.put(item), loop).result()
+
+    def run() -> None:
+        nonlocal iterator
+        try:
+            iterator = iter(context.run(func, request))
+            while not stop.is_set():
+                try:
+                    chunk = context.run(next, iterator)
+                except StopIteration:
+                    break
+                put(chunk)
+        except BaseException as e:
+            put(e)
+        finally:
+            if stop.is_set() and hasattr(iterator, "close"):
+                context.run(iterator.close)
+            put(_STREAM_DONE)
+
+    thread = threading.Thread(target=run, name="mlflow-agent-server-stream", daemon=True)
+    thread.start()
+    try:
+        while True:
+            item = await queue.get()
+            if item is _STREAM_DONE:
+                break
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+    finally:
+        stop.set()
+        if thread.is_alive():
+            await asyncio.to_thread(thread.join, 1)
 
 
 def invoke() -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
@@ -319,7 +369,7 @@ class AgentServer:
                 if inspect.iscoroutinefunction(func):
                     result = await func(request)
                 else:
-                    result = func(request)
+                    result = await asyncio.to_thread(func, request)
 
                 result = self.validator.validate_and_convert_result(result)
                 if self.agent_type == "ResponsesAgent":
@@ -354,6 +404,7 @@ class AgentServer:
     ) -> AsyncGenerator[str, None]:
         func_name = func.__name__
         all_chunks: list[dict[str, Any]] = []
+        request_context = contextvars.copy_context()
         try:
             with mlflow.start_span(name=f"{func_name}") as span:
                 span.set_inputs(request)
@@ -363,7 +414,7 @@ class AgentServer:
                         all_chunks.append(chunk)
                         yield f"data: {json.dumps(chunk)}\n\n"
                 else:
-                    for chunk in func(request):
+                    async for chunk in _iterate_sync_stream(func, request, request_context):
                         chunk = self.validator.validate_and_convert_result(chunk, stream=True)
                         all_chunks.append(chunk)
                         yield f"data: {json.dumps(chunk)}\n\n"

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1,4 +1,6 @@
+import asyncio
 import contextvars
+import time
 from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -430,6 +432,58 @@ def test_invocations_endpoint_success_stream():
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
         mock_span.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_invoke_does_not_block_event_loop():
+    @invoke()
+    def test_invoke(request):
+        time.sleep(0.2)
+        return {"output": "done"}
+
+    server = AgentServer()
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+
+    with patch("mlflow.start_span", return_value=mock_span_instance):
+        task = asyncio.create_task(server._handle_invoke_request({"input": "hello"}, False))
+        start = time.perf_counter()
+        await asyncio.sleep(0.02)
+
+        assert time.perf_counter() - start < 0.12
+        assert not task.done()
+        assert await task == {"output": "done"}
+
+
+@pytest.mark.asyncio
+async def test_sync_stream_does_not_block_event_loop():
+    @stream()
+    def test_stream(request):
+        time.sleep(0.2)
+        yield {"delta": "done"}
+
+    server = AgentServer()
+    mock_span_instance = Mock()
+    mock_span_instance.__enter__ = Mock(return_value=mock_span_instance)
+    mock_span_instance.__exit__ = Mock(return_value=None)
+
+    with patch("mlflow.start_span", return_value=mock_span_instance):
+        generator = server._generate(get_stream_function(), {"input": "hello"}, False)
+        task = asyncio.create_task(anext(generator))
+        start = time.perf_counter()
+        await asyncio.sleep(0.02)
+
+        assert time.perf_counter() - start < 0.12
+        assert not task.done()
+        assert await task == 'data: {"delta": "done"}\n\n'
+        assert await anext(generator) == "data: [DONE]\n\n"
+        try:
+            await anext(generator)
+        except StopAsyncIteration:
+            pass
+        else:
+            pytest.fail("stream generator should be exhausted")
 
 
 def test_health_endpoint_returns_status():


### PR DESCRIPTION
### Related Issues/PRs

Closes #23953

### What changes are proposed in this pull request?

This keeps synchronous AgentServer handlers off the asyncio event loop:

- non-streaming sync invoke handlers now run through `asyncio.to_thread`
- streaming sync generators now run on one background thread and bridge chunks back to the async response generator
- the sync stream bridge uses the request context captured before the server tracing span is entered, so the worker does not inherit an OpenTelemetry span token owned by the event-loop context

A slow sync handler or a sync generator waiting between chunks no longer blocks unrelated requests such as `/health`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Validated locally:

- `python -m py_compile mlflow\genai\agent_server\server.py tests\genai\test_agent_server.py`
- `python -m ruff check mlflow\genai\agent_server\server.py tests\genai\test_agent_server.py`
- `python -m ruff format --check mlflow\genai\agent_server\server.py tests\genai\test_agent_server.py`
- `python -m pytest -p no:recording tests\genai\test_agent_server.py -q`

The plain `python -m pytest tests\genai\test_agent_server.py -q` command is blocked in my local Windows environment by an unrelated `pytest-recording` / current pytest incompatibility: the plugin still reads `request.node.fspath`, which no longer exists. Disabling that plugin lets the targeted file pass: 82 passed.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes synchronous GenAI AgentServer handlers and sync streaming generators blocking the asyncio event loop while they run.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

