### PR TITLE
Send strict-compatible `response_format` for AI Gateway judges and scorers

### DIFF
--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -144,19 +144,11 @@ def _build_request(
 
     if include_response_format:
         schema_cls = response_format or _get_default_judge_response_schema()
-        # OpenAI's structured output API requires "additionalProperties": false
-        # and "strict": true for json_schema response format. LiteLLM adds these
-        # automatically when given a Pydantic model; we must add them explicitly.
-        schema = schema_cls.model_json_schema()
-        schema["additionalProperties"] = False
-        payload["response_format"] = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": schema_cls.__name__,
-                "schema": schema,
-                "strict": True,
-            },
-        }
+        # OpenAI's structured output API requires "strict": true and
+        # "additionalProperties": false on every object (including nested $defs).
+        # pydantic_to_response_format applies both, keeping this path consistent
+        # with the other response_format builders.
+        payload["response_format"] = pydantic_to_response_format(schema_cls)
 
     if inference_params:
         payload.update(inference_params)

--- a/mlflow/genai/utils/llm_utils.py
+++ b/mlflow/genai/utils/llm_utils.py
@@ -13,6 +13,7 @@ import requests
 import mlflow
 from mlflow.gateway.config import EndpointType
 from mlflow.genai.judges.adapters.litellm_adapter import _is_litellm_available
+from mlflow.genai.utils.message_utils import pydantic_to_response_format
 from mlflow.metrics.genai.model_utils import _get_provider_instance, _parse_model_uri, _send_request
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._tracking_service.utils import _get_store
@@ -219,7 +220,7 @@ def _call_llm_via_gateway(
     if inference_params:
         payload.update(inference_params)
     if response_format is not None:
-        payload["response_format"] = _pydantic_to_response_format(response_format)
+        payload["response_format"] = pydantic_to_response_format(response_format)
     elif json_mode:
         payload["response_format"] = {"type": "json_object"}
 
@@ -245,16 +246,6 @@ def _call_llm_via_gateway(
     if token_counter is not None:
         token_counter.track(response)
     return response
-
-
-def _pydantic_to_response_format(cls: type[pydantic.BaseModel]) -> dict[str, Any]:
-    return {
-        "type": "json_schema",
-        "json_schema": {
-            "name": cls.__name__,
-            "schema": cls.model_json_schema(),
-        },
-    }
 
 
 @dataclass(frozen=True)

--- a/mlflow/genai/utils/message_utils.py
+++ b/mlflow/genai/utils/message_utils.py
@@ -79,9 +79,13 @@ def _enforce_strict_json_schema(node: Any) -> None:
     array ``items``, or combinators like ``anyOf`` - declares
     ``additionalProperties: false``. Pydantic's ``model_json_schema()`` does not
     emit this field, so we add it in place before sending the request.
+
+    An object node is detected either by an explicit ``type: object`` or by the
+    presence of ``properties``, since Pydantic does not always emit ``type`` on
+    object schemas.
     """
     if isinstance(node, dict):
-        if node.get("type") == "object":
+        if node.get("type") == "object" or "properties" in node:
             node["additionalProperties"] = False
         for value in node.values():
             _enforce_strict_json_schema(value)

--- a/mlflow/genai/utils/message_utils.py
+++ b/mlflow/genai/utils/message_utils.py
@@ -70,11 +70,34 @@ def serialize_chat_messages_to_prompts(
     return serialize_messages_to_prompts(messages)
 
 
+def _enforce_strict_json_schema(node: Any) -> None:
+    """Recursively set ``additionalProperties: false`` on every object schema.
+
+    OpenAI's strict structured output API (used by the MLflow AI Gateway and the
+    ``openai``/``azure`` providers) rejects a ``json_schema`` response format
+    unless every object - including those nested under ``$defs``, ``properties``,
+    array ``items``, or combinators like ``anyOf`` - declares
+    ``additionalProperties: false``. Pydantic's ``model_json_schema()`` does not
+    emit this field, so we add it in place before sending the request.
+    """
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            node["additionalProperties"] = False
+        for value in node.values():
+            _enforce_strict_json_schema(value)
+    elif isinstance(node, list):
+        for item in node:
+            _enforce_strict_json_schema(item)
+
+
 def pydantic_to_response_format(cls: type[BaseModel]) -> dict[str, Any]:
+    schema = cls.model_json_schema()
+    _enforce_strict_json_schema(schema)
     return {
         "type": "json_schema",
         "json_schema": {
             "name": cls.__name__,
-            "schema": cls.model_json_schema(),
+            "schema": schema,
+            "strict": True,
         },
     }

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -213,7 +213,7 @@ def _call_llm_provider_api(
             URL for the LLM provider will be used.
         messages: Pre-built list of message dicts (``[{"role": ..., "content": ...}]``).
             Mutually exclusive with ``input_data``.
-        response_format: Response format dict (e.g. from ``_pydantic_to_response_format``).
+        response_format: Response format dict (e.g. from ``pydantic_to_response_format``).
     """
     from mlflow.gateway.config import Provider
     from mlflow.gateway.schemas import chat

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -438,10 +438,15 @@ def test_build_request_with_inference_params():
 def test_build_request_response_format_is_strict():
     # Regression test for https://github.com/mlflow/mlflow/issues/23981: the AI
     # Gateway (and openai/azure providers) reject a json_schema response format
-    # unless it is strict and every object declares additionalProperties=False.
+    # unless it is strict and every object - including nested $defs - declares
+    # additionalProperties=False.
+    class Address(pydantic.BaseModel):
+        city: str
+
     class CustomSchema(pydantic.BaseModel):
         result: int
         rationale: str
+        address: Address
 
     payload = _build_request(
         messages=[ChatMessage(role="user", content="test")],
@@ -454,7 +459,9 @@ def test_build_request_response_format_is_strict():
     response_format = payload["response_format"]
     assert response_format["type"] == "json_schema"
     assert response_format["json_schema"]["strict"] is True
-    assert response_format["json_schema"]["schema"]["additionalProperties"] is False
+    schema = response_format["json_schema"]["schema"]
+    assert schema["additionalProperties"] is False
+    assert schema["$defs"]["Address"]["additionalProperties"] is False
 
 
 # --- _parse_response_message tests ---

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -435,6 +435,28 @@ def test_build_request_with_inference_params():
     assert payload["max_tokens"] == 100
 
 
+def test_build_request_response_format_is_strict():
+    # Regression test for https://github.com/mlflow/mlflow/issues/23981: the AI
+    # Gateway (and openai/azure providers) reject a json_schema response format
+    # unless it is strict and every object declares additionalProperties=False.
+    class CustomSchema(pydantic.BaseModel):
+        result: int
+        rationale: str
+
+    payload = _build_request(
+        messages=[ChatMessage(role="user", content="test")],
+        tools=None,
+        response_format=CustomSchema,
+        include_response_format=True,
+        inference_params=None,
+    )
+
+    response_format = payload["response_format"]
+    assert response_format["type"] == "json_schema"
+    assert response_format["json_schema"]["strict"] is True
+    assert response_format["json_schema"]["schema"]["additionalProperties"] is False
+
+
 # --- _parse_response_message tests ---
 
 

--- a/tests/genai/scorers/test_llm_backend.py
+++ b/tests/genai/scorers/test_llm_backend.py
@@ -135,9 +135,13 @@ def test_complete_with_pydantic_response_format(monkeypatch):
         )
 
     mock_call.assert_called_once()
-    call_kwargs = mock_call.call_args
-    assert call_kwargs.kwargs["response_format"] is not None
-    assert isinstance(call_kwargs.kwargs["response_format"], dict)
+    response_format = mock_call.call_args.kwargs["response_format"]
+    assert isinstance(response_format, dict)
+    # The MLflow AI Gateway (and openai/azure providers) reject a json_schema response
+    # format unless it is strict and every object declares additionalProperties=False.
+    assert response_format["type"] == "json_schema"
+    assert response_format["json_schema"]["strict"] is True
+    assert response_format["json_schema"]["schema"]["additionalProperties"] is False
 
 
 def test_complete_with_dict_response_format(monkeypatch):

--- a/tests/genai/utils/test_llm_utils.py
+++ b/tests/genai/utils/test_llm_utils.py
@@ -10,7 +10,6 @@ from mlflow.genai.utils.llm_utils import (
     _fetch_model_cost,
     _lookup_model_cost,
     _ModelCost,
-    _pydantic_to_response_format,
     _resolve_model_for_gateway,
     _TokenCounter,
 )
@@ -95,20 +94,6 @@ def test_call_llm_uses_litellm_when_available():
 
     mock_avail.assert_called_once()
     mock_ll.assert_called_once()
-
-
-def test_pydantic_to_response_format():
-    class MySchema(pydantic.BaseModel):
-        name: str
-        score: int
-
-    result = _pydantic_to_response_format(MySchema)
-
-    assert result["type"] == "json_schema"
-    assert result["json_schema"]["name"] == "MySchema"
-    schema = result["json_schema"]["schema"]
-    assert "name" in schema["properties"]
-    assert "score" in schema["properties"]
 
 
 def test_lookup_model_cost_returns_calculated_cost():

--- a/tests/genai/utils/test_message_utils.py
+++ b/tests/genai/utils/test_message_utils.py
@@ -208,6 +208,29 @@ def test_pydantic_to_response_format():
 
     assert result["type"] == "json_schema"
     assert result["json_schema"]["name"] == "MySchema"
+    # OpenAI / Azure strict structured outputs (used by the MLflow AI Gateway) reject
+    # the request unless the schema declares strict=True and additionalProperties=False.
+    assert result["json_schema"]["strict"] is True
     schema = result["json_schema"]["schema"]
+    assert schema["additionalProperties"] is False
     assert "name" in schema["properties"]
     assert "score" in schema["properties"]
+
+
+def test_pydantic_to_response_format_sets_additional_properties_on_nested_objects():
+    class Address(pydantic.BaseModel):
+        city: str
+
+    class Person(pydantic.BaseModel):
+        name: str
+        addresses: list[Address]
+        primary_address: Address
+
+    result = pydantic_to_response_format(Person)
+    schema = result["json_schema"]["schema"]
+
+    assert result["json_schema"]["strict"] is True
+    assert schema["additionalProperties"] is False
+    # Every nested object - including those under $defs reached via list items and
+    # direct references - must also declare additionalProperties=False under strict mode.
+    assert schema["$defs"]["Address"]["additionalProperties"] is False

--- a/tests/genai/utils/test_message_utils.py
+++ b/tests/genai/utils/test_message_utils.py
@@ -2,6 +2,7 @@ import pydantic
 import pytest
 
 from mlflow.genai.utils.message_utils import (
+    _enforce_strict_json_schema,
     pydantic_to_response_format,
     serialize_messages_to_prompts,
 )
@@ -234,3 +235,18 @@ def test_pydantic_to_response_format_sets_additional_properties_on_nested_object
     # Every nested object - including those under $defs reached via list items and
     # direct references - must also declare additionalProperties=False under strict mode.
     assert schema["$defs"]["Address"]["additionalProperties"] is False
+
+
+def test_enforce_strict_json_schema_detects_objects_without_explicit_type():
+    # Object nodes that omit an explicit "type": "object" (identified by the presence
+    # of "properties") must still get additionalProperties=False under strict mode.
+    schema = {
+        "properties": {
+            "nested": {"properties": {"x": {"type": "string"}}},
+        },
+        "title": "NoType",
+    }
+    _enforce_strict_json_schema(schema)
+
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["nested"]["additionalProperties"] is False


### PR DESCRIPTION
### Related Issues/PRs

Closes #23981

### What changes are proposed in this pull request?

`mlflow.genai.utils.message_utils.pydantic_to_response_format` produced an OpenAI `json_schema` response format whose schema omitted `additionalProperties: false` and `strict: true`. OpenAI / Azure, both directly and through the MLflow AI Gateway, reject such a schema with HTTP 400:

```
{"detail":"Invalid schema for response_format 'ResponseFormat': In context=(), 'additionalProperties' is required to be supplied and to be false."}
```

The custom-judge / builtin-scorer gateway path (`make_judge(model="gateway:/...")`, `Completeness(model="gateway:/...")`, etc.) was already routed through `gateway_adapter._build_request` (which adds these fields) as an incidental side effect of #23586, but that behavior was unguarded, and the same broken builder was still used by:

- the 3rd-party scorer backends (TruLens, Phoenix, RAGAS, DeepEval) via `ScorerLLMClient`, and
- the conversation simulator via `ScorerLLMClient.complete(response_format=...)`.

This PR fixes the helper itself so every caller emits a strict-compatible schema:

- `pydantic_to_response_format` now sets `strict: true` and recursively applies `additionalProperties: false` to every object in the schema, including nested `$defs`, array `items`, and combinators (`anyOf`/`allOf`/`oneOf`).
- Removed the duplicate `_pydantic_to_response_format` in `llm_utils.py` (its only caller now uses the shared helper).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added regression coverage:
- `test_message_utils.py`: asserts `strict` + `additionalProperties: false`, including a nested-object (`$defs`) case.
- `test_llm_backend.py`: the `ScorerLLMClient` native path now asserts the outgoing `response_format` is strict (this is also the conversation simulator's code path).
- `test_gateway_adapter.py`: new `test_build_request_response_format_is_strict` pins the original issue's path so it cannot silently regress.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed LLM judges and scorers failing with an HTTP 400 (`additionalProperties` is required to be false) when used with `gateway:/` endpoints or strict OpenAI/Azure providers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release