### PR TITLE
Normalize review-queue add-items ids before the trace-existence check

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -90,6 +90,7 @@ from mlflow.gateway.budget_tracker import _policy_applies, get_budget_tracker
 from mlflow.gateway.utils import is_valid_endpoint_name
 from mlflow.genai.label_schemas.label_schemas import LabelSchemaType, _input_from_proto
 from mlflow.genai.review_queues import ReviewItemType, ReviewQueueType, ReviewStatus
+from mlflow.genai.review_queues.validation import validate_item_ids_for_attach
 from mlflow.genai.scorers.scorer_utils import DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR
 from mlflow.models import Model
 from mlflow.prompt.constants import PROMPT_TEXT_TAG_KEY, PROMPT_TYPE_TAG_KEY
@@ -4811,7 +4812,11 @@ def _add_items_to_review_queue():
         schema={"queue_id": [_assert_required, _assert_string]},
     )
     store = _get_tracking_store()
-    item_ids = list(request_message.item_ids)
+    # Normalize (strip + de-dup) up front so the existence check below validates
+    # the same ids the store persists. The store re-normalizes (idempotent); doing
+    # it here too keeps the raw-vs-stored mismatch from rejecting a padded-but-valid
+    # id as non-existent.
+    item_ids = validate_item_ids_for_attach(list(request_message.item_ids))
     kwargs: dict[str, object] = {"item_ids": item_ids}
     if (
         request_message.HasField("item_type")

--- a/tests/server/test_review_queue_handlers.py
+++ b/tests/server/test_review_queue_handlers.py
@@ -305,6 +305,23 @@ def test_add_items_forwards_explicit_item_type():
     store.batch_get_trace_infos.assert_called_once_with(["tr-1"])
 
 
+def test_add_items_normalizes_ids_before_existence_check():
+    # Whitespace-padded / duplicate ids must be stripped + de-duped BEFORE the
+    # trace-existence check, so the check validates the same ids the store writes.
+    # Otherwise a padded-but-valid id (" tr-1 ") is looked up raw, misses, and is
+    # wrongly rejected as non-existent even though the store would store it stripped.
+    request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=[" tr-1 ", "tr-1", "tr-2\t"])
+    store, response = _run_add_items(
+        request_message,
+        trace_infos=[_trace_info("tr-1"), _trace_info("tr-2")],
+        add_return=[_item_entity("tr-1"), _item_entity("tr-2")],
+    )
+    assert response.status_code == 200
+    # Both the existence check and the store write see the normalized, de-duped ids.
+    store.batch_get_trace_infos.assert_called_once_with(["tr-1", "tr-2"])
+    assert store.add_items_to_review_queue.call_args[1]["item_ids"] == ["tr-1", "tr-2"]
+
+
 def test_add_items_rejects_traces_not_in_queue_experiment():
     # tr-2 doesn't exist anywhere; tr-3 exists but in a different experiment.
     request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=["tr-1", "tr-2", "tr-3"])
@@ -319,6 +336,37 @@ def test_add_items_rejects_traces_not_in_queue_experiment():
     assert body["error_code"] == "RESOURCE_DOES_NOT_EXIST"
     assert "tr-2" in body["message"]
     assert "tr-3" in body["message"]
+    store.add_items_to_review_queue.assert_not_called()
+
+
+def test_add_items_reports_missing_padded_id_by_its_stripped_form():
+    # A padded id that doesn't exist is checked (and reported) by its normalized
+    # form, not the raw padded form -- the existence lookup uses the stripped id.
+    request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=[" tr-9 "])
+    store, response = _run_add_items(
+        request_message,
+        queue_experiment_id="1",
+        trace_infos=[],
+        add_return=[],
+    )
+    assert response.status_code == 404
+    body = json.loads(response.get_data())
+    assert body["error_code"] == "RESOURCE_DOES_NOT_EXIST"
+    assert "tr-9" in body["message"]
+    store.batch_get_trace_infos.assert_called_once_with(["tr-9"])
+    store.add_items_to_review_queue.assert_not_called()
+
+
+def test_add_items_rejects_empty_ids_before_touching_the_store():
+    # Malformed input fails fast: an empty (or whitespace-only) item_ids list is
+    # rejected before the queue lookup / existence check / store write.
+    request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=[])
+    store, response = _run_add_items(request_message, trace_infos=[], add_return=[])
+    assert response.status_code == 400
+    body = json.loads(response.get_data())
+    assert body["error_code"] == "INVALID_PARAMETER_VALUE"
+    store.get_review_queue.assert_not_called()
+    store.batch_get_trace_infos.assert_not_called()
     store.add_items_to_review_queue.assert_not_called()
 
 

--- a/tests/server/test_review_queue_handlers.py
+++ b/tests/server/test_review_queue_handlers.py
@@ -357,10 +357,11 @@ def test_add_items_reports_missing_padded_id_by_its_stripped_form():
     store.add_items_to_review_queue.assert_not_called()
 
 
-def test_add_items_rejects_empty_ids_before_touching_the_store():
-    # Malformed input fails fast: an empty (or whitespace-only) item_ids list is
-    # rejected before the queue lookup / existence check / store write.
-    request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=[])
+@pytest.mark.parametrize("item_ids", [[], ["   ", "\t"]])
+def test_add_items_rejects_malformed_ids_before_touching_the_store(item_ids):
+    # Malformed input fails fast: an empty list, or ids that are empty after
+    # stripping, are rejected before the queue lookup / existence check / store write.
+    request_message = AddItemsToReviewQueue(queue_id="rq-1", item_ids=item_ids)
     store, response = _run_add_items(request_message, trace_infos=[], add_return=[])
     assert response.status_code == 400
     body = json.loads(response.get_data())


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `_add_items_to_review_queue` server handler validated trace existence against the **raw** `request_message.item_ids`, but the store persists `normalize_item_id`-stripped (and de-duped) ids (via `validate_item_ids_for_attach`). So the guard checked one value and the store wrote another: a whitespace-padded id (e.g. `" tr-1 "`) was looked up raw, missed the existence check, and was wrongly rejected as non-existent — even though the store would have stripped it to `"tr-1"` and stored it fine.

(It's fail-*closed* — a passing guard implied the raw id matched a real trace id, which has no whitespace — so there was no ghost-item / cross-experiment risk; the symptom is over-rejection of padded ids.)

Fix: normalize the ids with `validate_item_ids_for_attach` at the top of the handler, so the existence check **and** the store write operate on the same normalized, de-duped list. The store still re-normalizes internally (idempotent), so direct store/client callers are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `tests/server/test_review_queue_handlers.py` cases: padded/duplicate ids are stripped + de-duped before both the existence check and the store write; a padded **missing** id is reported by its stripped form (and looked up by it); and empty input fails fast with `INVALID_PARAMETER_VALUE` before the queue lookup / existence check / store write.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Attaching a trace to a review queue with incidental surrounding whitespace in its id is no longer rejected as non-existent.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.