### PR TITLE
Enable inline endpoint creation in Playground selector (re-land of #23872)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
@@ -61,7 +61,7 @@ export const PlaygroundTopBar = ({
         componentIdPrefix="mlflow.playground.endpoint-selector"
         currentEndpointName={endpointName}
         onEndpointSelect={onEndpointSelect}
-        showCreateButton={false}
+        showCreateButton
         triggerMaxWidth={400}
       />
       <ParametersButton


### PR DESCRIPTION
### Related Issues/PRs

Re-lands #23872, which was merged into the `feat/playground` branch on 2026-06-11
but was lost when `feat/playground` was force-pushed/rebased before being
squash-merged to `master` as #23273 (same root cause as #23852, re-landed in
#24023).

### What changes are proposed in this pull request?

Enables inline endpoint creation in the Playground endpoint selector by passing
`showCreateButton` to the selector (it was hardcoded to `false` on `master`).
This is a one-line re-application of #23872.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Re-land of previously reviewed and merged #23872.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No. (Restores behavior for the unreleased Prompt Playground feature.)

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - This PR does not need to be mentioned in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Co-authored-by: Haoji Tang <haoji.tang@databricks.com>
