### PR TITLE
Redesign Playground `Tools` settings with an Add-tools entry flow

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1965,6 +1965,7 @@ module.exports = {
   "mlflow.playground.submit": "",
   "mlflow.playground.tools.add": "",
   "mlflow.playground.tools.input": "",
+  "mlflow.playground.tools.remove": "",
   "mlflow.playground.tools.tool_choice": "",
   "mlflow.playground.variables.drawer": "",
   "mlflow.playground.variables.drawer.trigger": "",

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1963,6 +1963,7 @@ module.exports = {
   "mlflow.playground.save_prompt_version.target": "",
   "mlflow.playground.save_to_registry": "",
   "mlflow.playground.submit": "",
+  "mlflow.playground.tools.add": "",
   "mlflow.playground.tools.input": "",
   "mlflow.playground.tools.tool_choice": "",
   "mlflow.playground.variables.drawer": "",

--- a/docs/docs/genai/prompt-registry/playground.mdx
+++ b/docs/docs/genai/prompt-registry/playground.mdx
@@ -99,13 +99,12 @@ Not every provider accepts every parameter. Values the provider doesn't understa
 
 ### Tools
 
-The **Tools** section accepts a JSON array of tool definitions plus a **tool choice** strategy:
+By default, tools are not sent with the request. Click **Add tools** to provide one or more function definitions in a JSON array and pick a **tool choice** strategy:
 
-- **None** (default) — tools are not sent with the request.
-- **Auto** — the model decides whether to call a tool.
-- **Required** — the model must call one of the supplied tools.
+- **Auto** (default) — the model decides whether to call one or more tools.
+- **Required** — the model must call at least one tool.
 
-When **tool choice** is `Auto` or `Required`, at least one valid tool definition is required. The Submit button stays disabled with a "Add at least one tool definition" or "Fix the Tools JSON" blocker until the JSON parses as a non-empty array.
+Once tools are added, at least one valid tool definition is required. The Submit button stays disabled with a "Add at least one tool definition" or "Fix the Tools JSON" blocker until the JSON parses as a non-empty array. Use the trash icon to remove the tools from the request.
 
 ### Response format
 

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.test.tsx
@@ -166,6 +166,7 @@ describe('PlaygroundPage', () => {
     expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled();
 
     await openSettingsDrawer();
+    await userEvent.click(screen.getByRole('button', { name: 'Add tools' }));
     await userEvent.click(screen.getByRole('radio', { name: 'Required' }));
     await closeDrawer();
 
@@ -180,8 +181,9 @@ describe('PlaygroundPage', () => {
     await userEvent.type(screen.getByPlaceholderText('Type a message'), 'Hello');
 
     await openSettingsDrawer();
+    await userEvent.click(screen.getByRole('button', { name: 'Add tools' }));
     await userEvent.click(screen.getByRole('radio', { name: 'Required' }));
-    fireEvent.change(screen.getByLabelText('JSON Tool Definition'), { target: { value: '[]' } });
+    fireEvent.change(screen.getByLabelText('JSON tool definitions'), { target: { value: '[]' } });
     await closeDrawer();
 
     expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled();
@@ -251,9 +253,10 @@ describe('PlaygroundPage', () => {
     await userEvent.type(screen.getByLabelText('Frequency penalty'), '0.5');
     fireEvent.change(screen.getByLabelText('Stop sequences'), { target: { value: 'STOP\nFIN' } });
 
-    // Switch tool_choice to required and supply a valid tools array.
+    // Add tools, switch tool_choice to required and supply a valid tools array.
+    await userEvent.click(screen.getByRole('button', { name: 'Add tools' }));
     await userEvent.click(screen.getByRole('radio', { name: 'Required' }));
-    fireEvent.change(screen.getByLabelText('JSON Tool Definition'), {
+    fireEvent.change(screen.getByLabelText('JSON tool definitions'), {
       target: { value: '[{"type":"function","function":{"name":"echo"}}]' },
     });
 
@@ -315,7 +318,7 @@ describe('PlaygroundPage', () => {
     });
   });
 
-  it('omits tools and tool_choice when toolChoice stays at none, even with tool text typed', async () => {
+  it('omits tools and tool_choice when the tools are removed, even after tool text was typed', async () => {
     const chatCompletionSpy = jest.spyOn(PlaygroundApi, 'chatCompletion').mockResolvedValue({
       choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
     });
@@ -326,13 +329,13 @@ describe('PlaygroundPage', () => {
     await userEvent.type(endpointInput, 'my-endpoint');
     await userEvent.type(screen.getByPlaceholderText('Type a message'), 'Hello there');
 
-    // Pick Required just to reveal the textarea, type something, then revert to None.
+    // Add tools and type a definition, then remove them with the trash icon.
     await openSettingsDrawer();
-    await userEvent.click(screen.getByRole('radio', { name: 'Required' }));
-    fireEvent.change(screen.getByLabelText('JSON Tool Definition'), {
+    await userEvent.click(screen.getByRole('button', { name: 'Add tools' }));
+    fireEvent.change(screen.getByLabelText('JSON tool definitions'), {
       target: { value: '[{"type":"function","function":{"name":"echo"}}]' },
     });
-    await userEvent.click(screen.getByRole('radio', { name: 'None' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove tools' }));
 
     await closeDrawer();
     await userEvent.click(screen.getByRole('button', { name: /submit/i }));

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -39,7 +39,8 @@ const PlaygroundPage = () => {
   const [params, setParams] = useState<PlaygroundParams>({});
   const [variables, setVariables] = useState<Record<string, string>>({});
   const [toolsText, setToolsText] = useState<string>('');
-  const [toolChoice, setToolChoice] = useState<ToolChoice>('none');
+  const [toolsAdded, setToolsAdded] = useState<boolean>(false);
+  const [toolChoice, setToolChoice] = useState<ToolChoice>('auto');
   const [responseFormatType, setResponseFormatType] = useState<ResponseFormatType>('text');
   const [responseFormatSchemaText, setResponseFormatSchemaText] = useState<string>('');
   const [showRegistryPicker, setShowRegistryPicker] = useState(false);
@@ -146,7 +147,7 @@ const PlaygroundPage = () => {
         }),
       );
     }
-    if (toolChoice !== 'none') {
+    if (toolsAdded) {
       if (isToolsValueEmpty(toolsText)) {
         blockers.push(
           intl.formatMessage({
@@ -192,7 +193,7 @@ const PlaygroundPage = () => {
       );
     }
     return blockers;
-  }, [endpointName, messages, toolChoice, toolsText, toolsError, responseFormatSchemaError, variables, intl]);
+  }, [endpointName, messages, toolsAdded, toolsText, toolsError, responseFormatSchemaError, variables, intl]);
 
   const canSubmit = submitBlockers.length === 0 && !isLoading;
 
@@ -200,7 +201,7 @@ const PlaygroundPage = () => {
     if (!canSubmit) {
       return;
     }
-    const tools = toolChoice !== 'none' && toolsText.trim() ? (JSON.parse(toolsText) as unknown[]) : undefined;
+    const tools = toolsAdded && toolsText.trim() ? (JSON.parse(toolsText) as unknown[]) : undefined;
     let response_format: ResponseFormat | undefined;
     if (responseFormatType === 'json_object') {
       response_format = { type: 'json_object' };
@@ -266,6 +267,8 @@ const PlaygroundPage = () => {
         toolsText={toolsText}
         onToolsChange={setToolsText}
         toolsError={toolsError}
+        toolsAdded={toolsAdded}
+        onToolsAddedChange={setToolsAdded}
         toolChoice={toolChoice}
         onToolChoiceChange={setToolChoice}
         responseFormatType={responseFormatType}

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/ParametersButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/ParametersButton.test.tsx
@@ -13,19 +13,22 @@ interface RenderProps {
   toolChoice?: ToolChoice;
   toolsText?: string;
   toolsError?: string | null;
+  toolsAdded?: boolean;
   params?: PlaygroundParams;
   responseFormatType?: ResponseFormatType;
 }
 
 const renderButton = ({
-  toolChoice = 'none',
+  toolChoice = 'auto',
   toolsText = '',
   toolsError = null,
+  toolsAdded = false,
   params = {},
   responseFormatType = 'text',
 }: RenderProps = {}) => {
   const onChange = jest.fn();
   const onToolsChange = jest.fn();
+  const onToolsAddedChange = jest.fn<(next: boolean) => void>();
   const onToolChoiceChange = jest.fn<(next: ToolChoice) => void>();
   const onResponseFormatTypeChange = jest.fn();
   const onResponseFormatSchemaChange = jest.fn();
@@ -38,6 +41,8 @@ const renderButton = ({
           toolsText={toolsText}
           onToolsChange={onToolsChange}
           toolsError={toolsError}
+          toolsAdded={toolsAdded}
+          onToolsAddedChange={onToolsAddedChange}
           toolChoice={toolChoice}
           onToolChoiceChange={onToolChoiceChange}
           responseFormatType={responseFormatType}
@@ -48,7 +53,7 @@ const renderButton = ({
       </DesignSystemProvider>
     </IntlProvider>,
   );
-  return { onChange, onToolsChange, onToolChoiceChange, onResponseFormatTypeChange };
+  return { onChange, onToolsChange, onToolsAddedChange, onToolChoiceChange, onResponseFormatTypeChange };
 };
 
 const openDrawer = async () => {
@@ -64,18 +69,18 @@ describe('ParametersButton', () => {
     expect(screen.getByText('Response format')).toBeInTheDocument();
   });
 
-  it('renders the Tool choice picker defaulting to None and hides the JSON textarea', async () => {
-    renderButton({ toolChoice: 'none' });
+  it('shows the Add tools button and hides the JSON textarea before tools are added', async () => {
+    renderButton({ toolsAdded: false });
     await openDrawer();
-    expect(screen.getByRole('radio', { name: 'None' })).toBeChecked();
-    expect(screen.queryByLabelText('JSON Tool Definition')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add tools' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('JSON tool definitions')).not.toBeInTheDocument();
   });
 
-  it('reveals the JSON textarea and fires onToolChoiceChange when picker switches to Auto', async () => {
-    const { onToolChoiceChange } = renderButton({ toolChoice: 'none' });
+  it('fires onToolsAddedChange(true) when Add tools is clicked', async () => {
+    const { onToolsAddedChange } = renderButton({ toolsAdded: false });
     await openDrawer();
-    await userEvent.click(screen.getByRole('radio', { name: 'Auto' }));
-    expect(onToolChoiceChange).toHaveBeenLastCalledWith('auto');
+    await userEvent.click(screen.getByRole('button', { name: 'Add tools' }));
+    expect(onToolsAddedChange).toHaveBeenLastCalledWith(true);
   });
 
   it('opens the Parameters info popover and shows the provider-disclaimer line', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/ParametersButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/ParametersButton.tsx
@@ -20,6 +20,8 @@ interface Props {
   toolsText: string;
   onToolsChange: (next: string) => void;
   toolsError?: string | null;
+  toolsAdded: boolean;
+  onToolsAddedChange: (next: boolean) => void;
   toolChoice: ToolChoice;
   onToolChoiceChange: (next: ToolChoice) => void;
   responseFormatType: ResponseFormatType;
@@ -51,6 +53,8 @@ export const ParametersButton = ({
   toolsText,
   onToolsChange,
   toolsError,
+  toolsAdded,
+  onToolsAddedChange,
   toolChoice,
   onToolChoiceChange,
   responseFormatType,
@@ -81,7 +85,7 @@ export const ParametersButton = ({
       </Drawer.Trigger>
       <Drawer.Content
         componentId="mlflow.playground.params.drawer"
-        width={420}
+        width={580}
         title={
           <span
             css={{
@@ -163,58 +167,45 @@ export const ParametersButton = ({
               <Popover.Content align="start" css={{ maxWidth: 360 }}>
                 <Typography.Paragraph withoutMargins>
                   <FormattedMessage
-                    defaultMessage="Have the model call functions you define. Tool choice strategies:"
+                    defaultMessage="Provide one or more function definitions in a JSON array. Choose how the model invokes them:"
                     description="Intro line of the info popover next to the Tools section header"
                   />
                 </Typography.Paragraph>
                 <ul css={{ margin: `${theme.spacing.xs}px 0 0`, paddingLeft: theme.spacing.lg }}>
                   <li>
-                    <Typography.Text bold>None</Typography.Text>{' '}
-                    <FormattedMessage
-                      defaultMessage="— never call a tool (default)."
-                      description="Description of the None tool choice in the Tools info popover"
-                    />
-                  </li>
-                  <li>
                     <Typography.Text bold>Auto</Typography.Text>{' '}
                     <FormattedMessage
-                      defaultMessage="— model decides whether to call a tool."
+                      defaultMessage="— The model decides whether to call one or more tools (default)."
                       description="Description of the Auto tool choice in the Tools info popover"
                     />
                   </li>
                   <li>
                     <Typography.Text bold>Required</Typography.Text>{' '}
                     <FormattedMessage
-                      defaultMessage="— model must call a tool."
+                      defaultMessage="— The model must call at least one tool."
                       description="Description of the Required tool choice in the Tools info popover"
                     />
                   </li>
                 </ul>
                 <Typography.Paragraph withoutMargins css={{ marginTop: theme.spacing.xs }}>
                   <FormattedMessage
-                    defaultMessage="Pick Auto or Required to enter the JSON tool definitions."
-                    description="Closing line of the Tools info popover hinting at the conditional definitions input"
+                    defaultMessage="Use the trash icon to remove the tools from the request."
+                    description="Closing line of the Tools info popover explaining how the trash icon removes tools"
                   />
                 </Typography.Paragraph>
                 <Popover.Arrow />
               </Popover.Content>
             </Popover.Root>
           </div>
-          <div
-            css={{
-              border: `1px solid ${theme.colors.border}`,
-              borderRadius: theme.general.borderRadiusBase,
-              padding: theme.spacing.md,
-            }}
-          >
-            <ToolsForm
-              value={toolsText}
-              onChange={onToolsChange}
-              error={toolsError}
-              toolChoice={toolChoice}
-              onToolChoiceChange={onToolChoiceChange}
-            />
-          </div>
+          <ToolsForm
+            value={toolsText}
+            onChange={onToolsChange}
+            error={toolsError}
+            toolsAdded={toolsAdded}
+            onToolsAddedChange={onToolsAddedChange}
+            toolChoice={toolChoice}
+            onToolChoiceChange={onToolChoiceChange}
+          />
 
           <Spacer size="md" />
 

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
-import type { ToolChoice } from '../types';
 
 jest.mock('../../../components/EndpointSelector', () => ({
   EndpointSelector: ({
@@ -41,7 +40,9 @@ const renderTopBar = () => {
           toolsText=""
           onToolsChange={noop}
           toolsError={null}
-          toolChoice={'none' as ToolChoice}
+          toolsAdded={false}
+          onToolsAddedChange={noop}
+          toolChoice="auto"
           onToolChoiceChange={noop}
           responseFormatType="text"
           onResponseFormatTypeChange={noop}

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
@@ -14,6 +14,8 @@ interface Props {
   toolsText: string;
   onToolsChange: (next: string) => void;
   toolsError?: string | null;
+  toolsAdded: boolean;
+  onToolsAddedChange: (next: boolean) => void;
   toolChoice: ToolChoice;
   onToolChoiceChange: (next: ToolChoice) => void;
   responseFormatType: ResponseFormatType;
@@ -37,6 +39,8 @@ export const PlaygroundTopBar = ({
   toolsText,
   onToolsChange,
   toolsError,
+  toolsAdded,
+  onToolsAddedChange,
   toolChoice,
   onToolChoiceChange,
   responseFormatType,
@@ -75,6 +79,8 @@ export const PlaygroundTopBar = ({
         toolsText={toolsText}
         onToolsChange={onToolsChange}
         toolsError={toolsError}
+        toolsAdded={toolsAdded}
+        onToolsAddedChange={onToolsAddedChange}
         toolChoice={toolChoice}
         onToolChoiceChange={onToolChoiceChange}
         responseFormatType={responseFormatType}

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/ToolsForm.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/ToolsForm.test.tsx
@@ -9,11 +9,13 @@ import { ToolsForm } from './ToolsForm';
 interface RenderProps {
   value?: string;
   error?: string | null;
+  toolsAdded?: boolean;
   toolChoice?: ToolChoice;
 }
 
-const renderForm = ({ value = '', error, toolChoice = 'none' }: RenderProps = {}) => {
+const renderForm = ({ value = '', error, toolsAdded = false, toolChoice = 'auto' }: RenderProps = {}) => {
   const onChange = jest.fn<(next: string) => void>();
+  const onToolsAddedChange = jest.fn<(next: boolean) => void>();
   const onToolChoiceChange = jest.fn<(next: ToolChoice) => void>();
   render(
     <IntlProvider locale="en">
@@ -22,54 +24,72 @@ const renderForm = ({ value = '', error, toolChoice = 'none' }: RenderProps = {}
           value={value}
           onChange={onChange}
           error={error}
+          toolsAdded={toolsAdded}
+          onToolsAddedChange={onToolsAddedChange}
           toolChoice={toolChoice}
           onToolChoiceChange={onToolChoiceChange}
         />
       </DesignSystemProvider>
     </IntlProvider>,
   );
-  return { onChange, onToolChoiceChange };
+  return { onChange, onToolsAddedChange, onToolChoiceChange };
 };
 
 describe('ToolsForm', () => {
-  it('hides the JSON textarea when toolChoice is none', () => {
-    renderForm({ toolChoice: 'none' });
-    expect(screen.queryByLabelText('JSON Tool Definition')).not.toBeInTheDocument();
+  it('shows the Add tools button and hides the JSON textarea before tools are added', () => {
+    renderForm({ toolsAdded: false });
+    expect(screen.getByRole('button', { name: 'Add tools' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('JSON tool definitions')).not.toBeInTheDocument();
   });
 
-  it('shows the JSON textarea when toolChoice is auto or required', () => {
-    renderForm({ toolChoice: 'auto' });
-    expect(screen.getByLabelText('JSON Tool Definition')).toBeInTheDocument();
+  it('fires onToolsAddedChange(true) when Add tools is clicked', async () => {
+    const { onToolsAddedChange } = renderForm({ toolsAdded: false });
+    await userEvent.click(screen.getByRole('button', { name: 'Add tools' }));
+    expect(onToolsAddedChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('shows the JSON textarea and the Auto/Required selector once tools are added', () => {
+    renderForm({ toolsAdded: true });
+    expect(screen.getByLabelText('JSON tool definitions')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Auto' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Required' })).toBeInTheDocument();
   });
 
   it('forwards picker changes via onToolChoiceChange', async () => {
-    const { onToolChoiceChange } = renderForm({ toolChoice: 'none' });
-    await userEvent.click(screen.getByRole('radio', { name: 'Auto' }));
-    expect(onToolChoiceChange).toHaveBeenLastCalledWith('auto');
+    const { onToolChoiceChange } = renderForm({ toolsAdded: true, toolChoice: 'auto' });
+    await userEvent.click(screen.getByRole('radio', { name: 'Required' }));
+    expect(onToolChoiceChange).toHaveBeenLastCalledWith('required');
   });
 
-  it('renders an inline error when error is non-null and toolChoice is not none', () => {
-    renderForm({ toolChoice: 'auto', value: '{not-json', error: 'Invalid JSON' });
+  it('returns to the empty state without clearing the JSON when the trash icon is clicked', async () => {
+    const { onChange, onToolsAddedChange } = renderForm({ toolsAdded: true, value: '[{"x":1}]' });
+    await userEvent.click(screen.getByRole('button', { name: 'Remove tools' }));
+    expect(onToolsAddedChange).toHaveBeenLastCalledWith(false);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders an inline error when error is non-null and tools are added', () => {
+    renderForm({ toolsAdded: true, value: '{not-json', error: 'Invalid JSON' });
     expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
   });
 
-  it('does not render the inline error when toolChoice is none', () => {
-    renderForm({ toolChoice: 'none', error: 'Invalid JSON' });
+  it('does not render the inline error before tools are added', () => {
+    renderForm({ toolsAdded: false, error: 'Invalid JSON' });
     expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument();
   });
 
-  it('shows an empty-required inline error when toolChoice is not none and the textarea is empty', () => {
-    renderForm({ toolChoice: 'auto', value: '' });
+  it('shows an empty-required inline error when tools are added and the textarea is empty', () => {
+    renderForm({ toolsAdded: true, value: '' });
     expect(screen.getByText('Add at least one tool definition')).toBeInTheDocument();
   });
 
-  it('shows the empty-required inline error when toolChoice is not none and the value parses to []', () => {
-    renderForm({ toolChoice: 'required', value: '[]' });
+  it('shows the empty-required inline error when tools are added and the value parses to []', () => {
+    renderForm({ toolsAdded: true, value: '[]' });
     expect(screen.getByText('Add at least one tool definition')).toBeInTheDocument();
   });
 
   it('prefers the empty-required error over a stale parse-error prop when the value is empty', () => {
-    renderForm({ toolChoice: 'auto', value: '', error: 'Invalid JSON' });
+    renderForm({ toolsAdded: true, value: '', error: 'Invalid JSON' });
     expect(screen.getByText('Add at least one tool definition')).toBeInTheDocument();
     expect(screen.queryByText('Invalid JSON')).not.toBeInTheDocument();
   });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/ToolsForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/ToolsForm.tsx
@@ -1,8 +1,12 @@
 import {
+  Button,
   FormUI,
   Input,
+  PlusIcon,
   SegmentedControlButton,
   SegmentedControlGroup,
+  TrashIcon,
+  Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import type { ChangeEvent } from 'react';
@@ -16,12 +20,13 @@ interface Props {
   value: string;
   onChange: (next: string) => void;
   error?: string | null;
+  toolsAdded: boolean;
+  onToolsAddedChange: (next: boolean) => void;
   toolChoice: ToolChoice;
   onToolChoiceChange: (next: ToolChoice) => void;
 }
 
 const TOOL_CHOICE_OPTIONS: { value: ToolChoice; label: string }[] = [
-  { value: 'none', label: 'None' },
   { value: 'auto', label: 'Auto' },
   { value: 'required', label: 'Required' },
 ];
@@ -43,19 +48,100 @@ const TOOLS_PLACEHOLDER = `[
   }
 ]`;
 
-export const ToolsForm = ({ value, onChange, error, toolChoice, onToolChoiceChange }: Props) => {
+export const ToolsForm = ({
+  value,
+  onChange,
+  error,
+  toolsAdded,
+  onToolsAddedChange,
+  toolChoice,
+  onToolChoiceChange,
+}: Props) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
-  return (
-    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-      <div>
-        <FormUI.Label htmlFor="mlflow.playground.tools.tool_choice">
+  if (!toolsAdded) {
+    return (
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.general.borderRadiusBase,
+            padding: theme.spacing.lg,
+            minHeight: 104,
+          }}
+        >
+          <Button
+            componentId="mlflow.playground.tools.add"
+            icon={<PlusIcon />}
+            onClick={() => onToolsAddedChange(true)}
+          >
+            <FormattedMessage
+              defaultMessage="Add tools"
+              description="Label for the button that reveals the playground tool definitions input and tool choice selector"
+            />
+          </Button>
+        </div>
+        <Typography.Hint>
           <FormattedMessage
-            defaultMessage="Tool choice"
-            description="Label above the tool choice segmented picker inside the Tools card"
+            defaultMessage="Provide one or more function definitions in a JSON array for the model to call."
+            description="Help text shown under the Add tools button in the playground settings drawer before any tools are added"
           />
-        </FormUI.Label>
+        </Typography.Hint>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.md,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.general.borderRadiusBase,
+        padding: theme.spacing.md,
+      }}
+    >
+      <div>
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'space-between',
+            marginBottom: theme.spacing.sm,
+            '& label': { marginBottom: 0 },
+          }}
+        >
+          <FormUI.Label htmlFor="mlflow.playground.tools.tool_choice">
+            <FormattedMessage
+              defaultMessage="Tool choice"
+              description="Label above the tool choice segmented picker inside the Tools card"
+            />
+          </FormUI.Label>
+          <button
+            type="button"
+            onClick={() => onToolsAddedChange(false)}
+            aria-label={intl.formatMessage({
+              defaultMessage: 'Remove tools',
+              description: 'Aria label for the trash button that removes the playground tools from the request',
+            })}
+            css={{
+              border: 0,
+              background: 'none',
+              padding: theme.spacing.xs,
+              display: 'inline-flex',
+              cursor: 'pointer',
+              color: theme.colors.textSecondary,
+              '&:hover': { color: theme.colors.textPrimary },
+            }}
+          >
+            <TrashIcon />
+          </button>
+        </div>
         <SegmentedControlGroup
           componentId="mlflow.playground.tools.tool_choice"
           id="mlflow.playground.tools.tool_choice"
@@ -70,48 +156,59 @@ export const ToolsForm = ({ value, onChange, error, toolChoice, onToolChoiceChan
             </SegmentedControlButton>
           ))}
         </SegmentedControlGroup>
-      </div>
-
-      {toolChoice !== 'none' && (
-        <div>
-          <FormUI.Label htmlFor="mlflow.playground.tools.input">
+        <Typography.Hint css={{ display: 'block', marginTop: theme.spacing.xs }}>
+          {toolChoice === 'required' ? (
             <FormattedMessage
-              defaultMessage="JSON Tool Definition"
-              description="Label for the JSON tool definitions textarea inside the Tools card"
-            />
-          </FormUI.Label>
-          <TextArea
-            componentId="mlflow.playground.tools.input"
-            id="mlflow.playground.tools.input"
-            value={value}
-            onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
-            autoSize={{ minRows: 4, maxRows: 16 }}
-            placeholder={intl.formatMessage(
-              {
-                defaultMessage: 'e.g. {example}',
-                description: 'Placeholder shown above the playground tools JSON textarea',
-              },
-              { example: TOOLS_PLACEHOLDER },
-            )}
-            css={{
-              fontFamily: 'monospace',
-              fontSize: theme.typography.fontSizeSm,
-            }}
-          />
-          {isToolsValueEmpty(value) ? (
-            <FormUI.Message
-              type="error"
-              message={intl.formatMessage({
-                defaultMessage: 'Add at least one tool definition',
-                description:
-                  'Inline error shown in the Tools card when tool choice is not none but no tool definitions are provided',
-              })}
+              defaultMessage="The model must call at least one tool."
+              description="Hint shown under the tool choice selector when Required is selected"
             />
           ) : (
-            error && <FormUI.Message type="error" message={error} />
+            <FormattedMessage
+              defaultMessage="The model decides whether to call one or more tools."
+              description="Hint shown under the tool choice selector when Auto is selected"
+            />
           )}
-        </div>
-      )}
+        </Typography.Hint>
+      </div>
+
+      <div>
+        <FormUI.Label htmlFor="mlflow.playground.tools.input">
+          <FormattedMessage
+            defaultMessage="JSON tool definitions"
+            description="Label for the JSON tool definitions textarea inside the Tools card"
+          />
+        </FormUI.Label>
+        <TextArea
+          componentId="mlflow.playground.tools.input"
+          id="mlflow.playground.tools.input"
+          value={value}
+          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange(event.target.value)}
+          autoSize={{ minRows: 4, maxRows: 16 }}
+          placeholder={intl.formatMessage(
+            {
+              defaultMessage: 'e.g. {example}',
+              description: 'Placeholder shown above the playground tools JSON textarea',
+            },
+            { example: TOOLS_PLACEHOLDER },
+          )}
+          css={{
+            fontFamily: 'monospace',
+            fontSize: theme.typography.fontSizeSm,
+          }}
+        />
+        {isToolsValueEmpty(value) ? (
+          <FormUI.Message
+            type="error"
+            message={intl.formatMessage({
+              defaultMessage: 'Add at least one tool definition',
+              description:
+                'Inline error shown in the Tools card when tools are added but no tool definitions are provided',
+            })}
+          />
+        ) : (
+          error && <FormUI.Message type="error" message={error} />
+        )}
+      </div>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/ToolsForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/ToolsForm.tsx
@@ -122,25 +122,21 @@ export const ToolsForm = ({
               description="Label above the tool choice segmented picker inside the Tools card"
             />
           </FormUI.Label>
-          <button
-            type="button"
+          <Button
+            componentId="mlflow.playground.tools.remove"
+            type="tertiary"
+            size="small"
+            icon={<TrashIcon />}
             onClick={() => onToolsAddedChange(false)}
             aria-label={intl.formatMessage({
               defaultMessage: 'Remove tools',
               description: 'Aria label for the trash button that removes the playground tools from the request',
             })}
             css={{
-              border: 0,
-              background: 'none',
-              padding: theme.spacing.xs,
-              display: 'inline-flex',
-              cursor: 'pointer',
-              color: theme.colors.textSecondary,
-              '&:hover': { color: theme.colors.textPrimary },
+              '& svg': { color: theme.colors.textSecondary },
+              '&:hover svg': { color: theme.colors.textPrimary },
             }}
-          >
-            <TrashIcon />
-          </button>
+          />
         </div>
         <SegmentedControlGroup
           componentId="mlflow.playground.tools.tool_choice"

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/types.ts
@@ -40,7 +40,7 @@ export type ResponseFormat =
       json_schema: { name: string; schema: unknown; strict?: boolean };
     };
 
-export type ToolChoice = 'auto' | 'none' | 'required';
+export type ToolChoice = 'auto' | 'required';
 
 export interface ChatCompletionRequest {
   model: string;

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -115,10 +115,6 @@
     "defaultMessage": "{count, plural, one {# question} other {# questions}} selected",
     "description": "Queue settings: questions dropdown selected-count summary"
   },
-  "+asYF/": {
-    "defaultMessage": "Have the model call functions you define. Tool choice strategies:",
-    "description": "Intro line of the info popover next to the Tools section header"
-  },
   "+d9nXK": {
     "defaultMessage": "Output cost",
     "description": "Label for output cost"
@@ -130,10 +126,6 @@
   "+dbgRR": {
     "defaultMessage": "{numUniqueValues} values",
     "description": "Text for number of unique values for categorical assessment"
-  },
-  "+dueuC": {
-    "defaultMessage": "JSON Tool Definition",
-    "description": "Label for the JSON tool definitions textarea inside the Tools card"
   },
   "+erxn2": {
     "defaultMessage": "Optimize prompts",
@@ -402,6 +394,10 @@
   "/m44jJ": {
     "defaultMessage": "View docs",
     "description": "Text for docs link button on experiment view page header"
+  },
+  "/mU2Ud": {
+    "defaultMessage": "JSON tool definitions",
+    "description": "Label for the JSON tool definitions textarea inside the Tools card"
   },
   "/nPZbt": {
     "defaultMessage": "{totalTokens} total tokens",
@@ -1567,10 +1563,6 @@
     "defaultMessage": "Detailed assessments",
     "description": "Evaluation review > assessments > detailed assessments > title"
   },
-  "5kc6dO": {
-    "defaultMessage": "— model decides whether to call a tool.",
-    "description": "Description of the Auto tool choice in the Tools info popover"
-  },
   "5lsHqm": {
     "defaultMessage": "Cancel",
     "description": "Cancel button for the edit model config modal"
@@ -2091,6 +2083,10 @@
     "defaultMessage": "None",
     "description": "Cell value when there's no content"
   },
+  "8Glngx": {
+    "defaultMessage": "Provide one or more function definitions in a JSON array. Choose how the model invokes them:",
+    "description": "Intro line of the info popover next to the Tools section header"
+  },
   "8GmtjT": {
     "defaultMessage": "Clear the search",
     "description": "Link text to clear the search filter on the V2 dataset records list"
@@ -2110,6 +2106,10 @@
   "8Mwwrq": {
     "defaultMessage": "No matching users",
     "description": "Review queue: no users match the owner search"
+  },
+  "8Rlf8s": {
+    "defaultMessage": "— The model decides whether to call one or more tools (default).",
+    "description": "Description of the Auto tool choice in the Tools info popover"
   },
   "8Uwpjw": {
     "defaultMessage": "Create run",
@@ -2875,6 +2875,10 @@
     "defaultMessage": "Description",
     "description": "Workspaces table description column header"
   },
+  "BunFCp": {
+    "defaultMessage": "Provide one or more function definitions in a JSON array for the model to call.",
+    "description": "Help text shown under the Add tools button in the playground settings drawer before any tools are added"
+  },
   "BuykLs": {
     "defaultMessage": "Delete judge",
     "description": "Title for the delete judge confirmation modal"
@@ -3454,10 +3458,6 @@
   "F4K195": {
     "defaultMessage": "No evaluation datasets found",
     "description": "Empty state for the evaluation datasets page"
-  },
-  "F6YQTG": {
-    "defaultMessage": "Pick Auto or Required to enter the JSON tool definitions.",
-    "description": "Closing line of the Tools info popover hinting at the conditional definitions input"
   },
   "F8MqzZ": {
     "defaultMessage": "Path",
@@ -4531,6 +4531,10 @@
     "defaultMessage": "Trace status: OK, ERROR, or IN_PROGRESS",
     "description": "Tooltip description for the State column in the traces table"
   },
+  "Kzrwuh": {
+    "defaultMessage": "Remove tools",
+    "description": "Aria label for the trash button that removes the playground tools from the request"
+  },
   "L/4iQO": {
     "defaultMessage": "Delete",
     "description": "Label for the delete experiments action on the experiments list page"
@@ -4586,6 +4590,10 @@
   "LK+UHk": {
     "defaultMessage": "Show first 20",
     "description": "Menu option for showing only 20 first runs in the evaluation runs table"
+  },
+  "LKA/ko": {
+    "defaultMessage": "Add tools",
+    "description": "Label for the button that reveals the playground tool definitions input and tool choice selector"
   },
   "LKAZ2n": {
     "defaultMessage": "Disable grouped runs to compare",
@@ -5198,6 +5206,10 @@
   "OH7mDs": {
     "defaultMessage": "Expectations",
     "description": "Column selector label for the expectations column"
+  },
+  "OHDirZ": {
+    "defaultMessage": "Use the trash icon to remove the tools from the request.",
+    "description": "Closing line of the Tools info popover explaining how the trash icon removes tools"
   },
   "OLZyxe": {
     "defaultMessage": "{errorCount, plural, one {# error} other {# errors}}",
@@ -8463,6 +8475,10 @@
     "defaultMessage": "Account",
     "description": "Accessible label for the account-page icon avatar"
   },
+  "eCMHlc": {
+    "defaultMessage": "— The model must call at least one tool.",
+    "description": "Description of the Required tool choice in the Tools info popover"
+  },
   "eCleLG": {
     "defaultMessage": "Failed to load API keys. Please check your connection and try again.",
     "description": "Gateway > API keys list > Error loading API keys"
@@ -9843,6 +9859,10 @@
     "defaultMessage": "Correctness",
     "description": "LLM template option"
   },
+  "kD2Vww": {
+    "defaultMessage": "The model decides whether to call one or more tools.",
+    "description": "Hint shown under the tool choice selector when Auto is selected"
+  },
   "kEmVw4": {
     "defaultMessage": "Trace Archival Retention",
     "description": "Label for workspace trace archival retention field"
@@ -9974,6 +9994,10 @@
   "knJfuf": {
     "defaultMessage": "Learn more about the AI Gateway in the {gatewayDocs}.",
     "description": "AI Gateway setup guide > Documentation link"
+  },
+  "knNmQq": {
+    "defaultMessage": "Add at least one tool definition",
+    "description": "Inline error shown in the Tools card when tools are added but no tool definitions are provided"
   },
   "ktiuki": {
     "defaultMessage": "Get Link",
@@ -10670,10 +10694,6 @@
   "oHW+ks": {
     "defaultMessage": "Description",
     "description": "Title text for the description section under details tab on the model\n                   view page"
-  },
-  "oJg/Kk": {
-    "defaultMessage": "— model must call a tool.",
-    "description": "Description of the Required tool choice in the Tools info popover"
   },
   "oKNOju": {
     "defaultMessage": "Conversational tool call efficiency",
@@ -11971,10 +11991,6 @@
     "defaultMessage": "Edit Workspace",
     "description": "Title for edit workspace modal"
   },
-  "um/4MQ": {
-    "defaultMessage": "Add at least one tool definition",
-    "description": "Inline error shown in the Tools card when tool choice is not none but no tool definitions are provided"
-  },
   "umeTwG": {
     "defaultMessage": "Latest",
     "description": "Column title for the column displaying the latest metric values for a metric"
@@ -12426,6 +12442,10 @@
   "x7NsCC": {
     "defaultMessage": "Reasoning",
     "description": "Label for the collapsible reasoning section in chat message"
+  },
+  "x90XmL": {
+    "defaultMessage": "The model must call at least one tool.",
+    "description": "Hint shown under the tool choice selector when Required is selected"
   },
   "xBIlD4": {
     "defaultMessage": "Expectation",
@@ -12934,10 +12954,6 @@
   "ze1m7Z": {
     "defaultMessage": "Run name cannot consist only of whitespace!",
     "description": "An error shown when user sets the run's name to whitespace characters only"
-  },
-  "zehip9": {
-    "defaultMessage": "— never call a tool (default).",
-    "description": "Description of the None tool choice in the Tools info popover"
   },
   "zfpA2q": {
     "defaultMessage": "Source run",


### PR DESCRIPTION
### Related Issues/PRs

Rework of #24065

### What changes are proposed in this pull request?

Restyles the **Settings → Tools** section of the GenAI Playground as the first, structural slice of the Tools UX redesign. The single JSON-string tools model is unchanged — this PR only changes the entry flow and layout:

- **Empty state with an "Add tools" button.** When no tools are configured, the Tools section shows a centered "Add tools" button with helper text ("Provide one or more function definitions in a JSON array for the model to call."). Clicking it reveals the controls.
- **Tool choice selector (Auto / Required).** Dropped `'none'` from the `ToolChoice` type and added a separate `toolsAdded` boolean to track whether the tools block is shown. Submit gating now keys off `toolsAdded` rather than `toolChoice !== 'none'`, so `PlaygroundPage` keeps its existing request/validation semantics.
- **Trash icon to remove tools.** A grey trash icon removes the tools from the request but **keeps the typed JSON** so an accidental click is recoverable.
- **Bordered box + relabel.** Tool choice, the JSON tool definitions input, and the trash icon are grouped in a bordered box mirroring the Parameters section. The textarea label is now "JSON tool definitions" (lowercase, pluralized) to match the "Tool choice" header.
- **Wider Settings drawer:** 420px → 580px.
- Refreshed the Tools tooltip/helper copy and updated the Playground doc accordingly.

Out of scope (later tickets): per-tool cards, the syntax-highlighted JSON editor, function-name/description inputs, templates, save/load, and the full-screen editor.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Updated/extended the `ToolsForm`, `ParametersButton`, `PlaygroundTopBar`, and `PlaygroundPage` Jest suites for the new `toolsAdded` flow (all 15 playground suites pass). Also verified end-to-end in the dev server: empty state → Add tools → Auto/Required + JSON input → trash removes from request while retaining the JSON. `lint`, `prettier:check`, `i18n:check`, and `type-check` all pass.

https://github.com/user-attachments/assets/d2c13caf-51ab-4d9c-9161-801191f57c69

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Redesigned the GenAI Playground's Tools settings: tools are added via an "Add tools" button, with an Auto/Required tool choice selector and a trash control to remove them, in a wider Settings panel.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release