### PR TITLE
Improve experiment Chart view rendering performance with large amount of charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
@@ -1,5 +1,5 @@
 import { Empty, useDesignSystemTheme } from '@databricks/design-system';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUpdateRunsChartsUIConfiguration } from '../hooks/useRunsChartsUIConfiguration';
 import type { RunsChartsCardConfig } from '../runs-charts.types';
 import type { RunsChartsRunData } from './RunsCharts.common';
@@ -168,6 +168,51 @@ export const RunsChartsDraggableCardsGridSection = memo(
       });
     }, [cardsConfig, chartRunData, hideEmptyCharts]);
 
+    // Grid virtualization: with a high chart count, mounting every card at once
+    // is the dominant rendering cost. Instead, we wrap the grid in a fixed-height
+    // scroll container and only mount the cards whose rows are within (or just
+    // ahead of) the visible window. Off-window cards collapse to `null`, while a
+    // spacer keeps the scrollbar sized to the full grid so scrolling is accurate.
+    const gridHeight = useMemo(() => {
+      const rowCount = Math.ceil(cardsToRender.length / columns);
+      return rowCount * (cardHeight + theme.spacing.sm);
+    }, [cardsToRender, columns, cardHeight, theme]);
+
+    // Cap each section's scroll viewport at three card rows. Sections taller than
+    // this scroll internally; shorter sections shrink to fit their content.
+    const scrollContainerHeight = useMemo(() => Math.min(gridHeight, cardHeight * 3), [gridHeight, cardHeight]);
+
+    const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+    const [scrollContainerOffset, setScrollContainerOffset] = useState<number>(0);
+
+    const updateScrollContainerOffset = useCallback(() => {
+      if (scrollContainerRef.current) {
+        setScrollContainerOffset(scrollContainerRef.current.scrollTop);
+      }
+    }, []);
+
+    useEffect(updateScrollContainerOffset, [updateScrollContainerOffset]);
+
+    const { firstVisibleRowOffset, firstVisibleCard, numVisibleCards } = useMemo(() => {
+      // Preload a buffer of rows below the fold so cards have a head start on
+      // mounting (and fetching) before they scroll into view.
+      const extraRowsToPreload = 8;
+      const gap = theme.spacing.sm;
+      const rowCount = Math.ceil(cardsToRender.length / columns);
+      const firstVisibleRow = Math.floor(scrollContainerOffset / (cardHeight + gap));
+      const lastVisibleRow = Math.min(
+        rowCount - 1,
+        Math.ceil((scrollContainerOffset + scrollContainerHeight) / (cardHeight + gap)) + extraRowsToPreload,
+      );
+      const numVisibleRows = lastVisibleRow - firstVisibleRow + 1;
+      const firstVisibleRowOffset = firstVisibleRow * (cardHeight + gap);
+      const firstVisibleCard = firstVisibleRow * columns;
+      const lastVisibleCard = Math.min(cardsToRender.length - 1, firstVisibleCard + numVisibleRows * columns - 1);
+      const numVisibleCards = lastVisibleCard - firstVisibleCard + 1;
+      return { firstVisibleCard, numVisibleCards, firstVisibleRowOffset };
+    }, [theme, cardsToRender, columns, scrollContainerOffset, cardHeight, scrollContainerHeight]);
+
     // Calculate the transforms for each card based on the dragged card and its position.
     const cardTransforms = useMemo(() => {
       if (!draggedCardUuid || position === null) {
@@ -311,82 +356,109 @@ export const RunsChartsDraggableCardsGridSection = memo(
 
     return (
       <div
-        ref={gridBoxRef}
-        css={[
-          { position: 'relative' },
-          cardsToRender.length > 0 && {
-            display: 'grid',
-            gap: theme.spacing.sm,
-          },
-        ]}
-        style={{
-          gridTemplateColumns: 'repeat(' + columns + ', 1fr)',
-          ...(draggedCardUuid && {
-            [DRAGGABLE_CARD_TRANSITION_NAME]: 'transform 0.1s',
-          }),
+        ref={scrollContainerRef}
+        css={{
+          height: `${scrollContainerHeight}px`,
+          position: 'relative',
+          overflowY: 'auto',
         }}
-        data-testid="draggable-chart-cards-grid"
-        onMouseMove={mouseMove}
-        onMouseLeave={() => {
-          setPositionInSection(null);
-        }}
+        onScroll={updateScrollContainerOffset}
       >
-        {(draggedCardUuid || resizePreview) && (
-          <Global
-            styles={{
-              'body, :host': {
-                userSelect: 'none',
+        <div
+          ref={gridBoxRef}
+          css={{
+            height: `${gridHeight}px`,
+            position: 'relative',
+          }}
+          onMouseMove={mouseMove}
+          onMouseLeave={() => {
+            setPositionInSection(null);
+          }}
+          data-testid="draggable-chart-cards-grid"
+        >
+          <div
+            css={[
+              {
+                position: 'relative',
+                top: `${firstVisibleRowOffset}px`,
               },
+              cardsToRender.length > 0 && {
+                display: 'grid',
+                gap: theme.spacing.sm,
+              },
+            ]}
+            style={{
+              gridTemplateColumns: 'repeat(' + columns + ', 1fr)',
+              ...(draggedCardUuid && {
+                [DRAGGABLE_CARD_TRANSITION_NAME]: 'transform 0.1s',
+              }),
             }}
-          />
-        )}
-        {cardsToRender.length === 0 && (
-          <div css={{ display: 'flex', justifyContent: 'center', minHeight: 160 }}>
-            <Empty
-              title={
-                <FormattedMessage
-                  defaultMessage="No charts in this section"
-                  description="Runs compare page > Charts tab > No charts placeholder title"
+          >
+            {(draggedCardUuid || resizePreview) && (
+              <Global
+                styles={{
+                  'body, :host': {
+                    userSelect: 'none',
+                  },
+                }}
+              />
+            )}
+            {cardsToRender.length === 0 && (
+              <div css={{ display: 'flex', justifyContent: 'center', minHeight: 160 }}>
+                <Empty
+                  title={
+                    <FormattedMessage
+                      defaultMessage="No charts in this section"
+                      description="Runs compare page > Charts tab > No charts placeholder title"
+                    />
+                  }
+                  description={
+                    <FormattedMessage
+                      defaultMessage="Click 'Add chart' or drag and drop to add charts here."
+                      description="Runs compare page > Charts tab > No charts placeholder description"
+                    />
+                  }
                 />
+              </div>
+            )}
+            {cardsToRender.map((cardConfig, index, array) => {
+              // Only the cards within the virtualization window are mounted; the
+              // rest collapse to `null`. We still iterate the full array so that
+              // each card keeps its absolute index and neighbor references, which
+              // drive reordering ("move up/down/to top/bottom") correctly.
+              if (index < firstVisibleCard || index >= firstVisibleCard + numVisibleCards) {
+                return null;
               }
-              description={
-                <FormattedMessage
-                  defaultMessage="Click 'Add chart' or drag and drop to add charts here."
-                  description="Runs compare page > Charts tab > No charts placeholder description"
+              return (
+                <RunsChartsDraggableCard
+                  key={cardConfig.uuid}
+                  uuid={cardConfig.uuid ?? ''}
+                  translateBy={cardTransforms[cardConfig.uuid ?? '']}
+                  onResizeStart={onResizeStart}
+                  onResizeStop={onResizeStop}
+                  onResize={onResize}
+                  cardConfig={cardConfig}
+                  chartRunData={chartRunData}
+                  onReorderWith={onSwapCards}
+                  index={index}
+                  height={cardHeight}
+                  canMoveDown={Boolean(array[index + 1])}
+                  canMoveUp={Boolean(array[index - 1])}
+                  canMoveToTop={index > 0}
+                  canMoveToBottom={index < array.length - 1}
+                  previousChartUuid={array[index - 1]?.uuid}
+                  nextChartUuid={array[index + 1]?.uuid}
+                  hideEmptyCharts={hideEmptyCharts}
+                  firstChartUuid={array[0]?.uuid}
+                  lastChartUuid={array[array.length - 1]?.uuid}
+                  {...cardProps}
                 />
-              }
-            />
+              );
+            })}
+            {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
+            {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
           </div>
-        )}
-        {cardsToRender.map((cardConfig, index, array) => {
-          return (
-            <RunsChartsDraggableCard
-              key={cardConfig.uuid}
-              uuid={cardConfig.uuid ?? ''}
-              translateBy={cardTransforms[cardConfig.uuid ?? '']}
-              onResizeStart={onResizeStart}
-              onResizeStop={onResizeStop}
-              onResize={onResize}
-              cardConfig={cardConfig}
-              chartRunData={chartRunData}
-              onReorderWith={onSwapCards}
-              index={index}
-              height={cardHeight}
-              canMoveDown={Boolean(array[index + 1])}
-              canMoveUp={Boolean(array[index - 1])}
-              canMoveToTop={index > 0}
-              canMoveToBottom={index < array.length - 1}
-              previousChartUuid={array[index - 1]?.uuid}
-              nextChartUuid={array[index + 1]?.uuid}
-              hideEmptyCharts={hideEmptyCharts}
-              firstChartUuid={array[0]?.uuid}
-              lastChartUuid={array[array.length - 1]?.uuid}
-              {...cardProps}
-            />
-          );
-        })}
-        {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
-        {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
+        </div>
       </div>
     );
   },

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx
@@ -30,6 +30,7 @@ import userEvent from '@testing-library/user-event';
 import { RunsChartsLineChartXAxisType } from '../runs-charts/components/RunsCharts.common';
 import { useState } from 'react';
 import { DesignSystemProvider } from '@databricks/design-system';
+import Utils from '../../../common/utils/Utils';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000); // Larger timeout for integration testing
@@ -1279,6 +1280,38 @@ describe.each(testCases)('RunsCompare $description', ({ setup: testCaseSetup }) 
         // Runs difference view is visible even if hide empty charts is set
         expect(screen.getByText(/Runs difference view/)).toBeInTheDocument();
       });
+    });
+
+    test('overrides hiding empty charts and notifies the user when the chart count is too high for performance', async () => {
+      const notificationSpy = jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
+      currentUIState.hideEmptyCharts = true;
+      // More than HIDE_EMPTY_CHARTS_MAX_NUM_CHARTS_SUPPORTED (512) empty charts:
+      // past this threshold empty-chart hiding is disabled for performance.
+      currentUIState.compareRunCharts = Array.from(
+        { length: 513 },
+        (_, index) =>
+          ({
+            type: RunsChartType.BAR,
+            uuid: `chart-empty-${index}`,
+            runsCountToCompare: 10,
+            metricKey: 'metric-alpha',
+            metricSectionId: 'metric-section-1',
+            deleted: false,
+            isGenerated: true,
+          }) as RunsChartsBarCardConfig,
+      );
+      createComponentMock(componentProps);
+
+      await waitFor(() => {
+        // The empty chart is still rendered (hiding was overridden)...
+        expect(screen.getAllByText(/metric-alpha/).length).toBeGreaterThan(0);
+        // ...and the user was told why (the notification fires from an effect,
+        // so assert it inside waitFor rather than synchronously).
+        expect(notificationSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(notificationSpy).toHaveBeenCalledWith(expect.stringContaining('empty charts will not be hidden'));
+
+      notificationSpy.mockRestore();
     });
 
     test('does not display parallel coords or runs difference chart when not configured and hiding empty charts is set', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -51,6 +51,12 @@ import { RunsChartsGlobalChartSettingsDropdown } from '../runs-charts/components
 import { RunsChartsDraggableCardsGridContextProvider } from '../runs-charts/components/RunsChartsDraggableCardsGridContext';
 import { RunsChartsFilterInput } from '../runs-charts/components/RunsChartsFilterInput';
 import { RUNS_CHARTS_UI_Z_INDEX } from '../runs-charts/utils/runsCharts.const';
+import Utils from '../../../common/utils/Utils';
+
+// Above this many charts, the per-render `isEmptyChartCard` scan (which walks
+// every run's metric history for each card) dominates rendering. Past this
+// threshold we stop hiding empty charts so the page stays responsive.
+const HIDE_EMPTY_CHARTS_MAX_NUM_CHARTS_SUPPORTED = 512;
 
 export interface RunsCompareProps {
   comparedRuns: RunRowType[];
@@ -346,14 +352,41 @@ const RunsCompareImpl = ({
     [chartData, onHideRun, onTogglePin],
   );
 
+  const [hideEmptyChartsPerformanceOverrideShown, setHideEmptyChartsPerformanceOverrideShown] = useState(false);
+
+  // Hiding empty charts requires running the expensive `isEmptyChartCard` scan
+  // over every chart on each render. With a very high chart count this becomes a
+  // performance bottleneck, so above a threshold we override `hideEmptyCharts`
+  // off (and notify the user once, via the effect below).
+  const hideEmptyChartsPerformanceOverrideActive =
+    Boolean(hideEmptyCharts) && (compareRunCharts?.length || 0) > HIDE_EMPTY_CHARTS_MAX_NUM_CHARTS_SUPPORTED;
+
+  const hideEmptyChartsWithPerformanceOverride = Boolean(hideEmptyCharts) && !hideEmptyChartsPerformanceOverrideActive;
+
+  // Notify the user once when the override kicks in. This must run as an effect
+  // (not during render) because the global notification API reads context that
+  // is only available after commit — calling it mid-render throws.
+  useEffect(() => {
+    if (hideEmptyChartsPerformanceOverrideActive && !hideEmptyChartsPerformanceOverrideShown) {
+      Utils.displayGlobalInfoNotification(
+        formatMessage({
+          defaultMessage: 'High number of charts. For performance reasons, empty charts will not be hidden by default.',
+          description:
+            'Runs compare page > Charts tab > Notification shown when empty charts are not hidden due to a high chart count',
+        }),
+      );
+      setHideEmptyChartsPerformanceOverrideShown(true);
+    }
+  }, [hideEmptyChartsPerformanceOverrideActive, hideEmptyChartsPerformanceOverrideShown, formatMessage]);
+
   // If using draggable grid layout, already filter out charts that are empty or deleted
   const visibleChartCards = useMemo(() => {
-    if (hideEmptyCharts) {
+    if (hideEmptyChartsWithPerformanceOverride) {
       const isEmptyChartCard = createEmptyChartCardPredicate(chartData);
       return compareRunCharts?.filter((chartCard) => !chartCard.deleted && !isEmptyChartCard(chartCard));
     }
     return compareRunCharts?.filter((chartCard) => !chartCard.deleted);
-  }, [chartData, compareRunCharts, hideEmptyCharts]);
+  }, [chartData, compareRunCharts, hideEmptyChartsWithPerformanceOverride]);
 
   if (!initiallyLoaded) {
     return <RunsCompareSkeleton />;
@@ -424,7 +457,7 @@ const RunsCompareImpl = ({
             groupBy={groupByNormalized}
             setFullScreenChart={setFullScreenChart}
             autoRefreshEnabled={autoRefreshEnabled}
-            hideEmptyCharts={hideEmptyCharts}
+            hideEmptyCharts={hideEmptyChartsWithPerformanceOverride}
             globalLineChartConfig={globalLineChartConfig}
           />
         </RunsChartsDraggableCardsGridContextProvider>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5155,6 +5155,10 @@
     "defaultMessage": "Actions{count}",
     "description": "Trace actions dropdown button"
   },
+  "PwoWal": {
+    "defaultMessage": "High number of charts. For performance reasons, empty charts will not be hidden by default.",
+    "description": "Runs compare page > Charts tab > Notification shown when empty charts are not hidden due to a high chart count"
+  },
   "Px7S/2": {
     "defaultMessage": "Close",
     "description": "Close button"


### PR DESCRIPTION
The experiment/run Chart view renders slowly and stutters once an experiment has a high chart count. Two contributors, both addressed here:

- Virtualize the draggable chart grid: each section becomes a fixed-height scroll container (capped at three card rows) that mounts only the cards within the visible window plus an 8-row preload buffer, instead of mounting every card at once. Cards outside the window collapse to `null` while still iterating the full array, so absolute index and neighbor references (used for reordering) stay correct.
- Override `hideEmptyCharts` above 512 charts. Hiding empty charts runs the expensive `isEmptyChartCard` scan on every render; past the threshold we disable it and show a one-time info notification.

### Related Issues/PRs

Closes #24012

### What changes are proposed in this pull request?

The experiment **Chart view** (`RunsCompare`) mounts every chart card in a section to the DOM at once. With a high chart count - one chart card is generated per metric key - this dominates rendering: the initial render and every re-render get slow, scrolling stutters, and at a large enough count the tab becomes unresponsive and can crash. When "hide empty charts" is enabled, an additional per-render `isEmptyChartCard` scan over every card compounds the cost.

This PR addresses both contributors:

- **Grid virtualization** (`RunsChartsDraggableCardsGridSection.tsx`): each section is wrapped in a fixed-height scroll container (capped at three card rows) and only the cards whose rows fall within the visible window - plus an 8-row preload buffer - are mounted. A spacer keeps the scrollbar sized to the full grid so scrolling stays accurate. The full card list is still iterated, rendering `null` for off-window cards, so each rendered card keeps its absolute index and neighbor references; drag-to-reorder and the "move up/down/to top/bottom" actions are unaffected.
- **`hideEmptyCharts` performance override** (`RunsCompare.tsx`): above 512 charts, the empty-chart filtering is disabled (the `isEmptyChartCard` scan is the bottleneck precisely when there are many charts) and a one-time, non-blocking info notification informs the user. The notification is fired from an effect, after commit, so it does not run as a render side effect.

Files changed:
- `mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx` - grid virtualization
- `mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx` - hideEmptyCharts override + notification
- `mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx` - test for the override path
- `mlflow/server/js/src/lang/default/en.json` - extracted i18n message for the notification

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Existing `RunsChartsDraggableCardsGrid` drag/drop/resize tests pass against the virtualized grid. A new test in `RunsCompare.test.tsx` covers the >512-chart override (empty charts remain rendered and the notification fires once). Manually verified on a local server with an experiment of 5 runs × 9000 metrics: on `master` the Chart view becomes unresponsive and the tab crashes; with this change it renders and scrolls smoothly.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improves experiment Chart view performance with a high number of charts: the chart grid is virtualized so only visible charts are rendered, keeping the page responsive instead of freezing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
