### PR TITLE
Fix Python 3.14 Traversable import compatibility

### DIFF
--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -8,7 +8,10 @@ which points to the https://github.com/mlflow/skills repository.
 import shutil
 from dataclasses import dataclass
 from importlib import resources
-from importlib.abc import Traversable
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:
+    from importlib.abc import Traversable
 from pathlib import Path
 
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter


### PR DESCRIPTION
### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

### Is this a user-facing change?

- [x] Yes. This fixes Python 3.14 compatibility for MLflow assistant/agent/skills CLI commands by importing `Traversable` from `importlib.resources.abc` with a fallback to `importlib.abc` for older Python versions.

### What component(s), interfaces, languages, and integrations does this PR affect?

#### Components

- [x] area/build

### How should the PR be classified in the release notes? Choose one:

- [x] rn/bug-fix

### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release