### PR TITLE
Fix `make_judge` doc: self-referential deprecation note and link typo

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/index.mdx
@@ -25,7 +25,7 @@ The fastest way to create LLM judges is through the **Judge Builder UI** - no co
 
 ## Prompts and template variables
 
-To create a judge, you provide a prompt with natural language instructions on how to assess the quality of your agent. <APILink fn="mlflow.genai.judges.make_jduge">`make_judge()`</APILink> accepts template variables to access the agent's inputs, outputs, expected outputs or behaviors, and even complete traces.
+To create a judge, you provide a prompt with natural language instructions on how to assess the quality of your agent. <APILink fn="mlflow.genai.judges.make_judge">`make_judge()`</APILink> accepts template variables to access the agent's inputs, outputs, expected outputs or behaviors, and even complete traces.
 
 Your instructions must include at least one template variable, but you don't need to use all of them.
 

--- a/mlflow/genai/judges/make_judge.py
+++ b/mlflow/genai/judges/make_judge.py
@@ -122,11 +122,6 @@ def make_judge(
     include_timing_in_conversation: bool = False,
 ) -> Judge:
     """
-
-    .. note::
-        As of MLflow 3.4.0, this function is deprecated in favor of `mlflow.genai.make_judge`
-        and may be removed in a future version.
-
     Create a custom MLflow judge instance.
 
     Args:


### PR DESCRIPTION
### Related Issues/PRs

Closes #24039
Closes #24038

### What changes are proposed in this pull request?

Two small documentation fixes for `make_judge`:

- **#24039**: Removed an incorrect `.. note::` in the `mlflow.genai.make_judge` docstring that claimed the function is "deprecated in favor of `mlflow.genai.make_judge`" - i.e. deprecated in favor of itself. This was a copy-paste error; `make_judge` is the recommended API, not deprecated.
- **#24038**: Fixed a typo in the custom-judges docs page (`docs/.../custom-judges/index.mdx`) where the `APILink` referenced `mlflow.genai.judges.make_jduge`, producing a broken link. Corrected to `mlflow.genai.judges.make_judge`, matching the anchor used by every other reference in the docs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Documentation-only change. No behavior change.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Corrects the `make_judge` docstring (which wrongly stated the function is deprecated) and a broken `make_judge` API link in the custom-judges guide.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release