### PR TITLE
Drop `guardrails-ai` from genai CI until upstream `typer`/`click` pins are lifted

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -328,22 +328,28 @@ jobs:
           # fix for the removed `langchain_community.chat_models.vertexai`
           # import (0.4.2 dropped the shim).
           # https://github.com/vibrantlabsai/ragas/issues/2745
+          #
+          # guardrails-ai is intentionally omitted: it caps typer<0.20 and
+          # click<=8.2.0, which the synced env no longer satisfies, so an
+          # unpinned install backtracks to the ancient 0.1.8 (imports the
+          # removed openai.error). Restore it once upstream lifts the pins.
+          # https://github.com/guardrails-ai/guardrails/issues/1505
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]' guardrails-ai
+            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]'
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |
-          uv run --no-sync pytest tests/genai
+          # guardrails-ai is not installed (see the install step), so skip its
+          # tests to keep collection of the rest of tests/genai from breaking.
+          # https://github.com/guardrails-ai/guardrails/issues/1505
+          uv run --no-sync pytest tests/genai \
+            --ignore tests/genai/scorers/guardrails
 
       - name: Run GenAI Tests (Databricks)
         run: |
-          # google-adk pins opentelemetry-sdk<1.39.0, so the base venv resolves
-          # to 1.38. The --with databricks-agents overlay pulls a newer
-          # opentelemetry-sdk on top, and guardrails-ai's OTLP grpc exporter
-          # (still 1.38 in the venv) tries to import LogData from the overlay
-          # sdk where it no longer exists. The guardrails tests already run in
-          # the OSS step above; skip them here until google-adk relaxes its pin.
+          # guardrails-ai is not installed (see the install step), so skip its
+          # tests here too. https://github.com/guardrails-ai/guardrails/issues/1505
           #
           # test_pytest_integration.py spawns a subprocess pytest from a temp dir,
           # which imports the published mlflow-skinny that databricks-agents pulls


### PR DESCRIPTION
### Related Issues/PRs

Relates to guardrails-ai/guardrails#1505

### What changes are proposed in this pull request?

The `genai` job installs `guardrails-ai` unpinned on top of the synced env. `guardrails-ai==0.10.2` (latest) caps `typer<0.20` and `click<=8.2.0`, but the synced env now resolves `typer==0.26.7` / `click==8.3.3`, so the resolver silently backtracks to the 3-year-old `guardrails-ai==0.1.8`. That version imports the long-removed `openai.error`, raising `AttributeError` and aborting collection of the **entire** `tests/genai` tree.

The upstream fix (guardrails-ai/guardrails#1501, lifts the pins) is not released yet, and `0.10.2` is the latest. So this:

- Removes `guardrails-ai` from the genai install line (it can only resolve to the broken 0.1.8 and drags `trulens` etc. down with it).
- Skips `tests/genai/scorers/guardrails` in the OSS step (Databricks already skipped it).

Restore both once a fixed `guardrails-ai` ships.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)