### PR TITLE
Prevent review queues from shadowing usernames

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2230,23 +2230,80 @@ def _can_delete_or_prune_review_queue(queue, username: str) -> bool:
     )
 
 
-def _update_review_queue_reassigns_owner() -> bool:
-    """Whether an ``UpdateReviewQueue`` request reassigns the owner.
+def _parse_update_review_queue_request() -> UpdateReviewQueue:
+    """Parse the ``UpdateReviewQueue`` request body once for the gate to inspect.
 
-    Detected by parsing the proto and checking field presence — matching how the
-    handler reads it — rather than scanning raw JSON keys. Protobuf JSON accepts
-    both ``new_owner`` and its camelCase ``newOwner``, so a raw-key check would
-    miss the latter and under-gate the MANAGE-only owner reassignment.
+    Field presence is read from the parsed proto, not raw JSON keys, so protobuf
+    JSON's camelCase aliases (e.g. ``newOwner``) are detected the same way the
+    handler reads them; a raw-key scan would miss the camelCase form.
     """
     body = request.get_json(silent=True)
     message = UpdateReviewQueue()
     parse_dict(body if isinstance(body, dict) else {}, message)
-    return message.HasField("new_owner")
+    return message
+
+
+def _registered_username_match(name: object) -> str | None:
+    """The registered user whose name equals ``name`` (case-insensitive), or None.
+
+    User queues are named after their user (lowercased by ``normalize_user``), so a
+    custom queue or a rename that takes a username shadows that user's personal
+    queue. The match is intentionally case-insensitive — broader than the store's
+    case-sensitive name uniqueness — so a look-alike like ``"Alice"`` is rejected
+    too, not just the exact ``"alice"`` that would hard-collide and lock the user out.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return None
+    target = name.strip().lower()
+    return next(
+        (u.username for u in store.list_users() if u.username.strip().lower() == target), None
+    )
+
+
+def _reject_create_review_queue_shadowing_user():
+    """Reject creating a CUSTOM queue whose name is a registered username."""
+    from mlflow.genai.review_queues import ReviewQueueType
+
+    body = request.get_json(silent=True)
+    message = CreateReviewQueue()
+    parse_dict(body if isinstance(body, dict) else {}, message)
+    # Only CUSTOM queues choose an arbitrary name; a USER queue *is* its username.
+    # Compare the raw proto enum (an unset queue_type is 0/UNSPECIFIED, which
+    # `from_proto` would reject) so a non-CUSTOM request just skips the check.
+    if message.queue_type != ReviewQueueType.CUSTOM.to_proto():
+        return
+    if (matched := _registered_username_match(message.name)) is not None:
+        raise MlflowException.invalid_parameter_value(
+            f"'{matched}' is a registered user. A custom review queue cannot use a "
+            "username as its name; assign that user to a queue instead.",
+        )
+
+
+def _reject_rename_review_queue_shadowing_user(queue, message):
+    """Reject renaming a CUSTOM queue onto a registered username.
+
+    User queues can't be renamed at all (the store rejects that), so this only
+    concerns a CUSTOM queue being renamed onto a username.
+    """
+    from mlflow.genai.review_queues import ReviewQueueType
+
+    if queue.queue_type != ReviewQueueType.CUSTOM or not message.HasField("name"):
+        return
+    if (matched := _registered_username_match(message.name)) is not None:
+        raise MlflowException.invalid_parameter_value(
+            f"'{matched}' is a registered user. A custom review queue cannot be "
+            "renamed to a username; assign that user to a queue instead.",
+        )
 
 
 def validate_can_create_review_queue():
     # Creating (and thereby owning) a queue requires experiment EDIT.
-    return _get_permission_from_experiment_id().can_update
+    permission = _get_permission_from_experiment_id().can_update
+    # A custom queue may not take a registered username, which would shadow that
+    # user's personal queue. Only enforced once the caller is authorized.
+    if permission:
+        _reject_create_review_queue_shadowing_user()
+    return permission
 
 
 def validate_can_update_review_queue():
@@ -2255,9 +2312,34 @@ def validate_can_update_review_queue():
     # an owner cannot transfer their own queue.
     username = authenticate_request().username
     queue = _get_tracking_store().get_review_queue(_get_request_param("queue_id"))
-    if _update_review_queue_reassigns_owner():
-        return _get_experiment_permission(queue.experiment_id, username).can_manage
-    return _can_own_or_manage_review_queue(queue, username)
+    message = _parse_update_review_queue_request()
+    if message.HasField("new_owner"):
+        permission = _get_experiment_permission(queue.experiment_id, username).can_manage
+    else:
+        permission = _can_own_or_manage_review_queue(queue, username)
+    # A rename can't take a registered username either (same shadowing concern).
+    if permission:
+        _reject_rename_review_queue_shadowing_user(queue, message)
+    return permission
+
+
+def enforce_review_queue_name_not_username():
+    """Reject a review-queue create/rename that shadows a username, for admins.
+
+    A custom queue (or a rename) named after a registered user shadows that user's
+    personal queue, so this is a data-integrity rule that applies to *every* caller,
+    not a permission. Non-admins hit it inside the validators above, after the
+    permission gate. Admins bypass validators entirely, so ``_before_request`` calls
+    this for them. A no-op for every endpoint other than create/update review queue.
+    """
+    # Resolve via the dispatcher (not a raw path lookup) so this stays correct if
+    # these routes ever gain a path parameter, matching how non-admins are routed.
+    validator = _find_validator(request)
+    if validator is validate_can_create_review_queue:
+        _reject_create_review_queue_shadowing_user()
+    elif validator is validate_can_update_review_queue:
+        queue = _get_tracking_store().get_review_queue(_get_request_param("queue_id"))
+        _reject_rename_review_queue_shadowing_user(queue, _parse_update_review_queue_request())
 
 
 def validate_can_remove_items_from_review_queue():
@@ -2802,8 +2884,12 @@ def _before_request():
     # Expose the authenticated user to handlers (e.g. to stamp a review-queue owner).
     g.mlflow_authenticated_user = authorization.username
 
-    # admins don't need to be authorized
+    # admins don't need to be authorized, but data-integrity rules still apply to
+    # them. A custom review queue (or rename) may not shadow a username; admins skip
+    # the validators, so the guard runs here for them (non-admins hit it post-gate
+    # inside the validators).
     if sender_is_admin():
+        enforce_review_queue_name_not_username()
         return
 
     # authorization

--- a/tests/server/auth/test_review_queue_auth.py
+++ b/tests/server/auth/test_review_queue_auth.py
@@ -7,7 +7,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from mlflow.exceptions import MlflowException
 from mlflow.genai.review_queues import ReviewQueueType
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.protos.review_queues_pb2 import ListReviewQueues
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 
@@ -164,6 +166,216 @@ def test_owner_reassignment_requires_manage(monkeypatch):
         update_body={"queue_id": "q1", "new_owner": "victim"},
     )
     assert auth.validate_can_update_review_queue() is True
+
+
+def _users(*names):
+    return [SimpleNamespace(username=n) for n in names]
+
+
+def _forbid_list_users():
+    raise AssertionError("store.list_users must not be called here")
+
+
+def test_create_custom_queue_rejects_registered_username(monkeypatch):
+    # A custom queue named after a registered user would shadow that user's
+    # personal queue; reject it case-insensitively ("Alice" vs user "alice").
+    _setup(
+        monkeypatch,
+        permission="EDIT",
+        update_body={"experiment_id": "123", "name": "Alice", "queue_type": "CUSTOM"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    with pytest.raises(MlflowException, match="registered user") as exc:
+        auth.validate_can_create_review_queue()
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_create_custom_queue_allows_non_username(monkeypatch):
+    _setup(
+        monkeypatch,
+        permission="EDIT",
+        update_body={"experiment_id": "123", "name": "Hallucinations", "queue_type": "CUSTOM"},
+    )
+    consulted = []
+    monkeypatch.setattr(
+        auth.store, "list_users", lambda: consulted.append(True) or _users("alice", "bob")
+    )
+    assert auth.validate_can_create_review_queue() is True
+    # The roster was actually consulted (guards against the match silently no-opping).
+    assert consulted == [True]
+
+
+def test_create_unset_queue_type_skips_shadow_check(monkeypatch):
+    # No queue_type (proto 0/UNSPECIFIED) skips the check without calling list_users
+    # and without `from_proto` raising on the unspecified value.
+    _setup(monkeypatch, permission="EDIT", update_body={"experiment_id": "123", "name": "alice"})
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    assert auth.validate_can_create_review_queue() is True
+
+
+def test_create_blank_name_skips_shadow_check(monkeypatch):
+    # A blank name can't match a user; skip before querying the roster (the
+    # handler/store validate the empty name separately).
+    _setup(
+        monkeypatch,
+        permission="EDIT",
+        update_body={"experiment_id": "123", "name": "   ", "queue_type": "CUSTOM"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    assert auth.validate_can_create_review_queue() is True
+
+
+def test_create_user_queue_named_after_user_is_allowed(monkeypatch):
+    # A USER queue *is* its username, so the CUSTOM-only shadowing guard skips it.
+    _setup(
+        monkeypatch,
+        permission="EDIT",
+        update_body={"experiment_id": "123", "name": "alice", "queue_type": "USER"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    assert auth.validate_can_create_review_queue() is True
+
+
+def test_create_shadow_check_skipped_when_unauthorized(monkeypatch):
+    # The permission gate denies first; the name check (and user-list query) never runs.
+    _setup(
+        monkeypatch,
+        permission="READ",
+        update_body={"experiment_id": "123", "name": "alice", "queue_type": "CUSTOM"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    assert auth.validate_can_create_review_queue() is False
+
+
+def test_rename_custom_queue_to_username_rejected(monkeypatch):
+    _setup(
+        monkeypatch,
+        permission="MANAGE",
+        created_by="bob",
+        username="alice",
+        update_body={"queue_id": "q1", "name": "Bob"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    with pytest.raises(MlflowException, match="registered user") as exc:
+        auth.validate_can_update_review_queue()
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_rename_custom_queue_to_non_username_allowed(monkeypatch):
+    _setup(
+        monkeypatch,
+        permission="MANAGE",
+        created_by="bob",
+        username="alice",
+        update_body={"queue_id": "q1", "name": "Renamed"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    assert auth.validate_can_update_review_queue() is True
+
+
+def test_rename_shadow_guard_skips_user_queues(monkeypatch):
+    # Renaming a USER queue is rejected by the store, not this guard; the guard is
+    # CUSTOM-only, so it neither fires nor queries the user list here.
+    _setup(
+        monkeypatch,
+        permission="MANAGE",
+        created_by="alice",
+        username="alice",
+        queue_type=ReviewQueueType.USER,
+        update_body={"queue_id": "q1", "name": "bob"},
+    )
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    assert auth.validate_can_update_review_queue() is True
+
+
+def _route_for(validator):
+    # The exact (path, method) the dispatcher would match to this validator.
+    return next(
+        (path, method)
+        for (path, method), v in auth.BEFORE_REQUEST_VALIDATORS.items()
+        if v is validator
+    )
+
+
+def _patch_request(monkeypatch, validator, body):
+    path, method = _route_for(validator)
+    monkeypatch.setattr(
+        auth,
+        "request",
+        SimpleNamespace(path=path, method=method, get_json=lambda silent=False: dict(body)),
+    )
+
+
+def test_admin_create_shadowing_username_is_blocked(monkeypatch):
+    # Admins bypass the validators, so `_before_request` runs the integrity guard
+    # directly for them; shadowing a username is still rejected. permission is
+    # irrelevant here (admins never hit the permission gate).
+    body = {"experiment_id": "123", "name": "Bob", "queue_type": "CUSTOM"}
+    _setup(monkeypatch, permission="READ", update_body=body)
+    _patch_request(monkeypatch, auth.validate_can_create_review_queue, body)
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    with pytest.raises(MlflowException, match="registered user") as exc:
+        auth.enforce_review_queue_name_not_username()
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_admin_rename_onto_username_is_blocked(monkeypatch):
+    body = {"queue_id": "q1", "name": "Bob"}
+    _setup(monkeypatch, permission="READ", created_by="bob", update_body=body)
+    _patch_request(monkeypatch, auth.validate_can_update_review_queue, body)
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    with pytest.raises(MlflowException, match="registered user") as exc:
+        auth.enforce_review_queue_name_not_username()
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def test_admin_create_non_shadowing_name_is_allowed(monkeypatch):
+    body = {"experiment_id": "123", "name": "Hallucinations", "queue_type": "CUSTOM"}
+    _setup(monkeypatch, permission="READ", update_body=body)
+    _patch_request(monkeypatch, auth.validate_can_create_review_queue, body)
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    auth.enforce_review_queue_name_not_username()
+
+
+def test_name_guard_is_a_noop_off_the_review_queue_routes(monkeypatch):
+    # On any other route the guard does nothing and never touches the roster, so
+    # adding it to `_before_request`'s admin branch is free for every endpoint.
+    _setup(monkeypatch, permission="READ")
+    _patch_request(monkeypatch, auth.validate_can_read_experiment, {})
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    auth.enforce_review_queue_name_not_username()
+
+
+def test_admin_owner_reassignment_without_rename_is_a_noop(monkeypatch):
+    # An admin update that only reassigns the owner (no `name`) is not a rename, so
+    # the guard short-circuits before querying the roster.
+    body = {"queue_id": "q1", "new_owner": "victim"}
+    _setup(monkeypatch, permission="READ", created_by="bob", update_body=body)
+    _patch_request(monkeypatch, auth.validate_can_update_review_queue, body)
+    monkeypatch.setattr(auth.store, "list_users", _forbid_list_users)
+    auth.enforce_review_queue_name_not_username()
+
+
+def test_admin_owner_reassignment_with_shadowing_rename_is_blocked(monkeypatch):
+    # Reassigning the owner and renaming onto a username in the same request: the
+    # rename still shadows, so it's rejected even alongside `new_owner`.
+    body = {"queue_id": "q1", "new_owner": "victim", "name": "Bob"}
+    _setup(monkeypatch, permission="READ", created_by="bob", update_body=body)
+    _patch_request(monkeypatch, auth.validate_can_update_review_queue, body)
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    with pytest.raises(MlflowException, match="registered user"):
+        auth.enforce_review_queue_name_not_username()
+
+
+def test_admin_create_shadowing_username_via_camelcase_is_blocked(monkeypatch):
+    # Protobuf JSON accepts camelCase keys; the guard parses the proto (not raw
+    # keys), so `queueType` is detected the same way the handler reads it.
+    body = {"experimentId": "123", "name": "Bob", "queueType": "CUSTOM"}
+    _setup(monkeypatch, permission="READ", update_body=body)
+    _patch_request(monkeypatch, auth.validate_can_create_review_queue, body)
+    monkeypatch.setattr(auth.store, "list_users", lambda: _users("alice", "bob"))
+    with pytest.raises(MlflowException, match="registered user"):
+        auth.enforce_review_queue_name_not_username()
 
 
 def test_owner_reassignment_via_camelcase_still_requires_manage(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23844

### What changes are proposed in this pull request?

A user (USER) review queue *is* its username, so a custom (CUSTOM) queue, or a rename of one, named after a registered user would shadow that user's personal queue. This adds a guard in the basic-auth layer (the only layer with the user roster, via `store.list_users()`):

- `validate_can_create_review_queue`: rejects creating a CUSTOM queue named after a registered user.
- `validate_can_update_review_queue`: rejects renaming a CUSTOM queue onto a registered username.

The match is case-insensitive (intentionally broader than the store's case-sensitive name uniqueness), so a look-alike like `Alice` is rejected too, not just the exact `alice` that would hard-collide and lock the user out. USER queues are exempt (a USER queue *is* its username), and renaming a USER queue is already blocked by the store.

Shadowing a username is a data-integrity rule, not a permission, so it applies to **every** caller including admins. Admins bypass the auth validators by design (`sender_is_admin()` short-circuits in `_before_request`), so the same guard (`enforce_review_queue_name_not_username`) also runs in that admin branch. For non-admins the guard runs inside the validators, after the permission gate, so an unauthorized caller never triggers a roster lookup. The reactive `get_or_create_user_queue` collision remains the backstop for users registered after a name was already taken.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/server/auth/test_review_queue_auth.py` cover: create/rename rejection (case-insensitive), non-username names allowed, blank-name and unset-`queue_type` short-circuits, USER-queue exemption, the permission gate denying before any roster lookup, the admin path (create + rename blocked, non-shadow allowed, camelCase body, owner-reassignment-only no-op), and the no-op on non-review-queue routes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Custom review queues can no longer be created or renamed using a registered user's name, which would have shadowed that user's personal review queue.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.