### PR TITLE
Added Text A2UI primitive and A2UI dependencies

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -23,6 +23,8 @@
     "graphql-codegen:clean": "find . -path '**/__generated__/*.ts' | xargs rm"
   },
   "dependencies": {
+    "@a2ui/react": "^0.10.0",
+    "@a2ui/web_core": "^0.10.0",
     "@ag-grid-community/client-side-row-model": "^27.2.1",
     "@ag-grid-community/core": "^27.2.1",
     "@ag-grid-community/react": "^27.2.1",
@@ -233,5 +235,6 @@
         ]
       }
     }
-  }
+  },
+  "packageManager": "yarn@4.17.0"
 }

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -235,6 +235,5 @@
         ]
       }
     }
-  },
-  "packageManager": "yarn@4.17.0"
+  }
 }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import { Catalog, ComponentContext, ComponentModel, SurfaceModel } from '@a2ui/web_core/v0_9';
+import { DesignSystemProvider } from '@databricks/design-system';
+
+import { Text } from './Text';
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DesignSystemProvider>{children}</DesignSystemProvider>
+);
+
+// Renders the Text implementation through a minimal A2UI surface so the generic
+// binder resolves the component's props the same way the renderer does at runtime.
+const renderText = (props: Record<string, unknown>) => {
+  const catalog = new Catalog<any>('test', [], []);
+  const surface = new SurfaceModel<any>('test-surface', catalog);
+  surface.componentsModel.addComponent(new ComponentModel('c1', 'Text', props));
+  const context = new ComponentContext(surface, 'c1', '/');
+  return render(<Text.render context={context} buildChild={() => null} />, { wrapper: Wrapper });
+};
+
+describe('Text primitive', () => {
+  it('renders body text', () => {
+    renderText({ text: 'Hello World' });
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+  });
+
+  it('renders a heading for the h1 variant', () => {
+    renderText({ text: 'Big Title', variant: 'h1' });
+    expect(screen.getByRole('heading', { level: 1, name: 'Big Title' })).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
@@ -1,0 +1,45 @@
+import { createComponentImplementation } from '@a2ui/react/v0_9';
+import { TextApi } from '@a2ui/web_core/v0_9/basic_catalog';
+import { Typography } from '@databricks/design-system';
+
+/**
+ * Custom Text primitive that overrides the basic catalog's Text.
+ */
+const asString = (value: unknown): string => (typeof value === 'string' ? value : String(value ?? ''));
+
+const HEADING_STYLE: Record<string, { fontSize: number; lineHeight: string; fontWeight: number }> = {
+  h1: { fontSize: 32, lineHeight: '40px', fontWeight: 700 },
+  h2: { fontSize: 26, lineHeight: '34px', fontWeight: 700 },
+  h3: { fontSize: 22, lineHeight: '30px', fontWeight: 600 },
+  h4: { fontSize: 19, lineHeight: '26px', fontWeight: 600 },
+  h5: { fontSize: 16, lineHeight: '22px', fontWeight: 600 },
+};
+
+export const Text = createComponentImplementation(TextApi, ({ props }) => {
+  const text = asString(props.text);
+  const variant = typeof props.variant === 'string' ? props.variant : 'body';
+  const weight = typeof props.weight === 'number' ? props.weight : undefined;
+  const flexStyle = weight !== undefined ? { flex: `${weight}`, minWidth: 0 } : undefined;
+
+  const headingStyle = HEADING_STYLE[variant];
+  if (headingStyle) {
+    // h1–h3 map to a Title element for semantics; h4/h5 use the explicit size
+    // on a lower-emphasis Title level so the override drives the visual size.
+    const level = variant === 'h1' ? 1 : variant === 'h2' ? 2 : 3;
+    return (
+      <Typography.Title level={level} withoutMargins css={{ ...flexStyle, ...headingStyle }}>
+        {text}
+      </Typography.Title>
+    );
+  }
+
+  if (variant === 'caption') {
+    return (
+      <Typography.Text size="sm" color="secondary" css={flexStyle}>
+        {text}
+      </Typography.Text>
+    );
+  }
+
+  return <Typography.Text css={flexStyle}>{text}</Typography.Text>;
+});

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -16,6 +16,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@a2ui/markdown-it@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "@a2ui/markdown-it@npm:0.0.4"
+  dependencies:
+    dompurify: "npm:^3.3.1"
+    markdown-it: "npm:^14.1.0"
+  peerDependencies:
+    "@a2ui/web_core": ^0.9.2
+  checksum: 10c0/19d53625f14cf64cd61778ed5e0131601b4010b274ef401a013e3a8c4a81b422ba4173ee7baea7a44cb7f29ec19dd5d1400c0d07cbca2f50639de4de58fec4ef
+  languageName: node
+  linkType: hard
+
+"@a2ui/react@npm:^0.10.0":
+  version: 0.10.1
+  resolution: "@a2ui/react@npm:0.10.1"
+  dependencies:
+    "@a2ui/markdown-it": "npm:^0.0.4"
+    "@a2ui/web_core": "npm:^0.10.1"
+    clsx: "npm:^2.1.1"
+    markdown-it: "npm:^14.2.0"
+    zod: "npm:^3.25.76"
+  peerDependencies:
+    react: ^19.2.7
+    react-dom: ^19.2.7
+    zod: ^3.25.76
+  checksum: 10c0/742d7e8ebc3982837736bde2143515f489b13af8f780ed9d903599d979e1cc41ba26f71126213f0b84c86316adcd31649294df988915c694f174a78ba890a8a9
+  languageName: node
+  linkType: hard
+
+"@a2ui/web_core@npm:^0.10.0, @a2ui/web_core@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "@a2ui/web_core@npm:0.10.1"
+  dependencies:
+    "@preact/signals-core": "npm:^1.14.2"
+    date-fns: "npm:^4.4.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.2"
+  checksum: 10c0/0d7ce3b55ee8a9aabc11a36853e60cf6416e72ef9b42cb6aea679fe20c7a9278bb04a5e6a840260d2371703c1961fc3fd921d8dd21f287c8e71a21073b87b894
+  languageName: node
+  linkType: hard
+
 "@aashutoshrathi/word-wrap@npm:^1.2.3":
   version: 1.2.6
   resolution: "@aashutoshrathi/word-wrap@npm:1.2.6"
@@ -4798,6 +4839,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mlflow/mlflow@workspace:."
   dependencies:
+    "@a2ui/react": "npm:^0.10.0"
+    "@a2ui/web_core": "npm:^0.10.0"
     "@ag-grid-community/client-side-row-model": "npm:^27.2.1"
     "@ag-grid-community/core": "npm:^27.2.1"
     "@ag-grid-community/react": "npm:^27.2.1"
@@ -5719,6 +5762,13 @@ __metadata:
     webpack-plugin-serve:
       optional: true
   checksum: 10c0/afe7d5d5895f2edc1f4336e57082072736a27d79389eabc6c4e1297dae08da06e01d17f1b3866ed871989e070dbc3ec14ad8a1a88a22b11c1c530db5aa67fa12
+  languageName: node
+  linkType: hard
+
+"@preact/signals-core@npm:^1.14.2":
+  version: 1.14.3
+  resolution: "@preact/signals-core@npm:1.14.3"
+  checksum: 10c0/fb4af3fe8eaac8dc0fa865e4117dc52b27fa7717f099c7b40e4fa86448e95b02a8bc0df3f3b22191e7ff61223b8feb4416fde1dd2dd61cdf2289e673a35c879a
   languageName: node
   linkType: hard
 
@@ -10470,7 +10520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:*, @types/trusted-types@npm:^2.0.2":
+"@types/trusted-types@npm:*, @types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
@@ -16564,6 +16614,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "date-fns@npm:4.4.0"
+  checksum: 10c0/988f0a13db183f5dfc85c36bbb6847a9c135a9225888bbea4005876ec15539a8613c21a07370a4e7ea543918d5a1cafb423c528b42cdbbde5fdfddb178126b21
+  languageName: node
+  linkType: hard
+
 "date-now@npm:^0.1.4":
   version: 0.1.4
   resolution: "date-now@npm:0.1.4"
@@ -17241,6 +17298,18 @@ __metadata:
   version: 2.5.9
   resolution: "dompurify@npm:2.5.9"
   checksum: 10c0/91cf3fd8ad07f969a740813a2101d573547954fd87925d729e8cfc592fa93c51fc3f7b298d336bd90c1a5eae1ad65d1ca06254b938fd84af84ef081c9c4b75ee
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.1":
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
   languageName: node
   linkType: hard
 
@@ -24682,6 +24751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "linkify-it@npm:5.0.1"
+  dependencies:
+    uc.micro: "npm:^2.0.0"
+  checksum: 10c0/d06d04f1ed03be131740fc900a5e74ea1f49886b052213599e306d469d5ffe2303db76dd8f771de9f28e2b0b38852de22ec46ae597d245f8b66439b0ceb19b10
+  languageName: node
+  linkType: hard
+
 "listr2@npm:^4.0.5":
   version: 4.0.5
   resolution: "listr2@npm:4.0.5"
@@ -25239,6 +25317,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^14.1.0, markdown-it@npm:^14.2.0":
+  version: 14.2.0
+  resolution: "markdown-it@npm:14.2.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    entities: "npm:^4.4.0"
+    linkify-it: "npm:^5.0.1"
+    mdurl: "npm:^2.0.0"
+    punycode.js: "npm:^2.3.1"
+    uc.micro: "npm:^2.1.0"
+  bin:
+    markdown-it: bin/markdown-it.mjs
+  checksum: 10c0/1d3a50061d2fe4efbcf317aac853dbee6892ed6f5a217570eead723f2ef2dd1c9baaeef5a687cd283480c45c2d20724a73e84a9ed72843cf7b3b719067af40ef
+  languageName: node
+  linkType: hard
+
 "markdown-table@npm:^3.0.0":
   version: 3.0.3
   resolution: "markdown-table@npm:3.0.3"
@@ -25584,6 +25678,13 @@ __metadata:
   version: 1.0.1
   resolution: "mdurl@npm:1.0.1"
   checksum: 10c0/ea8534341eb002aaa532a722daef6074cd8ca66202e10a2b4cda46722c1ebdb1da92197ac300bc953d3ef1bf41cd6561ef2cc69d82d5d0237dae00d4a61a4eee
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdurl@npm:2.0.0"
+  checksum: 10c0/633db522272f75ce4788440669137c77540d74a83e9015666a9557a152c02e245b192edc20bc90ae953bbab727503994a53b236b4d9c99bdaee594d0e7dd2ce0
   languageName: node
   linkType: hard
 
@@ -29996,6 +30097,13 @@ __metadata:
     inherits: "npm:^2.0.3"
     pump: "npm:^2.0.0"
   checksum: 10c0/0bcabf9e3dbf2d0cc1f9b84ac80d3c75386111caf8963bfd98817a1e2192000ac0ccc804ca6ccd5b2b8430fdb71347b20fb2f014fe3d41adbacb1b502a841c45
+  languageName: node
+  linkType: hard
+
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 10c0/1d12c1c0e06127fa5db56bd7fdf698daf9a78104456a6b67326877afc21feaa821257b171539caedd2f0524027fa38e67b13dd094159c8d70b6d26d2bea4dfdb
   languageName: node
   linkType: hard
 
@@ -35828,6 +35936,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10c0/8862eddb412dda76f15db8ad1c640ccc2f47cdf8252a4a30be908d535602c8d33f9855dfcccb8b8837855c1ce1eaa563f7fa7ebe3c98fd0794351aab9b9c55fa
+  languageName: node
+  linkType: hard
+
 "uglify-js@npm:^3.1.4":
   version: 3.19.3
   resolution: "uglify-js@npm:3.19.3"
@@ -38255,6 +38370,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.25.2":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+  languageName: node
+  linkType: hard
+
 "zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
@@ -38268,6 +38392,13 @@ __metadata:
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.76":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24154/files) to review incremental changes.
- [stack/1-n-custom-view](https://github.com/mlflow/mlflow/pull/24139) [[Files changed](https://github.com/mlflow/mlflow/pull/24139/files)] [MERGED]
  - [**stack/2-n-custom-view**](https://github.com/mlflow/mlflow/pull/24154) [[Files changed](https://github.com/mlflow/mlflow/pull/24154/files)] ← _this PR_

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Signed-off-by: Aaron Teo <atwkdeveloper@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

**A2UI dependencies:** add `@a2ui/react` and `@a2ui/web_core` (`^0.10.0`)
  to `mlflow/server/js/package.json` and regenerate `yarn.lock`. Every
  custom-view primitive imports `@a2ui/*`, so this must land before any of
  them compiles.

**`Text` catalog primitive:** add
  `shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx`,
  a custom override of the basic catalog's `Text` built via
  `createComponentImplementation`. It maps `variant` to Design System
  `Typography` (h1–h5 headings, caption, body) and supports a `weight`
  flex hint. Plus a minimal render test (`Text.test.tsx`).

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
