### PR TITLE
Fix `ChrfScore` RAGAS scorer instantiation due to class name mismatch

### DIFF
--- a/mlflow/genai/scorers/ragas/registry.py
+++ b/mlflow/genai/scorers/ragas/registry.py
@@ -73,7 +73,7 @@ _METRIC_REGISTRY: dict[str, MetricConfig] = {
     "BleuScore": MetricConfig(
         "ragas.metrics.collections.BleuScore", requires_llm_in_constructor=False
     ),
-    "CHRFScore": MetricConfig(
+    "ChrfScore": MetricConfig(
         "ragas.metrics.collections.CHRFScore", requires_llm_in_constructor=False
     ),
     "RougeScore": MetricConfig(

--- a/tests/genai/scorers/ragas/test_ragas_scorer.py
+++ b/tests/genai/scorers/ragas/test_ragas_scorer.py
@@ -16,6 +16,8 @@ from mlflow.genai.scorers.ragas import (
     AgentGoalAccuracyWithReference,
     AnswerRelevancy,
     AspectCritic,
+    BleuScore,
+    ChrfScore,
     ContextEntityRecall,
     ContextPrecision,
     ContextRecall,
@@ -184,6 +186,8 @@ def test_missing_reference_parameter_returns_mlflow_error():
         (Faithfulness, "Faithfulness", {}),
         # Comparison Metrics
         (FactualCorrectness, "FactualCorrectness", {}),
+        (BleuScore, "BleuScore", {}),
+        (ChrfScore, "ChrfScore", {}),
         (RougeScore, "RougeScore", {}),
         (StringPresence, "StringPresence", {}),
         (ExactMatch, "ExactMatch", {}),


### PR DESCRIPTION
### Related Issues/PRs

Closes #23978

### What changes are proposed in this pull request?

`mlflow.genai.scorers.ragas.ChrfScore` failed at instantiation with `Unknown RAGAS metric: 'ChrfScore'`.

The scorer class `ChrfScore` declares `metric_name = "ChrfScore"`, but the metric registry keyed its entry under `"CHRFScore"`. As a result `get_metric_class("ChrfScore")` missed the registry entry and fell back to the default classpath `ragas.metrics.collections.ChrfScore`, which does not exist (the real RAGAS class is `CHRFScore`).

This PR keys the registry entry under `"ChrfScore"` (matching the scorer's `metric_name`) while keeping the classpath pointed at the real `ragas.metrics.collections.CHRFScore` class. This mirrors the existing `SummarizationScore` -> `ragas.metrics.collections.SummaryScore` convention, where the registry key matches the MLflow scorer name and the classpath points to the actual RAGAS class.

Repro (now succeeds):

```python
from mlflow.genai.scorers.ragas import ChrfScore

ChrfScore()
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `BleuScore` and `ChrfScore` to the `test_namespaced_class_properly_instantiates` parametrization, which previously skipped both comparison metrics (this is why the bug went unnoticed).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.genai.scorers.ragas.ChrfScore` can now be instantiated and used; previously it raised an `Unknown RAGAS metric` error due to a registry key mismatch.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release