### PR TITLE
Fix TS SDK traces storage when MLflow server uses a local FS artifact root without mlflow-artifacts:// uri schema

### DIFF
--- a/libs/typescript/core/src/clients/artifacts/mlflow.ts
+++ b/libs/typescript/core/src/clients/artifacts/mlflow.ts
@@ -1,11 +1,11 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { TraceTagKey } from '../../core/constants';
 import { SerializedTraceData, TraceData } from '../../core/entities/trace_data';
 import { TraceInfo } from '../../core/entities/trace_info';
 import { JSONBig } from '../../core/utils/json';
 import { makeRequest } from '../utils';
-import { artifactUriToLocalPath, isLocalArtifactUri } from '../../core/utils/artifact_uri';
+import { isLocalArtifactUri, toAbsoluteLocalPath } from '../../core/utils/artifact_uri';
 import { ArtifactsClient } from './base';
 import { AuthProvider, HeadersProvider } from '../../auth';
 
@@ -46,7 +46,6 @@ export class MlflowArtifactsClient implements ArtifactsClient {
       return;
     }
 
-    // Serialize trace data to JSON string (equivalent to Python's json.dumps)
     const traceDataJson = traceData.toJson();
 
     const artifactUrl = this.resolveArtifactUri(artifactUri, TRACE_DATA_FILE_NAME);
@@ -57,7 +56,7 @@ export class MlflowArtifactsClient implements ArtifactsClient {
    * Write trace data to a local filesystem artifact location.
    */
   private async uploadTraceDataLocal(artifactUri: string, traceData: TraceData): Promise<void> {
-    const dir = artifactUriToLocalPath(artifactUri);
+    const dir = toAbsoluteLocalPath(artifactUri);
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, TRACE_DATA_FILE_NAME), JSONBig.stringify(traceData.toJson()), 'utf8');
   }
@@ -72,8 +71,14 @@ export class MlflowArtifactsClient implements ArtifactsClient {
    * @returns The downloaded and parsed trace data
    */
   async downloadTraceData(traceInfo: TraceInfo): Promise<TraceData> {
+    const artifactUri = this.getArtifactLocation(traceInfo);
+
+    if (isLocalArtifactUri(artifactUri)) {
+      return this.downloadTraceDataLocal(artifactUri);
+    }
+
     // Download the trace data file
-    const artifactUrl = this.getArtifactUrlForTrace(traceInfo);
+    const artifactUrl = this.resolveArtifactUri(artifactUri, TRACE_DATA_FILE_NAME);
     const traceDataJson = await makeRequest<SerializedTraceData>(
       'GET',
       artifactUrl,
@@ -91,17 +96,18 @@ export class MlflowArtifactsClient implements ArtifactsClient {
   }
 
   /**
-   * Construct the artifact URL from the trace info. The artifact location is set as a tag
-   * on the trace info by the backend.
-   *
-   * This implements the same URI resolution logic as Python's MlflowArtifactsRepository.resolve_uri()
-   * converting mlflow-artifacts:// URIs to HTTP endpoints.
+   * Read trace data from a local filesystem artifact location.
    */
-  private getArtifactUrlForTrace(traceInfo: TraceInfo): string {
-    const artifactUri = this.getArtifactLocation(traceInfo);
-
-    // Resolve mlflow-artifacts:// URI to HTTP endpoint
-    return this.resolveArtifactUri(artifactUri, TRACE_DATA_FILE_NAME);
+  private async downloadTraceDataLocal(artifactUri: string): Promise<TraceData> {
+    const filePath = join(toAbsoluteLocalPath(artifactUri), TRACE_DATA_FILE_NAME);
+    const contents = await readFile(filePath, 'utf8');
+    try {
+      return TraceData.fromJson(JSONBig.parse(contents) as SerializedTraceData);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse trace data JSON: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   /**

--- a/libs/typescript/core/src/clients/artifacts/mlflow.ts
+++ b/libs/typescript/core/src/clients/artifacts/mlflow.ts
@@ -1,7 +1,11 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { TraceTagKey } from '../../core/constants';
 import { SerializedTraceData, TraceData } from '../../core/entities/trace_data';
 import { TraceInfo } from '../../core/entities/trace_info';
+import { JSONBig } from '../../core/utils/json';
 import { makeRequest } from '../utils';
+import { artifactUriToLocalPath, isLocalArtifactUri } from '../../core/utils/artifact_uri';
 import { ArtifactsClient } from './base';
 import { AuthProvider, HeadersProvider } from '../../auth';
 
@@ -35,12 +39,27 @@ export class MlflowArtifactsClient implements ArtifactsClient {
    * @param traceData The trace data to upload
    */
   async uploadTraceData(traceInfo: TraceInfo, traceData: TraceData): Promise<void> {
+    const artifactUri = this.getArtifactLocation(traceInfo);
+
+    if (isLocalArtifactUri(artifactUri)) {
+      await this.uploadTraceDataLocal(artifactUri, traceData);
+      return;
+    }
+
     // Serialize trace data to JSON string (equivalent to Python's json.dumps)
     const traceDataJson = traceData.toJson();
 
-    // Upload trace data to the artifact store
-    const artifactUrl = this.getArtifactUrlForTrace(traceInfo);
+    const artifactUrl = this.resolveArtifactUri(artifactUri, TRACE_DATA_FILE_NAME);
     await makeRequest<void>('PUT', artifactUrl, this.headersProvider, traceDataJson);
+  }
+
+  /**
+   * Write trace data to a local filesystem artifact location.
+   */
+  private async uploadTraceDataLocal(artifactUri: string, traceData: TraceData): Promise<void> {
+    const dir = artifactUriToLocalPath(artifactUri);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, TRACE_DATA_FILE_NAME), JSONBig.stringify(traceData.toJson()), 'utf8');
   }
 
   /**
@@ -79,14 +98,23 @@ export class MlflowArtifactsClient implements ArtifactsClient {
    * converting mlflow-artifacts:// URIs to HTTP endpoints.
    */
   private getArtifactUrlForTrace(traceInfo: TraceInfo): string {
+    const artifactUri = this.getArtifactLocation(traceInfo);
+
+    // Resolve mlflow-artifacts:// URI to HTTP endpoint
+    return this.resolveArtifactUri(artifactUri, TRACE_DATA_FILE_NAME);
+  }
+
+  /**
+   * Read the artifact location tag set on the trace by the backend.
+   */
+  private getArtifactLocation(traceInfo: TraceInfo): string {
     const artifactUri = traceInfo.tags[TraceTagKey.MLFLOW_ARTIFACT_LOCATION];
 
     if (!artifactUri) {
       throw new Error('Artifact location not found in trace tags');
     }
 
-    // Resolve mlflow-artifacts:// URI to HTTP endpoint
-    return this.resolveArtifactUri(artifactUri, TRACE_DATA_FILE_NAME);
+    return artifactUri;
   }
 
   /**

--- a/libs/typescript/core/src/core/utils/artifact_uri.ts
+++ b/libs/typescript/core/src/core/utils/artifact_uri.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
@@ -26,11 +27,25 @@ export function isLocalArtifactUri(uri: string): boolean {
 }
 
 /**
- * Convert a local artifact URI to an absolute filesystem path.
+ * Convert a local artifact URI to an filesystem path.
  */
 export function artifactUriToLocalPath(uri: string): string {
   if (getArtifactUriScheme(uri) === 'file') {
     return fileURLToPath(uri);
   }
   return uri;
+}
+
+/**
+ * Convert a local artifact URI to a filesystem path, requiring it to be absolute.
+ */
+export function toAbsoluteLocalPath(uri: string): string {
+  const dir = artifactUriToLocalPath(uri);
+  if (!isAbsolute(dir)) {
+    throw new Error(
+      `Refusing to use a relative local artifact location "${uri}". ` +
+        `Expected an absolute filesystem path or a file:// URI.`,
+    );
+  }
+  return dir;
 }

--- a/libs/typescript/core/src/core/utils/artifact_uri.ts
+++ b/libs/typescript/core/src/core/utils/artifact_uri.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Extract the scheme from an artifact URI.
+ */
+export function getArtifactUriScheme(uri: string): string {
+  const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(uri);
+  if (!match) {
+    return '';
+  }
+  const scheme = match[1].toLowerCase();
+  // A single-letter scheme is a Windows drive designator (e.g. `C:`), not a URI
+  // scheme; treat it as a bare local path.
+  if (scheme.length === 1) {
+    return '';
+  }
+  return scheme;
+}
+
+/**
+ * Whether an artifact URI refers to a location on the local filesystem.
+ */
+export function isLocalArtifactUri(uri: string): boolean {
+  const scheme = getArtifactUriScheme(uri);
+  return scheme === '' || scheme === 'file';
+}
+
+/**
+ * Convert a local artifact URI to an absolute filesystem path.
+ */
+export function artifactUriToLocalPath(uri: string): string {
+  if (getArtifactUriScheme(uri) === 'file') {
+    return fileURLToPath(uri);
+  }
+  return uri;
+}

--- a/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
+++ b/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { MlflowArtifactsClient } from '../../../src/clients/artifacts/mlflow';
 import { TraceInfo } from '../../../src/core/entities/trace_info';
 import { TraceData } from '../../../src/core/entities/trace_data';
@@ -84,6 +88,64 @@ describe('MlflowArtifactsClient', () => {
       );
 
       // Test passes if error is thrown as expected
+    });
+  });
+
+  describe('uploadTraceData with local artifact roots', () => {
+    let tmpRoot: string;
+
+    const makeTraceInfo = (artifactLocation: string) =>
+      new TraceInfo({
+        traceId: 'tr-local',
+        traceLocation: {
+          type: TraceLocationType.MLFLOW_EXPERIMENT,
+          mlflowExperiment: { experimentId: '0' },
+        },
+        state: TraceState.OK,
+        requestTime: 1000,
+        tags: {
+          'mlflow.artifactLocation': artifactLocation,
+        },
+      });
+
+    beforeEach(async () => {
+      tmpRoot = await mkdtemp(join(tmpdir(), 'mlflow-wal-test-'));
+    });
+
+    afterEach(async () => {
+      await rm(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('writes traces.json to a bare local path, creating the directory', async () => {
+      const artifactDir = join(tmpRoot, '0', 'traces', 'tr-local', 'artifacts');
+      const traceInfo = makeTraceInfo(artifactDir);
+      const traceData = new TraceData([]);
+
+      await client.uploadTraceData(traceInfo, traceData);
+
+      const written = await readFile(join(artifactDir, 'traces.json'), 'utf8');
+      expect(JSON.parse(written)).toEqual({ spans: [] });
+    });
+
+    it('writes traces.json for a file:// artifact location', async () => {
+      const artifactDir = join(tmpRoot, '0', 'traces', 'tr-local', 'artifacts');
+      const fileUri = pathToFileURL(artifactDir).href;
+      const traceInfo = makeTraceInfo(fileUri);
+      const traceData = new TraceData([]);
+
+      await client.uploadTraceData(traceInfo, traceData);
+
+      const written = await readFile(join(artifactDir, 'traces.json'), 'utf8');
+      expect(JSON.parse(written)).toEqual({ spans: [] });
+    });
+
+    it('rejects unsupported remote schemes via resolveArtifactUri', async () => {
+      const traceInfo = makeTraceInfo('s3://bucket/0/traces/tr-local/artifacts');
+      const traceData = new TraceData([]);
+
+      await expect(client.uploadTraceData(traceInfo, traceData)).rejects.toThrow(
+        'Expected mlflow-artifacts:// URI, got s3:',
+      );
     });
   });
 

--- a/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
+++ b/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
@@ -147,6 +147,38 @@ describe('MlflowArtifactsClient', () => {
         'Expected mlflow-artifacts:// URI, got s3:',
       );
     });
+
+    it('refuses to write to a relative local artifact path', async () => {
+      const traceInfo = makeTraceInfo('relative/0/traces/tr-local/artifacts');
+      const traceData = new TraceData([]);
+
+      await expect(client.uploadTraceData(traceInfo, traceData)).rejects.toThrow(
+        /Refusing to use a relative local artifact location/,
+      );
+    });
+
+    it('round-trips trace data through a bare local path (upload then download)', async () => {
+      const artifactDir = join(tmpRoot, '0', 'traces', 'tr-local', 'artifacts');
+      const traceInfo = makeTraceInfo(artifactDir);
+
+      await client.uploadTraceData(traceInfo, new TraceData([]));
+      const result = await client.downloadTraceData(traceInfo);
+
+      expect(result).toBeInstanceOf(TraceData);
+      expect(result.spans).toHaveLength(0);
+    });
+
+    it('reads trace data from a file:// artifact location', async () => {
+      const artifactDir = join(tmpRoot, '0', 'traces', 'tr-local', 'artifacts');
+      const fileUri = pathToFileURL(artifactDir).href;
+      const traceInfo = makeTraceInfo(fileUri);
+
+      await client.uploadTraceData(traceInfo, new TraceData([]));
+      const result = await client.downloadTraceData(traceInfo);
+
+      expect(result).toBeInstanceOf(TraceData);
+      expect(result.spans).toHaveLength(0);
+    });
   });
 
   describe('downloadTraceData', () => {

--- a/libs/typescript/core/tests/core/utils/artifact_uri.test.ts
+++ b/libs/typescript/core/tests/core/utils/artifact_uri.test.ts
@@ -1,0 +1,58 @@
+import {
+  artifactUriToLocalPath,
+  getArtifactUriScheme,
+  isLocalArtifactUri,
+} from '../../../src/core/utils/artifact_uri';
+
+describe('artifact_uri helpers', () => {
+  describe('getArtifactUriScheme', () => {
+    it('returns the scheme for URIs that have one', () => {
+      expect(getArtifactUriScheme('mlflow-artifacts:/0/traces/tr-1/artifacts')).toBe(
+        'mlflow-artifacts',
+      );
+      expect(getArtifactUriScheme('file:///tmp/a/b')).toBe('file');
+      expect(getArtifactUriScheme('s3://bucket/key')).toBe('s3');
+      expect(getArtifactUriScheme('S3://bucket/key')).toBe('s3');
+    });
+
+    it('returns an empty string for bare filesystem paths', () => {
+      expect(getArtifactUriScheme('/tmp/mlflow-artifacts/0/traces/tr-1/artifacts')).toBe('');
+      expect(getArtifactUriScheme('relative/path')).toBe('');
+    });
+
+    it('treats a single-letter (Windows drive) scheme as a bare path', () => {
+      expect(getArtifactUriScheme('C:\\tmp\\artifacts')).toBe('');
+      expect(getArtifactUriScheme('d:/tmp/artifacts')).toBe('');
+    });
+  });
+
+  describe('isLocalArtifactUri', () => {
+    it('treats bare paths and file:// URIs as local', () => {
+      expect(isLocalArtifactUri('/tmp/mlflow-artifacts/0')).toBe(true);
+      expect(isLocalArtifactUri('file:///tmp/mlflow-artifacts/0')).toBe(true);
+      expect(isLocalArtifactUri('C:\\tmp\\artifacts')).toBe(true);
+    });
+
+    it('treats mlflow-artifacts and remote schemes as non-local', () => {
+      expect(isLocalArtifactUri('mlflow-artifacts:/0/traces/tr-1/artifacts')).toBe(false);
+      expect(isLocalArtifactUri('s3://bucket/key')).toBe(false);
+      expect(isLocalArtifactUri('gs://bucket/key')).toBe(false);
+    });
+  });
+
+  describe('artifactUriToLocalPath', () => {
+    it('returns bare paths unchanged', () => {
+      expect(artifactUriToLocalPath('/tmp/mlflow-artifacts/0/traces/tr-1/artifacts')).toBe(
+        '/tmp/mlflow-artifacts/0/traces/tr-1/artifacts',
+      );
+    });
+
+    it('decodes file:// URIs to filesystem paths', () => {
+      expect(artifactUriToLocalPath('file:///tmp/mlflow-artifacts/0')).toBe(
+        '/tmp/mlflow-artifacts/0',
+      );
+      // Percent-encoded spaces are decoded.
+      expect(artifactUriToLocalPath('file:///tmp/with%20space/0')).toBe('/tmp/with space/0');
+    });
+  });
+});

--- a/libs/typescript/core/tests/core/utils/artifact_uri.test.ts
+++ b/libs/typescript/core/tests/core/utils/artifact_uri.test.ts
@@ -2,6 +2,7 @@ import {
   artifactUriToLocalPath,
   getArtifactUriScheme,
   isLocalArtifactUri,
+  toAbsoluteLocalPath,
 } from '../../../src/core/utils/artifact_uri';
 
 describe('artifact_uri helpers', () => {
@@ -53,6 +54,19 @@ describe('artifact_uri helpers', () => {
       );
       // Percent-encoded spaces are decoded.
       expect(artifactUriToLocalPath('file:///tmp/with%20space/0')).toBe('/tmp/with space/0');
+    });
+  });
+
+  describe('toAbsoluteLocalPath', () => {
+    it('returns absolute bare paths and file:// URIs unchanged', () => {
+      expect(toAbsoluteLocalPath('/tmp/mlflow-artifacts/0')).toBe('/tmp/mlflow-artifacts/0');
+      expect(toAbsoluteLocalPath('file:///tmp/mlflow-artifacts/0')).toBe('/tmp/mlflow-artifacts/0');
+    });
+
+    it('throws for relative paths', () => {
+      expect(() => toAbsoluteLocalPath('relative/path')).toThrow(
+        /Refusing to use a relative local artifact location/,
+      );
     });
   });
 });


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/23992/files) to review incremental changes.
- [**stack/bug-cc-tracing-uri-resolution**](https://github.com/mlflow/mlflow/pull/23992) [[Files changed](https://github.com/mlflow/mlflow/pull/23992/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The TypeScript SDK's artifact client only supported mlflow-artifacts: URIs. When the MLflow server is started with a local --default-artifact-root (e.g. mlflow server --default-artifact-root /tmp/artifacts), traces are tagged with a bare filesystem path. The TS uploader threw TypeError: Invalid URL on that path, so span data was never uploaded - the trace appeared in the UI with no spans ("ghost trace")

This fix brings use to parity with our Python SDK which supports local FS path as artifact roots

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Before fix:

Ghost trace with no spans when capturing traces using the TS SDK CC Tracing (affects both sync / async batch use cases) - no local directory for artifacts was created, resulting in the lost of span data when user specifies local bare FS directory for --default-artifact-root

<img width="1704" height="601" alt="Screenshot 2026-06-15 at 4 58 07 PM" src="https://github.com/user-attachments/assets/01204619-27fb-42e4-b551-99c42befaac9" />

After fix:

<img width="1451" height="950" alt="Screenshot 2026-06-15 at 5 00 07 PM" src="https://github.com/user-attachments/assets/bda744d0-c492-4e60-bd31-81504f2a9a82" />

Directory to store trace data is created
```
aaron.teo@#### mlflow-artifacts % pwd 
/tmp/mlflow-artifacts

# trace data is stored
aaron.teo@#### traces % ls
tr-da47e61a3b29facf17f50fed74aa1ab0	tr-e98c75618b94a2c3f178ef26c20b5371
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
