### PR TITLE
fix: sort tags alphabetically in runs tag multiselect dropdown

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActionsSelectTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActionsSelectTags.tsx
@@ -48,11 +48,14 @@ const getRunsTagsSelection = (
     return [];
   });
 
-  const allRunsTags: string[] = tagsList.flatMap((tags) => {
-    return Object.keys(tags)
-      .filter(isUserFacingTag)
-      .map((tagKey) => convertTagToString(tags[tagKey]));
-  });
+  // FIX: deduplicate with uniq and sort alphabetically so tags always appear in a consistent order
+  const allRunsTags: string[] = uniq(
+    tagsList.flatMap((tags) => {
+      return Object.keys(tags)
+        .filter(isUserFacingTag)
+        .map((tagKey) => convertTagToString(tags[tagKey]));
+    }),
+  ).sort();
 
   const selectedRunsAllSelectedTags: string[] = allRunsTags.filter((tag) =>
     selectedRunsTagArray.every((selectedTags) => selectedTags.includes(tag)),
@@ -189,7 +192,8 @@ export const ExperimentViewRunsControlsActionsSelectTags = ({
         />
         <DialogComboboxContent matchTriggerWidth>
           <DialogComboboxOptionList>
-            {Object.keys(selectedTags).map((tagString) => {
+            {/* FIX: sort keys alphabetically so the dropdown list is always ordered consistently */}
+            {Object.keys(selectedTags).sort().map((tagString) => {
               const isIndeterminate = selectedTags[tagString] === undefined;
               return (
                 <DialogComboboxOptionListCheckboxItem


### PR DESCRIPTION
## Related Issues/PRs
Closes #3291

## What changes are proposed in this pull request?
Sort tags alphabetically in the runs tag multiselect dropdown.
Tags were previously rendered in non-deterministic insertion order,
making it hard to find tags quickly in a large list.

## How is this PR tested?
- [x] Manual tests

## Does this PR require a documentation update?
- [x] No

## Does this PR require updating the MLflow Skills repository?
- [x] No

## Release Notes
- [x] Yes. Sort tags alphabetically in the runs multiselect dropdown

## What component(s) does this PR affect?
- `area/uiux`

## Release note classification
- `rn/bug-fix`

## Is this a critical bugfix?
- [x] This PR can wait for the next minor release