### PR TITLE
Surface review-queue trace-removal failures and keep the selection on error

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -73,7 +73,7 @@ const ExperimentReviewQueuePage = () => {
   });
   const { labelSchemas } = useListLabelSchemasQuery({ experimentId: experimentId ?? '' });
   const { setReviewQueueItemStatusAsync, isSettingStatus } = useSetReviewQueueItemStatusMutation();
-  const { removeItemsFromReviewQueue, isRemovingItems } = useRemoveItemsFromReviewQueueMutation();
+  const { removeItemsFromReviewQueueAsync, isRemovingItems } = useRemoveItemsFromReviewQueueMutation();
   const { deleteReviewQueueAsync, isDeletingQueue } = useDeleteReviewQueueMutation();
   const { updateReviewQueueAsync, isUpdatingQueue } = useUpdateReviewQueueMutation();
   const { getOrCreateUserQueueAsync } = useGetOrCreateUserQueueMutation();
@@ -397,7 +397,23 @@ const ExperimentReviewQueuePage = () => {
         latestQuestionCreatedAtMs={latestQuestionCreatedAtMs}
         onRemoveItems={
           canRemoveItemsFromSelectedQueue
-            ? (itemIds) => removeItemsFromReviewQueue({ queue_id: selectedQueue.queue_id, item_ids: itemIds })
+            ? async (itemIds) => {
+                try {
+                  await removeItemsFromReviewQueueAsync({ queue_id: selectedQueue.queue_id, item_ids: itemIds });
+                } catch (e) {
+                  Utils.displayGlobalErrorNotification(
+                    intl.formatMessage(
+                      {
+                        defaultMessage: 'Could not remove traces: {error}',
+                        description: 'Review queue: error toast when removing traces from a queue fails',
+                      },
+                      { error: e instanceof Error ? e.message : String(e) },
+                    ),
+                  );
+                  // Re-throw so the list keeps the selection for a retry.
+                  throw e;
+                }
+              }
             : undefined
         }
         isRemovingItems={isRemovingItems}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, jest, it, expect } from '@jest/globals';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -214,7 +214,7 @@ describe('ReviewQueueList', () => {
         items={[item('tr-1', 'PENDING'), item('tr-2', 'COMPLETE', 'bob')]}
         onOpen={jest.fn()}
         nowMs={NOW}
-        onRemoveItems={jest.fn()}
+        onRemoveItems={jest.fn<(ids: string[]) => Promise<void>>().mockResolvedValue(undefined)}
       />,
     );
     // checkboxes[0] is select-all; [1] is the first row.
@@ -224,6 +224,44 @@ describe('ReviewQueueList', () => {
     // Switching filters resets the selection so hidden rows can't be deleted.
     fireEvent.click(screen.getByText('Completed (1)'));
     expect(screen.queryByRole('button', { name: 'Unassign' })).not.toBeInTheDocument();
+  });
+
+  it('clears the selection only after a successful removal', async () => {
+    const onRemoveItems = jest.fn<(ids: string[]) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithProviders(
+      <ReviewQueueList
+        items={[item('tr-1', 'PENDING')]}
+        onOpen={jest.fn()}
+        nowMs={NOW}
+        onRemoveItems={onRemoveItems}
+      />,
+    );
+    fireEvent.click(screen.getAllByRole('checkbox')[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Unassign' }));
+    await waitFor(() => expect(onRemoveItems).toHaveBeenCalledTimes(1));
+    expect(onRemoveItems).toHaveBeenCalledWith(['tr-1']);
+    // The Unassign button only shows with a selection, so its absence proves the
+    // selection was cleared once the removal landed.
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Unassign' })).not.toBeInTheDocument());
+  });
+
+  it('keeps the selection when the removal fails, so the reviewer can retry', async () => {
+    const onRemoveItems = jest.fn<(ids: string[]) => Promise<void>>().mockRejectedValue(new Error('boom'));
+    renderWithProviders(
+      <ReviewQueueList
+        items={[item('tr-1', 'PENDING')]}
+        onOpen={jest.fn()}
+        nowMs={NOW}
+        onRemoveItems={onRemoveItems}
+      />,
+    );
+    const firstRow = screen.getAllByRole('checkbox')[1];
+    fireEvent.click(firstRow);
+    fireEvent.click(screen.getByRole('button', { name: 'Unassign' }));
+    await waitFor(() => expect(onRemoveItems).toHaveBeenCalledTimes(1));
+    // The removal rejected, so the row stays checked and its Unassign button persists.
+    expect(firstRow).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Unassign' })).toBeInTheDocument();
   });
 
   it('offers copy-link menu items even without manage/delete permissions', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.test.tsx
@@ -259,9 +259,13 @@ describe('ReviewQueueList', () => {
     fireEvent.click(firstRow);
     fireEvent.click(screen.getByRole('button', { name: 'Unassign' }));
     await waitFor(() => expect(onRemoveItems).toHaveBeenCalledTimes(1));
-    // The removal rejected, so the row stays checked and its Unassign button persists.
-    expect(firstRow).toBeChecked();
-    expect(screen.getByRole('button', { name: 'Unassign' })).toBeInTheDocument();
+    // The rejection is swallowed in handleDelete's no-op catch (no state update),
+    // so the row stays checked and its Unassign button persists. waitFor lets the
+    // rejected promise settle before asserting, mirroring the success test.
+    await waitFor(() => {
+      expect(firstRow).toBeChecked();
+      expect(screen.getByRole('button', { name: 'Unassign' })).toBeInTheDocument();
+    });
   });
 
   it('offers copy-link menu items even without manage/delete permissions', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -161,8 +161,9 @@ export const ReviewQueueList = ({
   /** Newest question's creation time; flags completed traces reviewed before it. */
   latestQuestionCreatedAtMs?: number;
   /** When provided, rows become checkbox-selectable and a delete action appears
-   *  so the queue's manager can remove traces from this view. */
-  onRemoveItems?: (itemIds: string[]) => void;
+   *  so the queue's manager can remove traces from this view. Rejects if the
+   *  removal fails, so the selection is kept (and the caller surfaces the error). */
+  onRemoveItems?: (itemIds: string[]) => Promise<void>;
   isRemovingItems?: boolean;
   /** Copy a shareable link to this queue; `startReview` deep-links into the
    *  focused review of the first to-do trace. Permission-free, so unlike the
@@ -250,10 +251,17 @@ export const ReviewQueueList = ({
     });
   const toggleAll = (checked: boolean) =>
     setSelected(checked ? new Set(filteredItems.map((i) => i.item_id)) : new Set());
-  const handleDelete = () => {
-    if (onRemoveItems && selected.size > 0) {
-      onRemoveItems([...selected]);
+  const handleDelete = async () => {
+    if (!onRemoveItems || selected.size === 0) {
+      return;
+    }
+    try {
+      await onRemoveItems([...selected]);
+      // Clear only once the removal lands; on failure keep the selection so the
+      // reviewer can retry (the caller surfaces the error).
       setSelected(new Set());
+    } catch {
+      // Surfaced by the caller's onRemoveItems; leave the selection intact.
     }
   };
   // Changing the filter drops any row selection: a row checked under one filter

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueList.tsx
@@ -161,8 +161,11 @@ export const ReviewQueueList = ({
   /** Newest question's creation time; flags completed traces reviewed before it. */
   latestQuestionCreatedAtMs?: number;
   /** When provided, rows become checkbox-selectable and a delete action appears
-   *  so the queue's manager can remove traces from this view. Rejects if the
-   *  removal fails, so the selection is kept (and the caller surfaces the error). */
+   *  so the queue's manager can remove traces from this view. The returned promise
+   *  MUST reject if the removal fails: on rejection the list keeps the selection so
+   *  the reviewer can retry, and the caller is responsible for surfacing the error.
+   *  A caller that swallows the failure (resolves anyway) will clear the selection
+   *  as if it succeeded. */
   onRemoveItems?: (itemIds: string[]) => Promise<void>;
   isRemovingItems?: boolean;
   /** Copy a shareable link to this queue; `startReview` deep-links into the

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4783,6 +4783,10 @@
     "defaultMessage": "Pending ({count})",
     "description": "Issue status filter > Pending button label"
   },
+  "MkP0XP": {
+    "defaultMessage": "Could not remove traces: {error}",
+    "description": "Review queue: error toast when removing traces from a queue fails"
+  },
   "Mmrsqt": {
     "defaultMessage": "Failed to load webhooks",
     "description": "Error message informing the user that webhooks did not load successfully"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Removing traces from a review queue silently swallowed failures. The page wired `onRemoveItems` as a fire-and-forget `removeItemsFromReviewQueue({...})` (the non-async mutate, whose `error` was never read), and `ReviewQueueList.handleDelete` cleared the checkbox selection **synchronously, before the mutation settled**. On a failed removal the rows stayed (not removed) but the selection was lost with no feedback — inconsistent with every other mutation on the page (delete-queue, copy-link, status changes all surface errors).

This makes the removal path behave like the sibling delete-queue handler:

- `onRemoveItems` is now `(itemIds) => Promise<void>`. `ReviewQueueList.handleDelete` is async, `await`s it, and clears the selection **only on success** — keeping it on rejection so the reviewer can retry.
- The page `await`s `removeItemsFromReviewQueueAsync(...)` in a try/catch that toasts *"Could not remove traces: {error}"* and **re-throws**, so the list's `await` sees the failure and preserves the selection. Exactly one toast fires (the mutation hook has no `onError`).
- The "Unassign" button is already disabled/loading via `isRemovingItems`, so an in-flight removal can't be re-fired.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `ReviewQueueList.test.tsx` cases: the selection is cleared only after a successful removal, and on failure the row stays checked and the Unassign action persists (with a single `onRemoveItems` call). The page-level error toast mirrors the existing delete-queue handler in the same file; like that handler it has no dedicated page test (there is no `ExperimentReviewQueuePage.test.tsx`).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Failing to remove traces from a review queue now shows an error and keeps the selection for retry, instead of silently leaving the traces in place.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.