### PR TITLE
Fix: safely extract endpoint_type in score_model_on_payload

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -41,7 +41,8 @@ def get_endpoint_type(endpoint_uri: str) -> str | None:
 
     endpoint = client.get_endpoint(path)
     # TODO: Standardize the return type of `get_endpoint` and remove this check
-    endpoint = endpoint.dict() if isinstance(endpoint, BaseModel) else endpoint
+    if isinstance(endpoint, BaseModel):
+        endpoint = endpoint.model_dump() if hasattr(endpoint, "model_dump") else endpoint.dict()
     return endpoint.get("task", endpoint.get("endpoint_type"))
 
 
@@ -71,11 +72,14 @@ def score_model_on_payload(
         )
 
     elif prefix == "endpoints":
-        from mlflow.deployments import get_deploy_client
-
         if isinstance(payload, str) and endpoint_type is None:
-            client = get_deploy_client()
-            endpoint_type = client.get_endpoint(suffix).endpoint_type
+            endpoint_type = get_endpoint_type(model_uri)
+            if endpoint_type is None:
+                raise MlflowException(
+                    f"Failed to infer endpoint type for '{model_uri}'. "
+                    "Please specify the endpoint type explicitly or provide a dictionary payload.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         return call_deployments_api(suffix, payload, eval_parameters, endpoint_type)
     elif prefix in ("model", "runs"):
         # TODO: call _load_model_or_server

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -839,3 +839,54 @@ def test_send_request_uses_timeout_from_env_var(monkeypatch):
 
         _, kwargs = mock_post.call_args
         assert kwargs["timeout"] == 2
+
+
+def test_score_model_endpoints_infer_endpoint_type(set_deployment_envs):
+    from pydantic import BaseModel
+
+    class DummyEndpoint(BaseModel):
+        name: str
+        endpoint_type: str
+
+    with (
+        mock.patch("mlflow.deployments.get_deploy_client") as mock_get_deploy_client,
+        mock.patch("mlflow.metrics.genai.model_utils.call_deployments_api") as mock_call_api,
+    ):
+        client = mock_get_deploy_client.return_value
+
+        # Case 1: get_endpoint returns a BaseModel (Pydantic model)
+        client.get_endpoint.return_value = DummyEndpoint(name="my-endpoint", endpoint_type="llm/v1/chat")
+        score_model_on_payload(
+            model_uri="endpoints:/my-endpoint",
+            payload="my prompt",
+            endpoint_type=None,
+        )
+        mock_call_api.assert_called_with("my-endpoint", "my prompt", {}, "llm/v1/chat")
+
+        # Case 2: get_endpoint returns a raw dictionary with "endpoint_type"
+        client.get_endpoint.return_value = {"endpoint_type": "llm/v1/completions"}
+        score_model_on_payload(
+            model_uri="endpoints:/my-endpoint",
+            payload="my prompt",
+            endpoint_type=None,
+        )
+        mock_call_api.assert_called_with("my-endpoint", "my prompt", {}, "llm/v1/completions")
+
+        # Case 3: get_endpoint returns a raw dictionary with "task"
+        client.get_endpoint.return_value = {"task": "llm/v1/embeddings"}
+        score_model_on_payload(
+            model_uri="endpoints:/my-endpoint",
+            payload="my prompt",
+            endpoint_type=None,
+        )
+        mock_call_api.assert_called_with("my-endpoint", "my prompt", {}, "llm/v1/embeddings")
+
+        # Case 4: get_endpoint returns a dictionary without endpoint type or task (fails to infer)
+        client.get_endpoint.return_value = {}
+        with pytest.raises(MlflowException, match="Failed to infer endpoint type for 'endpoints:/my-endpoint'"):
+            score_model_on_payload(
+                model_uri="endpoints:/my-endpoint",
+                payload="my prompt",
+                endpoint_type=None,
+            )
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes a potential `AttributeError: 'dict' object has no attribute 'endpoint_type'` in `score_model_on_payload()` within `mlflow/metrics/genai/model_utils.py`. 

Instead of directly accessing `.endpoint_type` on the result of `client.get_endpoint()`, which returns a raw dictionary for some deployment providers (e.g. OpenAI), we now use the safe `get_endpoint_type()` utility function.

## How was this patch tested?
- Inspected the implementation of `get_endpoint_type()` to confirm it safely converts `BaseModel` objects to dictionaries and handles dictionary returns using `.get()`.
- Validated that the code changes lint and compile correctly.

## Did you update the docs?
- [x] No.

## Release Note
- [x] rn/bug-fix - Fixes potential AttributeError when extracting endpoint type from raw dictionary endpoint configs.

## MLflow Component
- [x] area/evaluation - MLflow model evaluation features, evaluation metrics, and evaluation workflows

## Fast Track
- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release