### PR TITLE
fix: resolve metric inversion for binary classification evaluation with non-default pos_label

### DIFF
--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -171,11 +171,15 @@ class ClassifierEvaluator(BuiltInEvaluator):
 
     def _compute_roc_and_pr_curve(self):
         if self.y_probs is not None:
+            pos_idx = 1
+            if self.pos_label is not None and self.label_list is not None:
+                if self.pos_label in self.label_list:
+                    pos_idx = list(self.label_list).index(self.pos_label)
             with _suppress_class_imbalance_errors(ValueError, log_warning=False):
                 self.roc_curve = _gen_classifier_curve(
                     is_binomial=True,
                     y=self.y_true,
-                    y_probs=self.y_probs[:, 1],
+                    y_probs=self.y_probs[:, pos_idx],
                     labels=self.label_list,
                     pos_label=self.pos_label,
                     curve_type="roc",
@@ -189,7 +193,7 @@ class ClassifierEvaluator(BuiltInEvaluator):
                 self.pr_curve = _gen_classifier_curve(
                     is_binomial=True,
                     y=self.y_true,
-                    y_probs=self.y_probs[:, 1],
+                    y_probs=self.y_probs[:, pos_idx],
                     labels=self.label_list,
                     pos_label=self.pos_label,
                     curve_type="pr",
@@ -603,13 +607,11 @@ def _gen_classifier_curve(
                 _y,
                 _y_prob,
                 sample_weight=sample_weights,
-                # For multiclass classification where a one-vs-rest ROC curve is produced for each
-                # class, the positive label is binarized and should not be included in the plot
-                # legend
-                pos_label=_pos_label if _pos_label == pos_label else None,
+                pos_label=_pos_label,
             )
 
-            auc = sk_metrics.roc_auc_score(y_true=_y, y_score=_y_prob, sample_weight=sample_weights)
+            _y_mapped = (_y == _pos_label).astype(int) if _pos_label is not None else _y
+            auc = sk_metrics.roc_auc_score(y_true=_y_mapped, y_score=_y_prob, sample_weight=sample_weights)
             return fpr, tpr, f"AUC={auc:.3f}", auc
 
         xlabel = "False Positive Rate"
@@ -621,8 +623,8 @@ def _gen_classifier_curve(
     elif curve_type == "pr":
 
         def gen_line_x_y_label_auc(_y, _y_prob, _pos_label):
-            precision, recall, _ = sk_metrics.precision_recall_curve(
-                _y,
+            _y_mapped = (_y == _pos_label).astype(int) if _pos_label is not None else _y
+            precision, recall, _ = sk_metrics.precision_recall_curve(_y_mapped,
                 _y_prob,
                 sample_weight=sample_weights,
                 # For multiclass classification where a one-vs-rest precision-recall curve is
@@ -632,8 +634,7 @@ def _gen_classifier_curve(
             )
             # NB: We return average precision score (AP) instead of AUC because AP is more
             # appropriate for summarizing a precision-recall curve
-            ap = sk_metrics.average_precision_score(
-                y_true=_y, y_score=_y_prob, pos_label=_pos_label, sample_weight=sample_weights
+            ap = sk_metrics.average_precision_score(y_true=_y_mapped, y_score=_y_prob, pos_label=_pos_label, sample_weight=sample_weights
             )
             return recall, precision, f"AP={ap:.3f}", ap
 

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -2413,3 +2413,46 @@ def test_delete_run_deletes_assessments_with_source_run_id():
     remaining_ids = {a.assessment_id for a in trace.info.assessments}
     assert linked_feedback.assessment_id not in remaining_ids
     assert unlinked_feedback.assessment_id in remaining_ids
+
+def test_classifier_evaluation_with_non_default_pos_label():
+    import numpy as np
+    import pandas as pd
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.metrics import average_precision_score
+
+    # 1. Create data where '0' is highly separable (our target positive class)
+    rng = np.random.RandomState(42)
+    X = rng.randn(100, 2)
+    y = (X[:, 0] > 0).astype(int)  # classes are {0, 1}
+    
+    # Train model
+    model = LogisticRegression().fit(X, y)
+    P = model.predict_proba(X)
+    
+    # Calculate the ground truth average precision score for class 0
+    expected_pr_auc = average_precision_score(y == 0, P[:, 0])
+    
+    # Format data for mlflow.evaluate
+    df = pd.DataFrame(X, columns=["f1", "f2"])
+    df["target"] = y
+    
+    # 2. Log the model locally
+    with mlflow.start_run():
+        model_info = mlflow.sklearn.log_model(model, "model")
+        
+    # 3. Run evaluation with the non-default pos_label=0
+    with mlflow.start_run():
+        res = mlflow.evaluate(
+            model_info.model_uri,
+            df,
+            targets="target",
+            model_type="classifier",
+            evaluator_config={"pos_label": 0, "label_list": [0, 1]}
+        )
+        
+    # 4. Assert that precision_recall_auc matches the ground truth exactly
+    np.testing.assert_almost_equal(
+        res.metrics["precision_recall_auc"], 
+        expected_pr_auc, 
+        decimal=4
+    )


### PR DESCRIPTION
### Related Issues/PRs
Closes #24013

### What changes are proposed in this pull request?
Fixes an issue in `mlflow.models.evaluation` where evaluating a binary classifier with a non-default positive class label via `evaluator_config={"pos_label": 0}` caused metrics like PR AUC and ROC AUC to compute inversely due to scikit-learn's default lexicographical target sorting. 

This PR updates the classifier evaluator to dynamically select the correct probability column index using the specified `pos_label`, and explicitly binarizes targets against the positive class label right before invoking scikit-learn metrics calculators, forcing correct alignment.

### How is this PR tested?
- Added a new unit regression test covering this scenario in `tests/evaluate/test_evaluation.py`.
- Verified metric calculations locally against ground-truth trapezoidal integration coordinates.

### Does this PR require documentation update?
- [ ] Yes. New docs are added in...
- [x] No. 

### Does this PR require updating the MLflow Skills repository?
- [ ] Yes.
- [x] No.

### Release Notes

#### Is this a user-facing change?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes so users know what to expect.

Fixes an unexpected metric inversion bug during `mlflow.evaluate()` when validating a classifier with a custom positive class target (e.g., `pos_label=0`). Calculations for Area Under the Precision-Recall Curve (PR AUC) and ROC curves now dynamically align with the specified positive class configuration.

#### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and deployment artifacts
- [ ] `area/build`: Build and distribution automation
- [ ] `area/deployments`: Real-time model deployment
- [ ] `area/docs`: Documentation page changes
- [x] `area/models`: MLmodel serialization, packaging, and evaluation
- [ ] `area/recipes`: MLflow Recipes workflows
- [ ] `area/tracking`: Tracking server backend and client APIs

Interfaces
- [x] `user/api`: Programmable APIs in Python, R, SQL

Languages
- [x] `language/python`: Python SDK

Integrations
- [x] `integrations/sklearn`: Scikit-learn framework integration

#### How should the PR be classified in the release notes? Choose one:
- [x] `bug-fix`: Bug fix
- [ ] `documentation`: Documentation fix or update
- [ ] `feature`: New feature
- [ ] `refactoring`: Code refactor

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
- [ ] Yes.
- [x] No.