### PR TITLE
Restart UI preview app after deploy so new code is loaded

### DIFF
--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -235,6 +235,54 @@ jobs:
           databricks workspace import-dir /tmp/app-deploy "$WORKSPACE_PATH" --overwrite
           databricks apps deploy "$APP_NAME" --source-code-path "/Workspace$WORKSPACE_PATH"
 
+      - name: Restart app to load the new code
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          APP_NAME: ${{ github.event_name == 'push' && 'mlflow-ui-preview-dev' || format('mlflow-ui-preview-pr-{0}', github.event.pull_request.number) }}
+        run: |
+          # `apps deploy` restarts the app process and re-extracts the UI assets,
+          # but reuses the existing Python env, so the freshly built wheel is not
+          # reinstalled and backend code changes never take effect. Stop then start
+          # the app so the env is rebuilt from the deployed source.
+          echo "Stopping app..."
+          databricks apps stop "$APP_NAME"
+          for i in $(seq 1 40); do
+            STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
+            echo "Compute state: $STATE"
+            if [ "$STATE" = "STOPPED" ]; then
+              break
+            elif [ "$STATE" = "ERROR" ]; then
+              echo "::error::Compute entered ERROR state while stopping"
+              exit 1
+            fi
+            sleep 15
+          done
+          if [ "$STATE" != "STOPPED" ]; then
+            echo "::error::Timed out waiting for compute to stop (last state: $STATE)"
+            exit 1
+          fi
+
+          echo "Starting app..."
+          databricks apps start "$APP_NAME"
+          for i in $(seq 1 40); do
+            STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
+            echo "Compute state: $STATE"
+            if [ "$STATE" = "ACTIVE" ]; then
+              break
+            elif [ "$STATE" = "ERROR" ]; then
+              echo "::error::Compute entered ERROR state"
+              exit 1
+            fi
+            sleep 15
+          done
+          if [ "$STATE" != "ACTIVE" ]; then
+            echo "::error::Timed out waiting for compute to become ACTIVE (last state: $STATE)"
+            exit 1
+          fi
+
       - name: Print app URL
         if: github.event_name == 'push'
         env:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The UI preview deploy job runs `databricks apps deploy` against the already-running app. That restarts the app process and re-extracts the UI assets, but reuses the existing Python environment, so the freshly built wheel is **not** reinstalled. As a result, backend code changes in a PR don't take effect on the preview even though the deploy reports success. Frontend changes still show up because the UI assets are re-extracted on each process start (`app.py`'s `setup()`); only the backend (the installed wheel) is left stale.

This was hit on #24158: a backend-only change (new demo data) deployed "successfully" but the preview kept serving the old code until the app was manually stopped and restarted, which rebuilt the env from scratch.

This PR adds a step that stops then starts the app after deploy, so the environment is rebuilt from the freshly deployed source and the new code is actually loaded.

### How is this PR tested?

- [x] Manual tests

Confirmed manually that stopping and starting the preview app rebuilds the environment and loads the new wheel (the preview began serving the updated backend code only after a stop/start). This PR's own UI preview run also exercises the new step end-to-end.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)