### PR TITLE
Skip tracking backend prompt in `mlflow agent setup` when `MLFLOW_TRACKING_URI` is set

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -12,6 +12,7 @@ from mlflow.agent.agents import AGENTS, AgentName, AgentTool, detect_installed, 
 from mlflow.agent.setup.prompt import build_prompt
 from mlflow.agent.setup.select import arrow_select
 from mlflow.assistant.skill_installer import install_skills
+from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.telemetry.events import AgentSetupEvent
 from mlflow.telemetry.track import _record_event
 from mlflow.tracking import MlflowClient
@@ -28,6 +29,18 @@ def _resolve_experiment_id(tracking_uri: str, ref: str) -> str:
     experiment_id = client.create_experiment(ref)
     click.secho(f"Created experiment {ref!r} (ID {experiment_id}).", fg="green", err=True)
     return experiment_id
+
+
+def _prompt_experiment_id(tracking_uri: str) -> str:
+    experiment_ref = click.prompt(
+        click.style(
+            "Experiment ID, or path (auto-created if it doesn't exist)",
+            fg="cyan",
+            bold=True,
+        ),
+        err=True,
+    ).strip()
+    return _resolve_experiment_id(tracking_uri, experiment_ref)
 
 
 def _find_available_port(start: int = 5000, end: int = 5100) -> int:
@@ -120,47 +133,46 @@ def _run_setup(
     else:
         click.secho("Skipping skill installation.", fg="yellow", err=True)
 
-    backend_choice = arrow_select(
-        "Tracking backend:",
-        [
-            "Start a new local server",
-            "Databricks workspace",
-            "Existing server URL (e.g. http://localhost:5000)",
-        ],
-    )
     experiment_id: str | None = None
     local_server_port: int | None = None
-    match backend_choice:
-        case 0:
-            local_server_port = _find_available_port()
-            tracking_uri = f"http://127.0.0.1:{local_server_port}"
-            click.secho(f"Picked local tracking URI: {tracking_uri}", fg="green", err=True)
-        case 1:
-            profile = click.prompt(
-                click.style(
-                    "Databricks configuration profile, or empty for default",
-                    fg="cyan",
-                    bold=True,
-                ),
-                default="",
-                show_default=False,
-                err=True,
-            ).strip()
-            tracking_uri = f"databricks://{profile}" if profile else "databricks"
-            experiment_ref = click.prompt(
-                click.style(
-                    "Experiment ID, or path (auto-created if it doesn't exist)",
-                    fg="cyan",
-                    bold=True,
-                ),
-                err=True,
-            ).strip()
-            experiment_id = _resolve_experiment_id(tracking_uri, experiment_ref)
-        case _:
-            tracking_uri = click.prompt(
-                click.style("Tracking server URL", fg="cyan", bold=True),
-                err=True,
-            ).strip()
+    if tracking_uri := MLFLOW_TRACKING_URI.get():
+        click.secho(
+            f"Using tracking URI from MLFLOW_TRACKING_URI: {tracking_uri}", fg="green", err=True
+        )
+        if tracking_uri == "databricks" or tracking_uri.startswith("databricks://"):
+            experiment_id = _prompt_experiment_id(tracking_uri)
+    else:
+        backend_choice = arrow_select(
+            "Tracking backend:",
+            [
+                "Start a new local server",
+                "Databricks workspace",
+                "Existing server URL (e.g. http://localhost:5000)",
+            ],
+        )
+        match backend_choice:
+            case 0:
+                local_server_port = _find_available_port()
+                tracking_uri = f"http://127.0.0.1:{local_server_port}"
+                click.secho(f"Picked local tracking URI: {tracking_uri}", fg="green", err=True)
+            case 1:
+                profile = click.prompt(
+                    click.style(
+                        "Databricks configuration profile, or empty for default",
+                        fg="cyan",
+                        bold=True,
+                    ),
+                    default="",
+                    show_default=False,
+                    err=True,
+                ).strip()
+                tracking_uri = f"databricks://{profile}" if profile else "databricks"
+                experiment_id = _prompt_experiment_id(tracking_uri)
+            case _:
+                tracking_uri = click.prompt(
+                    click.style("Tracking server URL", fg="cyan", bold=True),
+                    err=True,
+                ).strip()
 
     prompt = build_prompt(
         repo_root,

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -344,4 +344,3 @@ def test_setup_env_databricks_still_prompts_for_experiment(
     assert "Experiment ID, or path (auto-created if it doesn't exist)" in result.stderr
     assert 'mlflow.set_experiment(experiment_id="1234567890")' in result.stdout
     mock_which.assert_called()
-    mock_which.assert_called()

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -17,6 +17,9 @@ from mlflow.telemetry.events import AgentSetupEvent
 def tmp_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     monkeypatch.chdir(tmp_path)
+    # The backend prompt only appears when no tracking URI is configured, so clear it to keep
+    # the tests deterministic regardless of the developer's environment.
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
     return tmp_path
 
 
@@ -312,3 +315,33 @@ def test_setup_databricks_threads_profile_into_tracking_uri(tmp_git_repo: Path):
     assert result.exit_code == 0, result.stderr
     assert "MLFLOW_TRACKING_URI=databricks://my-profile" in result.stdout
     assert 'WorkspaceClient(profile="my-profile").current_user.me()' in result.stdout
+
+
+def test_setup_uses_tracking_uri_from_env(tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://my-server:5000")
+    with mock.patch(
+        "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+    ) as mock_which:
+        result = CliRunner().invoke(setup, ["--agent", "claude", "--print"], input="1\n")
+    assert result.exit_code == 0, result.stderr
+    assert "Tracking backend:" not in result.stderr
+    assert "MLFLOW_TRACKING_URI=http://my-server:5000" in result.stdout
+    mock_which.assert_called()
+
+
+def test_setup_env_databricks_still_prompts_for_experiment(
+    tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
+    with mock.patch(
+        "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
+    ) as mock_which:
+        result = CliRunner().invoke(
+            setup, ["--agent", "claude", "--print"], input="1\n1234567890\n"
+        )
+    assert result.exit_code == 0, result.stderr
+    assert "Tracking backend:" not in result.stderr
+    assert "Experiment ID, or path (auto-created if it doesn't exist)" in result.stderr
+    assert 'mlflow.set_experiment(experiment_id="1234567890")' in result.stdout
+    mock_which.assert_called()
+    mock_which.assert_called()


### PR DESCRIPTION
### Related Issues/PRs

Relates to the experimental `mlflow agent setup` CLI (no tracked issue).

### What changes are proposed in this pull request?

`mlflow agent setup` always prompted for a "Tracking backend" even when the user had already configured one via `MLFLOW_TRACKING_URI`. This change skips that prompt when `MLFLOW_TRACKING_URI` is set and uses the configured URI directly.

- When `MLFLOW_TRACKING_URI` is set, the backend prompt is skipped and the URI is used as-is (treated as an existing server, so no local server is started).
- A Databricks URI still needs an experiment. It is taken from `MLFLOW_EXPERIMENT_ID` / `MLFLOW_EXPERIMENT_NAME` when set (fully non-interactive), and only prompted for otherwise. The tracking URI itself is never re-asked.
- When `MLFLOW_TRACKING_URI` is unset, the existing interactive flow is unchanged.

The backend-resolution logic is extracted into `_resolve_tracking_backend()`, which returns a small `_TrackingBackend` dataclass, keeping `_run_setup` straightforward.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests cover: skipping the prompt for an env URL, not starting a local server for a localhost env URI, Databricks with experiment id/name from env (non-interactive), and Databricks prompting only for the experiment when no experiment env var is set. Manually verified with `mlflow agent setup --agent claude --print` across env-set, env-unset, and Databricks cases.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow agent setup` now skips the tracking-backend prompt when `MLFLOW_TRACKING_URI` is already set, using the configured URI directly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release