### PR TITLE
Fix pos_label not passed to ROC/PR curve artifacts in sklearn autolog

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -304,7 +304,7 @@ def _get_class_labels_from_estimator(estimator):
     return estimator.classes_ if hasattr(estimator, "classes_") else None
 
 
-def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight):
+def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight, pos_label):
     """
     Draw and record various common artifacts for classifier
 
@@ -391,6 +391,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
                     "X": X,
                     "y": y_true,
                     "sample_weight": sample_weight,
+                    "pos_label": pos_label,
                 },
                 title="ROC curve",
             ),
@@ -404,6 +405,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
                     "X": X,
                     "y": y_true,
                     "sample_weight": sample_weight,
+                    "pos_label": pos_label,
                 },
                 title="Precision recall curve",
             ),
@@ -555,7 +557,7 @@ def _log_specialized_estimator_content(
     if sklearn.base.is_classifier(fitted_estimator):
         try:
             artifacts = _get_classifier_artifacts(
-                fitted_estimator, prefix, X, y_true, sample_weight
+                fitted_estimator, prefix, X, y_true, sample_weight, pos_label
             )
         except Exception as e:
             msg = (

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -31,6 +31,7 @@ from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.sklearn.utils import (
     _get_arg_names,
+    _get_classifier_artifacts,
     _is_estimator_html_repr_supported,
     _is_metric_supported,
     _is_plotting_supported,
@@ -1836,6 +1837,61 @@ def test_autolog_pos_label_used_for_training_metric():
                 pos_label=1,
             )
     assert training_metrics == expected_training_metrics
+
+
+def test_get_classifier_artifacts_respects_pos_label():
+    X = np.array([[1, 0], [0, 1], [1, 0], [1, 1], [1, 1], [1, 2]])
+    y = np.array(
+        [
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Positive_label",
+            "Positive_label",
+        ]
+    )
+    model = sklearn.linear_model.LogisticRegression()
+    model.fit(X, y)
+
+    artifacts = _get_classifier_artifacts(model, "training_", X, y, None, "Positive_label")
+    roc_artifact = next(a for a in artifacts if a.name == "training_roc_curve")
+    pr_artifact = next(a for a in artifacts if a.name == "training_precision_recall_curve")
+
+    assert roc_artifact.arguments["pos_label"] == "Positive_label"
+    assert pr_artifact.arguments["pos_label"] == "Positive_label"
+
+    if _is_plotting_supported():
+        roc_artifact.function(**roc_artifact.arguments)
+        plt.close()
+        pr_artifact.function(**pr_artifact.arguments)
+        plt.close()
+
+
+def test_autolog_pos_label_used_for_classifier_artifact_curves():
+    mlflow.sklearn.autolog(pos_label="Positive_label")
+
+    X = np.array([[1, 0], [0, 1], [1, 0], [1, 1], [1, 1], [1, 2]])
+    y = np.array(
+        [
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Positive_label",
+            "Positive_label",
+        ]
+    )
+    model = sklearn.linear_model.LogisticRegression()
+
+    with mlflow.start_run() as run:
+        model.fit(X, y)
+
+    client = MlflowClient()
+    artifacts = [x.path for x in client.list_artifacts(run.info.run_id)]
+    if _is_plotting_supported():
+        assert "training_roc_curve.png" in artifacts
+        assert "training_precision_recall_curve.png" in artifacts
 
 
 def test_autolog_emits_warning_message_when_pos_label_used_for_multilabel():


### PR DESCRIPTION
## What changes?

Fixes #6797

`mlflow.sklearn.autolog(pos_label=...)` correctly used `pos_label` for scalar
classification metrics, but autologged ROC and precision-recall curve artifacts
did not receive `pos_label`. For binary classifiers whose positive class is not
`classes_[1]`, the logged curves were computed for the wrong class.

This threads `pos_label` through `_get_classifier_artifacts()` into the sklearn
ROC / precision-recall plot calls.

## How did I test?

Added regression tests:

- `test_get_classifier_artifacts_respects_pos_label` — verifies `pos_label` is
  passed into ROC/PR artifact plot kwargs
- `test_autolog_pos_label_used_for_classifier_artifact_curves` — end-to-end
  autolog integration test for string-labeled binary classifiers

```bash
pytest tests/sklearn/test_sklearn_autolog.py::test_get_classifier_artifacts_respects_pos_label
pytest tests/sklearn/test_sklearn_autolog.py::test_autolog_pos_label_used_for_classifier_artifact_curves