### PR TITLE
Captured OTLP spans to the tracking store from the WAL daemon

### DIFF
--- a/libs/typescript/core/src/exporters/wal/daemon.ts
+++ b/libs/typescript/core/src/exporters/wal/daemon.ts
@@ -342,13 +342,36 @@ function isAuthRefreshableError(err: unknown): boolean {
 }
 
 /**
- * Perform the create-trace + upload-trace-data sequence.
+ * Perform the create-trace + upload-trace-data sequence, then send
+ * the captured OTLP spans to the tracking-store DB.
  */
 async function performUpload(client: MlflowClient, record: WalRecord): Promise<void> {
   const traceInfo = TraceInfo.fromJson(record.traceInfo as unknown as SerializedTraceInfo);
   const traceData = TraceData.fromJson(record.traceData as SerializedTraceData);
   const resolvedInfo = await client.createTrace(traceInfo);
   await client.uploadTraceData(resolvedInfo, traceData);
+  await sendOtlpSpans(client, record);
+}
+
+/**
+ * Ship the record's captured OTLP spans to the tracking store's
+ * span-ingestion endpoint (`exportOtlpSpans` → `/v1/traces`) so they land in the
+ * `SqlSpan` table that powers DB-backed span metrics (e.g. the "Tool calls"
+ * overview).
+ */
+async function sendOtlpSpans(client: MlflowClient, record: WalRecord): Promise<void> {
+  if (!record.otlpSpans) {
+    return;
+  }
+  try {
+    const bytes = Buffer.from(record.otlpSpans, 'base64');
+    await client.exportOtlpSpans(record.experimentId, bytes);
+  } catch (err) {
+    log(
+      `Failed to log OTLP spans for record ${record.id} to ${record.trackingUri}; ` +
+        `spans remain in the JSON artifact only: ${formatError(err)}`,
+    );
+  }
 }
 
 /**

--- a/libs/typescript/core/tests/exporters/wal/daemon.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/daemon.test.ts
@@ -76,13 +76,22 @@ function makeRecord(overrides: Partial<WalRecord> = {}): WalRecord {
   return { ...base, ...overrides };
 }
 
-function makeClient(opts: { createTrace?: jest.Mock; uploadTraceData?: jest.Mock }): MlflowClient {
+function makeClient(opts: {
+  createTrace?: jest.Mock;
+  uploadTraceData?: jest.Mock;
+  exportOtlpSpans?: jest.Mock;
+}): MlflowClient {
   return {
     createTrace:
       opts.createTrace ?? jest.fn().mockImplementation((info: TraceInfo) => Promise.resolve(info)),
     uploadTraceData:
       opts.uploadTraceData ??
       jest.fn().mockImplementation((_info: TraceInfo, _data: TraceData) => Promise.resolve()),
+    exportOtlpSpans:
+      opts.exportOtlpSpans ??
+      jest
+        .fn()
+        .mockImplementation((_experimentId: string, _bytes: Uint8Array) => Promise.resolve()),
     getHost: () => 'http://localhost:5000',
   } as unknown as MlflowClient;
 }
@@ -310,6 +319,63 @@ describe('wal/daemon', () => {
       // After tombstone the record should not be in the live set.
       const pending = await readPending();
       expect(pending.find((r) => r.id === 'row-success')).toBeUndefined();
+    });
+
+    it('logs captured OTLP spans to the DB when record.otlpSpans is present', async () => {
+      const exportOtlpSpans = jest
+        .fn()
+        .mockImplementation((_experimentId: string, _bytes: Uint8Array) => Promise.resolve());
+      const client = makeClient({ exportOtlpSpans });
+
+      const otlpBytes = Buffer.from([0x0a, 0x01, 0x02, 0x03]);
+      const record = makeRecord({
+        id: 'row-otlp',
+        experimentId: 'exp-7',
+        otlpSpans: otlpBytes.toString('base64'),
+      });
+      await uploadOne(record, client, new BatchingWriter());
+
+      expect(exportOtlpSpans).toHaveBeenCalledTimes(1);
+      const [experimentId, bytes] = exportOtlpSpans.mock.calls[0] as [string, Uint8Array];
+      expect(experimentId).toBe('exp-7');
+      expect(Buffer.from(bytes).equals(otlpBytes)).toBe(true);
+
+      const pending = await readPending();
+      expect(pending.find((r) => r.id === 'row-otlp')).toBeUndefined();
+    });
+
+    it('skips span logging when record.otlpSpans is absent', async () => {
+      const exportOtlpSpans = jest.fn();
+      const client = makeClient({ exportOtlpSpans });
+
+      const record = makeRecord({ id: 'row-no-otlp' });
+      await uploadOne(record, client, new BatchingWriter());
+
+      expect(exportOtlpSpans).not.toHaveBeenCalled();
+    });
+
+    it('tombstones the record even when span logging fails (non-fatal)', async () => {
+      const exportOtlpSpans = jest.fn().mockRejectedValue(new Error('501 not supported'));
+      const createTrace = jest.fn().mockImplementation((info: TraceInfo) => Promise.resolve(info));
+      const uploadTraceData = jest
+        .fn()
+        .mockImplementation((_info: TraceInfo, _data: TraceData) => Promise.resolve());
+      const client = makeClient({ createTrace, uploadTraceData, exportOtlpSpans });
+
+      const record = makeRecord({
+        id: 'row-otlp-fail',
+        otlpSpans: Buffer.from([0x0a, 0x01]).toString('base64'),
+      });
+      await uploadOne(record, client, new BatchingWriter());
+
+      expect(createTrace).toHaveBeenCalledTimes(1);
+      expect(uploadTraceData).toHaveBeenCalledTimes(1);
+      expect(exportOtlpSpans).toHaveBeenCalledTimes(1);
+
+      // The trace info + artifact already uploaded, so a span-log failure must
+      // not retry or dead-letter: the row is tombstoned and nothing re-appended.
+      const pending = await readPending();
+      expect(pending).toHaveLength(0);
     });
 
     it('re-appends a fresh row with bumped attempts on transient failure', async () => {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24089/files) to review incremental changes.
- [**stack/daemon-oltp-async**](https://github.com/mlflow/mlflow/pull/24089) [[Files changed](https://github.com/mlflow/mlflow/pull/24089/files)] ← _this PR_
  - [stack/async-cli-tracing-decode-oltpspans](https://github.com/mlflow/mlflow/pull/24090) [[Files changed](https://github.com/mlflow/mlflow/pull/24090/files/a14a8cb4640b2ea5cfd3c7c8a2e868c08daec41e..1ac152b7fd17924727ed79614561bd5e6793800e)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Spans logged by the TypeScript SDK were uploaded only as a JSON trace artifact,
so they never reached the `SqlSpan` table. As a result, DB-backed span views
(notably the Overview page's "Tool calls" tab, which aggregates `SqlSpan` rows)
showed nothing, even though the spans were visible in the trace explorer's
"Details" view that reads the artifact.

This wires the WAL daemon to also push the captured OTLP protobuf bytes to the
tracking store's span-ingestion endpoint, matching how the Python SDK's
`log_spans` populates the DB.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
