### PR TITLE
Surface assignable-users load error in review-queue pickers

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -63,8 +63,9 @@ jest.mock('./hooks/useGetOrCreateUserQueueMutation', () => ({
   }),
 }));
 
+let mockUsersError: Error | null = null;
 jest.mock('./hooks/useAssignableUsersQuery', () => ({
-  useAssignableUsersQuery: () => ({ users: [], isLoading: false }),
+  useAssignableUsersQuery: () => ({ users: [], isLoading: false, error: mockUsersError }),
 }));
 // The experiment's queues (the unfiltered call). One assignable CUSTOM queue
 // (its schema_id resolves against the experiment schema below), so tests can
@@ -117,6 +118,7 @@ describe('AddToReviewQueueDropdown', () => {
     mockAuthAvailable = false;
     mockCanEdit = true;
     mockCanManage = false;
+    mockUsersError = null;
     mockMemberQueues = [];
     mockMembersLoading = false;
     mockListQueues = [
@@ -148,6 +150,17 @@ describe('AddToReviewQueueDropdown', () => {
     expect(screen.queryByText('Default queue')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Trigger'));
     expect(screen.getByText('Default queue')).toBeInTheDocument();
+  });
+
+  it('surfaces a failed user-roster load in the Users section instead of an empty state', () => {
+    // On an auth server the Users section lists assignable users; a failed load
+    // must show the error rather than the "Search by name" prompt (which would
+    // otherwise mask the failure until the reviewer types).
+    mockAuthAvailable = true;
+    mockUsersError = new Error('boom');
+    renderDropdown({ open: true });
+    expect(screen.getByText(/couldn't load users/i)).toBeInTheDocument();
+    expect(screen.queryByText(/search by name to add/i)).not.toBeInTheDocument();
   });
 
   it('immediately adds traces when a queue is clicked and shows a toast', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -118,7 +118,11 @@ export const AddToReviewQueueDropdown = ({
     error: queuesError,
   } = useListReviewQueuesQuery({ experimentId, enabled: isOpen || createOpen });
   const { labelSchemas } = useListLabelSchemasQuery({ experimentId, enabled: isOpen || createOpen });
-  const { users, isLoading: usersLoading } = useAssignableUsersQuery({
+  const {
+    users,
+    isLoading: usersLoading,
+    error: usersError,
+  } = useAssignableUsersQuery({
     enabled: (isOpen || createOpen) && canListUsers,
   });
   const { addItemsToReviewQueueAsync, reset: resetAdd } = useAddItemsToReviewQueueMutation();
@@ -561,7 +565,18 @@ export const AddToReviewQueueDropdown = ({
                             {username}
                           </DialogComboboxOptionListCheckboxItem>
                         ))}
-                        {!query ? (
+                        {usersError ? (
+                          // Error first: otherwise a failed roster load reads as the
+                          // search prompt or "No matching users", hiding the failure.
+                          <DialogComboboxEmpty
+                            emptyText={
+                              <FormattedMessage
+                                defaultMessage="Couldn't load users. Try again."
+                                description="Add to review queue: users roster failed to load"
+                              />
+                            }
+                          />
+                        ) : !query ? (
                           <DialogComboboxEmpty
                             emptyText={
                               <FormattedMessage

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/CreateReviewQueueModal.tsx
@@ -72,7 +72,11 @@ export const CreateReviewQueueModal = ({
   // Any authenticated user may list users server-side, so fetch the roster
   // whenever auth is on; the Reviewers picker is hidden otherwise.
   const canListUsers = authAvailable;
-  const { users: assignableUsers, isLoading: usersLoading } = useAssignableUsersQuery({ enabled: canListUsers });
+  const {
+    users: assignableUsers,
+    isLoading: usersLoading,
+    error: usersError,
+  } = useAssignableUsersQuery({ enabled: canListUsers });
 
   const [name, setName] = useState('');
   // No questions are selected by default; the creator chooses them.
@@ -269,6 +273,7 @@ export const CreateReviewQueueModal = ({
                   triggerValue={reviewersTriggerValue}
                   dropdownZIndex={dropdownZIndex}
                   isLoading={usersLoading}
+                  error={usersError}
                   // The creator is auto-added as a member, so reserve one slot for them.
                   maxSelected={MAX_ASSIGNED_USERS - 1}
                 />

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/OwnerCombobox.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/OwnerCombobox.test.tsx
@@ -7,12 +7,26 @@ import { IntlProvider } from '@databricks/i18n';
 
 import { OwnerCombobox } from './OwnerCombobox';
 
-const renderBox = ({ usernames, selectedUser = '' }: { usernames: string[]; selectedUser?: string }) => {
+const renderBox = ({
+  usernames,
+  selectedUser = '',
+  error,
+}: {
+  usernames: string[];
+  selectedUser?: string;
+  error?: Error | null;
+}) => {
   const onSelect = jest.fn();
   render(
     <IntlProvider locale="en">
       <DesignSystemProvider>
-        <OwnerCombobox componentId="test.owner" usernames={usernames} selectedUser={selectedUser} onSelect={onSelect} />
+        <OwnerCombobox
+          componentId="test.owner"
+          usernames={usernames}
+          selectedUser={selectedUser}
+          onSelect={onSelect}
+          error={error}
+        />
       </DesignSystemProvider>
     </IntlProvider>,
   );
@@ -123,6 +137,12 @@ describe('OwnerCombobox', () => {
   it('shows an empty state with no assignable users', () => {
     renderBox({ usernames: [] });
     expect(screen.getByText(/no assignable users/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a load error instead of the empty state', () => {
+    renderBox({ usernames: [], error: new Error('boom') });
+    expect(screen.getByText(/couldn't load users/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no assignable users/i)).not.toBeInTheDocument();
   });
 
   it('shows an empty state when the search matches nothing', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/OwnerCombobox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/OwnerCombobox.tsx
@@ -38,6 +38,7 @@ export const OwnerCombobox = ({
   disabled,
   dropdownZIndex,
   isLoading,
+  error,
 }: {
   componentId: string;
   usernames: string[];
@@ -47,6 +48,8 @@ export const OwnerCombobox = ({
   dropdownZIndex?: number;
   /** Whether the assignable-user roster is still loading (drives the empty state). */
   isLoading?: boolean;
+  /** Set when the roster failed to load; shown in place of the empty state. */
+  error?: Error | null;
 }) => {
   const intl = useIntl();
   const [search, setSearch] = useState('');
@@ -126,7 +129,14 @@ export const OwnerCombobox = ({
                   <DialogComboboxEmpty
                     key="__empty"
                     emptyText={
-                      query ? (
+                      // Error first: a failed roster load otherwise reads as an
+                      // empty roster ("No assignable users"), hiding the error.
+                      error ? (
+                        <FormattedMessage
+                          defaultMessage="Couldn't load users. Try again."
+                          description="Review queue: owner roster failed to load"
+                        />
+                      ) : query ? (
                         <FormattedMessage
                           defaultMessage="No matching users"
                           description="Review queue: no users match the owner search"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
@@ -60,7 +60,11 @@ export const QueueSettingsModal = ({
 
   const { labelSchemas, isLoading: schemasLoading } = useListLabelSchemasQuery({ experimentId: queue.experiment_id });
   const { items: traces, isLoading: itemsLoading } = useListReviewQueueItemsQuery({ queueId: queue.queue_id });
-  const { users: assignableUsers, isLoading: usersLoading } = useAssignableUsersQuery({ enabled: canListUsers });
+  const {
+    users: assignableUsers,
+    isLoading: usersLoading,
+    error: usersError,
+  } = useAssignableUsersQuery({ enabled: canListUsers });
   const { updateReviewQueueAsync, isUpdatingQueue } = useUpdateReviewQueueMutation();
 
   // Questions are an experiment-manager concern (`canManage`) and additionally
@@ -283,6 +287,7 @@ export const QueueSettingsModal = ({
                   onSelect={setNewOwner}
                   dropdownZIndex={dropdownZIndex}
                   isLoading={usersLoading}
+                  error={usersError}
                 />
               </div>
             )}
@@ -306,6 +311,7 @@ export const QueueSettingsModal = ({
                   triggerValue={reviewersTriggerValue}
                   dropdownZIndex={dropdownZIndex}
                   isLoading={usersLoading}
+                  error={usersError}
                   maxSelected={owner ? MAX_ASSIGNED_USERS - 1 : MAX_ASSIGNED_USERS}
                 />
               </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.test.tsx
@@ -7,7 +7,15 @@ import { IntlProvider } from '@databricks/i18n';
 
 import { ReviewerChecklistCombobox } from './ReviewerChecklistCombobox';
 
-const renderBox = ({ usernames, checkedUsers }: { usernames: string[]; checkedUsers: Set<string> }) => {
+const renderBox = ({
+  usernames,
+  checkedUsers,
+  error,
+}: {
+  usernames: string[];
+  checkedUsers: Set<string>;
+  error?: Error | null;
+}) => {
   const onToggle = jest.fn();
   render(
     <IntlProvider locale="en">
@@ -18,6 +26,7 @@ const renderBox = ({ usernames, checkedUsers }: { usernames: string[]; checkedUs
           checkedUsers={checkedUsers}
           onToggle={onToggle}
           triggerValue={[]}
+          error={error}
         />
       </DesignSystemProvider>
     </IntlProvider>,
@@ -253,6 +262,12 @@ describe('ReviewerChecklistCombobox', () => {
   it('shows an empty state with no assignable reviewers', () => {
     renderBox({ usernames: [], checkedUsers: new Set() });
     expect(screen.getByText(/no assignable reviewers/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a load error instead of the empty state', () => {
+    renderBox({ usernames: [], checkedUsers: new Set(), error: new Error('boom') });
+    expect(screen.getByText(/couldn't load reviewers/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no assignable reviewers/i)).not.toBeInTheDocument();
   });
 
   it('shows an empty state when the search matches nothing', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewerChecklistCombobox.tsx
@@ -52,6 +52,7 @@ export const ReviewerChecklistCombobox = ({
   disabled,
   dropdownZIndex,
   isLoading,
+  error,
   maxSelected,
 }: {
   componentId: string;
@@ -64,6 +65,8 @@ export const ReviewerChecklistCombobox = ({
   dropdownZIndex?: number;
   /** Whether the assignable-user roster is still loading (gates the initial seed). */
   isLoading?: boolean;
+  /** Set when the roster failed to load; shown in place of the empty state. */
+  error?: Error | null;
   /** Max reviewers selectable; unchecked rows disable once this many are checked. */
   maxSelected?: number;
 }) => {
@@ -222,7 +225,14 @@ export const ReviewerChecklistCombobox = ({
                   <DialogComboboxEmpty
                     key="__empty"
                     emptyText={
-                      query ? (
+                      // Error first: a failed roster load otherwise reads as an
+                      // empty roster ("No assignable reviewers"), hiding the error.
+                      error ? (
+                        <FormattedMessage
+                          defaultMessage="Couldn't load reviewers. Try again."
+                          description="Review queue: reviewers roster failed to load"
+                        />
+                      ) : query ? (
                         <FormattedMessage
                           defaultMessage="No matching reviewers"
                           description="Review queue: no reviewers match the search"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -435,6 +435,10 @@
     "defaultMessage": "{formattedAverage} (AVG)",
     "description": "Label showing the average value of numeric assessments"
   },
+  "/z8VeL": {
+    "defaultMessage": "Couldn't load users. Try again.",
+    "description": "Add to review queue: users roster failed to load"
+  },
   "/zbm8T": {
     "defaultMessage": "Continue editing the question to see a preview.",
     "description": "Review question preview render-error empty description"
@@ -5631,6 +5635,10 @@
     "defaultMessage": "Advanced settings (optional)",
     "description": "Toggle button for advanced settings in prompt creation modal"
   },
+  "R1kmVV": {
+    "defaultMessage": "Couldn't load reviewers. Try again.",
+    "description": "Review queue: reviewers roster failed to load"
+  },
   "R28jzs": {
     "defaultMessage": "Action",
     "description": "Guardrail action column header"
@@ -6934,6 +6942,10 @@
   "XIWwOm": {
     "defaultMessage": "Session ID",
     "description": "Label for the session id section"
+  },
+  "XIicPZ": {
+    "defaultMessage": "Couldn't load users. Try again.",
+    "description": "Review queue: owner roster failed to load"
   },
   "XJP2Uv": {
     "defaultMessage": "Pick a workspace from the workspace selector to see its roles.",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The assignable-users query (`useAssignableUsersQuery`) already returned its `error`, but all three consumers dropped it. On a failed `users/list` call the hook falls back to an empty roster, so the picker silently rendered its "No assignable reviewers" / "No assignable users" empty state — indistinguishable from a genuinely empty roster. A 500 or permission failure looked like "there's nobody to assign."

This threads the hook's `error` into the two pickers (`ReviewerChecklistCombobox`, `OwnerCombobox`) and the inline user list in `AddToReviewQueueDropdown`, and renders an error message ("Couldn't load reviewers/users. Try again.") in place of the empty-state text. The error branch is checked **first**, ahead of the search/loading/empty branches, in all three surfaces, so the failure is never masked by a search prompt or "no matches" text.

Scope is intentionally limited to replacing the misleading empty-state text (no toast, no banner), keeping the message co-located in the picker where the user is looking.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added error-state tests for all three surfaces: `ReviewerChecklistCombobox`, `OwnerCombobox`, and the `AddToReviewQueueDropdown` user list (asserting the error text shows and the empty/prompt text does not).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Review-queue user pickers now show a load error instead of silently displaying an empty roster when the assignable-users list fails to load.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.