### PR TITLE
Fix AccessDenied on API reference links with trailing slash before fragment

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,8 +1,34 @@
+import path from 'path';
 import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import { postProcessSidebar, apiReferencePrefix } from './docusaurusConfigUtils';
 import tailwindPlugin from './src/plugins/tailwind-config.cjs';
+
+// Wrap `@docusaurus/Link` so links to static files (e.g. the Sphinx-built API
+// reference `*.html`) render as plain anchors. With `trailingSlash: true`, the
+// default Link appends a slash before the hash and breaks those URLs. See
+// `src/components/SmartLink` and https://github.com/mlflow/mlflow/issues/23966.
+function smartLinkPlugin() {
+  return {
+    name: 'mlflow-smart-link-alias',
+    configureWebpack() {
+      return {
+        resolve: {
+          alias: {
+            // Override Docusaurus' own `@docusaurus/Link` alias (same key) so the
+            // merge replaces it; a `$`-suffixed key would be added alongside and
+            // lose to the non-exact entry Docusaurus registers first.
+            '@docusaurus/Link': path.resolve(__dirname, 'src/components/SmartLink'),
+            // `@docusaurus/Link` is itself an alias Docusaurus maps into core, so
+            // resolve the underlying module directly to avoid a circular alias.
+            '@docusaurus-original/Link': require.resolve('@docusaurus/core/lib/client/exports/Link'),
+          },
+        },
+      };
+    },
+  };
+}
 
 // ensure baseUrl always ends in `/`
 const baseUrl = (process.env.DOCS_BASE_URL ?? '/docs/latest/').replace(/\/?$/, '/');
@@ -297,6 +323,7 @@ const config: Config = {
   } satisfies Preset.ThemeConfig,
 
   plugins: [
+    smartLinkPlugin,
     tailwindPlugin,
     [
       '@signalwire/docusaurus-plugin-llms-txt',

--- a/docs/src/components/SmartLink/index.tsx
+++ b/docs/src/components/SmartLink/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { Props } from '@docusaurus/Link';
+import OriginalLink from '@docusaurus-original/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+// Docusaurus is configured with `trailingSlash: true`, which appends a slash to
+// `<Link>` targets. For a target that ends in a real file (e.g. the Sphinx-built
+// API reference `rest-api.html`), this inserts a slash before the hash
+// (`rest-api.html#foo` -> `rest-api.html/#foo`). The resulting path does not exist
+// as an object on the S3-hosted site and returns an "AccessDenied" error.
+//
+// Such links point at static files, not Docusaurus routes, so render them as plain
+// anchors. A plain <a> bypasses the trailing-slash normalization (matching the
+// existing `APILink` component). Non-file links fall through to the real Link and
+// keep client-side navigation. See https://github.com/mlflow/mlflow/issues/23966.
+function isStaticFileLink(to: string | undefined): to is string {
+  if (!to) {
+    return false;
+  }
+  const [pathname] = to.split(/[#?]/);
+  // The last path segment has a file extension (e.g. `rest-api.html`).
+  return /\.[^/]+$/.test(pathname);
+}
+
+export default function Link(props: Props) {
+  const { to, href, isNavLink, activeClassName, activeStyle, autoAddBaseUrl, ...anchorProps } = props as Props & {
+    autoAddBaseUrl?: boolean;
+  };
+  const target = to ?? href;
+  const isInternal = typeof target === 'string' && target.startsWith('/');
+  // Hooks must run unconditionally; the result is only used for internal targets.
+  const internalHref = useBaseUrl(isInternal ? (target as string) : '/');
+
+  if (isStaticFileLink(target)) {
+    return <a href={isInternal ? internalHref : target} {...anchorProps} />;
+  }
+
+  return <OriginalLink {...props} />;
+}

--- a/docs/src/components/SmartLink/original-link.d.ts
+++ b/docs/src/components/SmartLink/original-link.d.ts
@@ -1,0 +1,9 @@
+// The webpack alias `@docusaurus-original/Link` resolves to the real
+// `@docusaurus/Link` module, letting the SmartLink wrapper import the original
+// component without a circular reference through the aliased `@docusaurus/Link`.
+declare module '@docusaurus-original/Link' {
+  import type Link from '@docusaurus/Link';
+
+  const OriginalLink: typeof Link;
+  export default OriginalLink;
+}


### PR DESCRIPTION
### Related Issues/PRs

Closes #23966

### What changes are proposed in this pull request?

Links to the Sphinx-built API reference HTML files (e.g. `/api_reference/rest-api.html#anchor`) are authored with `<Link>`. Because the docs site is configured with `trailingSlash: true`, Docusaurus rewrites those targets to insert a slash before the fragment (`rest-api.html/#anchor`). That path does not exist as an object on the S3-hosted docs and returns an `AccessDenied` error, while the slash-less form works.

This PR wraps `@docusaurus/Link` via a webpack alias (`src/components/SmartLink`) so that targets pointing at a static file (a path whose last segment has a file extension) render as a plain `<a>`, bypassing the trailing-slash normalization. All client-side route links fall through to the original `Link` unchanged.

Notes:
- This mirrors the existing `APILink` component, which already renders a plain `<a>` and is therefore unaffected.
- The project's `prefer-apilink-component` lint rule intentionally exempts `rest-api.html` / `auth/rest-api.html` from `APILink`, so those links are expected to stay on `<Link>` — this fix makes that supported pattern work.

### How is this PR tested?

- [x] Manual tests

Verified with a production build (`npm run build`): the broken `*.html/#` pattern drops from 65+ occurrences (on the basic-http-auth page alone) to 0 across all generated pages, and the `onBrokenLinks` / `onBrokenAnchors` checks still pass. Normal client-side route links are unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes API reference documentation links that returned an `AccessDenied` error due to a trailing slash being inserted before the URL fragment.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release