### PR TITLE
Capture OTLP protobuf spans at WAL-write time for TS SDK

### DIFF
--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -41,6 +41,7 @@
     "@databricks/sdk-experimental": "0.15.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.205.0",
+    "@opentelemetry/otlp-transformer": "^0.205.0",
     "@opentelemetry/sdk-node": "^0.205.0",
     "@opentelemetry/sdk-trace-base": "^2.1.0",
     "fast-safe-stringify": "^2.1.1",

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -14,17 +14,22 @@ import { WalRecord } from './types';
  * endpoint
  */
 function serializeSpansToOtlpBase64(spans: OTelReadableSpan[]): string | undefined {
-  if (spans.length === 0) {
+  const serializable = spans.filter((s) => s?.resource != null && s?.instrumentationScope != null);
+  if (serializable.length === 0) {
     return undefined;
   }
   try {
-    const bytes = ProtobufTraceSerializer.serializeRequest(spans);
+    const bytes = ProtobufTraceSerializer.serializeRequest(serializable);
     if (!bytes || bytes.length === 0) {
       return undefined;
     }
     return Buffer.from(bytes).toString('base64');
   } catch (err) {
-    console.warn('[mlflow][wal] Failed to serialize spans to OTLP protobuf.', err);
+    console.warn(
+      '[mlflow][wal] Failed to serialize spans to OTLP protobuf; ' +
+        'falling back to JSON artifact upload (spans will not appear in DB-backed span metrics).',
+      err,
+    );
     return undefined;
   }
 }

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -1,10 +1,36 @@
 import { randomUUID } from 'node:crypto';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan as OTelReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { getConfig, MLflowTracingConfig } from '../../core/config';
 import { InMemoryTraceManager } from '../../core/trace_manager';
 import { submitRecord } from './ipc';
 import { WalRecord } from './types';
+
+/**
+ * Serialize live OTel spans into a base64-encoded OTLP
+ * `ExportTraceServiceRequest` protobuf, suitable for storing on a
+ * {@link WalRecord} and later POSTing to the server's OTLP span-ingestion
+ * endpoint
+ */
+function serializeSpansToOtlpBase64(spans: OTelReadableSpan[]): string | undefined {
+  if (spans.length === 0) {
+    return undefined;
+  }
+  try {
+    const bytes = ProtobufTraceSerializer.serializeRequest(spans);
+    if (!bytes || bytes.length === 0) {
+      return undefined;
+    }
+    return Buffer.from(bytes).toString('base64');
+  } catch (err) {
+    console.warn(
+      '[mlflow][wal] Failed to serialize spans to OTLP protobuf.',
+      err,
+    );
+    return undefined;
+  }
+}
 
 /**
  * Hook-side submit function. Returns once the daemon has fsynced the
@@ -62,6 +88,8 @@ export class MlflowWalSpanExporter implements SpanExporter {
 
       traceManager.lastActiveTraceId = trace.info.traceId;
 
+      const otlpSpans = serializeSpansToOtlpBase64(trace.data.spans.map((s) => s._span));
+
       const record: WalRecord = {
         id: randomUUID(),
         trackingUri: cfg.trackingUri,
@@ -71,6 +99,7 @@ export class MlflowWalSpanExporter implements SpanExporter {
         attempts: 0,
         nextAttemptAt: 0,
         createdAt: Date.now(),
+        otlpSpans,
       };
 
       const pending = this._submit(record).catch((err) => {

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -24,10 +24,7 @@ function serializeSpansToOtlpBase64(spans: OTelReadableSpan[]): string | undefin
     }
     return Buffer.from(bytes).toString('base64');
   } catch (err) {
-    console.warn(
-      '[mlflow][wal] Failed to serialize spans to OTLP protobuf.',
-      err,
-    );
+    console.warn('[mlflow][wal] Failed to serialize spans to OTLP protobuf.', err);
     return undefined;
   }
 }

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -458,7 +458,9 @@ describe('wal/exporter', () => {
 
     const record = submit.mock.calls[0][0];
     expect(typeof record.otlpSpans).toBe('string');
-    expect(Buffer.from(record.otlpSpans as string, 'base64').length).toBeGreaterThan(0);
+    const decoded = Buffer.from(record.otlpSpans as string, 'base64');
+    expect(decoded[0]).toBe(0x0a);
+    expect(decoded.includes(Buffer.from('tool-call'))).toBe(true);
   });
 
   it('warns and submits without otlpSpans when OTLP serialization throws', async () => {

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -54,7 +54,11 @@ function makeTraceWithSpans(traceId: string): Trace {
 
   const provider = new BasicTracerProvider();
   const tracer = provider.getTracer('wal-exporter-test');
-  const otelSpan = tracer.startSpan('tool-call', { kind: SpanKind.INTERNAL }, ROOT_CONTEXT) as OTelSpan;
+  const otelSpan = tracer.startSpan(
+    'tool-call',
+    { kind: SpanKind.INTERNAL },
+    ROOT_CONTEXT,
+  ) as OTelSpan;
   otelSpan.setAttribute(SpanAttributeKey.TRACE_ID, JSON.stringify(traceId));
   otelSpan.end();
 

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -1,16 +1,24 @@
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { ROOT_CONTEXT, SpanKind } from '@opentelemetry/api';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
-import { ReadableSpan as OTelReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  BasicTracerProvider,
+  ReadableSpan as OTelReadableSpan,
+  Span as OTelSpan,
+} from '@opentelemetry/sdk-trace-base';
+import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { MlflowWalSpanExporter } from '../../../src/exporters/wal/exporter';
 import { init, resetConfig } from '../../../src/core/config';
 import { InMemoryTraceManager } from '../../../src/core/trace_manager';
 import { Trace } from '../../../src/core/entities/trace';
+import { Span as MlflowSpan } from '../../../src/core/entities/span';
 import { TraceInfo } from '../../../src/core/entities/trace_info';
 import { TraceData } from '../../../src/core/entities/trace_data';
 import { createTraceLocationFromExperimentId } from '../../../src/core/entities/trace_location';
 import { TraceState } from '../../../src/core/entities/trace_state';
+import { SpanAttributeKey } from '../../../src/core/constants';
 import type { WalRecord } from '../../../src/exporters/wal/types';
 
 function makeTrace(traceId: string): Trace {
@@ -26,6 +34,31 @@ function makeTrace(traceId: string): Trace {
   });
   const data = new TraceData([]);
   return new Trace(info, data);
+}
+
+/**
+ * Build a trace whose `data.spans` carries real, ended OTel spans (wrapped in
+ * MLflow `Span`s) so the exporter's OTLP serialization runs end-to-end
+ */
+function makeTraceWithSpans(traceId: string): Trace {
+  const info = new TraceInfo({
+    traceId,
+    traceLocation: createTraceLocationFromExperimentId('exp-test'),
+    requestTime: 1_700_000_000_000,
+    state: TraceState.OK,
+    executionDuration: 42,
+    traceMetadata: { 'mlflow.trace.schemaVersion': '3' },
+    tags: {},
+    assessments: [],
+  });
+
+  const provider = new BasicTracerProvider();
+  const tracer = provider.getTracer('wal-exporter-test');
+  const otelSpan = tracer.startSpan('tool-call', { kind: SpanKind.INTERNAL }, ROOT_CONTEXT) as OTelSpan;
+  otelSpan.setAttribute(SpanAttributeKey.TRACE_ID, JSON.stringify(traceId));
+  otelSpan.end();
+
+  return new Trace(info, new TraceData([new MlflowSpan(otelSpan)]));
 }
 
 function makeSpan(opts: { traceId: string; rootSpan: boolean; name?: string }): OTelReadableSpan {
@@ -359,6 +392,78 @@ describe('wal/exporter', () => {
       );
     } finally {
       errSpy.mockRestore();
+    }
+  });
+
+  it('captures OTLP protobuf bytes on the record when the trace has spans', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTraceWithSpans('tr-with-spans'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback, promise } = captureExportResult();
+    exporter.export([span], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    await exporter.forceFlush();
+
+    const record = submit.mock.calls[0][0];
+    expect(typeof record.otlpSpans).toBe('string');
+    // Valid base64 that decodes to a non-empty OTLP ExportTraceServiceRequest.
+    const decoded = Buffer.from(record.otlpSpans as string, 'base64');
+    expect(decoded.length).toBeGreaterThan(0);
+    // The JSON trace data is retained alongside the OTLP bytes (artifact fallback).
+    expect((record.traceData as { spans: unknown[] }).spans).toHaveLength(1);
+  });
+
+  it('omits otlpSpans when the trace has no spans', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTrace('tr-no-spans'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback, promise } = captureExportResult();
+    exporter.export([span], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    await exporter.forceFlush();
+
+    const record = submit.mock.calls[0][0];
+    expect(record.otlpSpans).toBeUndefined();
+  });
+
+  it('warns and submits without otlpSpans when OTLP serialization throws', async () => {
+    const serializeSpy = jest
+      .spyOn(ProtobufTraceSerializer, 'serializeRequest')
+      .mockImplementation(() => {
+        throw new Error('boom');
+      });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTraceWithSpans('tr-serialize-fail'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    try {
+      const { callback, promise } = captureExportResult();
+      exporter.export([span], callback);
+
+      expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+      await exporter.forceFlush();
+
+      // The record is still submitted (artifact fallback), just without spans.
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit.mock.calls[0][0].otlpSpans).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to serialize spans to OTLP protobuf'),
+        expect.any(Error),
+      );
+    } finally {
+      serializeSpy.mockRestore();
+      warnSpy.mockRestore();
     }
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -414,9 +414,12 @@ describe('wal/exporter', () => {
 
     const record = submit.mock.calls[0][0];
     expect(typeof record.otlpSpans).toBe('string');
-    // Valid base64 that decodes to a non-empty OTLP ExportTraceServiceRequest.
     const decoded = Buffer.from(record.otlpSpans as string, 'base64');
-    expect(decoded.length).toBeGreaterThan(0);
+
+    expect(decoded[0]).toBe(0x0a);
+    // And the span itself must be encoded in the payload, not just an empty
+    // envelope: its name is embedded as a UTF-8 string in the protobuf.
+    expect(decoded.includes(Buffer.from('tool-call'))).toBe(true);
     // The JSON trace data is retained alongside the OTLP bytes (artifact fallback).
     expect((record.traceData as { spans: unknown[] }).spans).toHaveLength(1);
   });

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -13,7 +13,7 @@ import { MlflowWalSpanExporter } from '../../../src/exporters/wal/exporter';
 import { init, resetConfig } from '../../../src/core/config';
 import { InMemoryTraceManager } from '../../../src/core/trace_manager';
 import { Trace } from '../../../src/core/entities/trace';
-import { Span as MlflowSpan } from '../../../src/core/entities/span';
+import { Span as MlflowSpan, NoOpSpan } from '../../../src/core/entities/span';
 import { TraceInfo } from '../../../src/core/entities/trace_info';
 import { TraceData } from '../../../src/core/entities/trace_data';
 import { createTraceLocationFromExperimentId } from '../../../src/core/entities/trace_location';
@@ -436,6 +436,26 @@ describe('wal/exporter', () => {
 
     const record = submit.mock.calls[0][0];
     expect(record.otlpSpans).toBeUndefined();
+  });
+
+  it('filters malformed spans (missing resource/scope) and still serializes the valid ones', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    const trace = makeTraceWithSpans('tr-mixed');
+    trace.data.spans.push(new NoOpSpan());
+    popTraceSpy.mockReturnValue(trace);
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback, promise } = captureExportResult();
+    exporter.export([span], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    await exporter.forceFlush();
+
+    const record = submit.mock.calls[0][0];
+    expect(typeof record.otlpSpans).toBe('string');
+    expect(Buffer.from(record.otlpSpans as string, 'base64').length).toBeGreaterThan(0);
   });
 
   it('warns and submits without otlpSpans when OTLP serialization throws', async () => {

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -21,6 +21,7 @@
         "@databricks/sdk-experimental": "0.15.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.205.0",
+        "@opentelemetry/otlp-transformer": "^0.205.0",
         "@opentelemetry/sdk-node": "^0.205.0",
         "@opentelemetry/sdk-trace-base": "^2.1.0",
         "bignumber.js": "^9.0.0",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24022/files) to review incremental changes.
- [stack/ts-sdk-tool-calls-fix](https://github.com/mlflow/mlflow/pull/24019) [[Files changed](https://github.com/mlflow/mlflow/pull/24019/files)] [MERGED]
  - [**stack/capture-otlp-at-wal**](https://github.com/mlflow/mlflow/pull/24022) [[Files changed](https://github.com/mlflow/mlflow/pull/24022/files)]
    - [stack/oss-otlp-endpoint](https://github.com/mlflow/mlflow/pull/24030) [[Files changed](https://github.com/mlflow/mlflow/pull/24030/files/121fbf37fde8febcb70d653857f69438f25ccf74..fae7292b34a6f72718f23e097c5067a403e85b88)]
      - [stack/update-ipc-request-limit-for-otlp](https://github.com/mlflow/mlflow/pull/24032) [[Files changed](https://github.com/mlflow/mlflow/pull/24032/files/fae7292b34a6f72718f23e097c5067a403e85b88..1186dc37b786b6415455af75bd5954f6061da6e9)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Second step toward persisting TypeScript-SDK spans to the tracking-store DB (so span metrics like the Experiment Overview "Tool calls" tab work for TS traces). This change captures the spans as OTLP at the only point where live OTel ReadableSpans are available — the WAL exporter, in-process at trace end — and stashes them on the WAL record for the daemon to send later.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
