### PR TITLE
fix: prevent duplicate 'secrets' table creation during upgrade from 3.7.x (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -64,15 +64,19 @@ def _get_package_dir():
 
 
 def _all_tables_exist(engine):
-    # Check if all ORM-defined tables exist in the database.
-    # Derived from Base.metadata.tables so that newly added ORM models are
-    # automatically included without requiring a manual update here.
-    # Using issubset() instead of equality so that additional tables added by migrations
-    # don't cause this check to fail. This prevents unnecessary calls to _initialize_tables
-    # which can cause migration errors like "Can't locate revision identified by 'xxx'".
-    expected_tables = set(Base.metadata.tables)
+    # Check if all ORM-defined tables exist.
+    # For a database that already has alembic revision tracking, use Base.metadata.tables.
+    # For a fresh/empty database where alembic hasn't run yet, use InitialBase.metadata.tables
+    # to avoid falsely considering a partial 3.7.0 schema as "complete" when new ORM tables
+    # from 3.8.x are expected but don't exist yet.
+    inspector = sqlalchemy.inspect(engine)
+    has_alembic = any(t.startswith("alembic_") for t in inspector.get_table_names())
+    if has_alembic:
+        expected_tables = set(Base.metadata.tables)
+    else:
+        expected_tables = set(InitialBase.metadata.tables)
     actual_tables = {
-        t for t in sqlalchemy.inspect(engine).get_table_names() if not t.startswith("alembic_")
+        t for t in inspector.get_table_names() if not t.startswith("alembic_")
     }
     return expected_tables.issubset(actual_tables)
 


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with:
`pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`

This occurs because `_all_tables_exist()` now checks for all ORM-defined tables using `Base.metadata.tables`, which includes the new `secrets` table added in 3.8.x. Since the secrets table doesn't exist in a 3.7.0 database, the function incorrectly returns False, causing the code to call `_initialize_tables()` (which runs `InitialBase.metadata.create_all()`) instead of directly running the alembic migration. The `create_all()` creates the secrets table, and then the alembic migration tries to create it again, leading to a duplicate table error.

## Fix
Modify `_all_tables_exist()` to check for existing alembic revision markers. If alembic has already run (i.e., the `alembic_version` table exists), use `Base.metadata.tables` for comparison. If not (fresh database), use `InitialBase.metadata.tables` to only verify the initial schema, not tables added by later migrations. This ensures that an existing 3.7.0 database with alembic tracking correctly proceeds to `_upgrade_db()` rather than attempting `_initialize_tables()`.

Closes #19943