### PR TITLE
Fix MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS type and use in HttpArtifactRepository (#24092) 

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -607,6 +607,10 @@ MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable(
     "MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE", int, 100 * 1024**2
 )
 
+MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS = _BooleanEnvironmentVariable(
+    "MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS", False
+)
+
 #: Specifies whether or not to allow the MLflow server to follow redirects when
 #: making HTTP requests. If set to False, the server will throw an exception if it
 #: encounters a redirect response.

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -19,6 +19,7 @@ from mlflow.environment_variables import (
     MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR,
     MLFLOW_HTTP_REQUEST_MAX_RETRIES,
     MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS,
     MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
 )
 from mlflow.exceptions import (
@@ -30,7 +31,10 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartUploadMixin,
     verify_artifact_path,
 )
-from mlflow.store.artifact.cloud_artifact_repo import _complete_futures, _compute_num_chunks
+from mlflow.store.artifact.cloud_artifact_repo import (
+    _complete_futures,
+    _compute_num_chunks,
+)
 from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.file_utils import (
     ArtifactProgressBar,
@@ -323,7 +327,12 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
     @staticmethod
     def _upload_part(credential: MultipartUploadCredential, local_file, size, start_byte):
         data = read_chunk(local_file, size, start_byte)
-        response = requests.put(credential.url, data=data, headers=credential.headers)
+        response = requests.put(
+            credential.url,
+            data=data,
+            headers=credential.headers,
+            verify=not MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS.get(),
+        )
         augmented_raise_for_status(response)
         return MultipartUploadPart(
             part_number=credential.part_number,


### PR DESCRIPTION
### Related Issues/PRs

Closes #24092

### What changes are proposed in this pull request?
This PR addresses an issue with HTTP multipart uploads where custom certificates or test environments cannot bypass TLS verification. Specifically:
- Defines the `MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS` boolean environment variable in `mlflow environment_variables.py`.
- Incorporates `MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS` in `HttpArtifactRepository._upload_part` in `mlflow/store/artifact/http_artifact_repo.py` to disable TLS verification (`verify=not MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS.get()`) when transferring individual upload parts.
- Adds comprehensive parametrized unit testing in `tests/store/artifact/test_http_artifact_repo.py` to verify this behavior under different configuration states (`True`/`False`).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions
  
I might need direction in how to update and document the API changes.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduce the `MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS` environment variable to allow bypassing TLS verification for multipart uploads in the HTTP artifact repository.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
