### PR TITLE
Surface review-question modal failures as toasts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaFormModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaFormModal.test.tsx
@@ -1,0 +1,120 @@
+import { describe, beforeEach, afterEach, jest, it, expect } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import Utils from '../../../common/utils/Utils';
+import { LabelSchemaFormModal } from './LabelSchemaFormModal';
+import type { LabelSchema } from './types';
+
+const mockUpdateAsync = jest.fn();
+const mockCreateAsync = jest.fn();
+jest.mock('./hooks/useCreateLabelSchemaMutation', () => ({
+  useCreateLabelSchemaMutation: () => ({
+    createLabelSchemaAsync: mockCreateAsync,
+    isCreating: false,
+    reset: jest.fn(),
+  }),
+}));
+jest.mock('./hooks/useUpdateLabelSchemaMutation', () => ({
+  useUpdateLabelSchemaMutation: () => ({
+    updateLabelSchemaAsync: mockUpdateAsync,
+    isUpdating: false,
+    reset: jest.fn(),
+  }),
+}));
+
+// The form renderer, preview, and resizable pane are heavy and unrelated to the
+// submit/error path under test; stub them so the modal renders with just its Save
+// button. The form value comes from `editingSchema` via react-hook-form defaults.
+jest.mock('./LabelSchemaFormRenderer', () => ({ LabelSchemaFormRenderer: () => null }));
+jest.mock('./LabelSchemaPreview', () => ({ LabelSchemaPreview: () => null }));
+jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  ModelTraceExplorerResizablePane: () => null,
+}));
+
+// The form fields are stubbed out (above), so we can't type valid values; bypass
+// validation so submitting reaches the mutation in both create and edit mode. The
+// real validator is exercised by its own callers, not this submit/error test.
+jest.mock('./labelSchemaFormUtils', () => ({
+  ...jest.requireActual<typeof import('./labelSchemaFormUtils')>('./labelSchemaFormUtils'),
+  validateLabelSchemaForm: () => ({}),
+}));
+
+// A valid free-text FEEDBACK schema: it passes `validateLabelSchemaForm` with no
+// required sub-fields, so submitting reaches the update mutation.
+const editingSchema: LabelSchema = {
+  schema_id: 's1',
+  experiment_id: 'exp-1',
+  name: 'Q1',
+  type: 'FEEDBACK',
+  input: { text: {} },
+};
+
+const mockOnClose = jest.fn();
+// `editingSchema = null` opens the modal in create mode; otherwise it edits.
+const renderModal = (editing: LabelSchema | null = editingSchema) =>
+  render(
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <LabelSchemaFormModal experimentId="exp-1" editingSchema={editing} visible onClose={mockOnClose} />
+      </DesignSystemProvider>
+    </IntlProvider>,
+  );
+
+describe('LabelSchemaFormModal save', () => {
+  beforeEach(() => {
+    mockOnClose.mockReset();
+    mockUpdateAsync.mockReset().mockImplementation(() => Promise.resolve());
+    mockCreateAsync.mockReset().mockImplementation(() => Promise.resolve());
+    jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
+  });
+
+  // Restore the Utils spy so a fresh `beforeEach` spy doesn't wrap an already-spied
+  // method and stack layers across tests.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('surfaces a toast and keeps the modal open when saving fails', async () => {
+    mockUpdateAsync.mockImplementation(() => Promise.reject(new Error('boom')));
+    renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockUpdateAsync).toHaveBeenCalledTimes(1);
+    // Edit mode must route through update, never create.
+    expect(mockCreateAsync).not.toHaveBeenCalled();
+    await waitFor(() => expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledTimes(1));
+    expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    // The modal stays open (its title is still shown, and it isn't closed) so the
+    // user can retry.
+    expect(screen.getByText('Edit question')).toBeInTheDocument();
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('closes the modal without a toast on a successful save', async () => {
+    renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockUpdateAsync).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockOnClose).toHaveBeenCalledTimes(1));
+    expect(Utils.displayGlobalErrorNotification).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a toast and keeps the modal open when creating fails', async () => {
+    mockCreateAsync.mockImplementation(() => Promise.reject(new Error('boom')));
+    renderModal(null);
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockCreateAsync).toHaveBeenCalledTimes(1);
+    // Create mode must route through create, never update.
+    expect(mockUpdateAsync).not.toHaveBeenCalled();
+    await waitFor(() => expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledTimes(1));
+    expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    // The modal stays open (its create-mode title is still shown) so the user can retry.
+    expect(screen.getByText('Add question')).toBeInTheDocument();
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaFormModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/label-schemas/LabelSchemaFormModal.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Modal, useDesignSystemTheme } from '@databricks/design-system';
 import { ModelTraceExplorerResizablePane } from '@databricks/web-shared/model-trace-explorer';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useForm, useWatch } from 'react-hook-form';
+
+import Utils from '../../../common/utils/Utils';
 
 import { LabelSchemaFormRenderer } from './LabelSchemaFormRenderer';
 import { LabelSchemaPreview } from './LabelSchemaPreview';
@@ -64,10 +66,10 @@ export const LabelSchemaFormModal = ({
 
   const [leftPaneWidth, setLeftPaneWidth] = useState(0);
 
+  const intl = useIntl();
   const createMutation = useCreateLabelSchemaMutation();
   const updateMutation = useUpdateLabelSchemaMutation();
   const isSubmitting = createMutation.isCreating || updateMutation.isUpdating;
-  const submitError = createMutation.error ?? updateMutation.error;
 
   // Reset the form whenever the modal opens or the edited schema changes. The
   // modal stays mounted across open/close, so without this react-hook-form's
@@ -107,8 +109,19 @@ export const LabelSchemaFormModal = ({
         });
         onCreated?.(label_schema);
       }
-    } catch {
-      // Errors surface via `submitError`; keep the modal open.
+    } catch (e) {
+      // Surface as a toast rather than inline text, so the error doesn't shift
+      // the modal's layout/buttons. Keep the modal open so the reviewer can
+      // correct and retry.
+      Utils.displayGlobalErrorNotification(
+        intl.formatMessage(
+          {
+            defaultMessage: 'Failed to save question: {error}',
+            description: 'Review question modal: error toast shown when saving a question fails',
+          },
+          { error: e instanceof Error ? e.message : String(e) },
+        ),
+      );
       return;
     }
     reset(DEFAULT_FORM_VALUES);
@@ -197,15 +210,6 @@ export const LabelSchemaFormModal = ({
             }
           />
         </div>
-        {submitError && (
-          <Typography.Text color="error">
-            <FormattedMessage
-              defaultMessage="Failed to save: {message}"
-              description="Review question save error"
-              values={{ message: submitError.message }}
-            />
-          </Typography.Text>
-        )}
       </div>
     </Modal>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.test.tsx
@@ -1,21 +1,22 @@
-import { describe, beforeEach, jest, it, expect } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { describe, beforeEach, afterEach, jest, it, expect } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DesignSystemProvider } from '@databricks/design-system';
 import { IntlProvider } from '@databricks/i18n';
 
+import Utils from '../../../common/utils/Utils';
 import { ManageQuestionsModal } from './ManageQuestionsModal';
 import type { ReviewQueue } from './types';
 
-const mockDelete = jest.fn();
+const mockDeleteAsync = jest.fn();
 jest.mock('../../components/label-schemas', () => ({
   useListLabelSchemasQuery: () => ({
     labelSchemas: [{ schema_id: 's1', name: 'Q1', type: 'FEEDBACK', input: { text: {} } }],
     isLoading: false,
   }),
-  useDeleteLabelSchemaMutation: () => ({ deleteLabelSchema: mockDelete, isDeleting: false }),
+  useDeleteLabelSchemaMutation: () => ({ deleteLabelSchemaAsync: mockDeleteAsync, isDeleting: false }),
   LabelSchemaFormModal: () => null,
 }));
 
@@ -54,6 +55,14 @@ describe('ManageQuestionsModal delete confirmation', () => {
   // Reset to a known baseline so a prior test's queues can't bleed into the next.
   beforeEach(() => {
     mockQueues = [];
+    mockDeleteAsync.mockReset().mockImplementation(() => Promise.resolve());
+    jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
+  });
+
+  // Restore the Utils spy so a fresh `beforeEach` spy doesn't wrap an already-spied
+  // method and stack layers across tests.
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('lists the custom queues that use the question (as deep links) and excludes others', async () => {
@@ -103,5 +112,29 @@ describe('ManageQuestionsModal delete confirmation', () => {
     expect(screen.queryByText(/Used by/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Inherited by/)).not.toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a toast and closes the confirmation when the delete fails', async () => {
+    mockDeleteAsync.mockImplementation(() => Promise.reject(new Error('boom')));
+    renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockDeleteAsync).toHaveBeenCalledWith({ schema_id: 's1' });
+    await waitFor(() => expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledTimes(1));
+    expect(Utils.displayGlobalErrorNotification).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    // The confirmation closes, and the question stays in the list to retry.
+    await waitFor(() => expect(screen.queryByText('Delete question?')).not.toBeInTheDocument());
+    expect(screen.getByText('Q1')).toBeInTheDocument();
+  });
+
+  it('closes the confirmation without a toast on a successful delete', async () => {
+    renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Delete question' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockDeleteAsync).toHaveBeenCalledWith({ schema_id: 's1' });
+    await waitFor(() => expect(screen.queryByText('Delete question?')).not.toBeInTheDocument());
+    expect(Utils.displayGlobalErrorNotification).not.toHaveBeenCalled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ManageQuestionsModal.tsx
@@ -19,6 +19,7 @@ import {
   useListLabelSchemasQuery,
 } from '../../components/label-schemas';
 import type { LabelSchema } from '../../components/label-schemas';
+import Utils from '../../../common/utils/Utils';
 import { Link } from '../../../common/utils/RoutingUtils';
 import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
 import { getReviewQueuePageRoute } from './hooks/useReviewQueueSearchParams';
@@ -34,7 +35,7 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const { labelSchemas, isLoading } = useListLabelSchemasQuery({ experimentId });
-  const { deleteLabelSchema, isDeleting } = useDeleteLabelSchemaMutation();
+  const { deleteLabelSchemaAsync, isDeleting } = useDeleteLabelSchemaMutation();
   // Shares the cache with the Review tab's queue list (same query key), so this
   // is a cache hit; used to show which custom queues a deletion would affect.
   // First page only (no maxResults), matching the Review tab; an experiment with
@@ -210,9 +211,26 @@ export const ManageQuestionsModal = ({ experimentId, onClose }: { experimentId: 
           okButtonProps={{ danger: true, loading: isDeleting }}
           cancelText={<FormattedMessage defaultMessage="Cancel" description="Manage review questions: cancel delete" />}
           onCancel={() => setPendingDelete(null)}
-          onOk={() =>
-            deleteLabelSchema({ schema_id: pendingDelete.schema_id }, { onSettled: () => setPendingDelete(null) })
-          }
+          onOk={async () => {
+            try {
+              await deleteLabelSchemaAsync({ schema_id: pendingDelete.schema_id });
+            } catch (e) {
+              // Without this the delete failure was swallowed: the confirm closed and
+              // the question silently stayed. Surface it as a toast (matching the other
+              // review-queue modals); the question remains in the list to retry.
+              Utils.displayGlobalErrorNotification(
+                intl.formatMessage(
+                  {
+                    defaultMessage: 'Failed to delete question: {error}',
+                    description: 'Manage review questions: error toast shown when deleting a question fails',
+                  },
+                  { error: e instanceof Error ? e.message : String(e) },
+                ),
+              );
+            } finally {
+              setPendingDelete(null);
+            }
+          }}
         >
           <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
             <FormattedMessage

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -207,13 +207,13 @@
     "defaultMessage": "e.g. 0.7",
     "description": "Placeholder for the temperature input on the playground parameters panel"
   },
-  "//EoiB": {
-    "defaultMessage": "Search records by inputs or expectations",
-    "description": "Aria label for the search input on the V2 dataset records page (placeholder is not a label per WCAG 1.3.1)"
-  },
   "+z2xbc": {
     "defaultMessage": "Playground",
     "description": "Label for the playground tab in the MLflow experiment navbar"
+  },
+  "//EoiB": {
+    "defaultMessage": "Search records by inputs or expectations",
+    "description": "Aria label for the search input on the V2 dataset records page (placeholder is not a label per WCAG 1.3.1)"
   },
   "/2InJv": {
     "defaultMessage": "Grounded",
@@ -406,6 +406,10 @@
   "/nPZbt": {
     "defaultMessage": "{totalTokens} total tokens",
     "description": "Experiment page > artifact compare view > results table > total number of evaluated tokens"
+  },
+  "/pO3oR": {
+    "defaultMessage": "Failed to save question: {error}",
+    "description": "Review question modal: error toast shown when saving a question fails"
   },
   "/qIHh7": {
     "defaultMessage": "Traces",
@@ -7555,10 +7559,6 @@
     "defaultMessage": "Prompts",
     "description": "Header title for the registered prompts page"
   },
-  "aLyy52": {
-    "defaultMessage": "Failed to save: {message}",
-    "description": "Review question save error"
-  },
   "aMOq4p": {
     "defaultMessage": "See {mlflowLink} for more details.",
     "description": "Link to MLflow prompt optimization documentation"
@@ -11066,6 +11066,10 @@
   "r/mP0/": {
     "defaultMessage": "Add rationale (optional)",
     "description": "Evaluation review > assessments > rationale input placeholder"
+  },
+  "r/uvjS": {
+    "defaultMessage": "Failed to delete question: {error}",
+    "description": "Manage review questions: error toast shown when deleting a question fails"
   },
   "r0J+Jm": {
     "defaultMessage": "Selected guardrail model endpoint is unavailable. Please choose another endpoint.",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23844

### What changes are proposed in this pull request?

Two review-queue modals were mis-surfacing (or silently swallowing) action failures. This makes both consistent with the toast pattern already used by `QueueSettingsModal`.

- **Add/Edit question** (`LabelSchemaFormModal`): a save failure was rendered as inline error text below the form, which shifted the modal body and its buttons. It now surfaces as a toast (`Utils.displayGlobalErrorNotification`) and the modal stays open so the reviewer can correct and retry.
- **Delete question** (`ManageQuestionsModal`): the delete-confirmation was fire-and-forget (`deleteLabelSchema(..., { onSettled })` with no `onError`), so a failed delete was swallowed: the dialog closed and the question silently stayed. It now awaits `deleteLabelSchemaAsync` in a try/catch, toasts on failure, and closes the confirmation in `finally`. The question remains in the list to retry.

The old inline-error i18n key is removed by the i18n extractor (it is now orphaned).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New Jest failure-path tests for both modals mock the mutation to reject and assert the toast fires (with the error message) and the modal/dialog stays in the right state; the edit-mode test also asserts it routes through update, not create. The toast z-ordering over the modal was verified manually in the dev server.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Failures when adding, editing, or deleting a review question are now shown as a toast notification instead of being swallowed or shifting the modal layout.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.