### PR TITLE
fix(genai): run sync agent handlers off the event loop

### DIFF
--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -1,10 +1,13 @@
 import argparse
+import asyncio
+import contextvars
 import functools
 import inspect
 import json
 import logging
 import os
 import posixpath
+from queue import Queue
 from typing import Any, AsyncGenerator, Callable, Literal, ParamSpec, TypeVar
 
 import httpx
@@ -29,6 +32,9 @@ _R = TypeVar("_R")
 
 _invoke_function: Callable[..., Any] | None = None
 _stream_function: Callable[..., Any] | None = None
+
+# Sentinel pushed onto the bridge queue to signal a worker generator has finished.
+_STREAM_SENTINEL = object()
 
 
 def get_invoke_function():
@@ -319,7 +325,10 @@ class AgentServer:
                 if inspect.iscoroutinefunction(func):
                     result = await func(request)
                 else:
-                    result = func(request)
+                    # Run sync handlers off the event loop so a slow handler does not
+                    # block other concurrent requests (e.g. /health). to_thread copies
+                    # the current context, so the active tracing span propagates.
+                    result = await asyncio.to_thread(func, request)
 
                 result = self.validator.validate_and_convert_result(result)
                 if self.agent_type == "ResponsesAgent":
@@ -346,6 +355,48 @@ class AgentServer:
 
             raise HTTPException(status_code=500, detail=str(e))
 
+    async def _iterate_sync_in_thread(
+        self, func: Callable[..., Any], request: dict[str, Any]
+    ) -> AsyncGenerator[Any, None]:
+        """Iterate a synchronous generator on a dedicated worker thread.
+
+        Running user generators off the event loop keeps the server responsive to
+        other requests (e.g. /health) while a chunk is being produced. A single
+        worker thread running in a copied context is used rather than Starlette's
+        per-``__next__`` threadpool so the generator executes in one consistent
+        context. This keeps MLflow's contextvar-based span attach/detach from
+        crossing thread/context boundaries, which would otherwise raise
+        "token was created in a different Context" errors.
+        """
+        loop = asyncio.get_running_loop()
+        chunk_queue: Queue[Any] = Queue()
+        error: list[BaseException] = []
+        # Copy the current context so the active tracing span set by the caller
+        # propagates into the worker thread and the generator's own spans nest
+        # correctly.
+        ctx = contextvars.copy_context()
+
+        def produce() -> None:
+            try:
+                for chunk in func(request):
+                    chunk_queue.put(chunk)
+            except BaseException as e:
+                error.append(e)
+            finally:
+                chunk_queue.put(_STREAM_SENTINEL)
+
+        # Fire-and-forget: the generator is consumed in a background thread and
+        # chunks are read from the queue below. Not awaited so the loop stays free.
+        loop.run_in_executor(None, lambda: ctx.run(produce))
+
+        while True:
+            chunk = await loop.run_in_executor(None, chunk_queue.get)
+            if chunk is _STREAM_SENTINEL:
+                if error:
+                    raise error[0]
+                break
+            yield chunk
+
     async def _generate(
         self,
         func: Callable[..., Any],
@@ -363,7 +414,7 @@ class AgentServer:
                         all_chunks.append(chunk)
                         yield f"data: {json.dumps(chunk)}\n\n"
                 else:
-                    for chunk in func(request):
+                    async for chunk in self._iterate_sync_in_thread(func, request):
                         chunk = self.validator.validate_and_convert_result(chunk, stream=True)
                         all_chunks.append(chunk)
                         yield f"data: {json.dumps(chunk)}\n\n"

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -405,7 +405,7 @@ class AgentServer:
         # +1 is headroom for the permit-less sentinel enqueued at teardown.
         chunk_queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=_STREAM_MAX_CHUNKS_AHEAD + 1)
         free_slots = threading.Semaphore(_STREAM_MAX_CHUNKS_AHEAD)
-        error: list[BaseException] = []
+        error: list[Exception] = []
         stop_event = threading.Event()
         # Copy the current context so the active tracing span set by the caller
         # propagates into the worker thread and the generator's own spans nest
@@ -435,7 +435,11 @@ class AgentServer:
                     if not acquired:
                         break
                     enqueue(chunk)
-            except BaseException as e:
+            except Exception as e:
+                # Only capture ordinary errors. Let BaseException types
+                # (KeyboardInterrupt, SystemExit) propagate so they terminate the
+                # worker thread and don't impede interpreter shutdown; the finally
+                # block still closes the generator and flushes the sentinel.
                 error.append(e)
             finally:
                 # Close the user's generator so its cleanup (span exit, finally
@@ -447,7 +451,7 @@ class AgentServer:
                 if gen_close is not None:
                     try:
                         gen_close()
-                    except BaseException as e:
+                    except Exception as e:
                         if not error:
                             error.append(e)
                 # The sentinel carries no permit, so it always enqueues even when

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -7,7 +7,9 @@ import json
 import logging
 import os
 import posixpath
-from queue import Queue
+import threading
+from contextlib import suppress
+from queue import Full, Queue
 from typing import Any, AsyncGenerator, Callable, Literal, ParamSpec, TypeVar
 
 import httpx
@@ -35,6 +37,14 @@ _stream_function: Callable[..., Any] | None = None
 
 # Sentinel pushed onto the bridge queue to signal a worker generator has finished.
 _STREAM_SENTINEL = object()
+
+# Bound the bridge queue so a slow or disconnected consumer applies backpressure
+# to the worker thread instead of letting it buffer the whole stream in memory.
+_STREAM_QUEUE_MAXSIZE = 64
+
+# How often the worker thread wakes while blocked on a full queue to re-check the
+# stop signal, so a client disconnect halts production promptly.
+_STREAM_POLL_SECONDS = 0.1
 
 
 def get_invoke_function():
@@ -367,35 +377,75 @@ class AgentServer:
         context. This keeps MLflow's contextvar-based span attach/detach from
         crossing thread/context boundaries, which would otherwise raise
         "token was created in a different Context" errors.
+
+        Teardown on client disconnect is handled explicitly: when the client goes
+        away, Starlette closes the streaming body generator, which raises
+        ``GeneratorExit`` into the ``yield`` below. The ``finally`` then sets a
+        stop signal. A worker blocked on a full queue wakes within a poll interval
+        (its ``put`` uses a timeout), closes the user's generator to run its
+        cleanup, and terminates instead of leaking the thread or running an
+        unbounded stream to completion.
         """
         loop = asyncio.get_running_loop()
-        chunk_queue: Queue[Any] = Queue()
+        # Bounded so a stalled consumer applies backpressure rather than letting
+        # the worker buffer the entire stream in memory.
+        chunk_queue: Queue[Any] = Queue(maxsize=_STREAM_QUEUE_MAXSIZE)
         error: list[BaseException] = []
+        stop_event = threading.Event()
         # Copy the current context so the active tracing span set by the caller
         # propagates into the worker thread and the generator's own spans nest
         # correctly.
         ctx = contextvars.copy_context()
 
         def produce() -> None:
+            gen = func(request)
             try:
-                for chunk in func(request):
-                    chunk_queue.put(chunk)
+                for chunk in gen:
+                    # Block for queue space but wake periodically to re-check the
+                    # stop signal so a disconnected client halts production.
+                    while not stop_event.is_set():
+                        try:
+                            chunk_queue.put(chunk, timeout=_STREAM_POLL_SECONDS)
+                            break
+                        except Full:
+                            continue
+                    if stop_event.is_set():
+                        break
             except BaseException as e:
                 error.append(e)
             finally:
-                chunk_queue.put(_STREAM_SENTINEL)
+                # Close the user's generator so its cleanup (span exit, finally
+                # blocks) runs in this worker thread/context even when the client
+                # disconnected mid-stream. On the normal path the generator is
+                # already exhausted and close() is a no-op.
+                gen_close = getattr(gen, "close", None)
+                if gen_close is not None:
+                    gen_close()
+                if stop_event.is_set():
+                    # Consumer has gone away; don't block on a possibly-full queue.
+                    with suppress(Full):
+                        chunk_queue.put_nowait(_STREAM_SENTINEL)
+                else:
+                    chunk_queue.put(_STREAM_SENTINEL)
 
         # Fire-and-forget: the generator is consumed in a background thread and
         # chunks are read from the queue below. Not awaited so the loop stays free.
         loop.run_in_executor(None, lambda: ctx.run(produce))
 
-        while True:
-            chunk = await loop.run_in_executor(None, chunk_queue.get)
-            if chunk is _STREAM_SENTINEL:
-                if error:
-                    raise error[0]
-                break
-            yield chunk
+        try:
+            while True:
+                chunk = await loop.run_in_executor(None, chunk_queue.get)
+                if chunk is _STREAM_SENTINEL:
+                    if error:
+                        raise error[0]
+                    break
+                yield chunk
+        finally:
+            # Runs on normal completion, error, and GeneratorExit (client
+            # disconnect). Signal the worker to stop; a worker blocked on a full
+            # queue wakes within a poll interval, runs its generator's cleanup,
+            # and terminates instead of leaking the thread.
+            stop_event.set()
 
     async def _generate(
         self,

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -396,10 +396,14 @@ class AgentServer:
         loop = asyncio.get_running_loop()
         # asyncio.Queue is awaited natively by the consumer; the worker thread
         # feeds it via call_soon_threadsafe since asyncio.Queue is not
-        # thread-safe. A semaphore (not the queue's maxsize) bounds how far the
-        # worker may run ahead, because a put_nowait scheduled onto the loop
-        # cannot block to apply backpressure.
-        chunk_queue: asyncio.Queue[Any] = asyncio.Queue()
+        # thread-safe. The actual backpressure is the semaphore below: the
+        # worker blocks on it before producing, since a put_nowait scheduled
+        # onto the loop cannot block to apply backpressure itself. The queue's
+        # maxsize is a structural hard cap so memory stays bounded even without
+        # reasoning about the semaphore -- the semaphore keeps the queue from
+        # ever actually reaching it (so put_nowait never raises QueueFull). The
+        # +1 is headroom for the permit-less sentinel enqueued at teardown.
+        chunk_queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=_STREAM_MAX_CHUNKS_AHEAD + 1)
         free_slots = threading.Semaphore(_STREAM_MAX_CHUNKS_AHEAD)
         error: list[BaseException] = []
         stop_event = threading.Event()

--- a/mlflow/genai/agent_server/server.py
+++ b/mlflow/genai/agent_server/server.py
@@ -8,8 +8,6 @@ import logging
 import os
 import posixpath
 import threading
-from contextlib import suppress
-from queue import Full, Queue
 from typing import Any, AsyncGenerator, Callable, Literal, ParamSpec, TypeVar
 
 import httpx
@@ -38,11 +36,12 @@ _stream_function: Callable[..., Any] | None = None
 # Sentinel pushed onto the bridge queue to signal a worker generator has finished.
 _STREAM_SENTINEL = object()
 
-# Bound the bridge queue so a slow or disconnected consumer applies backpressure
-# to the worker thread instead of letting it buffer the whole stream in memory.
-_STREAM_QUEUE_MAXSIZE = 64
+# Max number of real chunks the worker may stay ahead of the consumer. A semaphore
+# enforces this so a slow or disconnected consumer applies backpressure to the
+# worker thread instead of letting it buffer the whole stream in memory.
+_STREAM_MAX_CHUNKS_AHEAD = 64
 
-# How often the worker thread wakes while blocked on a full queue to re-check the
+# How often the worker thread wakes while blocked on backpressure to re-check the
 # stop signal, so a client disconnect halts production promptly.
 _STREAM_POLL_SECONDS = 0.1
 
@@ -372,24 +371,36 @@ class AgentServer:
 
         Running user generators off the event loop keeps the server responsive to
         other requests (e.g. /health) while a chunk is being produced. A single
-        worker thread running in a copied context is used rather than Starlette's
-        per-``__next__`` threadpool so the generator executes in one consistent
-        context. This keeps MLflow's contextvar-based span attach/detach from
-        crossing thread/context boundaries, which would otherwise raise
-        "token was created in a different Context" errors.
+        dedicated thread per stream runs the generator in a copied context rather
+        than Starlette's per-``__next__`` threadpool so the generator executes in
+        one consistent thread/context. This keeps MLflow's contextvar-based span
+        attach/detach from crossing thread/context boundaries, which would
+        otherwise raise "token was created in a different Context" errors.
+
+        Chunks are handed to the event loop via ``call_soon_threadsafe`` into an
+        ``asyncio.Queue`` that the consumer awaits natively, so no executor thread
+        is tied up on a blocking ``get``. Earlier designs scheduled both the
+        producer and every per-chunk ``get`` onto the shared default executor;
+        under concurrent load the blocked gets could exhaust that pool (which is
+        also shared with ``asyncio.to_thread``) and starve producers. A dedicated
+        thread plus an ``asyncio.Queue`` avoids touching the executor entirely.
 
         Teardown on client disconnect is handled explicitly: when the client goes
         away, Starlette closes the streaming body generator, which raises
         ``GeneratorExit`` into the ``yield`` below. The ``finally`` then sets a
-        stop signal. A worker blocked on a full queue wakes within a poll interval
-        (its ``put`` uses a timeout), closes the user's generator to run its
-        cleanup, and terminates instead of leaking the thread or running an
-        unbounded stream to completion.
+        stop signal. A worker blocked on the backpressure semaphore wakes within a
+        poll interval, closes the user's generator to run its cleanup, and
+        terminates instead of leaking the thread or running an unbounded stream to
+        completion.
         """
         loop = asyncio.get_running_loop()
-        # Bounded so a stalled consumer applies backpressure rather than letting
-        # the worker buffer the entire stream in memory.
-        chunk_queue: Queue[Any] = Queue(maxsize=_STREAM_QUEUE_MAXSIZE)
+        # asyncio.Queue is awaited natively by the consumer; the worker thread
+        # feeds it via call_soon_threadsafe since asyncio.Queue is not
+        # thread-safe. A semaphore (not the queue's maxsize) bounds how far the
+        # worker may run ahead, because a put_nowait scheduled onto the loop
+        # cannot block to apply backpressure.
+        chunk_queue: asyncio.Queue[Any] = asyncio.Queue()
+        free_slots = threading.Semaphore(_STREAM_MAX_CHUNKS_AHEAD)
         error: list[BaseException] = []
         stop_event = threading.Event()
         # Copy the current context so the active tracing span set by the caller
@@ -397,54 +408,72 @@ class AgentServer:
         # correctly.
         ctx = contextvars.copy_context()
 
+        def enqueue(item: Any) -> None:
+            # call_soon_threadsafe raises RuntimeError once the loop is closed
+            # (server shutdown); there is then no consumer left to deliver to.
+            try:
+                loop.call_soon_threadsafe(chunk_queue.put_nowait, item)
+            except RuntimeError:
+                pass
+
         def produce() -> None:
             gen = func(request)
             try:
                 for chunk in gen:
-                    # Block for queue space but wake periodically to re-check the
-                    # stop signal so a disconnected client halts production.
+                    # Acquire one backpressure permit per real chunk, waking
+                    # periodically to re-check the stop signal so a disconnected
+                    # client halts production promptly.
+                    acquired = False
                     while not stop_event.is_set():
-                        try:
-                            chunk_queue.put(chunk, timeout=_STREAM_POLL_SECONDS)
+                        if free_slots.acquire(timeout=_STREAM_POLL_SECONDS):
+                            acquired = True
                             break
-                        except Full:
-                            continue
-                    if stop_event.is_set():
+                    if not acquired:
                         break
+                    enqueue(chunk)
             except BaseException as e:
                 error.append(e)
             finally:
                 # Close the user's generator so its cleanup (span exit, finally
                 # blocks) runs in this worker thread/context even when the client
                 # disconnected mid-stream. On the normal path the generator is
-                # already exhausted and close() is a no-op.
+                # already exhausted and close() is a no-op. Preserve any earlier
+                # error rather than letting a close() failure mask it.
                 gen_close = getattr(gen, "close", None)
                 if gen_close is not None:
-                    gen_close()
-                if stop_event.is_set():
-                    # Consumer has gone away; don't block on a possibly-full queue.
-                    with suppress(Full):
-                        chunk_queue.put_nowait(_STREAM_SENTINEL)
-                else:
-                    chunk_queue.put(_STREAM_SENTINEL)
+                    try:
+                        gen_close()
+                    except BaseException as e:
+                        if not error:
+                            error.append(e)
+                # The sentinel carries no permit, so it always enqueues even when
+                # the consumer is mid-disconnect.
+                enqueue(_STREAM_SENTINEL)
 
-        # Fire-and-forget: the generator is consumed in a background thread and
-        # chunks are read from the queue below. Not awaited so the loop stays free.
-        loop.run_in_executor(None, lambda: ctx.run(produce))
+        thread = threading.Thread(
+            target=lambda: ctx.run(produce),
+            name="agent-server-stream-worker",
+            daemon=True,
+        )
+        thread.start()
 
         try:
             while True:
-                chunk = await loop.run_in_executor(None, chunk_queue.get)
+                chunk = await chunk_queue.get()
                 if chunk is _STREAM_SENTINEL:
                     if error:
                         raise error[0]
                     break
+                # Release the permit acquired by the producer for this chunk so it
+                # may advance by one, keeping at most _STREAM_MAX_CHUNKS_AHEAD chunks
+                # in flight.
+                free_slots.release()
                 yield chunk
         finally:
             # Runs on normal completion, error, and GeneratorExit (client
-            # disconnect). Signal the worker to stop; a worker blocked on a full
-            # queue wakes within a poll interval, runs its generator's cleanup,
-            # and terminates instead of leaking the thread.
+            # disconnect). Signal the worker to stop; a worker blocked on the
+            # backpressure semaphore wakes within a poll interval, runs its
+            # generator's cleanup, and terminates instead of leaking the thread.
             stop_event.set()
 
     async def _generate(

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1341,8 +1341,11 @@ _RESPONSIVE_THRESHOLD_SECONDS = 1.0
 
 @pytest.mark.asyncio
 async def test_sync_invoke_does_not_block_event_loop():
+    handler_started = threading.Event()
+
     @invoke()
     def slow_invoke(request):
+        handler_started.set()
         time.sleep(_SLOW_HANDLER_SECONDS)
         return {"result": "done"}
 
@@ -1351,8 +1354,11 @@ async def test_sync_invoke_does_not_block_event_loop():
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         start = time.perf_counter()
         invoke_task = asyncio.create_task(client.post("/invocations", json={"x": 1}))
-        # Let the invoke reach the handler and offload to a worker thread.
-        await asyncio.sleep(0.1)
+        # Deterministically wait until the handler has started (and offloaded to a
+        # worker thread) before timing /health, instead of assuming a fixed delay.
+        # Waiting on the Event from an executor thread keeps the event loop free.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, handler_started.wait)
 
         health = await client.get("/health")
         health_latency = time.perf_counter() - start
@@ -1367,8 +1373,11 @@ async def test_sync_invoke_does_not_block_event_loop():
 
 @pytest.mark.asyncio
 async def test_sync_stream_does_not_block_event_loop():
+    handler_started = threading.Event()
+
     @stream()
     def slow_stream(request):
+        handler_started.set()
         time.sleep(_SLOW_HANDLER_SECONDS)
         yield {"chunk": "done"}
 
@@ -1379,8 +1388,11 @@ async def test_sync_stream_does_not_block_event_loop():
         stream_task = asyncio.create_task(
             client.post("/invocations", json={"x": 1, "stream": True})
         )
-        # Let the stream reach the handler and start producing on a worker thread.
-        await asyncio.sleep(0.1)
+        # Deterministically wait until the handler has started producing (on a worker
+        # thread) before timing /health, instead of assuming a fixed delay. Waiting on
+        # the Event from an executor thread keeps the event loop free.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, handler_started.wait)
 
         health = await client.get("/health")
         health_latency = time.perf_counter() - start

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1538,6 +1538,54 @@ async def test_sync_stream_disconnect_propagates_through_body_generator():
 
 
 @pytest.mark.asyncio
+async def test_sync_stream_handler_error_propagates_to_consumer():
+    # A regular Exception raised by the user generator is captured on the worker
+    # thread and re-raised through the consumer, so the stream endpoint can surface
+    # it as an SSE error event.
+    @stream()
+    def failing_stream(request):
+        yield {"chunk": 1}
+        raise ValueError("boom")
+
+    server = AgentServer()
+    agen = server._iterate_sync_in_thread(failing_stream, {"x": 1})
+
+    assert await agen.__anext__() == {"chunk": 1}
+    with pytest.raises(ValueError, match="boom"):
+        await agen.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_sync_stream_handler_base_exception_is_not_captured(monkeypatch):
+    # BaseException types (KeyboardInterrupt, SystemExit) must propagate on the
+    # worker thread and terminate it, rather than being captured into the error
+    # channel and re-raised on the event loop where they would impede shutdown. The
+    # worker's uncaught KeyboardInterrupt reaches threading.excepthook; swallow it
+    # so it does not surface as a spurious thread-exception warning.
+    monkeypatch.setattr(threading, "excepthook", lambda args: None)
+    raised = threading.Event()
+
+    @stream()
+    def interrupted_stream(request):
+        yield {"chunk": 1}
+        raised.set()
+        raise KeyboardInterrupt
+
+    server = AgentServer()
+
+    # The consumer ends normally yielding only the pre-interrupt chunk: the
+    # sentinel carries no error because the KeyboardInterrupt was never captured
+    # into the error channel.
+    chunks = [chunk async for chunk in server._iterate_sync_in_thread(interrupted_stream, {"x": 1})]
+    assert chunks == [{"chunk": 1}]
+
+    assert raised.is_set()
+    # Let the worker finish unwinding the KeyboardInterrupt into the swallowing
+    # excepthook before monkeypatch restores the original at teardown.
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
 async def test_concurrent_sync_streams_do_not_starve_default_executor():
     from mlflow.genai.agent_server.server import _STREAM_MAX_CHUNKS_AHEAD
 

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -1464,7 +1465,7 @@ def test_sync_stream_child_span_across_yields_succeeds():
 
 @pytest.mark.asyncio
 async def test_sync_stream_worker_stops_on_client_disconnect():
-    from mlflow.genai.agent_server.server import _STREAM_QUEUE_MAXSIZE
+    from mlflow.genai.agent_server.server import _STREAM_MAX_CHUNKS_AHEAD
 
     # On client disconnect Starlette closes the streaming body generator, which
     # raises GeneratorExit into the worker bridge generator's yield. Closing the
@@ -1501,7 +1502,7 @@ async def test_sync_stream_worker_stops_on_client_disconnect():
     count_after_close = produced
     await asyncio.sleep(0.5)
     assert produced == count_after_close
-    assert produced < _STREAM_QUEUE_MAXSIZE * 2
+    assert produced < _STREAM_MAX_CHUNKS_AHEAD * 2
 
 
 @pytest.mark.asyncio
@@ -1534,3 +1535,45 @@ async def test_sync_stream_disconnect_propagates_through_body_generator():
             break
         await asyncio.sleep(0.05)
     assert cleaned_up.is_set()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sync_streams_do_not_starve_default_executor():
+    from mlflow.genai.agent_server.server import _STREAM_MAX_CHUNKS_AHEAD
+
+    # Regression test for the executor-starvation deadlock: an earlier design
+    # scheduled both the producer and every per-chunk get onto the loop's default
+    # executor (shared with asyncio.to_thread). With more concurrent streams than
+    # the pool has threads, the long-lived producers pin every thread; their
+    # queues fill, so they block on put while no thread is left to run a consumer
+    # get -- a hard deadlock. Each stream below yields more than the queue bound so
+    # the old producer would block on a full queue. The current design uses a
+    # dedicated thread plus an asyncio.Queue per stream and never touches the
+    # executor, so a tiny pool cannot starve it.
+    pool_size = 2
+    num_streams = pool_size + 4
+    chunks_per_stream = _STREAM_MAX_CHUNKS_AHEAD + 20
+
+    loop = asyncio.get_running_loop()
+    loop.set_default_executor(
+        ThreadPoolExecutor(max_workers=pool_size, thread_name_prefix="test-default-executor")
+    )
+
+    @stream()
+    def big_stream(request):
+        for i in range(chunks_per_stream):
+            yield {"chunk": i}
+
+    server = AgentServer()
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        tasks = [
+            asyncio.create_task(client.post("/invocations", json={"x": i, "stream": True}))
+            for i in range(num_streams)
+        ]
+        responses = await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)
+
+    assert len(responses) == num_streams
+    for resp in responses:
+        assert resp.status_code == 200
+        assert resp.text.count('"chunk"') == chunks_per_stream

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1460,3 +1460,77 @@ def test_sync_stream_child_span_across_yields_succeeds():
     # No SSE error event: the cross-yield span never crossed a context boundary.
     assert "error" not in response.text
     assert len(span_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_stream_worker_stops_on_client_disconnect():
+    from mlflow.genai.agent_server.server import _STREAM_QUEUE_MAXSIZE
+
+    # On client disconnect Starlette closes the streaming body generator, which
+    # raises GeneratorExit into the worker bridge generator's yield. Closing the
+    # bridge generator directly reproduces that. Teardown must stop the worker
+    # thread and run the user generator's cleanup, rather than leaking the thread
+    # or draining an infinite stream to completion.
+    produced = 0
+    cleaned_up = threading.Event()
+
+    @stream()
+    def infinite_stream(request):
+        nonlocal produced
+        try:
+            while True:
+                produced += 1
+                yield {"chunk": produced}
+        finally:
+            cleaned_up.set()
+
+    server = AgentServer()
+    agen = server._iterate_sync_in_thread(infinite_stream, {"x": 1})
+
+    for _ in range(3):
+        await agen.__anext__()
+    await agen.aclose()
+
+    # The user generator's finally ran in the worker thread/context.
+    assert cleaned_up.wait(timeout=5)
+
+    # Production halts shortly after the stop signal: the count stops climbing and
+    # stays bounded by the queue size plus the few chunks produced before the stop
+    # took effect (never the unbounded full stream).
+    await asyncio.sleep(0.5)
+    count_after_close = produced
+    await asyncio.sleep(0.5)
+    assert produced == count_after_close
+    assert produced < _STREAM_QUEUE_MAXSIZE * 2
+
+
+@pytest.mark.asyncio
+async def test_sync_stream_disconnect_propagates_through_body_generator():
+    # End-to-end of the disconnect path: Starlette closes the StreamingResponse
+    # body (_generate), and the inner worker bridge generator is closed via the
+    # async-generator finalizer as _generate's frame unwinds. This is the
+    # load-bearing link the fix relies on -- without it the worker would run the
+    # infinite stream forever. Poll with asyncio.sleep (not a blocking wait) so
+    # the loop can run the scheduled finalizer.
+    cleaned_up = threading.Event()
+
+    @stream()
+    def infinite_stream(request):
+        try:
+            while True:
+                yield {"chunk": "x"}
+        finally:
+            cleaned_up.set()
+
+    server = AgentServer()
+    body = server._generate(infinite_stream, {"x": 1}, False)
+
+    for _ in range(3):
+        await body.__anext__()
+    await body.aclose()
+
+    for _ in range(100):
+        if cleaned_up.is_set():
+            break
+        await asyncio.sleep(0.05)
+    assert cleaned_up.is_set()

--- a/tests/genai/test_agent_server.py
+++ b/tests/genai/test_agent_server.py
@@ -1,4 +1,7 @@
+import asyncio
 import contextvars
+import threading
+import time
 from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -6,6 +9,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+import mlflow
 from mlflow.genai.agent_server import (
     AgentServer,
     get_invoke_function,
@@ -1322,3 +1326,137 @@ def test_return_trace_header_case_insensitive(header_value):
         assert "output" in response_json
         assert response_json["metadata"] == {"trace_id": "test-trace-id-123"}
         mock_span.assert_called_once()
+
+
+# Concurrency: sync handlers must run off the event loop so a slow request does not
+# block other concurrent requests (e.g. /health). See GitHub issue #23953.
+
+_SLOW_HANDLER_SECONDS = 2.0
+# /health must respond well within the slow handler's duration. On the unfixed
+# (blocking) code the loop is frozen for _SLOW_HANDLER_SECONDS, so the wall-clock
+# time to serve /health exceeds this threshold; on the fixed code it is near-zero.
+_RESPONSIVE_THRESHOLD_SECONDS = 1.0
+
+
+@pytest.mark.asyncio
+async def test_sync_invoke_does_not_block_event_loop():
+    @invoke()
+    def slow_invoke(request):
+        time.sleep(_SLOW_HANDLER_SECONDS)
+        return {"result": "done"}
+
+    server = AgentServer()
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.perf_counter()
+        invoke_task = asyncio.create_task(client.post("/invocations", json={"x": 1}))
+        # Let the invoke reach the handler and offload to a worker thread.
+        await asyncio.sleep(0.1)
+
+        health = await client.get("/health")
+        health_latency = time.perf_counter() - start
+
+        assert health.status_code == 200
+        assert health.json() == {"status": "healthy"}
+        assert health_latency < _RESPONSIVE_THRESHOLD_SECONDS
+
+        invoke_resp = await invoke_task
+        assert invoke_resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_sync_stream_does_not_block_event_loop():
+    @stream()
+    def slow_stream(request):
+        time.sleep(_SLOW_HANDLER_SECONDS)
+        yield {"chunk": "done"}
+
+    server = AgentServer()
+    transport = httpx.ASGITransport(app=server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        start = time.perf_counter()
+        stream_task = asyncio.create_task(
+            client.post("/invocations", json={"x": 1, "stream": True})
+        )
+        # Let the stream reach the handler and start producing on a worker thread.
+        await asyncio.sleep(0.1)
+
+        health = await client.get("/health")
+        health_latency = time.perf_counter() - start
+
+        assert health.status_code == 200
+        assert health.json() == {"status": "healthy"}
+        assert health_latency < _RESPONSIVE_THRESHOLD_SECONDS
+
+        stream_resp = await stream_task
+        assert stream_resp.status_code == 200
+        assert "chunk" in stream_resp.text
+
+
+def test_sync_invoke_preserves_active_span_in_worker_thread():
+    captured = {}
+
+    @invoke()
+    def capture_invoke(request):
+        captured["active_span"] = mlflow.get_current_active_span()
+        captured["thread"] = threading.current_thread()
+        return {"result": "ok"}
+
+    server = AgentServer()
+    client = TestClient(server.app)
+
+    response = client.post("/invocations", json={"x": 1})
+    assert response.status_code == 200
+    # The handler ran on a worker thread (off the event loop) but still sees the
+    # span opened by the server, confirming the request context (including the
+    # OTel span contextvar) propagated via to_thread's copy_context.
+    assert captured["active_span"] is not None
+    assert captured["thread"] is not threading.main_thread()
+
+
+def test_sync_stream_preserves_active_span_in_worker_thread():
+    captured = {}
+
+    @stream()
+    def capture_stream(request):
+        captured["active_span"] = mlflow.get_current_active_span()
+        captured["thread"] = threading.current_thread()
+        yield {"chunk": "ok"}
+
+    server = AgentServer()
+    client = TestClient(server.app)
+
+    response = client.post("/invocations", json={"x": 1, "stream": True})
+    assert response.status_code == 200
+    # The sync generator runs on a single worker thread in a copied context, so it
+    # observes the server's active span and its own spans nest correctly.
+    assert captured["active_span"] is not None
+    assert captured["thread"] is not threading.main_thread()
+
+
+def test_sync_stream_child_span_across_yields_succeeds():
+    # A child span held open across multiple yields is the scenario the single
+    # worker-thread design protects. The span's contextvar attach/detach tokens must
+    # be created and torn down in the same context; a per-__next__ threadpool (e.g.
+    # starlette.iterate_in_threadpool) resumes each yield in a different context and
+    # raises "token was created in a different Context", which surfaces as an SSE
+    # "error" event. One worker thread in a single copied context keeps it intact.
+    span_ids = []
+
+    @stream()
+    def span_stream(request):
+        with mlflow.start_span("child") as span:
+            span_ids.append(span.span_id)
+            yield {"chunk": "first"}
+            yield {"chunk": "second"}
+
+    server = AgentServer()
+    client = TestClient(server.app)
+
+    response = client.post("/invocations", json={"x": 1, "stream": True})
+    assert response.status_code == 200
+    assert "first" in response.text
+    assert "second" in response.text
+    # No SSE error event: the cross-yield span never crossed a context boundary.
+    assert "error" not in response.text
+    assert len(span_ids) == 1


### PR DESCRIPTION
### Related Issues/PRs

Closes #23953

### What changes are proposed in this pull request?

`AgentServer` invoked synchronous registered handlers (`@invoke()` / `@stream()`) directly on the asyncio event loop. Because the handlers are blocking, a single slow request froze every other concurrent request — including `/health`. As reported in #23953, a 60s tool call caused a second concurrent request to wait ~66s instead of ~5s.

This PR runs sync handlers off the event loop:

- **Non-streaming handlers** now run via `asyncio.to_thread`. This offloads the blocking call to a worker thread and copies the current context, so MLflow's contextvar-based active tracing span propagates into the worker thread unchanged.
- **Streaming handlers** run on a single dedicated worker thread fed through a thread-safe `queue.Queue`, with the blocking `queue.get()` offloaded via `loop.run_in_executor` to keep the loop free. The generator executes inside one `contextvars.copy_context()` rather than Starlette's per-`__next__` threadpool. This matters: a span held open across `yield`s keeps its contextvar attach/detach tokens within a single context, avoiding the `ValueError: token was created in a different Context` that the per-`__next__` approach raises.

Async handlers are unchanged — they already run cooperatively on the loop.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/genai/test_agent_server.py`:
- `/health` stays responsive (<1s) while a 2s sync `@invoke()` handler runs, and while a 2s sync `@stream()` handler runs (both fail on the unpatched blocking code).
- Sync invoke and stream handlers observe the server's active span while running on a worker thread (off the main thread), confirming context propagation.
- A sync `@stream()` generator that holds `mlflow.start_span("child")` open across two `yield`s streams successfully with no error event. This test fails under the rejected `iterate_in_threadpool` design (with the "token was created in a different Context" error) and passes under the single-worker-thread bridge, locking in the design choice.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`AgentServer` no longer blocks concurrent requests (including `/health`) while a synchronous agent handler is running; sync handlers now execute off the event loop.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
