### PR TITLE
Fix Python 3.14 Traversable import compatibility

### DIFF
--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -8,7 +8,10 @@ which points to the https://github.com/mlflow/skills repository.
 import shutil
 from dataclasses import dataclass
 from importlib import resources
-from importlib.abc import Traversable
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:
+    from importlib.abc import Traversable
 from pathlib import Path
 
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter


### PR DESCRIPTION
## Related Issue

Fixes #24080

## What changed

Python 3.14 removed `Traversable` from `importlib.abc`.

This change updates `mlflow/assistant/skill_installer.py` to import `Traversable` from `importlib.resources.abc` and falls back to `importlib.abc` for older Python versions.

## Root cause

On Python 3.14:

```python
from importlib.abc import Traversable
```

raises:

```python
ImportError: cannot import name 'Traversable'
```

This ImportError causes the assistant/agent/skills CLI command registration to fail, resulting in commands such as `mlflow agent setup` not being available.

## Verification

Verified on Python 3.14 that:

* `from importlib.abc import Traversable` fails
* `from importlib.resources.abc import Traversable` succeeds

The change preserves compatibility with older Python versions through a fallback import.
