### PR TITLE
fix: prevent table already exists error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,8 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use create_all with checkfirst=True to avoid error if tables already exist
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from version 3.7.0 to 3.8.x, the upgrade fails with an error: `Table 'secrets' already exists`. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, which attempts to create all tables unconditionally. If a table already exists from a previous migration, this raises an OperationalError.

## Fix
Added `checkfirst=True` to the `create_all` call. This tells SQLAlchemy to only create tables that don't already exist, preventing the duplicate table error. This is the minimal and safest fix for backward compatibility.

Closes #19943