### PR TITLE
Require at least one question when saving review queue settings

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.test.tsx
@@ -96,11 +96,14 @@ const trace = (itemId: string): ReviewQueueItem => ({
   last_update_time_ms: 0,
 });
 
-const renderModal = ({ canManage = true }: { canManage?: boolean } = {}) =>
+const renderModal = ({
+  canManage = true,
+  queueOverride = queue,
+}: { canManage?: boolean; queueOverride?: ReviewQueue } = {}) =>
   render(
     <IntlProvider locale="en">
       <DesignSystemProvider>
-        <QueueSettingsModal queue={queue} canManage={canManage} onClose={jest.fn()} />
+        <QueueSettingsModal queue={queueOverride} canManage={canManage} onClose={jest.fn()} />
       </DesignSystemProvider>
     </IntlProvider>,
   );
@@ -132,11 +135,21 @@ describe('QueueSettingsModal save', () => {
   it('sends schema_ids only when the questions actually change', async () => {
     mockTraces = [];
     renderModal();
-    // Toggle the one selected question off, changing the set from ['s1'] to [].
-    fireEvent.click(screen.getByText('toggle-question-s1'));
+    // Add a second question, changing the set from ['s1'] to ['s1','s2'].
+    fireEvent.click(screen.getByText('toggle-question-s2'));
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
-    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ queue_id: 'rq-1', schema_ids: [] }));
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ queue_id: 'rq-1', schema_ids: ['s1', 's2'] }));
+  });
+
+  it('blocks the empty-questions save: toggling off the last question disables Save', () => {
+    // Toggling the one selected question off would empty the set; the floor blocks
+    // the save rather than persisting a questionless (unreviewable) queue.
+    mockTraces = [];
+    renderModal();
+    fireEvent.click(screen.getByText('toggle-question-s1'));
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.getByText(/at least one question/i)).toBeInTheDocument();
   });
 
   it('detects a same-size question swap (different members, not just count)', async () => {
@@ -200,6 +213,43 @@ describe('QueueSettingsModal save', () => {
     expect(arg).toMatchObject({ queue_id: 'rq-1', name: 'Renamed' });
     expect('schema_ids' in arg).toBe(false);
     expect('new_owner' in arg).toBe(false);
+  });
+
+  it('disables Save (and blocks the update) when questions are editable and none are selected', () => {
+    mockTraces = [];
+    renderModal({ queueOverride: { ...queue, schema_ids: [] } });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    // A disabled OK button can't fire, so the destructive empty-questions save is blocked.
+    fireEvent.click(screen.getByText('Save'));
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(screen.getByText(/at least one question/i)).toBeInTheDocument();
+  });
+
+  it('re-enables Save and clears the error once a question is re-added', async () => {
+    mockTraces = [];
+    renderModal({ queueOverride: { ...queue, schema_ids: [] } });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.getByText(/at least one question/i)).toBeInTheDocument();
+    // Re-add the question: Save re-enables, the validation message clears, and the
+    // save now carries the non-empty schema set.
+    fireEvent.click(screen.getByText('toggle-question-s1'));
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    expect(screen.queryByText(/at least one question/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ schema_ids: ['s1'] }));
+  });
+
+  it('keeps Save enabled and omits schema_ids on a frozen zero-question queue', async () => {
+    // With traces attached, questions are frozen, so the floor doesn't apply and the
+    // empty schema set is never sent. A manager can still edit members.
+    mockTraces = [trace('tr-1')];
+    renderModal({ queueOverride: { ...queue, schema_ids: [] } });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    const arg = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+    expect('schema_ids' in arg).toBe(false);
   });
 
   it('omits unchanged fields entirely on a no-op save', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
@@ -187,6 +187,11 @@ export const QueueSettingsModal = ({
     selectedSchemaIds.size !== originalSchemaIds.size ||
     [...originalSchemaIds].some((id) => !selectedSchemaIds.has(id));
 
+  // Mirror the create modal's floor: an editable CUSTOM queue must keep at least one
+  // question. Saving with none persists an empty schema_ids, leaving the queue
+  // unreviewable. Frozen questions aren't sent, so the floor doesn't apply.
+  const questionsBelowFloor = canEditQuestions && selectedSchemaIds.size === 0;
+
   const handleSave = async () => {
     try {
       await updateReviewQueueAsync({
@@ -241,7 +246,7 @@ export const QueueSettingsModal = ({
               componentId={`${CID}.save`}
               type="primary"
               loading={isUpdatingQueue}
-              disabled={isUpdatingQueue || !canSave}
+              disabled={isUpdatingQueue || !canSave || questionsBelowFloor}
               onClick={handleSave}
             >
               <FormattedMessage defaultMessage="Save" description="Queue settings: save button" />
@@ -345,6 +350,16 @@ export const QueueSettingsModal = ({
                   triggerValue={questionsTriggerValue}
                   disabled={!canEditQuestions}
                   dropdownZIndex={dropdownZIndex}
+                />
+              )}
+
+              {questionsBelowFloor && (
+                <FormUI.Message
+                  type="error"
+                  message={intl.formatMessage({
+                    defaultMessage: "Select at least one question. A queue with no questions can't be reviewed.",
+                    description: 'Queue settings: validation shown when no questions are selected',
+                  })}
                 />
               )}
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -6407,6 +6407,10 @@
     "defaultMessage": "Usage example",
     "description": "A title of the modal showing the usage example of the prompt"
   },
+  "VtJXih": {
+    "defaultMessage": "Select at least one question. A queue with no questions can't be reviewed.",
+    "description": "Queue settings: validation shown when no questions are selected"
+  },
   "Vvs+79": {
     "defaultMessage": "Low",
     "description": "Issue severity tag label for low severity"


### PR DESCRIPTION
### Related Issues/PRs

N/A (no tracked issue)

### What changes are proposed in this pull request?

The **Create** queue modal requires at least one question, but **Queue settings** ("Manage queue") didn't: unchecking the last question and clicking **Save** persisted an empty `schema_ids`, leaving a CUSTOM queue with zero questions. Such a queue is unreviewable. Focus mode shows "No questions configured for this queue." with Submit disabled, so items can only be Declined.

This mirrors the create modal's floor in `QueueSettingsModal`: Save is disabled with an inline message when no question is selected. It's a UI-level invariant. The store intentionally allows empty `schema_ids` (to clear associations), so the server is unchanged.

Out of scope: deleting a queue's only question via "Manage questions" reaches the same state (pre-existing; tracked separately).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New `QueueSettingsModal` tests; verified manually (videos below).

**Before (bug): Queue settings saves 0 questions, leaving the queue unreviewable**

https://github.com/user-attachments/assets/e117bd21-9b83-4b9e-9f02-400f8fed3ebd

**After (fix): Save is disabled at 0 questions; re-adding a question re-enables it**

https://github.com/user-attachments/assets/f1697342-ba4e-4b51-9482-5ec12bd0a619

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed a bug where a custom review queue's questions could be cleared from Queue settings, leaving the queue unreviewable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)