### PR TITLE
feat: Add Kubernetes Gateway API support and update HTTPRoutes

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mlflow
 description: A production-ready Helm chart for deploying MLflow on Kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "3.13.0"

--- a/charts/README.md
+++ b/charts/README.md
@@ -156,6 +156,21 @@ ingress:
         - mlflow.example.com
 ```
 
+### Gateway API (HTTPRoute)
+
+Alternatively, you can use the Kubernetes Gateway API by configuring an `HTTPRoute`:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: internal-gateway
+      namespace: gateway-system
+      sectionName: http
+  hostnames:
+    - "mlflow.example.com"
+```
+
 ### Prometheus metrics
 
 ```yaml

--- a/charts/templates/httproute.yaml
+++ b/charts/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "mlflow.fullname" . }}
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.gateway.parentRefs }}
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml .Values.gateway.hostnames | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "mlflow.fullname" . }}
+          port: {{ .Values.server.value_options.port }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -111,6 +111,26 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Gateway API (HTTPRoute) for external access to the MLflow server.
+gateway:
+  enabled: false
+  # Annotations to be added to the HTTPRoute
+  annotations: {}
+  # Labels to be added to the HTTPRoute
+  labels: {}
+  # References to parent Gateway(s) to attach this HTTPRoute to.
+  # Example:
+  # parentRefs:
+  #   - name: internal-gateway
+  #     namespace: gateway-system
+  #     sectionName: http
+  parentRefs: []
+  # Hostnames defining the domains for this HTTPRoute.
+  # Example:
+  # hostnames:
+  #   - "mlflow.local"
+  hostnames: []
+
 mlflow:
   # URI of the database or file store used to record runs and metadata.
   # Examples: "sqlite:////mlflow/mlflow.db", "postgresql://user:pass@host/db"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #24057

### What changes are proposed in this pull request?

Added support for the Kubernetes Gateway API (`HTTPRoute`) to the official MLflow Helm chart as a modern alternative to `Ingress`.                                           
    - Added a `gateway` configuration block to `values.yaml`                                                                                                                     
    - Created `templates/httproute.yaml` to dynamically provision an `HTTPRoute` attaching the MLflow service to a parent Gateway.                                               
    - Updated `Chart.yaml` version from `0.1.0` to `0.2.0`.                                                                                                                      
    - Added Gateway API instructions to `README.md`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Successfully deployed the chart locally using an Istio Gateway and verified that the `HTTPRoute` correctly attaches to the Gateway's HTTPS listener and routes traffic to the
  MLflow pods, correctly enforcing Basic Authentication.      

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Added Kubernetes Gateway API (`HTTPRoute`) support to the official MLflow Helm chart.   


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

Helm chart updates do not strictly fall into the core component list, so these are left unchecked

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
