### PR TITLE
Send review-queue schema_ids only when the questions actually change

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.test.tsx
@@ -11,7 +11,25 @@ import Utils from '../../../common/utils/Utils';
 
 // The questions checklist and rich previews aren't under test here — the focus is
 // the schema-freeze save logic — so stub them out.
-jest.mock('./QuestionChecklistCombobox', () => ({ QuestionChecklistCombobox: () => null }));
+jest.mock('./QuestionChecklistCombobox', () => ({
+  // Expose `onToggle` per schema via buttons so a test can change the selected
+  // questions (toggle one off, another on, etc.).
+  QuestionChecklistCombobox: ({
+    schemas,
+    onToggle,
+  }: {
+    schemas: { schema_id: string }[];
+    onToggle: (id: string) => void;
+  }) => (
+    <>
+      {schemas.map((s) => (
+        <button key={s.schema_id} type="button" onClick={() => onToggle(s.schema_id)}>
+          {`toggle-question-${s.schema_id}`}
+        </button>
+      ))}
+    </>
+  ),
+}));
 // Stub the owner picker (its own UX is covered in OwnerCombobox.test.tsx): expose a
 // button that selects a fixed user, and keep the real reviewers picker the only
 // combobox so `getByRole('combobox')` stays unambiguous.
@@ -24,7 +42,10 @@ jest.mock('./OwnerCombobox', () => ({
 }));
 jest.mock('../../components/label-schemas', () => ({
   useListLabelSchemasQuery: () => ({
-    labelSchemas: [{ schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} }, enable_comment: true }],
+    labelSchemas: [
+      { schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} }, enable_comment: true },
+      { schema_id: 's2', name: 'Q2', type: 'FEEDBACK', input: { text: {} }, enable_comment: true },
+    ],
     isLoading: false,
   }),
   LabelSchemaInputRenderer: () => null,
@@ -96,12 +117,38 @@ describe('QueueSettingsModal save', () => {
       .mockImplementation(() => {});
   });
 
-  it('sends schema_ids when the queue has no traces (questions editable)', async () => {
+  it('omits schema_ids on a no-op save even when questions are editable', async () => {
+    // Editable but unchanged: re-writing the whole schema set would be needless
+    // churn and could clobber a concurrent question edit, so it's omitted.
     mockTraces = [];
     renderModal();
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
-    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ queue_id: 'rq-1', schema_ids: ['s1'] }));
+    const arg = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+    expect('schema_ids' in arg).toBe(false);
+    expect(arg).toMatchObject({ queue_id: 'rq-1' });
+  });
+
+  it('sends schema_ids only when the questions actually change', async () => {
+    mockTraces = [];
+    renderModal();
+    // Toggle the one selected question off, changing the set from ['s1'] to [].
+    fireEvent.click(screen.getByText('toggle-question-s1'));
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ queue_id: 'rq-1', schema_ids: [] }));
+  });
+
+  it('detects a same-size question swap (different members, not just count)', async () => {
+    // Swap s1 -> s2: the set stays size 1 but its membership changes, exercising
+    // the membership half of the change check (not just the size comparison).
+    mockTraces = [];
+    renderModal();
+    fireEvent.click(screen.getByText('toggle-question-s1'));
+    fireEvent.click(screen.getByText('toggle-question-s2'));
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ queue_id: 'rq-1', schema_ids: ['s2'] }));
   });
 
   it('omits schema_ids once the queue has traces (questions frozen)', async () => {
@@ -164,6 +211,8 @@ describe('QueueSettingsModal save', () => {
     expect('users' in arg).toBe(false);
     expect('name' in arg).toBe(false);
     expect('new_owner' in arg).toBe(false);
+    // Likewise the unchanged questions aren't rewritten.
+    expect('schema_ids' in arg).toBe(false);
   });
 
   it('toasts the error and keeps the modal open when the save fails', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
@@ -182,6 +182,10 @@ export const QueueSettingsModal = ({
     [queue.users, owner],
   );
   const membersChanged = members.size !== originalMembers.size || [...originalMembers].some((m) => !members.has(m));
+  const originalSchemaIds = useMemo(() => new Set(queue.schema_ids ?? []), [queue.schema_ids]);
+  const questionsChanged =
+    selectedSchemaIds.size !== originalSchemaIds.size ||
+    [...originalSchemaIds].some((id) => !selectedSchemaIds.has(id));
 
   const handleSave = async () => {
     try {
@@ -195,9 +199,11 @@ export const QueueSettingsModal = ({
         ...(membersChanged ? { users: Array.from(new Set([...(owner ? [owner] : []), ...members])) } : {}),
         ...(nameChanged ? { name: trimmedName } : {}),
         ...(ownerChanged ? { new_owner: trimmedNewOwner } : {}),
-        // Only send schema_ids when they're still editable; once the queue has
-        // traces (or the user lacks MANAGE) the backend freezes them.
-        ...(canEditQuestions ? { schema_ids: [...selectedSchemaIds] } : {}),
+        // Only send schema_ids when they're still editable AND actually changed:
+        // once the queue has traces (or the user lacks MANAGE) the backend freezes
+        // them, and a no-op rewrite would needlessly re-write the whole association
+        // set and clobber a concurrent question edit.
+        ...(canEditQuestions && questionsChanged ? { schema_ids: [...selectedSchemaIds] } : {}),
       });
       onClose();
     } catch (e) {


### PR DESCRIPTION
### Related Issues/PRs

Relates to the review-queue UI (no separate tracking issue).

### What changes are proposed in this pull request?

`QueueSettingsModal.handleSave` sent `schema_ids` on **every** save whenever the questions were editable — the only field not gated on a change check (`users`, `name`, and `new_owner` are all guarded by `membersChanged` / `nameChanged` / `ownerChanged`).

Two problems, both the ones the existing comment already calls out for `users`:

- **Clobbers a concurrent edit.** A reviewer who only renamed the queue (with a stale loaded question set) would, on save, rewrite the *old* `schema_ids` and silently revert another reviewer's question change.
- **Needless write churn.** The backend's `update_review_queue` deletes and re-inserts the entire `review_queue_label_schemas` association set whenever `schema_ids` is sent, and bumps `last_update_time_ms` — on every save, even a name-only edit.

Fix: add a `questionsChanged` set-diff (`selectedSchemaIds` vs `originalSchemaIds` from `queue.schema_ids`) and gate the field on `canEditQuestions && questionsChanged`, mirroring the existing `membersChanged` pattern. The frozen-once-traces and lacks-MANAGE behavior is unchanged (`canEditQuestions` still leads the condition).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated `QueueSettingsModal` tests: a no-op save (and the general unchanged-fields no-op) now asserts `schema_ids` is **omitted**; toggling a question off sends `schema_ids: []`; and a same-size swap (`s1` → `s2`) sends `schema_ids: ['s2']`, exercising the membership half of the diff (not just the size check). The frozen-when-traces-exist case is unchanged.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a review-queue issue where saving a queue's settings rewrote its full question set even when the questions were unchanged, which could revert a concurrent edit.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.