### PR TITLE
fix: avoid 'table already exists' error during db upgrade by creating only missing tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,16 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    from sqlalchemy import inspect
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    missing_tables = set(InitialBase.metadata.tables.keys()) - existing_tables
+    if missing_tables:
+        # Only create tables that don't already exist to avoid "table already exists"
+        for table_name in missing_tables:
+            InitialBase.metadata.tables[table_name].create(engine)
+    else:
+        _logger.info("All initial tables already exist, skipping creation.")
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating to 3.8.x, MySQL raises:
`pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`

This happens because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` which tries to create all tables unconditionally (including the new 'secrets' table) even if they already exist. SQLite handles this gracefully but MySQL does not.

## Fix
Instead of using `create_all()` which attempts to create every table, we first inspect which tables already exist in the database. Then we only create the missing tables individually. This avoids the 'table already exists' error on MySQL while preserving the same behavior for SQLite.

Closes #19943