### PR TITLE
Clamp otlpSpans to the IPC size budget and raise the cap to 32 MiB

### DIFF
--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -104,10 +104,11 @@ export class MlflowWalSpanExporter implements SpanExporter {
         otlpSpans,
       };
 
-      if (otlpSpans !== undefined && ipcRequestByteLength(record) > MAX_REQUEST_BYTES) {
+      const fullSizeBytes = ipcRequestByteLength(record);
+      if (otlpSpans !== undefined && fullSizeBytes > MAX_REQUEST_BYTES) {
         console.warn(
-          `[mlflow][wal] OTLP span payload for trace ${trace.info.traceId} would exceed the ` +
-            `${MAX_REQUEST_BYTES}-byte IPC request limit; falling back to JSON artifact upload ` +
+          `[mlflow][wal] WAL record for trace ${trace.info.traceId} is ${fullSizeBytes} bytes, exceeding the ` +
+            `${MAX_REQUEST_BYTES}-byte IPC request limit; dropping OTLP spans and attempting JSON artifact upload ` +
             '(spans will not appear in DB-backed span metrics).',
         );
         record.otlpSpans = undefined;

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -4,7 +4,7 @@ import { ReadableSpan as OTelReadableSpan, SpanExporter } from '@opentelemetry/s
 import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { getConfig, MLflowTracingConfig } from '../../core/config';
 import { InMemoryTraceManager } from '../../core/trace_manager';
-import { submitRecord } from './ipc';
+import { ipcRequestByteLength, MAX_REQUEST_BYTES, submitRecord } from './ipc';
 import { WalRecord } from './types';
 
 /**
@@ -103,6 +103,15 @@ export class MlflowWalSpanExporter implements SpanExporter {
         createdAt: Date.now(),
         otlpSpans,
       };
+
+      if (otlpSpans !== undefined && ipcRequestByteLength(record) > MAX_REQUEST_BYTES) {
+        console.warn(
+          `[mlflow][wal] OTLP span payload for trace ${trace.info.traceId} would exceed the ` +
+            `${MAX_REQUEST_BYTES}-byte IPC request limit; falling back to JSON artifact upload ` +
+            '(spans will not appear in DB-backed span metrics).',
+        );
+        record.otlpSpans = undefined;
+      }
 
       const pending = this._submit(record).catch((err) => {
         console.error(

--- a/libs/typescript/core/src/exporters/wal/ipc.ts
+++ b/libs/typescript/core/src/exporters/wal/ipc.ts
@@ -40,10 +40,23 @@ const CONNECT_RETRY_DELAYS_MS = Array.from(
 
 const DAEMON_NO_RESPONSE_CODE = 'EDAEMONNORESPONSE';
 
-const MAX_REQUEST_BYTES = 16 * 1024 * 1024;
+export const MAX_REQUEST_BYTES = 32 * 1024 * 1024;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Exact byte length of the wire payload {@link submitRecord} would send for
+ * `record`, including the `append` envelope and trailing newline. Use this to
+ * compare against {@link MAX_REQUEST_BYTES} before submitting.
+ */
+function buildRequestPayload(record: WalRecord): string {
+  return JSONBig.stringify({ op: 'append', record } satisfies IpcRequest) + '\n';
+}
+
+export function ipcRequestByteLength(record: WalRecord): number {
+  return Buffer.byteLength(buildRequestPayload(record), 'utf8');
 }
 
 function isConnectError(err: unknown): boolean {
@@ -82,7 +95,7 @@ function isConnectError(err: unknown): boolean {
  *
  */
 export async function submitRecord(record: WalRecord): Promise<void> {
-  const payload = JSONBig.stringify({ op: 'append', record } satisfies IpcRequest) + '\n';
+  const payload = buildRequestPayload(record);
   let lastErr: unknown;
   for (let i = 0; i <= CONNECT_RETRY_DELAYS_MS.length; i++) {
     if (i > 0) {

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { MlflowWalSpanExporter } from '../../../src/exporters/wal/exporter';
+import * as ipc from '../../../src/exporters/wal/ipc';
 import { init, resetConfig } from '../../../src/core/config';
 import { InMemoryTraceManager } from '../../../src/core/trace_manager';
 import { Trace } from '../../../src/core/entities/trace';
@@ -492,6 +493,37 @@ describe('wal/exporter', () => {
       );
     } finally {
       serializeSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('drops otlpSpans but still submits when the record would exceed the IPC size budget', async () => {
+    const sizeSpy = jest
+      .spyOn(ipc, 'ipcRequestByteLength')
+      .mockReturnValue(ipc.MAX_REQUEST_BYTES + 1);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(makeTraceWithSpans('tr-too-big'));
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    try {
+      const { callback, promise } = captureExportResult();
+      exporter.export([span], callback);
+
+      expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+      await exporter.forceFlush();
+
+      // The trace is not dropped: it is still submitted, just without the OTLP
+      // blob, so the artifact fallback (traceData) keeps it alive.
+      expect(submit).toHaveBeenCalledTimes(1);
+      const record = submit.mock.calls[0][0];
+      expect(record.otlpSpans).toBeUndefined();
+      expect((record.traceData as { spans: unknown[] }).spans).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('would exceed the'));
+    } finally {
+      sizeSpy.mockRestore();
       warnSpy.mockRestore();
     }
   });

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -521,7 +521,12 @@ describe('wal/exporter', () => {
       const record = submit.mock.calls[0][0];
       expect(record.otlpSpans).toBeUndefined();
       expect((record.traceData as { spans: unknown[] }).spans).toHaveLength(1);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('would exceed the'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('exceeding the'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dropping OTLP spans'),
+      );
     } finally {
       sizeSpy.mockRestore();
       warnSpy.mockRestore();

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -521,12 +521,8 @@ describe('wal/exporter', () => {
       const record = submit.mock.calls[0][0];
       expect(record.otlpSpans).toBeUndefined();
       expect((record.traceData as { spans: unknown[] }).spans).toHaveLength(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('exceeding the'),
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('dropping OTLP spans'),
-      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('exceeding the'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dropping OTLP spans'));
     } finally {
       sizeSpy.mockRestore();
       warnSpy.mockRestore();

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -3,7 +3,11 @@ import { createServer, Server } from 'net';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { BatchingWriter } from '../../../src/exporters/wal/batching_writer';
-import { createIpcConnectionHandler, submitRecord } from '../../../src/exporters/wal/ipc';
+import {
+  createIpcConnectionHandler,
+  MAX_REQUEST_BYTES,
+  submitRecord,
+} from '../../../src/exporters/wal/ipc';
 import { getLockSocketPath, getWalPath } from '../../../src/exporters/wal/paths';
 import type { IpcRequest, IpcResponse } from '../../../src/exporters/wal/protocol';
 import type { WalRecord } from '../../../src/exporters/wal/types';
@@ -236,23 +240,27 @@ describe('wal/ipc createIpcConnectionHandler', () => {
   });
 
   it('rejects oversized requests without exhausting memory', async () => {
-    // Stream bytes well past the 16 MiB cap without ever sending a
-    // newline. The handler should respond with ok=false, pause its
-    // read side so the kernel buffer stops growing, and half-close
-    // the write side so we observe a clean `'end'` here.
+    // Stream bytes well past the cap without ever sending a newline. The
+    // handler should respond with ok=false, pause its read side so the kernel
+    // buffer stops growing, and half-close the write side so we observe a clean
+    // `'end'` here.
     const writer = new BatchingWriter();
     server = await startHandlerServer(writer);
+
+    // One MiB per chunk; send just enough chunks to overshoot the cap by 1 MiB,
+    // derived from MAX_REQUEST_BYTES so the test tracks the constant.
+    const oneMibBytes = 1024 * 1024;
+    const chunkCount = Math.ceil(MAX_REQUEST_BYTES / oneMibBytes) + 1;
 
     const { createConnection } = await import('node:net');
     const result = await new Promise<string>((resolve, reject) => {
       const socket = createConnection(getLockSocketPath());
       const chunks: Buffer[] = [];
       socket.on('connect', () => {
-        // 1 MiB of 'A's per chunk × 17 chunks = 17 MiB, no trailing
-        // newline. We send chunks back-to-back; once the daemon's
-        // cumulative buffer crosses 16 MiB it must short-circuit and
-        // respond, after which it ignores any further bytes.
-        const oneMib = Buffer.alloc(1024 * 1024, 0x41);
+        // No trailing newline. We send chunks back-to-back; once the daemon's
+        // cumulative buffer crosses the cap it must short-circuit and respond,
+        // after which it ignores any further bytes.
+        const oneMib = Buffer.alloc(oneMibBytes, 0x41);
         const pump = (remaining: number): void => {
           if (remaining === 0 || socket.destroyed) {
             return;
@@ -263,7 +271,7 @@ describe('wal/ipc createIpcConnectionHandler', () => {
           }
           setImmediate(() => pump(remaining - 1));
         };
-        pump(17);
+        pump(chunkCount);
       });
       socket.on('data', (chunk) => chunks.push(chunk));
       socket.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
@@ -289,12 +297,18 @@ describe('wal/ipc createIpcConnectionHandler', () => {
     const writer = new BatchingWriter();
     server = await startHandlerServer(writer);
 
+    // Each '中' is 3 UTF-8 bytes but a single UTF-16 code unit, so a cap
+    // measured in code units would count this chunk at a third of its wire
+    // size. Send enough chunks to overshoot the (byte-measured) cap; a
+    // code-unit measurement would stay well under it and never trip.
+    const cjkChunk = Buffer.from('中'.repeat(349_525), 'utf8');
+    const chunkCount = Math.ceil(MAX_REQUEST_BYTES / cjkChunk.length) + 1;
+
     const { createConnection } = await import('node:net');
     const result = await new Promise<string>((resolve, reject) => {
       const socket = createConnection(getLockSocketPath());
       const chunks: Buffer[] = [];
       socket.on('connect', () => {
-        const cjkChunk = Buffer.from('中'.repeat(349_525), 'utf8');
         const pump = (remaining: number): void => {
           if (remaining === 0 || socket.destroyed) {
             return;
@@ -305,7 +319,7 @@ describe('wal/ipc createIpcConnectionHandler', () => {
           }
           setImmediate(() => pump(remaining - 1));
         };
-        pump(17);
+        pump(chunkCount);
       });
       socket.on('data', (chunk) => chunks.push(chunk));
       socket.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -12,6 +12,7 @@ import {
 import { getLockSocketPath, getWalPath } from '../../../src/exporters/wal/paths';
 import type { IpcRequest, IpcResponse } from '../../../src/exporters/wal/protocol';
 import type { WalRecord } from '../../../src/exporters/wal/types';
+import { JSONBig } from '../../../src/core/utils/json';
 
 function makeRecord(idSuffix: string, overrides: Partial<WalRecord> = {}): WalRecord {
   return {
@@ -407,10 +408,12 @@ describe('wal/ipc createIpcConnectionHandler', () => {
 });
 
 describe('wal/ipc ipcRequestByteLength', () => {
-  it('measures the real wire size of a record (envelope + newline)', () => {
-    const record = makeRecord('measure');
+  it('measures the real wire size of a record, including BigInt fields', () => {
+    const record = makeRecord('measure', {
+      traceData: { spans: [{ startTimeUnixNano: 1_700_000_000_000_000_000n }] },
+    });
 
-    const expected = Buffer.byteLength(JSON.stringify({ op: 'append', record }) + '\n', 'utf8');
+    const expected = Buffer.byteLength(JSONBig.stringify({ op: 'append', record }) + '\n', 'utf8');
     expect(ipcRequestByteLength(record)).toBe(expected);
   });
 

--- a/libs/typescript/core/tests/exporters/wal/ipc.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/ipc.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { BatchingWriter } from '../../../src/exporters/wal/batching_writer';
 import {
   createIpcConnectionHandler,
+  ipcRequestByteLength,
   MAX_REQUEST_BYTES,
   submitRecord,
 } from '../../../src/exporters/wal/ipc';
@@ -402,5 +403,25 @@ describe('wal/ipc createIpcConnectionHandler', () => {
     await submitRecord(makeRecord('after-probe'));
     const lines = (await readFile(getWalPath(), 'utf8')).split('\n').filter((l) => l.length > 0);
     expect(lines).toHaveLength(1);
+  });
+});
+
+describe('wal/ipc ipcRequestByteLength', () => {
+  it('measures the real wire size of a record (envelope + newline)', () => {
+    const record = makeRecord('measure');
+
+    const expected = Buffer.byteLength(JSON.stringify({ op: 'append', record }) + '\n', 'utf8');
+    expect(ipcRequestByteLength(record)).toBe(expected);
+  });
+
+  it('returns a value above the cap for a genuinely oversized otlpSpans payload', () => {
+    // A baseline record sits comfortably under the cap...
+    expect(ipcRequestByteLength(makeRecord('small'))).toBeLessThan(MAX_REQUEST_BYTES);
+
+    // ...while a record carrying an over-cap otlpSpans blob measures over it.
+    const oversized = makeRecord('oversized', {
+      otlpSpans: 'A'.repeat(MAX_REQUEST_BYTES + 1),
+    });
+    expect(ipcRequestByteLength(oversized)).toBeGreaterThan(MAX_REQUEST_BYTES);
   });
 });


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24032/files) to review incremental changes.
- [stack/ts-sdk-tool-calls-fix](https://github.com/mlflow/mlflow/pull/24019) [[Files changed](https://github.com/mlflow/mlflow/pull/24019/files)] [MERGED]
  - [stack/capture-otlp-at-wal](https://github.com/mlflow/mlflow/pull/24022) [[Files changed](https://github.com/mlflow/mlflow/pull/24022/files)] [MERGED]
    - [stack/oss-otlp-endpoint](https://github.com/mlflow/mlflow/pull/24030) [[Files changed](https://github.com/mlflow/mlflow/pull/24030/files)] [MERGED]
      - [**stack/update-ipc-request-limit-for-otlp**](https://github.com/mlflow/mlflow/pull/24032) [[Files changed](https://github.com/mlflow/mlflow/pull/24032/files)]
        - [stack/ts-client-add-logspan](https://github.com/mlflow/mlflow/pull/24061) [[Files changed](https://github.com/mlflow/mlflow/pull/24061/files/ca363c16e2ab4d00862e033afae64e398cefa999..f0c3ddc1b3352c5a629a9a7c9f8001fd5f733654)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Makes the new `otlpSpans` WAL field safe against the hook→daemon IPC size cap, preserving the invariant that **a trace is never dropped because of the OTLP span payload**.
`otlpSpans` carries a trace's spans a second time on top of `traceData` (a base64-encoded OTLP copy of the same spans), so the per-trace IPC payload roughly doubles. The daemon rejects any request over `MAX_REQUEST_BYTES`; on rejection `submitRecord` throws and the exporter only logs it, so the **whole record is dropped** — no `queue.log` line, no artifact fallback, and no DB spans (the trace is lost entirely). Adding `otlpSpans` could turn a previously-uploadable large trace into a dropped one.

- **Raise the cap (`ipc.ts`)** — `MAX_REQUEST_BYTES` bumped from **16 MiB → 32 MiB** so traces that fit before `otlpSpans` existed keep their spans rather than silently degrading to artifact-only upload.
- **Export the budget + exact-size helper (`ipc.ts`)** — `MAX_REQUEST_BYTES` is now exported, and a new `ipcRequestByteLength(record)` measures the *exact* wire payload `submitRecord` would send. Both go through a shared `buildRequestPayload` helper so the measurement can't drift from the real `{ op: 'append', record }` envelope + trailing newline.
- **Pre-flight clamp (`exporter.ts`)** — after building the record with `otlpSpans`, if `ipcRequestByteLength(record) > MAX_REQUEST_BYTES` the exporter drops `otlpSpans` (keeps `traceData`) and warns, so the trace still uploads as an artifact. (A `traceData`-only overflow remains the pre-existing limitation, out of scope.)
- **Tests** — new exporter test: an oversized record → `otlpSpans` omitted, record still submitted with `traceData` intact. The two daemon-side oversize tests in `ipc.test.ts` now derive their stream sizes from `MAX_REQUEST_BYTES` so they keep crossing the cap at any value.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
