### PR TITLE
Remove `react-hooks/exhaustive-deps` suppressions in `QueueSettingsModal`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/QueueSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
   ApplyDesignSystemContextOverrides,
@@ -79,7 +79,7 @@ export const QueueSettingsModal = ({
   // member set, then re-add on save — consistent with the create flow, where the
   // creator is auto-assigned and hidden from the picker.
   const owner = queue.created_by;
-  const withoutOwner = (users: string[]) => users.filter((u) => !owner || !sameUser(u, owner));
+  const withoutOwner = useCallback((users: string[]) => users.filter((u) => !owner || !sameUser(u, owner)), [owner]);
   // Owner reassignment is manager-only; a free-text new owner pre-filled with
   // the current one. Distinct from `owner` above, which is the immutable key
   // used to filter the reviewer picker.
@@ -136,8 +136,7 @@ export const QueueSettingsModal = ({
   // are chosen from the roster rather than free text.
   const usernames = useMemo(
     () => withoutOwner(assignableUsers.map((u) => u.username).filter((u): u is string => Boolean(u))),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [assignableUsers, owner],
+    [assignableUsers, withoutOwner],
   );
   // Owner picker spans the whole roster (anyone with experiment EDIT can own a
   // queue), unlike the reviewers list which hides the current owner.
@@ -180,11 +179,7 @@ export const QueueSettingsModal = ({
   const canSave = trimmedName !== '';
   // Dedupe the stored members before diffing so a duplicate in `queue.users`
   // can't read as a spurious change (and trigger a needless update_users write).
-  const originalMembers = useMemo(
-    () => new Set(withoutOwner(queue.users ?? [])),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [queue.users, owner],
-  );
+  const originalMembers = useMemo(() => new Set(withoutOwner(queue.users ?? [])), [queue.users, withoutOwner]);
   const membersChanged = members.size !== originalMembers.size || [...originalMembers].some((m) => !members.has(m));
   const originalSchemaIds = useMemo(() => new Set(queue.schema_ids ?? []), [queue.schema_ids]);
   const questionsChanged =


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Two `useMemo` hooks in the review-queue `QueueSettingsModal` suppressed `react-hooks/exhaustive-deps` because they call `withoutOwner`, an inline function recreated every render. To avoid listing the unstable function, the deps instead listed the `owner` primitive it closes over, with an eslint disable.

This wraps `withoutOwner` in `useCallback([owner])` so it's a stable reference, letting both hooks depend on it directly and dropping both suppressions. Runtime behavior is unchanged.

The remaining two `exhaustive-deps` disables in the feature are intentional fire-once-on-load effects and are left as-is.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Verified `yarn lint` and `yarn type-check` pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)