### PR TITLE
Add MlflowClient.exportOtlpSpans for OSS span logging for TS SDK

### DIFF
--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -5,16 +5,17 @@ import {
   CreateTraceInfoV4,
   DeleteExperiment,
   ExportOtlpTraces,
+  ExportOtlpTracesOss,
   GetExperiment,
   GetExperimentByName,
   GetTraceInfoV3,
   StartTraceV3,
 } from './spec';
-import { makeRequest, MlflowHttpError } from './utils';
+import { makeRawRequest, makeRequest, MlflowHttpError } from './utils';
 import { TraceData } from '../core/entities/trace_data';
 import { ArtifactsClient, getArtifactsClient } from './artifacts';
 import { AuthProvider, HeadersProvider } from '../auth';
-import { DATABRICKS_UC_TABLE_HEADER } from '../core/constants';
+import { DATABRICKS_UC_TABLE_HEADER, MLFLOW_EXPERIMENT_ID_HEADER } from '../core/constants';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import type { ReadableSpan as OTelReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { ExportResultCode, type ExportResult } from '@opentelemetry/core';
@@ -151,6 +152,29 @@ export class MlflowClient {
       // Drain any pending state so the exporter doesn't keep handles open.
       await exporter.shutdown().catch(() => undefined);
     }
+  }
+
+  /**
+   * Export OTLP spans to an OSS (non-Databricks) tracking server.
+   *
+   * `otlpProtoBytes` is an already-serialized OTLP `ExportTraceServiceRequest`
+   * protobuf (captured at WAL-write time), POSTed as `application/x-protobuf`
+   * with the experiment id forwarded via the `x-mlflow-experiment-id` header.
+   */
+  async exportOtlpSpans(experimentId: string, otlpProtoBytes: Uint8Array): Promise<void> {
+    if (otlpProtoBytes.length === 0) {
+      return;
+    }
+    await makeRawRequest(
+      'POST',
+      ExportOtlpTracesOss.getEndpoint(this.hostUrl),
+      this.headersProvider,
+      otlpProtoBytes,
+      {
+        'Content-Type': 'application/x-protobuf',
+        [MLFLOW_EXPERIMENT_ID_HEADER]: experimentId,
+      },
+    );
   }
 
   // === TRACE RETRIEVAL METHODS ===

--- a/libs/typescript/core/src/clients/utils.ts
+++ b/libs/typescript/core/src/clients/utils.ts
@@ -130,8 +130,17 @@ export async function makeRawRequest(
   timeout?: number,
 ): Promise<void> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout ?? getDefaultTimeout());
-  const headers = { ...(await headerProvider()), ...extraHeaders };
+  const effectiveTimeout = timeout ?? getDefaultTimeout();
+  const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
+
+  const headers: Record<string, string> = { ...(await headerProvider()) };
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    const existingKey = Object.keys(headers).find((h) => h.toLowerCase() === key.toLowerCase());
+    if (existingKey) {
+      delete headers[existingKey];
+    }
+    headers[key] = value;
+  }
 
   try {
     const response = await fetch(url, {
@@ -161,7 +170,7 @@ export async function makeRawRequest(
 
     if (error instanceof Error) {
       if (error.name === 'AbortError') {
-        throw new Error(`Request timeout after ${timeout}ms`);
+        throw new Error(`Request timeout after ${effectiveTimeout}ms`);
       }
       throw new Error(`API request failed: ${error.message}`);
     }

--- a/libs/typescript/core/src/clients/utils.ts
+++ b/libs/typescript/core/src/clients/utils.ts
@@ -115,6 +115,60 @@ export async function makeRequest<T>(
   }
 }
 
+/**
+ * Send a raw (already-serialized) body — e.g. OTLP protobuf bytes — to `url`.
+ * `extraHeaders` merge over the auth headers (to override `Content-Type` etc).
+ * The response body is ignored; non-2xx throws {@link MlflowHttpError} so
+ * callers can branch on `status` (e.g. 501 capability gating).
+ */
+export async function makeRawRequest(
+  method: string,
+  url: string,
+  headerProvider: HeadersProvider,
+  body: BodyInit,
+  extraHeaders: Record<string, string> = {},
+  timeout?: number,
+): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout ?? getDefaultTimeout());
+  const headers = { ...(await headerProvider()), ...extraHeaders };
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      let responseBody = '';
+      try {
+        responseBody = await response.text();
+      } catch {
+        // If we can't read the body, leave it empty
+      }
+      throw new MlflowHttpError(response.status, response.statusText, responseBody);
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    if (error instanceof MlflowHttpError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        throw new Error(`Request timeout after ${timeout}ms`);
+      }
+      throw new Error(`API request failed: ${error.message}`);
+    }
+    throw new Error(`API request failed: ${String(error)}`);
+  }
+}
+
 function getDefaultTimeout(): number {
   const envTimeout = process.env.MLFLOW_HTTP_REQUEST_TIMEOUT;
   if (envTimeout) {

--- a/libs/typescript/core/tests/clients/exportOtlpSpans.test.ts
+++ b/libs/typescript/core/tests/clients/exportOtlpSpans.test.ts
@@ -1,0 +1,71 @@
+import { MlflowClient } from '../../src/clients/client';
+import { createAuthProvider } from '../../src/auth';
+import { MlflowHttpError } from '../../src/clients/utils';
+
+/**
+ * Unit tests for {@link MlflowClient.exportOtlpSpans} used for OSS (non-Databricks)
+ * tracking servers. These mock `global.fetch` so they exercise the request shaping
+ * (endpoint, headers, body) and error mapping without needing a live tracking server.
+ */
+describe('MlflowClient.exportOtlpSpans', () => {
+  const trackingUri = 'http://localhost:5000';
+  let client: MlflowClient;
+  let fetchMock: jest.Mock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    const authProvider = createAuthProvider({ trackingUri });
+    client = new MlflowClient({ trackingUri, authProvider });
+    fetchMock = jest.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('POSTs OTLP protobuf to the OSS endpoint with the protobuf content type and experiment header', async () => {
+    const bytes = new Uint8Array([0x0a, 0x01, 0x02, 0x03]);
+
+    await client.exportOtlpSpans('exp-123', bytes);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:5000/v1/traces');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/x-protobuf');
+    expect(headers['x-mlflow-experiment-id']).toBe('exp-123');
+    expect(init.body).toBe(bytes);
+  });
+
+  it('does not call fetch when there are no span bytes to send', async () => {
+    await client.exportOtlpSpans('exp-123', new Uint8Array(0));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 501 as an MlflowHttpError so callers can fall back', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('REST OTLP span logging is not supported', {
+        status: 501,
+        statusText: 'Not Implemented',
+      }),
+    );
+
+    await expect(
+      client.exportOtlpSpans('exp-123', new Uint8Array([0x0a, 0x01])),
+    ).rejects.toBeInstanceOf(MlflowHttpError);
+  });
+
+  it('propagates the 501 status code on the thrown error', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('nope', { status: 501, statusText: 'Not Implemented' }),
+    );
+
+    await expect(
+      client.exportOtlpSpans('exp-123', new Uint8Array([0x0a, 0x01])),
+    ).rejects.toMatchObject({
+      status: 501,
+    });
+  });
+});


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24061/files) to review incremental changes.
- [stack/ts-sdk-tool-calls-fix](https://github.com/mlflow/mlflow/pull/24019) [[Files changed](https://github.com/mlflow/mlflow/pull/24019/files)] [MERGED]
  - [stack/capture-otlp-at-wal](https://github.com/mlflow/mlflow/pull/24022) [[Files changed](https://github.com/mlflow/mlflow/pull/24022/files)] [MERGED]
    - [stack/oss-otlp-endpoint](https://github.com/mlflow/mlflow/pull/24030) [[Files changed](https://github.com/mlflow/mlflow/pull/24030/files)] [MERGED]
      - [stack/update-ipc-request-limit-for-otlp](https://github.com/mlflow/mlflow/pull/24032) [[Files changed](https://github.com/mlflow/mlflow/pull/24032/files)] [MERGED]
        - [**stack/ts-client-add-logspan**](https://github.com/mlflow/mlflow/pull/24061) [[Files changed](https://github.com/mlflow/mlflow/pull/24061/files)] ← _this PR_
          - [stack/daemon-changes-exportOtlpSpans](https://github.com/mlflow/mlflow/pull/24087) [[Files changed](https://github.com/mlflow/mlflow/pull/24087/files/e1c0934b1648dfa3310895fea2bad2006096fa69..1b17e1331247f4afbca37ca760a84d1787d5b92c)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Signed-off-by: Aaron Teo <atwkdeveloper@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

Adds `MlflowClient.exportOtlpSpans`, the OSS (non-Databricks) counterpart to the existing `exportOtlpSpansToUc`, so the TypeScript SDK can log OTLP spans to an OSS tracking server. This is the client piece needed to close the gap where TS-traced tool calls appeared in the trace Details view but not the DB-backed "Tool calls" overview (which aggregates the `SqlSpan` table). Mirrors Python's `RestStore.log_spans`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
