### PR TITLE
Support Gemini thought signature in AI Gateway

### DIFF
--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -136,7 +136,9 @@ class GeminiAdapter(ProviderAdapter):
                                 "args": json.loads(tool_call["function"]["arguments"]),
                             }
                             if tool_call["id"] in call_id_to_thought_signature_map:
-                                fc["thoughtSignature"] = call_id_to_thought_signature_map[tool_call["id"]]
+                                fc["thoughtSignature"] = call_id_to_thought_signature_map[
+                                    tool_call["id"]
+                                ]
 
                             gemini_function_calls.append({"functionCall": fc})
                 if gemini_function_calls:
@@ -226,7 +228,9 @@ class GeminiAdapter(ProviderAdapter):
             func_name = function_call["name"]
             func_arguments = json.dumps(function_call["args"])
             call_id = function_call.get("id")
-            thought_sig = function_call.get("thoughtSignature") or function_call.get("thought_signature")
+            thought_sig = function_call.get("thoughtSignature") or function_call.get(
+                "thought_signature"
+            )
             if call_id is None:
                 # Gemini model response might not contain function call id,
                 # in order to make it compatible with Openai chat protocol,

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -111,6 +111,7 @@ class GeminiAdapter(ProviderAdapter):
         system_message = None
 
         call_id_to_function_name_map = {}
+        call_id_to_thought_signature_map = {}
 
         for message in payload["messages"]:
             role = message["role"]
@@ -126,13 +127,18 @@ class GeminiAdapter(ProviderAdapter):
                             call_id_to_function_name_map[tool_call["id"]] = tool_call["function"][
                                 "name"
                             ]
-                            gemini_function_calls.append({
-                                "functionCall": {
-                                    "id": tool_call["id"],
-                                    "name": tool_call["function"]["name"],
-                                    "args": json.loads(tool_call["function"]["arguments"]),
-                                }
-                            })
+                            if sig := tool_call.get("thought_signature"):
+                                call_id_to_thought_signature_map[tool_call["id"]] = sig
+
+                            fc = {
+                                "id": tool_call["id"],
+                                "name": tool_call["function"]["name"],
+                                "args": json.loads(tool_call["function"]["arguments"]),
+                            }
+                            if tool_call["id"] in call_id_to_thought_signature_map:
+                                fc["thoughtSignature"] = call_id_to_thought_signature_map[tool_call["id"]]
+
+                            gemini_function_calls.append({"functionCall": fc})
                 if gemini_function_calls:
                     contents.append({"role": "model", "parts": gemini_function_calls})
                 else:
@@ -220,6 +226,7 @@ class GeminiAdapter(ProviderAdapter):
             func_name = function_call["name"]
             func_arguments = json.dumps(function_call["args"])
             call_id = function_call.get("id")
+            thought_sig = function_call.get("thoughtSignature") or function_call.get("thought_signature")
             if call_id is None:
                 # Gemini model response might not contain function call id,
                 # in order to make it compatible with Openai chat protocol,
@@ -241,6 +248,7 @@ class GeminiAdapter(ProviderAdapter):
                             arguments=func_arguments,
                         ),
                         type="function",
+                        thought_signature=thought_sig,
                     )
                 )
             else:
@@ -252,6 +260,7 @@ class GeminiAdapter(ProviderAdapter):
                             arguments=func_arguments,
                         ),
                         type="function",
+                        thought_signature=thought_sig,
                     )
                 )
         if stream:

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -67,6 +67,17 @@ class ToolCall(BaseModel):
     id: str
     type: str = Field(default="function")
     function: Function
+    # Gemini thinking-mode models return a thought_signature with each
+    # function call that must be echoed back in subsequent turns.
+    # https://ai.google.dev/gemini-api/docs/thought-signatures
+    thought_signature: str | None = Field(default=None)
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if data.get("thought_signature") is None:
+            data.pop("thought_signature", None)
+        return data
 
 
 class ChatMessage(BaseModel):
@@ -264,6 +275,17 @@ class ToolCallDelta(BaseModel):
     id: str | None = None
     type: str | None = None
     function: Function
+    # Gemini thinking-mode models return a thought_signature with each
+    # function call that must be echoed back in subsequent turns.
+    # https://ai.google.dev/gemini-api/docs/thought-signatures
+    thought_signature: str | None = Field(default=None)
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if data.get("thought_signature") is None:
+            data.pop("thought_signature", None)
+        return data
 
 
 class ChatChoiceDelta(BaseModel):

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -835,6 +835,126 @@ async def test_gemini_chat_function_calling_second_turn():
     )
 
 
+@pytest.mark.asyncio
+async def test_gemini_chat_function_calling_thought_signature():
+    config = chat_config()
+    provider = GeminiProvider(EndpointConfig(**config))
+    payload = chat_function_calling_payload()
+
+    payload["messages"].extend([
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_001",
+                    "function": {
+                        "arguments": '{"location": "Singapore"}',
+                        "name": "get_weather",
+                    },
+                    "type": "function",
+                    "thought_signature": "opaque_thought_sig_token",
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_001",
+            "content": '{"temperature": 31.2, "condition": "sunny"}',
+        },
+    ])
+
+    expected_url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+    )
+
+    resp = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "get_weather",
+                                "args": {"location": "Kuala Lumpur"},
+                                "id": "call_002",
+                                "thoughtSignature": "new_thought_sig_token",
+                            },
+                        },
+                    ],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ]
+    }
+    with (
+        mock.patch("time.time", return_value=1234567890),
+        mock.patch(
+            "aiohttp.ClientSession.post",
+            return_value=MockAsyncResponse(resp),
+        ) as mock_post,
+    ):
+        response = await provider.chat(chat.RequestPayload(**payload))
+
+    assert response.choices[0].message.tool_calls[0].thought_signature == "new_thought_sig_token"
+
+    expected_payload = {
+        "contents": [
+            {"role": "user", "parts": [{"text": "What's the weather like in Singapore today?"}]},
+            {
+                "role": "model",
+                "parts": [
+                    {
+                        "functionCall": {
+                            "id": "call_001",
+                            "name": "get_weather",
+                            "args": {"location": "Singapore"},
+                            "thoughtSignature": "opaque_thought_sig_token",
+                        }
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "functionResponse": {
+                            "id": "call_001",
+                            "name": "get_weather",
+                            "response": {"temperature": 31.2, "condition": "sunny"},
+                        }
+                    }
+                ],
+            },
+        ],
+        "generationConfig": {"temperature": 0.5, "candidateCount": 1},
+        "tools": [
+            {
+                "functionDeclarations": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get current temperature for a given location.",
+                        "parametersJsonSchema": {
+                            "properties": {
+                                "location": {"type": "string", "description": "The name of a city"}
+                            },
+                            "type": "object",
+                            "required": ["location"],
+                        },
+                    }
+                ]
+            }
+        ],
+    }
+
+    mock_post.assert_called_once_with(
+        expected_url,
+        json=expected_payload,
+        timeout=mock.ANY,
+    )
+
+
 def chat_stream_response():
     return [
         b'data: {"candidates":[{"content":{"parts":[{"text":"a"}]},"finishReason":null}],"'


### PR DESCRIPTION
### Related Issues/PRs

Closes #23989

### What changes are proposed in this pull request?

This pull request resolves a `400 Bad Request` error when performing multi-turn tool-calling chats with Gemini thinking-mode models (e.g., `gemini-3.1-flash-lite`) via the MLflow AI Gateway. 

Gemini models that support thinking mode return a `thought_signature` with each `functionCall` that must be echoed back in the conversational history on subsequent turns. Previously, MLflow's translation layer stripped this parameter during conversion to OpenAI-compatible schemas, causing upstream requests to fail.

To resolve this, we:
1. Added an optional `thought_signature` field to the `ToolCall` and `ToolCallDelta` schemas in `mlflow/types/chat.py`.
2. Implemented a custom model serializer for both `ToolCall` and `ToolCallDelta` to automatically omit the `thought_signature` key from serialized outputs when it is `None`, ensuring complete backward-compatibility and preserving existing tests.
3. Updated `mlflow/gateway/providers/gemini.py` to:
   - Extract `thought_signature` from the upstream Gemini `functionCall` response object and set it in the constructed `ToolCall`/`ToolCallDelta` choices.
   - Cache and inject the `thought_signature` back into the outgoing Gemini `functionCall` payloads during conversational history translation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Support Gemini models using thinking mode (e.g., `gemini-3.1-flash-lite`) by preserving and passing the `thought_signature` in multi-turn tool calling chats.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release