### PR TITLE
Fix `traces/batchGet` 500 on span attributes containing lone surrogates

### DIFF
--- a/mlflow/tracing/utils/otlp.py
+++ b/mlflow/tracing/utils/otlp.py
@@ -1,6 +1,7 @@
 import base64
 import gzip
 import os
+import re
 import zlib
 from typing import Any
 
@@ -156,6 +157,23 @@ def _otel_proto_bytes_to_id(id_bytes: bytes) -> int:
     return int.from_bytes(id_bytes, byteorder="big", signed=False)
 
 
+# Matches lone UTF-16 surrogate code points (U+D800-U+DFFF). A valid Python str never
+# contains surrogate pairs (astral characters are stored as single code points), so any
+# code point in this range is necessarily a lone surrogate that cannot be encoded as UTF-8.
+_LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def _sanitize_proto_str(value: str) -> str:
+    """Replace lone UTF-16 surrogates so the string can be assigned to a protobuf field.
+
+    Protobuf ``string`` fields require valid UTF-8. A span attribute coming from bad upstream
+    data may hold a lone surrogate (e.g. ``"\\ud83e"``), which round-trips through JSON storage
+    but raises ``UnicodeEncodeError`` when assigned to a protobuf ``string_value``. Each lone
+    surrogate is replaced with the Unicode replacement character (U+FFFD).
+    """
+    return _LONE_SURROGATE_RE.sub("�", value)
+
+
 def _set_otel_proto_anyvalue(pb_any_value: AnyValue, value: Any) -> None:
     """Set a value on an OTel protobuf AnyValue message.
 
@@ -169,7 +187,7 @@ def _set_otel_proto_anyvalue(pb_any_value: AnyValue, value: Any) -> None:
     elif isinstance(value, bool):
         pb_any_value.bool_value = value
     elif isinstance(value, str):
-        pb_any_value.string_value = value
+        pb_any_value.string_value = _sanitize_proto_str(value)
     elif isinstance(value, int):
         pb_any_value.int_value = value
     elif isinstance(value, float):
@@ -192,7 +210,7 @@ def _set_otel_proto_anyvalue(pb_any_value: AnyValue, value: Any) -> None:
         pb_any_value.kvlist_value.CopyFrom(kvlist_value)
     else:
         # For unknown types, convert to string
-        pb_any_value.string_value = str(value)
+        pb_any_value.string_value = _sanitize_proto_str(str(value))
 
 
 def _decode_otel_proto_anyvalue(pb_any_value: AnyValue) -> Any:

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -399,6 +399,52 @@ def test_otel_attribute_conversion(attributes):
     assert decoded == attributes
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Lone leading surrogate (e.g. the high half of a 4-byte emoji from bad upstream data)
+        ("x" * 149 + "\ud83e", "x" * 149 + "�"),
+        # Lone trailing surrogate
+        ("\udc00bad", "�bad"),
+        # Multiple lone surrogates
+        ("\ud800\ud801", "��"),
+        # Nested inside a list and dict
+        (["ok", "\ud83e"], ["ok", "�"]),
+        ({"k": "\ud83e"}, {"k": "�"}),
+        # Valid astral characters (stored as single code points) are left untouched
+        ("hello 🦾", "hello 🦾"),
+    ],
+)
+def test_otel_attribute_conversion_lone_surrogate(value, expected):
+    from opentelemetry.proto.common.v1.common_pb2 import KeyValue
+
+    from mlflow.tracing.utils.otlp import _decode_otel_proto_anyvalue, _set_otel_proto_anyvalue
+
+    kv = KeyValue()
+    kv.key = "bad"
+    # Must not raise UnicodeEncodeError when assigning the lone surrogate to the proto field
+    _set_otel_proto_anyvalue(kv.value, value)
+    assert _decode_otel_proto_anyvalue(kv.value) == expected
+
+
+def test_span_to_otel_proto_with_lone_surrogate_attribute():
+    # Reproduces #24123: a span attribute holding a lone surrogate must not crash to_otel_proto.
+    otel_span = OTelReadableSpan(
+        name="s",
+        context=build_otel_context(
+            trace_id=0x12345678901234567890123456789012,
+            span_id=0x1234567890123456,
+        ),
+        start_time=1000000000,
+        end_time=2000000000,
+        attributes={"bad": "x" * 149 + "\ud83e"},
+    )
+    otel_proto = Span(otel_span).to_otel_proto()
+
+    bad_attr = next(attr for attr in otel_proto.attributes if attr.key == "bad")
+    assert bad_attr.value.string_value == "x" * 149 + "�"
+
+
 def test_span_to_otel_proto_conversion(sample_otel_span_for_conversion):
     # Create MLflow span from OTel span
     mlflow_span = Span(sample_otel_span_for_conversion)


### PR DESCRIPTION
### Related Issues/PRs

Closes #24123

### What changes are proposed in this pull request?

`GET /api/3.0/mlflow/traces/batchGet` returns **500** for any batch containing a trace whose span attributes hold a string with a **lone UTF-16 surrogate** (e.g. `"\ud83e"`, the leading half of a 4-byte emoji from bad upstream data). Such a value round-trips through JSON storage cleanly, but raises `UnicodeEncodeError` when assigned to a protobuf `string_value` inside `Span.to_otel_proto()` — and because the batch response is built in a single comprehension, one bad span fails the whole batch (unrelated traces included).

This PR sanitizes string values in `_set_otel_proto_anyvalue` (the single place strings are assigned to an OTel protobuf `AnyValue`, covering top-level, list, and dict-nested values). Each lone surrogate is replaced with the Unicode replacement character (U+FFFD) before assignment. A valid Python `str` never stores surrogate *pairs* (astral characters are single code points), so any code point in `U+D800`–`U+DFFF` is necessarily a lone surrogate — valid text and emoji are left untouched.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_otel_attribute_conversion_lone_surrogate` (parametrized over leading/trailing/multiple lone surrogates, nesting in list/dict, and a valid-emoji no-op case) and `test_span_to_otel_proto_with_lone_surrogate_attribute` (the issue repro at the span level) in `tests/entities/test_span.py`. Also confirmed the issue's `to_otel_proto()` repro no longer raises.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Fixed a 500 error from `traces/batchGet` (and the traces failing to render in the UI) when a span attribute contained a lone UTF-16 surrogate.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release