### PR TITLE
Allow remote access to the MLflow Assistant for API-based providers

### DIFF
--- a/mlflow/assistant/providers/base.py
+++ b/mlflow/assistant/providers/base.py
@@ -54,6 +54,11 @@ class AssistantProvider(ABC):
     def is_available(self) -> bool:
         """Check if the provider is available and ready to use."""
 
+    @property
+    def requires_local_execution(self) -> bool:
+        """Whether this provider must run on the same host as the MLflow server."""
+        return True
+
     @abstractmethod
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
         """

--- a/mlflow/assistant/providers/base.py
+++ b/mlflow/assistant/providers/base.py
@@ -55,9 +55,9 @@ class AssistantProvider(ABC):
         """Check if the provider is available and ready to use."""
 
     @property
-    def requires_local_execution(self) -> bool:
-        """Whether this provider must run on the same host as the MLflow server."""
-        return True
+    def allows_remote_execution(self) -> bool:
+        """Whether this provider can serve requests from remote clients."""
+        return False
 
     @abstractmethod
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:

--- a/mlflow/assistant/providers/base.py
+++ b/mlflow/assistant/providers/base.py
@@ -55,7 +55,7 @@ class AssistantProvider(ABC):
         """Check if the provider is available and ready to use."""
 
     @property
-    def allows_remote_execution(self) -> bool:
+    def allows_remote_access(self) -> bool:
         """Whether this provider can serve requests from remote clients."""
         return False
 

--- a/mlflow/assistant/providers/mlflow_gateway.py
+++ b/mlflow/assistant/providers/mlflow_gateway.py
@@ -35,4 +35,5 @@ class MlflowGatewayProvider(OpenAICompatibleProvider):
                 "Configure an LLM chat endpoint on the MLflow AI Gateway and select it."
             ),
             chat_url_builder=self._build_chat_url,
+            allows_remote_execution=True,
         )

--- a/mlflow/assistant/providers/mlflow_gateway.py
+++ b/mlflow/assistant/providers/mlflow_gateway.py
@@ -35,5 +35,5 @@ class MlflowGatewayProvider(OpenAICompatibleProvider):
                 "Configure an LLM chat endpoint on the MLflow AI Gateway and select it."
             ),
             chat_url_builder=self._build_chat_url,
-            allows_remote_execution=True,
+            allows_remote_access=True,
         )

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -253,7 +253,7 @@ class OpenAICompatibleProvider(AssistantProvider):
         chat_url_builder: ChatUrlBuilder = _default_chat_url_builder,
         default_base_url: str | None = None,
         skills_dirname: str | None = None,
-        requires_local_execution: bool = True,
+        allows_remote_execution: bool = False,
     ):
         self._name = name
         self._display_name = display_name
@@ -266,7 +266,7 @@ class OpenAICompatibleProvider(AssistantProvider):
         # OAI-compat providers don't actually load skills at runtime, but the
         # path is preserved so users can opt-in later via skill_installer.
         self._skills_dirname = skills_dirname or ".agent"
-        self._requires_local_execution = requires_local_execution
+        self._allows_remote_execution = allows_remote_execution
 
     @property
     def name(self) -> str:
@@ -281,8 +281,8 @@ class OpenAICompatibleProvider(AssistantProvider):
         return self._description
 
     @property
-    def requires_local_execution(self) -> bool:
-        return self._requires_local_execution
+    def allows_remote_execution(self) -> bool:
+        return self._allows_remote_execution
 
     def is_available(self) -> bool:
         return True

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -253,6 +253,7 @@ class OpenAICompatibleProvider(AssistantProvider):
         chat_url_builder: ChatUrlBuilder = _default_chat_url_builder,
         default_base_url: str | None = None,
         skills_dirname: str | None = None,
+        requires_local_execution: bool = True,
     ):
         self._name = name
         self._display_name = display_name
@@ -265,6 +266,7 @@ class OpenAICompatibleProvider(AssistantProvider):
         # OAI-compat providers don't actually load skills at runtime, but the
         # path is preserved so users can opt-in later via skill_installer.
         self._skills_dirname = skills_dirname or ".agent"
+        self._requires_local_execution = requires_local_execution
 
     @property
     def name(self) -> str:
@@ -277,6 +279,10 @@ class OpenAICompatibleProvider(AssistantProvider):
     @property
     def description(self) -> str:
         return self._description
+
+    @property
+    def requires_local_execution(self) -> bool:
+        return self._requires_local_execution
 
     def is_available(self) -> bool:
         return True

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -253,7 +253,7 @@ class OpenAICompatibleProvider(AssistantProvider):
         chat_url_builder: ChatUrlBuilder = _default_chat_url_builder,
         default_base_url: str | None = None,
         skills_dirname: str | None = None,
-        allows_remote_execution: bool = False,
+        allows_remote_access: bool = False,
     ):
         self._name = name
         self._display_name = display_name
@@ -266,7 +266,7 @@ class OpenAICompatibleProvider(AssistantProvider):
         # OAI-compat providers don't actually load skills at runtime, but the
         # path is preserved so users can opt-in later via skill_installer.
         self._skills_dirname = skills_dirname or ".agent"
-        self._allows_remote_execution = allows_remote_execution
+        self._allows_remote_access = allows_remote_access
 
     @property
     def name(self) -> str:
@@ -281,8 +281,8 @@ class OpenAICompatibleProvider(AssistantProvider):
         return self._description
 
     @property
-    def allows_remote_execution(self) -> bool:
-        return self._allows_remote_execution
+    def allows_remote_access(self) -> bool:
+        return self._allows_remote_access
 
     def is_available(self) -> bool:
         return True

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -117,7 +117,7 @@ MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES
 
 #: Controls whether the MLflow Assistant API is reachable from non-localhost clients.
 #: One of ``"off"`` (default, localhost only), ``"api-only"`` (remote allowed only for
-#: providers that don't require local execution, e.g. the MLflow Gateway), or ``"all"``.
+#: providers that don't require local execution, e.g. the MLflow Gateway).
 MLFLOW_ALLOW_REMOTE_ASSISTANT = _EnvironmentVariable("MLFLOW_ALLOW_REMOTE_ASSISTANT", str, "off")
 
 #: When true, newly created workspaces are seeded with two default RBAC roles

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -115,6 +115,7 @@ MLFLOW_WORKSPACE_STORE_URI = _EnvironmentVariable("MLFLOW_WORKSPACE_STORE_URI", 
 #: (default: ``False``)
 MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES", False)
 
+#: **Experimental** — subject to change or removal in a future release.
 #: Controls whether the MLflow Assistant API is reachable from non-localhost clients.
 #: One of ``"off"`` (default, localhost only), ``"api-only"`` (remote allowed only for
 #: providers that don't require local execution, e.g. the MLflow Gateway).

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -115,6 +115,11 @@ MLFLOW_WORKSPACE_STORE_URI = _EnvironmentVariable("MLFLOW_WORKSPACE_STORE_URI", 
 #: (default: ``False``)
 MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES", False)
 
+#: Controls whether the MLflow Assistant API is reachable from non-localhost clients.
+#: One of ``"off"`` (default, localhost only), ``"api-only"`` (remote allowed only for
+#: providers that don't require local execution, e.g. the MLflow Gateway), or ``"all"``.
+MLFLOW_ALLOW_REMOTE_ASSISTANT = _EnvironmentVariable("MLFLOW_ALLOW_REMOTE_ASSISTANT", str, "off")
+
 #: When true, newly created workspaces are seeded with two default RBAC roles
 #: (``admin``, ``user``) that super-admins can assign to other
 #: users. ``CreateWorkspace`` is gated to super-admins, whose ``is_admin`` flag already

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -117,9 +117,12 @@ MLFLOW_ENABLE_WORKSPACES = _BooleanEnvironmentVariable("MLFLOW_ENABLE_WORKSPACES
 
 #: **Experimental** — subject to change or removal in a future release.
 #: Controls whether the MLflow Assistant API is reachable from non-localhost clients.
-#: One of ``"off"`` (default, localhost only), ``"api-only"`` (remote allowed only for
-#: providers that don't require local execution, e.g. the MLflow Gateway).
-MLFLOW_ALLOW_REMOTE_ASSISTANT = _EnvironmentVariable("MLFLOW_ALLOW_REMOTE_ASSISTANT", str, "off")
+#: Remote access is still limited to providers that don't require local execution
+#: (e.g. the MLflow Gateway); this only opts into that check.
+#: (default: ``False``)
+MLFLOW_ENABLE_REMOTE_ASSISTANT = _BooleanEnvironmentVariable(
+    "MLFLOW_ENABLE_REMOTE_ASSISTANT", False
+)
 
 #: When true, newly created workspaces are seeded with two default RBAC roles
 #: (``admin``, ``user``) that super-admins can assign to other

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -48,7 +48,7 @@ def _get_selected_provider(config: AssistantConfig | None = None):
 _BLOCK_REMOTE_ACCESS_ERROR_MSG = (
     "Assistant API is only accessible from the same host where the MLflow server is running."
 )
-_REMOTE_ACCESS_MODES = ("off", "api-only", "all")
+_REMOTE_ACCESS_MODES = ("off", "api-only")
 _INVALID_REMOTE_ACCESS_MODES_WARNED: set[str] = set()
 
 
@@ -80,8 +80,6 @@ def _get_remote_access_mode() -> str:
 
 def _provider_allows_remote_access(provider: AssistantProvider | None) -> bool:
     mode = _get_remote_access_mode()
-    if mode == "all":
-        return True
     if mode == "api-only":
         return provider is not None and not provider.requires_local_execution
     return False

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -1,12 +1,15 @@
 import ipaddress
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, AsyncGenerator, Literal
 
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from fastapi.routing import APIRoute
 from pydantic import BaseModel, Field
+from starlette.responses import Response
 
 from mlflow.assistant import clear_project_path_cache, get_project_path
 from mlflow.assistant.config import AssistantConfig, PermissionsConfig, ProjectConfig
@@ -33,8 +36,9 @@ def _get_provider(name: str):
     return None
 
 
-def _get_selected_provider():
-    config = AssistantConfig.load()
+def _get_selected_provider(config: AssistantConfig | None = None):
+    if config is None:
+        config = AssistantConfig.load()
     for provider_name, provider_config in config.providers.items():
         if provider_config.selected:
             return _get_provider(provider_name)
@@ -45,6 +49,7 @@ _BLOCK_REMOTE_ACCESS_ERROR_MSG = (
     "Assistant API is only accessible from the same host where the MLflow server is running."
 )
 _REMOTE_ACCESS_MODES = ("off", "api-only", "all")
+_INVALID_REMOTE_ACCESS_MODES_WARNED: set[str] = set()
 
 
 def _is_localhost(request: Request) -> bool:
@@ -61,12 +66,14 @@ def _is_localhost(request: Request) -> bool:
 def _get_remote_access_mode() -> str:
     mode = MLFLOW_ALLOW_REMOTE_ASSISTANT.get()
     if mode not in _REMOTE_ACCESS_MODES:
-        _logger.warning(
-            "Invalid value %r for %s, falling back to 'off'. Valid values are: %s",
-            mode,
-            MLFLOW_ALLOW_REMOTE_ASSISTANT.name,
-            _REMOTE_ACCESS_MODES,
-        )
+        if mode not in _INVALID_REMOTE_ACCESS_MODES_WARNED:
+            _logger.warning(
+                "Invalid value %r for %s, falling back to 'off'. Valid values are: %s",
+                mode,
+                MLFLOW_ALLOW_REMOTE_ASSISTANT.name,
+                _REMOTE_ACCESS_MODES,
+            )
+            _INVALID_REMOTE_ACCESS_MODES_WARNED.add(mode)
         return "off"
     return mode
 
@@ -87,9 +94,50 @@ def _enforce_remote_access(request: Request, provider: AssistantProvider | None)
         raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
 
 
+_RemoteAccessPolicy = Literal["selected_provider", "path_provider", "config_write", "none"]
+_REMOTE_ACCESS_POLICY_ATTR = "_assistant_remote_access_policy"
+
+
+def _remote_access_policy(policy: _RemoteAccessPolicy):
+    def decorator(func):
+        setattr(func, _REMOTE_ACCESS_POLICY_ATTR, policy)
+        return func
+
+    return decorator
+
+
+def _get_route_provider(request: Request, policy: _RemoteAccessPolicy) -> AssistantProvider | None:
+    match policy:
+        case "selected_provider":
+            return _get_selected_provider()
+        case "path_provider":
+            provider_name = request.path_params.get("provider")
+            return _get_provider(provider_name) if provider_name else None
+        case "config_write":
+            return None
+        case "none":
+            return None
+
+
+class _AssistantAPIRoute(APIRoute):
+    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+        original_route_handler = super().get_route_handler()
+        policy = getattr(self.endpoint, _REMOTE_ACCESS_POLICY_ATTR, "selected_provider")
+
+        async def route_handler(request: Request) -> Response:
+            if policy != "none":
+                provider = _get_route_provider(request, policy)
+                if policy != "path_provider" or provider is not None:
+                    _enforce_remote_access(request, provider)
+            return await original_route_handler(request)
+
+        return route_handler
+
+
 assistant_router = APIRouter(
     prefix="/ajax-api/3.0/mlflow/assistant",
     tags=["assistant"],
+    route_class=_AssistantAPIRoute,
 )
 
 
@@ -154,8 +202,6 @@ async def send_message(http_request: Request, request: MessageRequest) -> Messag
     Returns:
         MessageResponse with session_id and stream_url
     """
-    _enforce_remote_access(http_request, _get_selected_provider())
-
     # Generate or use existing session ID
     session_id = request.session_id or str(uuid.uuid4())
 
@@ -193,8 +239,6 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
     Returns:
         StreamingResponse with SSE events
     """
-    _enforce_remote_access(request, _get_selected_provider())
-
     session = SessionManager.load(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -281,8 +325,6 @@ async def patch_session(
     Returns:
         SessionPatchResponse indicating success
     """
-    _enforce_remote_access(http_request, _get_selected_provider())
-
     session = SessionManager.load(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -329,12 +371,11 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
 
 
 @assistant_router.get("/providers/{provider}/health")
+@_remote_access_policy("path_provider")
 async def provider_health_check(http_request: Request, provider: str) -> dict[str, str]:
     p = _get_provider(provider)
     if p is None:
         raise HTTPException(status_code=404, detail=f"Provider '{provider}' not found")
-
-    _enforce_remote_access(http_request, p)
 
     try:
         p.check_connection()
@@ -352,6 +393,7 @@ async def provider_health_check(http_request: Request, provider: str) -> dict[st
 
 
 @assistant_router.get("/config")
+@_remote_access_policy("none")
 async def get_config(request: Request) -> ConfigResponse:
     """
     Get the current assistant configuration.
@@ -368,11 +410,12 @@ async def get_config(request: Request) -> ConfigResponse:
     return ConfigResponse(
         providers=providers,
         projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
-        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider()),
+        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
     )
 
 
 @assistant_router.put("/config")
+@_remote_access_policy("config_write")
 async def update_config(http_request: Request, request: ConfigUpdateRequest) -> ConfigResponse:
     """
     Update the assistant configuration.
@@ -384,8 +427,6 @@ async def update_config(http_request: Request, request: ConfigUpdateRequest) -> 
     Returns:
         Updated configuration.
     """
-    _enforce_remote_access(http_request, None)
-
     config = AssistantConfig.load()
 
     # Update providers
@@ -443,7 +484,7 @@ async def update_config(http_request: Request, request: ConfigUpdateRequest) -> 
     return ConfigResponse(
         providers={name: p.model_dump() for name, p in config.providers.items()},
         projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
-        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider()),
+        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
     )
 
 
@@ -465,8 +506,6 @@ async def install_skills_endpoint(
     Raises:
         HTTPException 400: If custom type without custom_path or project type without experiment_id.
     """
-    _enforce_remote_access(http_request, _get_selected_provider())
-
     config = AssistantConfig.load()
 
     project_path: Path | None = None
@@ -514,6 +553,7 @@ async def install_skills_endpoint(
 
 
 @assistant_router.get("/providers/{provider}/models")
+@_remote_access_policy("path_provider")
 async def list_provider_models(
     http_request: Request,
     provider: str,
@@ -531,8 +571,6 @@ async def list_provider_models(
             status_code=404,
             detail=f"Provider '{provider}' not found",
         )
-
-    _enforce_remote_access(http_request, p)
 
     try:
         models = p.list_models(base_url, api_key)

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -139,6 +139,11 @@ class _AssistantAPIRoute(APIRoute):
 
         async def route_handler(request: Request) -> Response:
             if policy != "none":
+                if (
+                    not _is_localhost(request)
+                    and _get_remote_access_mode() == _RemoteAccessMode.OFF
+                ):
+                    raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
                 provider = _get_route_provider(request, policy)
                 if policy != "path_provider" or provider is not None:
                     _enforce_remote_access(request, provider)
@@ -403,7 +408,7 @@ async def provider_health_check(provider: str) -> dict[str, str]:
 
 @assistant_router.get("/config")
 @_remote_access_policy("none")
-async def get_config() -> ConfigResponse:
+async def get_config(request: Request) -> ConfigResponse:
     """
     Get the current assistant configuration.
 
@@ -415,9 +420,14 @@ async def get_config() -> ConfigResponse:
     for provider_data in providers.values():
         provider_data.pop("api_key", None)
 
+    projects = {exp_id: p.model_dump() for exp_id, p in config.projects.items()}
+    if not _is_localhost(request):
+        for project_data in projects.values():
+            project_data.pop("location", None)
+
     return ConfigResponse(
         providers=providers,
-        projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
+        projects=projects,
         remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
     )
 

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -1,3 +1,4 @@
+import enum
 import ipaddress
 import logging
 import uuid
@@ -48,7 +49,13 @@ def _get_selected_provider(config: AssistantConfig | None = None):
 _BLOCK_REMOTE_ACCESS_ERROR_MSG = (
     "Assistant API is only accessible from the same host where the MLflow server is running."
 )
-_REMOTE_ACCESS_MODES = ("off", "api-only")
+
+
+class _RemoteAccessMode(str, enum.Enum):
+    OFF = "off"
+    API_ONLY = "api-only"
+
+
 _INVALID_REMOTE_ACCESS_MODES_WARNED: set[str] = set()
 
 
@@ -63,25 +70,26 @@ def _is_localhost(request: Request) -> bool:
     return ip.is_loopback
 
 
-def _get_remote_access_mode() -> str:
-    mode = MLFLOW_ALLOW_REMOTE_ASSISTANT.get()
-    if mode not in _REMOTE_ACCESS_MODES:
-        if mode not in _INVALID_REMOTE_ACCESS_MODES_WARNED:
+def _get_remote_access_mode() -> _RemoteAccessMode:
+    raw = MLFLOW_ALLOW_REMOTE_ASSISTANT.get()
+    try:
+        return _RemoteAccessMode(raw)
+    except ValueError:
+        if raw not in _INVALID_REMOTE_ACCESS_MODES_WARNED:
             _logger.warning(
                 "Invalid value %r for %s, falling back to 'off'. Valid values are: %s",
-                mode,
+                raw,
                 MLFLOW_ALLOW_REMOTE_ASSISTANT.name,
-                _REMOTE_ACCESS_MODES,
+                [m.value for m in _RemoteAccessMode],
             )
-            _INVALID_REMOTE_ACCESS_MODES_WARNED.add(mode)
-        return "off"
-    return mode
+            _INVALID_REMOTE_ACCESS_MODES_WARNED.add(raw)
+        return _RemoteAccessMode.OFF
 
 
 def _provider_allows_remote_access(provider: AssistantProvider | None) -> bool:
     mode = _get_remote_access_mode()
-    if mode == "api-only":
-        return provider is not None and not provider.requires_local_execution
+    if mode == _RemoteAccessMode.API_ONLY:
+        return provider is not None and provider.allows_remote_execution
     return False
 
 
@@ -92,6 +100,11 @@ def _enforce_remote_access(request: Request, provider: AssistantProvider | None)
         raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
 
 
+# Per-route remote-access policy:
+#   "selected_provider" — gate on whichever provider the user has currently selected
+#   "path_provider"     — gate on the provider identified by a {provider} path parameter
+#   "config_write"      — always block remote access (config writes stay localhost-only)
+#   "none"              — no gating (e.g. GET /config, which redacts secrets instead)
 _RemoteAccessPolicy = Literal["selected_provider", "path_provider", "config_write", "none"]
 _REMOTE_ACCESS_POLICY_ATTR = "_assistant_remote_access_policy"
 
@@ -120,7 +133,9 @@ def _get_route_provider(request: Request, policy: _RemoteAccessPolicy) -> Assist
 class _AssistantAPIRoute(APIRoute):
     def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
         original_route_handler = super().get_route_handler()
-        policy = getattr(self.endpoint, _REMOTE_ACCESS_POLICY_ATTR, "selected_provider")
+        policy: _RemoteAccessPolicy = getattr(
+            self.endpoint, _REMOTE_ACCESS_POLICY_ATTR, "selected_provider"
+        )
 
         async def route_handler(request: Request) -> Response:
             if policy != "none":
@@ -189,12 +204,11 @@ class SkillsInstallResponse(BaseModel):
 
 
 @assistant_router.post("/message")
-async def send_message(http_request: Request, request: MessageRequest) -> MessageResponse:
+async def send_message(request: MessageRequest) -> MessageResponse:
     """
     Send a message to the assistant and get a session for streaming the response.
 
     Args:
-        http_request: The FastAPI request object, used for remote-access gating
         request: MessageRequest with message, context, and optional session_id
 
     Returns:
@@ -306,9 +320,7 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
 
 
 @assistant_router.patch("/sessions/{session_id}")
-async def patch_session(
-    http_request: Request, session_id: str, request: SessionPatchRequest
-) -> SessionPatchResponse:
+async def patch_session(session_id: str, request: SessionPatchRequest) -> SessionPatchResponse:
     """
     Update session status.
 
@@ -316,7 +328,6 @@ async def patch_session(
     the running assistant process.
 
     Args:
-        http_request: The FastAPI request object, used for remote-access gating
         session_id: The session ID
         request: SessionPatchRequest with status to set
 
@@ -370,7 +381,7 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
 
 @assistant_router.get("/providers/{provider}/health")
 @_remote_access_policy("path_provider")
-async def provider_health_check(http_request: Request, provider: str) -> dict[str, str]:
+async def provider_health_check(provider: str) -> dict[str, str]:
     p = _get_provider(provider)
     if p is None:
         raise HTTPException(status_code=404, detail=f"Provider '{provider}' not found")
@@ -392,7 +403,7 @@ async def provider_health_check(http_request: Request, provider: str) -> dict[st
 
 @assistant_router.get("/config")
 @_remote_access_policy("none")
-async def get_config(request: Request) -> ConfigResponse:
+async def get_config() -> ConfigResponse:
     """
     Get the current assistant configuration.
 
@@ -401,9 +412,8 @@ async def get_config(request: Request) -> ConfigResponse:
     """
     config = AssistantConfig.load()
     providers = {name: p.model_dump() for name, p in config.providers.items()}
-    if not _is_localhost(request):
-        for provider_data in providers.values():
-            provider_data.pop("api_key", None)
+    for provider_data in providers.values():
+        provider_data.pop("api_key", None)
 
     return ConfigResponse(
         providers=providers,
@@ -414,12 +424,11 @@ async def get_config(request: Request) -> ConfigResponse:
 
 @assistant_router.put("/config")
 @_remote_access_policy("config_write")
-async def update_config(http_request: Request, request: ConfigUpdateRequest) -> ConfigResponse:
+async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
     """
     Update the assistant configuration.
 
     Args:
-        http_request: The FastAPI request object, used for remote-access gating
         request: Partial configuration update.
 
     Returns:
@@ -479,23 +488,24 @@ async def update_config(http_request: Request, request: ConfigUpdateRequest) -> 
     clear_config_cache()
     clear_project_path_cache()
 
+    providers = {name: p.model_dump() for name, p in config.providers.items()}
+    for provider_data in providers.values():
+        provider_data.pop("api_key", None)
+
     return ConfigResponse(
-        providers={name: p.model_dump() for name, p in config.providers.items()},
+        providers=providers,
         projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
         remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
     )
 
 
 @assistant_router.post("/skills/install")
-async def install_skills_endpoint(
-    http_request: Request, request: SkillsInstallRequest
-) -> SkillsInstallResponse:
+async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstallResponse:
     """
     Install skills bundled with MLflow.
     This endpoint only handles installation. Config updates should be done via PUT /config.
 
     Args:
-        http_request: The FastAPI request object, used for remote-access gating
         request: SkillsInstallRequest with type, custom_path, and experiment_id.
 
     Returns:
@@ -553,7 +563,6 @@ async def install_skills_endpoint(
 @assistant_router.get("/providers/{provider}/models")
 @_remote_access_policy("path_provider")
 async def list_provider_models(
-    http_request: Request,
     provider: str,
     base_url: str | None = None,
     x_api_key: str | None = Header(default=None, alias="X-API-Key"),

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -1,9 +1,10 @@
 import ipaddress
+import logging
 import uuid
 from pathlib import Path
 from typing import Any, AsyncGenerator, Literal
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -11,6 +12,7 @@ from mlflow.assistant import clear_project_path_cache, get_project_path
 from mlflow.assistant.config import AssistantConfig, PermissionsConfig, ProjectConfig
 from mlflow.assistant.providers import list_providers
 from mlflow.assistant.providers.base import (
+    AssistantProvider,
     CLINotInstalledError,
     NotAuthenticatedError,
     ProviderNotConfiguredError,
@@ -18,7 +20,10 @@ from mlflow.assistant.providers.base import (
 )
 from mlflow.assistant.skill_installer import install_skills, list_installed_skills
 from mlflow.assistant.types import EventType
+from mlflow.environment_variables import MLFLOW_ALLOW_REMOTE_ASSISTANT
 from mlflow.server.assistant.session import SessionManager, terminate_session_process
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_provider(name: str):
@@ -39,35 +44,52 @@ def _get_selected_provider():
 _BLOCK_REMOTE_ACCESS_ERROR_MSG = (
     "Assistant API is only accessible from the same host where the MLflow server is running."
 )
+_REMOTE_ACCESS_MODES = ("off", "api-only", "all")
 
 
-async def _require_localhost(request: Request) -> None:
-    """
-    Dependency that restricts access to localhost only.
-
-    Uses ipaddress library for robust loopback detection.
-
-    Raises:
-        HTTPException: If request is not from localhost
-    """
+def _is_localhost(request: Request) -> bool:
     client_host = request.client.host if request.client else None
-
     if not client_host:
-        raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
-
+        return False
     try:
         ip = ipaddress.ip_address(client_host)
     except ValueError:
-        raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
+        return False
+    return ip.is_loopback
 
-    if not ip.is_loopback:
+
+def _get_remote_access_mode() -> str:
+    mode = MLFLOW_ALLOW_REMOTE_ASSISTANT.get()
+    if mode not in _REMOTE_ACCESS_MODES:
+        _logger.warning(
+            "Invalid value %r for %s, falling back to 'off'. Valid values are: %s",
+            mode,
+            MLFLOW_ALLOW_REMOTE_ASSISTANT.name,
+            _REMOTE_ACCESS_MODES,
+        )
+        return "off"
+    return mode
+
+
+def _provider_allows_remote_access(provider: AssistantProvider | None) -> bool:
+    mode = _get_remote_access_mode()
+    if mode == "all":
+        return True
+    if mode == "api-only":
+        return provider is not None and not provider.requires_local_execution
+    return False
+
+
+def _enforce_remote_access(request: Request, provider: AssistantProvider | None) -> None:
+    if _is_localhost(request):
+        return
+    if not _provider_allows_remote_access(provider):
         raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
 
 
 assistant_router = APIRouter(
     prefix="/ajax-api/3.0/mlflow/assistant",
     tags=["assistant"],
-    dependencies=[Depends(_require_localhost)],
 )
 
 
@@ -87,6 +109,7 @@ class MessageResponse(BaseModel):
 class ConfigResponse(BaseModel):
     providers: dict[str, Any] = Field(default_factory=dict)
     projects: dict[str, Any] = Field(default_factory=dict)
+    remote_chat_allowed: bool = False
 
 
 class ConfigUpdateRequest(BaseModel):
@@ -120,16 +143,19 @@ class SkillsInstallResponse(BaseModel):
 
 
 @assistant_router.post("/message")
-async def send_message(request: MessageRequest) -> MessageResponse:
+async def send_message(http_request: Request, request: MessageRequest) -> MessageResponse:
     """
     Send a message to the assistant and get a session for streaming the response.
 
     Args:
+        http_request: The FastAPI request object, used for remote-access gating
         request: MessageRequest with message, context, and optional session_id
 
     Returns:
         MessageResponse with session_id and stream_url
     """
+    _enforce_remote_access(http_request, _get_selected_provider())
+
     # Generate or use existing session ID
     session_id = request.session_id or str(uuid.uuid4())
 
@@ -167,6 +193,8 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
     Returns:
         StreamingResponse with SSE events
     """
+    _enforce_remote_access(request, _get_selected_provider())
+
     session = SessionManager.load(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -193,8 +221,7 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
         context["tool_decisions"] = tool_decisions
 
     # Extract the MLflow server URL from the request for the assistant to use.
-    # This assumes the assistant is accessing the same MLflow server that serves this API,
-    # which works because the assistant endpoint is localhost-only.
+    # This assumes the assistant is accessing the same MLflow server that serves this API.
     # TODO: Extend this to support remote/proxy scenarios where the tracking URI may differ.
     tracking_uri = str(request.base_url).rstrip("/")
 
@@ -237,7 +264,9 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
 
 
 @assistant_router.patch("/sessions/{session_id}")
-async def patch_session(session_id: str, request: SessionPatchRequest) -> SessionPatchResponse:
+async def patch_session(
+    http_request: Request, session_id: str, request: SessionPatchRequest
+) -> SessionPatchResponse:
     """
     Update session status.
 
@@ -245,12 +274,15 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
     the running assistant process.
 
     Args:
+        http_request: The FastAPI request object, used for remote-access gating
         session_id: The session ID
         request: SessionPatchRequest with status to set
 
     Returns:
         SessionPatchResponse indicating success
     """
+    _enforce_remote_access(http_request, _get_selected_provider())
+
     session = SessionManager.load(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -297,10 +329,12 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
 
 
 @assistant_router.get("/providers/{provider}/health")
-async def provider_health_check(provider: str) -> dict[str, str]:
+async def provider_health_check(http_request: Request, provider: str) -> dict[str, str]:
     p = _get_provider(provider)
     if p is None:
         raise HTTPException(status_code=404, detail=f"Provider '{provider}' not found")
+
+    _enforce_remote_access(http_request, p)
 
     try:
         p.check_connection()
@@ -318,7 +352,7 @@ async def provider_health_check(provider: str) -> dict[str, str]:
 
 
 @assistant_router.get("/config")
-async def get_config() -> ConfigResponse:
+async def get_config(request: Request) -> ConfigResponse:
     """
     Get the current assistant configuration.
 
@@ -326,23 +360,32 @@ async def get_config() -> ConfigResponse:
         Current configuration including providers and projects.
     """
     config = AssistantConfig.load()
+    providers = {name: p.model_dump() for name, p in config.providers.items()}
+    if not _is_localhost(request):
+        for provider_data in providers.values():
+            provider_data.pop("api_key", None)
+
     return ConfigResponse(
-        providers={name: p.model_dump() for name, p in config.providers.items()},
+        providers=providers,
         projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
+        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider()),
     )
 
 
 @assistant_router.put("/config")
-async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
+async def update_config(http_request: Request, request: ConfigUpdateRequest) -> ConfigResponse:
     """
     Update the assistant configuration.
 
     Args:
+        http_request: The FastAPI request object, used for remote-access gating
         request: Partial configuration update.
 
     Returns:
         Updated configuration.
     """
+    _enforce_remote_access(http_request, None)
+
     config = AssistantConfig.load()
 
     # Update providers
@@ -400,16 +443,20 @@ async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
     return ConfigResponse(
         providers={name: p.model_dump() for name, p in config.providers.items()},
         projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
+        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider()),
     )
 
 
 @assistant_router.post("/skills/install")
-async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstallResponse:
+async def install_skills_endpoint(
+    http_request: Request, request: SkillsInstallRequest
+) -> SkillsInstallResponse:
     """
     Install skills bundled with MLflow.
     This endpoint only handles installation. Config updates should be done via PUT /config.
 
     Args:
+        http_request: The FastAPI request object, used for remote-access gating
         request: SkillsInstallRequest with type, custom_path, and experiment_id.
 
     Returns:
@@ -418,6 +465,8 @@ async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstal
     Raises:
         HTTPException 400: If custom type without custom_path or project type without experiment_id.
     """
+    _enforce_remote_access(http_request, _get_selected_provider())
+
     config = AssistantConfig.load()
 
     project_path: Path | None = None
@@ -466,13 +515,14 @@ async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstal
 
 @assistant_router.get("/providers/{provider}/models")
 async def list_provider_models(
+    http_request: Request,
     provider: str,
     base_url: str | None = None,
     x_api_key: str | None = Header(default=None, alias="X-API-Key"),
 ) -> dict[str, Any]:
     # api_key is read from the X-API-Key header (not a query param) so the
     # bearer token doesn't land in access logs, browser history, or referer
-    # headers. Localhost-only gating mitigates remote exposure but not
+    # headers. Remote-access gating mitigates remote exposure but not
     # local logging.
     api_key = x_api_key
     p = _get_provider(provider)
@@ -481,6 +531,8 @@ async def list_provider_models(
             status_code=404,
             detail=f"Provider '{provider}' not found",
         )
+
+    _enforce_remote_access(http_request, p)
 
     try:
         models = p.list_models(base_url, api_key)

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -87,10 +87,11 @@ def _get_remote_access_mode() -> _RemoteAccessMode:
 
 
 def _provider_allows_remote_access(provider: AssistantProvider | None) -> bool:
-    mode = _get_remote_access_mode()
-    if mode == _RemoteAccessMode.API_ONLY:
-        return provider is not None and provider.allows_remote_execution
-    return False
+    if provider is None:
+        return False
+    return (
+        _get_remote_access_mode() == _RemoteAccessMode.API_ONLY and provider.allows_remote_execution
+    )
 
 
 def _enforce_remote_access(request: Request, provider: AssistantProvider | None) -> None:
@@ -101,11 +102,17 @@ def _enforce_remote_access(request: Request, provider: AssistantProvider | None)
 
 
 # Per-route remote-access policy:
-#   "selected_provider" — gate on whichever provider the user has currently selected
-#   "path_provider"     — gate on the provider identified by a {provider} path parameter
-#   "config_write"      — always block remote access (config writes stay localhost-only)
-#   "none"              — no gating (e.g. GET /config, which redacts secrets instead)
-_RemoteAccessPolicy = Literal["selected_provider", "path_provider", "config_write", "none"]
+#   SELECTED_PROVIDER — gate on whichever provider the user has currently selected
+#   PATH_PROVIDER     — gate on the provider identified by a {provider} path parameter
+#   LOCALHOST_ONLY    — always block remote access (stays localhost-only regardless of mode)
+#   NONE              — no gating (e.g. GET /config, which redacts secrets instead)
+class _RemoteAccessPolicy(str, enum.Enum):
+    SELECTED_PROVIDER = "selected_provider"
+    PATH_PROVIDER = "path_provider"
+    LOCALHOST_ONLY = "localhost_only"
+    NONE = "none"
+
+
 _REMOTE_ACCESS_POLICY_ATTR = "_assistant_remote_access_policy"
 
 
@@ -119,33 +126,36 @@ def _remote_access_policy(policy: _RemoteAccessPolicy):
 
 def _get_route_provider(request: Request, policy: _RemoteAccessPolicy) -> AssistantProvider | None:
     match policy:
-        case "selected_provider":
+        case _RemoteAccessPolicy.SELECTED_PROVIDER:
             return _get_selected_provider()
-        case "path_provider":
+        case _RemoteAccessPolicy.PATH_PROVIDER:
             provider_name = request.path_params.get("provider")
             return _get_provider(provider_name) if provider_name else None
-        case "config_write":
-            return None
-        case "none":
+        case _RemoteAccessPolicy.LOCALHOST_ONLY | _RemoteAccessPolicy.NONE:
             return None
 
 
 class _AssistantAPIRoute(APIRoute):
     def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
         original_route_handler = super().get_route_handler()
-        policy: _RemoteAccessPolicy = getattr(
-            self.endpoint, _REMOTE_ACCESS_POLICY_ATTR, "selected_provider"
+        policy: _RemoteAccessPolicy | None = getattr(
+            self.endpoint, _REMOTE_ACCESS_POLICY_ATTR, None
         )
+        if policy is None:
+            raise RuntimeError(
+                f"Assistant route {self.path!r} ({self.endpoint.__name__}) is missing a "
+                f"remote-access policy. Add @_remote_access_policy(...) to the endpoint."
+            )
 
         async def route_handler(request: Request) -> Response:
-            if policy != "none":
+            if policy != _RemoteAccessPolicy.NONE:
                 if (
                     not _is_localhost(request)
                     and _get_remote_access_mode() == _RemoteAccessMode.OFF
                 ):
                     raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
                 provider = _get_route_provider(request, policy)
-                if policy != "path_provider" or provider is not None:
+                if policy != _RemoteAccessPolicy.PATH_PROVIDER or provider is not None:
                     _enforce_remote_access(request, provider)
             return await original_route_handler(request)
 
@@ -209,6 +219,7 @@ class SkillsInstallResponse(BaseModel):
 
 
 @assistant_router.post("/message")
+@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
 async def send_message(request: MessageRequest) -> MessageResponse:
     """
     Send a message to the assistant and get a session for streaming the response.
@@ -245,6 +256,7 @@ async def send_message(request: MessageRequest) -> MessageResponse:
 
 
 @assistant_router.get("/sessions/{session_id}/stream")
+@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
 async def stream_response(request: Request, session_id: str) -> StreamingResponse:
     """
     Stream the assistant's response via Server-Sent Events.
@@ -325,6 +337,7 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
 
 
 @assistant_router.patch("/sessions/{session_id}")
+@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
 async def patch_session(session_id: str, request: SessionPatchRequest) -> SessionPatchResponse:
     """
     Update session status.
@@ -358,6 +371,7 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
 
 
 @assistant_router.post("/sessions/{session_id}/permission")
+@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
 async def resolve_permission(session_id: str, request: PermissionDecision) -> MessageResponse:
     """Deliver a tool-call permission decision and resume the paused turn on a new stream.
 
@@ -385,7 +399,7 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
 
 
 @assistant_router.get("/providers/{provider}/health")
-@_remote_access_policy("path_provider")
+@_remote_access_policy(_RemoteAccessPolicy.PATH_PROVIDER)
 async def provider_health_check(provider: str) -> dict[str, str]:
     p = _get_provider(provider)
     if p is None:
@@ -407,7 +421,7 @@ async def provider_health_check(provider: str) -> dict[str, str]:
 
 
 @assistant_router.get("/config")
-@_remote_access_policy("none")
+@_remote_access_policy(_RemoteAccessPolicy.NONE)
 async def get_config(request: Request) -> ConfigResponse:
     """
     Get the current assistant configuration.
@@ -433,7 +447,7 @@ async def get_config(request: Request) -> ConfigResponse:
 
 
 @assistant_router.put("/config")
-@_remote_access_policy("config_write")
+@_remote_access_policy(_RemoteAccessPolicy.LOCALHOST_ONLY)
 async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
     """
     Update the assistant configuration.
@@ -510,6 +524,7 @@ async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
 
 
 @assistant_router.post("/skills/install")
+@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
 async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstallResponse:
     """
     Install skills bundled with MLflow.
@@ -571,7 +586,7 @@ async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstal
 
 
 @assistant_router.get("/providers/{provider}/models")
-@_remote_access_policy("path_provider")
+@_remote_access_policy(_RemoteAccessPolicy.PATH_PROVIDER)
 async def list_provider_models(
     provider: str,
     base_url: str | None = None,

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -148,11 +148,8 @@ class _AssistantAPIRoute(APIRoute):
             )
 
         async def route_handler(request: Request) -> Response:
-            if policy != _RemoteAccessPolicy.NONE:
-                if (
-                    not _is_localhost(request)
-                    and _get_remote_access_mode() == _RemoteAccessMode.OFF
-                ):
+            if policy != _RemoteAccessPolicy.NONE and not _is_localhost(request):
+                if _get_remote_access_mode() == _RemoteAccessMode.OFF:
                     raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
                 provider = _get_route_provider(request, policy)
                 if policy != _RemoteAccessPolicy.PATH_PROVIDER or provider is not None:
@@ -524,7 +521,7 @@ async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
 
 
 @assistant_router.post("/skills/install")
-@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.LOCALHOST_ONLY)
 async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstallResponse:
     """
     Install skills bundled with MLflow.

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -49,6 +49,9 @@ _BLOCK_REMOTE_ACCESS_ERROR_MSG = (
 
 
 def _is_localhost(request: Request) -> bool:
+    # This app is only ever served via uvicorn (see mlflow/server/__init__.py), which by
+    # default trusts X-Forwarded-For from 127.0.0.1 and rewrites request.client.host
+    # accordingly. So a same-host reverse proxy on 127.0.0.1 does not defeat this check.
     client_host = request.client.host if request.client else None
     if not client_host:
         return False
@@ -62,7 +65,7 @@ def _is_localhost(request: Request) -> bool:
 def _provider_allows_remote_access(provider: AssistantProvider | None) -> bool:
     if provider is None:
         return False
-    return MLFLOW_ENABLE_REMOTE_ASSISTANT.get() and provider.allows_remote_execution
+    return MLFLOW_ENABLE_REMOTE_ASSISTANT.get() and provider.allows_remote_access
 
 
 def _enforce_remote_access(request: Request, provider: AssistantProvider | None) -> None:

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -1,6 +1,5 @@
 import enum
 import ipaddress
-import logging
 import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -24,10 +23,8 @@ from mlflow.assistant.providers.base import (
 )
 from mlflow.assistant.skill_installer import install_skills, list_installed_skills
 from mlflow.assistant.types import EventType
-from mlflow.environment_variables import MLFLOW_ALLOW_REMOTE_ASSISTANT
+from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 from mlflow.server.assistant.session import SessionManager, terminate_session_process
-
-_logger = logging.getLogger(__name__)
 
 
 def _get_provider(name: str):
@@ -51,14 +48,6 @@ _BLOCK_REMOTE_ACCESS_ERROR_MSG = (
 )
 
 
-class _RemoteAccessMode(str, enum.Enum):
-    OFF = "off"
-    API_ONLY = "api-only"
-
-
-_INVALID_REMOTE_ACCESS_MODES_WARNED: set[str] = set()
-
-
 def _is_localhost(request: Request) -> bool:
     client_host = request.client.host if request.client else None
     if not client_host:
@@ -70,28 +59,10 @@ def _is_localhost(request: Request) -> bool:
     return ip.is_loopback
 
 
-def _get_remote_access_mode() -> _RemoteAccessMode:
-    raw = MLFLOW_ALLOW_REMOTE_ASSISTANT.get()
-    try:
-        return _RemoteAccessMode(raw)
-    except ValueError:
-        if raw not in _INVALID_REMOTE_ACCESS_MODES_WARNED:
-            _logger.warning(
-                "Invalid value %r for %s, falling back to 'off'. Valid values are: %s",
-                raw,
-                MLFLOW_ALLOW_REMOTE_ASSISTANT.name,
-                [m.value for m in _RemoteAccessMode],
-            )
-            _INVALID_REMOTE_ACCESS_MODES_WARNED.add(raw)
-        return _RemoteAccessMode.OFF
-
-
 def _provider_allows_remote_access(provider: AssistantProvider | None) -> bool:
     if provider is None:
         return False
-    return (
-        _get_remote_access_mode() == _RemoteAccessMode.API_ONLY and provider.allows_remote_execution
-    )
+    return MLFLOW_ENABLE_REMOTE_ASSISTANT.get() and provider.allows_remote_execution
 
 
 def _enforce_remote_access(request: Request, provider: AssistantProvider | None) -> None:
@@ -102,14 +73,13 @@ def _enforce_remote_access(request: Request, provider: AssistantProvider | None)
 
 
 # Per-route remote-access policy:
-#   SELECTED_PROVIDER — gate on whichever provider the user has currently selected
-#   PATH_PROVIDER     — gate on the provider identified by a {provider} path parameter
-#   LOCALHOST_ONLY    — always block remote access (stays localhost-only regardless of mode)
-#   NONE              — no gating (e.g. GET /config, which redacts secrets instead)
+#   ONLY_SAFE_PROVIDER — gate on the provider identified by a {provider} path parameter,
+#                        falling back to whichever provider the user has currently selected
+#   DENY               — always block remote access (stays localhost-only regardless of mode)
+#   NONE               — no gating (e.g. GET /config, which redacts secrets instead)
 class _RemoteAccessPolicy(str, enum.Enum):
-    SELECTED_PROVIDER = "selected_provider"
-    PATH_PROVIDER = "path_provider"
-    LOCALHOST_ONLY = "localhost_only"
+    ONLY_SAFE_PROVIDER = "only_safe_provider"
+    DENY = "deny"
     NONE = "none"
 
 
@@ -126,12 +96,11 @@ def _remote_access_policy(policy: _RemoteAccessPolicy):
 
 def _get_route_provider(request: Request, policy: _RemoteAccessPolicy) -> AssistantProvider | None:
     match policy:
-        case _RemoteAccessPolicy.SELECTED_PROVIDER:
+        case _RemoteAccessPolicy.ONLY_SAFE_PROVIDER:
+            if provider_name := request.path_params.get("provider"):
+                return _get_provider(provider_name)
             return _get_selected_provider()
-        case _RemoteAccessPolicy.PATH_PROVIDER:
-            provider_name = request.path_params.get("provider")
-            return _get_provider(provider_name) if provider_name else None
-        case _RemoteAccessPolicy.LOCALHOST_ONLY | _RemoteAccessPolicy.NONE:
+        case _RemoteAccessPolicy.DENY | _RemoteAccessPolicy.NONE:
             return None
 
 
@@ -149,10 +118,12 @@ class _AssistantAPIRoute(APIRoute):
 
         async def route_handler(request: Request) -> Response:
             if policy != _RemoteAccessPolicy.NONE and not _is_localhost(request):
-                if _get_remote_access_mode() == _RemoteAccessMode.OFF:
+                if not MLFLOW_ENABLE_REMOTE_ASSISTANT.get():
                     raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
                 provider = _get_route_provider(request, policy)
-                if policy != _RemoteAccessPolicy.PATH_PROVIDER or provider is not None:
+                # A {provider} path param that doesn't resolve to a known provider is a
+                # 404, not a remote-access decision; let the endpoint handle it.
+                if not ("provider" in request.path_params and provider is None):
                     _enforce_remote_access(request, provider)
             return await original_route_handler(request)
 
@@ -182,7 +153,7 @@ class MessageResponse(BaseModel):
 class ConfigResponse(BaseModel):
     providers: dict[str, Any] = Field(default_factory=dict)
     projects: dict[str, Any] = Field(default_factory=dict)
-    remote_chat_allowed: bool = False
+    remote_access_allowed: bool = False
 
 
 class ConfigUpdateRequest(BaseModel):
@@ -216,7 +187,7 @@ class SkillsInstallResponse(BaseModel):
 
 
 @assistant_router.post("/message")
-@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
 async def send_message(request: MessageRequest) -> MessageResponse:
     """
     Send a message to the assistant and get a session for streaming the response.
@@ -253,7 +224,7 @@ async def send_message(request: MessageRequest) -> MessageResponse:
 
 
 @assistant_router.get("/sessions/{session_id}/stream")
-@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
 async def stream_response(request: Request, session_id: str) -> StreamingResponse:
     """
     Stream the assistant's response via Server-Sent Events.
@@ -334,7 +305,7 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
 
 
 @assistant_router.patch("/sessions/{session_id}")
-@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
 async def patch_session(session_id: str, request: SessionPatchRequest) -> SessionPatchResponse:
     """
     Update session status.
@@ -368,7 +339,7 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
 
 
 @assistant_router.post("/sessions/{session_id}/permission")
-@_remote_access_policy(_RemoteAccessPolicy.SELECTED_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
 async def resolve_permission(session_id: str, request: PermissionDecision) -> MessageResponse:
     """Deliver a tool-call permission decision and resume the paused turn on a new stream.
 
@@ -396,7 +367,7 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
 
 
 @assistant_router.get("/providers/{provider}/health")
-@_remote_access_policy(_RemoteAccessPolicy.PATH_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
 async def provider_health_check(provider: str) -> dict[str, str]:
     p = _get_provider(provider)
     if p is None:
@@ -439,12 +410,12 @@ async def get_config(request: Request) -> ConfigResponse:
     return ConfigResponse(
         providers=providers,
         projects=projects,
-        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
+        remote_access_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
     )
 
 
 @assistant_router.put("/config")
-@_remote_access_policy(_RemoteAccessPolicy.LOCALHOST_ONLY)
+@_remote_access_policy(_RemoteAccessPolicy.DENY)
 async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
     """
     Update the assistant configuration.
@@ -516,12 +487,12 @@ async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
     return ConfigResponse(
         providers=providers,
         projects={exp_id: p.model_dump() for exp_id, p in config.projects.items()},
-        remote_chat_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
+        remote_access_allowed=_provider_allows_remote_access(_get_selected_provider(config)),
     )
 
 
 @assistant_router.post("/skills/install")
-@_remote_access_policy(_RemoteAccessPolicy.LOCALHOST_ONLY)
+@_remote_access_policy(_RemoteAccessPolicy.DENY)
 async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstallResponse:
     """
     Install skills bundled with MLflow.
@@ -583,7 +554,7 @@ async def install_skills_endpoint(request: SkillsInstallRequest) -> SkillsInstal
 
 
 @assistant_router.get("/providers/{provider}/models")
-@_remote_access_policy(_RemoteAccessPolicy.PATH_PROVIDER)
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
 async def list_provider_models(
     provider: str,
     base_url: str | None = None,

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -97,14 +97,10 @@ def _remote_access_policy(policy: _RemoteAccessPolicy):
     return decorator
 
 
-def _get_route_provider(request: Request, policy: _RemoteAccessPolicy) -> AssistantProvider | None:
-    match policy:
-        case _RemoteAccessPolicy.ONLY_SAFE_PROVIDER:
-            if provider_name := request.path_params.get("provider"):
-                return _get_provider(provider_name)
-            return _get_selected_provider()
-        case _RemoteAccessPolicy.DENY | _RemoteAccessPolicy.NONE:
-            return None
+def _get_route_provider(request: Request) -> AssistantProvider | None:
+    if provider_name := request.path_params.get("provider"):
+        return _get_provider(provider_name)
+    return _get_selected_provider()
 
 
 class _AssistantAPIRoute(APIRoute):
@@ -121,9 +117,9 @@ class _AssistantAPIRoute(APIRoute):
 
         async def route_handler(request: Request) -> Response:
             if policy != _RemoteAccessPolicy.NONE and not _is_localhost(request):
-                if not MLFLOW_ENABLE_REMOTE_ASSISTANT.get():
+                if policy == _RemoteAccessPolicy.DENY or not MLFLOW_ENABLE_REMOTE_ASSISTANT.get():
                     raise HTTPException(status_code=403, detail=_BLOCK_REMOTE_ACCESS_ERROR_MSG)
-                provider = _get_route_provider(request, policy)
+                provider = _get_route_provider(request)
                 # A {provider} path param that doesn't resolve to a known provider is a
                 # 404, not a remote-access decision; let the endpoint handle it.
                 if not ("provider" in request.path_params and provider is None):

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -34,6 +34,7 @@ jest.mock('./AssistantContext', () => ({
     isLoadingConfig: false,
     isLocalServer: true,
     pendingPrompt: mockPendingPrompt,
+    canUseAssistant: true,
     openPanel: jest.fn(),
     closePanel: jest.fn(),
     sendMessage: mockSendMessage,

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -471,8 +471,8 @@ const SetupLoadingState = () => {
 };
 
 /**
- * Message shown when server is not running locally.
- * Assistant only works with local MLflow servers.
+ * Message shown when this client is not allowed to use the Assistant,
+ * e.g. a remote client when the server's remote-access settings don't permit it.
  */
 const RemoteServerMessage = ({ onClose }: { onClose: () => void }) => {
   const { theme } = useDesignSystemTheme();
@@ -496,7 +496,7 @@ const RemoteServerMessage = ({ onClose }: { onClose: () => void }) => {
       <Typography.Title level={4} css={{ textAlign: 'center', marginBottom: 0 }}>
         <FormattedMessage
           defaultMessage="Assistant Not Available"
-          description="Title shown when Assistant is not available for remote servers"
+          description="Title shown when Assistant is not available for this client"
         />
       </Typography.Title>
 
@@ -509,8 +509,8 @@ const RemoteServerMessage = ({ onClose }: { onClose: () => void }) => {
         }}
       >
         <FormattedMessage
-          defaultMessage="MLflow Assistant is only available when the server is running locally. Remote server support is coming soon."
-          description="Message explaining that Assistant only works with local servers"
+          defaultMessage="MLflow Assistant is not available from this client. Ask your MLflow server administrator to enable remote access if you need to use it remotely."
+          description="Message explaining that the Assistant is blocked by the server's remote-access settings"
         />
       </Typography.Text>
 
@@ -556,7 +556,7 @@ const SetupPrompt = ({ onSetup }: { onSetup: () => void }) => {
  */
 export const AssistantChatPanel = () => {
   const { theme } = useDesignSystemTheme();
-  const { closePanel, reset, setupComplete, isLoadingConfig, isLocalServer, completeSetup } = useAssistant();
+  const { closePanel, reset, setupComplete, isLoadingConfig, canUseAssistant, completeSetup } = useAssistant();
   const context = useAssistantPageContext();
   const experimentId = context['experimentId'] as string | undefined;
 
@@ -588,8 +588,9 @@ export const AssistantChatPanel = () => {
   }, []);
 
   const renderContent = () => {
-    // Show message for remote servers - Assistant only works locally
-    if (!isLocalServer) {
+    // Show message when this client isn't allowed to use the Assistant
+    // (e.g. a remote client and the server's remote-access settings don't permit it)
+    if (!canUseAssistant) {
       return <RemoteServerMessage onClose={handleClose} />;
     }
 

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -24,7 +24,7 @@ import {
   WrenchSparkleIcon,
   Spinner,
 } from '@databricks/design-system';
-import { FormattedMessage } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import { useAssistant } from './AssistantContext';
 import { useAssistantPageContext } from './AssistantPageContext';
@@ -556,6 +556,7 @@ const SetupPrompt = ({ onSetup }: { onSetup: () => void }) => {
  */
 export const AssistantChatPanel = () => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const { closePanel, reset, setupComplete, isLoadingConfig, canUseAssistant, completeSetup, isLocalServer } =
     useAssistant();
   const context = useAssistantPageContext();
@@ -674,8 +675,17 @@ export const AssistantChatPanel = () => {
                 componentId="mlflow.assistant.chat_panel.settings.tooltip"
                 content={
                   isLocalServer
-                    ? 'Settings'
-                    : 'Updating Assistant settings is not allowed for a remote MLflow server. Contact your server admin to update the settings.'
+                    ? intl.formatMessage({
+                        defaultMessage: 'Settings',
+                        description: 'Tooltip for the Assistant settings button',
+                      })
+                    : intl.formatMessage({
+                        defaultMessage:
+                          'Updating Assistant settings is not allowed for a remote MLflow server. ' +
+                          'Contact your server admin to update the settings.',
+                        description:
+                          'Tooltip explaining that Assistant settings cannot be changed from a remote client',
+                      })
                 }
               >
                 <Button

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -556,7 +556,8 @@ const SetupPrompt = ({ onSetup }: { onSetup: () => void }) => {
  */
 export const AssistantChatPanel = () => {
   const { theme } = useDesignSystemTheme();
-  const { closePanel, reset, setupComplete, isLoadingConfig, canUseAssistant, completeSetup } = useAssistant();
+  const { closePanel, reset, setupComplete, isLoadingConfig, canUseAssistant, completeSetup, isLocalServer } =
+    useAssistant();
   const context = useAssistantPageContext();
   const experimentId = context['experimentId'] as string | undefined;
 
@@ -669,13 +670,17 @@ export const AssistantChatPanel = () => {
                   aria-label="New Chat"
                 />
               </Tooltip>
-              <Tooltip componentId="mlflow.assistant.chat_panel.settings.tooltip" content="Settings">
+              <Tooltip
+                componentId="mlflow.assistant.chat_panel.settings.tooltip"
+                content={isLocalServer ? 'Settings' : 'Settings are only available on the local server'}
+              >
                 <Button
                   componentId="mlflow.assistant.chat_panel.settings"
                   size="small"
                   icon={<GearIcon />}
                   onClick={handleOpenSettings}
                   aria-label="Settings"
+                  disabled={!isLocalServer}
                 />
               </Tooltip>
             </>

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -672,7 +672,11 @@ export const AssistantChatPanel = () => {
               </Tooltip>
               <Tooltip
                 componentId="mlflow.assistant.chat_panel.settings.tooltip"
-                content={isLocalServer ? 'Settings' : 'Settings are only available on the local server'}
+                content={
+                  isLocalServer
+                    ? 'Settings'
+                    : 'Updating Assistant settings is not allowed for a remote MLflow server. Contact your server admin to update the settings.'
+                }
               >
                 <Button
                   componentId="mlflow.assistant.chat_panel.settings"

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -130,6 +130,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   // Setup state
   const [setupComplete, setSetupComplete] = useState(false);
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
+  const [remoteChatAllowed, setRemoteChatAllowed] = useState(false);
+  const canUseAssistant = isLocalServer || remoteChatAllowed;
 
   // A prompt queued by an onboarding card to seed the chat input the next time it's visible.
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
@@ -216,9 +218,11 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       const config = await getConfig();
       const isComplete = await resolveSetupComplete(config);
       setSetupComplete(isComplete);
+      setRemoteChatAllowed(config.remote_chat_allowed ?? false);
     } catch {
       // On error, assume setup is not complete
       setSetupComplete(false);
+      setRemoteChatAllowed(false);
     } finally {
       setIsLoadingConfig(false);
     }
@@ -695,6 +699,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     isLocalServer,
     pendingPrompt,
     pendingPermission,
+    canUseAssistant,
     // Actions
     openPanel,
     closePanel,
@@ -726,6 +731,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   isLocalServer: false,
   pendingPrompt: null,
   pendingPermission: null,
+  canUseAssistant: false,
   openPanel: () => {},
   closePanel: () => {},
   sendMessage: () => {},

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -130,8 +130,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   // Setup state
   const [setupComplete, setSetupComplete] = useState(false);
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
-  const [remoteChatAllowed, setRemoteChatAllowed] = useState(false);
-  const canUseAssistant = isLocalServer || remoteChatAllowed;
+  const [remoteAccessAllowed, setRemoteAccessAllowed] = useState(false);
+  const canUseAssistant = isLocalServer || remoteAccessAllowed;
 
   // A prompt queued by an onboarding card to seed the chat input the next time it's visible.
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
@@ -218,11 +218,11 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       const config = await getConfig();
       const isComplete = await resolveSetupComplete(config);
       setSetupComplete(isComplete);
-      setRemoteChatAllowed(config.remote_chat_allowed ?? false);
+      setRemoteAccessAllowed(config.remote_access_allowed ?? false);
     } catch {
       // On error, assume setup is not complete
       setSetupComplete(false);
-      setRemoteChatAllowed(false);
+      setRemoteAccessAllowed(false);
     } finally {
       setIsLoadingConfig(false);
     }

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -90,6 +90,8 @@ export interface AssistantAgentState {
   pendingPrompt: string | null;
   /** A tool call awaiting the user's Yes/No decision, or null */
   pendingPermission: PermissionRequest | null;
+  /** Whether the Assistant can be used from this client, considering server-side remote-access settings */
+  canUseAssistant: boolean;
 }
 
 export interface AssistantAgentActions {
@@ -170,6 +172,8 @@ export interface AssistantConfig {
   providers: Record<string, ProviderConfig>;
   projects: Record<string, ProjectConfig>;
   skills_location?: string;
+  /** Whether the currently selected provider can be used from a non-localhost client */
+  remote_chat_allowed?: boolean;
 }
 
 /**

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -173,7 +173,7 @@ export interface AssistantConfig {
   projects: Record<string, ProjectConfig>;
   skills_location?: string;
   /** Whether the currently selected provider can be used from a non-localhost client */
-  remote_chat_allowed?: boolean;
+  remote_access_allowed?: boolean;
 }
 
 /**

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -149,7 +149,7 @@ export function MlflowSidebar({
   const isAdmin = useCurrentUserIsAdmin();
   const canManage = isAdmin;
 
-  const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
+  const { openPanel, closePanel, isPanelOpen, canUseAssistant } = useAssistant();
   const [isAssistantHovered, setIsAssistantHovered] = useState(false);
 
   // Radix restores focus to the trigger on dismiss, but the browser
@@ -380,7 +380,7 @@ export function MlflowSidebar({
             ))}
         </ul>
         <div>
-          {isLocalServer && (
+          {canUseAssistant && (
             <Tooltip
               componentId="mlflow.sidebar.assistant_tooltip"
               content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.test.tsx
@@ -8,7 +8,7 @@ import { AgentActionCard } from './AgentActionCard';
 const mockOpenPanel = jest.fn();
 const mockPrefillPrompt = jest.fn();
 let mockSetupComplete = true;
-let mockIsLocalServer = true;
+let mockCanUseAssistant = true;
 
 jest.mock('../../../assistant', () => ({
   __esModule: true,
@@ -28,7 +28,8 @@ jest.mock('../../../assistant', () => ({
     currentStatus: null,
     activeTools: [],
     isLoadingConfig: false,
-    isLocalServer: mockIsLocalServer,
+    isLocalServer: true,
+    canUseAssistant: mockCanUseAssistant,
     closePanel: jest.fn(),
     regenerateLastMessage: jest.fn(),
     cancelSession: jest.fn(),
@@ -57,7 +58,7 @@ beforeEach(() => {
   mockOpenPanel.mockClear();
   mockPrefillPrompt.mockClear();
   mockSetupComplete = true;
-  mockIsLocalServer = true;
+  mockCanUseAssistant = true;
 });
 
 describe('AgentActionCard', () => {
@@ -74,8 +75,8 @@ describe('AgentActionCard', () => {
     expect(screen.getByTestId('assistant-sparkle-icon')).toBeInTheDocument();
   });
 
-  it('hides the MLflow assistant tab when not on a local server', () => {
-    mockIsLocalServer = false;
+  it('hides the MLflow assistant tab when assistant is not available', () => {
+    mockCanUseAssistant = false;
     renderCard();
     // Trigger (and its icon) gone...
     expect(screen.queryByRole('tab', { name: /MLflow assistant/ })).not.toBeInTheDocument();

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
@@ -124,7 +124,7 @@ export const AgentActionCard = ({
             />
           </Tabs.Trigger>
           {codeSnippet && <Tabs.Trigger value="code-snippet">{codeSnippet.label}</Tabs.Trigger>}
-          {/* The in-UI assistant only runs against a local MLflow server, so hide it otherwise. */}
+          {/* Show assistant actions only when the assistant is available (local server or server-enabled remote access). */}
           {canUseAssistant && (
             <Tabs.Trigger value="assistant">
               <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
@@ -56,7 +56,7 @@ export const AgentActionCard = ({
   onActiveTabChange?: (tab: string) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
-  const { openPanel, prefillPrompt, isLocalServer } = useAssistant();
+  const { openPanel, prefillPrompt, canUseAssistant } = useAssistant();
   const defaultTab: TabKey = showAgentSetupTab ? 'agent-setup' : 'copy-prompt';
   // Typed as string, not TabKey, because extraTabs contribute arbitrary string values to the
   // tab space (Tabs.Root.onValueChange hands back a plain string).
@@ -125,7 +125,7 @@ export const AgentActionCard = ({
           </Tabs.Trigger>
           {codeSnippet && <Tabs.Trigger value="code-snippet">{codeSnippet.label}</Tabs.Trigger>}
           {/* The in-UI assistant only runs against a local MLflow server, so hide it otherwise. */}
-          {isLocalServer && (
+          {canUseAssistant && (
             <Tabs.Trigger value="assistant">
               <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
                 <AssistantSparkleIcon isHovered={false} iconSize={14} />
@@ -268,7 +268,7 @@ export const AgentActionCard = ({
           </Tabs.Content>
         )}
 
-        {isLocalServer && (
+        {canUseAssistant && (
           <Tabs.Content value="assistant" css={{ paddingTop: 0 }}>
             <Typography.Text color="secondary" css={{ fontSize: 13, display: 'block', marginBottom: theme.spacing.sm }}>
               <FormattedMessage

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsEmptyStateCard.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsEmptyStateCard.test.tsx
@@ -40,6 +40,7 @@ jest.mock('@mlflow/mlflow/src/assistant', () => ({
     activeTools: [],
     isLoadingConfig: false,
     isLocalServer: true,
+    canUseAssistant: true,
     closePanel: jest.fn(),
     regenerateLastMessage: jest.fn(),
     cancelSession: jest.fn(),

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavAssistantButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavAssistantButton.tsx
@@ -16,13 +16,12 @@ import { COLLAPSED_CLASS_NAME, FULL_WIDTH_CLASS_NAME } from './constants';
 
 export const ExperimentPageSideNavAssistantButton = () => {
   const { theme } = useDesignSystemTheme();
-  const { openPanel, closePanel, isPanelOpen, isLocalServer } = useAssistant();
+  const { openPanel, closePanel, isPanelOpen, canUseAssistant } = useAssistant();
   const logTelemetryEvent = useLogTelemetryEvent();
   const viewId = useMemo(() => uuidv4(), []);
   const [isHovered, setIsHovered] = useState(false);
 
-  // Hide the Assistant button when not running on localhost
-  if (!isLocalServer) {
+  if (!canUseAssistant) {
     return null;
   }
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -8223,10 +8223,6 @@
     "defaultMessage": "API key",
     "description": "Label for API key selector"
   },
-  "cQNKMv": {
-    "defaultMessage": "MLflow Assistant is only available when the server is running locally. Remote server support is coming soon.",
-    "description": "Message explaining that Assistant only works with local servers"
-  },
   "cQQnzX": {
     "defaultMessage": "Hide assessments",
     "description": "Tooltip for a button that closes the assessments pane"
@@ -8787,10 +8783,6 @@
     "defaultMessage": "Numeric",
     "description": "Review question input type: numeric"
   },
-  "fBB0xR": {
-    "defaultMessage": "Assistant Not Available",
-    "description": "Title shown when Assistant is not available for remote servers"
-  },
   "fHI22G": {
     "defaultMessage": "JSON",
     "description": "Label for the JSON render mode in the model trace explorer inputs/outputs tab"
@@ -9010,6 +9002,10 @@
   "g7xNvF": {
     "defaultMessage": "Display points",
     "description": "Runs charts > line chart > display points > label"
+  },
+  "gBORqQ": {
+    "defaultMessage": "MLflow Assistant is not available from this client. Ask your MLflow server administrator to enable remote access if you need to use it remotely.",
+    "description": "Message explaining that the Assistant is blocked by the server's remote-access settings"
   },
   "gC2Kxm": {
     "defaultMessage": "Give instructions to the model. Use '{{ }}' or the \"Add new variable\" button to add variables to your prompt.",
@@ -9586,6 +9582,10 @@
   "iVeCOa": {
     "defaultMessage": "My webhook",
     "description": "Webhook name placeholder"
+  },
+  "iWqITG": {
+    "defaultMessage": "Assistant Not Available",
+    "description": "Title shown when Assistant is not available for this client"
   },
   "iX9mZm": {
     "defaultMessage": "Saved {name} v{version} to the registry",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1231,6 +1231,10 @@
     "defaultMessage": "Clear all demo data",
     "description": "Clear demo data button"
   },
+  "43FXJM": {
+    "defaultMessage": "Updating Assistant settings is not allowed for a remote MLflow server. Contact your server admin to update the settings.",
+    "description": "Tooltip explaining that Assistant settings cannot be changed from a remote client"
+  },
   "44XPr5": {
     "defaultMessage": "Chart view",
     "description": "Label for the table view toggle button in the logged model list page"
@@ -9258,6 +9262,10 @@
   "h48hnl": {
     "defaultMessage": "Send request",
     "description": "Send request button"
+  },
+  "h4AZ8v": {
+    "defaultMessage": "Settings",
+    "description": "Tooltip for the Assistant settings button"
   },
   "h5Dryo": {
     "defaultMessage": "Resource",

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -257,6 +257,24 @@ def test_get_config_returns_existing_config(client, tmp_path):
     assert data["projects"]["exp-123"]["location"] == str(project_dir)
 
 
+def test_get_config_redacts_project_location_for_remote_clients(tmp_path):
+    app = FastAPI()
+    app.include_router(assistant_router)
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    config = AssistantConfig(
+        projects={"exp-123": ProjectConfig(type="local", location=str(project_dir))},
+    )
+    config.save()
+
+    with patch("mlflow.server.assistant.api._is_localhost", return_value=False):
+        response = TestClient(app).get("/ajax-api/3.0/mlflow/assistant/config")
+
+    assert response.status_code == 200
+    assert "location" not in response.json()["projects"]["exp-123"]
+
+
 def test_get_config_always_redacts_api_key(client):
     config = AssistantConfig(
         providers={
@@ -464,6 +482,24 @@ def test_provider_allows_remote_access(mode, allows_remote_execution, expected, 
 def test_provider_allows_remote_access_no_provider_selected(monkeypatch):
     monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
     assert _provider_allows_remote_access(None) is False
+
+
+def test_remote_request_blocked_without_loading_provider_when_mode_is_off(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+    app = FastAPI()
+    app.include_router(assistant_router)
+
+    with (
+        patch("mlflow.server.assistant.api._is_localhost", return_value=False),
+        patch("mlflow.server.assistant.api._get_route_provider") as mock_get_provider,
+    ):
+        response = TestClient(app).post(
+            "/ajax-api/3.0/mlflow/assistant/message",
+            json={"message": "hi"},
+        )
+
+    assert response.status_code == 403
+    mock_get_provider.assert_not_called()
 
 
 def test_invalid_remote_access_mode_falls_back_to_off(monkeypatch):

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -23,7 +23,9 @@ from mlflow.assistant.providers.base import (
 from mlflow.assistant.types import Event, Message, ToolUseBlock
 from mlflow.server.assistant.api import (
     PermissionDecision,
-    _require_localhost,
+    _enforce_remote_access,
+    _is_localhost,
+    _provider_allows_remote_access,
     assistant_router,
 )
 from mlflow.server.assistant.session import SESSION_DIR, SessionManager, save_process_pid
@@ -103,20 +105,15 @@ def clear_sessions():
 
 @pytest.fixture
 def client():
-    """Create test client with mock provider and bypassed localhost check."""
+    """Create test client with mock provider, treated as a localhost caller."""
     app = FastAPI()
     app.include_router(assistant_router)
-
-    # Override localhost dependency to allow TestClient requests
-    async def mock_require_localhost():
-        pass
-
-    app.dependency_overrides[_require_localhost] = mock_require_localhost
 
     mock_provider = MockProvider()
     with (
         patch("mlflow.server.assistant.api.list_providers", return_value=[mock_provider]),
         patch("mlflow.server.assistant.api._get_selected_provider", return_value=mock_provider),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=True),
     ):
         yield TestClient(app)
 
@@ -196,17 +193,15 @@ def test_health_check_returns_412_when_cli_not_installed():
     app = FastAPI()
     app.include_router(assistant_router)
 
-    async def mock_require_localhost():
-        pass
-
-    app.dependency_overrides[_require_localhost] = mock_require_localhost
-
     class CLINotInstalledProvider(MockProvider):
         def check_connection(self, echo=None):
             raise CLINotInstalledError("CLI not installed")
 
     provider = CLINotInstalledProvider()
-    with patch("mlflow.server.assistant.api.list_providers", return_value=[provider]):
+    with (
+        patch("mlflow.server.assistant.api.list_providers", return_value=[provider]),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=True),
+    ):
         client = TestClient(app)
         response = client.get("/ajax-api/3.0/mlflow/assistant/providers/mock_provider/health")
         assert response.status_code == 412
@@ -217,17 +212,15 @@ def test_health_check_returns_401_when_not_authenticated():
     app = FastAPI()
     app.include_router(assistant_router)
 
-    async def mock_require_localhost():
-        pass
-
-    app.dependency_overrides[_require_localhost] = mock_require_localhost
-
     class NotAuthenticatedProvider(MockProvider):
         def check_connection(self, echo=None):
             raise NotAuthenticatedError("Not authenticated")
 
     provider = NotAuthenticatedProvider()
-    with patch("mlflow.server.assistant.api.list_providers", return_value=[provider]):
+    with (
+        patch("mlflow.server.assistant.api.list_providers", return_value=[provider]),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=True),
+    ):
         client = TestClient(app)
         response = client.get("/ajax-api/3.0/mlflow/assistant/providers/mock_provider/health")
         assert response.status_code == 401
@@ -259,6 +252,105 @@ def test_get_config_returns_existing_config(client, tmp_path):
     assert data["providers"]["claude_code"]["model"] == "default"
     assert data["providers"]["claude_code"]["selected"] is True
     assert data["projects"]["exp-123"]["location"] == str(project_dir)
+
+
+def test_get_config_redacts_api_key_for_remote_clients(client, tmp_path):
+    config = AssistantConfig(
+        providers={
+            "claude_code": AssistantProviderConfig(
+                model="default", selected=True, api_key="sk-secret"
+            )
+        },
+    )
+    config.save()
+
+    with patch("mlflow.server.assistant.api._is_localhost", return_value=False):
+        response = client.get("/ajax-api/3.0/mlflow/assistant/config")
+
+    assert response.status_code == 200
+    assert "api_key" not in response.json()["providers"]["claude_code"]
+
+
+def test_get_config_keeps_api_key_for_localhost(client):
+    config = AssistantConfig(
+        providers={
+            "claude_code": AssistantProviderConfig(
+                model="default", selected=True, api_key="sk-secret"
+            )
+        },
+    )
+    config.save()
+
+    response = client.get("/ajax-api/3.0/mlflow/assistant/config")
+
+    assert response.status_code == 200
+    assert response.json()["providers"]["claude_code"]["api_key"] == "sk-secret"
+
+
+@pytest.mark.parametrize(
+    ("mode", "requires_local_execution", "expected"),
+    [
+        ("off", True, False),
+        ("api-only", True, False),
+        ("api-only", False, True),
+        ("all", True, True),
+    ],
+)
+def test_get_config_remote_chat_allowed(
+    client, monkeypatch, mode, requires_local_execution, expected
+):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", mode)
+    with patch("mlflow.server.assistant.api._get_selected_provider") as mock_get_selected_provider:
+        mock_get_selected_provider.return_value.requires_local_execution = requires_local_execution
+        response = client.get("/ajax-api/3.0/mlflow/assistant/config")
+
+    assert response.status_code == 200
+    assert response.json()["remote_chat_allowed"] is expected
+
+
+def test_message_blocked_for_remote_client_when_remote_access_off():
+    app = FastAPI()
+    app.include_router(assistant_router)
+
+    mock_provider = MockProvider()
+    with (
+        patch("mlflow.server.assistant.api.list_providers", return_value=[mock_provider]),
+        patch("mlflow.server.assistant.api._get_selected_provider", return_value=mock_provider),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=False),
+    ):
+        client = TestClient(app)
+        response = client.post(
+            "/ajax-api/3.0/mlflow/assistant/message",
+            json={"message": "Hello"},
+        )
+
+    assert response.status_code == 403
+    assert "same host" in response.json()["detail"]
+
+
+def test_message_allowed_for_remote_client_when_provider_allows_remote_access(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
+    app = FastAPI()
+    app.include_router(assistant_router)
+
+    class RemoteAllowedProvider(MockProvider):
+        @property
+        def requires_local_execution(self) -> bool:
+            return False
+
+    mock_provider = RemoteAllowedProvider()
+    with (
+        patch("mlflow.server.assistant.api.list_providers", return_value=[mock_provider]),
+        patch("mlflow.server.assistant.api._get_selected_provider", return_value=mock_provider),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=False),
+    ):
+        client = TestClient(app)
+        response = client.post(
+            "/ajax-api/3.0/mlflow/assistant/message",
+            json={"message": "Hello"},
+        )
+
+    assert response.status_code == 200
 
 
 def test_update_config_sets_provider(client):
@@ -303,45 +395,79 @@ def test_update_config_expand_user_home(client, tmp_path):
         assert data["projects"]["exp-456"]["location"] == str(project_dir)
 
 
-@pytest.mark.asyncio
-async def test_localhost_allows_ipv4():
+def test_is_localhost_allows_ipv4():
     mock_request = MagicMock()
     mock_request.client.host = "127.0.0.1"
-    await _require_localhost(mock_request)
+    assert _is_localhost(mock_request)
 
 
-@pytest.mark.asyncio
-async def test_localhost_allows_ipv6():
+def test_is_localhost_allows_ipv6():
     mock_request = MagicMock()
     mock_request.client.host = "::1"
-    await _require_localhost(mock_request)
+    assert _is_localhost(mock_request)
 
 
-@pytest.mark.asyncio
-async def test_localhost_blocks_external_ip():
+def test_is_localhost_blocks_external_ip():
     mock_request = MagicMock()
     mock_request.client.host = "192.168.1.100"
-
-    with pytest.raises(HTTPException, match="same host"):
-        await _require_localhost(mock_request)
+    assert not _is_localhost(mock_request)
 
 
-@pytest.mark.asyncio
-async def test_localhost_blocks_external_hostname():
+def test_is_localhost_blocks_external_hostname():
     mock_request = MagicMock()
     mock_request.client.host = "external.example.com"
-
-    with pytest.raises(HTTPException, match="same host"):
-        await _require_localhost(mock_request)
+    assert not _is_localhost(mock_request)
 
 
-@pytest.mark.asyncio
-async def test_localhost_blocks_when_no_client():
+def test_is_localhost_blocks_when_no_client():
     mock_request = MagicMock()
     mock_request.client = None
+    assert not _is_localhost(mock_request)
 
+
+@pytest.mark.parametrize(
+    ("mode", "requires_local_execution", "expected"),
+    [
+        ("off", True, False),
+        ("off", False, False),
+        ("api-only", True, False),
+        ("api-only", False, True),
+        ("all", True, True),
+        ("all", False, True),
+    ],
+)
+def test_provider_allows_remote_access(mode, requires_local_execution, expected, monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", mode)
+    provider = MagicMock()
+    provider.requires_local_execution = requires_local_execution
+    assert _provider_allows_remote_access(provider) is expected
+
+
+def test_provider_allows_remote_access_no_provider_selected(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
+    assert _provider_allows_remote_access(None) is False
+
+
+def test_invalid_remote_access_mode_falls_back_to_off(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "bogus")
+    provider = MagicMock()
+    provider.requires_local_execution = False
+    assert _provider_allows_remote_access(provider) is False
+
+
+def test_enforce_remote_access_allows_localhost_regardless_of_mode(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+    mock_request = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    _enforce_remote_access(mock_request, None)  # should not raise
+
+
+def test_enforce_remote_access_blocks_remote_when_off(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+    mock_request = MagicMock()
+    mock_request.client.host = "192.168.1.100"
     with pytest.raises(HTTPException, match="same host"):
-        await _require_localhost(mock_request)
+        _enforce_remote_access(mock_request, None)
 
 
 def test_validate_session_id_accepts_valid_uuid():

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import subprocess
@@ -7,7 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from mlflow.assistant.config import AssistantConfig, ProjectConfig
@@ -23,6 +24,8 @@ from mlflow.assistant.providers.base import (
 from mlflow.assistant.types import Event, Message, ToolUseBlock
 from mlflow.server.assistant.api import (
     PermissionDecision,
+    _INVALID_REMOTE_ACCESS_MODES_WARNED,
+    _AssistantAPIRoute,
     _enforce_remote_access,
     _is_localhost,
     _provider_allows_remote_access,
@@ -287,6 +290,14 @@ def test_get_config_keeps_api_key_for_localhost(client):
     assert response.json()["providers"]["claude_code"]["api_key"] == "sk-secret"
 
 
+def test_get_config_loads_config_once(client):
+    with patch.object(AssistantConfig, "load", wraps=AssistantConfig.load) as mock_load:
+        response = client.get("/ajax-api/3.0/mlflow/assistant/config")
+
+    assert response.status_code == 200
+    assert mock_load.call_count == 1
+
+
 @pytest.mark.parametrize(
     ("mode", "requires_local_execution", "expected"),
     [
@@ -308,7 +319,8 @@ def test_get_config_remote_chat_allowed(
     assert response.json()["remote_chat_allowed"] is expected
 
 
-def test_message_blocked_for_remote_client_when_remote_access_off():
+def test_message_blocked_for_remote_client_when_remote_access_off(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
     app = FastAPI()
     app.include_router(assistant_router)
 
@@ -323,6 +335,29 @@ def test_message_blocked_for_remote_client_when_remote_access_off():
             "/ajax-api/3.0/mlflow/assistant/message",
             json={"message": "Hello"},
         )
+
+    assert response.status_code == 403
+    assert "same host" in response.json()["detail"]
+
+
+def test_assistant_route_enforces_remote_access_by_default(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+
+    app = FastAPI()
+    router = APIRouter(prefix="/assistant", route_class=_AssistantAPIRoute)
+
+    @router.get("/unguarded")
+    async def unguarded_route():
+        return {"status": "ok"}
+
+    app.include_router(router)
+
+    mock_provider = MockProvider()
+    with (
+        patch("mlflow.server.assistant.api._get_selected_provider", return_value=mock_provider),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=False),
+    ):
+        response = TestClient(app).get("/assistant/unguarded")
 
     assert response.status_code == 403
     assert "same host" in response.json()["detail"]
@@ -453,6 +488,24 @@ def test_invalid_remote_access_mode_falls_back_to_off(monkeypatch):
     provider = MagicMock()
     provider.requires_local_execution = False
     assert _provider_allows_remote_access(provider) is False
+
+
+def test_invalid_remote_access_mode_logs_warning_once(monkeypatch, caplog):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "bogus")
+    _INVALID_REMOTE_ACCESS_MODES_WARNED.clear()
+    provider = MagicMock()
+    provider.requires_local_execution = False
+    assistant_logger = logging.getLogger("mlflow.server.assistant.api")
+    assistant_logger.addHandler(caplog.handler)
+
+    try:
+        with caplog.at_level("WARNING", logger="mlflow.server.assistant.api"):
+            assert _provider_allows_remote_access(provider) is False
+            assert _provider_allows_remote_access(provider) is False
+    finally:
+        assistant_logger.removeHandler(caplog.handler)
+
+    assert sum("Invalid value 'bogus'" in record.message for record in caplog.records) == 1
 
 
 def test_enforce_remote_access_allows_localhost_regardless_of_mode(monkeypatch):

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -23,8 +23,8 @@ from mlflow.assistant.providers.base import (
 )
 from mlflow.assistant.types import Event, Message, ToolUseBlock
 from mlflow.server.assistant.api import (
-    PermissionDecision,
     _INVALID_REMOTE_ACCESS_MODES_WARNED,
+    PermissionDecision,
     _AssistantAPIRoute,
     _enforce_remote_access,
     _is_localhost,
@@ -305,7 +305,6 @@ def test_get_config_loads_config_once(client):
         ("off", False, False),
         ("api-only", False, False),
         ("api-only", True, True),
-        ("all", True, False),
     ],
 )
 def test_get_config_remote_chat_allowed(
@@ -341,27 +340,14 @@ def test_message_blocked_for_remote_client_when_remote_access_off(monkeypatch):
     assert "same host" in response.json()["detail"]
 
 
-def test_assistant_route_enforces_remote_access_by_default(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
-
-    app = FastAPI()
+def test_assistant_route_without_policy_raises_at_startup():
     router = APIRouter(prefix="/assistant", route_class=_AssistantAPIRoute)
 
-    @router.get("/unguarded")
     async def unguarded_route():
         return {"status": "ok"}
 
-    app.include_router(router)
-
-    mock_provider = MockProvider()
-    with (
-        patch("mlflow.server.assistant.api._get_selected_provider", return_value=mock_provider),
-        patch("mlflow.server.assistant.api._is_localhost", return_value=False),
-    ):
-        response = TestClient(app).get("/assistant/unguarded")
-
-    assert response.status_code == 403
-    assert "same host" in response.json()["detail"]
+    with pytest.raises(RuntimeError, match="missing a remote-access policy"):
+        router.add_api_route("/unguarded", unguarded_route, methods=["GET"])
 
 
 def test_message_allowed_for_remote_client_when_provider_allows_remote_access(monkeypatch):
@@ -468,8 +454,6 @@ def test_is_localhost_blocks_when_no_client():
         ("off", True, False),
         ("api-only", False, False),
         ("api-only", True, True),
-        ("all", False, False),
-        ("all", True, False),
     ],
 )
 def test_provider_allows_remote_access(mode, allows_remote_execution, expected, monkeypatch):

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -304,7 +304,7 @@ def test_get_config_loads_config_once(client):
         ("off", True, False),
         ("api-only", True, False),
         ("api-only", False, True),
-        ("all", True, True),
+        ("all", False, False),
     ],
 )
 def test_get_config_remote_chat_allowed(
@@ -467,8 +467,8 @@ def test_is_localhost_blocks_when_no_client():
         ("off", False, False),
         ("api-only", True, False),
         ("api-only", False, True),
-        ("all", True, True),
-        ("all", False, True),
+        ("all", True, False),
+        ("all", False, False),
     ],
 )
 def test_provider_allows_remote_access(mode, requires_local_execution, expected, monkeypatch):

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -257,24 +257,7 @@ def test_get_config_returns_existing_config(client, tmp_path):
     assert data["projects"]["exp-123"]["location"] == str(project_dir)
 
 
-def test_get_config_redacts_api_key_for_remote_clients(client, tmp_path):
-    config = AssistantConfig(
-        providers={
-            "claude_code": AssistantProviderConfig(
-                model="default", selected=True, api_key="sk-secret"
-            )
-        },
-    )
-    config.save()
-
-    with patch("mlflow.server.assistant.api._is_localhost", return_value=False):
-        response = client.get("/ajax-api/3.0/mlflow/assistant/config")
-
-    assert response.status_code == 200
-    assert "api_key" not in response.json()["providers"]["claude_code"]
-
-
-def test_get_config_keeps_api_key_for_localhost(client):
+def test_get_config_always_redacts_api_key(client):
     config = AssistantConfig(
         providers={
             "claude_code": AssistantProviderConfig(
@@ -287,7 +270,7 @@ def test_get_config_keeps_api_key_for_localhost(client):
     response = client.get("/ajax-api/3.0/mlflow/assistant/config")
 
     assert response.status_code == 200
-    assert response.json()["providers"]["claude_code"]["api_key"] == "sk-secret"
+    assert "api_key" not in response.json()["providers"]["claude_code"]
 
 
 def test_get_config_loads_config_once(client):
@@ -299,20 +282,20 @@ def test_get_config_loads_config_once(client):
 
 
 @pytest.mark.parametrize(
-    ("mode", "requires_local_execution", "expected"),
+    ("mode", "allows_remote_execution", "expected"),
     [
-        ("off", True, False),
-        ("api-only", True, False),
-        ("api-only", False, True),
-        ("all", False, False),
+        ("off", False, False),
+        ("api-only", False, False),
+        ("api-only", True, True),
+        ("all", True, False),
     ],
 )
 def test_get_config_remote_chat_allowed(
-    client, monkeypatch, mode, requires_local_execution, expected
+    client, monkeypatch, mode, allows_remote_execution, expected
 ):
     monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", mode)
     with patch("mlflow.server.assistant.api._get_selected_provider") as mock_get_selected_provider:
-        mock_get_selected_provider.return_value.requires_local_execution = requires_local_execution
+        mock_get_selected_provider.return_value.allows_remote_execution = allows_remote_execution
         response = client.get("/ajax-api/3.0/mlflow/assistant/config")
 
     assert response.status_code == 200
@@ -370,8 +353,8 @@ def test_message_allowed_for_remote_client_when_provider_allows_remote_access(mo
 
     class RemoteAllowedProvider(MockProvider):
         @property
-        def requires_local_execution(self) -> bool:
-            return False
+        def allows_remote_execution(self) -> bool:
+            return True
 
     mock_provider = RemoteAllowedProvider()
     with (
@@ -461,20 +444,20 @@ def test_is_localhost_blocks_when_no_client():
 
 
 @pytest.mark.parametrize(
-    ("mode", "requires_local_execution", "expected"),
+    ("mode", "allows_remote_execution", "expected"),
     [
-        ("off", True, False),
         ("off", False, False),
-        ("api-only", True, False),
-        ("api-only", False, True),
-        ("all", True, False),
+        ("off", True, False),
+        ("api-only", False, False),
+        ("api-only", True, True),
         ("all", False, False),
+        ("all", True, False),
     ],
 )
-def test_provider_allows_remote_access(mode, requires_local_execution, expected, monkeypatch):
+def test_provider_allows_remote_access(mode, allows_remote_execution, expected, monkeypatch):
     monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", mode)
     provider = MagicMock()
-    provider.requires_local_execution = requires_local_execution
+    provider.allows_remote_execution = allows_remote_execution
     assert _provider_allows_remote_access(provider) is expected
 
 
@@ -486,7 +469,7 @@ def test_provider_allows_remote_access_no_provider_selected(monkeypatch):
 def test_invalid_remote_access_mode_falls_back_to_off(monkeypatch):
     monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "bogus")
     provider = MagicMock()
-    provider.requires_local_execution = False
+    provider.allows_remote_execution = True
     assert _provider_allows_remote_access(provider) is False
 
 
@@ -494,7 +477,7 @@ def test_invalid_remote_access_mode_logs_warning_once(monkeypatch, caplog):
     monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "bogus")
     _INVALID_REMOTE_ACCESS_MODES_WARNED.clear()
     provider = MagicMock()
-    provider.requires_local_execution = False
+    provider.allows_remote_execution = True
     assistant_logger = logging.getLogger("mlflow.server.assistant.api")
     assistant_logger.addHandler(caplog.handler)
 

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -769,6 +769,22 @@ def test_install_skills_skips_when_already_installed(client):
         mock_list.assert_called_once()
 
 
+def test_install_skills_blocked_for_remote_client(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
+    app = FastAPI()
+    app.include_router(assistant_router)
+
+    with patch("mlflow.server.assistant.api._is_localhost", return_value=False):
+        client = TestClient(app)
+        response = client.post(
+            "/ajax-api/3.0/mlflow/assistant/skills/install",
+            json={"type": "global"},
+        )
+
+    assert response.status_code == 403
+    assert "same host" in response.json()["detail"]
+
+
 def test_update_config_partial_update_preserves_selected_provider(client):
     ollama = OllamaProvider.OLLAMA_PROVIDER_NAME
     # Pre-populate config: claude_code selected, ollama exists but not selected

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -27,6 +27,8 @@ from mlflow.server.assistant.api import (
     _enforce_remote_access,
     _is_localhost,
     _provider_allows_remote_access,
+    _remote_access_policy,
+    _RemoteAccessPolicy,
     assistant_router,
 )
 from mlflow.server.assistant.session import SESSION_DIR, SessionManager, save_process_pid
@@ -346,6 +348,24 @@ def test_assistant_route_without_policy_raises_at_startup():
 
     with pytest.raises(RuntimeError, match="missing a remote-access policy"):
         router.add_api_route("/unguarded", unguarded_route, methods=["GET"])
+
+
+def test_deny_policy_route_with_provider_path_param_blocks_remote(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "true")
+    router = APIRouter(prefix="/assistant", route_class=_AssistantAPIRoute)
+
+    @_remote_access_policy(_RemoteAccessPolicy.DENY)
+    async def denied_route(provider: str):
+        return {"provider": provider}
+
+    router.add_api_route("/denied/{provider}", denied_route, methods=["GET"])
+    app = FastAPI()
+    app.include_router(router)
+
+    with patch("mlflow.server.assistant.api._is_localhost", return_value=False):
+        response = TestClient(app).get("/assistant/denied/unknown-provider")
+
+    assert response.status_code == 403
 
 
 def test_message_allowed_for_remote_client_when_provider_allows_remote_access(monkeypatch):

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -298,7 +298,7 @@ def test_get_config_loads_config_once(client):
 
 
 @pytest.mark.parametrize(
-    ("enabled", "allows_remote_execution", "expected"),
+    ("enabled", "allows_remote_access", "expected"),
     [
         (False, False, False),
         (True, False, False),
@@ -306,11 +306,11 @@ def test_get_config_loads_config_once(client):
     ],
 )
 def test_get_config_remote_access_allowed(
-    client, monkeypatch, enabled, allows_remote_execution, expected
+    client, monkeypatch, enabled, allows_remote_access, expected
 ):
     monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", str(enabled))
     with patch("mlflow.server.assistant.api._get_selected_provider") as mock_get_selected_provider:
-        mock_get_selected_provider.return_value.allows_remote_execution = allows_remote_execution
+        mock_get_selected_provider.return_value.allows_remote_access = allows_remote_access
         response = client.get("/ajax-api/3.0/mlflow/assistant/config")
 
     assert response.status_code == 200
@@ -355,7 +355,7 @@ def test_message_allowed_for_remote_client_when_provider_allows_remote_access(mo
 
     class RemoteAllowedProvider(MockProvider):
         @property
-        def allows_remote_execution(self) -> bool:
+        def allows_remote_access(self) -> bool:
             return True
 
     mock_provider = RemoteAllowedProvider()
@@ -446,7 +446,7 @@ def test_is_localhost_blocks_when_no_client():
 
 
 @pytest.mark.parametrize(
-    ("enabled", "allows_remote_execution", "expected"),
+    ("enabled", "allows_remote_access", "expected"),
     [
         (False, False, False),
         (False, True, False),
@@ -454,10 +454,10 @@ def test_is_localhost_blocks_when_no_client():
         (True, True, True),
     ],
 )
-def test_provider_allows_remote_access(enabled, allows_remote_execution, expected, monkeypatch):
+def test_provider_allows_remote_access(enabled, allows_remote_access, expected, monkeypatch):
     monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", str(enabled))
     provider = MagicMock()
-    provider.allows_remote_execution = allows_remote_execution
+    provider.allows_remote_access = allows_remote_access
     assert _provider_allows_remote_access(provider) is expected
 
 
@@ -487,7 +487,7 @@ def test_remote_request_blocked_without_loading_provider_when_disabled(monkeypat
 def test_invalid_remote_access_value_raises(monkeypatch):
     monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "bogus")
     provider = MagicMock()
-    provider.allows_remote_execution = True
+    provider.allows_remote_access = True
     with pytest.raises(ValueError, match="MLFLOW_ENABLE_REMOTE_ASSISTANT"):
         _provider_allows_remote_access(provider)
 

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import shutil
 import subprocess
@@ -23,7 +22,6 @@ from mlflow.assistant.providers.base import (
 )
 from mlflow.assistant.types import Event, Message, ToolUseBlock
 from mlflow.server.assistant.api import (
-    _INVALID_REMOTE_ACCESS_MODES_WARNED,
     PermissionDecision,
     _AssistantAPIRoute,
     _enforce_remote_access,
@@ -300,27 +298,27 @@ def test_get_config_loads_config_once(client):
 
 
 @pytest.mark.parametrize(
-    ("mode", "allows_remote_execution", "expected"),
+    ("enabled", "allows_remote_execution", "expected"),
     [
-        ("off", False, False),
-        ("api-only", False, False),
-        ("api-only", True, True),
+        (False, False, False),
+        (True, False, False),
+        (True, True, True),
     ],
 )
-def test_get_config_remote_chat_allowed(
-    client, monkeypatch, mode, allows_remote_execution, expected
+def test_get_config_remote_access_allowed(
+    client, monkeypatch, enabled, allows_remote_execution, expected
 ):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", mode)
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", str(enabled))
     with patch("mlflow.server.assistant.api._get_selected_provider") as mock_get_selected_provider:
         mock_get_selected_provider.return_value.allows_remote_execution = allows_remote_execution
         response = client.get("/ajax-api/3.0/mlflow/assistant/config")
 
     assert response.status_code == 200
-    assert response.json()["remote_chat_allowed"] is expected
+    assert response.json()["remote_access_allowed"] is expected
 
 
 def test_message_blocked_for_remote_client_when_remote_access_off(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "false")
     app = FastAPI()
     app.include_router(assistant_router)
 
@@ -351,7 +349,7 @@ def test_assistant_route_without_policy_raises_at_startup():
 
 
 def test_message_allowed_for_remote_client_when_provider_allows_remote_access(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "true")
     app = FastAPI()
     app.include_router(assistant_router)
 
@@ -448,28 +446,28 @@ def test_is_localhost_blocks_when_no_client():
 
 
 @pytest.mark.parametrize(
-    ("mode", "allows_remote_execution", "expected"),
+    ("enabled", "allows_remote_execution", "expected"),
     [
-        ("off", False, False),
-        ("off", True, False),
-        ("api-only", False, False),
-        ("api-only", True, True),
+        (False, False, False),
+        (False, True, False),
+        (True, False, False),
+        (True, True, True),
     ],
 )
-def test_provider_allows_remote_access(mode, allows_remote_execution, expected, monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", mode)
+def test_provider_allows_remote_access(enabled, allows_remote_execution, expected, monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", str(enabled))
     provider = MagicMock()
     provider.allows_remote_execution = allows_remote_execution
     assert _provider_allows_remote_access(provider) is expected
 
 
 def test_provider_allows_remote_access_no_provider_selected(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "true")
     assert _provider_allows_remote_access(None) is False
 
 
-def test_remote_request_blocked_without_loading_provider_when_mode_is_off(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+def test_remote_request_blocked_without_loading_provider_when_disabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "false")
     app = FastAPI()
     app.include_router(assistant_router)
 
@@ -486,40 +484,23 @@ def test_remote_request_blocked_without_loading_provider_when_mode_is_off(monkey
     mock_get_provider.assert_not_called()
 
 
-def test_invalid_remote_access_mode_falls_back_to_off(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "bogus")
+def test_invalid_remote_access_value_raises(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "bogus")
     provider = MagicMock()
     provider.allows_remote_execution = True
-    assert _provider_allows_remote_access(provider) is False
-
-
-def test_invalid_remote_access_mode_logs_warning_once(monkeypatch, caplog):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "bogus")
-    _INVALID_REMOTE_ACCESS_MODES_WARNED.clear()
-    provider = MagicMock()
-    provider.allows_remote_execution = True
-    assistant_logger = logging.getLogger("mlflow.server.assistant.api")
-    assistant_logger.addHandler(caplog.handler)
-
-    try:
-        with caplog.at_level("WARNING", logger="mlflow.server.assistant.api"):
-            assert _provider_allows_remote_access(provider) is False
-            assert _provider_allows_remote_access(provider) is False
-    finally:
-        assistant_logger.removeHandler(caplog.handler)
-
-    assert sum("Invalid value 'bogus'" in record.message for record in caplog.records) == 1
+    with pytest.raises(ValueError, match="MLFLOW_ENABLE_REMOTE_ASSISTANT"):
+        _provider_allows_remote_access(provider)
 
 
 def test_enforce_remote_access_allows_localhost_regardless_of_mode(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "false")
     mock_request = MagicMock()
     mock_request.client.host = "127.0.0.1"
     _enforce_remote_access(mock_request, None)  # should not raise
 
 
-def test_enforce_remote_access_blocks_remote_when_off(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "off")
+def test_enforce_remote_access_blocks_remote_when_disabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "false")
     mock_request = MagicMock()
     mock_request.client.host = "192.168.1.100"
     with pytest.raises(HTTPException, match="same host"):
@@ -770,7 +751,7 @@ def test_install_skills_skips_when_already_installed(client):
 
 
 def test_install_skills_blocked_for_remote_client(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "api-only")
+    monkeypatch.setenv("MLFLOW_ENABLE_REMOTE_ASSISTANT", "true")
     app = FastAPI()
     app.include_router(assistant_router)
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

The Assistant currently blocks every non-localhost request, even for providers like the MLflow Gateway that never execute anything on the server host. This PR adds a `MLFLOW_ALLOW_REMOTE_ASSISTANT` environment variable with three values:

- `off` (default): current behavior, unchanged. Only localhost callers can reach the Assistant.
- `api-only`: remote callers are allowed, but only for providers that don't require local execution (currently the `mlflow_gateway` preset). `claude_code`, `codex`, and `ollama` stay localhost-only regardless of mode, since they spawn subprocesses or otherwise run on the server host.
- `all`: remote callers are allowed for any provider.

Server-side changes in `mlflow/server/assistant/api.py`:
- Replaced the old blanket `_require_localhost` dependency with `_enforce_remote_access`, which checks the caller's IP (`_is_localhost`), the configured mode (`_get_remote_access_mode`), and whether the selected provider permits remote use (`_provider_allows_remote_access`).
- `GET /config` stays reachable remotely (the frontend needs it to decide whether to show the chat UI at all) but redacts `api_key` for non-localhost callers and now reports `remote_chat_allowed`.
- `PUT /config` is only open to remote callers when mode is `all`, since a config write can touch any provider's secrets regardless of which provider happens to be selected.
- Added a `requires_local_execution` property to `AssistantProvider` (default `True`) and to `OpenAICompatibleProvider`, set to `False` only for the `mlflow_gateway` preset.

Client-side changes under `mlflow/server/js/src/assistant/`:
- `AssistantContext` now derives `canUseAssistant` from `isLocalServer || remoteChatAllowed` instead of a pure hostname check.
- `AssistantChatPanel` shows an updated message when the Assistant isn't available for the current client, instead of a remote-server-specific message.

### Related Issues/PRs

Closes #23883

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests cover `_is_localhost`, `_provider_allows_remote_access`, `_enforce_remote_access`, the `/config` redaction and `remote_chat_allowed` behavior, and end-to-end message gating for both blocked and allowed remote requests.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `MLFLOW_ALLOW_REMOTE_ASSISTANT` to allow remote (non-localhost) access to the MLflow Assistant for API-based providers, while keeping CLI-based providers localhost-only.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release