### PR TITLE
Add action verbs to `mlflow agent setup` tracking-backend menu

### DIFF
--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -158,7 +158,7 @@ def _run_setup(
             case 1:
                 profile = click.prompt(
                     click.style(
-                        "Databricks configuration profile, or empty for default",
+                        "Add a Databricks configuration profile, or leave empty for default",
                         fg="cyan",
                         bold=True,
                     ),

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -146,7 +146,7 @@ def _run_setup(
             "Tracking backend:",
             [
                 "Start a new local server",
-                "Enter a Databricks workspace",
+                "Configure the Databricks workspace",
                 "Enter an existing server URL (e.g. http://localhost:5000)",
             ],
         )

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -146,7 +146,7 @@ def _run_setup(
             "Tracking backend:",
             [
                 "Start a new local server",
-                "Configure the Databricks workspace",
+                "Connect to a Databricks workspace",
                 "Enter an existing server URL (e.g. http://localhost:5000)",
             ],
         )

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -146,8 +146,8 @@ def _run_setup(
             "Tracking backend:",
             [
                 "Start a new local server",
-                "Databricks workspace",
-                "Existing server URL (e.g. http://localhost:5000)",
+                "Enter a Databricks workspace",
+                "Enter an existing server URL (e.g. http://localhost:5000)",
             ],
         )
         match backend_choice:

--- a/mlflow/agent/setup/cli.py
+++ b/mlflow/agent/setup/cli.py
@@ -158,7 +158,7 @@ def _run_setup(
             case 1:
                 profile = click.prompt(
                     click.style(
-                        "Add a Databricks configuration profile, or leave empty for default",
+                        "Select a Databricks configuration profile, or leave empty for default",
                         fg="cyan",
                         bold=True,
                     ),


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `Tracking backend:` menu in the `mlflow agent setup` flow listed two of its
three options without an action verb (`Databricks workspace`, `Existing server
URL`), which read as labels rather than choices. This rewords them so each option
leads with a verb stating the action the user takes:

- `Start a new local server`
- `Connect to a Databricks workspace`
- `Enter an existing server URL (e.g. http://localhost:5000)`

Each verb describes the immediate action behind the choice: `Start` spins up a
local server, `Connect to` points the tracking URI at an existing Databricks
profile, and `Enter` takes a server URL. The Databricks profile prompt is also
reworded for clarity (`Select a Databricks configuration profile, or leave empty
for default`). The menu dispatch is index-based, so these wording changes do not
affect behavior.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran `mlflow agent setup` and confirmed the updated labels render in the menu:

https://github.com/user-attachments/assets/6c361f88-9068-4912-a7e2-1d518876ac82

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)