### PR TITLE
Fix Python 3.14 Traversable import compatibility

### DIFF
--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -8,7 +8,10 @@ which points to the https://github.com/mlflow/skills repository.
 import shutil
 from dataclasses import dataclass
 from importlib import resources
-from importlib.abc import Traversable
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:
+    from importlib.abc import Traversable
 from pathlib import Path
 
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter


### PR DESCRIPTION
### Related Issues/PRs

Closes #24080

### What changes are proposed in this pull request?

Python 3.14 removed `Traversable` from `importlib.abc`.

This change updates `mlflow/assistant/skill_installer.py` to import
`Traversable` from `importlib.resources.abc` and falls back to
`importlib.abc` for older Python versions.

### How is this PR tested?

- [x] Manual tests

Verified on Python 3.14.4 that:
- `from importlib.abc import Traversable` raises ImportError
- `from importlib.resources.abc import Traversable` succeeds

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes.

Fixes Python 3.14 compatibility for MLflow assistant/agent/skills CLI commands.

#### Components

- [x] area/build

#### Release note classification

- [x] rn/bug-fix

### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release