### PR TITLE
fix: handle table-already-exists error in database initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,14 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    from sqlalchemy.exc import OperationalError
+    try:
+        InitialBase.metadata.create_all(engine, checkfirst=True)
+    except OperationalError as e:
+        if "already exists" in str(e).lower():
+            _logger.warning("Some tables already exist, continuing with upgrade...")
+        else:
+            raise
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
The `mlflow db upgrade` command fails with `pymysql.err.OperationalError: (1050, \"Table 'secrets' already exists\")` when upgrading from MLflow 3.7.0 to 3.8.x. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` which tries to create all tables unconditionally, including the `secrets` table that was already created by a previous partial migration.

## Fix
- Wrap the `create_all` call in a try-except block to catch `OperationalError` exceptions containing "already exists".
- Log a warning and continue with the upgrade instead of failing.
- Ensure `checkfirst=True` is passed (default but explicit is better).

Closes #19943