### PR TITLE
Review queues: list the affected queues in the delete-question confirmation

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
@@ -1,0 +1,76 @@
+import { describe, jest, it, expect } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import { ManageQuestionsModal } from './ManageQuestionsModal';
+
+const mockDelete = jest.fn();
+jest.mock('../../components/label-schemas', () => ({
+  useListLabelSchemasQuery: () => ({
+    labelSchemas: [{ schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} } }],
+    isLoading: false,
+  }),
+  useDeleteLabelSchemaMutation: () => ({ deleteLabelSchema: mockDelete, isDeleting: false }),
+  LabelSchemaFormModal: () => null,
+}));
+
+let mockQueues: { queue_id: string; name: string; queue_type: string; schema_ids: string[] }[] = [];
+jest.mock('./hooks/useListReviewQueuesQuery', () => ({
+  useListReviewQueuesQuery: () => ({ reviewQueues: mockQueues }),
+}));
+
+jest.mock('./hooks/useReviewQueueSearchParams', () => ({
+  getReviewQueuePageRoute: (experimentId: string, queueId?: string) =>
+    `/experiments/${experimentId}/review-queue${queueId ? `?selectedQueueId=${queueId}` : ''}`,
+}));
+
+// Stub the router Link to a plain anchor so the test needs no Router context.
+jest.mock('../../../common/utils/RoutingUtils', () => ({
+  Link: ({ to, children, target }: { to: string; children: React.ReactNode; target?: string }) => (
+    <a href={to} target={target}>
+      {children}
+    </a>
+  ),
+}));
+
+const renderModal = () =>
+  render(
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <ManageQuestionsModal experimentId="exp-1" onClose={jest.fn()} />
+      </DesignSystemProvider>
+    </IntlProvider>,
+  );
+
+describe('ManageQuestionsModal delete confirmation', () => {
+  it('lists the custom queues that use the question (as deep links) and excludes others', () => {
+    mockQueues = [
+      { queue_id: 'rq-a', name: 'Queue A', queue_type: 'CUSTOM', schema_ids: ['s1'] },
+      { queue_id: 'rq-b', name: 'Queue B', queue_type: 'CUSTOM', schema_ids: ['s2'] },
+      { queue_id: 'rq-u', name: 'alice', queue_type: 'USER', schema_ids: [] },
+    ];
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+
+    expect(screen.getByText('Delete question?')).toBeInTheDocument();
+    // The one custom queue that uses the question is a new-tab deep link to it.
+    const link = screen.getByRole('link', { name: 'Queue A' });
+    expect(link).toHaveAttribute('href', '/experiments/exp-1/review-queue?selectedQueueId=rq-a');
+    expect(link).toHaveAttribute('target', '_blank');
+    // A custom queue that doesn't use it, and the inheriting user queue, are not listed.
+    expect(screen.queryByRole('link', { name: 'Queue B' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'alice' })).not.toBeInTheDocument();
+  });
+
+  it('omits the queue list when no custom queue uses the question', () => {
+    mockQueues = [{ queue_id: 'rq-b', name: 'Queue B', queue_type: 'CUSTOM', schema_ids: ['s2'] }];
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+
+    expect(screen.getByText('Delete question?')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
@@ -1,11 +1,13 @@
 import { describe, jest, it, expect } from '@jest/globals';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DesignSystemProvider } from '@databricks/design-system';
 import { IntlProvider } from '@databricks/i18n';
 
 import { ManageQuestionsModal } from './ManageQuestionsModal';
+import type { ReviewQueue } from './types';
 
 const mockDelete = jest.fn();
 jest.mock('../../components/label-schemas', () => ({
@@ -17,7 +19,9 @@ jest.mock('../../components/label-schemas', () => ({
   LabelSchemaFormModal: () => null,
 }));
 
-let mockQueues: { queue_id: string; name: string; queue_type: string; schema_ids: string[] }[] = [];
+// Typed to the real wire shape (Pick) so the queue_type literal union and field
+// names stay in sync with the production filter under test.
+let mockQueues: Pick<ReviewQueue, 'queue_id' | 'name' | 'queue_type' | 'schema_ids'>[] = [];
 jest.mock('./hooks/useListReviewQueuesQuery', () => ({
   useListReviewQueuesQuery: () => ({ reviewQueues: mockQueues }),
 }));
@@ -27,10 +31,11 @@ jest.mock('./hooks/useReviewQueueSearchParams', () => ({
     `/experiments/${experimentId}/review-queue${queueId ? `?selectedQueueId=${queueId}` : ''}`,
 }));
 
-// Stub the router Link to a plain anchor so the test needs no Router context.
+// Stub the router Link to a plain anchor so the test needs no Router context;
+// forward `rel` too so the new-tab safety attribute can be asserted.
 jest.mock('../../../common/utils/RoutingUtils', () => ({
-  Link: ({ to, children, target }: { to: string; children: React.ReactNode; target?: string }) => (
-    <a href={to} target={target}>
+  Link: ({ to, children, target, rel }: { to: string; children: React.ReactNode; target?: string; rel?: string }) => (
+    <a href={to} target={target} rel={rel}>
       {children}
     </a>
   ),
@@ -46,31 +51,52 @@ const renderModal = () =>
   );
 
 describe('ManageQuestionsModal delete confirmation', () => {
-  it('lists the custom queues that use the question (as deep links) and excludes others', () => {
+  it('lists the custom queues that use the question (as deep links) and excludes others', async () => {
     mockQueues = [
       { queue_id: 'rq-a', name: 'Queue A', queue_type: 'CUSTOM', schema_ids: ['s1'] },
       { queue_id: 'rq-b', name: 'Queue B', queue_type: 'CUSTOM', schema_ids: ['s2'] },
       { queue_id: 'rq-u', name: 'alice', queue_type: 'USER', schema_ids: [] },
     ];
     renderModal();
-    fireEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete question' }));
 
     expect(screen.getByText('Delete question?')).toBeInTheDocument();
-    // The one custom queue that uses the question is a new-tab deep link to it.
+    // Heading counts both the custom queues using it and the user queues (which
+    // inherit every question).
+    expect(screen.getByText('Used by 1 custom queue and 1 user queue:')).toBeInTheDocument();
+    // The one custom queue that uses the question is a new-tab deep link to it,
+    // carrying the rel safety attributes that pair with target="_blank".
     const link = screen.getByRole('link', { name: 'Queue A' });
     expect(link).toHaveAttribute('href', '/experiments/exp-1/review-queue?selectedQueueId=rq-a');
     expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     // A custom queue that doesn't use it, and the inheriting user queue, are not listed.
     expect(screen.queryByRole('link', { name: 'Queue B' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'alice' })).not.toBeInTheDocument();
   });
 
-  it('omits the queue list when no custom queue uses the question', () => {
+  it('shows a plain user-queue note when no custom queue uses the question', async () => {
+    mockQueues = [
+      { queue_id: 'rq-b', name: 'Queue B', queue_type: 'CUSTOM', schema_ids: ['s2'] },
+      { queue_id: 'rq-u1', name: 'alice', queue_type: 'USER', schema_ids: [] },
+      { queue_id: 'rq-u2', name: 'bob', queue_type: 'USER', schema_ids: [] },
+    ];
+    renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+
+    expect(screen.getByText('Inherited by 2 user queues.')).toBeInTheDocument();
+    // No custom queue uses it, so there are no queue links.
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('omits the queue section entirely when no custom or user queue is affected', async () => {
     mockQueues = [{ queue_id: 'rq-b', name: 'Queue B', queue_type: 'CUSTOM', schema_ids: ['s2'] }];
     renderModal();
-    fireEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete question' }));
 
     expect(screen.getByText('Delete question?')).toBeInTheDocument();
+    expect(screen.queryByText(/Used by/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Inherited by/)).not.toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, jest, it, expect } from '@jest/globals';
+import { describe, beforeEach, jest, it, expect } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -51,6 +51,11 @@ const renderModal = () =>
   );
 
 describe('ManageQuestionsModal delete confirmation', () => {
+  // Reset to a known baseline so a prior test's queues can't bleed into the next.
+  beforeEach(() => {
+    mockQueues = [];
+  });
+
   it('lists the custom queues that use the question (as deep links) and excludes others', async () => {
     mockQueues = [
       { queue_id: 'rq-a', name: 'Queue A', queue_type: 'CUSTOM', schema_ids: ['s1'] },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
@@ -37,18 +37,21 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
   const { deleteLabelSchema, isDeleting } = useDeleteLabelSchemaMutation();
   // Shares the cache with the Review tab's queue list (same query key), so this
   // is a cache hit; used to show which custom queues a deletion would affect.
+  // First page only (no maxResults), matching the Review tab; an experiment with
+  // more queues than the default page size would undercount the blast radius.
   const { reviewQueues } = useListReviewQueuesQuery({ experimentId });
 
   // The schema pending deletion confirmation; deleting a label schema is
   // experiment-wide (it removes the question from every queue), so it goes
   // through an explicit confirm rather than firing on the first click.
   const [pendingDelete, setPendingDelete] = useState<LabelSchema | null>(null);
-  // Custom queues that explicitly include the pending question (user queues
-  // inherit every question, so they aren't listed individually). Shown in the
-  // confirm so a manager sees exactly which queues a deletion touches.
+  // Custom queues that explicitly include the pending question (linked below).
+  // User queues inherit every question, so all of them are affected by a delete —
+  // we surface their count (not a list) so the manager sees the full blast radius.
   const affectedQueues = pendingDelete
     ? reviewQueues.filter((q) => q.queue_type === 'CUSTOM' && (q.schema_ids ?? []).includes(pendingDelete.schema_id))
     : [];
+  const userQueueCount = pendingDelete ? reviewQueues.filter((q) => q.queue_type === 'USER').length : 0;
   // The authoring modal: open with `null` to create, or a schema to edit.
   const [formOpen, setFormOpen] = useState(false);
   const [editingSchema, setEditingSchema] = useState<LabelSchema | null>(null);
@@ -217,16 +220,44 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
               description="Manage review questions: delete confirmation body"
               values={{ name: pendingDelete.name }}
             />
-            {affectedQueues.length > 0 && (
+            {affectedQueues.length > 0 ? (
               <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
                 <Typography.Text bold>
-                  <FormattedMessage
-                    defaultMessage="Used by {count, plural, one {# queue} other {# queues}}:"
-                    description="Manage review questions: heading above the list of queues that use the question being deleted"
-                    values={{ count: affectedQueues.length }}
-                  />
+                  {userQueueCount > 0 ? (
+                    // Each count is its own single-plural message, composed into a
+                    // plural-free sentence (formatjs disallows two plurals per message).
+                    <FormattedMessage
+                      defaultMessage="Used by {custom} and {user}:"
+                      description="Manage review questions: heading above the affected-queue list when the experiment also has user queues (which inherit every question)"
+                      values={{
+                        custom: intl.formatMessage(
+                          {
+                            defaultMessage: '{count, plural, one {# custom queue} other {# custom queues}}',
+                            description:
+                              'Manage review questions: count of custom queues using the question being deleted',
+                          },
+                          { count: affectedQueues.length },
+                        ),
+                        user: intl.formatMessage(
+                          {
+                            defaultMessage: '{count, plural, one {# user queue} other {# user queues}}',
+                            description:
+                              'Manage review questions: count of user queues affected by deleting the question',
+                          },
+                          { count: userQueueCount },
+                        ),
+                      }}
+                    />
+                  ) : (
+                    <FormattedMessage
+                      defaultMessage="Used by {count, plural, one {# queue} other {# queues}}:"
+                      description="Manage review questions: heading above the list of queues that use the question being deleted"
+                      values={{ count: affectedQueues.length }}
+                    />
+                  )}
                 </Typography.Text>
-                {/* Scrollable so a question used by many queues doesn't blow up the modal. */}
+                {/* Only custom queues are listed (user queues inherit every question);
+                    scrollable so a question used by many queues doesn't blow up the modal. */}
                 <div
                   css={{
                     maxHeight: 160,
@@ -254,6 +285,18 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
                   ))}
                 </div>
               </div>
+            ) : (
+              // No custom queue uses the question, but every user queue inherits it,
+              // so surface that count as a plain sentence (no list follows).
+              userQueueCount > 0 && (
+                <Typography.Text bold>
+                  <FormattedMessage
+                    defaultMessage="Inherited by {count, plural, one {# user queue} other {# user queues}}."
+                    description="Manage review questions: note shown when no custom queue uses the question but user queues (which inherit every question) do"
+                    values={{ count: userQueueCount }}
+                  />
+                </Typography.Text>
+              )
             )}
           </div>
         </Modal>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
@@ -19,6 +19,9 @@ import {
   useListLabelSchemasQuery,
 } from '../../components/label-schemas';
 import type { LabelSchema } from '../../components/label-schemas';
+import { Link } from '../../../common/utils/RoutingUtils';
+import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
+import { getReviewQueuePageRoute } from './hooks/useReviewQueueSearchParams';
 
 const CID = 'mlflow.experiment-review-queue.manage-questions';
 
@@ -32,11 +35,20 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
   const intl = useIntl();
   const { labelSchemas, isLoading } = useListLabelSchemasQuery({ experimentId });
   const { deleteLabelSchema, isDeleting } = useDeleteLabelSchemaMutation();
+  // Shares the cache with the Review tab's queue list (same query key), so this
+  // is a cache hit; used to show which custom queues a deletion would affect.
+  const { reviewQueues } = useListReviewQueuesQuery({ experimentId });
 
   // The schema pending deletion confirmation; deleting a label schema is
   // experiment-wide (it removes the question from every queue), so it goes
   // through an explicit confirm rather than firing on the first click.
   const [pendingDelete, setPendingDelete] = useState<LabelSchema | null>(null);
+  // Custom queues that explicitly include the pending question (user queues
+  // inherit every question, so they aren't listed individually). Shown in the
+  // confirm so a manager sees exactly which queues a deletion touches.
+  const affectedQueues = pendingDelete
+    ? reviewQueues.filter((q) => q.queue_type === 'CUSTOM' && (q.schema_ids ?? []).includes(pendingDelete.schema_id))
+    : [];
   // The authoring modal: open with `null` to create, or a schema to edit.
   const [formOpen, setFormOpen] = useState(false);
   const [editingSchema, setEditingSchema] = useState<LabelSchema | null>(null);
@@ -199,11 +211,51 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
             deleteLabelSchema({ schema_id: pendingDelete.schema_id }, { onSettled: () => setPendingDelete(null) })
           }
         >
-          <FormattedMessage
-            defaultMessage='Deleting "{name}" removes it from every review queue in this experiment. This cannot be undone.'
-            description="Manage review questions: delete confirmation body"
-            values={{ name: pendingDelete.name }}
-          />
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+            <FormattedMessage
+              defaultMessage='Deleting "{name}" removes it from every review queue in this experiment. This cannot be undone.'
+              description="Manage review questions: delete confirmation body"
+              values={{ name: pendingDelete.name }}
+            />
+            {affectedQueues.length > 0 && (
+              <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                <Typography.Text bold>
+                  <FormattedMessage
+                    defaultMessage="Used by {count, plural, one {# queue} other {# queues}}:"
+                    description="Manage review questions: heading above the list of queues that use the question being deleted"
+                    values={{ count: affectedQueues.length }}
+                  />
+                </Typography.Text>
+                {/* Scrollable so a question used by many queues doesn't blow up the modal. */}
+                <div
+                  css={{
+                    maxHeight: 160,
+                    overflowY: 'auto',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: theme.spacing.xs,
+                    border: `1px solid ${theme.colors.border}`,
+                    borderRadius: theme.borders.borderRadiusMd,
+                    padding: theme.spacing.sm,
+                  }}
+                >
+                  {affectedQueues.map((q) => (
+                    // Opens in a new tab so the manager can inspect a queue without
+                    // losing this confirmation. Only managers reach this modal.
+                    <Link
+                      key={q.queue_id}
+                      componentId={`${CID}.delete-confirm.queue-link`}
+                      to={getReviewQueuePageRoute(experimentId, q.queue_id)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {q.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
         </Modal>
       )}
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -9127,6 +9127,10 @@
     "defaultMessage": "Model metrics",
     "description": "Run details page > tab selector > Model metrics tab"
   },
+  "j2cg1p": {
+    "defaultMessage": "Used by {count, plural, one {# queue} other {# queues}}:",
+    "description": "Manage review questions: heading above the list of queues that use the question being deleted"
+  },
   "j3yKcX": {
     "defaultMessage": "Select the experiment you configured above.",
     "description": "Instruction to select the experiment configured for traces"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3299,6 +3299,10 @@
     "defaultMessage": "No datasets match \"{query}\"",
     "description": "Title for the empty state when a search returns no datasets in the V2 evaluation datasets list"
   },
+  "FNEy+/": {
+    "defaultMessage": "Used by {custom} and {user}:",
+    "description": "Manage review questions: heading above the affected-queue list when the experiment also has user queues (which inherit every question)"
+  },
   "FTx+Hi": {
     "defaultMessage": "(baseline)",
     "description": "A label displayed next to baseline version in the prompt versions comparison view"
@@ -3370,6 +3374,10 @@
   "Fk4w6k": {
     "defaultMessage": "Status",
     "description": "Review queue table: status column"
+  },
+  "Fk7Mme": {
+    "defaultMessage": "{count, plural, one {# user queue} other {# user queues}}",
+    "description": "Manage review questions: count of user queues affected by deleting the question"
   },
   "FmKAee": {
     "defaultMessage": "Observability",
@@ -6699,6 +6707,10 @@
     "defaultMessage": "Loading model definitions...",
     "description": "Loading message for model definitions"
   },
+  "XR45oU": {
+    "defaultMessage": "Inherited by {count, plural, one {# user queue} other {# user queues}}.",
+    "description": "Manage review questions: note shown when no custom queue uses the question but user queues (which inherit every question) do"
+  },
   "XREd2h": {
     "defaultMessage": "Learn more",
     "description": "Link text in column header tooltip that opens documentation in a new tab"
@@ -7762,6 +7774,10 @@
   "cb9LLM": {
     "defaultMessage": "Last updated",
     "description": "Header for the dataset record last-updated column"
+  },
+  "cbj8bg": {
+    "defaultMessage": "{count, plural, one {# custom queue} other {# custom queues}}",
+    "description": "Manage review questions: count of custom queues using the question being deleted"
   },
   "cfzQMh": {
     "defaultMessage": "baseline run",


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

The **"Delete question?"** confirmation (Manage questions → trash icon) only said the question would be removed from *"every review queue."* It didn't show *which* queues. This adds, below that warning, the list of **custom queues that actually use the question** — each a **deep link** (`getReviewQueuePageRoute`) that opens that queue in a **new tab** (so the manager can inspect a queue without losing the confirmation).

The list is in a **scrollable container** (`maxHeight` + `overflow-y: auto`) so a question used by many queues doesn't blow up the modal.

The heading also quantifies the full blast radius, since **user queues inherit every question** and so are all affected by a delete:
- When custom queues use the question: **"Used by N custom queue(s) and M user queue(s):"** above the list (the user-queue clause is dropped when the experiment has no user queues).
- When **no** custom queue uses it but user queues do: a plain **"Inherited by M user queues."** note, with no list (nothing to link).
- When nothing is affected: no queue section at all.

Notes:
- User queues are **counted, not enumerated** — only custom queues that explicitly include the question are listed and linked.
- The manage-questions modal is manager-gated, so only managers see and can act on these links.
- The queue list reuses the Review tab's `useListReviewQueuesQuery` (same query key → cache hit). It reflects the first page only, matching the Review tab.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `ManageQuestionsModal` tests cover: (1) the confirmation lists the custom queue that uses the question as a new-tab deep link (asserting `target`/`rel`), excludes a custom queue that doesn't use it and the inheriting user queue, and shows the combined custom+user count heading; (2) the "Inherited by M user queues." note when no custom queue uses it; (3) no queue section when nothing is affected.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The delete-question confirmation in the review-queue UI now lists (with links) the queues that use the question being deleted.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.