### PR TITLE
fix: skip GCS directory marker objects when listing artifacts

### DIFF
--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -160,10 +160,15 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             # returns subdirectories as well
             if result.name == prefix:
                 continue
+            # Skip GCS directory marker objects (0-byte blobs ending with "/")
+            # These are created by some GCS-compatible backends and should not
+            # be treated as regular files in artifact listings.
+            if result.name.endswith("/") and result.size == 0:
+                continue
             blob_path = result.name[len(artifact_path) + 1 :]
             infos.append(FileInfo(blob_path, False, result.size))
-
         return sorted(infos, key=lambda f: f.path)
+
 
     def _list_folders(self, bkt, prefix, artifact_path):
         results = bkt.list_blobs(prefix=prefix, delimiter="/")


### PR DESCRIPTION
### Related Issues/PRs

Closes #24160

### What changes are proposed in this pull request?

Some GCS-compatible backends (e.g. Hitachi HCP) create 0-byte objects
ending with "/" as directory markers. `GCSArtifactRepository.list_artifacts()`
was treating these as regular files, causing incorrect artifact listings
and 500 errors when downloading these marker objects.

Added a check to skip blobs where `name.endswith("/")` and `size == 0`,
consistent with the S3 fix applied in #23250.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. GCS artifact listings no longer incorrectly include directory marker objects, preventing 500 errors on GCS-compatible backends that create implicit directory markers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release