### PR TITLE
[Fix] Map OpenAI Agents SDK guardrail spans to `SpanType.GUARDRAIL`

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -55,7 +55,7 @@ _SPAN_TYPE_MAP = {
     OpenAISpanType.FUNCTION: SpanType.TOOL,
     OpenAISpanType.GENERATION: SpanType.CHAT_MODEL,
     OpenAISpanType.RESPONSE: SpanType.CHAT_MODEL,
-    OpenAISpanType.GUARDRAIL: SpanType.TOOL,
+    OpenAISpanType.GUARDRAIL: SpanType.GUARDRAIL,
     # Default to chain type
 }
 

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -12,7 +12,15 @@ try:
 except ImportError:
     pytest.skip("OpenAI SDK is not installed. Skipping tests.", allow_module_level=True)
 
-from agents import Agent, Runner, function_tool, set_default_openai_client, trace
+from agents import (
+    Agent,
+    GuardrailFunctionOutput,
+    Runner,
+    function_tool,
+    input_guardrail,
+    set_default_openai_client,
+    trace,
+)
 from agents.tracing import set_trace_processors
 from agents.tracing.processors import default_processor
 from agents.tracing.setup import get_trace_provider
@@ -270,6 +278,62 @@ async def test_autolog_agent_with_manual_trace():
     assert traces[0].info.status == "OK"
     spans = traces[0].data.spans
     assert len(spans) > 4
+
+
+@pytest.mark.asyncio
+async def test_autolog_agent_guardrail_span_type():
+    mlflow.openai.autolog()
+
+    DUMMY_RESPONSES = [
+        Response(
+            id="123",
+            created_at=12345678.0,
+            error=None,
+            model="gpt-4o-mini",
+            object="response",
+            instructions="You are a helpful assistant.",
+            output=[
+                ResponseOutputMessage(
+                    id="123",
+                    content=[
+                        ResponseOutputText(
+                            annotations=[],
+                            text="Hello!",
+                            type="output_text",
+                        )
+                    ],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            ],
+            tools=[],
+            tool_choice="auto",
+            temperature=1,
+            parallel_tool_calls=True,
+        ),
+    ]
+
+    set_dummy_client(DUMMY_RESPONSES)
+
+    @input_guardrail(name="Ethics check")
+    async def ethics_guardrail(ctx, agent, user_input):
+        return GuardrailFunctionOutput(tripwire_triggered=False, output_info={})
+
+    agent = Agent(
+        name="Assistant",
+        instructions="You are a helpful assistant.",
+        input_guardrails=[ethics_guardrail],
+    )
+
+    await Runner.run(agent, "Hello!")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    spans = traces[0].data.spans
+    guardrail_spans = [s for s in spans if s.name == "Ethics check"]
+    assert len(guardrail_spans) == 1
+    assert guardrail_spans[0].span_type == SpanType.GUARDRAIL
 
 
 @pytest.mark.asyncio

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -12,15 +12,7 @@ try:
 except ImportError:
     pytest.skip("OpenAI SDK is not installed. Skipping tests.", allow_module_level=True)
 
-from agents import (
-    Agent,
-    GuardrailFunctionOutput,
-    Runner,
-    function_tool,
-    input_guardrail,
-    set_default_openai_client,
-    trace,
-)
+from agents import Agent, Runner, function_tool, set_default_openai_client, trace
 from agents.tracing import set_trace_processors
 from agents.tracing.processors import default_processor
 from agents.tracing.setup import get_trace_provider
@@ -278,62 +270,6 @@ async def test_autolog_agent_with_manual_trace():
     assert traces[0].info.status == "OK"
     spans = traces[0].data.spans
     assert len(spans) > 4
-
-
-@pytest.mark.asyncio
-async def test_autolog_agent_guardrail_span_type():
-    mlflow.openai.autolog()
-
-    DUMMY_RESPONSES = [
-        Response(
-            id="123",
-            created_at=12345678.0,
-            error=None,
-            model="gpt-4o-mini",
-            object="response",
-            instructions="You are a helpful assistant.",
-            output=[
-                ResponseOutputMessage(
-                    id="123",
-                    content=[
-                        ResponseOutputText(
-                            annotations=[],
-                            text="Hello!",
-                            type="output_text",
-                        )
-                    ],
-                    role="assistant",
-                    status="completed",
-                    type="message",
-                )
-            ],
-            tools=[],
-            tool_choice="auto",
-            temperature=1,
-            parallel_tool_calls=True,
-        ),
-    ]
-
-    set_dummy_client(DUMMY_RESPONSES)
-
-    @input_guardrail(name="Ethics check")
-    async def ethics_guardrail(ctx, agent, user_input):
-        return GuardrailFunctionOutput(tripwire_triggered=False, output_info={})
-
-    agent = Agent(
-        name="Assistant",
-        instructions="You are a helpful assistant.",
-        input_guardrails=[ethics_guardrail],
-    )
-
-    await Runner.run(agent, "Hello!")
-
-    traces = get_traces()
-    assert len(traces) == 1
-    spans = traces[0].data.spans
-    guardrail_spans = [s for s in spans if s.name == "Ethics check"]
-    assert len(guardrail_spans) == 1
-    assert guardrail_spans[0].span_type == SpanType.GUARDRAIL
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues/PRs

Closes #24037

### What changes are proposed in this pull request?

- The OpenAI Agents SDK autolog tracer mapped `OpenAISpanType.GUARDRAIL` to `SpanType.TOOL`, so input/output guardrail spans were recorded and rendered as tool calls in the trace UI.
- This maps `OpenAISpanType.GUARDRAIL` to the existing `SpanType.GUARDRAIL` in `mlflow/openai/_agent_tracer.py` so guardrail spans are classified correctly.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Guardrail spans produced when tracing OpenAI Agents SDK applications via `mlflow.openai.autolog()` are now correctly classified as `GUARDRAIL` spans instead of `TOOL` spans.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release