### PR TITLE
Compare review-queue picker usernames case-insensitively

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -24,7 +24,7 @@ import Utils from '../../../common/utils/Utils';
 import { Link } from '../../../common/utils/RoutingUtils';
 import { CreateReviewQueueModal } from './CreateReviewQueueModal';
 import { getQueueAssignability } from './queueAssignability';
-import { canRemoveQueueItems, sameUser } from './queuePermissions';
+import { canRemoveQueueItems, normalizeUser, sameUser } from './queuePermissions';
 import { useAddItemsToReviewQueueMutation } from './hooks/useAddItemsToReviewQueueMutation';
 import { useAssignableUsersQuery } from './hooks/useAssignableUsersQuery';
 import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueueMutation';
@@ -154,7 +154,7 @@ export const AddToReviewQueueDropdown = ({
     () => memberQueues.filter((q) => q.queue_type === 'USER').map((q) => q.name),
     [memberQueues],
   );
-  const memberUserSet = useMemo(() => new Set(memberUserNames.map((n) => n.toLowerCase())), [memberUserNames]);
+  const memberUserSet = useMemo(() => new Set(memberUserNames.map(normalizeUser)), [memberUserNames]);
   // While a single trace's memberships are still loading we don't yet know which
   // rows are checked/locked, so disable toggling to avoid e.g. adding to a queue
   // the reviewer only meant to remove from. Bulk selections never query this.
@@ -172,7 +172,9 @@ export const AddToReviewQueueDropdown = ({
     // section (canListUsers) on an auth server, or just the pinned `default`
     // queue on no-auth. Seeding an invisible user would be unreachable state.
     const seedableUsers = canListUsers ? memberUserNames : memberUserNames.filter((n) => sameUser(n, DEFAULT_REVIEWER));
-    setAddedUsers(new Set(seedableUsers));
+    // `addedUsers` is keyed on the normalized (lowercase) name, matching the row
+    // checks and `toggleUserQueue`, so a roster row's display casing still matches.
+    setAddedUsers(new Set(seedableUsers.map(normalizeUser)));
   }, [isOpen, singleItemId, membersLoading, memberQueueIds, memberUserNames, canListUsers]);
 
   // Shared queues anyone can route into. The no-auth catch-all (the reserved
@@ -220,7 +222,7 @@ export const AddToReviewQueueDropdown = ({
         (u) =>
           !sameUser(u.username, reviewer) &&
           // Members are listed separately (checked) above the search results.
-          !memberUserSet.has(u.username.toLowerCase()) &&
+          !memberUserSet.has(normalizeUser(u.username)) &&
           u.username.toLowerCase().includes(query),
       )
       .slice(0, MAX_USER_MATCHES);
@@ -325,9 +327,14 @@ export const AddToReviewQueueDropdown = ({
   };
 
   const toggleUserQueue = async (username: string) => {
-    if (busyIds.has(username) || !reviewerResolved || itemIds.length === 0) return;
-    markBusy(username);
-    const alreadyAdded = addedUsers.has(username);
+    // Identity is case-insensitive: the server stores a user queue's name
+    // lowercased while the roster carries display case. Key the local checked /
+    // busy state on the normalized name so a row's checked state (and therefore
+    // whether a toggle adds or removes) is correct regardless of casing.
+    const key = normalizeUser(username);
+    if (busyIds.has(key) || !reviewerResolved || itemIds.length === 0) return;
+    markBusy(key);
+    const alreadyAdded = addedUsers.has(key);
     try {
       const { review_queue } = await getOrCreateUserQueueAsync({
         experiment_id: experimentId,
@@ -338,18 +345,18 @@ export const AddToReviewQueueDropdown = ({
         await removeItemsFromReviewQueueAsync({ queue_id: review_queue.queue_id, item_ids: itemIds });
         setAddedUsers((prev) => {
           const next = new Set(prev);
-          next.delete(username);
+          next.delete(key);
           return next;
         });
       } else {
         await addItemsToReviewQueueAsync({ queue_id: review_queue.queue_id, item_ids: itemIds });
-        setAddedUsers((prev) => new Set(prev).add(username));
+        setAddedUsers((prev) => new Set(prev).add(key));
         showSuccessToast(review_queue.queue_id);
       }
     } catch (e) {
       showErrorToast(e);
     } finally {
-      clearBusy(username);
+      clearBusy(key);
     }
   };
 
@@ -546,8 +553,8 @@ export const AddToReviewQueueDropdown = ({
                           <DialogComboboxOptionListCheckboxItem
                             key={`member-${username}`}
                             value={username}
-                            checked={addedUsers.has(username)}
-                            disabled={!canManage || busyIds.has(username) || membershipPending}
+                            checked={addedUsers.has(normalizeUser(username))}
+                            disabled={!canManage || busyIds.has(normalizeUser(username)) || membershipPending}
                             disabledReason={!canManage ? lockedMemberReason : undefined}
                             onChange={() => toggleUserQueue(username)}
                           >
@@ -587,8 +594,10 @@ export const AddToReviewQueueDropdown = ({
                               <DialogComboboxOptionListCheckboxItem
                                 key={u.username}
                                 value={u.username}
-                                checked={addedUsers.has(u.username)}
-                                disabled={!inheritAllAssignable || busyIds.has(u.username) || membershipPending}
+                                checked={addedUsers.has(normalizeUser(u.username))}
+                                disabled={
+                                  !inheritAllAssignable || busyIds.has(normalizeUser(u.username)) || membershipPending
+                                }
                                 disabledReason={inheritAllAssignable ? undefined : reasonText('no-experiment-schemas')}
                                 onChange={() => toggleUserQueue(u.username)}
                               >

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.test.tsx
@@ -94,6 +94,28 @@ describe('ReviewerChecklistCombobox', () => {
     expect(screen.getByRole('checkbox', { name: 'alice' })).not.toBeChecked();
   });
 
+  it('checks a member whose stored casing differs from the roster, without duplicating the row', () => {
+    // Assigned users are stored normalized (lowercase); the roster carries display
+    // casing. The member must render checked against its roster row, and appear once.
+    renderBox({ usernames: ['Alice', 'Bob'], checkedUsers: new Set(['alice']) });
+    expect(screen.getByRole('checkbox', { name: 'Alice' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Bob' })).not.toBeChecked();
+    // No separate lowercase "alice" row leaks in alongside the roster's "Alice".
+    expect(screen.queryByRole('checkbox', { name: 'alice' })).not.toBeInTheDocument();
+  });
+
+  it('removes (not duplicates) a case-mismatched member when its row is unchecked', () => {
+    // The caller's checked set is seeded from the server-normalized (lowercase)
+    // assigned users, while the roster row carries display casing. Unchecking must
+    // remove the member; emitting the roster casing would instead add a cased
+    // duplicate, leaving the row stuck checked.
+    renderStateful({ usernames: ['Alice'], initial: ['alice'] });
+    const row = screen.getByRole('checkbox', { name: 'Alice' });
+    expect(row).toBeChecked();
+    fireEvent.click(row);
+    expect(screen.getByRole('checkbox', { name: 'Alice' })).not.toBeChecked();
+  });
+
   it('caps the default reviewers at five and hints to search for the rest', () => {
     renderBox({ usernames: ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7'], checkedUsers: new Set() });
     expect(screen.getByRole('checkbox', { name: 'u1' })).toBeInTheDocument();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.tsx
@@ -11,6 +11,8 @@ import {
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { normalizeUser } from './queuePermissions';
+
 // Max reviewers a queue may have assigned. Keep in sync with `MAX_ASSIGNED_USERS`
 // in mlflow/genai/review_queues/validation.py — the server rejects more, so the
 // picker gates selection at the limit the caller passes (the create modal reserves
@@ -69,18 +71,36 @@ export const ReviewerChecklistCombobox = ({
   const [search, setSearch] = useState('');
   const query = search.trim().toLowerCase();
 
+  // Reviewer identity is case-insensitive: assigned users are stored normalized
+  // while the roster carries display case, so a member assigned as `alice` must
+  // still render checked against a roster row `Alice`. Compare on the normalized
+  // form, and never list the same person twice across the two sources.
+  const checkedLower = useMemo(() => new Set(Array.from(checkedUsers, normalizeUser)), [checkedUsers]);
+  const isChecked = (username: string) => checkedLower.has(normalizeUser(username));
+
   // The display order, rebuilt by `recompact` whenever the list view is (re)entered.
   const [order, setOrder] = useState<string[]>([]);
   // Selected reviewers (keeping their current order, newest search-pick leading)
   // followed by a fresh set of unselected defaults; rows no longer selected drop.
   const recompact = () =>
     setOrder((prev) => {
+      // Show a checked user under the roster's display casing when it's on the
+      // roster (the stored value is normalized), falling back to the stored value
+      // for an off-roster reviewer.
+      const rosterByKey = new Map(usernames.map((u) => [normalizeUser(u), u]));
+      const display = (u: string) => rosterByKey.get(normalizeUser(u)) ?? u;
+      const prevKeys = new Set(prev.map(normalizeUser));
       const selected = [
-        ...prev.filter((u) => checkedUsers.has(u)),
-        ...[...checkedUsers].filter((u) => !prev.includes(u)),
+        ...prev.filter((u) => isChecked(u)).map(display),
+        // Checked users not already represented (case-insensitively) in `prev`,
+        // so a member shown under its roster casing isn't duplicated by its
+        // normalized counterpart.
+        ...Array.from(checkedUsers)
+          .filter((u) => !prevKeys.has(normalizeUser(u)))
+          .map(display),
       ];
-      const selectedSet = new Set(selected);
-      const defaults = usernames.filter((u) => !selectedSet.has(u)).slice(0, DEFAULT_REVIEWER_COUNT);
+      const selectedKeys = new Set(selected.map(normalizeUser));
+      const defaults = usernames.filter((u) => !selectedKeys.has(normalizeUser(u))).slice(0, DEFAULT_REVIEWER_COUNT);
       return [...selected, ...defaults];
     });
   // Seed once, when the roster first resolves. `useQuery` commits `data` and
@@ -97,13 +117,17 @@ export const ReviewerChecklistCombobox = ({
   }, [isLoading]);
 
   const handleToggle = (username: string) => {
-    if (query && !checkedUsers.has(username)) {
+    if (query && !isChecked(username)) {
       // Selecting from search leads the selected group; the list recompacts (drops
       // unselected rows, refreshes defaults) once the search is cleared.
-      setOrder((prev) => [username, ...prev.filter((u) => u !== username)]);
+      setOrder((prev) => [username, ...prev.filter((u) => normalizeUser(u) !== normalizeUser(username))]);
     }
     // With no search active, an in-place toggle never moves or removes a row.
-    onToggle(username);
+    // Emit the normalized identity so the caller's checked set stays canonical
+    // (it's seeded from the server-normalized assigned users); otherwise toggling
+    // a roster row whose casing differs from the stored value would add a
+    // duplicate instead of removing the member.
+    onToggle(normalizeUser(username));
   };
 
   // Recompact when a search is cleared (returning to the list view).
@@ -118,9 +142,11 @@ export const ReviewerChecklistCombobox = ({
   // more. The reason is surfaced as an inline hint row below rather than a
   // per-row `disabledReason` tooltip: the tooltip renders behind the dropdown
   // (which sits at an elevated z-index inside a modal), so it isn't visible.
-  const atLimit = maxSelected !== undefined && checkedUsers.size >= maxSelected;
+  // Count distinct reviewers case-insensitively, matching the deduped render, so a
+  // stray cased-duplicate in the caller's set can't trip the cap a slot early.
+  const atLimit = maxSelected !== undefined && checkedLower.size >= maxSelected;
   const renderItem = (username: string) => {
-    const checked = checkedUsers.has(username);
+    const checked = isChecked(username);
     return (
       <DialogComboboxOptionListCheckboxItem
         key={username}
@@ -141,7 +167,17 @@ export const ReviewerChecklistCombobox = ({
     if (!query) {
       return { matches: order, searchTruncated: false };
     }
-    const universe = [...new Set([...usernames, ...checkedUsers])];
+    // Dedupe case-insensitively with the roster listed first, so a selected
+    // off-roster user appears once and keeps the roster's display casing.
+    const seen = new Set<string>();
+    const universe: string[] = [];
+    for (const u of [...usernames, ...checkedUsers]) {
+      const key = normalizeUser(u);
+      if (!seen.has(key)) {
+        seen.add(key);
+        universe.push(u);
+      }
+    }
     const filtered = universe.filter((u) => u.toLowerCase().includes(query));
     return { matches: filtered.slice(0, MAX_SEARCH_MATCHES), searchTruncated: filtered.length > MAX_SEARCH_MATCHES };
   }, [order, usernames, checkedUsers, query]);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/queuePermissions.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/queuePermissions.ts
@@ -1,8 +1,14 @@
 import type { ReviewQueue } from './types';
 
+/**
+ * Canonical form of a user identifier. Mirrors the server's `normalize_user`
+ * (strip + lowercase): assigned users and user-queue names are stored normalized,
+ * while the user roster carries display casing, so compare/key on this form.
+ */
+export const normalizeUser = (user: string | undefined): string => (user ?? '').trim().toLowerCase();
+
 /** Case-insensitive identity compare (created_by may be normalized server-side). */
-export const sameUser = (a: string | undefined, b: string): boolean =>
-  (a ?? '').trim().toLowerCase() === b.trim().toLowerCase();
+export const sameUser = (a: string | undefined, b: string): boolean => normalizeUser(a) === normalizeUser(b);
 
 /** Whether the reviewer owns the queue (its server-stamped `created_by`). */
 export const isQueueOwner = (queue: ReviewQueue, reviewer: string): boolean => sameUser(queue.created_by, reviewer);


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

Usernames are stored normalized (lowercase) server-side (`normalize_user`), while the user roster (`useAssignableUsersQuery`) carries display casing. Two review-queue pickers compared/keyed usernames with an exact-case `Set`, so the two sources could disagree on casing.

**Bug (reviewer picker, `ReviewerChecklistCombobox`):** the checked state was `checkedUsers.has(username)`, exact-case. A member assigned as `alice` rendered **unchecked** against a roster row `Alice`. The fix:
- Compare on the normalized form (a shared `normalizeUser` helper, added next to the existing `sameUser`).
- Prefer the roster's display casing in the list and dedupe case-insensitively, so a member appears once under its display name.
- **Emit the normalized identity on toggle.** Without this, unchecking a case-mismatched member would `add` a cased duplicate (`Alice`) to the caller's lowercase-seeded `members` set instead of removing `alice`, leaving the row stuck checked and writing a duplicated reviewer on save. Count the cap case-insensitively for the same reason.

**Defensive hardening (Flag-for-review picker, `AddToReviewQueueDropdown`):** key `addedUsers` (seed / toggle / row checks) on the normalized form too. This is a robustness fix, not a user-visible bug: members are already excluded from the search results case-insensitively, so the prior exact-case keying was internally consistent within a session. I could not construct a flow where it mis-checked, so there is no regression test for it specifically; the change keeps the keying correct if the roster or membership casing ever diverges.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `ReviewerChecklistCombobox` tests: a case-mismatched member (stored `alice`, roster `Alice`) renders checked without a duplicate row; and a toggle round-trip that unchecks that member **removes** it (rather than adding a cased duplicate that leaves it checked). Existing picker tests still pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a review-queue bug where an assigned reviewer whose stored username casing differed from the roster rendered unchecked in the reviewers picker (and could not be unassigned correctly).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.