### PR TITLE
fix: prevent 'table already exists' error during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,13 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create tables that don't already exist to avoid "table already exists" errors
+    existing_tables = set(sqlalchemy.inspect(engine).get_table_names())
+    tables_to_create = [
+        t for t in InitialBase.metadata.tables.values() if t.name not in existing_tables
+    ]
+    for table in tables_to_create:
+        table.create(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, the `mlflow db upgrade` command fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` unconditionally calls `InitialBase.metadata.create_all(engine)`, which attempts to create all initial tables including those already created by previous migrations.

## Fix
Modified `_initialize_tables` to check which tables already exist in the database before attempting to create them. It now only creates tables that are missing, preventing the "table already exists" error during upgrade.

Closes #19943