### PR TITLE
Fix broken `/genai/llm-evaluate` redirects

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -720,7 +720,11 @@ const config: Config = {
           // Evaluation and Monitoring Redirects
           {
             to: '/genai/eval-monitor',
-            from: ['/llms/llm-evaluate'],
+            from: ['/llms/llm-evaluate', '/genai/llm-evaluate'],
+          },
+          {
+            to: '/genai/eval-monitor/scorers',
+            from: ['/genai/llm-evaluate/llm-as-judge', '/llms/llm-evaluate/llm-as-judge'],
           },
           {
             to: '/genai/eval-monitor',


### PR DESCRIPTION
### Related Issues/PRs

NA

### What changes are proposed in this pull request?

Two documentation URLs are currently broken (403):

- https://mlflow.org/docs/latest/genai/llm-evaluate/
- https://mlflow.org/docs/latest/genai/llm-evaluate/llm-as-judge/

This adds client redirects in `docs/docusaurus.config.ts` so these legacy GenAI evaluation URLs resolve to their current locations:

- `/genai/llm-evaluate` → `/genai/eval-monitor`
- `/genai/llm-evaluate/llm-as-judge` → `/genai/eval-monitor/scorers`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Built the docs locally (`npm run build`) and served the static output, then verified with `curl`:

- `/genai/llm-evaluate/` emits `<meta http-equiv="refresh" ... url=/docs/latest/genai/eval-monitor/>` and the target returns `200`.
- `/genai/llm-evaluate/llm-as-judge/` emits `<meta http-equiv="refresh" ... url=/docs/latest/genai/eval-monitor/scorers/>` and the target returns `200`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release