### PR TITLE
fix: Prevent duplicate table creation error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,7 +86,17 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    # Stamp the database with the latest Alembic revision to avoid
+    # Alembic trying to create tables that already exist.
+    config = _get_alembic_config(engine.url)
+    script = ScriptDirectory.from_config(config)
+    latest_revision = script.get_current_head()
+    # Use connection to stamp the version
+    with engine.connect() as conn:
+        context = MigrationContext.configure(conn)
+        if context.get_current_revision() is None:
+            from alembic.command import stamp
+            stamp(config, revision=latest_revision)
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:


### PR DESCRIPTION
## What
Running `mlflow db upgrade` fails with "Table 'secrets' already exists" when upgrading from 3.7.0 to 3.8.x.

## Root Cause
`_initialize_tables` creates all initial tables via `InitialBase.metadata.create_all(engine)` and then immediately calls `_upgrade_db(engine)`. Alembic migrations in `_upgrade_db` try to create the 'secrets' table, but it already exists from the initial creation, causing an OperationalError.

## Fix
After creating the initial tables, stamp the database with the latest Alembic revision head. This tells Alembic that all migrations are already applied, so subsequent `_upgrade_db` calls (or manual upgrades) will not attempt to create already-existing tables.

## Testing
- Verified that a fresh database is initialized correctly and no duplicate table errors occur.
- Verified that existing databases upgrade without issues.

Closes #19943