### PR TITLE
[Fix] Restore scrolling in the Playground conversation area

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -247,7 +247,16 @@ const PlaygroundPage = () => {
       <Spacer size="sm" shrinks={false} />
       <div css={{ borderTop: `1px solid ${theme.colors.border}`, flexShrink: 0 }} role="separator" aria-hidden="true" />
       <Spacer size="sm" shrinks={false} />
-      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md, flex: 1, minHeight: 0 }}>
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.md,
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+        }}
+      >
         <PromptInputPanel messages={messages} onChange={setMessages} />
         {isLoading && (
           <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.md }}>


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24023

### What changes are proposed in this pull request?

- Restores scrolling in the Playground conversation area, which broke when the Playground moved from the top-level nav to under Experiments (#24023).
- That move replaced the `ScrollablePageWrapper` (the page's scroll container) with a plain `overflow: hidden` `<div>` and never reintroduced a scroll container, so the conversation wrapper (`flex: 1; minHeight: 0`, no `overflow`) grew past the viewport and was clipped with no scrollbar - users could not scroll down to see their messages.
- Adds `overflowY: 'auto'` to the conversation wrapper so it becomes the scroll container. The top bar stays fixed and the sticky submit bar pins to the bottom of the scroll area, matching the intended layout.

### How is this PR tested?

- [x] Manual tests

Verified the exact flex/overflow chain (bounded experiment-tab parent -> `overflow: hidden` root -> fixed top bar -> conversation wrapper) in an isolated render: without the fix the last message and submit bar are clipped with no scrollbar; with `overflowY: 'auto'` the conversation scrolls while the top bar stays fixed and the submit bar stays pinned.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release