### PR TITLE
fix: use Base.metadata instead of InitialBase.metadata to avoid 'table already exists' error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. 

## Root Cause
`_initialize_tables` uses `InitialBase.metadata.create_all(engine)` which attempts to create tables defined in `initial_models.py`. If a table (like 'secrets') was already created by an Alembic migration in a previous version (or by a partial upgrade), `create_all` will fail because `checkfirst` behavior depends on the metadata object tracking which tables it has created. The `InitialBase.metadata` does not include tables added by migrations, so it might try to recreate them.

## Fix
Replace `InitialBase.metadata.create_all(engine)` with `Base.metadata.create_all(engine)`. `Base.metadata` includes all ORM-registered tables (including those from initial models and any added later). SQLAlchemy's `create_all` defaults to `checkfirst=True`, which skips creation if the table already exists, thus avoiding the duplicate table error while ensuring all required tables are present before running Alembic migrations.

Closes #19943