### PR TITLE
Add review queue demo data generator

### DIFF
--- a/mlflow/demo/README.md
+++ b/mlflow/demo/README.md
@@ -19,7 +19,9 @@ mlflow/demo/
     ├── prompts.py           # Prompt versions and aliases
     ├── traces.py            # Sample traces with various patterns
     ├── evaluation.py        # Evaluation runs and datasets
-    └── scorers.py           # Registered LLM judges
+    ├── judges.py            # Registered LLM judges
+    ├── issues.py            # Detected issues linked to failing traces
+    └── review_queues.py     # Review queues, label schemas, and queued items
 ```
 
 **Generator order matters** - some generators depend on others (e.g., traces depend on prompts, evaluation depends on traces).

--- a/mlflow/demo/base.py
+++ b/mlflow/demo/base.py
@@ -19,6 +19,7 @@ class DemoFeature(str, Enum):
     PROMPTS = "prompts"
     JUDGES = "judges"
     ISSUES = "issues"
+    REVIEW_QUEUES = "review_queues"
 
 
 @dataclass

--- a/mlflow/demo/generators/__init__.py
+++ b/mlflow/demo/generators/__init__.py
@@ -2,6 +2,7 @@ from mlflow.demo.generators.evaluation import EvaluationDemoGenerator
 from mlflow.demo.generators.issues import IssuesDemoGenerator
 from mlflow.demo.generators.judges import JudgesDemoGenerator
 from mlflow.demo.generators.prompts import PromptsDemoGenerator
+from mlflow.demo.generators.review_queues import ReviewQueuesDemoGenerator
 from mlflow.demo.generators.traces import TracesDemoGenerator
 from mlflow.demo.registry import demo_registry
 
@@ -9,16 +10,19 @@ from mlflow.demo.registry import demo_registry
 # and traces must exist before evaluation (which references them).
 # Judges are independent and can be registered last.
 # Issues should be registered after traces exist (since they reference trace problems).
+# Review queues should be registered after traces exist (since they attach traces).
 demo_registry.register(PromptsDemoGenerator)
 demo_registry.register(TracesDemoGenerator)
 demo_registry.register(EvaluationDemoGenerator)
 demo_registry.register(JudgesDemoGenerator)
 demo_registry.register(IssuesDemoGenerator)
+demo_registry.register(ReviewQueuesDemoGenerator)
 
 __all__ = [
     "EvaluationDemoGenerator",
     "IssuesDemoGenerator",
     "JudgesDemoGenerator",
     "PromptsDemoGenerator",
+    "ReviewQueuesDemoGenerator",
     "TracesDemoGenerator",
 ]

--- a/mlflow/demo/generators/review_queues.py
+++ b/mlflow/demo/generators/review_queues.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlflow
+from mlflow.demo.base import (
+    DEMO_EXPERIMENT_NAME,
+    BaseDemoGenerator,
+    DemoFeature,
+    DemoResult,
+)
+from mlflow.exceptions import MlflowException
+from mlflow.genai.label_schemas import InputCategorical, InputPassFail, InputText
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
+from mlflow.tracking._tracking_service.utils import _get_store
+
+_logger = logging.getLogger(__name__)
+
+_DEMO_CREATED_BY = "demo"
+
+# Custom queue bundling a curated set of traces and questions for an expert review pass.
+DEMO_REVIEW_QUEUE_NAME = "Demo Response Review"
+# Reviewers assigned to the custom queue. Each also gets a personal user queue so the
+# demo shows both queue flavors (a curated custom task and per-reviewer worklists).
+DEMO_REVIEWERS = ["alice", "bob"]
+# The no-auth current viewer. Its user queue is the "Default" queue the UI shows, so we
+# seed it too (it would otherwise render empty until the viewer flags traces themselves).
+DEMO_DEFAULT_REVIEWER = "default"
+
+# Questions (label schemas) reviewers answer for each attached trace.
+DEMO_LABEL_SCHEMAS = [
+    {
+        "name": "response_quality",
+        "type": "feedback",
+        "input": InputCategorical(options=["Excellent", "Good", "Fair", "Poor"]),
+        "instruction": "Rate the overall quality of the assistant's response.",
+        "enable_comment": True,
+    },
+    {
+        "name": "is_helpful",
+        "type": "feedback",
+        "input": InputPassFail(positive_label="Helpful", negative_label="Not helpful"),
+        "instruction": "Did the response help the user accomplish their goal?",
+        "enable_comment": False,
+    },
+    {
+        "name": "correct_answer",
+        "type": "expectation",
+        "input": InputText(),
+        "instruction": "If the response was wrong, provide the correct answer.",
+        "enable_comment": False,
+    },
+]
+
+_MAX_QUEUE_ITEMS = 12
+_MAX_USER_QUEUE_ITEMS = 5
+
+
+class ReviewQueuesDemoGenerator(BaseDemoGenerator):
+    """Generates demo review queues showing the expert trace-review workflow.
+
+    Creates a set of label schemas (the questions reviewers answer), one curated
+    ``custom`` queue with traces attached and mixed review progress, and a personal
+    ``user`` queue per demo reviewer. Together these populate the Review Queue UI
+    with a realistic worklist so users can explore the labeling experience.
+    """
+
+    name = DemoFeature.REVIEW_QUEUES
+    version = 1
+
+    def generate(self) -> DemoResult:
+        store = _get_store()
+        experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+        if experiment is None:
+            raise ValueError(f"Demo experiment '{DEMO_EXPERIMENT_NAME}' not found")
+
+        experiment_id = experiment.experiment_id
+
+        schema_ids = [
+            self._get_or_create_label_schema(store, experiment_id, spec).schema_id
+            for spec in DEMO_LABEL_SCHEMAS
+        ]
+
+        traces = mlflow.search_traces(
+            locations=[experiment_id], max_results=1000, return_type="list", flush=True
+        )
+        trace_ids = [trace.info.trace_id for trace in traces]
+
+        custom_queue = store.create_review_queue(
+            experiment_id,
+            name=DEMO_REVIEW_QUEUE_NAME,
+            queue_type="custom",
+            created_by=_DEMO_CREATED_BY,
+            users=DEMO_REVIEWERS,
+            schema_ids=schema_ids,
+        )
+        created_queue_ids = [custom_queue.queue_id]
+
+        if custom_item_ids := trace_ids[:_MAX_QUEUE_ITEMS]:
+            store.add_items_to_review_queue(custom_queue.queue_id, item_ids=custom_item_ids)
+            self._seed_progress(store, custom_queue.queue_id, custom_item_ids)
+
+        # Personal user queues: each reviewer's own worklist over a few traces. Includes
+        # the default (viewer) queue so the "Default" tab is populated out of the box.
+        for offset, reviewer in enumerate([*DEMO_REVIEWERS, DEMO_DEFAULT_REVIEWER]):
+            user_queue = store.get_or_create_user_queue(experiment_id, user=reviewer)
+            created_queue_ids.append(user_queue.queue_id)
+            start = offset * _MAX_USER_QUEUE_ITEMS
+            if user_item_ids := trace_ids[start : start + _MAX_USER_QUEUE_ITEMS]:
+                store.add_items_to_review_queue(user_queue.queue_id, item_ids=user_item_ids)
+
+        return DemoResult(
+            feature=self.name,
+            entity_ids=created_queue_ids,
+            navigation_url=f"#/experiments/{experiment_id}/review-queue",
+        )
+
+    def _get_or_create_label_schema(self, store, experiment_id: str, spec: dict[str, Any]):
+        """Create a demo label schema, reusing an existing one with the same name.
+
+        Idempotent so a re-run after a partially-completed generation (schemas created
+        but queues not, which `_data_exists` doesn't detect) doesn't crash on the
+        duplicate-name ``RESOURCE_ALREADY_EXISTS`` from ``create_label_schema``.
+        """
+        try:
+            return store.create_label_schema(
+                experiment_id,
+                name=spec["name"],
+                type=spec["type"],
+                input=spec["input"],
+                instruction=spec["instruction"],
+                enable_comment=spec["enable_comment"],
+            )
+        except MlflowException as e:
+            if e.error_code != ErrorCode.Name(RESOURCE_ALREADY_EXISTS):
+                raise
+            return store.get_label_schema_by_name(experiment_id, spec["name"])
+
+    def _seed_progress(self, store, queue_id: str, item_ids: list[str]) -> None:
+        """Mark a mix of items complete/declined so the queue shows realistic progress."""
+        for index, item_id in enumerate(item_ids):
+            reviewer = DEMO_REVIEWERS[index % len(DEMO_REVIEWERS)]
+            # Roughly: every 3rd item complete, every 5th declined, rest left pending.
+            if index % 5 == 4:
+                status = "declined"
+            elif index % 3 == 0:
+                status = "complete"
+            else:
+                continue
+            store.set_review_queue_item_status(
+                queue_id, item_id=item_id, status=status, completed_by=reviewer
+            )
+
+    def _data_exists(self) -> bool:
+        try:
+            store = _get_store()
+            experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+            if experiment is None:
+                return False
+            store.get_review_queue_by_name(experiment.experiment_id, name=DEMO_REVIEW_QUEUE_NAME)
+            return True
+        except Exception:
+            return False
+
+    def delete_demo(self) -> None:
+        store = _get_store()
+        experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+        if experiment is None:
+            return
+
+        experiment_id = experiment.experiment_id
+        for name in [DEMO_REVIEW_QUEUE_NAME, *DEMO_REVIEWERS, DEMO_DEFAULT_REVIEWER]:
+            try:
+                queue = store.get_review_queue_by_name(experiment_id, name=name)
+                store.delete_review_queue(queue.queue_id)
+            except Exception:
+                _logger.debug("Failed to delete demo review queue %s", name, exc_info=True)
+
+        # Look each demo schema up by name rather than paging through the experiment's
+        # schemas: direct lookup can't miss a demo schema regardless of how many
+        # (possibly user-created) schemas the experiment has.
+        for spec in DEMO_LABEL_SCHEMAS:
+            try:
+                schema = store.get_label_schema_by_name(experiment_id, spec["name"])
+                if not schema.is_default:
+                    store.delete_label_schema(schema.schema_id)
+            except Exception:
+                _logger.debug("Failed to delete demo label schema %s", spec["name"], exc_info=True)

--- a/tests/demo/test_review_queues_generator.py
+++ b/tests/demo/test_review_queues_generator.py
@@ -1,0 +1,148 @@
+import pytest
+
+import mlflow
+from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
+from mlflow.demo.generators.review_queues import (
+    DEMO_DEFAULT_REVIEWER,
+    DEMO_LABEL_SCHEMAS,
+    DEMO_REVIEW_QUEUE_NAME,
+    DEMO_REVIEWERS,
+    ReviewQueuesDemoGenerator,
+)
+from mlflow.tracking._tracking_service.utils import _get_store
+
+
+@pytest.fixture
+def demo_experiment_with_traces():
+    """Seed the demo experiment with a handful of traces for queues to attach to."""
+    mlflow.set_experiment(DEMO_EXPERIMENT_NAME)
+
+    @mlflow.trace
+    def predict(question: str) -> str:
+        return f"answer to {question}"
+
+    for i in range(15):
+        predict(f"question {i}")
+
+    experiment = mlflow.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    return experiment.experiment_id
+
+
+@pytest.fixture
+def review_queues_generator():
+    generator = ReviewQueuesDemoGenerator()
+    original_version = generator.version
+    yield generator
+    ReviewQueuesDemoGenerator.version = original_version
+
+
+def test_generator_attributes():
+    generator = ReviewQueuesDemoGenerator()
+    assert generator.name == DemoFeature.REVIEW_QUEUES
+    assert generator.version == 1
+
+
+def test_data_exists_false_when_no_queues():
+    generator = ReviewQueuesDemoGenerator()
+    assert generator._data_exists() is False
+
+
+def test_generate_creates_queues(demo_experiment_with_traces):
+    generator = ReviewQueuesDemoGenerator()
+    result = generator.generate()
+
+    assert isinstance(result, DemoResult)
+    assert result.feature == DemoFeature.REVIEW_QUEUES
+    assert "/review-queue" in result.navigation_url
+    # One custom queue plus one user queue per reviewer and the default (viewer) queue.
+    assert len(result.entity_ids) == 1 + len(DEMO_REVIEWERS) + 1
+
+
+def test_generate_creates_schemas_queue_and_items(demo_experiment_with_traces):
+    experiment_id = demo_experiment_with_traces
+    generator = ReviewQueuesDemoGenerator()
+    generator.generate()
+
+    store = _get_store()
+
+    schema_names = {s.name for s in store.list_label_schemas(experiment_id, max_results=100)}
+    for spec in DEMO_LABEL_SCHEMAS:
+        assert spec["name"] in schema_names
+
+    custom_queue = store.get_review_queue_by_name(experiment_id, name=DEMO_REVIEW_QUEUE_NAME)
+    assert custom_queue.queue_type == "custom"
+    assert set(custom_queue.users) == set(DEMO_REVIEWERS)
+    assert len(custom_queue.schema_ids) == len(DEMO_LABEL_SCHEMAS)
+
+    items = store.list_review_queue_items(custom_queue.queue_id)
+    assert len(items) > 0
+    # Progress seeding marks some items as terminal (complete/declined).
+    assert any(item.status != "pending" for item in items)
+
+    for reviewer in [*DEMO_REVIEWERS, DEMO_DEFAULT_REVIEWER]:
+        user_queue = store.get_review_queue_by_name(experiment_id, name=reviewer)
+        assert user_queue.queue_type == "user"
+        assert len(store.list_review_queue_items(user_queue.queue_id)) > 0
+
+
+def test_data_exists_true_after_generate(demo_experiment_with_traces):
+    generator = ReviewQueuesDemoGenerator()
+    assert generator._data_exists() is False
+
+    generator.generate()
+
+    assert generator._data_exists() is True
+
+
+def test_delete_demo_removes_queues(demo_experiment_with_traces):
+    generator = ReviewQueuesDemoGenerator()
+    generator.generate()
+    assert generator._data_exists() is True
+
+    generator.delete_demo()
+
+    assert generator._data_exists() is False
+
+
+def test_generate_is_idempotent_after_partial_schema_creation(demo_experiment_with_traces):
+    experiment_id = demo_experiment_with_traces
+    store = _get_store()
+    # Simulate a prior run that created the schemas but not the queue (which
+    # `_data_exists` keys off), so a re-run must not crash on duplicate schema names.
+    for spec in DEMO_LABEL_SCHEMAS:
+        store.create_label_schema(
+            experiment_id,
+            name=spec["name"],
+            type=spec["type"],
+            input=spec["input"],
+            instruction=spec["instruction"],
+            enable_comment=spec["enable_comment"],
+        )
+
+    generator = ReviewQueuesDemoGenerator()
+    assert generator._data_exists() is False
+
+    generator.generate()
+
+    assert generator._data_exists() is True
+
+
+def test_generate_without_traces_still_creates_queues():
+    mlflow.set_experiment(DEMO_EXPERIMENT_NAME)
+    generator = ReviewQueuesDemoGenerator()
+
+    result = generator.generate()
+
+    assert generator._data_exists() is True
+    assert len(result.entity_ids) == 1 + len(DEMO_REVIEWERS) + 1
+
+
+def test_is_generated_checks_version(demo_experiment_with_traces, review_queues_generator):
+    review_queues_generator.generate()
+    review_queues_generator.store_version()
+
+    assert review_queues_generator.is_generated() is True
+
+    ReviewQueuesDemoGenerator.version = 99
+    fresh_generator = ReviewQueuesDemoGenerator()
+    assert fresh_generator.is_generated() is False


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The MLflow demo experiment (`mlflow demo` / "Launch Demo") seeds traces, evaluations, judges, and issues, but the Review Queue page was empty. This adds a `ReviewQueuesDemoGenerator` so the Review Queue UI is populated out of the box, giving users something to explore without manually creating queues.

It seeds:

- Three label schemas (the reviewer questions): `response_quality` (categorical), `is_helpful` (pass/fail), `correct_answer` (expectation text).
- One curated `custom` queue ("Demo Response Review") with traces attached and a realistic mix of pending/complete/declined progress.
- A personal `user` queue per demo reviewer, plus the default (current viewer) queue shown as "Default", so it's populated out of the box rather than empty.

The generator is registered after the traces generator (it attaches existing demo traces) and follows the same pattern as the existing issues generator, including idempotent `_data_exists` / `delete_demo` for regeneration.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Verified end-to-end against the dev server: `POST /demo/generate` includes `review_queues`, and the Review Queue UI renders the custom queue (All/Needs review/Completed filters), the user queues, the 3 questions, and the focused review flow.

**Demo walkthrough:**

https://github.com/user-attachments/assets/1b0facd9-c173-4a53-9cf8-554c8b77fa80

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)