### PR TITLE
Decode JSON-encoded span attributes before OTLP serialization in WAL exporter

### DIFF
--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -7,6 +7,42 @@ import { InMemoryTraceManager } from '../../core/trace_manager';
 import { ipcRequestByteLength, MAX_REQUEST_BYTES, submitRecord } from './ipc';
 import { WalRecord } from './types';
 
+function decodeMlflowSpanAttributes(
+  attributes: OTelReadableSpan['attributes'],
+): Record<string, unknown> {
+  const decoded: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value === 'string') {
+      try {
+        decoded[key] = JSON.parse(value);
+      } catch {
+        decoded[key] = value;
+      }
+    } else {
+      decoded[key] = value;
+    }
+  }
+  return decoded;
+}
+
+/**
+ * Return a view of `span` whose `attributes` are decoded (see
+ * {@link decodeMlflowSpanAttributes}) while every other property/method is
+ * delegated to the original span untouched.
+ */
+function spanWithDecodedAttributes(span: OTelReadableSpan): OTelReadableSpan {
+  const decoded = decodeMlflowSpanAttributes(span.attributes);
+  return new Proxy(span, {
+    get(target, prop) {
+      if (prop === 'attributes') {
+        return decoded;
+      }
+      const value: unknown = Reflect.get(target, prop);
+      return typeof value === 'function' ? (value.bind(target) as unknown) : value;
+    },
+  });
+}
+
 /**
  * Serialize live OTel spans into a base64-encoded OTLP
  * `ExportTraceServiceRequest` protobuf, suitable for storing on a
@@ -19,7 +55,9 @@ function serializeSpansToOtlpBase64(spans: OTelReadableSpan[]): string | undefin
     return undefined;
   }
   try {
-    const bytes = ProtobufTraceSerializer.serializeRequest(serializable);
+    const bytes = ProtobufTraceSerializer.serializeRequest(
+      serializable.map(spanWithDecodedAttributes),
+    );
     if (!bytes || bytes.length === 0) {
       return undefined;
     }

--- a/libs/typescript/core/src/exporters/wal/exporter.ts
+++ b/libs/typescript/core/src/exporters/wal/exporter.ts
@@ -12,7 +12,7 @@ function decodeMlflowSpanAttributes(
 ): Record<string, unknown> {
   const decoded: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(attributes)) {
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && value.startsWith('"')) {
       try {
         decoded[key] = JSON.parse(value);
       } catch {

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -90,6 +90,33 @@ function captureExportResult(): {
   return { callback: resolveFn, promise };
 }
 
+/**
+ * In OTLP protobuf wire format, each attribute's key and value strings are
+ * emitted close together. Require `expectedValue` to appear after `attributeKey`
+ * so a bare substring scan cannot false-positive on unrelated fields.
+ */
+function expectOtlpAttributeValue(
+  decoded: Buffer,
+  attributeKey: string,
+  expectedValue: string,
+): void {
+  const keyOffset = decoded.indexOf(attributeKey);
+  expect(keyOffset).toBeGreaterThanOrEqual(0);
+  const valueOffset = decoded.indexOf(expectedValue, keyOffset + attributeKey.length);
+  expect(valueOffset).toBeGreaterThan(keyOffset);
+}
+
+function expectOtlpAttributeValueAbsent(
+  decoded: Buffer,
+  attributeKey: string,
+  unexpectedValue: string,
+): void {
+  const keyOffset = decoded.indexOf(attributeKey);
+  expect(keyOffset).toBeGreaterThanOrEqual(0);
+  const valueOffset = decoded.indexOf(unexpectedValue, keyOffset + attributeKey.length);
+  expect(valueOffset).toBe(-1);
+}
+
 describe('wal/exporter', () => {
   let walDir: string;
   let popTraceSpy: jest.SpyInstance;
@@ -555,12 +582,10 @@ describe('wal/exporter', () => {
     const record = submit.mock.calls[0][0];
     const decoded = Buffer.from(record.otlpSpans as string, 'base64');
 
-    // Decoded native values are present...
-    expect(decoded.includes(Buffer.from('TOOL'))).toBe(true);
-    expect(decoded.includes(Buffer.from('WebSearch'))).toBe(true);
-    // ...and the double-encoded (quoted) forms are NOT.
-    expect(decoded.includes(Buffer.from('"TOOL"'))).toBe(false);
-    expect(decoded.includes(Buffer.from('"WebSearch"'))).toBe(false);
+    expectOtlpAttributeValue(decoded, SpanAttributeKey.SPAN_TYPE, 'TOOL');
+    expectOtlpAttributeValue(decoded, 'tool_name', 'WebSearch');
+    expectOtlpAttributeValueAbsent(decoded, SpanAttributeKey.SPAN_TYPE, '"TOOL"');
+    expectOtlpAttributeValueAbsent(decoded, 'tool_name', '"WebSearch"');
   });
 
   it('keeps JSON object attributes as single-encoded strings in OTLP output', async () => {
@@ -588,11 +613,9 @@ describe('wal/exporter', () => {
     expect(record.otlpSpans).toBeDefined();
     const decoded = Buffer.from(record.otlpSpans as string, 'base64');
 
-    // Single-encoded JSON text is present...
-    expect(decoded.includes(Buffer.from(inputsJson))).toBe(true);
-    expect(decoded.includes(Buffer.from(outputsJson))).toBe(true);
-    // ...but not wrapped again as a JSON string scalar (the naive JSON.parse-all bug).
-    expect(decoded.includes(Buffer.from(JSON.stringify(inputsJson)))).toBe(false);
-    expect(decoded.includes(Buffer.from(JSON.stringify(outputsJson)))).toBe(false);
+    expectOtlpAttributeValue(decoded, SpanAttributeKey.INPUTS, inputsJson);
+    expectOtlpAttributeValue(decoded, SpanAttributeKey.OUTPUTS, outputsJson);
+    expectOtlpAttributeValueAbsent(decoded, SpanAttributeKey.INPUTS, JSON.stringify(inputsJson));
+    expectOtlpAttributeValueAbsent(decoded, SpanAttributeKey.OUTPUTS, JSON.stringify(outputsJson));
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -41,7 +41,7 @@ function makeTrace(traceId: string): Trace {
  * Build a trace whose `data.spans` carries real, ended OTel spans (wrapped in
  * MLflow `Span`s) so the exporter's OTLP serialization runs end-to-end
  */
-function makeTraceWithSpans(traceId: string): Trace {
+function makeTraceWithSpans(traceId: string, attributes: Record<string, string> = {}): Trace {
   const info = new TraceInfo({
     traceId,
     traceLocation: createTraceLocationFromExperimentId('exp-test'),
@@ -61,6 +61,11 @@ function makeTraceWithSpans(traceId: string): Trace {
     ROOT_CONTEXT,
   ) as OTelSpan;
   otelSpan.setAttribute(SpanAttributeKey.TRACE_ID, JSON.stringify(traceId));
+  // Attribute values are stored JSON-encoded on the OTel span, mirroring the
+  // SDK's `safeJsonStringify` behavior (see core/entities/span.ts).
+  for (const [key, value] of Object.entries(attributes)) {
+    otelSpan.setAttribute(key, value);
+  }
   otelSpan.end();
 
   return new Trace(info, new TraceData([new MlflowSpan(otelSpan)]));
@@ -527,5 +532,34 @@ describe('wal/exporter', () => {
       sizeSpy.mockRestore();
       warnSpy.mockRestore();
     }
+  });
+
+  it('serializes decoded attribute values (no double JSON-encoding)', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    popTraceSpy.mockReturnValue(
+      makeTraceWithSpans('tr-decode', {
+        [SpanAttributeKey.SPAN_TYPE]: JSON.stringify('TOOL'),
+        tool_name: JSON.stringify('WebSearch'),
+      }),
+    );
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback, promise } = captureExportResult();
+    exporter.export([span], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    await exporter.forceFlush();
+
+    const record = submit.mock.calls[0][0];
+    const decoded = Buffer.from(record.otlpSpans as string, 'base64');
+
+    // Decoded native values are present...
+    expect(decoded.includes(Buffer.from('TOOL'))).toBe(true);
+    expect(decoded.includes(Buffer.from('WebSearch'))).toBe(true);
+    // ...and the double-encoded (quoted) forms are NOT.
+    expect(decoded.includes(Buffer.from('"TOOL"'))).toBe(false);
+    expect(decoded.includes(Buffer.from('"WebSearch"'))).toBe(false);
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -563,7 +563,7 @@ describe('wal/exporter', () => {
     expect(decoded.includes(Buffer.from('"WebSearch"'))).toBe(false);
   });
 
-  it('still serializes OTLP when spans carry JSON object attributes (inputs/outputs)', async () => {
+  it('keeps JSON object attributes as single-encoded strings in OTLP output', async () => {
     const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
     const exporter = new MlflowWalSpanExporter({ submit });
 
@@ -587,8 +587,12 @@ describe('wal/exporter', () => {
     const record = submit.mock.calls[0][0];
     expect(record.otlpSpans).toBeDefined();
     const decoded = Buffer.from(record.otlpSpans as string, 'base64');
+
+    // Single-encoded JSON text is present...
     expect(decoded.includes(Buffer.from(inputsJson))).toBe(true);
     expect(decoded.includes(Buffer.from(outputsJson))).toBe(true);
-    expect(decoded.includes(Buffer.from('TOOL'))).toBe(true);
+    // ...but not wrapped again as a JSON string scalar (the naive JSON.parse-all bug).
+    expect(decoded.includes(Buffer.from(JSON.stringify(inputsJson)))).toBe(false);
+    expect(decoded.includes(Buffer.from(JSON.stringify(outputsJson)))).toBe(false);
   });
 });

--- a/libs/typescript/core/tests/exporters/wal/exporter.test.ts
+++ b/libs/typescript/core/tests/exporters/wal/exporter.test.ts
@@ -562,4 +562,33 @@ describe('wal/exporter', () => {
     expect(decoded.includes(Buffer.from('"TOOL"'))).toBe(false);
     expect(decoded.includes(Buffer.from('"WebSearch"'))).toBe(false);
   });
+
+  it('still serializes OTLP when spans carry JSON object attributes (inputs/outputs)', async () => {
+    const submit = jest.fn<Promise<void>, [WalRecord]>().mockResolvedValue(undefined);
+    const exporter = new MlflowWalSpanExporter({ submit });
+
+    const inputsJson = JSON.stringify({ prompt: 'hello' });
+    const outputsJson = JSON.stringify({ response: 'world' });
+    popTraceSpy.mockReturnValue(
+      makeTraceWithSpans('tr-obj-attrs', {
+        [SpanAttributeKey.SPAN_TYPE]: JSON.stringify('TOOL'),
+        [SpanAttributeKey.INPUTS]: inputsJson,
+        [SpanAttributeKey.OUTPUTS]: outputsJson,
+      }),
+    );
+    const span = makeSpan({ traceId: 'otel-1', rootSpan: true });
+
+    const { callback, promise } = captureExportResult();
+    exporter.export([span], callback);
+
+    expect((await promise).code).toBe(ExportResultCode.SUCCESS);
+    await exporter.forceFlush();
+
+    const record = submit.mock.calls[0][0];
+    expect(record.otlpSpans).toBeDefined();
+    const decoded = Buffer.from(record.otlpSpans as string, 'base64');
+    expect(decoded.includes(Buffer.from(inputsJson))).toBe(true);
+    expect(decoded.includes(Buffer.from(outputsJson))).toBe(true);
+    expect(decoded.includes(Buffer.from('TOOL'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24090/files) to review incremental changes.
- [stack/daemon-oltp-async](https://github.com/mlflow/mlflow/pull/24089) [[Files changed](https://github.com/mlflow/mlflow/pull/24089/files)] [MERGED]
  - [**stack/async-cli-tracing-decode-oltpspans**](https://github.com/mlflow/mlflow/pull/24090) [[Files changed](https://github.com/mlflow/mlflow/pull/24090/files)] ← _this PR_

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

This PR only fixes the missing tool calls metric issue for CLI async batch tracing, fix for the sync feature will have to be done separately since its handled by a different exporter (this is a known existing gap between our TS SDK vs Python SDK)

Fixes double JSON-encoding of span attributes when the TypeScript WAL exporter serializes OTLP spans for DB-backed span metrics.

MLflow stores span attribute values as JSON-encoded strings on OTel spans (via safeJsonStringify in the SDK). When the WAL exporter passed those spans directly to ProtobufTraceSerializer, OTLP serialization treated them as plain strings and encoded them again — so values like "TOOL" and "WebSearch" were stored as "\"TOOL\"" and "\"WebSearch\"" in the OTLP protobuf.

This change decodes JSON-encoded string attributes back to native values before OTLP serialization, so DB-ingested spans match the intended attribute values.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Before:

Tool calls from CLI tracing using async batching are not surfacing in the overview tool call metrics.

After (CLI tracing with async batching is now capturing tool calls made by the Claude):

<img width="1658" height="736" alt="Screenshot 2026-06-23 at 5 28 59 PM" src="https://github.com/user-attachments/assets/81eeeff2-8a4a-4e92-94e0-7b7beabff04a" />

<img width="1515" height="528" alt="Screenshot 2026-06-23 at 5 29 29 PM" src="https://github.com/user-attachments/assets/5494ee33-8a6a-4054-baef-11e6fc8e2c33" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
