### PR TITLE
Review queues: surface action errors as toasts instead of inline alerts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -132,6 +132,10 @@ describe('AddToReviewQueueDropdown', () => {
       .spyOn(Utils, 'displayGlobalInfoNotification')
       .mockReset()
       .mockImplementation(() => {});
+    jest
+      .spyOn(Utils, 'displayGlobalErrorNotification')
+      .mockReset()
+      .mockImplementation(() => {});
   });
 
   it('opens the dropdown when controlled with open=true', () => {
@@ -176,7 +180,8 @@ describe('AddToReviewQueueDropdown', () => {
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
 
-    expect(await screen.findByText('Queue resolution failed')).toBeInTheDocument();
+    await waitFor(() => expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledTimes(1));
+    expect(jest.mocked(Utils.displayGlobalErrorNotification).mock.calls[0][0]).toContain('Queue resolution failed');
     expect(mockAddItems).not.toHaveBeenCalled();
     expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
   });
@@ -187,7 +192,8 @@ describe('AddToReviewQueueDropdown', () => {
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Relevance' }));
 
-    expect(await screen.findByText('Attach failed')).toBeInTheDocument();
+    await waitFor(() => expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledTimes(1));
+    expect(jest.mocked(Utils.displayGlobalErrorNotification).mock.calls[0][0]).toContain('Attach failed');
     expect(Utils.displayGlobalInfoNotification).not.toHaveBeenCalled();
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -124,7 +124,6 @@ export const AddToReviewQueueDropdown = ({
   const { addItemsToReviewQueueAsync, reset: resetAdd } = useAddItemsToReviewQueueMutation();
   const { removeItemsFromReviewQueueAsync } = useRemoveItemsFromReviewQueueMutation();
   const { getOrCreateUserQueueAsync, reset: resetResolve } = useGetOrCreateUserQueueMutation();
-  const [submitError, setSubmitError] = useState<string | null>(null);
   // Tracks which queue IDs / usernames are currently being processed so only
   // those specific items are disabled — no full-list flash.
   const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
@@ -238,7 +237,6 @@ export const AddToReviewQueueDropdown = ({
     setAddedQueueIds(new Set());
     setAddedUsers(new Set());
     setCreateOpen(false);
-    setSubmitError(null);
     setBusyIds(new Set());
     // Allow the next open to re-seed membership from the server.
     seededItemRef.current = null;
@@ -277,6 +275,20 @@ export const AddToReviewQueueDropdown = ({
     );
   }, [experimentId, itemIds.length, intl]);
 
+  const showErrorToast = useCallback(
+    (e: unknown) =>
+      Utils.displayGlobalErrorNotification(
+        intl.formatMessage(
+          {
+            defaultMessage: 'Failed to update the review queue: {error}',
+            description: 'Add to review queue: error toast when adding or removing traces fails',
+          },
+          { error: e instanceof Error ? e.message : String(e) },
+        ),
+      ),
+    [intl],
+  );
+
   const markBusy = (id: string) => setBusyIds((prev) => new Set(prev).add(id));
   const clearBusy = (id: string) =>
     setBusyIds((prev) => {
@@ -288,7 +300,6 @@ export const AddToReviewQueueDropdown = ({
   const toggleCustomQueue = async (queueId: string) => {
     if (busyIds.has(queueId) || !reviewerResolved || itemIds.length === 0) return;
     markBusy(queueId);
-    setSubmitError(null);
     const alreadyAdded = addedQueueIds.has(queueId);
     try {
       if (alreadyAdded) {
@@ -304,7 +315,7 @@ export const AddToReviewQueueDropdown = ({
         showSuccessToast();
       }
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : String(e));
+      showErrorToast(e);
     } finally {
       clearBusy(queueId);
     }
@@ -313,7 +324,6 @@ export const AddToReviewQueueDropdown = ({
   const toggleUserQueue = async (username: string) => {
     if (busyIds.has(username) || !reviewerResolved || itemIds.length === 0) return;
     markBusy(username);
-    setSubmitError(null);
     const alreadyAdded = addedUsers.has(username);
     try {
       const { review_queue } = await getOrCreateUserQueueAsync({
@@ -334,7 +344,7 @@ export const AddToReviewQueueDropdown = ({
         showSuccessToast();
       }
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : String(e));
+      showErrorToast(e);
     } finally {
       clearBusy(username);
     }
@@ -600,21 +610,6 @@ export const AddToReviewQueueDropdown = ({
                   </DialogComboboxOptionListSearch>
                 </DialogComboboxOptionList>
               </DialogCombobox>
-
-              {submitError && (
-                <div css={{ padding: theme.spacing.sm }}>
-                  <Alert
-                    componentId={`${CID}.error`}
-                    type="error"
-                    closable={false}
-                    message={intl.formatMessage({
-                      defaultMessage: 'Something went wrong.',
-                      description: 'Add to review queue: error alert title',
-                    })}
-                    description={submitError}
-                  />
-                </div>
-              )}
             </>
           )}
         </Popover.Content>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 
 import {
-  Alert,
   ApplyDesignSystemContextOverrides,
   ChevronDownIcon,
   ChevronRightIcon,
@@ -26,6 +25,7 @@ import {
 import { QuestionChecklistCombobox } from './QuestionChecklistCombobox';
 import { MAX_ASSIGNED_USERS, ReviewerChecklistCombobox } from './ReviewerChecklistCombobox';
 import { useIsAuthAvailable } from '../../../account/hooks';
+import Utils from '../../../common/utils/Utils';
 import { useAssignableUsersQuery } from './hooks/useAssignableUsersQuery';
 import { useCreateReviewQueueMutation } from './hooks/useCreateReviewQueueMutation';
 import { useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
@@ -58,7 +58,7 @@ export const CreateReviewQueueModal = ({
   const reviewerResolved = useIsReviewerResolved();
   const authAvailable = useIsAuthAvailable();
   const { labelSchemas, isLoading } = useListLabelSchemasQuery({ experimentId });
-  const { createReviewQueueAsync, isCreatingQueue, error } = useCreateReviewQueueMutation();
+  const { createReviewQueueAsync, isCreatingQueue } = useCreateReviewQueueMutation();
 
   // Telemetry: count queues actually created from the UI (fired on success, not
   // on the click, so failed creates don't inflate the metric).
@@ -195,9 +195,18 @@ export const CreateReviewQueueModal = ({
       queueCreatedEventContext.onClick(undefined);
       onCreated?.(review_queue);
       onClose();
-    } catch {
-      // The failure (e.g. a duplicate queue name) is surfaced via the error Alert
-      // below; swallow the rejection so the modal stays open instead of crashing.
+    } catch (e) {
+      // Surface the failure (e.g. a duplicate queue name) as a toast rather than an
+      // inline alert, so the modal body doesn't shift. The modal stays open to retry.
+      Utils.displayGlobalErrorNotification(
+        intl.formatMessage(
+          {
+            defaultMessage: 'Failed to create the review queue: {error}',
+            description: 'Create review queue: error toast shown when creation fails',
+          },
+          { error: e instanceof Error ? e.message : String(e) },
+        ),
+      );
     }
   };
 
@@ -393,19 +402,6 @@ export const CreateReviewQueueModal = ({
                 </div>
               )}
             </div>
-
-            {error && (
-              <Alert
-                componentId={`${CID}.error`}
-                type="error"
-                closable={false}
-                message={intl.formatMessage({
-                  defaultMessage: 'Failed to create the review queue.',
-                  description: 'Create review queue: error alert title',
-                })}
-                description={error.message}
-              />
-            )}
           </div>
         </ApplyDesignSystemContextOverrides>
       </Modal>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -138,11 +138,14 @@ describe('FocusedReview single Pass/Fail auto-submit', () => {
 });
 
 describe('FocusedReview submit requires at least one answer', () => {
+  let errorToastSpy: jest.SpiedFunction<typeof Utils.displayGlobalErrorNotification>;
   beforeEach(() => {
+    errorToastSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
     mockCreateAssessment.mockReset();
     mockCreateAssessment.mockImplementation(() => Promise.resolve());
   });
   afterEach(() => {
+    errorToastSpy.mockRestore();
     mockPriorAnswersResult = { priorAnswers: [], isLoading: false, isFetching: false };
   });
 
@@ -201,8 +204,9 @@ describe('FocusedReview submit requires at least one answer', () => {
 
     fireEvent.click(screen.getAllByText('Pass')[0]);
     fireEvent.click(screen.getByText('Submit'));
-    // The error surfaces; the event must not fire (it sits after the writes succeed).
-    expect(await screen.findByText(/could not save your review/i)).toBeInTheDocument();
+    // The error surfaces as a toast; the event must not fire (it sits after the writes succeed).
+    await waitFor(() => expect(errorToastSpy).toHaveBeenCalledTimes(1));
+    expect(errorToastSpy.mock.calls[0][0]).toMatch(/could not save your review/i);
     expect(eventCallback).not.toHaveBeenCalledWith(
       expect.objectContaining({ componentId: FEEDBACK_SUBMITTED_COMPONENT_ID }),
     );
@@ -328,8 +332,10 @@ describe('FocusedReview trace content rendering', () => {
 
 describe('FocusedReview edit-in-place on a completed trace', () => {
   let toastSpy: jest.SpiedFunction<typeof Utils.displayGlobalInfoNotification>;
+  let errorToastSpy: jest.SpiedFunction<typeof Utils.displayGlobalErrorNotification>;
   beforeEach(() => {
     toastSpy = jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
+    errorToastSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
     mockCreateAssessment.mockReset();
     mockCreateAssessment.mockImplementation(() => Promise.resolve());
     // The completed trace prefills its prior answer (with its assessment id, so a
@@ -342,6 +348,7 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
   });
   afterEach(() => {
     toastSpy.mockRestore();
+    errorToastSpy.mockRestore();
     mockPriorAnswersResult = { priorAnswers: [], isLoading: false, isFetching: false };
   });
 
@@ -398,7 +405,8 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
     fireEvent.click(screen.getAllByText('Pass')[1]);
     fireEvent.click(screen.getByText('Save changes'));
 
-    expect(await screen.findByText(/could not save your review/i)).toBeInTheDocument();
+    await waitFor(() => expect(errorToastSpy).toHaveBeenCalledTimes(1));
+    expect(errorToastSpy.mock.calls[0][0]).toMatch(/could not save your review/i);
     expect(toastSpy).not.toHaveBeenCalledWith('Changes saved');
     expect(onSetStatus).not.toHaveBeenCalled();
   });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -197,7 +197,6 @@ export const FocusedReview = ({
   const priorAssessmentIds = useMemo(() => buildPriorAssessmentIds(priorAnswers, schemas), [priorAnswers, schemas]);
   const [edited, setEdited] = useState<Record<string, LabelSchemaValue>>({});
   const [editedRationales, setEditedRationales] = useState<Record<string, string>>({});
-  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const valueFor = (name: string): LabelSchemaValue => (name in edited ? edited[name] : prefilled[name]);
   const setAnswer = (name: string, value: LabelSchemaValue) => setEdited((prev) => ({ ...prev, [name]: value }));
@@ -267,8 +266,18 @@ export const FocusedReview = ({
     .concat(items.slice(0, Math.max(currentIndex, 0)))
     .find((i) => i.item_id !== item.item_id && i.status === 'PENDING')?.item_id;
 
+  const showSubmitError = (e: unknown) =>
+    Utils.displayGlobalErrorNotification(
+      intl.formatMessage(
+        {
+          defaultMessage: 'Could not save your review: {error}',
+          description: 'Review focused view: error toast when saving a review fails',
+        },
+        { error: e instanceof Error ? e.message : String(e) },
+      ),
+    );
+
   const submitAnswersAndComplete = async (answerOverrides?: Record<string, LabelSchemaValue>) => {
-    setSubmitError(null);
     // The supersede ids are derived from the prior-answers query, so submitting
     // against a still-refetching snapshot (e.g. reopen-and-resubmit before the
     // post-write refetch lands) could miss the prior and leave two live
@@ -337,16 +346,15 @@ export const FocusedReview = ({
         onBack();
       }
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : String(e));
+      showSubmitError(e);
     }
   };
 
   const handleSetStatus = async (status: ReviewStatus) => {
-    setSubmitError(null);
     try {
       await onSetStatus(status);
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : String(e));
+      showSubmitError(e);
     }
   };
 
@@ -595,21 +603,6 @@ export const FocusedReview = ({
                   </Button>
                 )}
               </div>
-            )}
-            {submitError && (
-              <Alert
-                componentId={`${CID}.submit-error`}
-                type="error"
-                closable
-                onClose={() => setSubmitError(null)}
-                message={intl.formatMessage(
-                  {
-                    defaultMessage: 'Could not save your review: {error}',
-                    description: 'Review focused view: submit error alert',
-                  },
-                  { error: submitError },
-                )}
-              />
             )}
             <div css={{ display: 'flex', gap: theme.spacing.sm, justifyContent: 'flex-end' }}>
               {isTerminal ? (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -871,10 +871,6 @@
     "defaultMessage": "Created at",
     "description": "Column header for created timestamp in the evaluation runs table"
   },
-  "2P5bVn": {
-    "defaultMessage": "Failed to create the review queue.",
-    "description": "Create review queue: error alert title"
-  },
   "2ROAqe": {
     "defaultMessage": "Record {id}",
     "description": "Heading at the top of the V2 dataset record side panel showing the record id"
@@ -4511,6 +4507,10 @@
     "defaultMessage": "Overall assessment:",
     "description": "Evaluation review > assessments > overall assessment > title"
   },
+  "ML7TiJ": {
+    "defaultMessage": "Could not save your review: {error}",
+    "description": "Review focused view: error toast when saving a review fails"
+  },
   "MNCAQh": {
     "defaultMessage": "Calls",
     "description": "Column header for call count"
@@ -6223,6 +6223,10 @@
     "defaultMessage": "View model",
     "description": "Label for a button that opens a new tab to view the details of a logged ML model while registering a model version"
   },
+  "VDumsF": {
+    "defaultMessage": "Failed to update the review queue: {error}",
+    "description": "Add to review queue: error toast when adding or removing traces fails"
+  },
   "VEuVfv": {
     "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
     "description": "Label showing number of traces selected in the run evaluation modal"
@@ -6286,10 +6290,6 @@
   "VVoQ5V": {
     "defaultMessage": "Structured output (JSON schema)",
     "description": "Label for the structured output JSON schema field in the prompt creation modal"
-  },
-  "VWIO8j": {
-    "defaultMessage": "Could not save your review: {error}",
-    "description": "Review focused view: submit error alert"
   },
   "VWngGA": {
     "defaultMessage": "e.g., PII Detection & Redaction",
@@ -6974,10 +6974,6 @@
   "Z+tEhr": {
     "defaultMessage": "Compare selected runs",
     "description": "Tooltip for the compare button when enabled"
-  },
-  "Z/7Ru5": {
-    "defaultMessage": "Something went wrong.",
-    "description": "Add to review queue: error alert title"
   },
   "Z/CtWD": {
     "defaultMessage": "Safety",
@@ -9862,6 +9858,10 @@
   "mtYPI8": {
     "defaultMessage": "Adheres to global guidelines",
     "description": "Evaluation results > global guideline adherence assessment > positive value label. Displayed if evaluation result adheres to the global guidelines."
+  },
+  "mtmTKV": {
+    "defaultMessage": "Failed to create the review queue: {error}",
+    "description": "Create review queue: error toast shown when creation fails"
   },
   "mtxqm8": {
     "defaultMessage": "Flexible, governed deployments with the new Model Registry UI",

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -8499,8 +8499,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             )
             if existing is not None:
                 raise MlflowException(
-                    f"Review queue with name '{validated.name}' already exists for experiment "
-                    f"'{experiment_id}'.",
+                    f"Review queue with name '{validated.name}' already exists.",
                     error_code=RESOURCE_ALREADY_EXISTS,
                 )
 
@@ -8539,8 +8538,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 if duplicate is not None:
                     # A parallel transaction won the create race.
                     raise MlflowException(
-                        f"Review queue with name '{validated.name}' already exists for experiment "
-                        f"'{experiment_id}'.",
+                        f"Review queue with name '{validated.name}' already exists.",
                         error_code=RESOURCE_ALREADY_EXISTS,
                     ) from e
                 experiment_present = (
@@ -8592,8 +8590,8 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 # A custom queue squatting on this user's name — don't hand it
                 # back as if it were the user's personal queue.
                 raise MlflowException(
-                    f"A non-user queue named '{name}' already exists for experiment "
-                    f"'{experiment_id}'; cannot get-or-create a user queue with that name.",
+                    f"A non-user queue named '{name}' already exists; cannot get-or-create "
+                    f"a user queue with that name.",
                     error_code=RESOURCE_ALREADY_EXISTS,
                 ) from e
             return existing


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23910

### What changes are proposed in this pull request?

Two related review-queue error-UX changes:

**1. Surface action errors as toasts instead of inline alerts.** The review-queue modals showed action failures (a duplicate queue name, a failed trace attach, a failed review submit) as inline `Alert`s inside the surface, which grew the modal/popover body and shifted the primary button right when the user wanted to retry. These **user-action / exception** errors now go through `Utils.displayGlobalErrorNotification` (matching the success toast this feature already uses):

- `CreateReviewQueueModal`: create failure (e.g. a duplicate queue name)
- `AddToReviewQueueDropdown`: add/remove-trace failure
- `FocusedReview`: review submit / set-status failure

Left as inline alerts on purpose: the dropdown's queue-list **load** error (it replaces the list content rather than reacting to a user action), and the "you're not assigned" **info** notice (it carries an "Assign myself" action button).

**2. Drop the internal experiment id from duplicate-name errors.** The create / get-or-create `RESOURCE_ALREADY_EXISTS` messages in `SqlAlchemyStore` no longer include `for experiment '<id>'`, so the toasts above read cleanly for end users.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated the affected jest suites to assert the error toast fires (with the underlying message) instead of an inline alert; the `experiment-review-queue` jest suite passes, type-check and lint clean. The store messages are covered by the existing `test_sqlalchemy_store_review_queues.py` duplicate-name tests (matched on `"already exists"`).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.