### PR TITLE
Add MLflow autologging integration for Aider CLI coding sessions

### DIFF
--- a/mlflow/aider/__init__.py
+++ b/mlflow/aider/__init__.py
@@ -1,0 +1,22 @@
+"""Aider integration for MLflow.
+
+This module provides automatic tracing of Aider coding sessions to MLflow.
+
+Usage::
+
+    import mlflow.aider
+    from aider.coders import Coder
+    from aider.models import Model
+
+    mlflow.aider.autolog()
+
+    coder = Coder.create(main_model=Model("gpt-4o"))
+    coder.run("Add type hints to all functions in utils.py")
+
+Traces will be captured in MLflow for each ``coder.run()`` call, including
+the prompt, model, in-chat files, LLM response, and token usage.
+"""
+
+from mlflow.aider.autolog import autolog
+
+__all__ = ["autolog"]

--- a/mlflow/aider/autolog.py
+++ b/mlflow/aider/autolog.py
@@ -1,0 +1,115 @@
+"""MLflow autologging integration for Aider coding sessions."""
+
+import functools
+import logging
+from typing import Any
+
+import mlflow
+from mlflow.entities import SpanType
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+
+_logger = logging.getLogger(__name__)
+
+_AIDER_PATCHED_ATTR = "_mlflow_patched"
+
+
+def autolog(disable: bool = False, silent: bool = False) -> None:
+    """Enable (or disable) automatic MLflow tracing for Aider coding sessions.
+
+    When enabled, every ``coder.run()`` call is wrapped in an MLflow trace that
+    captures the user prompt, model name, in-chat files, LLM response, and token
+    usage.
+
+    Args:
+        disable: If True, remove the autologging patches from Aider's Coder class.
+        silent: If True, suppress info-level log messages about patching status.
+    """
+    try:
+        from aider.coders import Coder
+    except ImportError as e:
+        raise ImportError(
+            "aider-chat is not installed. Install it with: pip install aider-chat"
+        ) from e
+
+    if disable:
+        _unpatch_coder(Coder)
+        if not silent:
+            _logger.info("MLflow Aider autologging disabled.")
+        return
+
+    _patch_coder(Coder)
+    if not silent:
+        _logger.info("MLflow Aider autologging enabled.")
+
+
+def _patch_coder(Coder: type) -> None:
+    if getattr(Coder, _AIDER_PATCHED_ATTR, False):
+        return
+
+    original_run_one = Coder.run_one
+
+    @functools.wraps(original_run_one)
+    def patched_run_one(self: Any, user_message: str, preproc: bool = True) -> str | None:
+        model_name = getattr(self.main_model, "name", "unknown")
+        in_chat_files = _get_chat_files(self)
+
+        # Snapshot token counts before the turn so we can compute per-turn usage.
+        tokens_sent_before = getattr(self, "total_tokens_sent", 0) or 0
+        tokens_received_before = getattr(self, "total_tokens_received", 0) or 0
+
+        with mlflow.start_span(
+            name="aider_turn",
+            span_type=SpanType.AGENT,
+        ) as span:
+            span.set_inputs({
+                "prompt": user_message,
+                "model": model_name,
+                "files": in_chat_files,
+            })
+            span.set_attribute("model", model_name)
+
+            result = original_run_one(self, user_message, preproc)
+
+            tokens_sent_after = getattr(self, "total_tokens_sent", 0) or 0
+            tokens_received_after = getattr(self, "total_tokens_received", 0) or 0
+            input_tokens = tokens_sent_after - tokens_sent_before
+            output_tokens = tokens_received_after - tokens_received_before
+
+            if input_tokens > 0 or output_tokens > 0:
+                span.set_attribute(
+                    SpanAttributeKey.CHAT_USAGE,
+                    {
+                        TokenUsageKey.INPUT_TOKENS: input_tokens,
+                        TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+                        TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
+                    },
+                )
+
+            total_cost = getattr(self, "total_cost", None)
+            if total_cost is not None:
+                span.set_attribute("total_cost_usd", total_cost)
+
+            span.set_outputs({"response": result or ""})
+
+        return result
+
+    Coder.run_one = patched_run_one
+    setattr(Coder, _AIDER_PATCHED_ATTR, True)
+
+
+def _unpatch_coder(Coder: type) -> None:
+    if not getattr(Coder, _AIDER_PATCHED_ATTR, False):
+        return
+
+    original = getattr(Coder.run_one, "__wrapped__", None)
+    if original is not None:
+        Coder.run_one = original
+
+    setattr(Coder, _AIDER_PATCHED_ATTR, False)
+
+
+def _get_chat_files(coder: Any) -> list[str]:
+    try:
+        return list(coder.get_inchat_relative_files())
+    except Exception:
+        return []

--- a/tests/aider/test_autolog.py
+++ b/tests/aider/test_autolog.py
@@ -1,0 +1,177 @@
+"""Tests for MLflow Aider autologging integration."""
+
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+import mlflow
+from mlflow.aider.autolog import _AIDER_PATCHED_ATTR, _get_chat_files, autolog
+from mlflow.entities import SpanType
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so tests run without aider-chat installed
+# ---------------------------------------------------------------------------
+
+
+class _FakeModel:
+    def __init__(self, name: str = "gpt-4o"):
+        self.name = name
+
+
+class _FakeCoder:
+    """Minimal stub that mirrors the Aider Coder interface used by autolog."""
+
+    main_model = _FakeModel()
+    total_tokens_sent = 0
+    total_tokens_received = 0
+    total_cost = 0.0
+
+    def run_one(self, user_message: str, preproc: bool = True) -> str:
+        self.total_tokens_sent += 100
+        self.total_tokens_received += 50
+        self.total_cost += 0.002
+        return f"Done: {user_message}"
+
+    def get_inchat_relative_files(self) -> list[str]:
+        return ["utils.py", "main.py"]
+
+
+def _make_aider_module() -> ModuleType:
+    """Build a fake `aider` package with a minimal `coders` sub-module."""
+    aider_mod = ModuleType("aider")
+    coders_mod = ModuleType("aider.coders")
+    coders_mod.Coder = _FakeCoder
+    aider_mod.coders = coders_mod
+    return aider_mod, coders_mod
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_aider(monkeypatch):
+    """Inject a fake aider package so tests never need aider-chat installed."""
+    aider_mod, coders_mod = _make_aider_module()
+    monkeypatch.setitem(sys.modules, "aider", aider_mod)
+    monkeypatch.setitem(sys.modules, "aider.coders", coders_mod)
+    # Reset patch state before each test
+    _FakeCoder._mlflow_patched = False
+    if hasattr(_FakeCoder.run_one, "__wrapped__"):
+        _FakeCoder.run_one = _FakeCoder.run_one.__wrapped__
+    yield
+    # Clean up patch state after each test
+    setattr(_FakeCoder, _AIDER_PATCHED_ATTR, False)
+
+
+# ---------------------------------------------------------------------------
+# Patching behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_autolog_patches_coder():
+    autolog()
+    assert getattr(_FakeCoder, _AIDER_PATCHED_ATTR, False) is True
+
+
+def test_autolog_is_idempotent():
+    autolog()
+    original_method = _FakeCoder.run_one
+    autolog()
+    assert _FakeCoder.run_one is original_method
+
+
+def test_autolog_disable_unpatches_coder():
+    autolog()
+    assert getattr(_FakeCoder, _AIDER_PATCHED_ATTR, False) is True
+    autolog(disable=True)
+    assert getattr(_FakeCoder, _AIDER_PATCHED_ATTR, False) is False
+
+
+def test_autolog_disable_when_not_patched_is_safe():
+    autolog(disable=True)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Trace content
+# ---------------------------------------------------------------------------
+
+
+def test_autolog_creates_trace_with_correct_inputs():
+    autolog()
+    coder = _FakeCoder()
+    coder.run_one("Add type hints to utils.py")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    root_span = trace.data.spans[0]
+    assert root_span.span_type == SpanType.AGENT
+    assert root_span.inputs["prompt"] == "Add type hints to utils.py"
+    assert root_span.inputs["model"] == "gpt-4o"
+    assert "utils.py" in root_span.inputs["files"]
+
+
+def test_autolog_captures_response():
+    autolog()
+    coder = _FakeCoder()
+    coder.run_one("Refactor main.py")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    root_span = trace.data.spans[0]
+    assert "Refactor main.py" in root_span.outputs["response"]
+
+
+def test_autolog_captures_token_usage():
+    autolog()
+    coder = _FakeCoder()
+    coder.run_one("Fix the bug")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    root_span = trace.data.spans[0]
+    usage = root_span.attributes.get(SpanAttributeKey.CHAT_USAGE)
+    assert usage is not None
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+
+
+def test_autolog_captures_total_cost():
+    autolog()
+    coder = _FakeCoder()
+    coder.run_one("Update README")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    root_span = trace.data.spans[0]
+    assert root_span.attributes.get("total_cost_usd") is not None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_autolog_raises_if_aider_not_installed(monkeypatch):
+    monkeypatch.delitem(sys.modules, "aider", raising=False)
+    monkeypatch.delitem(sys.modules, "aider.coders", raising=False)
+
+    with pytest.raises(ImportError, match="aider-chat"):
+        autolog()
+
+
+def test_get_chat_files_returns_empty_on_error():
+    class BrokenCoder:
+        def get_inchat_relative_files(self):
+            raise RuntimeError("broken")
+
+    assert _get_chat_files(BrokenCoder()) == []
+
+
+def test_autolog_handles_none_response():
+    autolog(disable=True)
+    original_run_one = _FakeCoder.run_one
+    _FakeCoder.run_one = mock.Mock(return_value=None)
+    _FakeCoder.total_tokens_sent = 0
+    _FakeCoder.total_tokens_received = 0
+    autolog()
+    coder = _FakeCoder()
+    result = coder.run_one("What is 2+2?", preproc=True)
+    assert result is None
+    _FakeCoder.run_one = original_run_one


### PR DESCRIPTION
## Summary

Partial implementation of #20307 — adds Aider CLI tracing support.

- Introduces `mlflow/aider/` module with `mlflow.aider.autolog()`
- Patches `Coder.run_one()` to wrap each coding turn with an MLflow `AGENT` span
- Captures: user prompt, model name, in-chat files, LLM response, per-turn token usage (input/output/total), and cumulative session cost
- Follows the same structure as `mlflow/claude_code/` (autolog pattern, `SpanAttributeKey.CHAT_USAGE`, `TokenUsageKey`)

## Usage

```python
import mlflow.aider
from aider.coders import Coder
from aider.models import Model

mlflow.aider.autolog()

coder = Coder.create(main_model=Model("gpt-4o"))
coder.run("Add type hints to all functions in utils.py")
# Trace is now visible in the MLflow UI
```

## Test plan

- [x] 11 unit tests added in `tests/aider/test_autolog.py`
- [x] Tests use a minimal `_FakeCoder` stub — no `aider-chat` install required
- [x] Covers: patch/unpatch idempotency, trace inputs/outputs, token usage, cost, error handling, `None` response
- [x] `ruff check` and `ruff format` pass with zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)