### PR TITLE
Fix Python 3.14 compatibility in skill_installer by using pathlib.Path

### DIFF
--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -8,7 +8,10 @@ which points to the https://github.com/mlflow/skills repository.
 import shutil
 from dataclasses import dataclass
 from importlib import resources
-from importlib.abc import Traversable
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:
+    from importlib.abc import Traversable
 from pathlib import Path
 
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter

--- a/mlflow/assistant/skill_installer.py
+++ b/mlflow/assistant/skill_installer.py
@@ -8,10 +8,6 @@ which points to the https://github.com/mlflow/skills repository.
 import shutil
 from dataclasses import dataclass
 from importlib import resources
-try:
-    from importlib.resources.abc import Traversable
-except ImportError:
-    from importlib.abc import Traversable
 from pathlib import Path
 
 from mlflow.ai_commands.ai_command_utils import parse_frontmatter
@@ -24,7 +20,7 @@ SKILLS_PACKAGE = "mlflow.assistant.skills"
 class BundledSkill:
     name: str
     description: str
-    path: Traversable
+    path: Path
 
 
 def _find_skill_directories(path: Path) -> list[Path]:
@@ -57,7 +53,7 @@ def list_bundled_skills() -> list[BundledSkill]:
             BundledSkill(
                 name=metadata.get("name") or item.name,
                 description=metadata.get("description") or "",
-                path=item,
+                path=Path(item),
             )
         )
     return sorted(skills, key=lambda skill: skill.name)


### PR DESCRIPTION
### Related Issues/PRs

Closes #24080

### What changes are proposed in this pull request?

`mlflow/assistant/skill_installer.py` imported `Traversable` from `importlib.abc`, which Python 3.14 removed. The import failure made the `agent`, `assistant`, and `skills` CLI commands silently disappear, since they are registered under `try/except ImportError: pass` in `mlflow/cli/__init__.py`.

`Traversable` was only used to annotate `BundledSkill.path`. Those values come from `resources.files(...).iterdir()`, which already yields real `pathlib.Path` objects, so this PR annotates the field as `pathlib.Path` and converts explicitly with `Path(item)`. This drops the `importlib.abc` dependency entirely and also avoids the `DeprecationWarning` that `importlib.abc.Traversable` emits on Python 3.12 and 3.13.

### How is this PR tested?

- [x] Existing unit/integration tests

`tests/assistant/test_skill_installer.py` and `tests/cli/test_skills.py` pass. Verified that the `agent`/`assistant`/`skills` CLI commands register and that `BundledSkill.path` resolves the bundled `SKILL.md`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes Python 3.14 compatibility for the MLflow `assistant`/`agent`/`skills` CLI commands, which failed to register because `skill_installer.py` imported `Traversable` from `importlib.abc` (removed in 3.14).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release