### PR TITLE
Show minute fidelity in the review-queue "Date added" column

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
@@ -62,6 +62,18 @@ describe('ReviewQueueList', () => {
     expect(screen.getByText('3d ago')).toBeInTheDocument();
   });
 
+  it('floors each tier so a near-boundary age never rounds up to the next unit', () => {
+    // 59.5 min and 23.5h must read "59m ago" / "23h ago", not round up to
+    // "1h ago" / "1d ago" (which would reintroduce the clamping bug a level down).
+    const items = [
+      item('tr-min-boundary', 'PENDING', undefined, NOW - (59 * 60 + 30) * 1000),
+      item('tr-hr-boundary', 'PENDING', undefined, NOW - (23 * 60 + 30) * 60 * 1000),
+    ];
+    renderWithProviders(<ReviewQueueList items={items} onOpen={jest.fn()} nowMs={NOW} />);
+    expect(screen.getByText('59m ago')).toBeInTheDocument();
+    expect(screen.getByText('23h ago')).toBeInTheDocument();
+  });
+
   it('renders status tags for all items in a flat list', () => {
     renderWithProviders(
       <ReviewQueueList

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
@@ -46,6 +46,22 @@ describe('ReviewQueueList', () => {
     expect(screen.getByText('Date added')).toBeInTheDocument();
   });
 
+  it('shows minute/second-fidelity relative time for the date added', () => {
+    // Regression: a freshly-added trace used to render "1h ago" because the
+    // formatter clamped its smallest unit to 1 hour.
+    const items = [
+      item('tr-just-now', 'PENDING', undefined, NOW - 10_000),
+      item('tr-min', 'PENDING', undefined, NOW - 5 * 60_000),
+      item('tr-hr', 'PENDING', undefined, NOW - 2 * 60 * 60_000),
+      item('tr-day', 'PENDING', undefined, NOW - 3 * 24 * 60 * 60_000),
+    ];
+    renderWithProviders(<ReviewQueueList items={items} onOpen={jest.fn()} nowMs={NOW} />);
+    expect(screen.getByText('just now')).toBeInTheDocument();
+    expect(screen.getByText('5m ago')).toBeInTheDocument();
+    expect(screen.getByText('2h ago')).toBeInTheDocument();
+    expect(screen.getByText('3d ago')).toBeInTheDocument();
+  });
+
   it('renders status tags for all items in a flat list', () => {
     renderWithProviders(
       <ReviewQueueList

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -77,21 +77,23 @@ export const StatusTag = ({ status }: { status: ReviewStatus }) => {
 };
 
 const formatAgo = (ms: number, nowMs: number, intl: IntlShape) => {
-  const seconds = Math.max(0, Math.round((nowMs - ms) / 1000));
+  // Floor each tier (not round): the label is "X ago", so it must never round up
+  // past its own threshold (e.g. 59.5 min must read "59m ago", not skip to "1h ago").
+  const seconds = Math.max(0, Math.floor((nowMs - ms) / 1000));
   if (seconds < 60) {
     return intl.formatMessage({
       defaultMessage: 'just now',
       description: 'Review queue table: date-added cell, less than a minute ago',
     });
   }
-  const minutes = Math.round(seconds / 60);
+  const minutes = Math.floor(seconds / 60);
   if (minutes < 60) {
     return intl.formatMessage(
       { defaultMessage: '{minutes}m ago', description: 'Review queue table: date-added cell, minutes ago' },
       { minutes },
     );
   }
-  const hours = Math.round(minutes / 60);
+  const hours = Math.floor(minutes / 60);
   if (hours < 24) {
     return intl.formatMessage(
       { defaultMessage: '{hours}h ago', description: 'Review queue table: date-added cell, hours ago' },
@@ -100,7 +102,7 @@ const formatAgo = (ms: number, nowMs: number, intl: IntlShape) => {
   }
   return intl.formatMessage(
     { defaultMessage: '{days}d ago', description: 'Review queue table: date-added cell, days ago' },
-    { days: Math.round(hours / 24) },
+    { days: Math.floor(hours / 24) },
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -22,7 +22,7 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { useGetTracesById } from '@databricks/web-shared/model-trace-explorer';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage, useIntl, type IntlShape } from 'react-intl';
 
 import { displayUser } from './hooks/useReviewer';
 import { ReviewQueueEmptyState } from './ReviewQueueEmptyState';
@@ -76,9 +76,32 @@ export const StatusTag = ({ status }: { status: ReviewStatus }) => {
   );
 };
 
-const formatAgo = (ms: number, nowMs: number) => {
-  const hours = Math.max(1, Math.round((nowMs - ms) / (60 * 60 * 1000)));
-  return hours < 24 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
+const formatAgo = (ms: number, nowMs: number, intl: IntlShape) => {
+  const seconds = Math.max(0, Math.round((nowMs - ms) / 1000));
+  if (seconds < 60) {
+    return intl.formatMessage({
+      defaultMessage: 'just now',
+      description: 'Review queue table: date-added cell, less than a minute ago',
+    });
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return intl.formatMessage(
+      { defaultMessage: '{minutes}m ago', description: 'Review queue table: date-added cell, minutes ago' },
+      { minutes },
+    );
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return intl.formatMessage(
+      { defaultMessage: '{hours}h ago', description: 'Review queue table: date-added cell, hours ago' },
+      { hours },
+    );
+  }
+  return intl.formatMessage(
+    { defaultMessage: '{days}d ago', description: 'Review queue table: date-added cell, days ago' },
+    { days: Math.round(hours / 24) },
+  );
 };
 
 type ColumnKey = 'request' | 'response' | 'status' | 'creation_time_ms';
@@ -282,7 +305,9 @@ export const ReviewQueueList = ({
             </Tag>
           )}
         </TableCell>
-        <TableCell css={{ flex: colFlex.get('creation_time_ms') }}>{formatAgo(item.creation_time_ms, nowMs)}</TableCell>
+        <TableCell css={{ flex: colFlex.get('creation_time_ms') }}>
+          {formatAgo(item.creation_time_ms, nowMs, intl)}
+        </TableCell>
       </TableRow>
     );
   };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -6303,6 +6303,10 @@
     "defaultMessage": "The provided value is not valid JSON",
     "description": "Error message for invalid JSON in an assessment creation form"
   },
+  "VYfxMp": {
+    "defaultMessage": "{hours}h ago",
+    "description": "Review queue table: date-added cell, hours ago"
+  },
   "VZRc73": {
     "defaultMessage": "Using the list of logged table artifacts, select at least one to start comparing results.",
     "description": "Experiment page > artifact compare view > table select dropdown tooltip"
@@ -6334,6 +6338,10 @@
   "VkK38/": {
     "defaultMessage": "Equivalence",
     "description": "LLM template option"
+  },
+  "VkRwrG": {
+    "defaultMessage": "{days}d ago",
+    "description": "Review queue table: date-added cell, days ago"
   },
   "Vm9CvZ": {
     "defaultMessage": "Description",
@@ -7667,6 +7675,10 @@
     "defaultMessage": "Maximum number of language tokens returned from evaluation.",
     "description": "Experiment page > prompt lab > max tokens parameter help text"
   },
+  "cHCKza": {
+    "defaultMessage": "{minutes}m ago",
+    "description": "Review queue table: date-added cell, minutes ago"
+  },
   "cHV5jh": {
     "defaultMessage": "Resources using this key via endpoints",
     "description": "Gateway > Bindings using key drawer > Subtitle"
@@ -8746,6 +8758,10 @@
   "hR27A2": {
     "defaultMessage": "View full dashboard",
     "description": "Link to view full usage dashboard"
+  },
+  "hRhWzR": {
+    "defaultMessage": "just now",
+    "description": "Review queue table: date-added cell, less than a minute ago"
   },
   "hT5ZGW": {
     "defaultMessage": "Remove message",


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

The "Date added" column in a review queue showed **"1h ago" for a just-added trace**. The relative-time formatter's smallest unit was hours, clamped to a minimum of 1 (`Math.max(1, ...)`), so anything under ~30 minutes rounded to "1h ago" — a 2-second-old trace included.

This adds finer tiers — **just now / `Xm ago` / `Xh ago` / `Xd ago`** — so recent additions read correctly. The strings are now run through `react-intl` (the previous hard-coded `"Xh ago"` / `"Xd ago"` weren't localized).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a `ReviewQueueList` test asserting a 10-second-old trace renders "just now" (the regression), plus the minute/hour/day tiers.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes the review-queue "Date added" column showing "1h ago" for traces that were just added; it now shows minute-level relative time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.