### PR TITLE
fix: Use Base.metadata with checkfirst in _initialize_tables to prevent duplicate table errors (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from 3.7.0 to 3.8.x, the `_initialize_tables` function fails with `Table 'secrets' already exists` because it uses `InitialBase.metadata.create_all(engine)` which does not check for existing tables. The workspace 'secrets' table may already exist in the database, causing a duplicate table error.

## Fix
Replace `InitialBase.metadata.create_all(engine)` with `Base.metadata.create_all(engine, checkfirst=True)`. This uses the full metadata (including all registered models) and the `checkfirst=True` option ensures SQLAlchemy adds `IF NOT EXISTS` clauses, making the operation safe for upgrades.

## Testing
- Verified locally with MySQL that `mlflow db upgrade` succeeds when 'secrets' table already exists.
- Existing tests for database upgrade paths pass.

Closes #19943