### PR TITLE
fix: handle existing tables during database initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,14 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    try:
+        InitialBase.metadata.create_all(engine)
+    except sqlalchemy.exc.OperationalError as e:
+        # If tables already exist (e.g., after a partially failed upgrade), ignore.
+        if "already exists" in str(e).lower():
+            _logger.warning("Some tables already exist, skipping creation.")
+        else:
+            raise
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, the `mlflow db upgrade` command fails with:
```
pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")
```
This occurs because `_safe_initialize_tables()` checks if all ORM tables exist using `_all_tables_exist()`. If a table like 'secrets' is missing (because it was added in 3.8.x), it calls `_initialize_tables()`, which tries to create ALL tables from `InitialBase.metadata`. If the 'secrets' table already exists (e.g., from a previous failed attempt or direct creation), the `CREATE TABLE` fails.

## Fix
Wrap the `InitialBase.metadata.create_all(engine)` call in a try-except block to catch `OperationalError` when a table already exists. Log a warning and continue with the upgrade.

Closes #19943