### PR TITLE
Show the review-queue in-place save confirmation as a global toast

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -8,6 +8,7 @@ import { IntlProvider } from '@databricks/i18n';
 import { FocusedReview } from './FocusedReview';
 import type { LabelSchema } from '../../components/label-schemas';
 import type { ReviewQueueItem } from './types';
+import Utils from '../../../common/utils/Utils';
 
 let mockTraceData: unknown[] = [];
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
@@ -278,7 +279,9 @@ describe('FocusedReview trace content rendering', () => {
 });
 
 describe('FocusedReview edit-in-place on a completed trace', () => {
+  let toastSpy: jest.SpiedFunction<typeof Utils.displayGlobalInfoNotification>;
   beforeEach(() => {
+    toastSpy = jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
     mockCreateAssessment.mockReset();
     mockCreateAssessment.mockImplementation(() => Promise.resolve());
     // The completed trace prefills its prior answer (with its assessment id, so a
@@ -290,6 +293,7 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
     };
   });
   afterEach(() => {
+    toastSpy.mockRestore();
     mockPriorAnswersResult = { priorAnswers: [], isLoading: false, isFetching: false };
   });
 
@@ -333,7 +337,9 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
     expect(onSetStatus).not.toHaveBeenCalled();
     expect(onSelect).not.toHaveBeenCalled();
     expect(onBack).not.toHaveBeenCalled();
-    expect(await screen.findByText('Changes saved')).toBeInTheDocument();
+    // The save is confirmed by a global toast (not an inline alert that would
+    // reflow the action buttons).
+    await waitFor(() => expect(toastSpy).toHaveBeenCalledWith('Changes saved'));
   });
 
   it('shows the save error and suppresses the saved confirmation when an in-place re-save fails', async () => {
@@ -345,7 +351,7 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
     fireEvent.click(screen.getByText('Save changes'));
 
     expect(await screen.findByText(/could not save your review/i)).toBeInTheDocument();
-    expect(screen.queryByText('Changes saved')).not.toBeInTheDocument();
+    expect(toastSpy).not.toHaveBeenCalledWith('Changes saved');
     expect(onSetStatus).not.toHaveBeenCalled();
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -186,21 +186,12 @@ export const FocusedReview = ({
   const [edited, setEdited] = useState<Record<string, LabelSchemaValue>>({});
   const [editedRationales, setEditedRationales] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
-  // Confirmation shown after an in-place edit of a completed trace is saved;
-  // cleared as soon as the reviewer edits again.
-  const [editSaved, setEditSaved] = useState(false);
 
   const valueFor = (name: string): LabelSchemaValue => (name in edited ? edited[name] : prefilled[name]);
-  const setAnswer = (name: string, value: LabelSchemaValue) => {
-    setEditSaved(false);
-    setEdited((prev) => ({ ...prev, [name]: value }));
-  };
+  const setAnswer = (name: string, value: LabelSchemaValue) => setEdited((prev) => ({ ...prev, [name]: value }));
   const rationaleFor = (name: string): string =>
     name in editedRationales ? editedRationales[name] : (prefilledRationales[name] ?? '');
-  const setRationale = (name: string, value: string) => {
-    setEditSaved(false);
-    setEditedRationales((prev) => ({ ...prev, [name]: value }));
-  };
+  const setRationale = (name: string, value: string) => setEditedRationales((prev) => ({ ...prev, [name]: value }));
 
   // A completed trace stays editable: the reviewer can revise their answers and
   // re-save without the trace leaving the "done" bucket (mirrors the review app,
@@ -305,8 +296,14 @@ export const FocusedReview = ({
       // (superseding the priors), but the trace stays COMPLETE and we keep the
       // reviewer on it. Re-saving an edit must not flip it back to PENDING / the
       // to-do list, and its `completed_by`/`completed_time_ms` attribution stands.
+      // A global toast confirms the save without reflowing the action buttons.
       if (isComplete) {
-        setEditSaved(true);
+        Utils.displayGlobalInfoNotification(
+          intl.formatMessage({
+            defaultMessage: 'Changes saved',
+            description: 'Review focused view: confirmation that edited answers were saved',
+          }),
+        );
         return;
       }
       await onSetStatus('COMPLETE');
@@ -582,18 +579,6 @@ export const FocusedReview = ({
                   </Button>
                 )}
               </div>
-            )}
-            {editSaved && !submitError && (
-              <Alert
-                componentId={`${CID}.edit-saved`}
-                type="success"
-                closable
-                onClose={() => setEditSaved(false)}
-                message={intl.formatMessage({
-                  defaultMessage: 'Changes saved',
-                  description: 'Review focused view: confirmation that edited answers were saved',
-                })}
-              />
             )}
             {submitError && (
               <Alert


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #23967 (edit-in-place) and #23915 (focus-mode fit-n-finish).

### What changes are proposed in this pull request?

After an in-place edit of a completed review, the "Changes saved" confirmation used an inline `Alert` that **reflowed the action buttons** (Move to Todo / Save changes shift down when it appears). This swaps it for the same global notification (`Utils.displayGlobalInfoNotification`) already used for the "All items in this queue have been reviewed!" toast, so the confirmation no longer shifts the layout.

Removes the now-unused `editSaved` state and its inline `Alert`; the fire point is unchanged (after the assessment writes succeed, on the in-place re-save path).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Updated `FocusedReview.test.tsx` to assert the save is confirmed via `Utils.displayGlobalInfoNotification('Changes saved')` (and not fired on a failed re-save) instead of the inline alert text. `yarn test FocusedReview` (17 passing), `yarn type-check`, `yarn lint`, `yarn prettier:check`, `yarn i18n:check` all clean.

<img width="505" height="515" alt="Screenshot 2026-06-15 at 10 29 25 AM" src="https://github.com/user-attachments/assets/d02ba5e9-66c7-428f-84ae-e1efc13ba189" />

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The review-queue "Changes saved" confirmation no longer shifts the focus-mode action buttons when it appears.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.