### PR TITLE
fix(gateway): handle missing finish_reason in openai_compatible streaming

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -118,7 +118,7 @@ class OpenAICompatibleAdapter(ProviderAdapter):
             choices=[
                 chat.StreamChoice(
                     index=c["index"],
-                    finish_reason=c["finish_reason"],
+                    finish_reason=c.get("finish_reason"),
                     delta=chat.StreamDelta(
                         role=c["delta"].get("role"),
                         content=c["delta"].get("content"),

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -204,6 +204,30 @@ async def test_chat_stream():
     result = jsonable_encoder(responses[0])
     assert result["choices"][0]["delta"]["content"] == "Hi"
 
+@pytest.mark.asyncio
+async def test_chat_stream_missing_finish_reason():
+    # Anthropic-compatible upstreams omit finish_reason on intermediate streaming chunks.
+    # model_to_chat_streaming should not raise KeyError when the key is absent.
+    provider = _make_provider()
+    chunk_data = (
+        b'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,'
+        b'"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant",'
+        b'"content":"Hi"}}]}\n\n'
+    )
+    chunks = [chunk_data, b"data: [DONE]\n\n"]
+    mock_client = mock_http_client(MockAsyncStreamingResponse(chunks))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        responses = [chunk async for chunk in provider.chat_stream(payload)]
+
+    assert len(responses) == 1
+    result = jsonable_encoder(responses[0])
+    assert result["choices"][0]["delta"]["content"] == "Hi"
+    assert result["choices"][0]["finish_reason"] is None
+
 
 @pytest.mark.asyncio
 async def test_embeddings():


### PR DESCRIPTION
### Related Issues/PRs

Closes #23139

### What changes are proposed in this pull request?

Some OpenAI-compatible backends omit the `finish_reason` key on intermediate streaming chunks. Anthropic-compatible endpoints, for example, only include `finish_reason` on the final chunk; OpenAI always sends `"finish_reason": null` on every chunk.

`model_to_chat_streaming` in `openai_compatible.py` used `c["finish_reason"]` (dict key access), which raises `KeyError` when the key is entirely absent. The non-streaming path (`model_to_chat`) already uses `c.get("finish_reason")` safely.

**Change:** Replace `c["finish_reason"]` with `c.get("finish_reason")` in `model_to_chat_streaming`, making it consistent with the non-streaming path.

### How is this PR tested?

- [x] New unit/integration tests

New test `test_chat_stream_missing_finish_reason` in `tests/gateway/providers/test_openai_compatible.py` sends a streaming chunk with no `finish_reason` key and asserts the response returns `finish_reason=None` without raising `KeyError`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Streaming chat via the `openai_compatible` AI Gateway provider no longer crashes with `KeyError: 'finish_reason'` when an upstream backend (e.g. Anthropic-compatible endpoint) omits the key on intermediate chunks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this a critical bugfix or security fix that should go into the next patch release?

- [ ] No.