### PR TITLE
docs: fix typos in tracing API reference and artifact store guide

### DIFF
--- a/docs/api_reference/source/python_api/mlflow.tracing.rst
+++ b/docs/api_reference/source/python_api/mlflow.tracing.rst
@@ -3,7 +3,7 @@ mlflow.tracing
 
 .. attention::
 
-    The ``mlflow.tracing`` namespace only contains a few utility functions fo managing traces. The main entry point for MLflow
+    The ``mlflow.tracing`` namespace only contains a few utility functions for managing traces. The main entry point for MLflow
     Tracing is :ref:`Tracing Fluent APIs <mlflow-tracing-fluent-python-apis>` defined directly under the
     :py:mod:`mlflow` namespace, or the low-level `Tracing Client APIs <../llms/tracing/index.html#tracing-client-apis>`_
 

--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -57,7 +57,7 @@ the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` depend
 these are available. For more information on how to set credentials, see
 [Set up AWS Credentials and Region for Development](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-credentials.html).
 
-Followings are commonly used environment variables for configuring S3 storage access. The complete list of configurable parameters for an S3 client is available in the
+The following are commonly used environment variables for configuring S3 storage access. The complete list of configurable parameters for an S3 client is available in the
 [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration).
 
 #### Passing Extra Arguments to S3 Upload


### PR DESCRIPTION
### Related Issues/PRs

Relates to general documentation quality.

### What changes are proposed in this pull request?

Two small typo fixes in documentation files:

1. **`docs/api_reference/source/python_api/mlflow.tracing.rst`** — Fixes a missing letter: `"fo managing traces"` → `"for managing traces"` in the attention note for the `mlflow.tracing` namespace.

2. **`docs/docs/self-hosting/architecture/artifact-store.mdx`** — Fixes grammatically incorrect phrasing: `"Followings are commonly used environment variables"` → `"The following are commonly used environment variables"` in the S3 artifact store configuration section.

Both are straightforward documentation typos with no behavior change.

### How is this PR tested?

- [x] Existing unit/integration tests

No code logic was changed, so no new tests are needed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

> Note: This fix was authored with AI-agent assistance.