### PR TITLE
Increase discoverability of Assistant

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -830,6 +830,7 @@ module.exports = {
   "mlflow.assistant.chat_panel.settings.tooltip": "",
   "mlflow.assistant.chat_panel.setup": "",
   "mlflow.assistant.chat_panel.suggestion.card": "",
+  "mlflow.assistant.fab": "",
   "mlflow.assistant.icon_button": "",
   "mlflow.assistant.icon_button.tooltip": "",
   "mlflow.assistant.setup.codex.api_keys": "",
@@ -871,6 +872,8 @@ module.exports = {
   "mlflow.assistant.setup.provider.continue": "",
   "mlflow.assistant.setup.provider.model": "",
   "mlflow.assistant.setup.provider.url": "",
+  "mlflow.assistant.trace_header_button": "",
+  "mlflow.assistant.traces_toolbar_button": "",
 
   // -- mlflow.charts --
   "mlflow.charts.bar_card_title.dataset_tag": "",

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -873,6 +873,9 @@ module.exports = {
   "mlflow.assistant.setup.provider.model": "",
   "mlflow.assistant.setup.provider.url": "",
   "mlflow.assistant.trace_header_button": "",
+  "mlflow.assistant.traces_guidance": "",
+  "mlflow.assistant.traces_guidance.dismiss": "",
+  "mlflow.assistant.traces_guidance.got_it": "",
   "mlflow.assistant.traces_toolbar_button": "",
 
   // -- mlflow.charts --

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { AssistantFloatingButton } from './AssistantFloatingButton';
+
+const mockOpenPanel = jest.fn();
+let mockAssistant: { isLocalServer: boolean; isPanelOpen: boolean; openPanel: jest.Mock };
+let mockObstructionWidth: number;
+
+jest.mock('./AssistantContext', () => ({
+  useAssistant: () => mockAssistant,
+}));
+
+jest.mock('./useFloatingObstruction', () => ({
+  useFloatingObstructionWidth: () => mockObstructionWidth,
+}));
+
+jest.mock('../telemetry/hooks/useLogTelemetryEvent', () => ({
+  useLogTelemetryEvent: jest.fn(() => jest.fn()),
+}));
+
+const renderFab = () =>
+  renderWithIntl(
+    <DesignSystemProvider>
+      <AssistantFloatingButton />
+    </DesignSystemProvider>,
+  );
+
+describe('AssistantFloatingButton', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockOpenPanel.mockClear();
+    mockAssistant = { isLocalServer: true, isPanelOpen: false, openPanel: mockOpenPanel };
+    mockObstructionWidth = 0;
+  });
+
+  test('auto-opens the panel once on first load', () => {
+    renderFab();
+    expect(mockOpenPanel).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'MLflow Assistant' })).toBeInTheDocument();
+  });
+
+  test('opens the panel when clicked', async () => {
+    renderFab();
+    // Ignore the first-load auto-open so we isolate the click.
+    mockOpenPanel.mockClear();
+    await userEvent.click(screen.getByRole('button', { name: 'MLflow Assistant' }));
+    expect(mockOpenPanel).toHaveBeenCalledTimes(1);
+  });
+
+  test('auto-opens only once across reloads', () => {
+    const { unmount } = renderFab();
+    expect(mockOpenPanel).toHaveBeenCalledTimes(1);
+
+    unmount();
+    mockOpenPanel.mockClear();
+    // localStorage is intentionally not cleared here — the persisted flag should suppress re-open.
+    renderFab();
+    expect(mockOpenPanel).not.toHaveBeenCalled();
+  });
+
+  test('does not auto-open or render on a remote server', () => {
+    mockAssistant.isLocalServer = false;
+    renderFab();
+    expect(mockOpenPanel).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'MLflow Assistant' })).not.toBeInTheDocument();
+  });
+
+  test('does not auto-open when the panel is already open', () => {
+    mockAssistant.isPanelOpen = true;
+    renderFab();
+    expect(mockOpenPanel).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'MLflow Assistant' })).not.toBeInTheDocument();
+  });
+
+  test('stays visible (repositioned) when a right-side surface is open', () => {
+    mockObstructionWidth = 600;
+    renderFab();
+    expect(screen.getByRole('button', { name: 'MLflow Assistant' })).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
@@ -104,9 +104,9 @@ export const AssistantFloatingButton = () => {
   // Standard DuBois control height, so the bubble stays in step with other UI controls.
   const fabSize = theme.general.heightBase;
   const iconSize = theme.typography.fontSizeXl;
-  // Inverted high-contrast surface: near-black in light mode, white in dark mode.
-  const bubbleBackground = theme.isDarkMode ? theme.colors.white : theme.colors.grey800;
-  const labelColor = theme.isDarkMode ? theme.colors.grey800 : theme.colors.white;
+  // Keep the page's own surface color and earn prominence from an AI-gradient border +
+  // elevation, mirroring the Detect Issues button so the two AI affordances read alike.
+  const bubbleBackground = `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`;
 
   // Plain button (not the DuBois Button) so we fully control the background and the
   // hover-to-expand pill behaviour without fighting the component's own styles.
@@ -123,12 +123,12 @@ export const AssistantFloatingButton = () => {
         maxWidth: fabSize,
         paddingInline: (fabSize - iconSize) / 2,
         paddingBlock: 0,
-        border: 'none',
+        border: '1px solid transparent',
         borderRadius: fabSize / 2,
         cursor: 'pointer',
         appearance: 'none',
         background: bubbleBackground,
-        color: labelColor,
+        color: theme.colors.textPrimary,
         boxShadow: theme.general.shadowHigh,
         overflow: 'hidden',
         whiteSpace: 'nowrap',

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  SparkleFillIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { useLocalStorage } from '@databricks/web-shared/hooks';
+import { useAssistant } from './AssistantContext';
+import { useFloatingObstructionWidth } from './useFloatingObstruction';
+import { useLogTelemetryEvent } from '../telemetry/hooks/useLogTelemetryEvent';
+
+// Width the pill expands to on hover; also used to keep it on-screen when shifted left.
+const FAB_EXPANDED_MAX_WIDTH = 240;
+
+// Tracks the viewport width reactively so the "does the button still fit beside the
+// drawer?" check re-runs when the window is resized (React won't re-render on resize alone).
+const useWindowWidth = (): number => {
+  const [width, setWidth] = useState(() => window.innerWidth);
+  useEffect(() => {
+    let frame = 0;
+    // Coalesce the burst of resize events into one update per animation frame; React
+    // then bails out of re-rendering when innerWidth hasn't actually changed.
+    const onResize = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => setWidth(window.innerWidth));
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+  return width;
+};
+
+/**
+ * Global floating entry point for the Assistant. Pinned bottom-right on every
+ * page (local server only), mirroring the convention used by other observability
+ * tools. Opens the existing Assistant side panel. Hidden while the panel is open
+ * to avoid overlapping it.
+ *
+ * On first load it opens the panel once (a one-time discovery boost), persisted so
+ * it never auto-opens again.
+ */
+export const AssistantFloatingButton = () => {
+  const { theme } = useDesignSystemTheme();
+  const { isLocalServer, isPanelOpen, openPanel } = useAssistant();
+  const obstructionWidth = useFloatingObstructionWidth();
+  const windowWidth = useWindowWidth();
+  const logTelemetryEvent = useLogTelemetryEvent();
+  const viewId = useMemo(() => uuidv4(), []);
+
+  // One-time first-load auto-open, persisted so the panel opens itself only once.
+  const [autoOpened, setAutoOpened] = useLocalStorage({
+    key: 'mlflow.assistant.fab.autoOpenedOnFirstLoad',
+    version: 1,
+    initialValue: false,
+  });
+
+  // On first load, open the panel once to surface the assistant. Mark it done even if the
+  // panel is already open (e.g. restored from a prior session) so a later reload won't force it.
+  useEffect(() => {
+    if (!isLocalServer || autoOpened) {
+      return;
+    }
+    setAutoOpened(true);
+    if (!isPanelOpen) {
+      openPanel();
+    }
+  }, [isLocalServer, isPanelOpen, autoOpened, setAutoOpened, openPanel]);
+
+  // Hide only when the assistant is unavailable or already open. When a right-side
+  // surface is open it doesn't hide the button — it reports the width it reserves (via
+  // useRegisterFloatingObstruction) and the button shifts to its left so it stays
+  // visible without overlapping. This is generic across any registering surface.
+  if (!isLocalServer || isPanelOpen) {
+    return null;
+  }
+
+  const baseInset = theme.spacing.md;
+  // Sit just to the left of an open right-side surface. If that surface is so wide the
+  // (expandable) button can't sit clear of it, yield entirely rather than float on top —
+  // the surface has its own assistant entry (e.g. the trace drawer's header button).
+  const rightInset = obstructionWidth > 0 ? obstructionWidth + theme.spacing.md : baseInset;
+  const fitsClearOfObstruction = rightInset + FAB_EXPANDED_MAX_WIDTH + theme.spacing.md <= windowWidth;
+  // When the surface is too wide for the button to sit clear, fade it out (kept mounted so
+  // the transition can play) rather than overlapping the surface.
+  const hiddenByObstruction = obstructionWidth > 0 && !fitsClearOfObstruction;
+
+  const handleOpen = () => {
+    openPanel();
+    logTelemetryEvent({
+      componentId: 'mlflow.assistant.fab',
+      componentViewId: viewId,
+      componentType: DesignSystemEventProviderComponentTypes.Button,
+      componentSubType: null,
+      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+    });
+  };
+
+  // Standard DuBois control height, so the bubble stays in step with other UI controls.
+  const fabSize = theme.general.heightBase;
+  const iconSize = theme.typography.fontSizeXl;
+  // Inverted high-contrast surface: near-black in light mode, white in dark mode.
+  const bubbleBackground = theme.isDarkMode ? theme.colors.white : theme.colors.grey800;
+  const labelColor = theme.isDarkMode ? theme.colors.grey800 : theme.colors.white;
+
+  // Plain button (not the DuBois Button) so we fully control the background and the
+  // hover-to-expand pill behaviour without fighting the component's own styles.
+  const fabButton = (
+    <button
+      type="button"
+      data-assistant-ui="true"
+      onClick={handleOpen}
+      css={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        height: fabSize,
+        minWidth: fabSize,
+        maxWidth: fabSize,
+        paddingInline: (fabSize - iconSize) / 2,
+        paddingBlock: 0,
+        border: 'none',
+        borderRadius: fabSize / 2,
+        cursor: 'pointer',
+        appearance: 'none',
+        background: bubbleBackground,
+        color: labelColor,
+        boxShadow: theme.general.shadowHigh,
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        '@media (prefers-reduced-motion: no-preference)': {
+          transition: 'max-width 0.25s ease',
+        },
+        // Expand into a pill that reveals the label on hover/focus.
+        '&:hover, &:focus-visible': {
+          maxWidth: FAB_EXPANDED_MAX_WIDTH,
+        },
+        '& .assistant-fab-label': {
+          opacity: 0,
+          marginLeft: 0,
+          fontWeight: theme.typography.typographyBoldFontWeight,
+          fontSize: theme.typography.fontSizeMd,
+          '@media (prefers-reduced-motion: no-preference)': {
+            transition: 'opacity 0.2s ease, margin 0.2s ease',
+          },
+        },
+        '&:hover .assistant-fab-label, &:focus-visible .assistant-fab-label': {
+          opacity: 1,
+          marginLeft: theme.spacing.sm,
+        },
+      }}
+    >
+      <SparkleFillIcon color="ai" css={{ fontSize: iconSize, flexShrink: 0 }} />
+      <span className="assistant-fab-label">
+        <FormattedMessage
+          defaultMessage="MLflow Assistant"
+          description="Label revealed when hovering the floating MLflow assistant button"
+        />
+      </span>
+    </button>
+  );
+
+  return (
+    // data-assistant-ui marks this as part of the assistant UI so that
+    // AssistantAwareDrawer does not treat clicks here as outside clicks.
+    // See AssistantAwareDrawer.tsx.
+    <div
+      data-assistant-ui="true"
+      css={{
+        position: 'fixed',
+        bottom: baseInset,
+        // Sits just left of any open right-side surface (e.g. a drawer) so it stays
+        // visible without overlapping; otherwise rests in the bottom-right corner.
+        right: rightInset,
+        // Above the drawer (design system drawer content sits at zIndexBase + 2/3).
+        zIndex: theme.options.zIndexBase + 10,
+        display: 'flex',
+        opacity: hiddenByObstruction ? 0 : 1,
+        // visibility (not unmount) so it drops out of focus/AT order once faded.
+        visibility: hiddenByObstruction ? 'hidden' : 'visible',
+        pointerEvents: hiddenByObstruction ? 'none' : 'auto',
+        '@media (prefers-reduced-motion: no-preference)': {
+          transition: hiddenByObstruction ? 'opacity 0.15s ease, visibility 0s 0.15s' : 'opacity 0.15s ease',
+        },
+      }}
+    >
+      {fabButton}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/assistant/index.ts
+++ b/mlflow/server/js/src/assistant/index.ts
@@ -5,6 +5,7 @@
  */
 export { AssistantProvider, useAssistant } from './AssistantContext';
 export { AssistantChatPanel } from './AssistantChatPanel';
+export { useRegisterFloatingObstruction, useFloatingObstructionWidth } from './useFloatingObstruction';
 export { AssistantSparkleIcon } from './AssistantIconButton';
 export {
   AssistantRouteContextProvider,

--- a/mlflow/server/js/src/assistant/useFloatingObstruction.ts
+++ b/mlflow/server/js/src/assistant/useFloatingObstruction.ts
@@ -1,0 +1,52 @@
+import { useEffect, useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { create } from '@databricks/web-shared/zustand';
+
+interface FloatingObstructionStore {
+  /** id -> width (px) reserved on the right edge by an open surface (e.g. a drawer). */
+  obstructions: Record<string, number>;
+  setObstruction: (id: string, reservedRightPx: number) => void;
+  removeObstruction: (id: string) => void;
+}
+
+const useFloatingObstructionStore = create<FloatingObstructionStore>((set) => ({
+  obstructions: {},
+  setObstruction: (id, reservedRightPx) =>
+    set((state) => ({ obstructions: { ...state.obstructions, [id]: reservedRightPx } })),
+  removeObstruction: (id) =>
+    set((state) => {
+      if (!(id in state.obstructions)) {
+        return state;
+      }
+      const next = { ...state.obstructions };
+      delete next[id];
+      return { obstructions: next };
+    }),
+}));
+
+/**
+ * Register that some surface (e.g. a right-side drawer) is currently occupying the right
+ * edge of the viewport, so the floating Assistant button can move clear of it instead of
+ * overlapping content. Pass the width (px) reserved on the right while the surface is open,
+ * or 0 when it isn't. Multiple surfaces compose; the button uses the widest reservation.
+ */
+export const useRegisterFloatingObstruction = (reservedRightPx: number) => {
+  const id = useMemo(() => uuidv4(), []);
+  const setObstruction = useFloatingObstructionStore((state) => state.setObstruction);
+  const removeObstruction = useFloatingObstructionStore((state) => state.removeObstruction);
+  useEffect(() => {
+    if (!reservedRightPx || reservedRightPx <= 0) {
+      removeObstruction(id);
+      return undefined;
+    }
+    setObstruction(id, reservedRightPx);
+    return () => removeObstruction(id);
+  }, [id, reservedRightPx, setObstruction, removeObstruction]);
+};
+
+/** The widest reservation (px) currently held on the right edge, or 0 if none. */
+export const useFloatingObstructionWidth = (): number =>
+  useFloatingObstructionStore((state) => {
+    const widths = Object.values(state.obstructions);
+    return widths.length > 0 ? Math.max(...widths) : 0;
+  });

--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
@@ -15,6 +15,7 @@ import { createPortal } from 'react-dom';
 import { Global } from '@emotion/react';
 import { Drawer, useDesignSystemTheme } from '@databricks/design-system';
 import { useAssistant } from '../../assistant/AssistantContext';
+import { useRegisterFloatingObstruction } from '../../assistant/useFloatingObstruction';
 
 const ASSISTANT_OPEN_DRAWER_WIDTH = '70vw';
 const MIN_DRAWER_WIDTH = 400;
@@ -89,6 +90,11 @@ function Content({
   useEffect(() => {
     setDrawerWidth(resolveWidthToPixels(isPanelOpen ? ASSISTANT_OPEN_DRAWER_WIDTH : width));
   }, [isPanelOpen, width]);
+
+  // While open on the right, this drawer reserves its width on the right edge so the
+  // floating Assistant button repositions to its left instead of overlapping it. When
+  // the assistant panel is open the drawer flips to the left, leaving the right edge free.
+  useRegisterFloatingObstruction(position === 'right' ? drawerWidth : 0);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {

--- a/mlflow/server/js/src/common/components/RootAssistantLayout.tsx
+++ b/mlflow/server/js/src/common/components/RootAssistantLayout.tsx
@@ -7,6 +7,7 @@ import { useDesignSystemTheme } from '@databricks/design-system';
 import { useCallback, useRef, useState, type ReactNode } from 'react';
 import { useAssistant } from '../../assistant/AssistantContext';
 import { AssistantChatPanel } from '../../assistant/AssistantChatPanel';
+import { AssistantFloatingButton } from '../../assistant/AssistantFloatingButton';
 
 const MIN_PANEL_WIDTH = 300;
 const MAX_PANEL_WIDTH_PERCENT = 60;
@@ -96,6 +97,7 @@ export const RootAssistantLayout = ({ children }: { children: ReactNode }) => {
           </div>
         )}
       </div>
+      <AssistantFloatingButton />
     </>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react';
 
-import { FormattedMessage } from 'react-intl';
-import { Button, SparkleIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { useDesignSystemTheme } from '@databricks/design-system';
 import { shouldEnableTracesTableStatePersistence } from '@databricks/web-shared/model-trace-explorer';
+import { AnalyzeWithAssistantButton } from '@databricks/web-shared/genai-traces-table';
 import { TracesV3Logs } from './TracesV3Logs';
 import {
   MonitoringConfigProvider,
@@ -43,19 +43,7 @@ const TracesV3Content = ({
         drawerWidth="80vw"
         toolbarAddons={
           isLocalServer ? (
-            // data-assistant-ui marks this as assistant UI so AssistantAwareDrawer won't treat
-            // the click as an outside-click and close. See AssistantAwareDrawer.tsx.
-            <Button
-              componentId="mlflow.assistant.traces_toolbar_button"
-              data-assistant-ui="true"
-              icon={<SparkleIcon color="ai" />}
-              onClick={openPanel}
-            >
-              <FormattedMessage
-                defaultMessage="Analyze with Assistant"
-                description="Traces table toolbar button that opens the MLflow assistant to analyze the current traces"
-              />
-            </Button>
+            <AnalyzeWithAssistantButton componentId="mlflow.assistant.traces_toolbar_button" onClick={openPanel} />
           ) : undefined
         }
       />

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 
-import { useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { Button, SparkleIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { shouldEnableTracesTableStatePersistence } from '@databricks/web-shared/model-trace-explorer';
 import { TracesV3Logs } from './TracesV3Logs';
 import {
@@ -11,6 +12,7 @@ import { TracesV3PageWrapper } from './TracesV3PageWrapper';
 import { useMonitoringViewState } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringViewState';
 import { useExperiments } from '../../hooks/useExperiments';
 import { TracesV3Toolbar } from './TracesV3Toolbar';
+import { useAssistant } from '@mlflow/mlflow/src/assistant';
 import {
   useMonitoringFilters,
   useMonitoringFiltersTimeRange,
@@ -30,6 +32,7 @@ const TracesV3Content = ({
   endpointName,
   timeRange,
 }: TracesV3ContentProps) => {
+  const { isLocalServer, openPanel } = useAssistant();
   if (viewState === 'logs') {
     return (
       <TracesV3Logs
@@ -38,6 +41,23 @@ const TracesV3Content = ({
         endpointName={endpointName || ''}
         timeRange={timeRange}
         drawerWidth="80vw"
+        toolbarAddons={
+          isLocalServer ? (
+            // data-assistant-ui marks this as assistant UI so AssistantAwareDrawer won't treat
+            // the click as an outside-click and close. See AssistantAwareDrawer.tsx.
+            <Button
+              componentId="mlflow.assistant.traces_toolbar_button"
+              data-assistant-ui="true"
+              icon={<SparkleIcon color="ai" />}
+              onClick={openPanel}
+            >
+              <FormattedMessage
+                defaultMessage="Analyze with Assistant"
+                description="Traces table toolbar button that opens the MLflow assistant to analyze the current traces"
+              />
+            </Button>
+          ) : undefined
+        }
       />
     );
   }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -627,6 +627,10 @@
     "defaultMessage": "Alerts",
     "description": "Tab label for budget alerts"
   },
+  "0vkexV": {
+    "defaultMessage": "Analyze in Assistant",
+    "description": "Button that opens the MLflow assistant side panel to analyze the current trace"
+  },
   "0vwlO5": {
     "defaultMessage": "Each message has a role that tells the model who is speaking:",
     "description": "Intro line for the playground role-selector help popover"
@@ -6975,6 +6979,10 @@
     "defaultMessage": "Previous trace",
     "description": "Review focused view: previous-trace button"
   },
+  "X1/rxD": {
+    "defaultMessage": "MLflow Assistant",
+    "description": "Label revealed when hovering the floating MLflow assistant button"
+  },
   "X11caV": {
     "defaultMessage": "Failed to override assessment. Error: {error}",
     "description": "Error message when overriding an assessment fails"
@@ -7626,6 +7634,10 @@
   "aAAHaS": {
     "defaultMessage": "Context insufficient",
     "description": "Evaluation results > context sufficiency assessment > negative value label. Displayed if retrieved context is insufficient to generate the expected response."
+  },
+  "aAcCh2": {
+    "defaultMessage": "Analyze with Assistant",
+    "description": "Traces table toolbar button that opens the MLflow assistant to analyze the current traces"
   },
   "aB6xFd": {
     "defaultMessage": "Outputs",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -739,6 +739,10 @@
     "defaultMessage": "Prompts",
     "description": "Title for linked prompts table on logged model details page"
   },
+  "1TTYjs": {
+    "defaultMessage": "Close guidance",
+    "description": "Aria label for closing the analyze with assistant guidance popover"
+  },
   "1Ujhc3": {
     "defaultMessage": "True",
     "description": "True assessment label"
@@ -890,6 +894,10 @@
   "2Hf+yU": {
     "defaultMessage": "Time (wall)",
     "description": "Label for a radio button that configures the x-axis on a line chart. This option is for the absolute time that the metrics were logged."
+  },
+  "2HyEkO": {
+    "defaultMessage": "Analyze traces with the MLflow assistant",
+    "description": "Aria label for the analyze with assistant button"
   },
   "2I27Yy": {
     "defaultMessage": "(empty)",
@@ -1438,6 +1446,10 @@
   "4ylmh/": {
     "defaultMessage": "Unique identifier for the trace",
     "description": "Tooltip description for the Trace ID column in the traces table"
+  },
+  "4yuYDg": {
+    "defaultMessage": "Got it",
+    "description": "Analyze with assistant guidance dismiss button"
   },
   "4zJtO4": {
     "defaultMessage": "Copy for coding agent",
@@ -6843,6 +6855,10 @@
     "defaultMessage": "Failed to update workspace. Please try again.",
     "description": "Generic error message for edit workspace modal"
   },
+  "WLGBoB": {
+    "defaultMessage": "Chat with Traces in Assistant",
+    "description": "Analyze with assistant guidance popover title"
+  },
   "WP1pyQ": {
     "defaultMessage": "Created by",
     "description": "Column title for created by column for a model in the registered model page"
@@ -12122,6 +12138,10 @@
   "vbRrqF": {
     "defaultMessage": "Add question",
     "description": "Add review question modal title"
+  },
+  "vcZc8z": {
+    "defaultMessage": "Open the MLflow Assistant to ask questions about your traces, debug failures, and investigate quality issues right alongside your data.",
+    "description": "Analyze with assistant guidance popover message"
   },
   "vedifc": {
     "defaultMessage": "Enter API key or select saved key",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -627,10 +627,6 @@
     "defaultMessage": "Alerts",
     "description": "Tab label for budget alerts"
   },
-  "0vkexV": {
-    "defaultMessage": "Analyze in Assistant",
-    "description": "Button that opens the MLflow assistant side panel to analyze the current trace"
-  },
   "0vwlO5": {
     "defaultMessage": "Each message has a role that tells the model who is speaking:",
     "description": "Intro line for the playground role-selector help popover"
@@ -1494,6 +1490,10 @@
   "5GCYzy": {
     "defaultMessage": "Experiment Runs - Databricks",
     "description": "Title on a page used to manage MLflow experiments runs"
+  },
+  "5K6npM": {
+    "defaultMessage": "Analyze with Assistant",
+    "description": "Button that opens the MLflow assistant side panel to analyze the current trace"
   },
   "5LORfM": {
     "defaultMessage": "Key name cannot be changed. Create a new key if a different name is needed.",

--- a/mlflow/server/js/src/shared/web-shared/design-system/aiGradientBorderStyle.ts
+++ b/mlflow/server/js/src/shared/web-shared/design-system/aiGradientBorderStyle.ts
@@ -1,0 +1,11 @@
+import type { ThemeType } from '@databricks/design-system';
+
+/**
+ * Border treatment for AI-powered affordances: keeps the page surface as the fill and paints the
+ * AI gradient onto the 1px border. Shared by the Detect Issues button and the assistant entry
+ * points so they read as one visual family and stay in sync with the design-system gradient.
+ */
+export const getAiGradientBorderStyle = (theme: ThemeType) => ({
+  border: '1px solid transparent !important',
+  background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/AnalyzeWithAssistantButton.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/AnalyzeWithAssistantButton.test.tsx
@@ -1,0 +1,136 @@
+import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IntlProvider } from '@databricks/i18n';
+
+import { AnalyzeWithAssistantButton } from './AnalyzeWithAssistantButton';
+import {
+  DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY,
+  DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT,
+} from './DetectIssuesButton';
+import { shouldEnableIssueDetection } from '../../../../common/utils/FeatureUtils';
+
+jest.mock('../../../../common/utils/FeatureUtils', () => ({
+  shouldEnableIssueDetection: jest.fn(),
+}));
+
+const ASSISTANT_GUIDANCE_KEY = 'mlflow.assistant.tracesGuidanceShown_v1';
+const DETECT_ISSUES_GUIDANCE_KEY = `${DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY}_v1`;
+const GUIDANCE_TITLE = 'Chat with Traces in Assistant';
+
+describe('AnalyzeWithAssistantButton', () => {
+  const onClickMock = jest.fn();
+  const componentId = 'test-analyze-with-assistant-button';
+
+  beforeEach(() => {
+    onClickMock.mockClear();
+    localStorage.clear();
+    jest.mocked(shouldEnableIssueDetection).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  const renderTestComponent = () =>
+    render(<AnalyzeWithAssistantButton componentId={componentId} onClick={onClickMock} />, {
+      wrapper: ({ children }) => <IntlProvider locale="en">{children}</IntlProvider>,
+    });
+
+  test('renders the Analyze with Assistant button', () => {
+    renderTestComponent();
+    expect(screen.getByText('Analyze with Assistant')).toBeInTheDocument();
+  });
+
+  test('shows guidance on first visit when issue detection is disabled', async () => {
+    jest.mocked(shouldEnableIssueDetection).mockReturnValue(false);
+    renderTestComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(GUIDANCE_TITLE)).toBeInTheDocument();
+    });
+  });
+
+  test('waits for the Detect Issues guidance before showing (sequential)', () => {
+    // Issue detection is enabled and its guidance has not been dismissed yet, so ours stays hidden.
+    jest.mocked(shouldEnableIssueDetection).mockReturnValue(true);
+    renderTestComponent();
+
+    expect(screen.queryByText(GUIDANCE_TITLE)).not.toBeInTheDocument();
+  });
+
+  test('shows guidance once the Detect Issues guidance has been dismissed', async () => {
+    jest.mocked(shouldEnableIssueDetection).mockReturnValue(true);
+    localStorage.setItem(DETECT_ISSUES_GUIDANCE_KEY, JSON.stringify(true));
+    renderTestComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(GUIDANCE_TITLE)).toBeInTheDocument();
+    });
+  });
+
+  test('reveals guidance immediately when the Detect Issues dismissal event fires', async () => {
+    jest.mocked(shouldEnableIssueDetection).mockReturnValue(true);
+    renderTestComponent();
+
+    // Hidden while the Detect Issues guidance is still pending.
+    expect(screen.queryByText(GUIDANCE_TITLE)).not.toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event(DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(GUIDANCE_TITLE)).toBeInTheDocument();
+    });
+  });
+
+  test('does not show guidance when it has already been seen', () => {
+    localStorage.setItem(ASSISTANT_GUIDANCE_KEY, JSON.stringify(true));
+    renderTestComponent();
+
+    expect(screen.queryByText(GUIDANCE_TITLE)).not.toBeInTheDocument();
+  });
+
+  test('dismissing guidance via "Got it" persists the flag and hides the popover', async () => {
+    renderTestComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(GUIDANCE_TITLE)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('Got it'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(GUIDANCE_TITLE)).not.toBeInTheDocument();
+    });
+    expect(localStorage.getItem(ASSISTANT_GUIDANCE_KEY)).toBe('true');
+  });
+
+  test('dismissing guidance via the close button persists the flag', async () => {
+    renderTestComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(GUIDANCE_TITLE)).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText('Close guidance'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(GUIDANCE_TITLE)).not.toBeInTheDocument();
+    });
+    expect(localStorage.getItem(ASSISTANT_GUIDANCE_KEY)).toBe('true');
+  });
+
+  test('onClick handler is called when the button is clicked', async () => {
+    // Mark guidance as seen so the popover does not intercept the click.
+    localStorage.setItem(ASSISTANT_GUIDANCE_KEY, JSON.stringify(true));
+    renderTestComponent();
+
+    await userEvent.click(screen.getByText('Analyze with Assistant'));
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/AnalyzeWithAssistantButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/AnalyzeWithAssistantButton.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+import { Button, CloseIcon, Popover, SparkleIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { getLocalStorageItemByParams, useLocalStorage } from '../../hooks/useLocalStorage';
+import { shouldEnableIssueDetection } from '../../../../common/utils/FeatureUtils';
+import {
+  DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY,
+  DETECT_ISSUES_GUIDANCE_STORAGE_VERSION,
+  DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT,
+} from './DetectIssuesButton';
+
+const ANALYZE_WITH_ASSISTANT_GUIDANCE_STORAGE_KEY = 'mlflow.assistant.tracesGuidanceShown';
+const ANALYZE_WITH_ASSISTANT_GUIDANCE_STORAGE_VERSION = 1;
+
+interface AnalyzeWithAssistantButtonProps {
+  componentId: string;
+  onClick: () => void;
+}
+
+export const AnalyzeWithAssistantButton: React.FC<AnalyzeWithAssistantButtonProps> = ({ componentId, onClick }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [hasSeenGuidance, setHasSeenGuidance] = useLocalStorage({
+    key: ANALYZE_WITH_ASSISTANT_GUIDANCE_STORAGE_KEY,
+    version: ANALYZE_WITH_ASSISTANT_GUIDANCE_STORAGE_VERSION,
+    initialValue: false,
+  });
+
+  // Wait for the Detect Issues spotlight to be dismissed before showing ours, so the two
+  // first-visit callouts appear one at a time rather than stacking dimming scrims and focus
+  // traps. When issue detection is disabled, Detect Issues never shows, so we go immediately.
+  // useLocalStorage only reads at mount, so we mirror the flag in state and react to the
+  // dismissal event — otherwise our popover wouldn't appear until this component remounts.
+  const [hasSeenDetectIssuesGuidance, setHasSeenDetectIssuesGuidance] = useState(() =>
+    getLocalStorageItemByParams({
+      key: DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY,
+      version: DETECT_ISSUES_GUIDANCE_STORAGE_VERSION,
+      initialValue: false,
+    }),
+  );
+  useEffect(() => {
+    const onDismissed = () => setHasSeenDetectIssuesGuidance(true);
+    window.addEventListener(DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT, onDismissed);
+    return () => window.removeEventListener(DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT, onDismissed);
+  }, []);
+  const detectIssuesGuidancePending = shouldEnableIssueDetection() && !hasSeenDetectIssuesGuidance;
+  const showGuidance = !hasSeenGuidance && !detectIssuesGuidancePending;
+
+  const handleDismissGuidance = () => {
+    setHasSeenGuidance(true);
+  };
+
+  const buttonContent = (
+    <Button
+      componentId={componentId}
+      onClick={onClick}
+      icon={<SparkleIcon color="ai" />}
+      // data-assistant-ui marks this as assistant UI so AssistantAwareDrawer won't treat the
+      // click as an outside-click and close. See AssistantAwareDrawer.tsx.
+      data-assistant-ui="true"
+      aria-label={intl.formatMessage({
+        defaultMessage: 'Analyze traces with the MLflow assistant',
+        description: 'Aria label for the analyze with assistant button',
+      })}
+      css={{
+        // AI-gradient border on the page surface signals this is an AI-powered action,
+        // matching the Detect Issues button and the assistant floating button.
+        border: '1px solid transparent !important',
+        background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
+      }}
+    >
+      <FormattedMessage
+        defaultMessage="Analyze with Assistant"
+        description="Traces table toolbar button that opens the MLflow assistant to analyze the current traces"
+      />
+    </Button>
+  );
+
+  if (!showGuidance) {
+    return <div>{buttonContent}</div>;
+  }
+
+  return (
+    <Popover.Root
+      componentId="mlflow.assistant.traces_guidance"
+      open={showGuidance}
+      onOpenChange={(open) => {
+        // Only allow closing via explicit dismiss actions, not by clicking outside.
+        if (!open) {
+          return;
+        }
+      }}
+      modal
+    >
+      <Popover.Trigger asChild>
+        <div css={{ position: 'relative', zIndex: 1001 }}>{buttonContent}</div>
+      </Popover.Trigger>
+      <Popover.Content
+        side="bottom"
+        align="end"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+        css={{
+          maxWidth: 320,
+          padding: theme.spacing.md,
+          zIndex: 1000,
+          boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.4)',
+        }}
+      >
+        <Popover.Arrow css={{ fill: theme.colors.backgroundPrimary }} />
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            marginBottom: theme.spacing.sm,
+          }}
+        >
+          <div
+            css={{
+              fontWeight: theme.typography.typographyBoldFontWeight,
+              fontSize: theme.typography.fontSizeMd,
+            }}
+          >
+            <FormattedMessage
+              defaultMessage="Chat with Traces in Assistant"
+              description="Analyze with assistant guidance popover title"
+            />
+          </div>
+          <Button
+            componentId="mlflow.assistant.traces_guidance.dismiss"
+            icon={<CloseIcon />}
+            onClick={handleDismissGuidance}
+            aria-label={intl.formatMessage({
+              defaultMessage: 'Close guidance',
+              description: 'Aria label for closing the analyze with assistant guidance popover',
+            })}
+            css={{
+              padding: 0,
+              minWidth: 'auto',
+              border: 'none',
+              background: 'transparent',
+            }}
+          />
+        </div>
+        <div css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary }}>
+          <FormattedMessage
+            defaultMessage="Open the MLflow Assistant to ask questions about your traces, debug failures, and investigate quality issues right alongside your data."
+            description="Analyze with assistant guidance popover message"
+          />
+        </div>
+        <Button
+          componentId="mlflow.assistant.traces_guidance.got_it"
+          onClick={handleDismissGuidance}
+          css={{ marginTop: theme.spacing.md, width: '100%' }}
+        >
+          <FormattedMessage defaultMessage="Got it" description="Analyze with assistant guidance dismiss button" />
+        </Button>
+      </Popover.Content>
+    </Popover.Root>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/AnalyzeWithAssistantButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/AnalyzeWithAssistantButton.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, CloseIcon, Popover, SparkleIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { getLocalStorageItemByParams, useLocalStorage } from '../../hooks/useLocalStorage';
+import { getAiGradientBorderStyle } from '../../design-system/aiGradientBorderStyle';
 import { shouldEnableIssueDetection } from '../../../../common/utils/FeatureUtils';
 import {
   DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY,
@@ -63,12 +64,9 @@ export const AnalyzeWithAssistantButton: React.FC<AnalyzeWithAssistantButtonProp
         defaultMessage: 'Analyze traces with the MLflow assistant',
         description: 'Aria label for the analyze with assistant button',
       })}
-      css={{
-        // AI-gradient border on the page surface signals this is an AI-powered action,
-        // matching the Detect Issues button and the assistant floating button.
-        border: '1px solid transparent !important',
-        background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
-      }}
+      // AI-gradient border signals this is an AI-powered action, matching the Detect Issues
+      // button and the trace drawer's assistant button.
+      css={getAiGradientBorderStyle(theme)}
     >
       <FormattedMessage
         defaultMessage="Analyze with Assistant"

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/DetectIssuesButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/DetectIssuesButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, CloseIcon, Popover, SparkleIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { getAiGradientBorderStyle } from '../../design-system/aiGradientBorderStyle';
 
 // Default storage key for tracking first-time user guidance
 export const DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY = 'mlflow.detectIssues.guidanceShown';
@@ -40,10 +41,7 @@ export const DetectIssuesButton: React.FC<DetectIssuesButtonProps> = ({ componen
         description: 'Aria label for the detect issues button',
       })}
       icon={<SparkleIcon color="ai" />}
-      css={{
-        border: '1px solid transparent !important',
-        background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
-      }}
+      css={getAiGradientBorderStyle(theme)}
     >
       <FormattedMessage defaultMessage="Detect Issues" description="Label for the detect issues button" />
     </Button>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/DetectIssuesButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/DetectIssuesButton.tsx
@@ -5,7 +5,10 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 
 // Default storage key for tracking first-time user guidance
 export const DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY = 'mlflow.detectIssues.guidanceShown';
-const DETECT_ISSUES_GUIDANCE_STORAGE_VERSION = 1;
+export const DETECT_ISSUES_GUIDANCE_STORAGE_VERSION = 1;
+// Broadcast on dismiss so a follow-on first-visit nudge (e.g. Analyze with Assistant) can reveal
+// itself in the same session instead of waiting for a remount to re-read the storage flag.
+export const DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT = 'mlflow.detectIssues.guidanceDismissed';
 
 interface DetectIssuesButtonProps {
   componentId: string;
@@ -25,6 +28,7 @@ export const DetectIssuesButton: React.FC<DetectIssuesButtonProps> = ({ componen
 
   const handleDismissGuidance = () => {
     setHasSeenGuidance(true);
+    window.dispatchEvent(new Event(DETECT_ISSUES_GUIDANCE_DISMISSED_EVENT));
   };
 
   const buttonContent = (

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -53,6 +53,8 @@ export { useColumnsURL } from './hooks/useColumnsURL';
 
 export { GenAiEvaluationTracesReviewModal } from './components/GenAiEvaluationTracesReviewModal';
 
+export { AnalyzeWithAssistantButton } from './components/AnalyzeWithAssistantButton';
+
 export * from './types';
 
 export {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -19,6 +19,7 @@ import { useAssistant } from '@mlflow/mlflow/src/assistant';
 import { ModelTraceExplorerSkeleton } from './ModelTraceExplorerSkeleton';
 import { useModelTraceExplorerContext } from './ModelTraceExplorerContext';
 import type { ModelTraceInfoV3 } from './ModelTrace.types';
+import { getAiGradientBorderStyle } from '../design-system/aiGradientBorderStyle';
 import { copyToClipboard } from '../../../common/utils/copyToClipboard';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
@@ -192,14 +193,10 @@ export const ModelTraceExplorerDrawer = ({
                 data-assistant-ui="true"
                 icon={<SparkleIcon color="ai" />}
                 onClick={openPanel}
-                css={{
-                  flexShrink: 0,
-                  border: '1px solid transparent !important',
-                  background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
-                }}
+                css={{ flexShrink: 0, ...getAiGradientBorderStyle(theme) }}
               >
                 <FormattedMessage
-                  defaultMessage="Analyze in Assistant"
+                  defaultMessage="Analyze with Assistant"
                   description="Button that opens the MLflow assistant side panel to analyze the current trace"
                 />
               </Button>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -8,11 +8,13 @@ import {
   FlagPointerIcon,
   PlusIcon,
   Notification,
+  SparkleIcon,
   Tooltip,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { Global } from '@emotion/react';
+import { useAssistant } from '@mlflow/mlflow/src/assistant';
 
 import { ModelTraceExplorerSkeleton } from './ModelTraceExplorerSkeleton';
 import { useModelTraceExplorerContext } from './ModelTraceExplorerContext';
@@ -54,6 +56,7 @@ export const ModelTraceExplorerDrawer = ({
   traceInfo,
 }: ModelTraceExplorerDrawerProps) => {
   const { theme } = useDesignSystemTheme();
+  const { isLocalServer, openPanel } = useAssistant();
   const [showDatasetModal, setShowDatasetModal] = useState(false);
   const [showCopiedNotification, setShowCopiedNotification] = useState(false);
   const [showCopyError, setShowCopyError] = useState(false);
@@ -181,6 +184,26 @@ export const ModelTraceExplorerDrawer = ({
               <ChevronRightIcon />
             </Button>
             <div css={{ flex: 1, overflow: 'hidden' }}>{renderModalTitle()}</div>
+            {isLocalServer && (
+              // data-assistant-ui marks this as assistant UI so AssistantAwareDrawer won't treat
+              // the click as an outside-click and close. See AssistantAwareDrawer.tsx.
+              <Button
+                componentId="mlflow.assistant.trace_header_button"
+                data-assistant-ui="true"
+                icon={<SparkleIcon color="ai" />}
+                onClick={openPanel}
+                css={{
+                  flexShrink: 0,
+                  border: '1px solid transparent !important',
+                  background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
+                }}
+              >
+                <FormattedMessage
+                  defaultMessage="Analyze in Assistant"
+                  description="Button that opens the MLflow assistant side panel to analyze the current trace"
+                />
+              </Button>
+            )}
             {showAddToDatasetButton && (
               <Button
                 componentId="mlflow.evaluations_review.modal.add_to_dataset"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->


### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR increases the discoverability of the MLflow AI Assistant.

The changes are: 
- On First Load, always open the assistant chat panel
- Put a button at the bottom right of the screen (we can consider removing the Assistant button on the sidebar)
  - This is the primary discoverabilty tool. In general, users know that if there's a bubble at the bottom right of the screen, its a chat tool, Let's do the same
- Surface `Analyze in Assistant` in various trace pages as a call to action

These features are only enabled for localhost, as Mlflow Assistant is only enabled for loalhost. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


Open on Load (only on first load, subsequent loads do not open chat automatically). We expect to see a nudge for the "Analyze in Assistant" button, similar to "Detect Issues". The chat should also automatically open.




https://github.com/user-attachments/assets/2e2fd661-14f5-443d-9508-1052c4509635






FAB buttons


https://github.com/user-attachments/assets/90a276f7-c3c1-4708-a578-ecc03c2cceb0


- Note the FAB at the bottom right corner.
- When the trace view page loads at the right drawer, the FAB is pushed left. If the trace page becomes too small, the FAB disappears



Dark Mode FAB vs Light Mode FAB


<img width="1694" height="944" alt="LightMode" src="https://github.com/user-attachments/assets/ae9041f6-ee71-46b9-8db7-67f9e82a7b86" />



<img width="1710" height="950" alt="DarkMode" src="https://github.com/user-attachments/assets/9a94e9bb-4340-4a76-b978-bd7ea7f126e9" />





### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
