### PR TITLE
Fix broken relative links to tracing integration pages

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/autogen.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/autogen.mdx
@@ -28,7 +28,7 @@ mlflow.autogen.autolog()
 
 Note that `mlflow.autogen.autolog()` should be called after importing AutoGen classes that are traced.
 Subclasses of `ChatCompletionClient` such as `OpenAIChatCompletionClient` or `AnthropicChatCompletionClient` and subclasses of `BaseChatAgent` such as `AssistantAgent` or `CodeExecutorAgent` should be imported before calling `mlflow.autogen.autolog()`.
-Also note that this integration is for AutoGen 0.4.9 or above. If you are using AutoGen 0.2, please use the [AG2 integration](../ag2) instead.
+Also note that this integration is for AutoGen 0.4.9 or above. If you are using AutoGen 0.2, please use the [AG2 integration](/genai/tracing/integrations/listing/ag2) instead.
 
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/databricks.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/databricks.mdx
@@ -121,7 +121,7 @@ Browse to your MLflow UI (for example, http://localhost:5000) and open the `Data
 
 ## Streaming and Async Support
 
-MLflow supports tracing for streaming and async Databricks APIs. Visit the [OpenAI Tracing documentation](../openai) for example code snippets for tracing streaming and async calls through OpenAI SDK.
+MLflow supports tracing for streaming and async Databricks APIs. Visit the [OpenAI Tracing documentation](/genai/tracing/integrations/listing/openai) for example code snippets for tracing streaming and async calls through OpenAI SDK.
 
 ## Combine with frameworks or manual tracing
 

--- a/docs/docs/genai/tracing/integrations/listing/ollama.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/ollama.mdx
@@ -156,7 +156,7 @@ To request support for additional APIs, please open a [feature request](https://
 
 ## Streaming and Async Support
 
-MLflow supports tracing for streaming and async Ollama APIs. Visit the [OpenAI Tracing documentation](../openai) for example code snippets for tracing streaming and async calls through OpenAI SDK.
+MLflow supports tracing for streaming and async Ollama APIs. Visit the [OpenAI Tracing documentation](/genai/tracing/integrations/listing/openai) for example code snippets for tracing streaming and async calls through OpenAI SDK.
 
 ## Combine with Manual Tracing
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to: N/A — no existing issue. Found while reading the tracing integration docs.

### What changes are proposed in this pull request?

Three tracing integration pages link to the AG2 and OpenAI integration pages with a relative path that points one directory too high:

- `genai/tracing/integrations/listing/autogen.mdx` → `[AG2 integration](../ag2)`
- `genai/tracing/integrations/listing/ollama.mdx` → `[OpenAI Tracing documentation](../openai)`
- `genai/tracing/integrations/listing/databricks.mdx` → `[OpenAI Tracing documentation](../openai)`

`ag2.mdx` and `openai.mdx` live in the same `listing/` directory, so `../ag2` and `../openai` resolve to `genai/tracing/integrations/ag2` and `.../openai`, which don't exist. Neither target page has a `slug` override, so its route is its file path.

This switches the three links to the absolute route the same pages already use elsewhere, e.g. `ollama.mdx` and `databricks.mdx` both link `/genai/tracing/integrations/listing/openai#combine-with-manual-tracing` a few lines later. No prose changes.

### How is this PR tested?

- [x] Manual tests

Confirmed `ag2.mdx` and `openai.mdx` exist under `listing/` and have no `slug` frontmatter, and that the new absolute routes match the working references already present in the same two files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release