### PR TITLE
Surface review-queue self-assign failures with an error toast

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -139,14 +139,26 @@ const ExperimentReviewQueuePage = () => {
   const canReviewSelectedQueue = !authAvailable || (canEdit && isAssignedToSelectedQueue);
   const handleAssignSelf =
     authAvailable && canManageSelectedQueue && !canReviewSelectedQueue && selectedQueue
-      ? () => {
+      ? async () => {
           // KNOWN LIMITATION (V1): read-modify-write of the assignee list from a
           // possibly-stale snapshot races a concurrent manager edit. A server-side
           // append RPC would remove it.
-          void updateReviewQueueAsync({
-            queue_id: selectedQueue.queue_id,
-            users: [...(selectedQueue.users ?? []), reviewer],
-          });
+          try {
+            await updateReviewQueueAsync({
+              queue_id: selectedQueue.queue_id,
+              users: [...(selectedQueue.users ?? []), reviewer],
+            });
+          } catch (e) {
+            Utils.displayGlobalErrorNotification(
+              intl.formatMessage(
+                {
+                  defaultMessage: 'Could not assign yourself to the queue: {error}',
+                  description: 'Review queue: error toast when self-assigning to a queue fails',
+                },
+                { error: e instanceof Error ? e.message : String(e) },
+              ),
+            );
+          }
         }
       : undefined;
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -859,6 +859,10 @@
     "defaultMessage": "Load the model",
     "description": "Heading text for stating how to load the model from the experiment run"
   },
+  "2Noq+z": {
+    "defaultMessage": "Could not assign yourself to the queue: {error}",
+    "description": "Review queue: error toast when self-assigning to a queue fails"
+  },
   "2OifbU": {
     "defaultMessage": "Inputs cannot be empty",
     "description": "Status text shown in the dataset record drawer footer when the inputs editor is empty (would otherwise wipe the field server-side)"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

On the experiment review-queue page, the "Assign myself" button fired `updateReviewQueueAsync` as a fire-and-forget call (`void ...`). When the request failed, the rejected promise became an unhandled rejection: the user got no feedback at all, while the button's loading state simply resolved as if nothing happened.

This awaits the mutation in a `try/catch` and surfaces an error toast on failure, matching the delete-queue and copy-link error handling already in this page.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Reproduced the failure path (HTTP 500 on the update RPC) in the running UI.

Before: the 500 is swallowed, no toast, the failure surfaces only as an unhandled promise rejection.

https://github.com/user-attachments/assets/87d60c2f-8e82-4cae-877a-44f46456ffac

After: the 500 is caught and shown as `Could not assign yourself to the queue: <error>`.

https://github.com/user-attachments/assets/4df11efc-e8a9-4175-bf6f-90cd820990ef

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Failures when self-assigning to a review queue now show an error notification instead of failing silently.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)