### PR TITLE
Don't prompt for tool calls the static permission policy already allows

### DIFF
--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -26,7 +26,11 @@ from mlflow.assistant.providers.base import (
     load_config,
 )
 from mlflow.assistant.providers.prompts import ASSISTANT_SYSTEM_PROMPT
-from mlflow.assistant.providers.tool_executor import build_tools_schema, execute_tool
+from mlflow.assistant.providers.tool_executor import (
+    build_tools_schema,
+    execute_tool,
+    static_permission_error,
+)
 from mlflow.assistant.types import Event, Message, ToolResultBlock, ToolUseBlock
 
 _logger = logging.getLogger(__name__)
@@ -515,13 +519,26 @@ class OpenAICompatibleProvider(AssistantProvider):
                         except json.JSONDecodeError:
                             tool_input = {}
 
-                        # Permission gating. With full access (config) tools run
-                        # without prompting. Otherwise a session pauses the turn
-                        # at a per-call Yes/No prompt and a later resume request
-                        # delivers the choice via `tool_decisions`; an explicit
-                        # allow overrides the static allowlist for that call.
-                        # With no session, fall back to static permissions.
-                        gated = not config.permissions.full_access and bool(mlflow_session_id)
+                        # Permission gating. With full access (config) tools run without
+                        # prompting. Otherwise we prompt only for a call that BOTH has a session
+                        # (so a decision can be delivered on resume) AND isn't already permitted by
+                        # the static policy: allowlisted Bash commands (e.g. `mlflow`) and
+                        # in-workspace file ops run without a prompt, as they did before tool-call
+                        # permissions existed; the prompt is kept as an override for the previously
+                        # hard-denied calls. The session pauses the turn at a per-call Yes/No
+                        # prompt; a later resume delivers the choice via `tool_decisions`, and an
+                        # explicit allow overrides the static allowlist for that call. Anything not
+                        # gated (no session, or a statically-allowed call) is left to the static
+                        # policy enforced by execute_tool.
+                        needs_prompt = (
+                            static_permission_error(tool_name, tool_input, config.permissions, cwd)
+                            is not None
+                        )
+                        gated = (
+                            not config.permissions.full_access
+                            and bool(mlflow_session_id)
+                            and needs_prompt
+                        )
                         decision = tool_decisions.get(tc["id"])
 
                         # Emit the tool-use block when a call is first surfaced

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -28,6 +28,50 @@ def _resolve_file_path(raw_path: str, cwd: Path | None) -> Path:
     return p.resolve()
 
 
+def static_permission_error(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    perms: PermissionsConfig,
+    cwd: Path | None,
+) -> str | None:
+    """Return a denial message if the call is NOT permitted under static (non-full-access)
+    permissions, or None if it is allowed.
+
+    Shared by ``execute_tool`` (to enforce the policy) and the assistant's per-call permission gate
+    (to decide whether an interactive prompt is even needed): a call the static policy already
+    allows — e.g. an ``mlflow`` CLI command or an in-workspace file op — runs without prompting,
+    just as it did before tool-call permissions existed.
+    """
+    if perms.full_access:
+        return None
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "").strip()
+        try:
+            argv = shlex.split(command)
+        except ValueError:
+            return "Permission denied: malformed command"
+        if not argv or argv[0] not in _ALLOWED_BASH_COMMANDS:
+            return (
+                f"Permission denied: only {', '.join(sorted(_ALLOWED_BASH_COMMANDS))} "
+                "commands are allowed"
+            )
+
+    if tool_name in _FILE_TOOLS and not perms.allow_edit_files:
+        return f"Permission denied: {tool_name} is not allowed"
+
+    if tool_name in {"Write", "Edit"} and not cwd:
+        return f"Permission denied: {tool_name} requires a configured project directory"
+
+    if tool_name in _FILE_TOOLS and cwd:
+        if raw_path := tool_input.get("file_path") or tool_input.get("path", ""):
+            target = _resolve_file_path(raw_path, cwd)
+            if not _is_path_within(target, cwd):
+                return f"Permission denied: path {raw_path} is outside the workspace {cwd}"
+
+    return None
+
+
 async def execute_tool(
     tool_name: str,
     tool_input: dict[str, Any],
@@ -37,32 +81,8 @@ async def execute_tool(
 ) -> tuple[str, bool]:
     perms = permissions or PermissionsConfig()
 
-    if not perms.full_access:
-        if tool_name == "Bash":
-            command = tool_input.get("command", "").strip()
-            try:
-                argv = shlex.split(command)
-            except ValueError:
-                return "Permission denied: malformed command", True
-            if not argv or argv[0] not in _ALLOWED_BASH_COMMANDS:
-                return (
-                    f"Permission denied: only {', '.join(sorted(_ALLOWED_BASH_COMMANDS))} "
-                    "commands are allowed"
-                ), True
-
-        if tool_name in _FILE_TOOLS and not perms.allow_edit_files:
-            return f"Permission denied: {tool_name} is not allowed", True
-
-        if tool_name in {"Write", "Edit"} and not cwd:
-            return f"Permission denied: {tool_name} requires a configured project directory", True
-
-        if tool_name in _FILE_TOOLS and cwd:
-            if raw_path := tool_input.get("file_path") or tool_input.get("path", ""):
-                target = _resolve_file_path(raw_path, cwd)
-                if not _is_path_within(target, cwd):
-                    return (
-                        f"Permission denied: path {raw_path} is outside the workspace {cwd}"
-                    ), True
+    if (denial := static_permission_error(tool_name, tool_input, perms, cwd)) is not None:
+        return denial, True
 
     try:
         match tool_name:

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mlflow.assistant.config import PermissionsConfig
 from mlflow.assistant.providers.base import clear_config_cache
 from mlflow.assistant.providers.openai_compatible import (
     _MAX_SESSION_BYTES,
@@ -12,6 +13,7 @@ from mlflow.assistant.providers.openai_compatible import (
     _strip_think_blocks,
     _trim_session,
 )
+from mlflow.assistant.providers.tool_executor import static_permission_error
 from mlflow.assistant.types import EventType
 
 # ---------------------------------------------------------------------------
@@ -713,3 +715,70 @@ async def test_astream_global_full_access_skips_prompt(tmp_path):
     clear_config_cache()
     assert not any(e.type == EventType.PERMISSION_REQUEST for e in events)
     mock_tool.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "allowed"),
+    [
+        ("Bash", {"command": "mlflow experiments search"}, True),
+        ("Bash", {"command": "python script.py"}, True),
+        ("Bash", {"command": "rm -rf /"}, False),
+        ("Bash", {"command": "ls"}, False),
+    ],
+)
+def test_static_permission_error_bash_allowlist(tool_name, tool_input, allowed):
+    err = static_permission_error(tool_name, tool_input, PermissionsConfig(full_access=False), None)
+    assert (err is None) == allowed
+
+
+def test_static_permission_error_full_access_allows_everything():
+    assert (
+        static_permission_error(
+            "Bash", {"command": "rm -rf /"}, PermissionsConfig(full_access=True), None
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_astream_allowlisted_command_runs_without_prompt(provider):
+    # Regression guard for #24084: an `mlflow` CLI command is on the static allowlist, so even with
+    # full access off and a session present it must run WITHOUT a per-call permission prompt.
+    turn1 = [
+        _sse(
+            _delta(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "Bash",
+                            "arguments": '{"command": "mlflow experiments search"}',
+                        },
+                    }
+                ]
+            )
+        ),
+        b"data: [DONE]\n",
+    ]
+    turn2 = [_sse(_delta(content="Done")), b"data: [DONE]\n"]
+    session, _ = _make_aiohttp_session([turn1, turn2])
+    with (
+        patch(
+            "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+            return_value=session,
+        ),
+        patch(
+            "mlflow.assistant.providers.openai_compatible.execute_tool",
+            AsyncMock(return_value=("ok", False)),
+        ) as mock_tool,
+    ):
+        events = [
+            e
+            async for e in provider.astream(
+                "go", "http://localhost:5000", mlflow_session_id=_SESSION_ID
+            )
+        ]
+    assert not any(e.type == EventType.PERMISSION_REQUEST for e in events)
+    mock_tool.assert_awaited_once()
+    assert events[-1].type == EventType.DONE


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

For Open AI Compatible Assistant Provider, we should continue to allow Static allowed listed commands to run without prompting the user.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
