### PR TITLE
Render playground tool-call args and JSON responses as code blocks

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1925,6 +1925,7 @@ module.exports = {
 
   // -- mlflow.playground --
   "mlflow.playground.clear": "",
+  "mlflow.playground.json_code_block.copy": "",
   "mlflow.playground.load_from_registry": "",
   "mlflow.playground.output.error": "",
   "mlflow.playground.params.drawer": "",

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1926,6 +1926,7 @@ module.exports = {
   // -- mlflow.playground --
   "mlflow.playground.clear": "",
   "mlflow.playground.json_code_block.copy": "",
+  "mlflow.playground.json_code_block.toggle": "",
   "mlflow.playground.load_from_registry": "",
   "mlflow.playground.output.error": "",
   "mlflow.playground.params.drawer": "",

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
@@ -25,6 +25,26 @@ const openVariablesDrawer = () => userEvent.click(screen.getByRole('button', { n
 // Drawers are focus-trapping Radix dialogs — Submit isn't reachable until the drawer is closed.
 const closeDrawer = () => userEvent.keyboard('{Escape}');
 
+// Tool-call arguments and JSON-format responses render through GenAIMarkdownRenderer's
+// CodeSnippet, which splits tokens across spans and prepends a line number to each line.
+// Collapse a <pre>'s text to just its JSON payload (drop the leading per-line digits and
+// all whitespace) so we can compare against an expected JSON string structurally.
+const normalizeCodeBlock = (text: string | null): string =>
+  (text ?? '')
+    .split('\n')
+    .map((line) => line.replace(/^\d+/, ''))
+    .join('')
+    .replace(/\s+/g, '');
+
+// Returns the <pre> code block whose normalized JSON payload equals the expected
+// (whitespace-insensitive) JSON, or undefined when none matches.
+const findJsonCodeBlock = (expectedJson: string): HTMLPreElement | undefined => {
+  const want = expectedJson.replace(/\s+/g, '');
+  return Array.from(document.querySelectorAll('pre')).find((pre) => normalizeCodeBlock(pre.textContent) === want) as
+    | HTMLPreElement
+    | undefined;
+};
+
 jest.mock('../../components/EndpointSelector', () => ({
   EndpointSelector: ({
     currentEndpointName,
@@ -572,16 +592,18 @@ describe('PlaygroundPage', () => {
       expect(screen.getByText('get_weather').tagName.toLowerCase()).toBe('strong');
     });
 
-    // Exactly one tool-call card holds the bold header + verbatim args; no text card.
+    // Exactly one tool-call card holds the bold header + args as a JSON code block; no text card.
     const toolCards = screen.getAllByTestId('mlflow.playground.assistant.tool_call_card');
     expect(toolCards).toHaveLength(1);
     expect(screen.queryByTestId('mlflow.playground.assistant.text_card')).not.toBeInTheDocument();
     expect(toolCards[0]).toContainElement(screen.getByText('get_weather'));
-    const weatherArgs = screen.getByText('{"city":"San Francisco"}');
-    expect(weatherArgs).toBeInTheDocument();
-    expect(toolCards[0]).toContainElement(weatherArgs);
+    // Arguments render inside a CodeSnippet <pre> whose JSON payload matches verbatim.
+    const weatherArgs = findJsonCodeBlock('{"city":"San Francisco"}');
+    expect(weatherArgs).toBeDefined();
+    expect(toolCards[0]).toContainElement(weatherArgs!);
+    // The JSON code block exposes a copy button.
+    expect(toolCards[0].querySelector('[data-testid="mlflow.playground.json_code_block"] button')).toBeInTheDocument();
     expect(screen.queryByText('Tools — get_weather')).not.toBeInTheDocument();
-    expect(screen.queryByText(/"city": "San Francisco"/)).not.toBeInTheDocument();
     expect(screen.queryByText('(no text content)')).not.toBeInTheDocument();
   });
 
@@ -618,8 +640,8 @@ describe('PlaygroundPage', () => {
       expect(screen.getByText('Checking the weather.')).toBeInTheDocument();
     });
     expect(screen.getByText('get_weather').tagName.toLowerCase()).toBe('strong');
-    const weatherArgs = screen.getByText('{"city":"San Francisco"}');
-    expect(weatherArgs).toBeInTheDocument();
+    const weatherArgs = findJsonCodeBlock('{"city":"San Francisco"}');
+    expect(weatherArgs).toBeDefined();
 
     // Assistant text gets its own first card, separate from the tool-call card.
     const textCard = screen.getByTestId('mlflow.playground.assistant.text_card');
@@ -628,7 +650,7 @@ describe('PlaygroundPage', () => {
     expect(textCard).not.toBe(toolCard);
     expect(textCard).not.toContainElement(screen.getByText('get_weather'));
     expect(toolCard).toContainElement(screen.getByText('get_weather'));
-    expect(toolCard).toContainElement(weatherArgs);
+    expect(toolCard).toContainElement(weatherArgs!);
   });
 
   it('renders tool names as bold body headers with token usage footer unchanged', async () => {
@@ -668,16 +690,18 @@ describe('PlaygroundPage', () => {
       expect(screen.getByText('Tokens — input: 340, output: 40, total: 380')).toBeInTheDocument();
     });
     expect(screen.getByText('search_jobs').tagName.toLowerCase()).toBe('strong');
-    expect(
-      screen.getByText('{"currency":"USD","minimum_salary":4000,"maximum_salary":6000,"pay_period":"MONTH"}'),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/"currency": "USD"/)).not.toBeInTheDocument();
+    // Arguments render verbatim inside a JSON code block (whitespace-insensitive match).
+    const jobArgs = findJsonCodeBlock(
+      '{"currency":"USD","minimum_salary":4000,"maximum_salary":6000,"pay_period":"MONTH"}',
+    );
+    expect(jobArgs).toBeDefined();
 
     // The token usage footer renders exactly once and lives outside (below) the cards.
     const footer = screen.getByText('Tokens — input: 340, output: 40, total: 380');
     expect(screen.getAllByText(/^Tokens —/)).toHaveLength(1);
     const toolCard = screen.getByTestId('mlflow.playground.assistant.tool_call_card');
     expect(toolCard).not.toContainElement(footer);
+    expect(toolCard).toContainElement(jobArgs!);
     expect(screen.queryByTestId('mlflow.playground.assistant.text_card')).not.toBeInTheDocument();
   });
 
@@ -726,10 +750,11 @@ describe('PlaygroundPage', () => {
     // No leading text card when the assistant returned no content.
     expect(screen.queryByTestId('mlflow.playground.assistant.text_card')).not.toBeInTheDocument();
 
-    const weatherArgs = screen.getByText('{"city":"San Francisco"}');
-    const timeArgs = screen.getByText('{"timezone": "America/Los_Angeles"}');
-    expect(weatherArgs).toBeInTheDocument();
-    expect(timeArgs).toBeInTheDocument();
+    // Each call's arguments render as their own JSON code block (whitespace-insensitive match).
+    const weatherArgs = findJsonCodeBlock('{"city":"San Francisco"}');
+    const timeArgs = findJsonCodeBlock('{"timezone":"America/Los_Angeles"}');
+    expect(weatherArgs).toBeDefined();
+    expect(timeArgs).toBeDefined();
 
     // get_weather's header + args live in one card; get_time's in a different card.
     const weatherCard = toolCards.find((card) => card.contains(screen.getByText('get_weather')));
@@ -737,13 +762,101 @@ describe('PlaygroundPage', () => {
     expect(weatherCard).toBeDefined();
     expect(timeCard).toBeDefined();
     expect(weatherCard).not.toBe(timeCard);
-    expect(weatherCard).toContainElement(weatherArgs);
-    expect(weatherCard).not.toContainElement(timeArgs);
-    expect(timeCard).toContainElement(timeArgs);
-    expect(timeCard).not.toContainElement(weatherArgs);
+    expect(weatherCard).toContainElement(weatherArgs!);
+    expect(weatherCard).not.toContainElement(timeArgs!);
+    expect(timeCard).toContainElement(timeArgs!);
+    expect(timeCard).not.toContainElement(weatherArgs!);
 
     expect(screen.queryByText('Tools — get_weather, get_time')).not.toBeInTheDocument();
-    expect(screen.queryByText(/"city": "San Francisco"/)).not.toBeInTheDocument();
+  });
+
+  it('renders the assistant reply as a JSON code block when response format is JSON', async () => {
+    jest.spyOn(PlaygroundApi, 'chatCompletion').mockResolvedValue({
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '{"user_name":"a_b","score":42}' },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+
+    renderPlayground();
+
+    const endpointInput = await screen.findByTestId('endpoint-selector-test-input');
+    await userEvent.type(endpointInput, 'my-endpoint');
+    await userEvent.type(screen.getByPlaceholderText('Type a message'), 'Give me JSON');
+
+    await openSettingsDrawer();
+    await userEvent.click(screen.getByRole('radio', { name: 'JSON' }));
+    await closeDrawer();
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    // The reply renders inside the text card as a JSON code block (CodeSnippet <pre>),
+    // pretty-printed and verbatim — not as a markdown paragraph where `a_b` would italicize.
+    await waitFor(() => {
+      expect(findJsonCodeBlock('{"user_name":"a_b","score":42}')).toBeDefined();
+    });
+    const textCard = screen.getByTestId('mlflow.playground.assistant.text_card');
+    expect(textCard).toContainElement(findJsonCodeBlock('{"user_name":"a_b","score":42}')!);
+  });
+
+  it('renders the assistant reply as a JSON code block when response format is JSON schema', async () => {
+    jest.spyOn(PlaygroundApi, 'chatCompletion').mockResolvedValue({
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '{"title":"hello_world"}' },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+
+    renderPlayground();
+
+    const endpointInput = await screen.findByTestId('endpoint-selector-test-input');
+    await userEvent.type(endpointInput, 'my-endpoint');
+    await userEvent.type(screen.getByPlaceholderText('Type a message'), 'Give me JSON');
+
+    await openSettingsDrawer();
+    await userEvent.click(screen.getByRole('radio', { name: 'JSON schema' }));
+    fireEvent.change(screen.getByLabelText('Schema'), {
+      target: { value: '{"type":"object","properties":{"title":{"type":"string"}}}' },
+    });
+    await closeDrawer();
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(findJsonCodeBlock('{"title":"hello_world"}')).toBeDefined();
+    });
+    const textCard = screen.getByTestId('mlflow.playground.assistant.text_card');
+    expect(textCard).toContainElement(findJsonCodeBlock('{"title":"hello_world"}')!);
+  });
+
+  it('does not reformat a plain-text reply as JSON when no response format is set', async () => {
+    jest.spyOn(PlaygroundApi, 'chatCompletion').mockResolvedValue({
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '{"user_name":"a_b"}' },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+
+    renderPlayground();
+
+    const endpointInput = await screen.findByTestId('endpoint-selector-test-input');
+    await userEvent.type(endpointInput, 'my-endpoint');
+    await userEvent.type(screen.getByPlaceholderText('Type a message'), 'Hello');
+
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    // Without a response format the content stays a markdown paragraph (no code block).
+    await waitFor(() => {
+      expect(screen.getByTestId('mlflow.playground.assistant.text_card')).toBeInTheDocument();
+    });
+    expect(findJsonCodeBlock('{"user_name":"a_b"}')).toBeUndefined();
   });
 
   it('strips tool calls from outbound follow-up conversation history', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -240,6 +240,7 @@ const PlaygroundPage = () => {
             ...assistant,
             content: assistant.content ?? '',
             ...(hasToolCalls && { tool_calls: assistant.tool_calls }),
+            ...(response_format && { contentIsJson: true }),
             usage: response.usage,
           };
           setMessages((current) => [...current, appended, { ...EMPTY_USER_MESSAGE }]);

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/JsonCodeBlock.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/JsonCodeBlock.tsx
@@ -1,0 +1,53 @@
+import { CopyIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { CodeSnippet } from '@databricks/web-shared/snippet';
+import { CopyButton } from '../../../../shared/building_blocks/CopyButton';
+import { prettyPrintJson } from '../utils';
+
+interface Props {
+  /** Raw JSON string (e.g. tool-call arguments or a JSON-format reply). */
+  raw: string;
+}
+
+/**
+ * Renders a JSON string as a syntax-highlighted code block with line numbers and
+ * a copy button. The JSON is pretty-printed when parseable and shown verbatim
+ * otherwise. The snippet background is transparent so the surrounding assistant
+ * card background shows through (the shared `CodeSnippet` prism theme would
+ * otherwise paint its own opaque background).
+ */
+export const JsonCodeBlock = ({ raw }: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const code = prettyPrintJson(raw);
+
+  return (
+    <div css={{ position: 'relative' }} data-testid="mlflow.playground.json_code_block">
+      <div css={{ position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs, zIndex: 1 }}>
+        <CopyButton
+          componentId="mlflow.playground.json_code_block.copy"
+          copyText={code}
+          showLabel={false}
+          size="small"
+          icon={<CopyIcon />}
+        />
+      </div>
+      <CodeSnippet
+        theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
+        language="json"
+        showLineNumbers
+        style={{
+          margin: 0,
+          padding: 0,
+          // Transparent so the assistant card background shows through instead of
+          // the prism theme's own (dark "purple") background.
+          backgroundColor: 'transparent',
+          // Cap the height so a large JSON payload scrolls within the card instead
+          // of stretching it; the prism theme already sets `overflow: auto` on the
+          // <pre>. Mirrors GenAIMarkdownRenderer's code-block max height.
+          maxHeight: 640,
+        }}
+      >
+        {code}
+      </CodeSnippet>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/JsonCodeBlock.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/JsonCodeBlock.tsx
@@ -1,7 +1,13 @@
-import { CopyIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, ChevronDownIcon, ChevronUpIcon, CopyIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { CodeSnippet } from '@databricks/web-shared/snippet';
+import { useEffect, useRef, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { CopyButton } from '../../../../shared/building_blocks/CopyButton';
 import { prettyPrintJson } from '../utils';
+
+// Collapse the code block once it grows past this height and reveal the rest
+// behind a "See more" toggle, so a large JSON payload does not dominate the card.
+const COLLAPSED_MAX_HEIGHT = 640;
 
 interface Props {
   /** Raw JSON string (e.g. tool-call arguments or a JSON-format reply). */
@@ -13,11 +19,26 @@ interface Props {
  * a copy button. The JSON is pretty-printed when parseable and shown verbatim
  * otherwise. The snippet background is transparent so the surrounding assistant
  * card background shows through (the shared `CodeSnippet` prism theme would
- * otherwise paint its own opaque background).
+ * otherwise paint its own opaque background). When the rendered output is taller
+ * than {@link COLLAPSED_MAX_HEIGHT}, it is collapsed behind a "See more" toggle.
  */
 export const JsonCodeBlock = ({ raw }: Props) => {
   const { theme } = useDesignSystemTheme();
   const code = prettyPrintJson(raw);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (el) {
+      // scrollHeight is the full content height regardless of the collapsed clamp,
+      // so this stays correct whether the block is expanded or not.
+      setIsOverflowing(el.scrollHeight > COLLAPSED_MAX_HEIGHT);
+    }
+  }, [code]);
+
+  const collapsed = isOverflowing && !expanded;
 
   return (
     <div css={{ position: 'relative' }} data-testid="mlflow.playground.json_code_block">
@@ -30,24 +51,44 @@ export const JsonCodeBlock = ({ raw }: Props) => {
           icon={<CopyIcon />}
         />
       </div>
-      <CodeSnippet
-        theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
-        language="json"
-        showLineNumbers
-        style={{
-          margin: 0,
-          padding: 0,
-          // Transparent so the assistant card background shows through instead of
-          // the prism theme's own (dark "purple") background.
-          backgroundColor: 'transparent',
-          // Cap the height so a large JSON payload scrolls within the card instead
-          // of stretching it; the prism theme already sets `overflow: auto` on the
-          // <pre>. Mirrors GenAIMarkdownRenderer's code-block max height.
-          maxHeight: 640,
-        }}
-      >
-        {code}
-      </CodeSnippet>
+      <div ref={viewportRef} css={{ maxHeight: collapsed ? COLLAPSED_MAX_HEIGHT : 'none', overflow: 'hidden' }}>
+        <CodeSnippet
+          theme={theme.isDarkMode ? 'duotoneDark' : 'light'}
+          language="json"
+          showLineNumbers
+          style={{
+            margin: 0,
+            padding: 0,
+            // Transparent so the assistant card background shows through instead of
+            // the prism theme's own (dark "purple") background.
+            backgroundColor: 'transparent',
+          }}
+        >
+          {code}
+        </CodeSnippet>
+      </div>
+      {isOverflowing && (
+        <Button
+          componentId="mlflow.playground.json_code_block.toggle"
+          css={{ width: '100%' }}
+          type="tertiary"
+          size="small"
+          icon={expanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          {expanded ? (
+            <FormattedMessage
+              defaultMessage="See less"
+              description="Toggle that collapses a long JSON code block on the playground page"
+            />
+          ) : (
+            <FormattedMessage
+              defaultMessage="See more"
+              description="Toggle that expands a collapsed long JSON code block on the playground page"
+            />
+          )}
+        </Button>
+      )}
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptInputPanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptInputPanel.tsx
@@ -15,6 +15,7 @@ import { GenAIMarkdownRenderer } from '@databricks/web-shared/genai-markdown-ren
 import { FormattedMessage, useIntl } from 'react-intl';
 import type { ChangeEvent } from 'react';
 import type { ChatRole, ConversationMessage } from '../types';
+import { JsonCodeBlock } from './JsonCodeBlock';
 
 const { TextArea } = Input;
 
@@ -108,7 +109,11 @@ export const PromptInputPanel = ({ messages, onChange }: Props) => {
               <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
                 {message.content ? (
                   <div css={cardStyles} data-testid="mlflow.playground.assistant.text_card">
-                    <GenAIMarkdownRenderer>{message.content}</GenAIMarkdownRenderer>
+                    {message.contentIsJson ? (
+                      <JsonCodeBlock raw={message.content} />
+                    ) : (
+                      <GenAIMarkdownRenderer>{message.content}</GenAIMarkdownRenderer>
+                    )}
                   </div>
                 ) : null}
                 {getNamedToolCalls(message).map((toolCall, toolCallIndex) => (
@@ -120,9 +125,7 @@ export const PromptInputPanel = ({ messages, onChange }: Props) => {
                     <Typography.Text bold>
                       <strong>{toolCall.function?.name}</strong>
                     </Typography.Text>
-                    {toolCall.function?.arguments && (
-                      <GenAIMarkdownRenderer>{toolCall.function.arguments}</GenAIMarkdownRenderer>
-                    )}
+                    {toolCall.function?.arguments && <JsonCodeBlock raw={toolCall.function.arguments} />}
                   </div>
                 ))}
                 {!message.content && getNamedToolCalls(message).length === 0 && (

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptInputPanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PromptInputPanel.tsx
@@ -119,7 +119,7 @@ export const PromptInputPanel = ({ messages, onChange }: Props) => {
                 {getNamedToolCalls(message).map((toolCall, toolCallIndex) => (
                   <div
                     key={toolCall.id ?? toolCallIndex}
-                    css={cardStyles}
+                    css={{ ...cardStyles, display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}
                     data-testid="mlflow.playground.assistant.tool_call_card"
                   >
                     <Typography.Text bold>

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/types.ts
@@ -22,6 +22,11 @@ export interface ToolCall {
 // Stripped to `{role, content}` before being sent to the gateway.
 export interface ConversationMessage extends ChatMessage {
   usage?: ChatCompletionUsage;
+  // True when this assistant reply was generated under a JSON / JSON-schema
+  // response format, so its content should render as a JSON code block. Captured
+  // at generation time so toggling the response-format control afterward does not
+  // retroactively reformat past replies. Display-only; stripped before sending.
+  contentIsJson?: boolean;
 }
 
 export type ResponseFormatType = 'text' | 'json_object' | 'json_schema';

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from '@jest/globals';
 import type { ChatMessage } from './types';
-import { extractTemplateVariables, getEmptyVariables, isToolsValueEmpty, substituteVariables } from './utils';
+import {
+  extractTemplateVariables,
+  getEmptyVariables,
+  isToolsValueEmpty,
+  prettyPrintJson,
+  substituteVariables,
+} from './utils';
 
 describe('extractTemplateVariables', () => {
   it('returns an empty list when there are no placeholders', () => {
@@ -110,5 +116,20 @@ describe('isToolsValueEmpty', () => {
   it('returns false for unparseable text so the parse-error path can claim it', () => {
     expect(isToolsValueEmpty('[not-json')).toBe(false);
     expect(isToolsValueEmpty('not-json')).toBe(false);
+  });
+});
+
+describe('prettyPrintJson', () => {
+  it('pretty-prints valid JSON with 2-space indentation', () => {
+    expect(prettyPrintJson('{"city":"San Francisco"}')).toBe('{\n  "city": "San Francisco"\n}');
+  });
+
+  it('re-stringifies regardless of input whitespace so output is canonical', () => {
+    expect(prettyPrintJson('{ "a" : 1 ,"b":2 }')).toBe('{\n  "a": 1,\n  "b": 2\n}');
+  });
+
+  it('falls back to the raw string for invalid/partial JSON', () => {
+    expect(prettyPrintJson('{"city":"San Francisco"')).toBe('{"city":"San Francisco"');
+    expect(prettyPrintJson('not json at all')).toBe('not json at all');
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/utils.ts
@@ -44,6 +44,21 @@ export const getEmptyVariables = (messages: ChatMessage[], values: Record<string
 };
 
 /**
+ * Pretty-prints a JSON string with 2-space indentation. Falls back to the
+ * original string when it is not valid JSON (e.g. a partial or malformed
+ * tool-call argument), so the displayed text stays verbatim rather than being
+ * dropped. Used by `JsonCodeBlock` to render assistant tool-call arguments and
+ * JSON-format responses.
+ */
+export const prettyPrintJson = (raw: string): string => {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+};
+
+/**
  * Returns true when the JSON tool-definitions text has no usable tools — either
  * empty/whitespace or parses to an empty array. Parse errors return false so
  * they flow to the separate parse-error path.

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2755,6 +2755,10 @@
     "defaultMessage": "This model is also registered to the <link>model registry</link>.",
     "description": "Sub text to tell the users where the registered models are located "
   },
+  "BRfxyC": {
+    "defaultMessage": "See less",
+    "description": "Toggle that collapses a long JSON code block on the playground page"
+  },
   "BTAzqb": {
     "defaultMessage": "Toggle visibility of rows",
     "description": "Accessibility label for the button that toggles visibility of rows in the experiment view logged models compare mode"
@@ -11110,6 +11114,10 @@
   "qTjYVU": {
     "defaultMessage": "Hide run",
     "description": "A tooltip for the visibility icon button in the runs table next to the visible run"
+  },
+  "qVOt+R": {
+    "defaultMessage": "See more",
+    "description": "Toggle that expands a collapsed long JSON code block on the playground page"
   },
   "qVQYZH": {
     "defaultMessage": "Show less",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24073 — addresses [this review comment](https://github.com/mlflow/mlflow/pull/24073#discussion_r3439791938) (follow-up on the merged tool-call rendering work).

### What changes are proposed in this pull request?

Tool-call arguments were passed to `GenAIMarkdownRenderer` as a bare string, so the renderer treated them as a markdown paragraph. That had two downsides the reviewer flagged:

1. **No copy button**, so users couldn't easily copy the arguments.
2. **Not truly verbatim** — markdown interpreted characters in the raw JSON (e.g. an underscore in a key like `user_name` rendered as italics), so the display could differ from what the provider returned.

This PR adds a small `JsonCodeBlock` component and uses it for both tool-call arguments and JSON-format assistant replies:

- Renders the JSON through the shared `CodeSnippet` (syntax highlighting + line numbers) that `GenAIMarkdownRenderer` already uses for code blocks.
- Pretty-prints the JSON when it parses, and falls back to the raw string verbatim for partial/invalid JSON.
- Adds a **copy button** (the shared `CopyButton`), since the vendored `CodeSnippet` does not render its `actions` prop in this codebase.
- Uses a **transparent background** so the surrounding assistant card shows through, instead of the prism theme's own opaque (dark) background.
- Also applies this to assistant replies generated under a **JSON / JSON-schema response format**, via a display-only `contentIsJson` flag captured at generation time (so toggling the response-format control afterward does not retroactively reformat past replies). The flag is stripped before the message is sent back to the gateway.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validated locally:

```bash
pushd mlflow/server/js
yarn lint
yarn type-check
yarn prettier:check
yarn i18n:check
yarn test src/experiment-tracking/pages/playground
popd
```

**Manual verification** (headed browser) against a live `openai-gpt-4o` gateway endpoint in the GenAI Playground, confirming both paths render as transparent-background JSON code blocks with line numbers and a working copy button:

| Scenario | Rendered as |
| --- | --- |
| Tool calls (Tool choice = Required, two tools) | one JSON code block per tool call (`get_weather`, `get_time`), pretty-printed args |
| Response format = JSON | the assistant reply as a JSON code block (e.g. `user_name` shown verbatim, no italics) |

Screenshots are attached below.
#### Before
<img width="1694" height="257" alt="image" src="https://github.com/user-attachments/assets/654989a1-faa0-419a-8726-b72122440425" />

#### After
Tested with tools and JSON response format
<img width="1715" height="1092" alt="image" src="https://github.com/user-attachments/assets/3ef7f670-d98f-479b-90d5-67491d071c09" />

Tested with the JSON schema response format
<img width="1715" height="846" alt="image" src="https://github.com/user-attachments/assets/91dd41bf-c402-48f1-a650-02a5edcb749c" />

Tested with the large JSON response
<img width="2400" height="2626" alt="seemore-collapsed" src="https://github.com/user-attachments/assets/d214dc37-2586-45b6-bf1c-951aacad060c" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The GenAI Playground now renders assistant tool-call arguments and JSON-format responses as syntax-highlighted, copyable JSON code blocks instead of plain markdown text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release