### PR TITLE
Block saving a review when a previously-answered question is cleared

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -502,7 +502,12 @@ describe('FocusedReview blocks saving a cleared prior answer', () => {
     expect(saveButton()).not.toBeDisabled();
     expect(screen.queryByTestId(hintTestId)).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Save changes'));
-    await waitFor(() => expect(mockCreateAssessment).toHaveBeenCalled());
+    // The re-entered value is what actually gets written, not a stale/empty one.
+    await waitFor(() =>
+      expect(mockCreateAssessment).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Score', value: 7, assessmentKind: 'feedback' }),
+      ),
+    );
   });
 
   it('blocks the save when a previously-selected multi-select answer is cleared', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, jest, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import React from 'react';
 
 import { DesignSystemEventProvider, DesignSystemProvider } from '@databricks/design-system';
@@ -41,6 +41,24 @@ const passFailSchema = (schemaId = 's1', name = 'Looks good?', enableComment = f
   type: 'FEEDBACK',
   input: { pass_fail: { positive_label: 'Pass', negative_label: 'Fail' } },
   enable_comment: enableComment,
+});
+
+const numericSchema = (schemaId: string, name: string): LabelSchema => ({
+  schema_id: schemaId,
+  experiment_id: 'exp-1',
+  name,
+  type: 'FEEDBACK',
+  input: { numeric: {} },
+  enable_comment: false,
+});
+
+const multiSelectSchema = (schemaId: string, name: string, options: string[]): LabelSchema => ({
+  schema_id: schemaId,
+  experiment_id: 'exp-1',
+  name,
+  type: 'FEEDBACK',
+  input: { categorical: { options, multi_select: true } },
+  enable_comment: false,
 });
 
 const pendingItem: ReviewQueueItem = {
@@ -438,5 +456,76 @@ describe('FocusedReview edit-in-place on a completed trace', () => {
     expect(screen.queryByText('Submit')).not.toBeInTheDocument();
     // The lock is the inputs being disabled, not just the missing button.
     expect(screen.getAllByRole('radio', { name: 'Pass' })[0]).toBeDisabled();
+  });
+});
+
+describe('FocusedReview blocks saving a cleared prior answer', () => {
+  beforeEach(() => {
+    mockCreateAssessment.mockReset();
+    mockCreateAssessment.mockImplementation(() => Promise.resolve());
+  });
+  afterEach(() => {
+    mockPriorAnswersResult = { priorAnswers: [], isLoading: false, isFetching: false };
+  });
+
+  const hintTestId = 'mlflow.experiment-review-queue.focused-review.cleared-answer-hint';
+  const saveButton = () => screen.getByText('Save changes').closest('button');
+
+  it('disables Save changes and explains when a cleared numeric answer would drop a prior', async () => {
+    // A completed trace whose two questions both have this reviewer's saved answers.
+    mockPriorAnswersResult = {
+      priorAnswers: [
+        { name: 'Score', kind: 'feedback', value: 5, valid: true, assessmentId: 'a1' },
+        { name: 'Looks good?', kind: 'feedback', value: true, valid: true, assessmentId: 'a2' },
+      ],
+      isLoading: false,
+      isFetching: false,
+    };
+    renderFocused(
+      [numericSchema('s1', 'Score'), passFailSchema('s2', 'Looks good?')],
+      jest.fn((_status: string) => Promise.resolve()),
+      { item: completeItem },
+    );
+
+    // No edits yet: nothing to save, and no warning.
+    expect(saveButton()).toBeDisabled();
+    expect(screen.queryByTestId(hintTestId)).not.toBeInTheDocument();
+
+    // Clear the numeric answer. Saving here would silently drop it and leave the
+    // prior 5 live, so the button stays disabled with an explanation instead.
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } });
+    expect(saveButton()).toBeDisabled();
+    expect(screen.getByTestId(hintTestId)).toBeInTheDocument();
+
+    // Entering a new value clears the block and the save goes through.
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '7' } });
+    expect(saveButton()).not.toBeDisabled();
+    expect(screen.queryByTestId(hintTestId)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Save changes'));
+    await waitFor(() => expect(mockCreateAssessment).toHaveBeenCalled());
+  });
+
+  it('blocks the save when a previously-selected multi-select answer is cleared', () => {
+    mockPriorAnswersResult = {
+      priorAnswers: [
+        { name: 'Tags', kind: 'feedback', value: ['low'], valid: true, assessmentId: 'a1' },
+        { name: 'Looks good?', kind: 'feedback', value: true, valid: true, assessmentId: 'a2' },
+      ],
+      isLoading: false,
+      isFetching: false,
+    };
+    renderFocused(
+      [multiSelectSchema('s1', 'Tags', ['low', 'high']), passFailSchema('s2', 'Looks good?')],
+      jest.fn((_status: string) => Promise.resolve()),
+      { item: completeItem },
+    );
+
+    expect(saveButton()).toBeDisabled();
+    // Deselect the only chosen tag, clearing the answer to an empty list.
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText('low'));
+
+    expect(saveButton()).toBeDisabled();
+    expect(screen.getByTestId(hintTestId)).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -630,7 +630,7 @@ export const FocusedReview = ({
                 data-testid={`${CID}.cleared-answer-hint`}
               >
                 <FormattedMessage
-                  defaultMessage="A saved answer can't be removed. Enter a value for every question you've answered, or keep your previous answer."
+                  defaultMessage="A cleared answer can't be saved. Enter a value for each question, or keep the previous answer."
                   description="Review focused view: shown when a previously-answered question is cleared, which can't be saved"
                 />
               </Typography.Hint>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -238,6 +238,19 @@ export const FocusedReview = ({
     [schemas, edited, prefilled],
   );
 
+  // A question the reviewer already answered can't be retracted to empty: the
+  // data model has no empty value for expectations and no single-answer delete,
+  // so a cleared question is silently dropped on save (its prior assessment stays
+  // live). Block the save in that state, so the reviewer must re-enter a value or
+  // keep the previous one rather than see a misleading "saved" over stale data.
+  const hasClearedPriorAnswer = useMemo(
+    () =>
+      schemas.some(
+        (s) => isAnswered(prefilled[s.name]) && !isAnswered(s.name in edited ? edited[s.name] : prefilled[s.name]),
+      ),
+    [schemas, edited, prefilled],
+  );
+
   // Position in the queue + adjacent traces for prev/next navigation.
   const currentIndex = items.findIndex((i) => i.item_id === item.item_id);
   const prevItemId = currentIndex > 0 ? items[currentIndex - 1].item_id : undefined;
@@ -289,6 +302,13 @@ export const FocusedReview = ({
     // set in the same click hasn't flushed yet.
     const effectiveValue = (name: string): LabelSchemaValue =>
       answerOverrides && name in answerOverrides ? answerOverrides[name] : valueFor(name);
+    // Defense in depth (the Submit button is already disabled in this state):
+    // never write when a previously-answered question has been cleared. Clearing
+    // has no value to record, and the cleared question would otherwise be silently
+    // skipped below, leaving its stale prior assessment live.
+    if (schemas.some((s) => isAnswered(prefilled[s.name]) && !isAnswered(effectiveValue(s.name)))) {
+      return;
+    }
     // Every answered question is (re)written here; an unchanged answer
     // re-supersedes its prior rather than being skipped.
     const answered = schemas.filter((s) => isAnswered(effectiveValue(s.name)));
@@ -604,6 +624,17 @@ export const FocusedReview = ({
                 )}
               </div>
             )}
+            {hasClearedPriorAnswer && !isDeclined && canReview && (
+              <Typography.Hint
+                css={{ textAlign: 'right', color: theme.colors.textValidationDanger }}
+                data-testid={`${CID}.cleared-answer-hint`}
+              >
+                <FormattedMessage
+                  defaultMessage="A saved answer can't be removed. Enter a value for every question you've answered, or keep your previous answer."
+                  description="Review focused view: shown when a previously-answered question is cleared, which can't be saved"
+                />
+              </Typography.Hint>
+            )}
             <div css={{ display: 'flex', gap: theme.spacing.sm, justifyContent: 'flex-end' }}>
               {/* A terminal trace can be sent back to the to-do list. Declining is
                   no longer offered in the UI (the API still supports it); a pending
@@ -630,6 +661,7 @@ export const FocusedReview = ({
                     !canReview ||
                     answeredCount === 0 ||
                     priorAnswersFetching ||
+                    hasClearedPriorAnswer ||
                     (isComplete && !hasEdits)
                   }
                   loading={isCreatingAssessment || isSettingStatus}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/FocusedReview.tsx
@@ -305,7 +305,12 @@ export const FocusedReview = ({
     // Defense in depth (the Submit button is already disabled in this state):
     // never write when a previously-answered question has been cleared. Clearing
     // has no value to record, and the cleared question would otherwise be silently
-    // skipped below, leaving its stale prior assessment live.
+    // skipped below, leaving its stale prior assessment live. This uses
+    // `effectiveValue` (folding in the auto-submit `answerOverrides`) while the
+    // button gates on `hasClearedPriorAnswer` via `valueFor`; the two can't
+    // disagree, because `answerOverrides` only ever carries a just-picked
+    // (answered) value, so this guard never fires on a question the button
+    // considered answered.
     if (schemas.some((s) => isAnswered(prefilled[s.name]) && !isAnswered(effectiveValue(s.name)))) {
       return;
     }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -7467,6 +7467,10 @@
     "defaultMessage": "Add/edit alias for prompt version {version}",
     "description": "Title for the edit aliases modal on the registered prompt details page"
   },
+  "b1WkXf": {
+    "defaultMessage": "A cleared answer can't be saved. Enter a value for each question, or keep the previous answer.",
+    "description": "Review focused view: shown when a previously-answered question is cleared, which can't be saved"
+  },
   "b1yfI9": {
     "defaultMessage": "Run details",
     "description": "Run page > Overview > Run details section heading"
@@ -9766,10 +9770,6 @@
   "mBhoMH": {
     "defaultMessage": "Last modified",
     "description": "Last modified column header"
-  },
-  "mBzOSV": {
-    "defaultMessage": "A saved answer can't be removed. Enter a value for every question you've answered, or keep your previous answer.",
-    "description": "Review focused view: shown when a previously-answered question is cleared, which can't be saved"
   },
   "mGUpJv": {
     "defaultMessage": "Failed to create record",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -9767,6 +9767,10 @@
     "defaultMessage": "Last modified",
     "description": "Last modified column header"
   },
+  "mBzOSV": {
+    "defaultMessage": "A saved answer can't be removed. Enter a value for every question you've answered, or keep your previous answer.",
+    "description": "Review focused view: shown when a previously-answered question is cleared, which can't be saved"
+  },
   "mGUpJv": {
     "defaultMessage": "Failed to create record",
     "description": "Generic fallback save-error text for the dataset record side panel (create mode)"


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

On the focused review page, clearing an already-saved answer (a numeric field emptied, or a multi-select cleared to `[]`) on a trace with a prior answer enabled **Save changes**, but the cleared question was silently dropped on save: `submitAnswersAndComplete` only writes questions that pass `isAnswered`, so the cleared one was skipped and its prior assessment stayed live. The reviewer saw "Changes saved" while the server kept serving the old value, with no way to tell the answer wasn't actually removed.

There is no clean retract in the data model: an `Expectation` rejects an empty value, and deleting an overriding assessment restores the prior it overrode (so a delete would resurrect an older answer, not clear it). So this PR **blocks the misleading save** rather than inventing a retract:

- A new `hasClearedPriorAnswer` check (a question that had a saved answer is now empty) disables **Submit** / **Save changes** and shows a short explanation, until the reviewer re-enters a value or keeps the previous one.
- `submitAnswersAndComplete` also guards the same invariant directly (defense in depth), so the cleared-answer write can't slip through any other code path.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `FocusedReview` tests: clearing a numeric answer on a completed two-question trace keeps **Save changes** disabled and shows the hint, then re-entering a value releases the block and the save writes; and clearing a multi-select answer to `[]` blocks the save the same way.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a review-queue issue where clearing a previously-answered review question appeared to save but left the old answer live; the save is now blocked with an explanation until a value is provided.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.