### PR TITLE
Prefill review answers from the most recent assessment by timestamp

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/reviewAnswers.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/reviewAnswers.test.ts
@@ -227,3 +227,131 @@ describe('buildPrefilledRationales', () => {
     expect(buildPrefilledRationales(priors, schemas)).toEqual({ correctness: 'second' });
   });
 });
+
+describe('most-recent selection by timestamp (not array order)', () => {
+  const schemas = [schema('correctness', 'FEEDBACK')];
+
+  // The fresh assessment is FIRST in the array but carries the newer timestamp;
+  // the stale one is LAST. The old `.at(-1)` array-order pick would wrongly
+  // choose the stale one, since the response order is backend heap-dependent.
+  const outOfOrder: RawTraceAssessment[] = [
+    {
+      assessment_id: 'fresh',
+      assessment_name: 'correctness',
+      feedback: { value: false },
+      rationale: 'fresh',
+      last_update_time: '2025-04-19T10:00:00.000Z',
+    },
+    {
+      assessment_id: 'stale',
+      assessment_name: 'correctness',
+      feedback: { value: true },
+      rationale: 'stale',
+      last_update_time: '2025-04-19T08:00:00.000Z',
+    },
+  ];
+
+  it('prefills the answer with the newest last_update_time, not the last in the array', () => {
+    expect(buildPrefilledAnswers(extractPriorAnswers(outOfOrder), schemas)).toEqual({ correctness: false });
+  });
+
+  it('prefills the rationale from the newest assessment', () => {
+    expect(buildPrefilledRationales(extractPriorAnswers(outOfOrder), schemas)).toEqual({ correctness: 'fresh' });
+  });
+
+  it('supersedes the newest assessment id', () => {
+    expect(buildPriorAssessmentIds(extractPriorAnswers(outOfOrder), schemas)).toEqual({ correctness: 'fresh' });
+  });
+
+  it('falls back to create_time when last_update_time is absent', () => {
+    const byCreateTime: RawTraceAssessment[] = [
+      {
+        assessment_id: 'fresh',
+        assessment_name: 'correctness',
+        feedback: { value: false },
+        create_time: '2025-04-19T10:00:00.000Z',
+      },
+      {
+        assessment_id: 'stale',
+        assessment_name: 'correctness',
+        feedback: { value: true },
+        create_time: '2025-04-19T08:00:00.000Z',
+      },
+    ];
+    expect(buildPriorAssessmentIds(extractPriorAnswers(byCreateTime), schemas)).toEqual({ correctness: 'fresh' });
+  });
+
+  it('falls back to array order when timestamps are equal', () => {
+    // Equal timestamps -> last in array wins, preserving the old `.at(-1)` behavior.
+    const sameTime: RawTraceAssessment[] = [
+      {
+        assessment_id: 'a1',
+        assessment_name: 'correctness',
+        feedback: { value: true },
+        last_update_time: '2025-04-19T10:00:00.000Z',
+      },
+      {
+        assessment_id: 'a2',
+        assessment_name: 'correctness',
+        feedback: { value: false },
+        last_update_time: '2025-04-19T10:00:00.000Z',
+      },
+    ];
+    expect(buildPriorAssessmentIds(extractPriorAnswers(sameTime), schemas)).toEqual({ correctness: 'a2' });
+  });
+
+  it('prefers a timestamped answer over an un-timestamped one regardless of array position', () => {
+    // The timestamped (fresh) answer is FIRST; the un-timestamped one is LAST.
+    // A missing timestamp sorts oldest, so the timestamped answer still wins.
+    const mixed: RawTraceAssessment[] = [
+      {
+        assessment_id: 'timestamped',
+        assessment_name: 'correctness',
+        feedback: { value: false },
+        last_update_time: '2025-04-19T10:00:00.000Z',
+      },
+      { assessment_id: 'untimed', assessment_name: 'correctness', feedback: { value: true } },
+    ];
+    expect(buildPriorAssessmentIds(extractPriorAnswers(mixed), schemas)).toEqual({ correctness: 'timestamped' });
+  });
+
+  it('treats an unparseable timestamp as missing (sorts oldest)', () => {
+    const badTime: RawTraceAssessment[] = [
+      {
+        assessment_id: 'valid-time',
+        assessment_name: 'correctness',
+        feedback: { value: false },
+        last_update_time: '2025-04-19T10:00:00.000Z',
+      },
+      {
+        assessment_id: 'garbage-time',
+        assessment_name: 'correctness',
+        feedback: { value: true },
+        last_update_time: 'not-a-date',
+      },
+    ];
+    expect(buildPriorAssessmentIds(extractPriorAnswers(badTime), schemas)).toEqual({ correctness: 'valid-time' });
+  });
+
+  it('prefers last_update_time over create_time when both are present', () => {
+    // The fresher last_update_time belongs to the assessment with the OLDER
+    // create_time, so a create_time-based pick would choose the wrong one.
+    const both: RawTraceAssessment[] = [
+      {
+        assessment_id: 'newer-update',
+        assessment_name: 'correctness',
+        feedback: { value: false },
+        create_time: '2025-04-19T08:00:00.000Z',
+        last_update_time: '2025-04-19T12:00:00.000Z',
+      },
+      {
+        assessment_id: 'older-update',
+        assessment_name: 'correctness',
+        feedback: { value: true },
+        create_time: '2025-04-19T10:00:00.000Z',
+        last_update_time: '2025-04-19T11:00:00.000Z',
+      },
+    ];
+    expect(buildPriorAssessmentIds(extractPriorAnswers(both), schemas)).toEqual({ correctness: 'newer-update' });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/reviewAnswers.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/reviewAnswers.ts
@@ -34,6 +34,12 @@ export interface PriorAnswer {
   valid: boolean;
   /** The source assessment's id, so a re-submit can supersede it. */
   assessmentId?: string;
+  /**
+   * Epoch ms from the assessment's `last_update_time` (falling back to
+   * `create_time`); `undefined` when neither is present or parseable. Used to
+   * pick the most recent answer per schema instead of trusting array order.
+   */
+  updatedAt?: number;
 }
 
 /**
@@ -49,7 +55,28 @@ export interface RawTraceAssessment {
   source?: { source_id?: string; source_type?: string };
   feedback?: { value?: LabelSchemaValue };
   expectation?: { value?: LabelSchemaValue; serialized_value?: { value?: string } };
+  /**
+   * ISO-8601 timestamps. Used to pick the most recent answer per schema rather
+   * than trusting the response array order, which comes from an unordered
+   * SQLAlchemy backref and is backend heap-dependent.
+   */
+  create_time?: string;
+  last_update_time?: string;
 }
+
+/**
+ * Comparable recency for an assessment: `last_update_time` (reflects the latest
+ * write) preferred, else `create_time`. `undefined` when neither is present or
+ * parseable, which sorts oldest.
+ */
+const assessmentTime = (assessment: RawTraceAssessment): number | undefined => {
+  const raw = assessment.last_update_time ?? assessment.create_time;
+  if (!raw) {
+    return undefined;
+  }
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? undefined : ms;
+};
 
 /**
  * Normalize raw trace assessments into {@link PriorAnswer}s. Feedback and
@@ -110,10 +137,27 @@ export const extractPriorAnswers = (assessments: RawTraceAssessment[], reviewerS
       rationale: assessment.rationale,
       valid: assessment.valid !== false,
       assessmentId: assessment.assessment_id,
+      updatedAt: assessmentTime(assessment),
     });
   }
   return priors;
 };
+
+/**
+ * The most recent valid prior answer matching a schema's name and kind, by
+ * `updatedAt`. Same-name duplicates accumulate across reopen/resubmit, so the
+ * latest timestamp wins rather than the last array position (the response order
+ * is backend heap-dependent). A missing timestamp sorts oldest, so a timestamped
+ * answer always beats an un-timestamped one; among equal timestamps (including
+ * when every match lacks one) the last in array order wins, preserving the
+ * previous `.at(-1)` behavior.
+ */
+const pickMostRecent = (priors: PriorAnswer[], name: string, kind: AssessmentKind): PriorAnswer | undefined =>
+  priors
+    .filter((p) => p.valid && p.name === name && p.kind === kind)
+    .reduce<
+      PriorAnswer | undefined
+    >((best, p) => (best === undefined || (p.updatedAt ?? 0) >= (best.updatedAt ?? 0) ? p : best), undefined);
 
 /**
  * Seed the focused-review widgets from a trace's existing answers.
@@ -130,8 +174,7 @@ export const buildPrefilledAnswers = (
   const prefilled: Record<string, LabelSchemaValue> = {};
   for (const schema of schemas) {
     const kind = schemaAssessmentKind(schema);
-    // Last match wins: later assessments override earlier ones for the same name.
-    const match = priors.filter((p) => p.valid && p.name === schema.name && p.kind === kind).at(-1);
+    const match = pickMostRecent(priors, schema.name, kind);
     if (match) {
       prefilled[schema.name] = match.value;
     }
@@ -142,13 +185,13 @@ export const buildPrefilledAnswers = (
 /**
  * Seed the focused-review rationale boxes from a trace's existing answers, so a
  * reopened trace shows the rationale recorded alongside each prior answer.
- * Same name/kind/last-wins matching as {@link buildPrefilledAnswers}.
+ * Same name/kind/most-recent matching as {@link buildPrefilledAnswers}.
  */
 export const buildPrefilledRationales = (priors: PriorAnswer[], schemas: LabelSchema[]): Record<string, string> => {
   const prefilled: Record<string, string> = {};
   for (const schema of schemas) {
     const kind = schemaAssessmentKind(schema);
-    const match = priors.filter((p) => p.valid && p.name === schema.name && p.kind === kind).at(-1);
+    const match = pickMostRecent(priors, schema.name, kind);
     if (match?.rationale) {
       prefilled[schema.name] = match.rationale;
     }
@@ -159,7 +202,7 @@ export const buildPrefilledRationales = (priors: PriorAnswer[], schemas: LabelSc
 /**
  * Map each schema to the assessment id of the reviewer's most recent valid prior
  * answer for it, so a re-submit can supersede that assessment (via `overrides`)
- * instead of accumulating a duplicate. Same name/kind/last-wins matching as
+ * instead of accumulating a duplicate. Same name/kind/most-recent matching as
  * {@link buildPrefilledAnswers}; `priors` should already be scoped to the
  * current reviewer (see {@link extractPriorAnswers}).
  */
@@ -167,7 +210,7 @@ export const buildPriorAssessmentIds = (priors: PriorAnswer[], schemas: LabelSch
   const ids: Record<string, string> = {};
   for (const schema of schemas) {
     const kind = schemaAssessmentKind(schema);
-    const match = priors.filter((p) => p.valid && p.name === schema.name && p.kind === kind).at(-1);
+    const match = pickMostRecent(priors, schema.name, kind);
     if (match?.assessmentId) {
       ids[schema.name] = match.assessmentId;
     }


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Review-queue focused-review prefill selected the "most recent" prior assessment with `.at(-1)` on the trace-get assessments array. But that array order comes from an unordered SQLAlchemy `backref("assessments")` (no `order_by`) — heap/engine-dependent, and a Postgres `UPDATE` can relocate a row. Same-name assessments also accumulate across reopen/resubmit (every Submit creates new ones). So `.at(-1)` ≠ "most recent," and a reopened trace could prefill a **stale** answer, a stale rationale, or supersede the wrong assessment id.

This fix selects by timestamp instead of array position:

- `RawTraceAssessment` now captures `create_time` / `last_update_time` (ISO-8601 strings already present on the trace-get payload — the same fields the trace explorer reads).
- `extractPriorAnswers` derives an `updatedAt` epoch-ms on each `PriorAnswer` (`last_update_time`, falling back to `create_time`; `undefined` when absent/unparseable).
- A shared `pickMostRecent(priors, name, kind)` helper replaces the three `.at(-1)` call sites, picking the max-`updatedAt` valid match. A missing timestamp sorts oldest; equal timestamps fall back to array order, preserving the previous last-wins behavior.

This mirrors the model trace explorer, which already sorts assessments by `new Date(last_update_time).getTime()`. Frontend-only; the unordered backref is left as-is since the client no longer relies on its order.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `reviewAnswers.test.ts` cases: newest-`last_update_time` wins regardless of array position, `create_time` fallback, equal-timestamp tie -> array order, timestamped beats un-timestamped regardless of position, unparseable timestamp treated as missing, and `last_update_time` precedence over `create_time`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Reopening a labeled trace now prefills the most recent recorded answer rather than an arbitrary one when multiple answers share a name.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.