### PR TITLE
fix: use consistent None check for run_name in update_run_info

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1089,17 +1089,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 run.status = RunStatus.to_string(run_status)
             if end_time is not None:
                 run.end_time = end_time
-            if run_name:
+            if run_name is not None:
                 run.name = run_name
                 run_name_tag = self._try_get_run_tag(session, run_id, MLFLOW_RUN_NAME)
                 if run_name_tag is None:
                     run.tags.append(SqlTag(key=MLFLOW_RUN_NAME, value=run_name))
                 else:
                     run_name_tag.value = run_name
-
             session.add(run)
             run = run.to_mlflow_entity()
-
             return run.info
 
     def _try_get_run_tag(self, session, run_id, tagKey, eager=False):


### PR DESCRIPTION
### Related Issues/PRs

Closes #8141

### What changes are proposed in this pull request?

`update_run_info` used `if run_name:` to guard the run name update, which
silently ignores an empty string `""` as a valid value. This is inconsistent
with how `run_status` and `end_time` are handled in the same function, both
of which correctly use `if x is not None:`.

**Change:** `if run_name:` → `if run_name is not None:`

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release