### PR TITLE
Review queues: remove the Decline action from the focused-review UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -165,6 +165,16 @@ describe('FocusedReview submit requires at least one answer', () => {
     );
   });
 
+  it('does not offer a Decline action on a pending trace (decline removed from the UI)', () => {
+    const onSetStatus = jest.fn((_status: string) => Promise.resolve());
+    renderFocused([passFailSchema(), passFailSchema('s2', 'Also good?')], onSetStatus);
+    // Decline is gone; a pending trace's only action is Submit (Move to Todo is
+    // terminal-only).
+    expect(screen.queryByText('Decline')).not.toBeInTheDocument();
+    expect(screen.queryByText('Move to Todo')).not.toBeInTheDocument();
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+  });
+
   it('logs a feedback-submitted telemetry event once the review is submitted', async () => {
     const eventCallback = jest.fn();
     const onSetStatus = jest.fn((_status: string) => Promise.resolve());

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -612,7 +612,10 @@ export const FocusedReview = ({
               />
             )}
             <div css={{ display: 'flex', gap: theme.spacing.sm, justifyContent: 'flex-end' }}>
-              {isTerminal ? (
+              {/* A terminal trace can be sent back to the to-do list. Declining is
+                  no longer offered in the UI (the API still supports it); a pending
+                  trace's only action is Submit. */}
+              {isTerminal && (
                 <Button
                   componentId={`${CID}.reopen`}
                   disabled={isSettingStatus || !canReview}
@@ -622,14 +625,6 @@ export const FocusedReview = ({
                     defaultMessage="Move to Todo"
                     description="Review focused view: send a completed/declined trace back to the to-do list"
                   />
-                </Button>
-              ) : (
-                <Button
-                  componentId={`${CID}.decline`}
-                  disabled={isSettingStatus || !canReview}
-                  onClick={() => handleSetStatus('DECLINED')}
-                >
-                  <FormattedMessage defaultMessage="Decline" description="Review focused view: decline action" />
                 </Button>
               )}
               {!hideSubmit && !isDeclined && (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2555,10 +2555,6 @@
     "defaultMessage": "Tags",
     "description": "Header for the tags column in the experiments table"
   },
-  "BBfa66": {
-    "defaultMessage": "Decline",
-    "description": "Review focused view: decline action"
-  },
   "BCpX6U": {
     "defaultMessage": "Registered models",
     "description": "Run page > Overview > Run models section label"


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

Removes the **"Decline" button** from the focused-review view. It was the only UI path that set a trace to `DECLINED` (verified: no keyboard shortcut, no bulk action, and `onSetStatus` is wired only to `FocusedReview`). After this change a pending trace's only action is **Submit**; a terminal trace can still **Move to Todo**.

The decline capability is intentionally left in place at the API layer — the `SetReviewQueueItemStatus` mutation, the proto, and the `DECLINED` status enum are unchanged — and existing declined traces still render as "Declined" (the read-only display paths are untouched). This only removes the ability to create *new* declines from the UI.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

The existing "locks a declined trace and offers only Move to Todo" test still passes; added a test asserting a pending trace offers no Decline action (only Submit).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The "Decline" action is no longer offered in the review-queue UI; reviewers submit a review or leave a trace pending.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.