### PR TITLE
Increase R client connect-wait default to 30s

### DIFF
--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -114,7 +114,7 @@ mlflow_validate_server <- function(client) {
         max_results = 1
       )
     ),
-    getOption("mlflow.connect.wait", 10),
+    getOption("mlflow.connect.wait", 30),
     getOption("mlflow.connect.sleep", 1)
   )
 }

--- a/mlflow/R/mlflow/tests/testthat/helpers.R
+++ b/mlflow/R/mlflow/tests/testthat/helpers.R
@@ -1,7 +1,3 @@
-# CI runners can be slow to boot a local tracking server; the package default
-# of 10s for mlflow_validate_server times out intermittently.
-options(mlflow.connect.wait = 30)
-
 mlflow_clear_test_dir <- function(path) {
   purrr::safely(mlflow_end_run)()
   mlflow:::mlflow_set_active_experiment_id(NULL)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Raise the `mlflow_validate_server` connect-wait default from 10s to 30s in the R client.

The 10s default times out intermittently in CI when a freshly-spawned local tracking server is slow to boot on a loaded runner (the `R / r` job fails with `Operation failed after waiting for 10 seconds` in the model predict/serve tests).

The test suite already bumped this to 30s via `tests/testthat/helpers.R`, but that override only applies to the main test R session. The failing tests run their MLflow work in child R processes (`mlflow models predict`, `mlflow_rfunc_serve`) that never source `helpers.R` and so fell back to the 10s package default. Raising the package default gives those subprocesses the same headroom; the `helpers.R` override is now redundant and removed.

The change is low-risk: `wait_for` returns as soon as the first poll succeeds, so the happy path is unaffected; only slow cold-starts get more time before failing.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release