### PR TITLE
fix(openai): use `SpanAttributeKey.CHAT_USAGE` instead of hardcoded `"usage"` key in `_parse_span_data`

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -238,7 +238,7 @@ def _parse_span_data(span_data: oai.SpanData) -> tuple[Any, Any, dict[str, Any]]
         attributes = {
             "model": span_data.model,
             "model_config": span_data.model_config,
-            "usage": span_data.usage,
+            SpanAttributeKey.CHAT_USAGE: span_data.usage,
         }
 
     elif span_data.type == OpenAISpanType.RESPONSE:


### PR DESCRIPTION
### Related Issues/PRs

Closes #24059

### What changes are proposed in this pull request?

In `_parse_span_data()` within `mlflow/openai/_agent_tracer.py`, the GENERATION span branch stores token usage under the plain string key `"usage"`:

```python
attributes = {
    "model": span_data.model,
    "model_config": span_data.model_config,
    "usage": span_data.usage,  # bug: should use SpanAttributeKey.CHAT_USAGE
}
```

However, `aggregate_usage_from_spans()` reads span attributes using `SpanAttributeKey.CHAT_USAGE` (= `"mlflow.chat.tokenUsage"`), not the plain `"usage"` key. This mismatch means token usage from OpenAI Agents SDK GENERATION spans is silently excluded from trace-level token aggregation.

This PR fixes it by using `SpanAttributeKey.CHAT_USAGE` as the attribute key, consistent with how all other span types store usage and how `aggregate_usage_from_spans()` reads it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug where token usage from OpenAI Agents SDK GENERATION spans was silently excluded from trace-level token aggregation because the attribute key `"usage"` didn't match the expected `SpanAttributeKey.CHAT_USAGE` (`"mlflow.chat.tokenUsage"`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release