### PR TITLE
fix: skip already existing tables in _initialize_tables to avoid upgrade failure (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,13 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    existing_tables = set(sqlalchemy.inspect(engine).get_table_names())
+    tables_to_create = [
+        table for name, table in InitialBase.metadata.tables.items()
+        if name not in existing_tables
+    ]
+    if tables_to_create:
+        InitialBase.metadata.create_all(engine, tables=tables_to_create)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating from 3.7.0 to 3.8.x, the operation fails with an error like `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` which attempts to create all tables from the initial schema, even if some of those tables already exist in the database from the current full schema (imported via `Base`).

## Fix
Modify `_initialize_tables` to filter out tables that already exist in the database before calling `create_all`. This ensures that only truly new tables are created, preventing conflicts with pre-existing tables.

Closes #19943