### PR TITLE
Fix clipped GitHub navbar label on mobile

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -432,6 +432,16 @@ html[data-genai-theme='true'] {
   flex-wrap: nowrap;
 }
 
+/* On narrow viewports the navbar collapses into the hamburger menu, which
+   already contains a "GitHub" entry. The persistent top-bar GitHub link
+   overlaps the search button at these widths and gets clipped to "GitHu",
+   so hide it here and rely on the hamburger menu entry instead. */
+@media (max-width: 996px) {
+  .navbar__items--right .github-link {
+    display: none;
+  }
+}
+
 /* --------------------------------
  * 4. Sidebar Styling
  * -------------------------------- */


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

On narrow viewports (≤996px) the docs navbar collapses into a hamburger menu — which already contains a **GitHub** entry. However, the persistent top-bar `.github-link` is *not* hidden at these widths, so it overlaps the search button and gets clipped to **"GitHu"**.

This PR adds a `@media (max-width: 996px)` rule to hide the top-bar GitHub link on mobile, relying on the existing hamburger-menu entry instead. No links are lost — GitHub remains reachable from the hamburger menu.

```css
@media (max-width: 996px) {
  .navbar__items--right .github-link {
    display: none;
  }
}
```

### How is this PR tested?

- [x] Manual tests

Verified at 390px / 500px viewport widths that the clipped "GitHu" label no longer renders in the top bar, and confirmed the "GitHub" entry is still present in the hamburger menu.
before
<img width="415" height="567" alt="image" src="https://github.com/user-attachments/assets/5d9524ef-a094-49c5-b473-40201e0bb862" />
after
<img width="494" height="314" alt="image" src="https://github.com/user-attachments/assets/bb63d615-068b-4b85-bf19-a2318920325b" />
<img width="482" height="328" alt="image" src="https://github.com/user-attachments/assets/5d59b6a5-d92b-4e0b-8d83-ba4318b5495c" />



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude Code.