### PR TITLE
Review queues: show the optional rationale box in the question preview

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
@@ -381,6 +381,19 @@ export const CreateReviewQueueModal = ({
                                       label={schema.name}
                                       instruction={schema.instruction}
                                     />
+                                    {/* Mirror the create-question form preview: a question
+                                        that collects an optional rationale shows the box here too. */}
+                                    {schema.enable_comment && (
+                                      <Input.TextArea
+                                        componentId={`${CID}.preview.rationale`}
+                                        rows={2}
+                                        disabled
+                                        placeholder={intl.formatMessage({
+                                          defaultMessage: 'Rationale (optional)',
+                                          description: 'Review question preview free-form rationale placeholder',
+                                        })}
+                                      />
+                                    )}
                                   </>
                                 )}
                               </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.test.tsx
@@ -13,7 +13,7 @@ import type { ReviewQueue, ReviewQueueItem } from './types';
 jest.mock('./QuestionChecklistCombobox', () => ({ QuestionChecklistCombobox: () => null }));
 jest.mock('../../components/label-schemas', () => ({
   useListLabelSchemasQuery: () => ({
-    labelSchemas: [{ schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} } }],
+    labelSchemas: [{ schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} }, enable_comment: true }],
     isLoading: false,
   }),
   LabelSchemaInputRenderer: () => null,
@@ -117,6 +117,14 @@ describe('QueueSettingsModal save', () => {
     expect('users' in arg).toBe(false);
     expect('name' in arg).toBe(false);
     expect('new_owner' in arg).toBe(false);
+  });
+
+  it('shows the optional rationale box in the question preview when the schema collects one', () => {
+    renderModal();
+    // The preview card is collapsed by default; expand it to reveal the question
+    // as a reviewer sees it, including the optional rationale box.
+    fireEvent.click(screen.getByText('Q1'));
+    expect(screen.getByPlaceholderText('Rationale (optional)')).toBeInTheDocument();
   });
 
   it('hides the queue owner from the picker but keeps them assigned on save', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
@@ -342,6 +342,19 @@ export const QueueSettingsModal = ({
                                   label={schema.name}
                                   instruction={schema.instruction}
                                 />
+                                {/* Mirror the create-question form preview: a question
+                                    that collects an optional rationale shows the box here too. */}
+                                {schema.enable_comment && (
+                                  <Input.TextArea
+                                    componentId={`${CID}.preview.rationale`}
+                                    rows={2}
+                                    disabled
+                                    placeholder={intl.formatMessage({
+                                      defaultMessage: 'Rationale (optional)',
+                                      description: 'Review question preview free-form rationale placeholder',
+                                    })}
+                                  />
+                                )}
                               </>
                             )}
                           </div>


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

When a review question collects an optional rationale (`enable_comment`), the **create-question form preview** and the **actual review form** (`FocusedReview`) both render the rationale text box. But the **queue's question preview** — shown when adding/managing questions in the create-queue and queue-settings modals — rendered only the structured input via `LabelSchemaInputRenderer`, **omitting the rationale box**. So the preview didn't match what reviewers actually see.

This renders the (disabled, placeholder) rationale box in both queue previews when `enable_comment` is set, reusing the existing "Rationale (optional)" string.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a `QueueSettingsModal` test that expands a question preview whose schema collects a rationale and asserts the rationale box appears.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The review-queue question preview now shows the optional rationale box for questions that collect one, matching the create-question form and the reviewer's view.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.