### PR TITLE
Fix pos_label not passed to ROC/PR curve artifacts in sklearn autolog

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -304,7 +304,7 @@ def _get_class_labels_from_estimator(estimator):
     return estimator.classes_ if hasattr(estimator, "classes_") else None
 
 
-def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight):
+def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight, pos_label):
     """
     Draw and record various common artifacts for classifier
 
@@ -391,6 +391,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
                     "X": X,
                     "y": y_true,
                     "sample_weight": sample_weight,
+                    "pos_label": pos_label,
                 },
                 title="ROC curve",
             ),
@@ -404,6 +405,7 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
                     "X": X,
                     "y": y_true,
                     "sample_weight": sample_weight,
+                    "pos_label": pos_label,
                 },
                 title="Precision recall curve",
             ),
@@ -555,7 +557,7 @@ def _log_specialized_estimator_content(
     if sklearn.base.is_classifier(fitted_estimator):
         try:
             artifacts = _get_classifier_artifacts(
-                fitted_estimator, prefix, X, y_true, sample_weight
+                fitted_estimator, prefix, X, y_true, sample_weight, pos_label
             )
         except Exception as e:
             msg = (

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -318,20 +318,19 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
     (3) roc curve:
     https://scikit-learn.org/stable/auto_examples/model_selection/plot_roc.html
 
-    Steps:
-    1. Extract X and y_true from fit_args and fit_kwargs, and split into train & test datasets.
-    2. If the sample_weight argument exists in fit_func (accuracy_score by default
-    has sample_weight), extract it from fit_args or fit_kwargs as
-    (y_true, y_pred, sample_weight, multioutput), otherwise as (y_true, y_pred, multioutput)
-    3. return a list of artifacts path to be logged
-
     Args:
-        fitted_estimator: The already fitted regressor
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
+        fitted_estimator: The already fitted classifier.
+        prefix: Prefix used to name the logged artifacts, e.g. `training_`.
+        X: The features used to compute the predictions the artifacts are drawn from.
+        y_true: The true labels corresponding to `X`.
+        sample_weight: Per-sample weights, or None to weight all samples equally.
+        pos_label: The label treated as positive when drawing the precision recall and roc
+            curves, which are only logged for binary classifiers. Ignored by the confusion
+            matrix, which covers all classes.
 
     Returns:
-        List of artifacts to be logged
+        List of artifacts to be logged, empty if the installed sklearn version does not
+        support plotting.
     """
     import sklearn
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -31,6 +31,7 @@ from mlflow.models import Model, infer_signature
 from mlflow.models.utils import _read_example
 from mlflow.sklearn.utils import (
     _get_arg_names,
+    _get_classifier_artifacts,
     _is_estimator_html_repr_supported,
     _is_metric_supported,
     _is_plotting_supported,
@@ -1836,6 +1837,61 @@ def test_autolog_pos_label_used_for_training_metric():
                 pos_label=1,
             )
     assert training_metrics == expected_training_metrics
+
+
+def test_get_classifier_artifacts_respects_pos_label():
+    X = np.array([[1, 0], [0, 1], [1, 0], [1, 1], [1, 1], [1, 2]])
+    y = np.array(
+        [
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Positive_label",
+            "Positive_label",
+        ]
+    )
+    model = sklearn.linear_model.LogisticRegression()
+    model.fit(X, y)
+
+    artifacts = _get_classifier_artifacts(model, "training_", X, y, None, "Positive_label")
+    roc_artifact = next(a for a in artifacts if a.name == "training_roc_curve")
+    pr_artifact = next(a for a in artifacts if a.name == "training_precision_recall_curve")
+
+    assert roc_artifact.arguments["pos_label"] == "Positive_label"
+    assert pr_artifact.arguments["pos_label"] == "Positive_label"
+
+    if _is_plotting_supported():
+        roc_artifact.function(**roc_artifact.arguments)
+        plt.close()
+        pr_artifact.function(**pr_artifact.arguments)
+        plt.close()
+
+
+def test_autolog_pos_label_used_for_classifier_artifact_curves():
+    mlflow.sklearn.autolog(pos_label="Positive_label")
+
+    X = np.array([[1, 0], [0, 1], [1, 0], [1, 1], [1, 1], [1, 2]])
+    y = np.array(
+        [
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Negative_label",
+            "Positive_label",
+            "Positive_label",
+        ]
+    )
+    model = sklearn.linear_model.LogisticRegression()
+
+    with mlflow.start_run() as run:
+        model.fit(X, y)
+
+    client = MlflowClient()
+    artifacts = [x.path for x in client.list_artifacts(run.info.run_id)]
+    if _is_plotting_supported():
+        assert "training_roc_curve.png" in artifacts
+        assert "training_precision_recall_curve.png" in artifacts
 
 
 def test_autolog_emits_warning_message_when_pos_label_used_for_multilabel():

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1839,18 +1839,20 @@ def test_autolog_pos_label_used_for_training_metric():
     assert training_metrics == expected_training_metrics
 
 
+@pytest.mark.skipif(
+    not _is_plotting_supported(),
+    reason="`_get_classifier_artifacts` returns no artifacts when plotting is unsupported",
+)
 def test_get_classifier_artifacts_respects_pos_label():
     X = np.array([[1, 0], [0, 1], [1, 0], [1, 1], [1, 1], [1, 2]])
-    y = np.array(
-        [
-            "Negative_label",
-            "Negative_label",
-            "Negative_label",
-            "Negative_label",
-            "Positive_label",
-            "Positive_label",
-        ]
-    )
+    y = np.array([
+        "Negative_label",
+        "Negative_label",
+        "Negative_label",
+        "Negative_label",
+        "Positive_label",
+        "Positive_label",
+    ])
     model = sklearn.linear_model.LogisticRegression()
     model.fit(X, y)
 
@@ -1861,27 +1863,24 @@ def test_get_classifier_artifacts_respects_pos_label():
     assert roc_artifact.arguments["pos_label"] == "Positive_label"
     assert pr_artifact.arguments["pos_label"] == "Positive_label"
 
-    if _is_plotting_supported():
-        roc_artifact.function(**roc_artifact.arguments)
-        plt.close()
-        pr_artifact.function(**pr_artifact.arguments)
-        plt.close()
+    roc_artifact.function(**roc_artifact.arguments)
+    plt.close()
+    pr_artifact.function(**pr_artifact.arguments)
+    plt.close()
 
 
 def test_autolog_pos_label_used_for_classifier_artifact_curves():
     mlflow.sklearn.autolog(pos_label="Positive_label")
 
     X = np.array([[1, 0], [0, 1], [1, 0], [1, 1], [1, 1], [1, 2]])
-    y = np.array(
-        [
-            "Negative_label",
-            "Negative_label",
-            "Negative_label",
-            "Negative_label",
-            "Positive_label",
-            "Positive_label",
-        ]
-    )
+    y = np.array([
+        "Negative_label",
+        "Negative_label",
+        "Negative_label",
+        "Negative_label",
+        "Positive_label",
+        "Positive_label",
+    ])
     model = sklearn.linear_model.LogisticRegression()
 
     with mlflow.start_run() as run:


### PR DESCRIPTION
### Related Issues/PRs

Closes #6797

### What changes are proposed in this pull request?

`mlflow.sklearn.autolog(pos_label=...)` correctly used `pos_label` for scalar
classification metrics, but autologged ROC and precision-recall curve artifacts
did not receive `pos_label`. For binary classifiers whose positive class is not
`classes_[1]`, the logged curves were computed for the wrong class.

This threads `pos_label` through `_get_classifier_artifacts()` into the sklearn
ROC / precision-recall plot calls.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added:
- `test_get_classifier_artifacts_respects_pos_label`
- `test_autolog_pos_label_used_for_classifier_artifact_curves`

```bash
pytest tests/sklearn/test_sklearn_autolog.py::test_get_classifier_artifacts_respects_pos_label
pytest tests/sklearn/test_sklearn_autolog.py::test_autolog_pos_label_used_for_classifier_artifact_curves
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where `mlflow.sklearn.autolog(pos_label=...)` did not pass
`pos_label` to autologged ROC and precision-recall curve artifacts, causing
incorrect curves for binary classifiers when the positive class was not
`classes_[1]`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
