### PR TITLE
Review queues: deep-link the "Added to review" toast to the selected queue

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -165,8 +165,9 @@ describe('AddToReviewQueueDropdown', () => {
       }
       return undefined;
     };
+    // The link deep-links to the queue the traces landed in, not just the tab.
     expect(findLinkTarget(toastNode)).toBe(
-      generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' }),
+      `${generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId: 'exp-1' })}?selectedQueueId=rq-default`,
     );
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -32,6 +32,7 @@ import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueue
 import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
 import { DEFAULT_REVIEWER, useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
+import { SELECTED_REVIEW_QUEUE_ID_QUERY_PARAM_KEY } from './hooks/useSelectedReviewQueueBySearchParam';
 import type { ReviewQueue } from './types';
 
 const CID = 'mlflow.experiment-review-queue.add-to-queue';
@@ -255,27 +256,35 @@ export const AddToReviewQueueDropdown = ({
     toggleCustomQueue(queue.queue_id);
   };
 
-  const showSuccessToast = useCallback(() => {
-    const reviewQueuePath = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
-    Utils.displayGlobalInfoNotification(
-      <span css={{ whiteSpace: 'nowrap' }}>
-        {intl.formatMessage(
-          {
-            defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
-            description: 'Add to review queue: success toast after traces are added',
-          },
-          { count: itemIds.length },
-        )}{' '}
-        <Link componentId={`${CID}.toast-view-queue`} to={reviewQueuePath}>
-          {intl.formatMessage({
-            defaultMessage: 'View review queue',
-            description: 'Add to review queue: success toast link to the review queue page',
-          })}
-        </Link>
-      </span>,
-      3,
-    );
-  }, [experimentId, itemIds.length, intl]);
+  const showSuccessToast = useCallback(
+    (targetQueueId: string) => {
+      const reviewQueuePath = generatePath(RoutePaths.experimentPageTabReviewQueue, { experimentId });
+      // Deep-link to the queue the traces landed in (not just the tab), so the
+      // page opens on that queue instead of auto-selecting the default. Build the
+      // query with URLSearchParams so it encodes exactly how the page reads it back.
+      const params = new URLSearchParams({ [SELECTED_REVIEW_QUEUE_ID_QUERY_PARAM_KEY]: targetQueueId });
+      const to = `${reviewQueuePath}?${params.toString()}`;
+      Utils.displayGlobalInfoNotification(
+        <span css={{ whiteSpace: 'nowrap' }}>
+          {intl.formatMessage(
+            {
+              defaultMessage: 'Added {count, plural, one {# trace} other {# traces}} to review.',
+              description: 'Add to review queue: success toast after traces are added',
+            },
+            { count: itemIds.length },
+          )}{' '}
+          <Link componentId={`${CID}.toast-view-queue`} to={to}>
+            {intl.formatMessage({
+              defaultMessage: 'View review queue',
+              description: 'Add to review queue: success toast link to the review queue page',
+            })}
+          </Link>
+        </span>,
+        3,
+      );
+    },
+    [experimentId, itemIds.length, intl],
+  );
 
   const markBusy = (id: string) => setBusyIds((prev) => new Set(prev).add(id));
   const clearBusy = (id: string) =>
@@ -301,7 +310,7 @@ export const AddToReviewQueueDropdown = ({
       } else {
         await addItemsToReviewQueueAsync({ queue_id: queueId, item_ids: itemIds });
         setAddedQueueIds((prev) => new Set(prev).add(queueId));
-        showSuccessToast();
+        showSuccessToast(queueId);
       }
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : String(e));
@@ -331,7 +340,7 @@ export const AddToReviewQueueDropdown = ({
       } else {
         await addItemsToReviewQueueAsync({ queue_id: review_queue.queue_id, item_ids: itemIds });
         setAddedUsers((prev) => new Set(prev).add(username));
-        showSuccessToast();
+        showSuccessToast(review_queue.queue_id);
       }
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : String(e));

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -25,6 +25,7 @@ import { useUpdateReviewQueueMutation } from './hooks/useUpdateReviewQueueMutati
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
 import { DEFAULT_REVIEWER, displayUser, useIsReviewerResolved, useReviewer } from './hooks/useReviewer';
 import { useSetReviewQueueItemStatusMutation } from './hooks/useSetReviewQueueItemStatusMutation';
+import { useSelectedReviewQueueBySearchParam } from './hooks/useSelectedReviewQueueBySearchParam';
 import { canDeleteQueue, canManageQueue, canRemoveQueueItems, sameUser } from './queuePermissions';
 import { useHeaderVisibility } from '../experiment-page-tabs/ExperimentPageHeaderVisibilityContext';
 import type { ReviewQueueItem, ReviewStatus } from './types';
@@ -51,7 +52,9 @@ const ExperimentReviewQueuePage = () => {
   const canManage = useCanManageReviews(experimentId ?? '');
   const canEdit = useCanEditReviews(experimentId ?? '');
 
-  const [selectedQueueIdState, setSelectedQueueIdState] = useState<string>();
+  // Selection lives in the URL (?selectedQueueId=...) so it's shareable and the
+  // "Added to review" toast can deep-link to the queue the traces landed in.
+  const [selectedQueueId, setSelectedQueueId] = useSelectedReviewQueueBySearchParam();
   // The trace open in focused review (null = show the queue's trace table).
   const [openItemId, setOpenItemId] = useState<string | null>(null);
   const [manageOpen, setManageOpen] = useState(false);
@@ -98,17 +101,26 @@ const ExperimentReviewQueuePage = () => {
   // fallback while `/users/current` is still in flight.
   const didAutoSelectQueue = useRef(false);
   useEffect(() => {
-    if (didAutoSelectQueue.current || selectedQueueIdState !== undefined || queuesLoading || !reviewerResolved) {
+    if (queuesLoading || !reviewerResolved) {
+      return;
+    }
+    // A stale/invalid ?selectedQueueId= (a deleted queue, or one a deep link
+    // points at that this reviewer can't see) would otherwise leave the pane stuck
+    // on the empty "select a queue" state. Clear it so the auto-select below can
+    // fall back to the reviewer's own queue.
+    if (selectedQueueId !== undefined && !reviewQueues.some((q) => q.queue_id === selectedQueueId)) {
+      setSelectedQueueId(undefined);
+      return;
+    }
+    if (didAutoSelectQueue.current || selectedQueueId !== undefined) {
       return;
     }
     const userQueue = reviewQueues.find((q) => q.queue_type === 'USER' && sameUser(q.name, reviewer));
     if (userQueue) {
       didAutoSelectQueue.current = true;
-      setSelectedQueueIdState(userQueue.queue_id);
+      setSelectedQueueId(userQueue.queue_id);
     }
-  }, [selectedQueueIdState, queuesLoading, reviewerResolved, reviewQueues, reviewer]);
-
-  const selectedQueueId = selectedQueueIdState;
+  }, [selectedQueueId, queuesLoading, reviewerResolved, reviewQueues, reviewer, setSelectedQueueId]);
   const selectedQueue = useMemo(
     () => reviewQueues.find((q) => q.queue_id === selectedQueueId) ?? null,
     [reviewQueues, selectedQueueId],
@@ -152,7 +164,7 @@ const ExperimentReviewQueuePage = () => {
         onSuccess: () => {
           // Drop the selection if the queue that was open got deleted.
           if (selectedQueueId === queueId) {
-            setSelectedQueueIdState(undefined);
+            setSelectedQueueId(undefined);
             setOpenItemId(null);
           }
         },
@@ -247,7 +259,7 @@ const ExperimentReviewQueuePage = () => {
   }, [inFocusMode, setHeaderHidden]);
 
   const selectQueue = (queueId: string) => {
-    setSelectedQueueIdState(queueId);
+    setSelectedQueueId(queueId);
     setOpenItemId(null);
   };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useSelectedReviewQueueBySearchParam.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useSelectedReviewQueueBySearchParam.test.tsx
@@ -1,0 +1,69 @@
+import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react';
+
+import { useSelectedReviewQueueBySearchParam } from './useSelectedReviewQueueBySearchParam';
+import { useSearchParams } from '../../../../common/utils/RoutingUtils';
+
+jest.mock('../../../../common/utils/RoutingUtils', () => ({
+  useSearchParams: jest.fn(),
+}));
+
+describe('useSelectedReviewQueueBySearchParam', () => {
+  let mockSearchParams = new URLSearchParams();
+  const mockSetSearchParams = jest.fn((setter) => {
+    // @ts-expect-error 'setter' is of type 'unknown'
+    mockSearchParams = setter(mockSearchParams);
+  });
+
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams();
+    jest.clearAllMocks();
+    jest.mocked(useSearchParams).mockReturnValue([new URLSearchParams(), mockSetSearchParams]);
+  });
+
+  test('returns the selected queue id from the URL', () => {
+    jest
+      .mocked(useSearchParams)
+      .mockReturnValue([new URLSearchParams({ selectedQueueId: 'rq-123' }), mockSetSearchParams]);
+
+    const {
+      result: {
+        current: [selectedQueueId],
+      },
+    } = renderHook(() => useSelectedReviewQueueBySearchParam());
+
+    expect(selectedQueueId).toEqual('rq-123');
+  });
+
+  test('sets the selected queue id in the URL', () => {
+    const {
+      result: {
+        current: [, setSelectedQueueId],
+      },
+    } = renderHook(() => useSelectedReviewQueueBySearchParam());
+
+    act(() => {
+      setSelectedQueueId('rq-456');
+    });
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    expect(mockSearchParams.get('selectedQueueId')).toEqual('rq-456');
+  });
+
+  test('clears the selected queue id when set to undefined', () => {
+    mockSearchParams = new URLSearchParams({ selectedQueueId: 'rq-123' });
+
+    const {
+      result: {
+        current: [, setSelectedQueueId],
+      },
+    } = renderHook(() => useSelectedReviewQueueBySearchParam());
+
+    act(() => {
+      setSelectedQueueId(undefined);
+    });
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    expect(mockSearchParams.get('selectedQueueId')).toBeNull();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useSelectedReviewQueueBySearchParam.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useSelectedReviewQueueBySearchParam.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+
+import { useSearchParams } from '../../../../common/utils/RoutingUtils';
+
+export const SELECTED_REVIEW_QUEUE_ID_QUERY_PARAM_KEY = 'selectedQueueId';
+
+/**
+ * Query-param-driven selected review-queue id, mirroring
+ * {@link useSelectedDatasetBySearchParam}. Keeping the selection in the URL makes
+ * it shareable and deep-linkable — e.g. the "Added to review" toast links straight
+ * to the queue the traces landed in. Writes use `replace` so selecting a queue
+ * doesn't stack history entries.
+ */
+export const useSelectedReviewQueueBySearchParam = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedQueueId = searchParams.get(SELECTED_REVIEW_QUEUE_ID_QUERY_PARAM_KEY) ?? undefined;
+
+  const setSelectedQueueId = useCallback(
+    (queueId: string | undefined) => {
+      setSearchParams(
+        (params) => {
+          if (!queueId) {
+            params.delete(SELECTED_REVIEW_QUEUE_ID_QUERY_PARAM_KEY);
+          } else {
+            params.set(SELECTED_REVIEW_QUEUE_ID_QUERY_PARAM_KEY, queueId);
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [selectedQueueId, setSelectedQueueId] as const;
+};


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

Clicking the **"View review queue"** link in the "Added to review" success toast only opened the review-queue *tab* — the page then auto-selected the reviewer's default queue, **not the queue the traces were just added to**.

The page's selected queue is now **URL-driven** via a `?selectedQueueId=` query param:
- New `useSelectedReviewQueueBySearchParam` hook, mirroring the existing `useSelectedDatasetBySearchParam` (selection lives in the URL, shareable, writes use `replace`).
- `ExperimentReviewQueuePage` derives its selection from the URL instead of local state.
- The toast link now carries `?selectedQueueId=<queueId>`, so it opens the actual queue.

A **stale/invalid** param (a deleted queue, or one a deep link points at that the reviewer can't see) is cleared on load, so the page falls back to auto-selecting the reviewer's own queue instead of sticking on the empty "select a queue" state.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `useSelectedReviewQueueBySearchParam` test (read/set/clear), and the `AddToReviewQueueDropdown` toast test now asserts the link includes `?selectedQueueId=`. The page-level stale-param fallback isn't covered by a test (there's no `ExperimentReviewQueuePage` test harness yet) — noted as a follow-up.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The "View review queue" link in the "Added to review" toast now opens the specific queue the traces were added to (and queue selection is reflected in the URL).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.