### PR TITLE
Add `heads-up` workflow to label external PRs touching agent instruction files

### DIFF
--- a/.github/workflows/heads-up.yml
+++ b/.github/workflows/heads-up.yml
@@ -11,6 +11,14 @@ on:
       - opened
       - synchronize
       - reopened
+    # Watched paths. Add new entries here to widen coverage.
+    paths:
+      - "AGENTS.md"
+      - "**/AGENTS.md"
+      - "CLAUDE.md"
+      - "**/CLAUDE.md"
+      - ".agents/**"
+      - ".claude/**"
 
 defaults:
   run:
@@ -35,23 +43,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        run: |
-          # Watched paths. Add new entries here to widen coverage.
-          PATTERN='(^|/)(AGENTS|CLAUDE)\.md$'
-          PATTERN+='|(^|/)\.agents/'
-          PATTERN+='|(^|/)\.claude/'
-
-          CHANGED=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
-          echo "Changed files:"
-          echo "$CHANGED"
-
-          if ! echo "$CHANGED" | grep -qE "$PATTERN"; then
-            echo "No watched files touched, skipping"
-            exit 0
-          fi
-
-          echo "Matched watched files:"
-          echo "$CHANGED" | grep -E "$PATTERN"
-
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "heads-up"
-          echo "Added 'heads-up' label to PR #$PR_NUMBER"
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "heads-up"

--- a/.github/workflows/heads-up.yml
+++ b/.github/workflows/heads-up.yml
@@ -1,0 +1,57 @@
+name: Heads-Up
+
+# Flag external PRs that touch files coding agents auto-load as instructions
+# (AGENTS.md, CLAUDE.md, .claude/, .agents/). Running an agent against such a
+# checkout silently obeys these files, so a malicious one can steer it without
+# approval. The 'heads-up' label warns reviewers to read them first.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  label-heads-up:
+    # Only flag external contributors. Internal edits to these files are routine
+    # and don't need a review signal.
+    if: >
+      github.repository == 'mlflow/mlflow'
+      && github.event.pull_request.user.type != 'Bot'
+      && !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Watched paths. Add new entries here to widen coverage.
+          PATTERN='(^|/)(AGENTS|CLAUDE)\.md$'
+          PATTERN+='|(^|/)\.agents/'
+          PATTERN+='|(^|/)\.claude/'
+
+          CHANGED=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          if ! echo "$CHANGED" | grep -qE "$PATTERN"; then
+            echo "No watched files touched, skipping"
+            exit 0
+          fi
+
+          echo "Matched watched files:"
+          echo "$CHANGED" | grep -E "$PATTERN"
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "heads-up"
+          echo "Added 'heads-up' label to PR #$PR_NUMBER"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds a `Heads-Up` GitHub Actions workflow that applies a `heads-up` label to **external** PRs touching files coding agents auto-load as instructions (`AGENTS.md`, `CLAUDE.md` incl. nested, `.claude/`, `.agents/`).

Why: if a maintainer checks out an external PR and runs a coding agent against it, these files are silently obeyed. A malicious change could steer the agent into unintended actions without the maintainer's approval. The label warns reviewers to read those changes before running any agent in the checkout.

Notes:
- Gated to external contributors only (skips bots and `OWNER`/`MEMBER`/`COLLABORATOR`), mirroring `community-label.yml`.
- Uses `pull_request_target` safely: it never checks out or executes PR code, only reads changed filenames via `gh pr diff --name-only` and applies the label. Least-privilege `pull-requests: write`.
- The `heads-up` label already exists in the repo, so the workflow only applies it. The path pattern can be extended to any file.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)