### PR TITLE
Add UI telemetry for review-queue creation and feedback submission

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.test.tsx
@@ -121,7 +121,11 @@ describe('CreateReviewQueueModal', () => {
     renderModal(eventCallback);
     fillAndSubmit();
     await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
-    expect(eventCallback).toHaveBeenCalledWith(expect.objectContaining({ componentId: QUEUE_CREATED_COMPONENT_ID }));
+    // The event fires after the awaited create resolves, so wait for it rather
+    // than asserting synchronously (mirrors the FocusedReview telemetry tests).
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith(expect.objectContaining({ componentId: QUEUE_CREATED_COMPONENT_ID })),
+    );
   });
 
   it('does not log the queue-created event when creation fails', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.test.tsx
@@ -2,11 +2,13 @@ import { describe, jest, it, expect, beforeEach } from '@jest/globals';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { DesignSystemProvider } from '@databricks/design-system';
+import { DesignSystemEventProvider, DesignSystemProvider } from '@databricks/design-system';
 import { IntlProvider } from '@databricks/i18n';
 
 import { CreateReviewQueueModal } from './CreateReviewQueueModal';
 import { MAX_ASSIGNED_USERS } from './ReviewerChecklistCombobox';
+
+const QUEUE_CREATED_COMPONENT_ID = 'mlflow.experiment-review-queue.create-queue.queue-created';
 
 // Stub the question picker so a question can be selected (required to submit).
 jest.mock('./QuestionChecklistCombobox', () => ({
@@ -60,14 +62,16 @@ jest.mock('./hooks/useCreateReviewQueueMutation', () => ({
   useCreateReviewQueueMutation: () => ({ createReviewQueueAsync: mockCreate, isCreatingQueue: false, error: null }),
 }));
 
-const renderModal = () => {
+const renderModal = (eventCallback?: (e: { componentId: string }) => void) => {
   const onClose = jest.fn();
   render(
-    <IntlProvider locale="en">
-      <DesignSystemProvider>
-        <CreateReviewQueueModal experimentId="exp-1" onClose={onClose} />
-      </DesignSystemProvider>
-    </IntlProvider>,
+    <DesignSystemEventProvider callback={eventCallback ?? (() => {})}>
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <CreateReviewQueueModal experimentId="exp-1" onClose={onClose} />
+        </DesignSystemProvider>
+      </IntlProvider>
+    </DesignSystemEventProvider>,
   );
   return { onClose };
 };
@@ -110,5 +114,24 @@ describe('CreateReviewQueueModal', () => {
     await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
     // The rejection is swallowed (surfaced via the error Alert), so the modal stays open.
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('logs a telemetry event when a queue is successfully created', async () => {
+    const eventCallback = jest.fn();
+    renderModal(eventCallback);
+    fillAndSubmit();
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    expect(eventCallback).toHaveBeenCalledWith(expect.objectContaining({ componentId: QUEUE_CREATED_COMPONENT_ID }));
+  });
+
+  it('does not log the queue-created event when creation fails', async () => {
+    mockCreate.mockImplementation(() => Promise.reject(new Error('Review queue with name already exists')));
+    const eventCallback = jest.fn();
+    renderModal(eventCallback);
+    fillAndSubmit();
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    expect(eventCallback).not.toHaveBeenCalledWith(
+      expect.objectContaining({ componentId: QUEUE_CREATED_COMPONENT_ID }),
+    );
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
@@ -5,12 +5,15 @@ import {
   ApplyDesignSystemContextOverrides,
   ChevronDownIcon,
   ChevronRightIcon,
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
   Empty,
   FormUI,
   Input,
   Modal,
   TableSkeleton,
   Typography,
+  useDesignSystemEventComponentCallbacks,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -56,6 +59,15 @@ export const CreateReviewQueueModal = ({
   const authAvailable = useIsAuthAvailable();
   const { labelSchemas, isLoading } = useListLabelSchemasQuery({ experimentId });
   const { createReviewQueueAsync, isCreatingQueue, error } = useCreateReviewQueueMutation();
+
+  // Telemetry: count queues actually created from the UI (fired on success, not
+  // on the click, so failed creates don't inflate the metric).
+  const queueCreatedEvents = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const queueCreatedEventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId: `${CID}.queue-created`,
+    analyticsEvents: queueCreatedEvents,
+  });
 
   // Any authenticated user may list users server-side, so fetch the roster
   // whenever auth is on; the Reviewers picker is hidden otherwise.
@@ -180,6 +192,7 @@ export const CreateReviewQueueModal = ({
         users,
         schema_ids: [...checkedIds],
       });
+      queueCreatedEventContext.onClick(undefined);
       onCreated?.(review_queue);
       onClose();
     } catch {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -2,12 +2,14 @@ import { describe, jest, it, expect, beforeEach, afterEach } from '@jest/globals
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { DesignSystemProvider } from '@databricks/design-system';
+import { DesignSystemEventProvider, DesignSystemProvider } from '@databricks/design-system';
 import { IntlProvider } from '@databricks/i18n';
 
 import { FocusedReview } from './FocusedReview';
 import type { LabelSchema } from '../../components/label-schemas';
 import type { ReviewQueueItem } from './types';
+
+const FEEDBACK_SUBMITTED_COMPONENT_ID = 'mlflow.experiment-review-queue.focused-review.feedback-submitted';
 
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
   useGetTracesById: () => ({ data: [], isLoading: false }),
@@ -57,26 +59,29 @@ const renderFocused = (
     item?: ReviewQueueItem;
     onSelect?: () => void;
     onBack?: () => void;
+    eventCallback?: (e: { componentId: string }) => void;
   } = {},
 ) => {
   const item = opts.item ?? pendingItem;
   return render(
-    <IntlProvider locale="en">
-      <DesignSystemProvider>
-        <FocusedReview
-          item={item}
-          items={[item]}
-          schemas={schemas}
-          completedBy="tester"
-          isSettingStatus={false}
-          canReview={opts.canReview ?? true}
-          onAssignSelf={opts.onAssignSelf}
-          onBack={opts.onBack ?? jest.fn()}
-          onSelect={opts.onSelect ?? jest.fn()}
-          onSetStatus={onSetStatus}
-        />
-      </DesignSystemProvider>
-    </IntlProvider>,
+    <DesignSystemEventProvider callback={opts.eventCallback ?? (() => {})}>
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <FocusedReview
+            item={item}
+            items={[item]}
+            schemas={schemas}
+            completedBy="tester"
+            isSettingStatus={false}
+            canReview={opts.canReview ?? true}
+            onAssignSelf={opts.onAssignSelf}
+            onBack={opts.onBack ?? jest.fn()}
+            onSelect={opts.onSelect ?? jest.fn()}
+            onSetStatus={onSetStatus}
+          />
+        </DesignSystemProvider>
+      </IntlProvider>
+    </DesignSystemEventProvider>,
   );
 };
 
@@ -155,6 +160,49 @@ describe('FocusedReview submit requires at least one answer', () => {
     expect(mockCreateAssessment).toHaveBeenCalledTimes(1);
     expect(mockCreateAssessment).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Looks good?', value: true, assessmentKind: 'feedback' }),
+    );
+  });
+
+  it('logs a feedback-submitted telemetry event once the review is submitted', async () => {
+    const eventCallback = jest.fn();
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { eventCallback });
+
+    fireEvent.click(screen.getAllByText('Pass')[0]);
+    fireEvent.click(screen.getByText('Submit'));
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ componentId: FEEDBACK_SUBMITTED_COMPONENT_ID }),
+      ),
+    );
+  });
+
+  it('logs the feedback-submitted event on the single Pass/Fail auto-submit path too', async () => {
+    const eventCallback = jest.fn();
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    // Single Pass/Fail -> picking the answer auto-submits (no explicit Submit click).
+    renderFocused([passFailSchema()], onSetStatus, { eventCallback });
+
+    fireEvent.click(screen.getByText('Pass'));
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ componentId: FEEDBACK_SUBMITTED_COMPONENT_ID }),
+      ),
+    );
+  });
+
+  it('does not log the feedback-submitted event when the assessment write fails', async () => {
+    mockCreateAssessment.mockImplementation(() => Promise.reject(new Error('boom')));
+    const eventCallback = jest.fn();
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus, { eventCallback });
+
+    fireEvent.click(screen.getAllByText('Pass')[0]);
+    fireEvent.click(screen.getByText('Submit'));
+    // The error surfaces; the event must not fire (it sits after the writes succeed).
+    expect(await screen.findByText(/could not save your review/i)).toBeInTheDocument();
+    expect(eventCallback).not.toHaveBeenCalledWith(
+      expect.objectContaining({ componentId: FEEDBACK_SUBMITTED_COMPONENT_ID }),
     );
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -5,11 +5,14 @@ import {
   Button,
   ChevronLeftIcon,
   ChevronRightIcon,
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
   Drawer,
   Empty,
   Input,
   TableSkeleton,
   Typography,
+  useDesignSystemEventComponentCallbacks,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { ModelTraceExplorer, useGetTracesById } from '@databricks/web-shared/model-trace-explorer';
@@ -79,6 +82,15 @@ export const FocusedReview = ({
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const { createReviewAssessmentAsync, isCreatingAssessment } = useCreateReviewAssessmentMutation();
+
+  // Telemetry: count reviews (feedback) submitted from the UI. Fired after the
+  // assessment writes succeed, so failed submits don't inflate the metric.
+  const feedbackEvents = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const feedbackSubmittedEventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId: `${CID}.feedback-submitted`,
+    analyticsEvents: feedbackEvents,
+  });
 
   // The trace's input/output for the middle panel. The full trace (spans,
   // timeline, etc.) is available on demand through the drawer.
@@ -220,6 +232,10 @@ export const FocusedReview = ({
           }),
         ),
       );
+      // Telemetry: a review (feedback) was submitted from the UI. Covers the
+      // explicit Submit, the single Pass/Fail auto-submit, and the edit-in-place
+      // re-save — all of which land here after the writes succeed.
+      feedbackSubmittedEventContext.onClick(undefined);
       // Editing an already-complete trace: the answers above are re-written
       // (superseding the priors), but the trace stays COMPLETE and we keep the
       // reviewer on it. Re-saving an edit must not flip it back to PENDING / the


### PR DESCRIPTION
### Related Issues/PRs

Relates to the OSS review-queue feature.

### What changes are proposed in this pull request?

Adds two UI telemetry events to the review-queue surface, so we can measure adoption:

- **`queue-created`** — fired in `CreateReviewQueueModal` after `createReviewQueueAsync` resolves successfully (componentId `mlflow.experiment-review-queue.create-queue.queue-created`).
- **`feedback-submitted`** — fired in `FocusedReview` after the assessment writes succeed (componentId `mlflow.experiment-review-queue.focused-review.feedback-submitted`). Placed before the in-place-edit early-return, so it covers the explicit Submit, the single Pass/Fail auto-submit, and the edit-in-place re-save.

Both use the same DuBois analytics pattern (`useDesignSystemEventComponentCallbacks` + firing the callback at the action point) already used by the multimodal attachment renderer (`ModelTraceExplorerAttachmentRenderer.tsx`). They fire on **success** rather than on the click, so failed creates/submits don't inflate the counts.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests assert the events fire (via a real `DesignSystemEventProvider` callback) on success, on the auto-submit path, and that they do **not** fire when the create / assessment write fails. `yarn test` (CreateReviewQueueModal + FocusedReview, 21 passing), `yarn type-check`, `yarn lint`, `yarn prettier:check`, `yarn i18n:check` all clean.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.