### PR TITLE
Add MCP Registry UI foundation: types, API client, page shell, and sidebar entry

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1859,6 +1859,23 @@ module.exports = {
   "mlflow.logged_models.table.registered_model_link": "",
   "mlflow.logged_models.table.source_run_link": "",
 
+  // -- mlflow.mcp_registry --
+  "mlflow.mcp_registry.bindings.empty_state.create": "",
+  "mlflow.mcp_registry.bindings.header.endpoint": "",
+  "mlflow.mcp_registry.bindings.header.last_updated": "",
+  "mlflow.mcp_registry.bindings.header.server": "",
+  "mlflow.mcp_registry.bindings.header.transport": "",
+  "mlflow.mcp_registry.bindings.header.version": "",
+  "mlflow.mcp_registry.bindings.search": "",
+  "mlflow.mcp_registry.create_server_button": "",
+  "mlflow.mcp_registry.empty_state.create_server": "",
+  "mlflow.mcp_registry.search": "",
+  "mlflow.mcp_registry.table.header.description": "",
+  "mlflow.mcp_registry.table.header.last_modified": "",
+  "mlflow.mcp_registry.table.header.name": "",
+  "mlflow.mcp_registry.tabs": "",
+  "mlflow.mcp_registry.view_toggle": "",
+
   // -- mlflow.model-registry --
   "mlflow.model-registry.model-list.model-name.tooltip": "",
   "mlflow.model-registry.model-list.model-tag.tooltip": "",
@@ -2150,6 +2167,7 @@ module.exports = {
   "mlflow.sidebar.logo_home_link": "",
   "mlflow.sidebar.logout": "",
   "mlflow.sidebar.manage": "",
+  "mlflow.sidebar.mcp_registry_tab_link": "",
   "mlflow.sidebar.models_tab_link": "",
   "mlflow.sidebar.prompts_tab_link": "",
   "mlflow.sidebar.settings_back_link": "",

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -27,6 +27,7 @@ import { getRouteDefs as getCommonRouteDefs } from './common/route-defs';
 import { getGatewayRouteDefs } from './gateway/route-defs';
 import { getAccountRouteDefs } from './account/route-defs';
 import { getAdminRouteDefs } from './admin/route-defs';
+import { getMCPRegistryRouteDefs } from './mcp-registry/route-defs';
 import { DEV_USER_SWITCHER_ENABLED } from './admin/DevUserSwitcher';
 import { useInitializeExperimentRunColors } from './experiment-tracking/components/experiment-page/hooks/useExperimentRunColor';
 import { MlflowSidebar } from './common/components/MlflowSidebar';
@@ -234,6 +235,7 @@ export const MlflowRouter = () => {
       ...getExperimentTrackingRouteDefs(),
       ...getModelRegistryRouteDefs(),
       ...getGatewayRouteDefs(),
+      ...getMCPRegistryRouteDefs(),
       ...getAccountRouteDefs(),
       ...getAdminRouteDefs(),
       ...getCommonRouteDefs(),

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -20,6 +20,7 @@ import {
   InfoBookIcon,
   Tooltip,
   NewWindowIcon,
+  WrenchIcon,
 } from '@databricks/design-system';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import type { Location } from '../utils/RoutingUtils';
@@ -27,6 +28,7 @@ import { Link, matchPath, useLocation, useNavigate, useParams, useSearchParams }
 import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
 import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
+import MCPRegistryRoutes from '../../mcp-registry/routes';
 import AccountRoutes from '../../account/routes';
 import AdminRoutes from '../../admin/routes';
 import { useCurrentUserIsAdmin, useCurrentUserQuery, useIsBasicAuth } from '../../account/hooks';
@@ -60,6 +62,7 @@ const isExperimentsActive = (location: Location) =>
 const isModelsActive = (location: Location) => Boolean(matchPath('/models/*', location.pathname));
 const isPromptsActive = (location: Location) => Boolean(matchPath('/prompts/*', location.pathname));
 const isGatewayActive = (location: Location) => Boolean(matchPath('/gateway/*', location.pathname));
+const isMCPRegistryActive = (location: Location) => Boolean(matchPath('/mcp-registry/*', location.pathname));
 const isSettingsActive = (location: Location) =>
   Boolean(
     matchPath({ path: '/settings', end: true }, location.pathname) ||
@@ -233,6 +236,22 @@ export function MlflowSidebar({
                 children: <FormattedMessage defaultMessage="Prompts" description="Sidebar link for prompts tab" />,
               },
               componentId: 'mlflow.sidebar.prompts_tab_link',
+            },
+          ]
+        : []),
+      ...(shouldShowGenAIFeatures(enableWorkflowBasedNavigation, workflowType) && !showNestedExperimentItems
+        ? [
+            {
+              key: 'mcp-registry',
+              icon: <WrenchIcon />,
+              linkProps: {
+                to: MCPRegistryRoutes.mcpRegistryPageRoute,
+                isActive: isMCPRegistryActive,
+                children: (
+                  <FormattedMessage defaultMessage="MCP registry" description="Sidebar link for MCP registry page" />
+                ),
+              },
+              componentId: 'mlflow.sidebar.mcp_registry_tab_link',
             },
           ]
         : []),

--- a/mlflow/server/js/src/common/utils/ErrorUtils.tsx
+++ b/mlflow/server/js/src/common/utils/ErrorUtils.tsx
@@ -11,6 +11,7 @@ class ErrorUtils {
     CHAT_SESSIONS: 'Chat Sessions',
     MODEL_SERVING: 'Model Serving',
     RUN_TRACKING: 'Run Tracking',
+    MCP_REGISTRY: 'MCP Registry',
   };
 }
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -819,6 +819,10 @@
     "defaultMessage": "View {count} {count, plural, one {issue} other {issues}}",
     "description": "Issue detection summary > View issues button"
   },
+  "1vy2L2": {
+    "defaultMessage": "Create and manage access bindings for your MCP servers.",
+    "description": "Empty state description for MCP access bindings tab"
+  },
   "1wfVV5": {
     "defaultMessage": "Currently sorted by",
     "description": "Label for the custom column group in the logged model column selector"
@@ -1831,6 +1835,10 @@
     "defaultMessage": "A unique name to identify this API key for reuse across endpoints",
     "description": "Hint text explaining API key name field"
   },
+  "7BNPN4": {
+    "defaultMessage": "MCP Server",
+    "description": "Access bindings table header for server name"
+  },
   "7Dhfxy": {
     "defaultMessage": "Fail",
     "description": "The label for a failing asseessment above a bar-chart in the summary stats."
@@ -1854,6 +1862,10 @@
   "7GU2wd": {
     "defaultMessage": "Add traces from the Traces tab to start reviewing them with your team.",
     "description": "Review queue: empty queue description"
+  },
+  "7Hw8oa": {
+    "defaultMessage": "Servers",
+    "description": "MCP Registry servers tab label"
   },
   "7KKvmS": {
     "defaultMessage": "Created by",
@@ -1899,9 +1911,17 @@
     "defaultMessage": "Create a custom judge function using the {decorator} decorator. All parameters ({inputs}, {outputs}, {expectations}, {trace}) are optional — include only the ones your logic needs. {link}",
     "description": "Step 1 description for defining judge function"
   },
+  "7ODAYz": {
+    "defaultMessage": "Search access bindings",
+    "description": "Placeholder for MCP access bindings search filter input"
+  },
   "7PCvDy": {
     "defaultMessage": "OK",
     "description": "Confirmation button text on the model version stage transition request/approval modal"
+  },
+  "7PqwjP": {
+    "defaultMessage": "Grid view",
+    "description": "Aria label for grid view toggle"
   },
   "7RNlsx": {
     "defaultMessage": "MLflow API documentation",
@@ -2483,6 +2503,10 @@
     "defaultMessage": "avg per request",
     "description": "Subtitle for average tokens per request in gateway"
   },
+  "A/vYwt": {
+    "defaultMessage": "Create MCP server",
+    "description": "Button to create a new MCP server"
+  },
   "A1ljDC": {
     "defaultMessage": "Docs",
     "description": "Sidebar link for docs page"
@@ -2790,6 +2814,10 @@
   "BUdrAE": {
     "defaultMessage": "One-line setup",
     "description": "Tab label for the mlflow agent setup CLI path in the agent action card"
+  },
+  "BVZjOe": {
+    "defaultMessage": "Name",
+    "description": "MCP servers table header for name column"
   },
   "BWH8UR": {
     "defaultMessage": "API key name:",
@@ -3138,6 +3166,10 @@
   "D9xvar": {
     "defaultMessage": "Cancel",
     "description": "Button to cancel editing"
+  },
+  "DAnoyO": {
+    "defaultMessage": "MCP registry",
+    "description": "Sidebar link for MCP registry page"
   },
   "DCC164": {
     "defaultMessage": "GenAI",
@@ -3698,6 +3730,10 @@
   "GKiPV1": {
     "defaultMessage": "Start Time:",
     "description": "Text for start time row header in the main table in the model comparison\n                page"
+  },
+  "GRC83e": {
+    "defaultMessage": "Create MCP server",
+    "description": "Empty state title for MCP servers tab"
   },
   "GRaplV": {
     "defaultMessage": "Context sufficiency",
@@ -4575,6 +4611,10 @@
     "defaultMessage": "Latency Comparison",
     "description": "Title for the tool latency comparison chart"
   },
+  "LA4/Jy": {
+    "defaultMessage": "Create and manage MCP servers using MLflow.",
+    "description": "Empty state description for MCP servers tab"
+  },
   "LBaK9z": {
     "defaultMessage": "Open dataset",
     "description": "Text for the button that opens the dataset source URL in a new tab"
@@ -4646,6 +4686,10 @@
   "LajLDb": {
     "defaultMessage": "Move to top",
     "description": "Experiment page > compare runs tab > chart header > move to top option"
+  },
+  "LbpFi1": {
+    "defaultMessage": "Create MCP server",
+    "description": "MCP Registry empty state CTA button"
   },
   "LfggX9": {
     "defaultMessage": "Loading users…",
@@ -5483,6 +5527,10 @@
     "defaultMessage": "Track every version of your model to understand how quality changes over time. {learnMoreLink}",
     "description": "Empty state description displayed when no models are logged in the machine learning logged models list page"
   },
+  "Pbi8zz": {
+    "defaultMessage": "Version/Alias",
+    "description": "Access bindings table header for version or alias"
+  },
   "PdoaF7": {
     "defaultMessage": "Model",
     "description": "Run page > Overview > Model used for issue detection"
@@ -5810,6 +5858,10 @@
   "RJenO+": {
     "defaultMessage": "Create prompt version",
     "description": "Label for the create prompt action on the registered prompt details page"
+  },
+  "RPlL7/": {
+    "defaultMessage": "List view",
+    "description": "Aria label for list view toggle"
   },
   "RQ80MZ": {
     "defaultMessage": "You're not assigned to this queue, so you can't submit reviews here.",
@@ -6570,6 +6622,10 @@
   "V5cjvM": {
     "defaultMessage": "Copy your MLflow models to another registered model for simple model promotion across environments. For more mature production-grade setups, we recommend setting up automated model training workflows to produce models in controlled environments. <link>Learn more</link>",
     "description": "Model registry > OSS Promote model modal > description paragraph body"
+  },
+  "V5hAI0": {
+    "defaultMessage": "MCP Registry",
+    "description": "MCP Registry page title"
   },
   "V6AwxC": {
     "defaultMessage": "Run judges",
@@ -8563,6 +8619,10 @@
     "defaultMessage": "Search runs",
     "description": "Placeholder text for the search input in the runs table on the logged model details page"
   },
+  "eQaVED": {
+    "defaultMessage": "Last updated",
+    "description": "Access bindings table header for last updated"
+  },
   "eQgPEi": {
     "defaultMessage": "{value} (step={step})",
     "description": "Formats a metric value along with the step number it corresponds to"
@@ -9026,6 +9086,10 @@
   "gRz1nB": {
     "defaultMessage": "{count, plural, one {Delete Trace} other {Delete Traces}}",
     "description": "Experiment page > traces view controls > Delete traces modal > Title"
+  },
+  "gSQgYt": {
+    "defaultMessage": "Create access binding",
+    "description": "Empty state title for MCP access bindings tab"
   },
   "gST1At": {
     "defaultMessage": "Key",
@@ -9987,6 +10051,10 @@
     "defaultMessage": "Params",
     "description": "Label for 'params' option group in the compare runs chart configure modal"
   },
+  "kZK2zW": {
+    "defaultMessage": "Create access binding",
+    "description": "MCP Registry bindings empty state CTA button"
+  },
   "kZaBMS": {
     "defaultMessage": "trace.status = 'OK'",
     "description": "Placeholder example for filter string input"
@@ -10046,6 +10114,10 @@
   "ktiuki": {
     "defaultMessage": "Get Link",
     "description": "Title text for get-link modal"
+  },
+  "kwXUSF": {
+    "defaultMessage": "Search MCP servers by name",
+    "description": "Placeholder for MCP server search filter input"
   },
   "kwqwaU": {
     "defaultMessage": "View starter code",
@@ -10614,6 +10686,10 @@
   "nYSJgH": {
     "defaultMessage": "Show all parent spans",
     "description": "Checkbox label for a setting that enables showing all parent spans in the trace explorer regardless of filter conditions."
+  },
+  "na79Zq": {
+    "defaultMessage": "Endpoint",
+    "description": "Access bindings table header for endpoint"
   },
   "naivho": {
     "defaultMessage": "of",
@@ -11555,6 +11631,10 @@
     "defaultMessage": "No runs logged",
     "description": "Empty state title text for experiment runs page when no runs are logged in the experiment"
   },
+  "sCavJv": {
+    "defaultMessage": "Access Bindings",
+    "description": "MCP Registry access bindings tab label"
+  },
   "sD3+jL": {
     "defaultMessage": "Failed to save webhook",
     "description": "Generic error message informing the user that webhook saving failed"
@@ -12391,6 +12471,10 @@
     "defaultMessage": "Columns",
     "description": "Evaluation review > evaluations list > filter dropdown button"
   },
+  "wmEHaX": {
+    "defaultMessage": "Transport",
+    "description": "Access bindings table header for transport type"
+  },
   "womPSY": {
     "defaultMessage": "Session",
     "description": "Column label for session"
@@ -12463,6 +12547,10 @@
     "defaultMessage": "Nothing to compare!",
     "description": "Header displayed in the metrics and params compare plot when no values are selected"
   },
+  "x0yivN": {
+    "defaultMessage": "Description",
+    "description": "MCP servers table header for description column"
+  },
   "x1Lbmd": {
     "defaultMessage": "{gpuCount, plural, =0 {} one {# GPU} other {# GPUs}} selected",
     "description": "Count of selected GPUs displayed in the node level metric charts node selector"
@@ -12474,6 +12562,10 @@
   "x5IuGA": {
     "defaultMessage": "Loaded {name} v{version}",
     "description": "Success toast shown on the playground after loading a prompt version that did not include stored settings"
+  },
+  "x5RW3f": {
+    "defaultMessage": "Last modified",
+    "description": "MCP servers table header for last modified column"
   },
   "x5ukxr": {
     "defaultMessage": "Runs",

--- a/mlflow/server/js/src/mcp-registry/api.ts
+++ b/mlflow/server/js/src/mcp-registry/api.ts
@@ -1,0 +1,251 @@
+import { fetchAPI, getAjaxUrl, HTTPMethods } from '../common/utils/FetchUtils';
+import type {
+  MCPServer,
+  MCPServerVersion,
+  MCPAccessBinding,
+  CreateMCPServerRequest,
+  UpdateMCPServerRequest,
+  CreateMCPServerVersionRequest,
+  UpdateMCPServerVersionRequest,
+  CreateMCPAccessBindingRequest,
+  UpdateMCPAccessBindingRequest,
+  SetMCPServerTagRequest,
+  SetMCPServerAliasRequest,
+  SearchMCPServersParams,
+  SearchMCPServerVersionsParams,
+  SearchMCPAccessBindingsParams,
+  SearchMCPServersResponse,
+  SearchMCPServerVersionsResponse,
+  SearchMCPAccessBindingsResponse,
+} from './types';
+
+const BASE_URL = 'ajax-api/3.0/mlflow/mcp-servers';
+
+function buildSearchParams(params: Record<string, string | number | string[] | undefined>): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, item);
+      }
+    } else {
+      searchParams.append(key, String(value));
+    }
+  }
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+// MCP Server endpoints
+
+export const MCPRegistryApi = {
+  createMCPServer: (request: CreateMCPServerRequest): Promise<MCPServer> => {
+    return fetchAPI(getAjaxUrl(BASE_URL), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<MCPServer>;
+  },
+
+  searchMCPServers: (params: SearchMCPServersParams = {}): Promise<SearchMCPServersResponse> => {
+    const query = buildSearchParams({
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(getAjaxUrl(`${BASE_URL}${query}`)) as Promise<SearchMCPServersResponse>;
+  },
+
+  getMCPServer: (name: string): Promise<MCPServer> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}`)) as Promise<MCPServer>;
+  },
+
+  updateMCPServer: (name: string, request: UpdateMCPServerRequest): Promise<MCPServer> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}`), {
+      method: HTTPMethods.PATCH,
+      body: request,
+    }) as Promise<MCPServer>;
+  },
+
+  deleteMCPServer: (name: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  // MCP Server Version endpoints
+
+  createMCPServerVersion: (name: string, request: CreateMCPServerVersionRequest): Promise<MCPServerVersion> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<MCPServerVersion>;
+  },
+
+  searchMCPServerVersions: (
+    name: string,
+    params: SearchMCPServerVersionsParams = {},
+  ): Promise<SearchMCPServerVersionsResponse> => {
+    const query = buildSearchParams({
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions${query}`),
+    ) as Promise<SearchMCPServerVersionsResponse>;
+  },
+
+  getMCPServerVersion: (name: string, version: string): Promise<MCPServerVersion> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`),
+    ) as Promise<MCPServerVersion>;
+  },
+
+  updateMCPServerVersion: (
+    name: string,
+    version: string,
+    request: UpdateMCPServerVersionRequest,
+  ): Promise<MCPServerVersion> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`), {
+      method: HTTPMethods.PATCH,
+      body: request,
+    }) as Promise<MCPServerVersion>;
+  },
+
+  deleteMCPServerVersion: (name: string, version: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  getLatestMCPServerVersion: (name: string): Promise<MCPServerVersion> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases/latest`)) as Promise<MCPServerVersion>;
+  },
+
+  // MCP Access Binding endpoints
+
+  createMCPAccessBinding: (name: string, request: CreateMCPAccessBindingRequest): Promise<MCPAccessBinding> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<MCPAccessBinding>;
+  },
+
+  searchMCPAccessBindingsAll: (
+    params: SearchMCPAccessBindingsParams = {},
+  ): Promise<SearchMCPAccessBindingsResponse> => {
+    const query = buildSearchParams({
+      server_version: params.server_version,
+      server_alias: params.server_alias,
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/bindings${query}`)) as Promise<SearchMCPAccessBindingsResponse>;
+  },
+
+  searchMCPAccessBindings: (
+    name: string,
+    params: SearchMCPAccessBindingsParams = {},
+  ): Promise<SearchMCPAccessBindingsResponse> => {
+    const query = buildSearchParams({
+      server_version: params.server_version,
+      server_alias: params.server_alias,
+      filter_string: params.filter_string,
+      max_results: params.max_results,
+      order_by: params.order_by,
+      page_token: params.page_token,
+    });
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings${query}`),
+    ) as Promise<SearchMCPAccessBindingsResponse>;
+  },
+
+  getMCPAccessBinding: (name: string, bindingId: number): Promise<MCPAccessBinding> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings/${bindingId}`),
+    ) as Promise<MCPAccessBinding>;
+  },
+
+  updateMCPAccessBinding: (
+    name: string,
+    bindingId: number,
+    request: UpdateMCPAccessBindingRequest,
+  ): Promise<MCPAccessBinding> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings/${bindingId}`), {
+      method: HTTPMethods.PATCH,
+      body: request,
+    }) as Promise<MCPAccessBinding>;
+  },
+
+  deleteMCPAccessBinding: (name: string, bindingId: number): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/bindings/${bindingId}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  // MCP Server Tag endpoints
+
+  setMCPServerTag: (name: string, request: SetMCPServerTagRequest): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/tags`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<void>;
+  },
+
+  deleteMCPServerTag: (name: string, key: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/tags/${encodeURIComponent(key)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+
+  // MCP Server Version Tag endpoints
+
+  setMCPServerVersionTag: (name: string, version: string, request: SetMCPServerTagRequest): Promise<void> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}/tags`),
+      {
+        method: HTTPMethods.POST,
+        body: request,
+      },
+    ) as Promise<void>;
+  },
+
+  deleteMCPServerVersionTag: (name: string, version: string, key: string): Promise<void> => {
+    return fetchAPI(
+      getAjaxUrl(
+        `${BASE_URL}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}/tags/${encodeURIComponent(key)}`,
+      ),
+      {
+        method: HTTPMethods.DELETE,
+      },
+    ) as Promise<void>;
+  },
+
+  // MCP Server Alias endpoints
+
+  setMCPServerAlias: (name: string, request: SetMCPServerAliasRequest): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases`), {
+      method: HTTPMethods.POST,
+      body: request,
+    }) as Promise<void>;
+  },
+
+  getMCPServerVersionByAlias: (name: string, alias: string): Promise<MCPServerVersion> => {
+    return fetchAPI(
+      getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases/${encodeURIComponent(alias)}`),
+    ) as Promise<MCPServerVersion>;
+  },
+
+  deleteMCPServerAlias: (name: string, alias: string): Promise<void> => {
+    return fetchAPI(getAjaxUrl(`${BASE_URL}/${encodeURIComponent(name)}/aliases/${encodeURIComponent(alias)}`), {
+      method: HTTPMethods.DELETE,
+    }) as Promise<void>;
+  },
+};

--- a/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
+import { setupServer } from '../../common/utils/setup-msw';
+import MCPRegistryPage from './MCPRegistryPage';
+import { getMockedSearchMCPServersResponse } from '../test-utils';
+
+describe('MCPRegistryPage', () => {
+  const server = setupServer(getMockedSearchMCPServersResponse([]));
+
+  const renderPage = (initialEntries = ['/']) => {
+    const queryClient = new QueryClient();
+    render(<MCPRegistryPage />, {
+      wrapper: ({ children }) => (
+        <IntlProvider locale="en">
+          <TestRouter
+            routes={[
+              testRoute(
+                <DesignSystemProvider>
+                  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                </DesignSystemProvider>,
+                '/',
+              ),
+              testRoute(<div />, '*'),
+            ]}
+            initialEntries={initialEntries}
+          />
+        </IntlProvider>
+      ),
+    });
+  };
+
+  it('renders page title', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('MCP Registry')).toBeInTheDocument();
+    });
+  });
+
+  it('renders both tabs', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Servers')).toBeInTheDocument();
+      expect(screen.getByText('Access Bindings')).toBeInTheDocument();
+    });
+  });
+
+  it('defaults to servers tab with search input', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search MCP servers by name')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to access bindings tab', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('MCP Registry')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('Access Bindings'));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search access bindings')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state on servers tab when no servers exist', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Create and manage MCP servers using MLflow.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state on access bindings tab when no servers exist', async () => {
+    renderPage(['/?tab=bindings']);
+    await waitFor(() => {
+      expect(screen.getByText('Create and manage access bindings for your MCP servers.')).toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.tsx
+++ b/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useState } from 'react';
+import {
+  Button,
+  Empty,
+  GridIcon,
+  Header,
+  ListIcon,
+  PlusIcon,
+  SegmentedControlButton,
+  SegmentedControlGroup,
+  WrenchIcon,
+  Spacer,
+  Table,
+  TableHeader,
+  TableRow,
+  TableFilterInput,
+  TableFilterLayout,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import type { RadioChangeEvent } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { ScrollablePageWrapper } from '../../common/components/ScrollablePageWrapper';
+import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
+import ErrorUtils from '../../common/utils/ErrorUtils';
+import { useSearchParams } from '../../common/utils/RoutingUtils';
+
+type ViewMode = 'list' | 'grid';
+type ActiveTab = 'servers' | 'bindings';
+
+const emptyCenterStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  minHeight: 400,
+  width: '100%',
+  '& > div': {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+};
+
+const MCPRegistryPage = () => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabFromUrl = searchParams.get('tab');
+  const activeTab: ActiveTab = tabFromUrl === 'bindings' ? 'bindings' : 'servers';
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [searchFilter, setSearchFilter] = useState('');
+
+  const handleTabChange = useCallback(
+    (e: RadioChangeEvent) => {
+      const value = e.target.value as ActiveTab;
+      setSearchFilter('');
+      const next = new URLSearchParams(searchParams);
+      if (value === 'servers') {
+        next.delete('tab');
+      } else {
+        next.set('tab', value);
+      }
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  // TODO: show create button only when server list is non-empty (matches PromptsPage pattern)
+  const isEmptyState = true;
+  const createButton = !isEmptyState ? (
+    <Button componentId="mlflow.mcp_registry.create_server_button" type="primary" disabled>
+      <FormattedMessage defaultMessage="Create MCP server" description="Button to create a new MCP server" />
+    </Button>
+  ) : null;
+
+  return (
+    <ScrollablePageWrapper css={{ overflow: 'hidden', display: 'flex', flexDirection: 'column', flex: 1 }}>
+      <Spacer shrinks={false} />
+      <Header
+        title={
+          <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <span
+              css={{
+                display: 'flex',
+                borderRadius: theme.borders.borderRadiusSm,
+                backgroundColor: theme.colors.backgroundSecondary,
+                padding: theme.spacing.sm,
+              }}
+            >
+              <WrenchIcon />
+            </span>
+            <FormattedMessage defaultMessage="MCP Registry" description="MCP Registry page title" />
+          </span>
+        }
+        buttons={createButton}
+      />
+      <Spacer shrinks={false} />
+      <div css={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        <SegmentedControlGroup
+          name="mcp-registry-tabs"
+          value={activeTab}
+          onChange={handleTabChange}
+          componentId="mlflow.mcp_registry.tabs"
+        >
+          <SegmentedControlButton value="servers">
+            <FormattedMessage defaultMessage="Servers" description="MCP Registry servers tab label" />
+          </SegmentedControlButton>
+          <SegmentedControlButton value="bindings">
+            <FormattedMessage defaultMessage="Access Bindings" description="MCP Registry access bindings tab label" />
+          </SegmentedControlButton>
+        </SegmentedControlGroup>
+
+        {activeTab === 'servers' && (
+          <>
+            <div
+              css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm, paddingTop: theme.spacing.md }}
+            >
+              <div css={{ flex: 1 }}>
+                <TableFilterLayout>
+                  <TableFilterInput
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'Search MCP servers by name',
+                      description: 'Placeholder for MCP server search filter input',
+                    })}
+                    componentId="mlflow.mcp_registry.search"
+                    value={searchFilter}
+                    onChange={(e) => setSearchFilter(e.target.value)}
+                  />
+                </TableFilterLayout>
+              </div>
+              <SegmentedControlGroup
+                name="mcp-registry-view-mode"
+                value={viewMode}
+                onChange={(e) => setViewMode(e.target.value as ViewMode)}
+                componentId="mlflow.mcp_registry.view_toggle"
+              >
+                <SegmentedControlButton
+                  value="list"
+                  icon={<ListIcon />}
+                  aria-label={intl.formatMessage({
+                    defaultMessage: 'List view',
+                    description: 'Aria label for list view toggle',
+                  })}
+                />
+                <SegmentedControlButton
+                  value="grid"
+                  icon={<GridIcon />}
+                  aria-label={intl.formatMessage({
+                    defaultMessage: 'Grid view',
+                    description: 'Aria label for grid view toggle',
+                  })}
+                />
+              </SegmentedControlGroup>
+            </div>
+            <Table
+              scrollable
+              empty={
+                <div css={emptyCenterStyles}>
+                  <Empty
+                    title={
+                      <FormattedMessage
+                        defaultMessage="Create MCP server"
+                        description="Empty state title for MCP servers tab"
+                      />
+                    }
+                    description={
+                      <FormattedMessage
+                        defaultMessage="Create and manage MCP servers using MLflow."
+                        description="Empty state description for MCP servers tab"
+                      />
+                    }
+                    button={
+                      <Button
+                        componentId="mlflow.mcp_registry.empty_state.create_server"
+                        type="primary"
+                        icon={<PlusIcon />}
+                        disabled
+                      >
+                        <FormattedMessage
+                          defaultMessage="Create MCP server"
+                          description="MCP Registry empty state CTA button"
+                        />
+                      </Button>
+                    }
+                  />
+                </div>
+              }
+            >
+              {viewMode === 'list' && (
+                <TableRow isHeader>
+                  <TableHeader componentId="mlflow.mcp_registry.table.header.name">
+                    <FormattedMessage defaultMessage="Name" description="MCP servers table header for name column" />
+                  </TableHeader>
+                  <TableHeader componentId="mlflow.mcp_registry.table.header.description">
+                    <FormattedMessage
+                      defaultMessage="Description"
+                      description="MCP servers table header for description column"
+                    />
+                  </TableHeader>
+                  <TableHeader componentId="mlflow.mcp_registry.table.header.last_modified">
+                    <FormattedMessage
+                      defaultMessage="Last modified"
+                      description="MCP servers table header for last modified column"
+                    />
+                  </TableHeader>
+                </TableRow>
+              )}
+            </Table>
+          </>
+        )}
+
+        {activeTab === 'bindings' && (
+          <>
+            <div css={{ paddingTop: theme.spacing.md }}>
+              <TableFilterLayout>
+                <TableFilterInput
+                  placeholder={intl.formatMessage({
+                    defaultMessage: 'Search access bindings',
+                    description: 'Placeholder for MCP access bindings search filter input',
+                  })}
+                  componentId="mlflow.mcp_registry.bindings.search"
+                  value={searchFilter}
+                  onChange={(e) => setSearchFilter(e.target.value)}
+                />
+              </TableFilterLayout>
+            </div>
+            <Table
+              scrollable
+              empty={
+                <div css={emptyCenterStyles}>
+                  <Empty
+                    title={
+                      <FormattedMessage
+                        defaultMessage="Create access binding"
+                        description="Empty state title for MCP access bindings tab"
+                      />
+                    }
+                    description={
+                      <FormattedMessage
+                        defaultMessage="Create and manage access bindings for your MCP servers."
+                        description="Empty state description for MCP access bindings tab"
+                      />
+                    }
+                    button={
+                      <Button
+                        componentId="mlflow.mcp_registry.bindings.empty_state.create"
+                        type="primary"
+                        icon={<PlusIcon />}
+                        disabled
+                      >
+                        <FormattedMessage
+                          defaultMessage="Create access binding"
+                          description="MCP Registry bindings empty state CTA button"
+                        />
+                      </Button>
+                    }
+                  />
+                </div>
+              }
+            >
+              <TableRow isHeader>
+                <TableHeader componentId="mlflow.mcp_registry.bindings.header.endpoint">
+                  <FormattedMessage defaultMessage="Endpoint" description="Access bindings table header for endpoint" />
+                </TableHeader>
+                <TableHeader componentId="mlflow.mcp_registry.bindings.header.server">
+                  <FormattedMessage
+                    defaultMessage="MCP Server"
+                    description="Access bindings table header for server name"
+                  />
+                </TableHeader>
+                <TableHeader componentId="mlflow.mcp_registry.bindings.header.version">
+                  <FormattedMessage
+                    defaultMessage="Version/Alias"
+                    description="Access bindings table header for version or alias"
+                  />
+                </TableHeader>
+                <TableHeader componentId="mlflow.mcp_registry.bindings.header.transport">
+                  <FormattedMessage
+                    defaultMessage="Transport"
+                    description="Access bindings table header for transport type"
+                  />
+                </TableHeader>
+                <TableHeader componentId="mlflow.mcp_registry.bindings.header.last_updated">
+                  <FormattedMessage
+                    defaultMessage="Last updated"
+                    description="Access bindings table header for last updated"
+                  />
+                </TableHeader>
+              </TableRow>
+            </Table>
+          </>
+        )}
+      </div>
+    </ScrollablePageWrapper>
+  );
+};
+
+export default withErrorBoundary(ErrorUtils.mlflowServices.MCP_REGISTRY, MCPRegistryPage);

--- a/mlflow/server/js/src/mcp-registry/route-defs.ts
+++ b/mlflow/server/js/src/mcp-registry/route-defs.ts
@@ -1,0 +1,14 @@
+import type { DocumentTitleHandle } from '../common/utils/RoutingUtils';
+import { createLazyRouteElement } from '../common/utils/RoutingUtils';
+import { MCPRegistryPageId, MCPRegistryRoutePaths } from './routes';
+
+export const getMCPRegistryRouteDefs = () => {
+  return [
+    {
+      path: MCPRegistryRoutePaths.mcpRegistryPage,
+      element: createLazyRouteElement(() => import('./pages/MCPRegistryPage')),
+      pageId: MCPRegistryPageId.mcpRegistryPage,
+      handle: { getPageTitle: () => 'MCP Registry' } satisfies DocumentTitleHandle,
+    },
+  ];
+};

--- a/mlflow/server/js/src/mcp-registry/routes.ts
+++ b/mlflow/server/js/src/mcp-registry/routes.ts
@@ -1,0 +1,21 @@
+import { createMLflowRoutePath } from '../common/utils/RoutingUtils';
+
+export enum MCPRegistryPageId {
+  mcpRegistryPage = 'mlflow.mcp-registry',
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- TODO(FEINF-4274)
+export class MCPRegistryRoutePaths {
+  static get mcpRegistryPage() {
+    return createMLflowRoutePath('/mcp-registry');
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- TODO(FEINF-4274)
+class MCPRegistryRoutes {
+  static get mcpRegistryPageRoute() {
+    return MCPRegistryRoutePaths.mcpRegistryPage;
+  }
+}
+
+export default MCPRegistryRoutes;

--- a/mlflow/server/js/src/mcp-registry/test-utils.ts
+++ b/mlflow/server/js/src/mcp-registry/test-utils.ts
@@ -1,0 +1,21 @@
+import { rest } from 'msw';
+import { getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import type { MCPServer } from './types';
+
+const BASE_URL = 'ajax-api/3.0/mlflow/mcp-servers';
+
+export const createMockMCPServer = (overrides: Partial<MCPServer> = {}): MCPServer => ({
+  name: 'io.github.test/server',
+  access_bindings: [],
+  aliases: [],
+  tags: {},
+  ...overrides,
+});
+
+export const getMockedSearchMCPServersResponse = (servers: MCPServer[] = []) =>
+  rest.get(getAjaxUrl(BASE_URL), (_req, res, ctx) =>
+    res(ctx.json({ mcp_servers: servers, next_page_token: undefined })),
+  );
+
+export const getMockedSearchMCPServersErrorResponse = (status = 500, message = 'Internal error') =>
+  rest.get(getAjaxUrl(BASE_URL), (_req, res, ctx) => res(ctx.status(status), ctx.json({ message })));

--- a/mlflow/server/js/src/mcp-registry/types.ts
+++ b/mlflow/server/js/src/mcp-registry/types.ts
@@ -1,0 +1,224 @@
+export type MCPStatus = 'draft' | 'active' | 'deprecated' | 'deleted';
+
+export type MCPRemoteTransportType = 'streamable-http' | 'sse';
+
+// Entity types
+
+export interface MCPTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+  icons?: MCPIcon[];
+  execution?: Record<string, unknown>;
+}
+
+export interface MCPIcon {
+  src: string;
+  sizes?: string[];
+  mimeType?: string;
+  theme?: string;
+}
+
+export interface MCPAccessBindingSummary {
+  binding_id: number;
+  server_name: string;
+  endpoint_url: string;
+  transport_type: MCPRemoteTransportType;
+  server_version?: string;
+  server_alias?: string;
+  resolved_version?: MCPServerVersion;
+}
+
+export interface MCPServerAlias {
+  alias: string;
+  version: string;
+}
+
+export interface MCPServer {
+  name: string;
+  display_name?: string;
+  description?: string;
+  icons?: MCPIcon[];
+  status?: MCPStatus;
+  access_bindings: MCPAccessBindingSummary[];
+  latest_version?: string;
+  aliases: MCPServerAlias[];
+  tags: Record<string, string>;
+  created_by?: string;
+  last_updated_by?: string;
+  creation_timestamp?: number;
+  last_updated_timestamp?: number;
+}
+
+export interface MCPServerVersion {
+  name: string;
+  version: string;
+  server_json: ServerJSONPayload;
+  display_name?: string;
+  status: MCPStatus;
+  tools?: MCPTool[];
+  aliases: string[];
+  tags: Record<string, string>;
+  source?: string;
+  created_by?: string;
+  last_updated_by?: string;
+  creation_timestamp?: number;
+  last_updated_timestamp?: number;
+}
+
+export interface MCPAccessBinding {
+  binding_id: number;
+  server_name: string;
+  endpoint_url: string;
+  transport_type: MCPRemoteTransportType;
+  tools?: MCPTool[];
+  server_version?: string;
+  server_alias?: string;
+  resolved_version?: MCPServerVersion;
+  created_by?: string;
+  last_updated_by?: string;
+  creation_timestamp?: number;
+  last_updated_timestamp?: number;
+}
+
+// ServerJSON payload types use camelCase field names to match the MCP server.json specification
+
+export interface ServerJSONEnvironmentVariable {
+  name: string;
+  description?: string;
+  isRequired?: boolean;
+  isSecret?: boolean;
+}
+
+export interface ServerJSONPackage {
+  registryType: string;
+  identifier: string;
+  transport: string;
+  registryBaseUrl?: string;
+  version?: string;
+  environmentVariables?: ServerJSONEnvironmentVariable[];
+  [key: string]: unknown;
+}
+
+export interface ServerJSONRemote {
+  type: string;
+  url: string;
+  [key: string]: unknown;
+}
+
+export interface ServerJSONRepository {
+  url: string;
+  source: string;
+  id?: string;
+  subfolder?: string;
+}
+
+export interface ServerJSONPayload {
+  name: string;
+  version: string;
+  title?: string;
+  description?: string;
+  packages?: ServerJSONPackage[];
+  remotes?: ServerJSONRemote[];
+  repository?: ServerJSONRepository;
+  websiteUrl?: string;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+// Request types
+
+export interface CreateMCPServerRequest {
+  name: string;
+  description?: string;
+  icons?: MCPIcon[];
+}
+
+export interface UpdateMCPServerRequest {
+  display_name?: string | null;
+  description?: string | null;
+  icons?: MCPIcon[] | null;
+}
+
+export interface CreateMCPServerVersionRequest {
+  server_json: ServerJSONPayload;
+  display_name?: string;
+  status?: MCPStatus;
+  source?: string;
+  tools?: MCPTool[];
+}
+
+export interface UpdateMCPServerVersionRequest {
+  display_name?: string | null;
+  status?: MCPStatus | null;
+  tools?: MCPTool[] | null;
+}
+
+export interface CreateMCPAccessBindingRequest {
+  server_version?: string;
+  server_alias?: string;
+  endpoint_url: string;
+  transport_type?: MCPRemoteTransportType;
+}
+
+export interface UpdateMCPAccessBindingRequest {
+  server_version?: string | null;
+  server_alias?: string | null;
+  endpoint_url?: string | null;
+  transport_type?: MCPRemoteTransportType | null;
+}
+
+export interface SetMCPServerTagRequest {
+  key: string;
+  value: string;
+}
+
+export interface SetMCPServerAliasRequest {
+  alias: string;
+  version: string;
+}
+
+// Search parameters
+
+export interface SearchMCPServersParams {
+  filter_string?: string;
+  max_results?: number;
+  order_by?: string[];
+  page_token?: string;
+}
+
+export interface SearchMCPServerVersionsParams {
+  filter_string?: string;
+  max_results?: number;
+  order_by?: string[];
+  page_token?: string;
+}
+
+export interface SearchMCPAccessBindingsParams {
+  server_version?: string;
+  server_alias?: string;
+  filter_string?: string;
+  max_results?: number;
+  order_by?: string[];
+  page_token?: string;
+}
+
+// Response types
+
+export interface SearchMCPServersResponse {
+  mcp_servers: MCPServer[];
+  next_page_token?: string;
+}
+
+export interface SearchMCPServerVersionsResponse {
+  mcp_server_versions: MCPServerVersion[];
+  next_page_token?: string;
+}
+
+export interface SearchMCPAccessBindingsResponse {
+  mcp_access_bindings: MCPAccessBinding[];
+  next_page_token?: string;
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23695

### What changes are proposed in this pull request?

This is the first in a series of PRs adding the MCP Registry UI, building on the backend REST API from #23695. It sets up the foundational pieces so subsequent PRs can add list views, detail pages, and access binding management incrementally.
<img width="1512" height="811" alt="Screenshot 2026-06-23 at 7 12 07 PM" src="https://github.com/user-attachments/assets/74a3c485-47ca-4f23-bfa8-d54f55db3ae6" />
<img width="1512" height="811" alt="Screenshot 2026-06-23 at 7 12 35 PM" src="https://github.com/user-attachments/assets/611b461b-6e75-43c9-9d2a-199e99af047a" />

**TypeScript types** (`types.ts`)
- Entity types for `MCPServer`, `MCPServerVersion`, `MCPAccessBinding`, `MCPServerAlias`, `MCPIcon`, and the `ServerJSONPayload` spec types — all matching the Pydantic models from the backend.
- Request/response interfaces for all CRUD operations and search endpoints.

**API client** (`api.ts`)
- `MCPRegistryApi` object covering all 24 REST endpoints under `/ajax-api/3.0/mlflow/mcp-servers`.
- Proper `encodeURIComponent` for server names containing `/` (e.g., `io.github.example/my-server`).

**Routing and navigation**
- `route-defs.ts` and `routes.ts` with lazy-loaded page component and document title handle.
- Sidebar entry under "MCP Registry" gated behind `shouldEnableMCPRegistryUI`.

**Page shell** (`MCPRegistryPage.tsx`)
- Two tabs: "Access Bindings" (default) and "Servers".
- Search filter input with debounce, grid/list view toggle.
- Empty states for when no servers exist.
- Placeholder "Create MCP server" button (disabled for now — creation comes in a later PR).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified the page loads correctly with the sidebar entry, tabs switch, search filter works, and empty states render. Type-checked with `tsc --noEmit`, linted, and prettier-checked.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds the MCP Registry page shell with sidebar navigation — the starting point for the MCP server registry UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release