### PR TITLE
Fix non-functional JSON/Table toggle in the review queue full-trace explorer

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -15,7 +15,13 @@ const FEEDBACK_SUBMITTED_COMPONENT_ID = 'mlflow.experiment-review-queue.focused-
 let mockTraceData: unknown[] = [];
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
   useGetTracesById: () => ({ data: mockTraceData, isLoading: false }),
-  ModelTraceExplorer: () => null,
+  // The explorer's JSON/Table render-mode toggle reads from this preferences
+  // context, so FocusedReview must wrap the explorer in it; mock both to assert
+  // the nesting in the regression test below.
+  ModelTraceExplorerPreferencesProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="trace-prefs-provider">{children}</div>
+  ),
+  ModelTraceExplorer: () => <div data-testid="full-trace-explorer" />,
 }));
 
 const mockCreateAssessment = jest.fn();
@@ -134,6 +140,27 @@ describe('FocusedReview single Pass/Fail auto-submit', () => {
     expect(screen.getByText('Submit')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Pass'));
     expect(onSetStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('FocusedReview full-trace explorer', () => {
+  afterEach(() => {
+    mockTraceData = [];
+  });
+
+  it('wraps the full-trace explorer in the preferences provider so the render-mode toggle works', async () => {
+    mockTraceData = [{ info: { trace_id: 'tr-1', request_preview: 'q', response_preview: 'a' } }];
+    renderFocused(
+      [passFailSchema()],
+      jest.fn((_status: string) => Promise.resolve()),
+    );
+
+    fireEvent.click(screen.getByText('View full trace'));
+
+    // Without the surrounding provider the JSON/Table render-mode buttons are no-ops,
+    // so assert the explorer is nested inside it.
+    const explorer = await screen.findByTestId('full-trace-explorer');
+    expect(screen.getByTestId('trace-prefs-provider')).toContainElement(explorer);
   });
 });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -157,8 +157,10 @@ describe('FocusedReview full-trace explorer', () => {
 
     fireEvent.click(screen.getByText('View full trace'));
 
-    // Without the surrounding provider the JSON/Table render-mode buttons are no-ops,
-    // so assert the explorer is nested inside it.
+    // Structural guard only: both the provider and the explorer are mocked to plain
+    // divs here, so this asserts the explorer is nested *under* the provider in the
+    // tree (the wiring this PR adds), not that real preferences context propagates.
+    // Without the surrounding provider the JSON/Table render-mode buttons are no-ops.
     const explorer = await screen.findByTestId('full-trace-explorer');
     expect(screen.getByTestId('trace-prefs-provider')).toContainElement(explorer);
   });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -668,18 +668,20 @@ export const FocusedReview = ({
           }
           width="60vw"
         >
-          {trace ? (
-            <div css={{ height: '100%' }} onWheel={(e) => e.stopPropagation()}>
-              {/* ModelTraceExplorer doesn't provide its own preferences context, so the
-                  JSON/Table render-mode toggle is a no-op without this wrapper (other
-                  consumers wrap it the same way). */}
-              <ModelTraceExplorerPreferencesProvider>
+          {/* ModelTraceExplorer doesn't provide its own preferences context, so the
+              JSON/Table render-mode toggle is a no-op without this wrapper (other
+              consumers wrap it the same way). It sits outside the `trace` conditional
+              so a background refetch (which can momentarily clear `trace`) doesn't
+              remount it and reset the user's chosen render mode. */}
+          <ModelTraceExplorerPreferencesProvider>
+            {trace ? (
+              <div css={{ height: '100%' }} onWheel={(e) => e.stopPropagation()}>
                 <ModelTraceExplorer modelTrace={trace} initialActiveView="detail" />
-              </ModelTraceExplorerPreferencesProvider>
-            </div>
-          ) : (
-            <TableSkeleton lines={8} />
-          )}
+              </div>
+            ) : (
+              <TableSkeleton lines={8} />
+            )}
+          </ModelTraceExplorerPreferencesProvider>
         </Drawer.Content>
       </Drawer.Root>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -16,7 +16,11 @@ import {
   useDesignSystemEventComponentCallbacks,
   useDesignSystemTheme,
 } from '@databricks/design-system';
-import { ModelTraceExplorer, useGetTracesById } from '@databricks/web-shared/model-trace-explorer';
+import {
+  ModelTraceExplorer,
+  ModelTraceExplorerPreferencesProvider,
+  useGetTracesById,
+} from '@databricks/web-shared/model-trace-explorer';
 import { GenAIMarkdownRenderer } from '../../../shared/web-shared/genai-markdown-renderer';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -666,7 +670,12 @@ export const FocusedReview = ({
         >
           {trace ? (
             <div css={{ height: '100%' }} onWheel={(e) => e.stopPropagation()}>
-              <ModelTraceExplorer modelTrace={trace} initialActiveView="detail" />
+              {/* ModelTraceExplorer doesn't provide its own preferences context, so the
+                  JSON/Table render-mode toggle is a no-op without this wrapper (other
+                  consumers wrap it the same way). */}
+              <ModelTraceExplorerPreferencesProvider>
+                <ModelTraceExplorer modelTrace={trace} initialActiveView="detail" />
+              </ModelTraceExplorerPreferencesProvider>
             </div>
           ) : (
             <TableSkeleton lines={8} />


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

On the focused review page, clicking **View full trace** opens a drawer with the `ModelTraceExplorer`, but the **JSON** and **Table** render-mode buttons (the `SegmentedControl` in the span content tab) did nothing.

Root cause: `ModelTraceExplorer` does not provide its own `ModelTraceExplorerPreferencesProvider`. The render-mode toggle reads `renderMode` / `setRenderMode` from that preferences context, and without the provider it falls back to the default context value whose `setRenderMode` is a no-op, so clicks were silently dropped. Every other consumer (`SimplifiedModelTraceExplorer`, `GenAITracesTableContext`, `ExperimentSingleChatSessionPage`) wraps the explorer in this provider; the review-queue drawer was missing it.

Fix: wrap the explorer in `ModelTraceExplorerPreferencesProvider` in `FocusedReview`, matching the established pattern.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a `FocusedReview` regression test that opens the full-trace drawer and asserts the explorer is rendered inside the preferences provider (the toggle is a no-op otherwise).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the JSON and Table view toggles not working in the full-trace explorer opened from a review queue's focused review page.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.