### PR TITLE
Add infinite scroll and server-side sorting to the review queues sidebar

### DIFF
--- a/mlflow/genai/review_queues/__init__.py
+++ b/mlflow/genai/review_queues/__init__.py
@@ -161,15 +161,21 @@ def list_review_queues(
     experiment_id: str | None = None,
     max_results: int | None = None,
     page_token: str | None = None,
+    order_by: list[str] | None = None,
 ) -> "PagedList[ReviewQueue]":
     """
-    List an experiment's review queues, newest first.
+    List an experiment's review queues.
 
     Args:
         user: If set, return only queues this user is assigned to.
         experiment_id: Parent experiment; defaults to the current experiment.
         max_results: Page size.
         page_token: Continuation token from a previous call.
+        order_by: Sort clauses, each ``"<field> [ASC|DESC]"`` (e.g.
+            ``["name ASC"]``). Supported fields: ``name``, ``created_by``,
+            ``creation_time_ms``. Defaults to ``["creation_time_ms DESC"]``
+            (newest first). A stable tiebreaker is always applied so paging is
+            deterministic.
 
     Returns:
         A :py:class:`PagedList` of :py:class:`ReviewQueue`.
@@ -179,6 +185,7 @@ def list_review_queues(
         user=user,
         max_results=max_results,
         page_token=page_token,
+        order_by=order_by,
     )
 
 

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ReviewQueues.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ReviewQueues.java
@@ -10798,6 +10798,59 @@ public final class ReviewQueues {
      */
     com.google.protobuf.ByteString
         getItemIdBytes();
+
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @return A list containing the orderBy.
+     */
+    java.util.List<java.lang.String>
+        getOrderByList();
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @return The count of orderBy.
+     */
+    int getOrderByCount();
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @param index The index of the element to return.
+     * @return The orderBy at the given index.
+     */
+    java.lang.String getOrderBy(int index);
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the orderBy at the given index.
+     */
+    com.google.protobuf.ByteString
+        getOrderByBytes(int index);
   }
   /**
    * <pre>
@@ -10821,6 +10874,7 @@ public final class ReviewQueues {
       user_ = "";
       pageToken_ = "";
       itemId_ = "";
+      orderBy_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -10883,6 +10937,15 @@ public final class ReviewQueues {
               itemId_ = bs;
               break;
             }
+            case 58: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
+                orderBy_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000020;
+              }
+              orderBy_.add(bs);
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -10898,6 +10961,9 @@ public final class ReviewQueues {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
+          orderBy_ = orderBy_.getUnmodifiableView();
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -12126,6 +12192,69 @@ public final class ReviewQueues {
       }
     }
 
+    public static final int ORDER_BY_FIELD_NUMBER = 7;
+    private com.google.protobuf.LazyStringList orderBy_;
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @return A list containing the orderBy.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getOrderByList() {
+      return orderBy_;
+    }
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @return The count of orderBy.
+     */
+    public int getOrderByCount() {
+      return orderBy_.size();
+    }
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @param index The index of the element to return.
+     * @return The orderBy at the given index.
+     */
+    public java.lang.String getOrderBy(int index) {
+      return orderBy_.get(index);
+    }
+    /**
+     * <pre>
+     * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+     * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+     * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+     * always appended so offset paging is deterministic.
+     * </pre>
+     *
+     * <code>repeated string order_by = 7;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the orderBy at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getOrderByBytes(int index) {
+      return orderBy_.getByteString(index);
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -12155,6 +12284,9 @@ public final class ReviewQueues {
       if (((bitField0_ & 0x00000010) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 6, itemId_);
       }
+      for (int i = 0; i < orderBy_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 7, orderBy_.getRaw(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -12179,6 +12311,14 @@ public final class ReviewQueues {
       }
       if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, itemId_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < orderBy_.size(); i++) {
+          dataSize += computeStringSizeNoTag(orderBy_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getOrderByList().size();
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -12220,6 +12360,8 @@ public final class ReviewQueues {
         if (!getItemId()
             .equals(other.getItemId())) return false;
       }
+      if (!getOrderByList()
+          .equals(other.getOrderByList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -12250,6 +12392,10 @@ public final class ReviewQueues {
       if (hasItemId()) {
         hash = (37 * hash) + ITEM_ID_FIELD_NUMBER;
         hash = (53 * hash) + getItemId().hashCode();
+      }
+      if (getOrderByCount() > 0) {
+        hash = (37 * hash) + ORDER_BY_FIELD_NUMBER;
+        hash = (53 * hash) + getOrderByList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -12399,6 +12545,8 @@ public final class ReviewQueues {
         bitField0_ = (bitField0_ & ~0x00000008);
         itemId_ = "";
         bitField0_ = (bitField0_ & ~0x00000010);
+        orderBy_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -12447,6 +12595,11 @@ public final class ReviewQueues {
           to_bitField0_ |= 0x00000010;
         }
         result.itemId_ = itemId_;
+        if (((bitField0_ & 0x00000020) != 0)) {
+          orderBy_ = orderBy_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000020);
+        }
+        result.orderBy_ = orderBy_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -12517,6 +12670,16 @@ public final class ReviewQueues {
         if (other.hasItemId()) {
           bitField0_ |= 0x00000010;
           itemId_ = other.itemId_;
+          onChanged();
+        }
+        if (!other.orderBy_.isEmpty()) {
+          if (orderBy_.isEmpty()) {
+            orderBy_ = other.orderBy_;
+            bitField0_ = (bitField0_ & ~0x00000020);
+          } else {
+            ensureOrderByIsMutable();
+            orderBy_.addAll(other.orderBy_);
+          }
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -12962,6 +13125,178 @@ public final class ReviewQueues {
   }
   bitField0_ |= 0x00000010;
         itemId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList orderBy_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureOrderByIsMutable() {
+        if (!((bitField0_ & 0x00000020) != 0)) {
+          orderBy_ = new com.google.protobuf.LazyStringArrayList(orderBy_);
+          bitField0_ |= 0x00000020;
+         }
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @return A list containing the orderBy.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getOrderByList() {
+        return orderBy_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @return The count of orderBy.
+       */
+      public int getOrderByCount() {
+        return orderBy_.size();
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @param index The index of the element to return.
+       * @return The orderBy at the given index.
+       */
+      public java.lang.String getOrderBy(int index) {
+        return orderBy_.get(index);
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the orderBy at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getOrderByBytes(int index) {
+        return orderBy_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @param index The index to set the value at.
+       * @param value The orderBy to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrderBy(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureOrderByIsMutable();
+        orderBy_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @param value The orderBy to add.
+       * @return This builder for chaining.
+       */
+      public Builder addOrderBy(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureOrderByIsMutable();
+        orderBy_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @param values The orderBy to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllOrderBy(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureOrderByIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, orderBy_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOrderBy() {
+        orderBy_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000020);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Sort order, as `"&lt;field&gt; [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+       * fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+       * `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+       * always appended so offset paging is deterministic.
+       * </pre>
+       *
+       * <code>repeated string order_by = 7;</code>
+       * @param value The bytes of the orderBy to add.
+       * @return This builder for chaining.
+       */
+      public Builder addOrderByBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureOrderByIsMutable();
+        orderBy_.add(value);
         onChanged();
         return this;
       }
@@ -23207,53 +23542,53 @@ public final class ReviewQueues {
       "id\030\001 \001(\tB\004\370\206\031\001\022\022\n\004name\030\002 \001(\tB\004\370\206\031\001\032C\n\010Re" +
       "sponse\0227\n\014review_queue\030\001 \001(\0132!.mlflow.re" +
       "view_queues.ReviewQueue:+\342?(\n&com.databr" +
-      "icks.rpc.RPC[$this.Response]\"\231\002\n\020ListRev" +
+      "icks.rpc.RPC[$this.Response]\"\253\002\n\020ListRev" +
       "iewQueues\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\022\014" +
       "\n\004user\030\002 \001(\t\022\023\n\013max_results\030\003 \001(\005\022\022\n\npag" +
-      "e_token\030\004 \001(\t\022\017\n\007item_id\030\006 \001(\t\032]\n\010Respon" +
-      "se\0228\n\rreview_queues\030\001 \003(\0132!.mlflow.revie" +
-      "w_queues.ReviewQueue\022\027\n\017next_page_token\030" +
-      "\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$this" +
-      ".Response]J\004\010\005\020\006R\016ensure_default\"\222\002\n\021Upd" +
-      "ateReviewQueue\022\026\n\010queue_id\030\001 \001(\tB\004\370\206\031\001\022\024" +
-      "\n\014update_users\030\002 \001(\010\022\r\n\005users\030\003 \003(\t\022\031\n\021u" +
-      "pdate_schema_ids\030\004 \001(\010\022\022\n\nschema_ids\030\005 \003" +
-      "(\t\022\014\n\004name\030\006 \001(\t\022\021\n\tnew_owner\030\007 \001(\t\032C\n\010R" +
-      "esponse\0227\n\014review_queue\030\001 \001(\0132!.mlflow.r" +
-      "eview_queues.ReviewQueue:+\342?(\n&com.datab" +
-      "ricks.rpc.RPC[$this.Response]\"d\n\021DeleteR" +
-      "eviewQueue\022\026\n\010queue_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Re" +
-      "sponse:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]\"\351\001\n\025AddItemsToReviewQueue\022\026\n" +
-      "\010queue_id\030\001 \001(\tB\004\370\206\031\001\0227\n\titem_type\030\002 \001(\016" +
-      "2$.mlflow.review_queues.ReviewItemType\022\020" +
-      "\n\010item_ids\030\003 \003(\t\032@\n\010Response\0224\n\005items\030\001 " +
+      "e_token\030\004 \001(\t\022\017\n\007item_id\030\006 \001(\t\022\020\n\010order_" +
+      "by\030\007 \003(\t\032]\n\010Response\0228\n\rreview_queues\030\001 " +
+      "\003(\0132!.mlflow.review_queues.ReviewQueue\022\027" +
+      "\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.databr" +
+      "icks.rpc.RPC[$this.Response]J\004\010\005\020\006R\016ensu" +
+      "re_default\"\222\002\n\021UpdateReviewQueue\022\026\n\010queu" +
+      "e_id\030\001 \001(\tB\004\370\206\031\001\022\024\n\014update_users\030\002 \001(\010\022\r" +
+      "\n\005users\030\003 \003(\t\022\031\n\021update_schema_ids\030\004 \001(\010" +
+      "\022\022\n\nschema_ids\030\005 \003(\t\022\014\n\004name\030\006 \001(\t\022\021\n\tne" +
+      "w_owner\030\007 \001(\t\032C\n\010Response\0227\n\014review_queu" +
+      "e\030\001 \001(\0132!.mlflow.review_queues.ReviewQue" +
+      "ue:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
+      "sponse]\"d\n\021DeleteReviewQueue\022\026\n\010queue_id" +
+      "\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.datab" +
+      "ricks.rpc.RPC[$this.Response]\"\351\001\n\025AddIte" +
+      "msToReviewQueue\022\026\n\010queue_id\030\001 \001(\tB\004\370\206\031\001\022" +
+      "7\n\titem_type\030\002 \001(\0162$.mlflow.review_queue" +
+      "s.ReviewItemType\022\020\n\010item_ids\030\003 \003(\t\032@\n\010Re" +
+      "sponse\0224\n\005items\030\001 \003(\0132%.mlflow.review_qu" +
+      "eues.ReviewQueueItem:+\342?(\n&com.databrick" +
+      "s.rpc.RPC[$this.Response]\"\177\n\032RemoveItems" +
+      "FromReviewQueue\022\026\n\010queue_id\030\001 \001(\tB\004\370\206\031\001\022" +
+      "\020\n\010item_ids\030\002 \003(\t\032\n\n\010Response:+\342?(\n&com." +
+      "databricks.rpc.RPC[$this.Response]\"\223\002\n\024L" +
+      "istReviewQueueItems\022\026\n\010queue_id\030\001 \001(\tB\004\370" +
+      "\206\031\001\0222\n\006status\030\002 \001(\0162\".mlflow.review_queu" +
+      "es.ReviewStatus\022\023\n\013max_results\030\003 \001(\005\022\022\n\n" +
+      "page_token\030\004 \001(\t\032Y\n\010Response\0224\n\005items\030\001 " +
       "\003(\0132%.mlflow.review_queues.ReviewQueueIt" +
-      "em:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\"\177\n\032RemoveItemsFromReviewQueue\022\026\n" +
-      "\010queue_id\030\001 \001(\tB\004\370\206\031\001\022\020\n\010item_ids\030\002 \003(\t\032" +
-      "\n\n\010Response:+\342?(\n&com.databricks.rpc.RPC" +
-      "[$this.Response]\"\223\002\n\024ListReviewQueueItem" +
-      "s\022\026\n\010queue_id\030\001 \001(\tB\004\370\206\031\001\0222\n\006status\030\002 \001(" +
-      "\0162\".mlflow.review_queues.ReviewStatus\022\023\n" +
-      "\013max_results\030\003 \001(\005\022\022\n\npage_token\030\004 \001(\t\032Y" +
-      "\n\010Response\0224\n\005items\030\001 \003(\0132%.mlflow.revie" +
-      "w_queues.ReviewQueueItem\022\027\n\017next_page_to" +
-      "ken\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"\207\002\n\030SetReviewQueueItemSta" +
-      "tus\022\026\n\010queue_id\030\001 \001(\tB\004\370\206\031\001\022\025\n\007item_id\030\002" +
-      " \001(\tB\004\370\206\031\001\0228\n\006status\030\003 \001(\0162\".mlflow.revi" +
-      "ew_queues.ReviewStatusB\004\370\206\031\001\022\024\n\014complete" +
-      "d_by\030\004 \001(\t\032?\n\010Response\0223\n\004item\030\001 \001(\0132%.m" +
-      "lflow.review_queues.ReviewQueueItem:+\342?(" +
-      "\n&com.databricks.rpc.RPC[$this.Response]" +
-      "*=\n\016ReviewItemType\022 \n\034REVIEW_ITEM_TYPE_U" +
-      "NSPECIFIED\020\000\022\t\n\005TRACE\020\001*J\n\017ReviewQueueTy" +
-      "pe\022!\n\035REVIEW_QUEUE_TYPE_UNSPECIFIED\020\000\022\010\n" +
-      "\004USER\020\001\022\n\n\006CUSTOM\020\002*V\n\014ReviewStatus\022\035\n\031R" +
-      "EVIEW_STATUS_UNSPECIFIED\020\000\022\013\n\007PENDING\020\001\022" +
-      "\014\n\010COMPLETE\020\002\022\014\n\010DECLINED\020\003B\031\n\024org.mlflo" +
-      "w.api.proto\220\001\001"
+      "em\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"\207\002\n\030Set" +
+      "ReviewQueueItemStatus\022\026\n\010queue_id\030\001 \001(\tB" +
+      "\004\370\206\031\001\022\025\n\007item_id\030\002 \001(\tB\004\370\206\031\001\0228\n\006status\030\003" +
+      " \001(\0162\".mlflow.review_queues.ReviewStatus" +
+      "B\004\370\206\031\001\022\024\n\014completed_by\030\004 \001(\t\032?\n\010Response" +
+      "\0223\n\004item\030\001 \001(\0132%.mlflow.review_queues.Re" +
+      "viewQueueItem:+\342?(\n&com.databricks.rpc.R" +
+      "PC[$this.Response]*=\n\016ReviewItemType\022 \n\034" +
+      "REVIEW_ITEM_TYPE_UNSPECIFIED\020\000\022\t\n\005TRACE\020" +
+      "\001*J\n\017ReviewQueueType\022!\n\035REVIEW_QUEUE_TYP" +
+      "E_UNSPECIFIED\020\000\022\010\n\004USER\020\001\022\n\n\006CUSTOM\020\002*V\n" +
+      "\014ReviewStatus\022\035\n\031REVIEW_STATUS_UNSPECIFI" +
+      "ED\020\000\022\013\n\007PENDING\020\001\022\014\n\010COMPLETE\020\002\022\014\n\010DECLI" +
+      "NED\020\003B\031\n\024org.mlflow.api.proto\220\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -23326,7 +23661,7 @@ public final class ReviewQueues {
     internal_static_mlflow_review_queues_ListReviewQueues_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_review_queues_ListReviewQueues_descriptor,
-        new java.lang.String[] { "ExperimentId", "User", "MaxResults", "PageToken", "ItemId", });
+        new java.lang.String[] { "ExperimentId", "User", "MaxResults", "PageToken", "ItemId", "OrderBy", });
     internal_static_mlflow_review_queues_ListReviewQueues_Response_descriptor =
       internal_static_mlflow_review_queues_ListReviewQueues_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_review_queues_ListReviewQueues_Response_fieldAccessorTable = new

--- a/mlflow/protos/review_queues.proto
+++ b/mlflow/protos/review_queues.proto
@@ -165,6 +165,12 @@ message ListReviewQueues {
   // which queues a trace is already a member of.
   optional string item_id = 6;
 
+  // Sort order, as `"<field> [ASC|DESC]"` clauses (e.g. `"name ASC"`). Supported
+  // fields: `name`, `created_by`, `creation_time_ms`. Defaults to
+  // `"creation_time_ms DESC"` (newest first). A stable `queue_id` tiebreaker is
+  // always appended so offset paging is deterministic.
+  repeated string order_by = 7;
+
   // Field 5 was `ensure_default` (no-auth default-queue seeding); removed with
   // the default queue. The no-auth catch-all is the reserved `default` USER
   // queue, seeded via GetOrCreateUserQueue.

--- a/mlflow/protos/review_queues_pb2.py
+++ b/mlflow/protos/review_queues_pb2.py
@@ -20,7 +20,7 @@ if Version(google.protobuf.__version__).major >= 5:
   from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13review_queues.proto\x12\x14mlflow.review_queues\x1a\x10\x64\x61tabricks.proto\x1a\x15scalapb/scalapb.proto\"\xff\x01\n\x0bReviewQueue\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x39\n\nqueue_type\x18\x04 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueType\x12\x12\n\ncreated_by\x18\x05 \x01(\t\x12\x18\n\x10\x63reation_time_ms\x18\x06 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x07 \x01(\x03\x12\r\n\x05users\x18\x08 \x03(\t\x12\x12\n\nschema_ids\x18\t \x03(\tJ\x04\x08\n\x10\x0bR\nis_default\"\x89\x02\n\x0fReviewQueueItem\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x0f\n\x07item_id\x18\x03 \x01(\t\x12\x32\n\x06status\x18\x04 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x14\n\x0c\x63ompleted_by\x18\x05 \x01(\t\x12\x19\n\x11\x63ompleted_time_ms\x18\x06 \x01(\x03\x12\x18\n\x10\x63reation_time_ms\x18\x07 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x08 \x01(\x03\"\xae\x02\n\x11\x43reateReviewQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12?\n\nqueue_type\x18\x03 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueTypeB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x04 \x01(\t\x12\r\n\x05users\x18\x05 \x03(\t\x12\x12\n\nschema_ids\x18\x06 \x03(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xcd\x01\n\x14GetOrCreateUserQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04user\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x03 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9a\x01\n\x0eGetReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb9\x01\n\x14GetReviewQueueByName\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x99\x02\n\x10ListReviewQueues\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x0f\n\x07item_id\x18\x06 \x01(\t\x1a]\n\x08Response\x12\x38\n\rreview_queues\x18\x01 \x03(\x0b\x32!.mlflow.review_queues.ReviewQueue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]J\x04\x08\x05\x10\x06R\x0e\x65nsure_default\"\x92\x02\n\x11UpdateReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x0cupdate_users\x18\x02 \x01(\x08\x12\r\n\x05users\x18\x03 \x03(\t\x12\x19\n\x11update_schema_ids\x18\x04 \x01(\x08\x12\x12\n\nschema_ids\x18\x05 \x03(\t\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x11\n\tnew_owner\x18\x07 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x11\x44\x65leteReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe9\x01\n\x15\x41\x64\x64ItemsToReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x10\n\x08item_ids\x18\x03 \x03(\t\x1a@\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x7f\n\x1aRemoveItemsFromReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08item_ids\x18\x02 \x03(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x93\x02\n\x14ListReviewQueueItems\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x32\n\x06status\x18\x02 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aY\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x87\x02\n\x18SetReviewQueueItemStatus\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07item_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x06status\x18\x03 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatusB\x04\xf8\x86\x19\x01\x12\x14\n\x0c\x63ompleted_by\x18\x04 \x01(\t\x1a?\n\x08Response\x12\x33\n\x04item\x18\x01 \x01(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*=\n\x0eReviewItemType\x12 \n\x1cREVIEW_ITEM_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05TRACE\x10\x01*J\n\x0fReviewQueueType\x12!\n\x1dREVIEW_QUEUE_TYPE_UNSPECIFIED\x10\x00\x12\x08\n\x04USER\x10\x01\x12\n\n\x06\x43USTOM\x10\x02*V\n\x0cReviewStatus\x12\x1d\n\x19REVIEW_STATUS_UNSPECIFIED\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0c\n\x08\x43OMPLETE\x10\x02\x12\x0c\n\x08\x44\x45\x43LINED\x10\x03\x42\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13review_queues.proto\x12\x14mlflow.review_queues\x1a\x10\x64\x61tabricks.proto\x1a\x15scalapb/scalapb.proto\"\xff\x01\n\x0bReviewQueue\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x39\n\nqueue_type\x18\x04 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueType\x12\x12\n\ncreated_by\x18\x05 \x01(\t\x12\x18\n\x10\x63reation_time_ms\x18\x06 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x07 \x01(\x03\x12\r\n\x05users\x18\x08 \x03(\t\x12\x12\n\nschema_ids\x18\t \x03(\tJ\x04\x08\n\x10\x0bR\nis_default\"\x89\x02\n\x0fReviewQueueItem\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x0f\n\x07item_id\x18\x03 \x01(\t\x12\x32\n\x06status\x18\x04 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x14\n\x0c\x63ompleted_by\x18\x05 \x01(\t\x12\x19\n\x11\x63ompleted_time_ms\x18\x06 \x01(\x03\x12\x18\n\x10\x63reation_time_ms\x18\x07 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x08 \x01(\x03\"\xae\x02\n\x11\x43reateReviewQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12?\n\nqueue_type\x18\x03 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueTypeB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x04 \x01(\t\x12\r\n\x05users\x18\x05 \x03(\t\x12\x12\n\nschema_ids\x18\x06 \x03(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xcd\x01\n\x14GetOrCreateUserQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04user\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x03 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9a\x01\n\x0eGetReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb9\x01\n\x14GetReviewQueueByName\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x02\n\x10ListReviewQueues\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x0f\n\x07item_id\x18\x06 \x01(\t\x12\x10\n\x08order_by\x18\x07 \x03(\t\x1a]\n\x08Response\x12\x38\n\rreview_queues\x18\x01 \x03(\x0b\x32!.mlflow.review_queues.ReviewQueue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]J\x04\x08\x05\x10\x06R\x0e\x65nsure_default\"\x92\x02\n\x11UpdateReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x0cupdate_users\x18\x02 \x01(\x08\x12\r\n\x05users\x18\x03 \x03(\t\x12\x19\n\x11update_schema_ids\x18\x04 \x01(\x08\x12\x12\n\nschema_ids\x18\x05 \x03(\t\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x11\n\tnew_owner\x18\x07 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x11\x44\x65leteReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe9\x01\n\x15\x41\x64\x64ItemsToReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x10\n\x08item_ids\x18\x03 \x03(\t\x1a@\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x7f\n\x1aRemoveItemsFromReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08item_ids\x18\x02 \x03(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x93\x02\n\x14ListReviewQueueItems\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x32\n\x06status\x18\x02 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aY\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x87\x02\n\x18SetReviewQueueItemStatus\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07item_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x06status\x18\x03 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatusB\x04\xf8\x86\x19\x01\x12\x14\n\x0c\x63ompleted_by\x18\x04 \x01(\t\x1a?\n\x08Response\x12\x33\n\x04item\x18\x01 \x01(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*=\n\x0eReviewItemType\x12 \n\x1cREVIEW_ITEM_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05TRACE\x10\x01*J\n\x0fReviewQueueType\x12!\n\x1dREVIEW_QUEUE_TYPE_UNSPECIFIED\x10\x00\x12\x08\n\x04USER\x10\x01\x12\n\n\x06\x43USTOM\x10\x02*V\n\x0cReviewStatus\x12\x1d\n\x19REVIEW_STATUS_UNSPECIFIED\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0c\n\x08\x43OMPLETE\x10\x02\x12\x0c\n\x08\x44\x45\x43LINED\x10\x03\x42\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
 
   _globals = globals()
   _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -84,12 +84,12 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_SETREVIEWQUEUEITEMSTATUS'].fields_by_name['status']._serialized_options = b'\370\206\031\001'
     _globals['_SETREVIEWQUEUEITEMSTATUS']._loaded_options = None
     _globals['_SETREVIEWQUEUEITEMSTATUS']._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
-    _globals['_REVIEWITEMTYPE']._serialized_start=3042
-    _globals['_REVIEWITEMTYPE']._serialized_end=3103
-    _globals['_REVIEWQUEUETYPE']._serialized_start=3105
-    _globals['_REVIEWQUEUETYPE']._serialized_end=3179
-    _globals['_REVIEWSTATUS']._serialized_start=3181
-    _globals['_REVIEWSTATUS']._serialized_end=3267
+    _globals['_REVIEWITEMTYPE']._serialized_start=3060
+    _globals['_REVIEWITEMTYPE']._serialized_end=3121
+    _globals['_REVIEWQUEUETYPE']._serialized_start=3123
+    _globals['_REVIEWQUEUETYPE']._serialized_end=3197
+    _globals['_REVIEWSTATUS']._serialized_start=3199
+    _globals['_REVIEWSTATUS']._serialized_end=3285
     _globals['_REVIEWQUEUE']._serialized_start=87
     _globals['_REVIEWQUEUE']._serialized_end=342
     _globals['_REVIEWQUEUEITEM']._serialized_start=345
@@ -111,33 +111,33 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_GETREVIEWQUEUEBYNAME_RESPONSE']._serialized_start=803
     _globals['_GETREVIEWQUEUEBYNAME_RESPONSE']._serialized_end=870
     _globals['_LISTREVIEWQUEUES']._serialized_start=1471
-    _globals['_LISTREVIEWQUEUES']._serialized_end=1752
-    _globals['_LISTREVIEWQUEUES_RESPONSE']._serialized_start=1592
-    _globals['_LISTREVIEWQUEUES_RESPONSE']._serialized_end=1685
-    _globals['_UPDATEREVIEWQUEUE']._serialized_start=1755
-    _globals['_UPDATEREVIEWQUEUE']._serialized_end=2029
+    _globals['_LISTREVIEWQUEUES']._serialized_end=1770
+    _globals['_LISTREVIEWQUEUES_RESPONSE']._serialized_start=1610
+    _globals['_LISTREVIEWQUEUES_RESPONSE']._serialized_end=1703
+    _globals['_UPDATEREVIEWQUEUE']._serialized_start=1773
+    _globals['_UPDATEREVIEWQUEUE']._serialized_end=2047
     _globals['_UPDATEREVIEWQUEUE_RESPONSE']._serialized_start=803
     _globals['_UPDATEREVIEWQUEUE_RESPONSE']._serialized_end=870
-    _globals['_DELETEREVIEWQUEUE']._serialized_start=2031
-    _globals['_DELETEREVIEWQUEUE']._serialized_end=2131
+    _globals['_DELETEREVIEWQUEUE']._serialized_start=2049
+    _globals['_DELETEREVIEWQUEUE']._serialized_end=2149
     _globals['_DELETEREVIEWQUEUE_RESPONSE']._serialized_start=803
     _globals['_DELETEREVIEWQUEUE_RESPONSE']._serialized_end=813
-    _globals['_ADDITEMSTOREVIEWQUEUE']._serialized_start=2134
-    _globals['_ADDITEMSTOREVIEWQUEUE']._serialized_end=2367
-    _globals['_ADDITEMSTOREVIEWQUEUE_RESPONSE']._serialized_start=2258
-    _globals['_ADDITEMSTOREVIEWQUEUE_RESPONSE']._serialized_end=2322
-    _globals['_REMOVEITEMSFROMREVIEWQUEUE']._serialized_start=2369
-    _globals['_REMOVEITEMSFROMREVIEWQUEUE']._serialized_end=2496
+    _globals['_ADDITEMSTOREVIEWQUEUE']._serialized_start=2152
+    _globals['_ADDITEMSTOREVIEWQUEUE']._serialized_end=2385
+    _globals['_ADDITEMSTOREVIEWQUEUE_RESPONSE']._serialized_start=2276
+    _globals['_ADDITEMSTOREVIEWQUEUE_RESPONSE']._serialized_end=2340
+    _globals['_REMOVEITEMSFROMREVIEWQUEUE']._serialized_start=2387
+    _globals['_REMOVEITEMSFROMREVIEWQUEUE']._serialized_end=2514
     _globals['_REMOVEITEMSFROMREVIEWQUEUE_RESPONSE']._serialized_start=803
     _globals['_REMOVEITEMSFROMREVIEWQUEUE_RESPONSE']._serialized_end=813
-    _globals['_LISTREVIEWQUEUEITEMS']._serialized_start=2499
-    _globals['_LISTREVIEWQUEUEITEMS']._serialized_end=2774
-    _globals['_LISTREVIEWQUEUEITEMS_RESPONSE']._serialized_start=2640
-    _globals['_LISTREVIEWQUEUEITEMS_RESPONSE']._serialized_end=2729
-    _globals['_SETREVIEWQUEUEITEMSTATUS']._serialized_start=2777
-    _globals['_SETREVIEWQUEUEITEMSTATUS']._serialized_end=3040
-    _globals['_SETREVIEWQUEUEITEMSTATUS_RESPONSE']._serialized_start=2932
-    _globals['_SETREVIEWQUEUEITEMSTATUS_RESPONSE']._serialized_end=2995
+    _globals['_LISTREVIEWQUEUEITEMS']._serialized_start=2517
+    _globals['_LISTREVIEWQUEUEITEMS']._serialized_end=2792
+    _globals['_LISTREVIEWQUEUEITEMS_RESPONSE']._serialized_start=2658
+    _globals['_LISTREVIEWQUEUEITEMS_RESPONSE']._serialized_end=2747
+    _globals['_SETREVIEWQUEUEITEMSTATUS']._serialized_start=2795
+    _globals['_SETREVIEWQUEUEITEMSTATUS']._serialized_end=3058
+    _globals['_SETREVIEWQUEUEITEMSTATUS_RESPONSE']._serialized_start=2950
+    _globals['_SETREVIEWQUEUEITEMSTATUS_RESPONSE']._serialized_end=3013
   # @@protoc_insertion_point(module_scope)
 
 else:
@@ -160,7 +160,7 @@ else:
   from .scalapb import scalapb_pb2 as scalapb_dot_scalapb__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13review_queues.proto\x12\x14mlflow.review_queues\x1a\x10\x64\x61tabricks.proto\x1a\x15scalapb/scalapb.proto\"\xff\x01\n\x0bReviewQueue\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x39\n\nqueue_type\x18\x04 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueType\x12\x12\n\ncreated_by\x18\x05 \x01(\t\x12\x18\n\x10\x63reation_time_ms\x18\x06 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x07 \x01(\x03\x12\r\n\x05users\x18\x08 \x03(\t\x12\x12\n\nschema_ids\x18\t \x03(\tJ\x04\x08\n\x10\x0bR\nis_default\"\x89\x02\n\x0fReviewQueueItem\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x0f\n\x07item_id\x18\x03 \x01(\t\x12\x32\n\x06status\x18\x04 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x14\n\x0c\x63ompleted_by\x18\x05 \x01(\t\x12\x19\n\x11\x63ompleted_time_ms\x18\x06 \x01(\x03\x12\x18\n\x10\x63reation_time_ms\x18\x07 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x08 \x01(\x03\"\xae\x02\n\x11\x43reateReviewQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12?\n\nqueue_type\x18\x03 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueTypeB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x04 \x01(\t\x12\r\n\x05users\x18\x05 \x03(\t\x12\x12\n\nschema_ids\x18\x06 \x03(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xcd\x01\n\x14GetOrCreateUserQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04user\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x03 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9a\x01\n\x0eGetReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb9\x01\n\x14GetReviewQueueByName\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x99\x02\n\x10ListReviewQueues\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x0f\n\x07item_id\x18\x06 \x01(\t\x1a]\n\x08Response\x12\x38\n\rreview_queues\x18\x01 \x03(\x0b\x32!.mlflow.review_queues.ReviewQueue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]J\x04\x08\x05\x10\x06R\x0e\x65nsure_default\"\x92\x02\n\x11UpdateReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x0cupdate_users\x18\x02 \x01(\x08\x12\r\n\x05users\x18\x03 \x03(\t\x12\x19\n\x11update_schema_ids\x18\x04 \x01(\x08\x12\x12\n\nschema_ids\x18\x05 \x03(\t\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x11\n\tnew_owner\x18\x07 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x11\x44\x65leteReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe9\x01\n\x15\x41\x64\x64ItemsToReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x10\n\x08item_ids\x18\x03 \x03(\t\x1a@\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x7f\n\x1aRemoveItemsFromReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08item_ids\x18\x02 \x03(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x93\x02\n\x14ListReviewQueueItems\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x32\n\x06status\x18\x02 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aY\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x87\x02\n\x18SetReviewQueueItemStatus\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07item_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x06status\x18\x03 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatusB\x04\xf8\x86\x19\x01\x12\x14\n\x0c\x63ompleted_by\x18\x04 \x01(\t\x1a?\n\x08Response\x12\x33\n\x04item\x18\x01 \x01(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*=\n\x0eReviewItemType\x12 \n\x1cREVIEW_ITEM_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05TRACE\x10\x01*J\n\x0fReviewQueueType\x12!\n\x1dREVIEW_QUEUE_TYPE_UNSPECIFIED\x10\x00\x12\x08\n\x04USER\x10\x01\x12\n\n\x06\x43USTOM\x10\x02*V\n\x0cReviewStatus\x12\x1d\n\x19REVIEW_STATUS_UNSPECIFIED\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0c\n\x08\x43OMPLETE\x10\x02\x12\x0c\n\x08\x44\x45\x43LINED\x10\x03\x42\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13review_queues.proto\x12\x14mlflow.review_queues\x1a\x10\x64\x61tabricks.proto\x1a\x15scalapb/scalapb.proto\"\xff\x01\n\x0bReviewQueue\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x39\n\nqueue_type\x18\x04 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueType\x12\x12\n\ncreated_by\x18\x05 \x01(\t\x12\x18\n\x10\x63reation_time_ms\x18\x06 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x07 \x01(\x03\x12\r\n\x05users\x18\x08 \x03(\t\x12\x12\n\nschema_ids\x18\t \x03(\tJ\x04\x08\n\x10\x0bR\nis_default\"\x89\x02\n\x0fReviewQueueItem\x12\x10\n\x08queue_id\x18\x01 \x01(\t\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x0f\n\x07item_id\x18\x03 \x01(\t\x12\x32\n\x06status\x18\x04 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x14\n\x0c\x63ompleted_by\x18\x05 \x01(\t\x12\x19\n\x11\x63ompleted_time_ms\x18\x06 \x01(\x03\x12\x18\n\x10\x63reation_time_ms\x18\x07 \x01(\x03\x12\x1b\n\x13last_update_time_ms\x18\x08 \x01(\x03\"\xae\x02\n\x11\x43reateReviewQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12?\n\nqueue_type\x18\x03 \x01(\x0e\x32%.mlflow.review_queues.ReviewQueueTypeB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x04 \x01(\t\x12\r\n\x05users\x18\x05 \x03(\t\x12\x12\n\nschema_ids\x18\x06 \x03(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xcd\x01\n\x14GetOrCreateUserQueue\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04user\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\ncreated_by\x18\x03 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9a\x01\n\x0eGetReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb9\x01\n\x14GetReviewQueueByName\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x02\n\x10ListReviewQueues\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x12\x0f\n\x07item_id\x18\x06 \x01(\t\x12\x10\n\x08order_by\x18\x07 \x03(\t\x1a]\n\x08Response\x12\x38\n\rreview_queues\x18\x01 \x03(\x0b\x32!.mlflow.review_queues.ReviewQueue\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]J\x04\x08\x05\x10\x06R\x0e\x65nsure_default\"\x92\x02\n\x11UpdateReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x0cupdate_users\x18\x02 \x01(\x08\x12\r\n\x05users\x18\x03 \x03(\t\x12\x19\n\x11update_schema_ids\x18\x04 \x01(\x08\x12\x12\n\nschema_ids\x18\x05 \x03(\t\x12\x0c\n\x04name\x18\x06 \x01(\t\x12\x11\n\tnew_owner\x18\x07 \x01(\t\x1a\x43\n\x08Response\x12\x37\n\x0creview_queue\x18\x01 \x01(\x0b\x32!.mlflow.review_queues.ReviewQueue:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x11\x44\x65leteReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe9\x01\n\x15\x41\x64\x64ItemsToReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x37\n\titem_type\x18\x02 \x01(\x0e\x32$.mlflow.review_queues.ReviewItemType\x12\x10\n\x08item_ids\x18\x03 \x03(\t\x1a@\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x7f\n\x1aRemoveItemsFromReviewQueue\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08item_ids\x18\x02 \x03(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x93\x02\n\x14ListReviewQueueItems\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x32\n\x06status\x18\x02 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatus\x12\x13\n\x0bmax_results\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aY\n\x08Response\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.mlflow.review_queues.ReviewQueueItem\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x87\x02\n\x18SetReviewQueueItemStatus\x12\x16\n\x08queue_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07item_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x38\n\x06status\x18\x03 \x01(\x0e\x32\".mlflow.review_queues.ReviewStatusB\x04\xf8\x86\x19\x01\x12\x14\n\x0c\x63ompleted_by\x18\x04 \x01(\t\x1a?\n\x08Response\x12\x33\n\x04item\x18\x01 \x01(\x0b\x32%.mlflow.review_queues.ReviewQueueItem:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*=\n\x0eReviewItemType\x12 \n\x1cREVIEW_ITEM_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05TRACE\x10\x01*J\n\x0fReviewQueueType\x12!\n\x1dREVIEW_QUEUE_TYPE_UNSPECIFIED\x10\x00\x12\x08\n\x04USER\x10\x01\x12\n\n\x06\x43USTOM\x10\x02*V\n\x0cReviewStatus\x12\x1d\n\x19REVIEW_STATUS_UNSPECIFIED\x10\x00\x12\x0b\n\x07PENDING\x10\x01\x12\x0c\n\x08\x43OMPLETE\x10\x02\x12\x0c\n\x08\x44\x45\x43LINED\x10\x03\x42\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
 
   _REVIEWITEMTYPE = DESCRIPTOR.enum_types_by_name['ReviewItemType']
   ReviewItemType = enum_type_wrapper.EnumTypeWrapper(_REVIEWITEMTYPE)
@@ -442,12 +442,12 @@ else:
     _SETREVIEWQUEUEITEMSTATUS.fields_by_name['status']._serialized_options = b'\370\206\031\001'
     _SETREVIEWQUEUEITEMSTATUS._options = None
     _SETREVIEWQUEUEITEMSTATUS._serialized_options = b'\342?(\n&com.databricks.rpc.RPC[$this.Response]'
-    _REVIEWITEMTYPE._serialized_start=3042
-    _REVIEWITEMTYPE._serialized_end=3103
-    _REVIEWQUEUETYPE._serialized_start=3105
-    _REVIEWQUEUETYPE._serialized_end=3179
-    _REVIEWSTATUS._serialized_start=3181
-    _REVIEWSTATUS._serialized_end=3267
+    _REVIEWITEMTYPE._serialized_start=3060
+    _REVIEWITEMTYPE._serialized_end=3121
+    _REVIEWQUEUETYPE._serialized_start=3123
+    _REVIEWQUEUETYPE._serialized_end=3197
+    _REVIEWSTATUS._serialized_start=3199
+    _REVIEWSTATUS._serialized_end=3285
     _REVIEWQUEUE._serialized_start=87
     _REVIEWQUEUE._serialized_end=342
     _REVIEWQUEUEITEM._serialized_start=345
@@ -469,32 +469,32 @@ else:
     _GETREVIEWQUEUEBYNAME_RESPONSE._serialized_start=803
     _GETREVIEWQUEUEBYNAME_RESPONSE._serialized_end=870
     _LISTREVIEWQUEUES._serialized_start=1471
-    _LISTREVIEWQUEUES._serialized_end=1752
-    _LISTREVIEWQUEUES_RESPONSE._serialized_start=1592
-    _LISTREVIEWQUEUES_RESPONSE._serialized_end=1685
-    _UPDATEREVIEWQUEUE._serialized_start=1755
-    _UPDATEREVIEWQUEUE._serialized_end=2029
+    _LISTREVIEWQUEUES._serialized_end=1770
+    _LISTREVIEWQUEUES_RESPONSE._serialized_start=1610
+    _LISTREVIEWQUEUES_RESPONSE._serialized_end=1703
+    _UPDATEREVIEWQUEUE._serialized_start=1773
+    _UPDATEREVIEWQUEUE._serialized_end=2047
     _UPDATEREVIEWQUEUE_RESPONSE._serialized_start=803
     _UPDATEREVIEWQUEUE_RESPONSE._serialized_end=870
-    _DELETEREVIEWQUEUE._serialized_start=2031
-    _DELETEREVIEWQUEUE._serialized_end=2131
+    _DELETEREVIEWQUEUE._serialized_start=2049
+    _DELETEREVIEWQUEUE._serialized_end=2149
     _DELETEREVIEWQUEUE_RESPONSE._serialized_start=803
     _DELETEREVIEWQUEUE_RESPONSE._serialized_end=813
-    _ADDITEMSTOREVIEWQUEUE._serialized_start=2134
-    _ADDITEMSTOREVIEWQUEUE._serialized_end=2367
-    _ADDITEMSTOREVIEWQUEUE_RESPONSE._serialized_start=2258
-    _ADDITEMSTOREVIEWQUEUE_RESPONSE._serialized_end=2322
-    _REMOVEITEMSFROMREVIEWQUEUE._serialized_start=2369
-    _REMOVEITEMSFROMREVIEWQUEUE._serialized_end=2496
+    _ADDITEMSTOREVIEWQUEUE._serialized_start=2152
+    _ADDITEMSTOREVIEWQUEUE._serialized_end=2385
+    _ADDITEMSTOREVIEWQUEUE_RESPONSE._serialized_start=2276
+    _ADDITEMSTOREVIEWQUEUE_RESPONSE._serialized_end=2340
+    _REMOVEITEMSFROMREVIEWQUEUE._serialized_start=2387
+    _REMOVEITEMSFROMREVIEWQUEUE._serialized_end=2514
     _REMOVEITEMSFROMREVIEWQUEUE_RESPONSE._serialized_start=803
     _REMOVEITEMSFROMREVIEWQUEUE_RESPONSE._serialized_end=813
-    _LISTREVIEWQUEUEITEMS._serialized_start=2499
-    _LISTREVIEWQUEUEITEMS._serialized_end=2774
-    _LISTREVIEWQUEUEITEMS_RESPONSE._serialized_start=2640
-    _LISTREVIEWQUEUEITEMS_RESPONSE._serialized_end=2729
-    _SETREVIEWQUEUEITEMSTATUS._serialized_start=2777
-    _SETREVIEWQUEUEITEMSTATUS._serialized_end=3040
-    _SETREVIEWQUEUEITEMSTATUS_RESPONSE._serialized_start=2932
-    _SETREVIEWQUEUEITEMSTATUS_RESPONSE._serialized_end=2995
+    _LISTREVIEWQUEUEITEMS._serialized_start=2517
+    _LISTREVIEWQUEUEITEMS._serialized_end=2792
+    _LISTREVIEWQUEUEITEMS_RESPONSE._serialized_start=2658
+    _LISTREVIEWQUEUEITEMS_RESPONSE._serialized_end=2747
+    _SETREVIEWQUEUEITEMSTATUS._serialized_start=2795
+    _SETREVIEWQUEUEITEMSTATUS._serialized_end=3058
+    _SETREVIEWQUEUEITEMSTATUS_RESPONSE._serialized_start=2950
+    _SETREVIEWQUEUEITEMSTATUS_RESPONSE._serialized_end=3013
   # @@protoc_insertion_point(module_scope)
 

--- a/mlflow/protos/review_queues_pb2.pyi
+++ b/mlflow/protos/review_queues_pb2.pyi
@@ -138,7 +138,7 @@ class GetReviewQueueByName(_message.Message):
     def __init__(self, experiment_id: _Optional[str] = ..., name: _Optional[str] = ...) -> None: ...
 
 class ListReviewQueues(_message.Message):
-    __slots__ = ("experiment_id", "user", "max_results", "page_token", "item_id")
+    __slots__ = ("experiment_id", "user", "max_results", "page_token", "item_id", "order_by")
     class Response(_message.Message):
         __slots__ = ("review_queues", "next_page_token")
         REVIEW_QUEUES_FIELD_NUMBER: _ClassVar[int]
@@ -151,12 +151,14 @@ class ListReviewQueues(_message.Message):
     MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
     PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
     ITEM_ID_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
     experiment_id: str
     user: str
     max_results: int
     page_token: str
     item_id: str
-    def __init__(self, experiment_id: _Optional[str] = ..., user: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ..., item_id: _Optional[str] = ...) -> None: ...
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, experiment_id: _Optional[str] = ..., user: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ..., item_id: _Optional[str] = ..., order_by: _Optional[_Iterable[str]] = ...) -> None: ...
 
 class UpdateReviewQueue(_message.Message):
     __slots__ = ("queue_id", "update_users", "users", "update_schema_ids", "schema_ids", "name", "new_owner")

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4757,12 +4757,14 @@ def _list_review_queues():
     page_token = request_message.page_token if request_message.HasField("page_token") else None
     user = request_message.user if request_message.HasField("user") else None
     item_id = request_message.item_id if request_message.HasField("item_id") else None
+    order_by = list(request_message.order_by) or None
     queues = _get_tracking_store().list_review_queues(
         request_message.experiment_id,
         user=user,
         item_id=item_id,
         max_results=max_results,
         page_token=page_token,
+        order_by=order_by,
     )
     response = ListReviewQueues.Response(
         review_queues=[q.to_proto() for q in queues],

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ExperimentReviewQueuePage.tsx
@@ -17,12 +17,17 @@ import { ManageQuestionsModal } from './ManageQuestionsModal';
 import { QueueSettingsModal } from './QueueSettingsModal';
 import { ReviewQueueEmptyState } from './ReviewQueueEmptyState';
 import { ReviewQueueList } from './ReviewQueueList';
-import { ReviewQueueSidebar } from './ReviewQueueSidebar';
+import {
+  DEFAULT_REVIEW_QUEUE_SORT,
+  ReviewQueueSidebar,
+  reviewQueueSortToOrderBy,
+  type ReviewQueueSort,
+} from './ReviewQueueSidebar';
 import { useCanEditReviews, useCanManageReviews } from './hooks/useCanManageReviews';
 import { useDeleteReviewQueueMutation } from './hooks/useDeleteReviewQueueMutation';
 import { useGetOrCreateUserQueueMutation } from './hooks/useGetOrCreateUserQueueMutation';
 import { useListReviewQueueItemsQuery } from './hooks/useListReviewQueueItemsQuery';
-import { useListReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
+import { useGetReviewQueueQuery, useInfiniteReviewQueuesQuery } from './hooks/useListReviewQueuesQuery';
 import { getReviewQueuePageRoute, useReviewQueueSearchParams } from './hooks/useReviewQueueSearchParams';
 import { useUpdateReviewQueueMutation } from './hooks/useUpdateReviewQueueMutation';
 import { useRemoveItemsFromReviewQueueMutation } from './hooks/useRemoveItemsFromReviewQueueMutation';
@@ -65,9 +70,20 @@ const ExperimentReviewQueuePage = () => {
   // The queue pending delete confirmation, from the right-pane gear.
   const [confirmDeleteQueueId, setConfirmDeleteQueueId] = useState<string>();
   const [paneWidth, setPaneWidth] = useState(320);
+  // Server-side sort for the queues list. Changing it refetches the list from
+  // page 1 in the new order (sorting the whole list, not just loaded pages).
+  const [queueSort, setQueueSort] = useState<ReviewQueueSort>(DEFAULT_REVIEW_QUEUE_SORT);
+  const queueOrderBy = useMemo(() => reviewQueueSortToOrderBy(queueSort), [queueSort]);
 
-  const { reviewQueues, isLoading: queuesLoading } = useListReviewQueuesQuery({
+  const {
+    reviewQueues,
+    isLoading: queuesLoading,
+    fetchNextPage: fetchMoreQueues,
+    hasNextPage: hasMoreQueues,
+    isFetchingNextPage: isFetchingMoreQueues,
+  } = useInfiniteReviewQueuesQuery({
     experimentId: experimentId ?? '',
+    orderBy: queueOrderBy,
     // Unscoped by reviewer on purpose: the server's `filter_list_review_queues`
     // narrows the list for non-managers.
   });
@@ -114,10 +130,18 @@ const ExperimentReviewQueuePage = () => {
       selectQueue(userQueue.queue_id, { preserveStartReview: true });
     }
   }, [selectedQueueId, queuesLoading, reviewerResolved, reviewQueues, reviewer, selectQueue]);
-  const selectedQueue = useMemo(
+  const selectedQueueInList = useMemo(
     () => reviewQueues.find((q) => q.queue_id === selectedQueueId) ?? null,
     [reviewQueues, selectedQueueId],
   );
+  // A selected/deep-linked queue may live past the loaded window (queues are
+  // paginated). Resolve it with a single fetch-by-id rather than paging through
+  // the whole list, so opening a queue never has to load every page.
+  const { reviewQueue: fetchedSelectedQueue } = useGetReviewQueueQuery({
+    queueId: selectedQueueId,
+    enabled: Boolean(selectedQueueId) && !selectedQueueInList,
+  });
+  const selectedQueue = selectedQueueInList ?? fetchedSelectedQueue ?? null;
   const editingQueue = useMemo(
     () => (editingQueueId ? (reviewQueues.find((q) => q.queue_id === editingQueueId) ?? null) : null),
     [reviewQueues, editingQueueId],
@@ -485,6 +509,12 @@ const ExperimentReviewQueuePage = () => {
                   onSelect={selectQueue}
                   onNewQueue={() => setCreateOpen(true)}
                   onManageQuestions={() => setManageOpen(true)}
+                  sort={queueSort}
+                  onSortChange={setQueueSort}
+                  // Infinite scroll: load the next page of queues on scroll.
+                  onLoadMore={fetchMoreQueues}
+                  hasMore={hasMoreQueues ?? false}
+                  isLoadingMore={isFetchingMoreQueues}
                 />
               </div>
             }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueSidebar.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueSidebar.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { IntlProvider } from '@databricks/i18n';
 
-import { ReviewQueueSidebar } from './ReviewQueueSidebar';
+import { DEFAULT_REVIEW_QUEUE_SORT, ReviewQueueSidebar } from './ReviewQueueSidebar';
 import type { ReviewQueue } from './types';
 
 let mockAuthAvailable = true;
@@ -49,6 +49,8 @@ const renderSidebar = (props: Partial<React.ComponentProps<typeof ReviewQueueSid
           onSelect={jest.fn()}
           onNewQueue={jest.fn()}
           onManageQuestions={jest.fn()}
+          sort={DEFAULT_REVIEW_QUEUE_SORT}
+          onSortChange={jest.fn()}
           {...props}
         />
       </DesignSystemProvider>
@@ -81,12 +83,27 @@ describe('ReviewQueueSidebar', () => {
     expect(screen.queryByText('Beta')).toBeNull();
   });
 
-  it('sorts by name and toggles direction when the Queue header is clicked', () => {
-    renderSidebar();
-    const order = () => screen.getAllByText(/^(Alpha|Beta|Gamma)$/).map((el) => el.textContent);
-    expect(order()).toEqual(['Alpha', 'Beta', 'Gamma']);
+  // Sorting is server-side: clicking a header requests a new sort (the parent
+  // refetches the whole list in that order) rather than reordering the loaded rows.
+  it('requests a name sort when the Queue header is clicked', () => {
+    const onSortChange = jest.fn();
+    renderSidebar({ onSortChange });
     fireEvent.click(screen.getByText('Queue'));
-    expect(order()).toEqual(['Gamma', 'Beta', 'Alpha']);
+    expect(onSortChange).toHaveBeenCalledWith({ field: 'name', direction: 'asc' });
+  });
+
+  it('toggles direction when the active sort column is re-clicked', () => {
+    const onSortChange = jest.fn();
+    renderSidebar({ sort: { field: 'name', direction: 'asc' }, onSortChange });
+    fireEvent.click(screen.getByText('Queue'));
+    expect(onSortChange).toHaveBeenCalledWith({ field: 'name', direction: 'desc' });
+  });
+
+  it('does not sort by the To do column (count is client-derived, not server-sortable)', () => {
+    const onSortChange = jest.fn();
+    renderSidebar({ onSortChange });
+    fireEvent.click(screen.getByText('To do'));
+    expect(onSortChange).not.toHaveBeenCalled();
   });
 
   it('does not fire onSelect when a non-inspectable (greyed) row is clicked', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueSidebar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/ReviewQueueSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   ArrowDownIcon,
@@ -8,6 +8,7 @@ import {
   PlusIcon,
   SegmentedControlButton,
   SegmentedControlGroup,
+  Spinner,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
@@ -15,6 +16,7 @@ import { useQueries } from '@databricks/web-shared/query-client';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useIsAuthAvailable } from '../../../account/hooks';
+import { useInfiniteScrollFetch } from '../experiment-evaluation-datasets/hooks/useInfiniteScrollFetch';
 import { buildReviewQueueItemsQuery } from './hooks/useListReviewQueueItemsQuery';
 import { displayUser } from './hooks/useReviewer';
 import { canInspectQueue, isQueueOwner } from './queuePermissions';
@@ -26,50 +28,71 @@ const CID = 'mlflow.experiment-review-queue.sidebar';
 const OWNER_COL_WIDTH = 120;
 const COUNT_COL_WIDTH = 48;
 
-type SortKey = 'name' | 'owner' | 'todo';
 type SortDir = 'asc' | 'desc';
+
+/** Server-sortable queue columns (must match the backend `order_by` whitelist). */
+export type ReviewQueueSortField = 'name' | 'created_by' | 'creation_time_ms';
+export type ReviewQueueSort = { field: ReviewQueueSortField; direction: SortDir };
+
+// Default: newest created first, matching the server's default order. The "To do"
+// count column is intentionally not sortable — it's derived client-side from the
+// per-queue count fetches, so it can't drive a server-side (whole-list) sort.
+export const DEFAULT_REVIEW_QUEUE_SORT: ReviewQueueSort = { field: 'creation_time_ms', direction: 'desc' };
+
+// Serialize the sidebar sort into backend `order_by` clauses. Sorting is done
+// server-side so it spans the entire queue list, not just the loaded pages
+// (client-side sorting a paginated list only orders the loaded window).
+export const reviewQueueSortToOrderBy = (sort: ReviewQueueSort): string[] => [
+  `${sort.field} ${sort.direction.toUpperCase()}`,
+];
 
 const SortHeader = ({
   label,
-  active,
-  dir,
+  active = false,
+  dir = 'asc',
   width,
   align,
   onClick,
 }: {
   label: React.ReactNode;
-  active: boolean;
-  dir: SortDir;
+  active?: boolean;
+  dir?: SortDir;
   /** Fixed pixel width; omit to flex-fill the remaining space. */
   width?: number;
   align: 'left' | 'right';
-  onClick: () => void;
+  /** Omit to render a plain, non-sortable column header (no arrow, not clickable). */
+  onClick?: () => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const sortable = Boolean(onClick);
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onClick();
-        }
-      }}
+      {...(sortable
+        ? {
+            role: 'button',
+            tabIndex: 0,
+            onClick,
+            onKeyDown: (e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick?.();
+              }
+            },
+          }
+        : {})}
       css={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
         gap: theme.spacing.xs,
-        cursor: 'pointer',
+        cursor: sortable ? 'pointer' : 'default',
         ...(width != null ? { width, flexShrink: 0 } : { flex: 1, minWidth: 0 }),
       }}
     >
       <Typography.Text size="sm" color="secondary" bold ellipsis>
         {label}
       </Typography.Text>
-      {active && (dir === 'asc' ? <ArrowUpIcon /> : <ArrowDownIcon />)}
+      {sortable && active && (dir === 'asc' ? <ArrowUpIcon /> : <ArrowDownIcon />)}
     </div>
   );
 };
@@ -163,6 +186,11 @@ export const ReviewQueueSidebar = ({
   onSelect,
   onNewQueue,
   onManageQuestions,
+  sort,
+  onSortChange,
+  onLoadMore,
+  hasMore,
+  isLoadingMore,
 }: {
   queues: ReviewQueue[];
   selectedQueueId: string | undefined;
@@ -173,12 +201,20 @@ export const ReviewQueueSidebar = ({
   onSelect: (queueId: string) => void;
   onNewQueue: () => void;
   onManageQuestions: () => void;
+  /** Current server-side sort, and a setter for it. Changing it refetches the
+   *  list from page 1 in the new order (sorting is done by the backend). */
+  sort: ReviewQueueSort;
+  onSortChange: (sort: ReviewQueueSort) => void;
+  /** Fetch the next page of queues; drives infinite scroll. `queues` only holds
+   *  the pages loaded so far, so the filter/sort and per-queue counts reflect
+   *  the loaded window. */
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const authAvailable = useIsAuthAvailable();
-  const [sortKey, setSortKey] = useState<SortKey>('name');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [mineOnly, setMineOnly] = useState(false);
 
   // Owner is only meaningful on an auth server; the filter only helps users who
@@ -208,45 +244,49 @@ export const ReviewQueueSidebar = ({
   const labelOf = (q: ReviewQueue) => (q.queue_type === 'USER' ? displayUser(q.name, intl) : q.name);
   const ownerOf = (q: ReviewQueue) => q.created_by ?? '';
 
-  const toggleSort = (key: SortKey) => {
-    if (key === sortKey) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortKey(key);
-      setSortDir('asc');
-    }
-  };
-
-  const dirMul = sortDir === 'asc' ? 1 : -1;
-  const byLabel = (a: ReviewQueue, b: ReviewQueue) =>
-    labelOf(a).localeCompare(labelOf(b), undefined, { sensitivity: 'base' });
-  const compare = (a: ReviewQueue, b: ReviewQueue): number => {
-    if (sortKey === 'todo') {
-      const pa = pendingByQueueId.get(a.queue_id);
-      const pb = pendingByQueueId.get(b.queue_id);
-      // Unknown counts (loading or not inspectable) always sort last.
-      if (pa == null && pb == null) return byLabel(a, b);
-      if (pa == null) return 1;
-      if (pb == null) return -1;
-      return pa !== pb ? dirMul * (pa - pb) : byLabel(a, b);
-    }
-    const va = sortKey === 'owner' ? ownerOf(a) : labelOf(a);
-    const vb = sortKey === 'owner' ? ownerOf(b) : labelOf(b);
-    const d = va.localeCompare(vb, undefined, { sensitivity: 'base' });
-    return d !== 0 ? dirMul * d : byLabel(a, b);
+  // Toggle direction when re-clicking the active column, else sort that column
+  // ascending. The backend performs the sort, so this only updates the request.
+  const requestSort = (field: ReviewQueueSortField) => {
+    onSortChange(
+      sort.field === field
+        ? { field, direction: sort.direction === 'asc' ? 'desc' : 'asc' }
+        : { field, direction: 'asc' },
+    );
   };
 
   // Ignore a stale `mineOnly` once the filter is hidden (can't get stuck filtered),
   // and always keep the selected queue visible even when it isn't owned.
   const effectiveMineOnly = showFilter && mineOnly;
-  const visible = (
-    effectiveMineOnly ? queues.filter((q) => isQueueOwner(q, reviewer) || q.queue_id === selectedQueueId) : queues
-  )
-    .slice()
-    .sort(compare);
+  const filtered = effectiveMineOnly
+    ? queues.filter((q) => isQueueOwner(q, reviewer) || q.queue_id === selectedQueueId)
+    : queues;
+  // The server returns queues already in `sort` order; render them as-is. (Client
+  // re-sorting would only reorder the loaded window, not the whole list.)
+  const visible = filtered;
+
+  // Infinite scroll: pull the next page when the list nears the bottom, and keep
+  // pulling while the loaded queues don't fill the scroll area (short first page
+  // or a tall pane).
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const fetchMoreOnBottomReached = useInfiniteScrollFetch({
+    isFetching: Boolean(isLoadingMore),
+    hasNextPage: Boolean(hasMore),
+    fetchNextPage: onLoadMore ?? (() => {}),
+  });
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el || !onLoadMore || !hasMore || isLoadingMore) {
+      return;
+    }
+    if (el.scrollHeight - el.clientHeight < 200) {
+      onLoadMore();
+    }
+  }, [onLoadMore, hasMore, isLoadingMore, visible.length]);
 
   return (
     <div
+      ref={scrollContainerRef}
+      onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}
       css={{
         display: 'flex',
         flexDirection: 'column',
@@ -309,21 +349,24 @@ export const ReviewQueueSidebar = ({
         >
           <SortHeader
             label={<FormattedMessage defaultMessage="Queue" description="Review queue sidebar: queue-name column" />}
-            active={sortKey === 'name'}
-            dir={sortDir}
+            active={sort.field === 'name'}
+            dir={sort.direction}
             align="left"
-            onClick={() => toggleSort('name')}
+            onClick={() => requestSort('name')}
           />
           {showOwner && (
             <SortHeader
               label={<FormattedMessage defaultMessage="Owner" description="Review queue sidebar: queue-owner column" />}
-              active={sortKey === 'owner'}
-              dir={sortDir}
+              active={sort.field === 'created_by'}
+              dir={sort.direction}
               width={OWNER_COL_WIDTH}
               align="left"
-              onClick={() => toggleSort('owner')}
+              onClick={() => requestSort('created_by')}
             />
           )}
+          {/* The "To do" count is derived client-side from the per-queue count
+              fetches, so it can't drive a server-side sort — render it as a plain,
+              non-sortable column header. */}
           <SortHeader
             label={
               <FormattedMessage
@@ -331,11 +374,8 @@ export const ReviewQueueSidebar = ({
                 description="Review queue sidebar: still-to-review count column"
               />
             }
-            active={sortKey === 'todo'}
-            dir={sortDir}
             width={COUNT_COL_WIDTH}
             align="right"
-            onClick={() => toggleSort('todo')}
           />
         </div>
       )}
@@ -365,6 +405,12 @@ export const ReviewQueueSidebar = ({
             />
           </Typography.Text>
         )
+      )}
+
+      {isLoadingMore && (
+        <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.sm }}>
+          <Spinner size="small" />
+        </div>
       )}
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useListReviewQueuesQuery.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useListReviewQueuesQuery.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+
+import { fetchAPI } from '../../../../common/utils/FetchUtils';
+import {
+  REVIEW_QUEUES_PAGE_SIZE,
+  useGetReviewQueueQuery,
+  useInfiniteReviewQueuesQuery,
+} from './useListReviewQueuesQuery';
+
+jest.mock('../../../../common/utils/FetchUtils', () => ({
+  fetchAPI: jest.fn(),
+  getAjaxUrl: (path: string) => path,
+}));
+
+const mockFetchAPI = jest.mocked(fetchAPI);
+
+const makeQueues = (start: number, count: number) =>
+  Array.from({ length: count }, (_, i) => ({ queue_id: `rq-${start + i}`, name: `Queue ${start + i}` }));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, cacheTime: 0 } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+const paramsOf = (callIndex: number) => {
+  const url = mockFetchAPI.mock.calls[callIndex][0] as string;
+  return new URLSearchParams(url.split('?')[1] ?? '');
+};
+
+describe('useInfiniteReviewQueuesQuery', () => {
+  beforeEach(() => {
+    mockFetchAPI.mockReset();
+    // Page 1 (no token) -> 20 queues + a continuation token; page 2 -> 5 queues, no token (last page).
+    mockFetchAPI.mockImplementation((async (url: string) => {
+      if (url.includes('review-queues/get?')) {
+        const queueId = new URLSearchParams(url.split('?')[1] ?? '').get('queue_id');
+        return { review_queue: { queue_id: queueId, name: `Queue ${queueId}` } };
+      }
+      const token = new URLSearchParams(url.split('?')[1] ?? '').get('page_token');
+      if (!token) {
+        return { review_queues: makeQueues(0, REVIEW_QUEUES_PAGE_SIZE), next_page_token: 'tok-2' };
+      }
+      return { review_queues: makeQueues(REVIEW_QUEUES_PAGE_SIZE, 5), next_page_token: '' };
+    }) as typeof fetchAPI);
+  });
+
+  it('requests the first page with max_results and no page_token, exposing hasNextPage', async () => {
+    const { result } = renderHook(() => useInfiniteReviewQueuesQuery({ experimentId: 'exp-1' }), { wrapper });
+
+    await waitFor(() => expect(result.current.reviewQueues).toHaveLength(REVIEW_QUEUES_PAGE_SIZE));
+
+    const firstParams = paramsOf(0);
+    expect(firstParams.get('experiment_id')).toBe('exp-1');
+    expect(firstParams.get('max_results')).toBe(String(REVIEW_QUEUES_PAGE_SIZE));
+    expect(firstParams.has('page_token')).toBe(false);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('sends order_by clauses to the backend for server-side sorting', async () => {
+    const { result } = renderHook(
+      () => useInfiniteReviewQueuesQuery({ experimentId: 'exp-1', orderBy: ['name ASC'] }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.reviewQueues).toHaveLength(REVIEW_QUEUES_PAGE_SIZE));
+    expect(paramsOf(0).getAll('order_by')).toEqual(['name ASC']);
+  });
+
+  it('feeds next_page_token back as page_token and flattens accumulated pages', async () => {
+    const { result } = renderHook(() => useInfiniteReviewQueuesQuery({ experimentId: 'exp-1' }), { wrapper });
+
+    await waitFor(() => expect(result.current.reviewQueues).toHaveLength(REVIEW_QUEUES_PAGE_SIZE));
+
+    act(() => {
+      result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.reviewQueues).toHaveLength(REVIEW_QUEUES_PAGE_SIZE + 5));
+    // The second request forwards the first page's continuation token.
+    expect(paramsOf(1).get('page_token')).toBe('tok-2');
+    // The flattened list preserves order across pages.
+    expect(result.current.reviewQueues[0].queue_id).toBe('rq-0');
+    expect(result.current.reviewQueues[REVIEW_QUEUES_PAGE_SIZE].queue_id).toBe(`rq-${REVIEW_QUEUES_PAGE_SIZE}`);
+  });
+
+  it('stops paging when the server returns an empty next_page_token', async () => {
+    const { result } = renderHook(() => useInfiniteReviewQueuesQuery({ experimentId: 'exp-1' }), { wrapper });
+
+    await waitFor(() => expect(result.current.reviewQueues).toHaveLength(REVIEW_QUEUES_PAGE_SIZE));
+    act(() => {
+      result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(result.current.reviewQueues).toHaveLength(REVIEW_QUEUES_PAGE_SIZE + 5));
+
+    // The last page's empty token maps to undefined, so no further pages remain.
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});
+
+describe('useGetReviewQueueQuery', () => {
+  beforeEach(() => {
+    mockFetchAPI.mockReset();
+    mockFetchAPI.mockImplementation((async (url: string) => {
+      const queueId = new URLSearchParams(url.split('?')[1] ?? '').get('queue_id');
+      return { review_queue: { queue_id: queueId, name: `Queue ${queueId}` } };
+    }) as typeof fetchAPI);
+  });
+
+  it('fetches a single queue by id from the get endpoint', async () => {
+    const { result } = renderHook(() => useGetReviewQueueQuery({ queueId: 'rq-42' }), { wrapper });
+
+    await waitFor(() => expect(result.current.reviewQueue?.queue_id).toBe('rq-42'));
+    const url = mockFetchAPI.mock.calls[0][0] as string;
+    expect(url).toContain('review-queues/get');
+    expect(new URLSearchParams(url.split('?')[1]).get('queue_id')).toBe('rq-42');
+  });
+
+  it('does not fetch when disabled or no queue id', () => {
+    renderHook(() => useGetReviewQueueQuery({ queueId: 'rq-1', enabled: false }), { wrapper });
+    renderHook(() => useGetReviewQueueQuery({ queueId: undefined }), { wrapper });
+    expect(mockFetchAPI).not.toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useListReviewQueuesQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/hooks/useListReviewQueuesQuery.tsx
@@ -1,14 +1,25 @@
-import { useQuery } from '@databricks/web-shared/query-client';
+import { useMemo } from 'react';
+
+import { useInfiniteQuery, useQuery } from '@databricks/web-shared/query-client';
 
 import { fetchAPI, getAjaxUrl } from '../../../../common/utils/FetchUtils';
 import type { ReviewQueue } from '../types';
 import { REVIEW_QUEUES_API_BASE } from './constants';
 
 export const LIST_REVIEW_QUEUES_QUERY_KEY = 'LIST_REVIEW_QUEUES';
+export const GET_REVIEW_QUEUE_QUERY_KEY = 'GET_REVIEW_QUEUE';
+
+// Small page so the queues sidebar streams in as the reviewer scrolls instead
+// of loading every queue (and its per-queue pending-count fetch) up front.
+export const REVIEW_QUEUES_PAGE_SIZE = 20;
 
 interface ListReviewQueuesResponse {
   review_queues?: ReviewQueue[];
   next_page_token?: string;
+}
+
+interface GetReviewQueueResponse {
+  review_queue?: ReviewQueue;
 }
 
 /**
@@ -69,4 +80,95 @@ export const useListReviewQueuesQuery = ({
     refetch,
     error,
   };
+};
+
+/**
+ * Infinite (page-token) variant of {@link useListReviewQueuesQuery} that powers
+ * the sidebar's infinite scroll. Pages accumulate as the caller invokes
+ * `fetchNextPage`, and the flattened `reviewQueues` exposes only the pages
+ * loaded so far, so the sidebar's filter/sort and per-queue counts (and the
+ * page's queue-selection lookup) operate over the loaded window. Mutations
+ * invalidate by the shared `LIST_REVIEW_QUEUES_QUERY_KEY` prefix, which matches
+ * this key too.
+ */
+export const useInfiniteReviewQueuesQuery = ({
+  experimentId,
+  user,
+  itemId,
+  orderBy,
+  enabled = true,
+}: {
+  experimentId: string;
+  user?: string;
+  itemId?: string;
+  /** Backend `order_by` clauses (e.g. `["name ASC"]`). Part of the query key, so
+   *  changing the sort refetches from page 1 in the new (whole-list) order. */
+  orderBy?: string[];
+  enabled?: boolean;
+}) => {
+  const { data, fetchNextPage, hasNextPage, isLoading, isFetching, isFetchingNextPage, refetch, error } =
+    useInfiniteQuery<ListReviewQueuesResponse, Error>({
+      queryKey: [LIST_REVIEW_QUEUES_QUERY_KEY, 'infinite', experimentId, user, itemId, orderBy],
+      queryFn: async ({ pageParam = undefined }) => {
+        const params = new URLSearchParams({ experiment_id: experimentId });
+        if (user) {
+          params.set('user', user);
+        }
+        if (itemId) {
+          params.set('item_id', itemId);
+        }
+        params.set('max_results', String(REVIEW_QUEUES_PAGE_SIZE));
+        if (pageParam) {
+          params.set('page_token', pageParam as string);
+        }
+        // Repeated query param: order_by=<clause>&order_by=<clause>.
+        (orderBy ?? []).forEach((clause) => params.append('order_by', clause));
+        return (await fetchAPI(getAjaxUrl(`${REVIEW_QUEUES_API_BASE}/list?${params.toString()}`), {
+          method: 'GET',
+        })) as ListReviewQueuesResponse;
+      },
+      // The handler returns an empty `next_page_token` (not an absent field) on
+      // the last page; map the empty string to `undefined` so react-query stops.
+      getNextPageParam: (lastPage) => lastPage.next_page_token || undefined,
+      cacheTime: 0,
+      refetchOnWindowFocus: false,
+      retry: false,
+      enabled: enabled && Boolean(experimentId),
+    });
+
+  const reviewQueues = useMemo(() => data?.pages.flatMap((page) => page.review_queues ?? []) ?? [], [data]);
+
+  return {
+    reviewQueues,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    refetch,
+    error,
+  };
+};
+
+/**
+ * Fetch a single review queue by id. Used to resolve a selected/deep-linked
+ * queue that isn't on a loaded page of the infinite list, so the right pane can
+ * open it with one request instead of paging through the whole list to find it.
+ */
+export const useGetReviewQueueQuery = ({ queueId, enabled = true }: { queueId?: string; enabled?: boolean }) => {
+  const { data, isLoading, error } = useQuery<GetReviewQueueResponse, Error>({
+    queryKey: [GET_REVIEW_QUEUE_QUERY_KEY, queueId],
+    queryFn: async () => {
+      const params = new URLSearchParams({ queue_id: queueId ?? '' });
+      return (await fetchAPI(getAjaxUrl(`${REVIEW_QUEUES_API_BASE}/get?${params.toString()}`), {
+        method: 'GET',
+      })) as GetReviewQueueResponse;
+    },
+    cacheTime: 0,
+    refetchOnWindowFocus: false,
+    retry: false,
+    enabled: enabled && Boolean(queueId),
+  });
+
+  return { reviewQueue: data?.review_queue, isLoading, error };
 };

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1170,7 +1170,14 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
         return ReviewQueue.from_proto(response_proto.review_queue)
 
     def list_review_queues(
-        self, experiment_id, *, user=None, item_id=None, max_results=None, page_token=None
+        self,
+        experiment_id,
+        *,
+        user=None,
+        item_id=None,
+        max_results=None,
+        page_token=None,
+        order_by=None,
     ):
         from mlflow.genai.review_queues import ReviewQueue
 
@@ -1183,6 +1190,8 @@ class RestStore(WorkspaceRestStoreMixin, RestGatewayStoreMixin, AbstractStore):
             req.max_results = max_results
         if page_token is not None:
             req.page_token = page_token
+        if order_by is not None:
+            req.order_by.extend(order_by)
         response_proto = self._call_endpoint(
             ListReviewQueues,
             message_to_json(req),

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -8636,8 +8636,55 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
             return self._hydrate_review_queues(session, [sql_queue])[0]
 
+    def _review_queue_order_by_clauses(self, order_by):
+        # Whitelisted sort columns. `name` sorts on the case-folded `name_key` so
+        # ordering is case-insensitive (matching the UI's name sort).
+        columns = {
+            "name": SqlReviewQueue.name_key,
+            "created_by": SqlReviewQueue.created_by,
+            "creation_time_ms": SqlReviewQueue.creation_time_ms,
+        }
+        # A unique, stable tiebreaker is always appended so offset paging stays
+        # deterministic even when the sort key has ties.
+        tiebreaker = SqlReviewQueue.queue_id.asc()
+        if not order_by:
+            return [SqlReviewQueue.creation_time_ms.desc(), tiebreaker]
+        clauses = []
+        for clause in order_by:
+            match clause.split():
+                case [field]:
+                    direction = "ASC"
+                case [field, direction]:
+                    direction = direction.upper()
+                case _:
+                    raise MlflowException(
+                        f"Invalid order_by clause: {clause!r}. Expected '<field> [ASC|DESC]'.",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
+            column = columns.get(field)
+            if column is None:
+                raise MlflowException(
+                    f"Invalid order_by field: {field!r}. Supported fields: {', '.join(columns)}.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            if direction not in ("ASC", "DESC"):
+                raise MlflowException(
+                    f"Invalid order_by direction: {direction!r}. Expected 'ASC' or 'DESC'.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            clauses.append(column.asc() if direction == "ASC" else column.desc())
+        clauses.append(tiebreaker)
+        return clauses
+
     def list_review_queues(
-        self, experiment_id, *, user=None, item_id=None, max_results=None, page_token=None
+        self,
+        experiment_id,
+        *,
+        user=None,
+        item_id=None,
+        max_results=None,
+        page_token=None,
+        order_by=None,
     ):
         from mlflow.genai.review_queues.validation import normalize_user
 
@@ -8646,6 +8693,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         else:
             self._validate_max_results_param(max_results)
         offset = SearchUtils.parse_start_offset_from_page_token(page_token) if page_token else 0
+        order_clauses = self._review_queue_order_by_clauses(order_by)
 
         with self.ManagedSessionMaker() as session:
             self._validate_experiment_exists(session, experiment_id)
@@ -8668,16 +8716,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 )
                 query = query.filter(SqlReviewQueue.queue_id.in_(containing_queue_ids))
 
-            results = (
-                query
-                .order_by(
-                    SqlReviewQueue.creation_time_ms.desc(),
-                    SqlReviewQueue.queue_id.asc(),
-                )
-                .offset(offset)
-                .limit(max_results + 1)
-                .all()
-            )
+            results = query.order_by(*order_clauses).offset(offset).limit(max_results + 1).all()
 
             next_token = None
             if len(results) > max_results:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -1017,9 +1017,14 @@ class TracingClient:
         user: str | None = None,
         max_results: int | None = None,
         page_token: str | None = None,
+        order_by: list[str] | None = None,
     ) -> "PagedList[ReviewQueue]":
         return self.store.list_review_queues(
-            experiment_id, user=user, max_results=max_results, page_token=page_token
+            experiment_id,
+            user=user,
+            max_results=max_results,
+            page_token=page_token,
+            order_by=order_by,
         )
 
     def _update_review_queue(

--- a/tests/genai/review_queues/test_review_queues_sdk.py
+++ b/tests/genai/review_queues/test_review_queues_sdk.py
@@ -119,9 +119,14 @@ def test_get_review_queue_requires_exactly_one_selector(kwargs):
 
 def test_list_review_queues_delegates():
     with patch(f"{_BASE}._list_review_queues", return_value=PagedList([_queue()], None)) as m:
-        list_review_queues(user="bob", experiment_id="1", max_results=5)
+        list_review_queues(user="bob", experiment_id="1", max_results=5, order_by=["name ASC"])
     assert m.call_args[0] == ("1",)
-    assert m.call_args[1] == {"user": "bob", "max_results": 5, "page_token": None}
+    assert m.call_args[1] == {
+        "user": "bob",
+        "max_results": 5,
+        "page_token": None,
+        "order_by": ["name ASC"],
+    }
 
 
 def test_update_review_queue_delegates():

--- a/tests/server/test_review_queue_handlers.py
+++ b/tests/server/test_review_queue_handlers.py
@@ -221,6 +221,22 @@ def test_list_review_queues_passes_item_filter():
     assert store.list_review_queues.call_args[1]["item_id"] == "tr-1"
 
 
+def test_list_review_queues_passes_order_by():
+    request_message = ListReviewQueues(experiment_id="1", order_by=["name ASC"])
+    store, _ = _run_handler(
+        _list_review_queues, request_message, "list_review_queues", PagedList([], token=None)
+    )
+    assert store.list_review_queues.call_args[1]["order_by"] == ["name ASC"]
+
+
+def test_list_review_queues_order_by_defaults_to_none():
+    request_message = ListReviewQueues(experiment_id="1")
+    store, _ = _run_handler(
+        _list_review_queues, request_message, "list_review_queues", PagedList([], token=None)
+    )
+    assert store.list_review_queues.call_args[1]["order_by"] is None
+
+
 @pytest.mark.parametrize(
     ("update_users", "users", "update_schema_ids", "schema_ids", "exp_users", "exp_schema_ids"),
     [

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_review_queues.py
@@ -408,6 +408,55 @@ def test_list_review_queues_pagination(store):
     assert len(all_ids) == 5
 
 
+def test_list_review_queues_order_by_name(store):
+    exp_id = _create_experiments(store, "list_order_name")
+    for nm in ["Charlie", "alpha", "Bravo"]:
+        store.create_review_queue(exp_id, name=nm, queue_type="custom")
+    # `name` sorts case-insensitively (on the folded name_key).
+    assert [q.name for q in store.list_review_queues(exp_id, order_by=["name ASC"])] == [
+        "alpha",
+        "Bravo",
+        "Charlie",
+    ]
+    assert [q.name for q in store.list_review_queues(exp_id, order_by=["name DESC"])] == [
+        "Charlie",
+        "Bravo",
+        "alpha",
+    ]
+
+
+def test_list_review_queues_order_by_defaults_to_creation_desc(store):
+    exp_id = _create_experiments(store, "list_order_default")
+    q1 = store.create_review_queue(exp_id, name="first", queue_type="custom")
+    time.sleep(0.005)
+    q2 = store.create_review_queue(exp_id, name="second", queue_type="custom")
+    # Omitting order_by keeps the historical newest-first default.
+    assert [q.queue_id for q in store.list_review_queues(exp_id)] == [q2.queue_id, q1.queue_id]
+
+
+def test_list_review_queues_order_by_paginates_stably(store):
+    exp_id = _create_experiments(store, "list_order_paginate")
+    for nm in ["d", "b", "e", "a", "c"]:
+        store.create_review_queue(exp_id, name=nm, queue_type="custom")
+    page1 = store.list_review_queues(exp_id, order_by=["name ASC"], max_results=2)
+    page2 = store.list_review_queues(
+        exp_id, order_by=["name ASC"], max_results=2, page_token=page1.token
+    )
+    page3 = store.list_review_queues(
+        exp_id, order_by=["name ASC"], max_results=2, page_token=page2.token
+    )
+    assert [q.name for q in [*page1, *page2, *page3]] == ["a", "b", "c", "d", "e"]
+
+
+@pytest.mark.parametrize("order_by", [["bogus ASC"], ["name SIDEWAYS"], ["a b c"]])
+def test_list_review_queues_order_by_invalid(store, order_by):
+    exp_id = _create_experiments(store, "list_order_invalid")
+    store.create_review_queue(exp_id, name="q", queue_type="custom")
+    with pytest.raises(MlflowException, match="order_by") as exc:
+        store.list_review_queues(exp_id, order_by=order_by)
+    _assert_error_code(exc, INVALID_PARAMETER_VALUE)
+
+
 # --------------------------------------------------------------------------
 # Update
 # --------------------------------------------------------------------------

--- a/tests/store/tracking/test_rest_store_review_queues.py
+++ b/tests/store/tracking/test_rest_store_review_queues.py
@@ -191,6 +191,18 @@ def test_list_review_queues_sends_item_filter():
     assert page[0].queue_id == "rq-1"
 
 
+def test_list_review_queues_sends_order_by():
+    resp = pb.ListReviewQueues.Response(
+        review_queues=[pb.ReviewQueue(queue_id="rq-1", name="q", queue_type=pb.CUSTOM)],
+        next_page_token="",
+    )
+    patcher, captured = _capture(resp)
+    with patcher:
+        _store().list_review_queues("1", order_by=["name ASC"])
+    assert captured["endpoint"] == "/api/3.0/mlflow/review-queues/list"
+    assert captured["body"]["order_by"] == ["name ASC"]
+
+
 def test_delete_review_queue_endpoint():
     patcher, captured = _capture(pb.DeleteReviewQueue.Response())
     with patcher:


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

The review queues sidebar previously fetched **every** queue (and a per-queue pending-count request for each) on load. This change makes the sidebar use the already-paginated `ListReviewQueues` endpoint and adds server-side sorting so the list scales to many queues.

**Infinite scroll (frontend)**

- New `useInfiniteReviewQueuesQuery` hook backed by react-query `useInfiniteQuery`: queues stream in 20 at a time as the reviewer scrolls, instead of loading the whole list up front.
- New `useGetReviewQueueQuery` resolves a selected/deep-linked queue that isn't on a loaded page with a single fetch-by-id, instead of paging through the entire list to find it.

**Server-side sorting (full stack)**

- Add a repeated `order_by` field to the `ListReviewQueues` proto and thread it through the REST and SQLAlchemy tracking stores, the server handler, `TracingClient`, and the public `mlflow.genai.review_queues.list_review_queues` SDK.
- Sorting is done in the store so it orders the **entire** set and paginates that order, rather than reordering only the rows already loaded into the sidebar (which is wrong for an infinitely-scrolled list).
- Supported fields: `name` (case-insensitive, via the existing `name_key` column), `created_by`, and `creation_time_ms`. Default remains `creation_time_ms DESC` (newest first). A stable `queue_id` tiebreaker is always appended so offset paging is deterministic. Invalid fields/directions raise `INVALID_PARAMETER_VALUE`.
- The sidebar's **Queue** and **Owner** column headers toggle the sort. The **To do** count is client-derived (a per-queue fan-out), so that column is intentionally not sortable.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests: SQLAlchemy store `order_by` (name sort, default, stable pagination, invalid-clause errors; workspace-enabled and disabled variants), REST store `order_by` passthrough, handler `order_by` parsing, SDK delegation, and frontend tests for `useInfiniteReviewQueuesQuery` / `useGetReviewQueueQuery` and the sidebar's sort headers.

Demo against a local dev server seeded with 200+ queues. The list streams in as you scroll, and clicking the **Queue** header re-sorts the whole set server-side (the oldest queue jumps to the top in name-ASC, then toggles to DESC):

https://github.com/user-attachments/assets/4c0cb9d5-1567-414f-8a74-55cf663a2186

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The review queues sidebar now loads queues incrementally via infinite scroll and supports sorting by name, owner, and creation time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release