### PR TITLE
feat: add Cursor model catalog with Auto and Composer 2.5 pricing

### DIFF
--- a/mlflow/utils/model_catalog/cursor.json
+++ b/mlflow/utils/model_catalog/cursor.json
@@ -16,7 +16,7 @@
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
+        "vision": true,
         "reasoning": true
       },
       "last_updated_at": "2026-06-18"
@@ -36,27 +36,7 @@
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
-        "reasoning": true
-      },
-      "last_updated_at": "2026-06-18"
-    },
-    "default": {
-      "mode": "chat",
-      "context_window": {
-        "max_input": 200000,
-        "max_output": 32000,
-        "max_tokens": 32000
-      },
-      "pricing": {
-        "input_per_million_tokens": 1.25,
-        "output_per_million_tokens": 6.0,
-        "cache_read_per_million_tokens": 0.25,
-        "cache_write_per_million_tokens": 1.25
-      },
-      "capabilities": {
-        "function_calling": true,
-        "vision": false,
+        "vision": true,
         "reasoning": true
       },
       "last_updated_at": "2026-06-18"

--- a/mlflow/utils/model_catalog/cursor.json
+++ b/mlflow/utils/model_catalog/cursor.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "auto": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000,
+        "max_tokens": 32000
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.25,
+        "output_per_million_tokens": 6.0,
+        "cache_read_per_million_tokens": 0.25,
+        "cache_write_per_million_tokens": 1.25
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true
+      },
+      "last_updated_at": "2026-06-18"
+    },
+    "composer-2.5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000,
+        "max_tokens": 32000
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.5,
+        "output_per_million_tokens": 2.5,
+        "cache_read_per_million_tokens": 0.2,
+        "cache_write_per_million_tokens": 0.5
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true
+      },
+      "last_updated_at": "2026-06-18"
+    },
+    "default": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 32000,
+        "max_tokens": 32000
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.25,
+        "output_per_million_tokens": 6.0,
+        "cache_read_per_million_tokens": 0.25,
+        "cache_write_per_million_tokens": 1.25
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true
+      },
+      "last_updated_at": "2026-06-18"
+    }
+  }
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to model catalog coverage for AI coding IDE providers.

### What changes are proposed in this pull request?

Adds `mlflow/utils/model_catalog/cursor.json` with pricing data for the Cursor AI coding IDE's model pool:

- **auto** — Cursor's Auto mode, dynamically selects the best model per request. Billed at flat rates: $1.25/M input + cache write, $6.00/M output, $0.25/M cache read.
- **composer-2.5** — Cursor's in-house model: $0.50/M input, $2.50/M output, $0.20/M cache read.
- **default** — Alias for auto (the Cursor SDK reports `model.id = "default"` on `RunResult`).

Pricing sourced from [Cursor Models & Pricing](https://cursor.com/docs/models-and-pricing).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The JSON file follows the exact same `schema_version: "1.0"` format as all other catalog files. Verified the file is valid JSON.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add Cursor AI model catalog with pricing for Auto mode, Composer 2.5, and the `default` alias — enables `fetch_model_pricing` to return per-token prices for Cursor SDK runs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Signed-off-by: Tomu Hirata <tomu.hirata@databricks.com>