### PR TITLE
fix: handle existing database upgrades when 'secrets' table already exists (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,6 +84,16 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
+    # Check if alembic_version table exists, indicating a prior migration attempt
+    inspector = sqlalchemy.inspect(engine)
+    if "alembic_version" in inspector.get_table_names():
+        _logger.info("Alembic version table found, skipping initial table creation and stamping head.")
+        # Stamp the current head to avoid re-running already executed migrations
+        from alembic.command import stamp
+        config = _get_alembic_config(engine.url)
+        stamp(config, "head")
+        _upgrade_db(engine)
+        return
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, the `mlflow db upgrade` command fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` which does not include the 'secrets' table, and then `_upgrade_db` attempts to apply ALL migrations from scratch, including one that creates the 'secrets' table. If the table already exists (e.g., from a previous partial upgrade or manual intervention), Alembic re-runs the migration and fails.

## Fix
The fix adds a check before creating initial tables: if the `alembic_version` table already exists in the database, we skip the initial table creation and stamp the Alembic head directly, then run `_upgrade_db` which will only apply any remaining migrations not yet executed. This prevents Alembic from attempting to re-create tables that already exist.

Closes #19943