### PR TITLE
Clear pending `CopyButton` timer on unmount

### DIFF
--- a/mlflow/server/js/src/shared/building_blocks/CopyButton.tsx
+++ b/mlflow/server/js/src/shared/building_blocks/CopyButton.tsx
@@ -12,19 +12,27 @@ interface CopyButtonProps extends Partial<ButtonProps> {
 export const CopyButton = ({ copyText, showLabel = true, componentId, ...buttonProps }: CopyButtonProps) => {
   const [showTooltip, setShowTooltip] = useState(false);
   const [showCopyError, setShowCopyError] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const tooltipTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
-  useEffect(() => () => clearTimeout(timerRef.current), []);
+  useEffect(
+    () => () => {
+      clearTimeout(tooltipTimerRef.current);
+      clearTimeout(errorTimerRef.current);
+    },
+    [],
+  );
 
   const handleClick = async () => {
     const success = await copyToClipboard(copyText);
-    clearTimeout(timerRef.current);
     if (success) {
       setShowTooltip(true);
-      timerRef.current = setTimeout(() => setShowTooltip(false), 3000);
+      clearTimeout(tooltipTimerRef.current);
+      tooltipTimerRef.current = setTimeout(() => setShowTooltip(false), 3000);
     } else {
       setShowCopyError(true);
-      timerRef.current = setTimeout(() => setShowCopyError(false), 3000);
+      clearTimeout(errorTimerRef.current);
+      errorTimerRef.current = setTimeout(() => setShowCopyError(false), 3000);
     }
   };
 

--- a/mlflow/server/js/src/shared/building_blocks/CopyButton.tsx
+++ b/mlflow/server/js/src/shared/building_blocks/CopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Button, type ButtonProps, Tooltip } from '@databricks/design-system';
 import { copyToClipboard } from '../../common/utils/copyToClipboard';
@@ -12,15 +12,19 @@ interface CopyButtonProps extends Partial<ButtonProps> {
 export const CopyButton = ({ copyText, showLabel = true, componentId, ...buttonProps }: CopyButtonProps) => {
   const [showTooltip, setShowTooltip] = useState(false);
   const [showCopyError, setShowCopyError] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
 
   const handleClick = async () => {
     const success = await copyToClipboard(copyText);
+    clearTimeout(timerRef.current);
     if (success) {
       setShowTooltip(true);
-      setTimeout(() => setShowTooltip(false), 3000);
+      timerRef.current = setTimeout(() => setShowTooltip(false), 3000);
     } else {
       setShowCopyError(true);
-      setTimeout(() => setShowCopyError(false), 3000);
+      timerRef.current = setTimeout(() => setShowCopyError(false), 3000);
     }
   };
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

`CopyButton` schedules a 3s `setTimeout` to hide the "Copied" tooltip after a copy, but never cleared it. When the button unmounts before the timer fires (e.g. the user navigates away, or a modal closes), the timer leaks. In Jest this surfaced as `A worker process has failed to exit gracefully` plus a flaky 5s timeout in `KeyValueTagFullViewModal.test.tsx`; at runtime it could fire `setState` on an unmounted component.

The fix tracks each timer in its own ref (`tooltipTimerRef` / `errorTimerRef`) and clears them on unmount (and before rescheduling the same timer) via a `useEffect` cleanup. Separate refs keep the success and error timers independent, so a flipped outcome between rapid clicks doesn't cancel the other state's timer and leave it stuck.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified live in the dev server by instrumenting `setTimeout`/`clearTimeout` and exercising a real `CopyButton`: on the unfixed build a 3000ms timer remained pending after the component unmounted; with the fix it is cleared on unmount. `CopyButton.test.tsx` and `KeyValueTagFullViewModal.test.tsx` pass with no force-exit warning.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a timer leak in the copy button that could trigger a state update after the button unmounted.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)