### PR TITLE
Scope review-queue permission UX gate to the active workspace

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useCanManageReviews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useCanManageReviews.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+import type { ListMyPermissionsResponse, UserRolePermissionRow } from '../../../../account/types';
+import { useCanEditReviews, useCanManageReviews } from './useCanManageReviews';
+
+let mockAuthAvailable = true;
+let mockPermissions: ListMyPermissionsResponse | undefined = { is_admin: false, permissions: [] };
+let mockActiveWorkspace: string | null = 'ws-a';
+let mockWorkspacesEnabled = true;
+let mockWorkspacesLoading = false;
+
+jest.mock('../../../../account/hooks', () => ({
+  useIsAuthAvailable: () => mockAuthAvailable,
+  useMyPermissionsQuery: () => ({ data: mockPermissions }),
+}));
+jest.mock('../../../../workspaces/utils/WorkspaceUtils', () => ({
+  useActiveWorkspace: () => mockActiveWorkspace,
+}));
+jest.mock('../../../hooks/useServerInfo', () => ({
+  useWorkspacesEnabled: () => ({ workspacesEnabled: mockWorkspacesEnabled, loading: mockWorkspacesLoading }),
+}));
+
+const perm = (over: Partial<UserRolePermissionRow> = {}): UserRolePermissionRow => ({
+  role_id: 1,
+  role_name: '__user_1__',
+  workspace: 'ws-a',
+  resource_type: 'experiment',
+  resource_pattern: '*',
+  permission: 'MANAGE',
+  ...over,
+});
+
+const canManage = (experimentId = 'exp-1') => renderHook(() => useCanManageReviews(experimentId)).result.current;
+const canEdit = (experimentId = 'exp-1') => renderHook(() => useCanEditReviews(experimentId)).result.current;
+
+describe('useCanManageReviews / useCanEditReviews', () => {
+  beforeEach(() => {
+    mockAuthAvailable = true;
+    mockActiveWorkspace = 'ws-a';
+    mockWorkspacesEnabled = true;
+    mockWorkspacesLoading = false;
+    mockPermissions = { is_admin: false, permissions: [] };
+  });
+
+  it('grants on a no-auth server regardless of permissions/workspace', () => {
+    mockAuthAvailable = false;
+    mockPermissions = undefined;
+    expect(canManage()).toBe(true);
+  });
+
+  it('denies while permissions are still loading', () => {
+    mockPermissions = undefined;
+    expect(canManage()).toBe(false);
+  });
+
+  it('grants everything to an admin', () => {
+    mockPermissions = { is_admin: true, permissions: [] };
+    expect(canManage()).toBe(true);
+  });
+
+  it('grants when a matching wildcard grant is in the active workspace', () => {
+    mockPermissions = { is_admin: false, permissions: [perm({ workspace: 'ws-a' })] };
+    expect(canManage()).toBe(true);
+  });
+
+  it('denies when the only matching wildcard grant is in a different workspace', () => {
+    // The bug: a `*` grant from another workspace must not unlock controls here.
+    mockPermissions = { is_admin: false, permissions: [perm({ workspace: 'ws-other' })] };
+    expect(canManage()).toBe(false);
+  });
+
+  it('matches an exact experiment grant in the active workspace', () => {
+    mockPermissions = { is_admin: false, permissions: [perm({ resource_pattern: 'exp-1', workspace: 'ws-a' })] };
+    expect(canManage()).toBe(true);
+  });
+
+  it('denies an exact experiment grant carried by a different workspace', () => {
+    mockPermissions = { is_admin: false, permissions: [perm({ resource_pattern: 'exp-1', workspace: 'ws-other' })] };
+    expect(canManage()).toBe(false);
+  });
+
+  it('ignores workspace when the feature is definitively disabled', () => {
+    mockWorkspacesEnabled = false;
+    mockWorkspacesLoading = false;
+    mockActiveWorkspace = null;
+    mockPermissions = { is_admin: false, permissions: [perm({ workspace: 'default' })] };
+    expect(canManage()).toBe(true);
+  });
+
+  it('denies during the load window rather than over-revealing (enabled, workspace unresolved)', () => {
+    // workspaces enabled but the active workspace hasn't resolved yet: don't skip
+    // the filter on the strength of a null workspace -- deny until it's known.
+    mockWorkspacesEnabled = true;
+    mockActiveWorkspace = null;
+    mockPermissions = { is_admin: false, permissions: [perm({ workspace: 'ws-a' })] };
+    expect(canManage()).toBe(false);
+  });
+
+  it('denies while the workspaces-enabled flag is still loading', () => {
+    mockWorkspacesEnabled = false;
+    mockWorkspacesLoading = true;
+    mockActiveWorkspace = null;
+    mockPermissions = { is_admin: false, permissions: [perm({ workspace: 'ws-a' })] };
+    expect(canManage()).toBe(false);
+  });
+
+  it('requires MANAGE for manage, while EDIT alone satisfies edit', () => {
+    mockPermissions = { is_admin: false, permissions: [perm({ permission: 'EDIT', workspace: 'ws-a' })] };
+    expect(canManage()).toBe(false);
+    expect(canEdit()).toBe(true);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useCanManageReviews.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useCanManageReviews.ts
@@ -1,4 +1,6 @@
 import { useIsAuthAvailable, useMyPermissionsQuery } from '../../../../account/hooks';
+import { useActiveWorkspace } from '../../../../workspaces/utils/WorkspaceUtils';
+import { useWorkspacesEnabled } from '../../../hooks/useServerInfo';
 
 /**
  * Whether the current user holds one of `levels` on the experiment. A UX gate
@@ -8,6 +10,8 @@ import { useIsAuthAvailable, useMyPermissionsQuery } from '../../../../account/h
 const useExperimentReviewPermission = (experimentId: string, levels: string[]): boolean => {
   const authAvailable = useIsAuthAvailable();
   const { data } = useMyPermissionsQuery();
+  const { workspacesEnabled, loading: workspacesLoading } = useWorkspacesEnabled();
+  const activeWorkspace = useActiveWorkspace();
 
   if (!authAvailable) {
     return true;
@@ -18,11 +22,19 @@ const useExperimentReviewPermission = (experimentId: string, levels: string[]): 
   if (data.is_admin) {
     return true;
   }
+  // The permissions endpoint returns grants across every workspace, and a `*`
+  // grant is workspace-relative, so only count grants in the workspace being
+  // viewed. Skip that filter only when workspaces are *definitively* disabled
+  // (single-workspace deployment, nothing to leak). While the flag is loading or
+  // the workspace hasn't resolved yet, require the match and deny rather than
+  // over-reveal a control that would 403 server-side.
+  const workspacesDefinitelyDisabled = !workspacesEnabled && !workspacesLoading;
   return (data.permissions ?? []).some(
     (p) =>
       p.resource_type === 'experiment' &&
       (p.resource_pattern === experimentId || p.resource_pattern === '*') &&
-      levels.includes(p.permission),
+      levels.includes(p.permission) &&
+      (workspacesDefinitelyDisabled || p.workspace === activeWorkspace),
   );
 };
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`useExperimentReviewPermission` (the UX gate behind the review-queue manage/edit controls) scans `GET /users/current/permissions`, which returns the user's grants across **every** workspace — each row tagged with its `workspace` (`UserRolePermissionRow.workspace`). The check matched `resource_pattern === experimentId || '*'` but **never compared `p.workspace`**, so a wildcard `*` experiment EDIT/MANAGE grant in *any* workspace revealed the management/edit controls for an experiment in a workspace where the user has no grant.

It's UX-only today (the server is the real gate, and hiding is the safe direction), but it over-reveals and will start 403-ing once server-side review-queue authz lands.

This requires the matching grant to be in the **active** workspace. The filter is skipped only when workspaces are *definitively disabled* (single-workspace deployment, nothing to leak); while the feature flag is still loading or the active workspace hasn't resolved, it denies rather than over-reveals — consistent with the hook's existing "deny while permissions load" stance. The filter applies uniformly to both the wildcard and exact-id matches (an exact-id grant is tagged with its experiment's workspace, so a legitimate grant matches the active workspace; a cross-workspace one shouldn't unlock).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `useCanManageReviews.test.tsx`: cross-workspace wildcard/exact-id grants are denied, same-workspace grants pass, workspaces-disabled is a passthrough, the enabled-but-unresolved and flag-loading windows deny (no over-reveal), plus admin / no-auth / loading / EDIT-vs-MANAGE.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Review-queue management controls are no longer shown for experiments in workspaces where the user lacks the required permission.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.