### PR TITLE
Surface review-queue deletion failures instead of swallowing them

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -74,7 +74,7 @@ const ExperimentReviewQueuePage = () => {
   const { labelSchemas } = useListLabelSchemasQuery({ experimentId: experimentId ?? '' });
   const { setReviewQueueItemStatusAsync, isSettingStatus } = useSetReviewQueueItemStatusMutation();
   const { removeItemsFromReviewQueue, isRemovingItems } = useRemoveItemsFromReviewQueueMutation();
-  const { deleteReviewQueue } = useDeleteReviewQueueMutation();
+  const { deleteReviewQueueAsync, isDeletingQueue } = useDeleteReviewQueueMutation();
   const { updateReviewQueueAsync, isUpdatingQueue } = useUpdateReviewQueueMutation();
   const { getOrCreateUserQueueAsync } = useGetOrCreateUserQueueMutation();
 
@@ -150,18 +150,13 @@ const ExperimentReviewQueuePage = () => {
         }
       : undefined;
 
-  const handleDeleteQueue = (queueId: string) =>
-    deleteReviewQueue(
-      { queue_id: queueId },
-      {
-        onSuccess: () => {
-          // Drop the selection if the queue that was open got deleted.
-          if (selectedQueueId === queueId) {
-            selectQueue(undefined);
-          }
-        },
-      },
-    );
+  const handleDeleteQueue = async (queueId: string) => {
+    await deleteReviewQueueAsync({ queue_id: queueId });
+    // Drop the selection if the queue that was open got deleted.
+    if (selectedQueueId === queueId) {
+      selectQueue(undefined);
+    }
+  };
 
   const { items: traces, isLoading: itemsLoading } = useListReviewQueueItemsQuery({
     queueId: selectedQueueId ?? '',
@@ -506,12 +501,33 @@ const ExperimentReviewQueuePage = () => {
           title={<FormattedMessage defaultMessage="Delete queue?" description="Delete review queue: confirm title" />}
           okText={<FormattedMessage defaultMessage="Delete" description="Delete review queue: confirm button" />}
           okButtonProps={{ danger: true }}
+          confirmLoading={isDeletingQueue}
           cancelText={<FormattedMessage defaultMessage="Cancel" description="Delete review queue: cancel button" />}
-          onOk={() => {
-            handleDeleteQueue(confirmDeleteQueue.queue_id);
-            setConfirmDeleteQueueId(undefined);
+          cancelButtonProps={{ disabled: isDeletingQueue }}
+          onOk={async () => {
+            try {
+              await handleDeleteQueue(confirmDeleteQueue.queue_id);
+              // Close only after the delete lands, so a failure keeps the dialog
+              // open for retry instead of looking like a silent no-op.
+              setConfirmDeleteQueueId(undefined);
+            } catch (e) {
+              Utils.displayGlobalErrorNotification(
+                intl.formatMessage(
+                  {
+                    defaultMessage: 'Could not delete queue: {error}',
+                    description: 'Review queue: error toast when deleting a queue fails',
+                  },
+                  { error: e instanceof Error ? e.message : String(e) },
+                ),
+              );
+            }
           }}
-          onCancel={() => setConfirmDeleteQueueId(undefined)}
+          onCancel={() => {
+            // Ignore dismissals while a delete is in flight.
+            if (!isDeletingQueue) {
+              setConfirmDeleteQueueId(undefined);
+            }
+          }}
         >
           <FormattedMessage
             defaultMessage='Permanently delete "{name}" and remove its traces from review? This cannot be undone.'

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4511,6 +4511,10 @@
     "defaultMessage": "Calls",
     "description": "Column header for call count"
   },
+  "MOGbwm": {
+    "defaultMessage": "Could not delete queue: {error}",
+    "description": "Review queue: error toast when deleting a queue fails"
+  },
   "MP+H1B": {
     "defaultMessage": "No webhooks configured. Create one to get started. <link>Learn more about webhooks.</link>",
     "description": "Empty state for webhooks list"


### PR DESCRIPTION
### Related Issues/PRs

N/A (follow-up to a review-queue UI bug finding)

### What changes are proposed in this pull request?

In the Review tab, the delete-queue confirm dialog fired the delete mutation fire-and-forget and closed the dialog synchronously. When the server rejected the delete, the failure was swallowed: no loading state, no error, and the queue stayed in the sidebar, so the action read as a silent no-op.

This awaits the delete instead, keeps the dialog open with a spinner (and a disabled Cancel) while it is in flight, shows an error toast on failure, and closes the dialog only after the delete succeeds.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Verified in the browser with the delete request mocked to HTTP 500 (before/after recordings below).

**Before (master) — failure swallowed, dialog closes silently:**

https://github.com/user-attachments/assets/96a9075f-7d6e-43ac-aaad-ff6347bc1dde

**After (this PR) — error toast shown, dialog stays open:**

https://github.com/user-attachments/assets/2b6aa8c7-67c1-435a-a528-f4732fc1a658

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A failed review-queue deletion now surfaces an error and keeps the confirm dialog open, instead of silently closing as though the delete had succeeded.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)