### PR TITLE
fix: Add checkfirst to create_all in _initialize_tables to prevent 'Table already exists' error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from 3.7.0 to 3.8.x, if some tables (like 'secrets') already exist from a previous upgrade attempt or incomplete migration, the `InitialBase.metadata.create_all(engine)` call fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This is because `create_all` defaults to `checkfirst=False`, which tries to create all tables unconditionally.

## Fix
Add `checkfirst=True` to the `InitialBase.metadata.create_all(engine)` call. This makes SQLAlchemy check if each table already exists before attempting to create it, avoiding the duplicate table error. This is consistent with the `_all_tables_exist` check that is supposed to prevent calling `_initialize_tables` when all tables are present, but it handles the edge case where some but not all tables exist.

Closes #19943