### PR TITLE
fix(genai): normalize ChrfScore to CHRFScore for ragas compatibility

### DIFF
--- a/mlflow/genai/scorers/ragas/registry.py
+++ b/mlflow/genai/scorers/ragas/registry.py
@@ -153,6 +153,8 @@ def requires_args_from_placeholders(metric_name: str) -> bool:
 
 
 def _get_config(metric_name: str) -> MetricConfig:
+    if metric_name == "ChrfScore":
+        metric_name = "CHRFScore"
     if metric_name in _METRIC_REGISTRY:
         return _METRIC_REGISTRY[metric_name]
     # Return default config for unknown metrics - dynamic import will be attempted


### PR DESCRIPTION
### Related Issues/PRs
Fixes tracking discrepancies regarding Ragas metric name casing updates. Relates to PR #14321.

### What changes are proposed in this pull request?
This pull request introduces a backward-compatible string normalization check inside `mlflow/genai/scorers/ragas/registry.py -> _get_config()`. 

When users call the `ChrfScore` evaluator, the literal string `"ChrfScore"` is passed to the config registry loader. In newer versions of the third-party `ragas` library, the internal class was updated to all-caps `CHRFScore`. While MLflow's registry map was updated to `"CHRFScore"`, the user-facing class still declares `metric_name = "ChrfScore"`. This discrepancy causes the config loader to miss the registry entry and dynamically build an invalid module path, triggering a failure. 

This change catches `"ChrfScore"` and routes it directly to the `"CHRFScore"` configuration payload, maintaining seamless compatibility across different `ragas` versions.

### How is this PR tested?
- Manually verified configuration fallback routines locally.
- Verified that existing dynamic module loaders correctly evaluate the overridden configuration properties without throwing structural attribute errors.

### Does this PR require documentation update?
No.

### Does this PR require updating the MLflow Skills repository?
No.

### Release Notes

#### Is this a user-facing change?
- [x] Yes. User-facing features and changes will generate a release notes entry.
- [ ] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?
- **Components**: LLM/GenAI evaluation tracking.
- **Integrations**: Ragas evaluation framework.

#### How should the PR be classified in the release notes? Choose one:
- [ ] `feature`: A new user-facing feature element.
- [x] `bugfix`: A user-facing bug fix implementation.
- [ ] `doc`: A documentation-only adjustment.
- [ ] `internal`: An internal structural layout change.

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
No.