### PR TITLE
Bound `get_metric_history_bulk_interval` rows per step

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -42,7 +42,6 @@ from mlflow.entities.workspace import TraceArchivalConfig
 from mlflow.exceptions import MlflowException, MlflowNotImplementedException
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import (
-    MAX_RESULTS_GET_METRIC_HISTORY,
     MAX_RESULTS_QUERY_TRACE_METRICS,
     SEARCH_MAX_RESULTS_DEFAULT,
     SEARCH_TRACES_DEFAULT_MAX_RESULTS,
@@ -984,16 +983,24 @@ class AbstractStore(GatewayStoreMixin):
             sampled_steps.add(all_steps[end_idx - 1])
 
         steps = sorted(sampled_steps.union(all_mins_and_maxes))
+        steps_set = set(steps)
+        # Cap the rows returned per (run, step) at ``max_results`` so a single step
+        # that accumulated many values (e.g. metrics logged without an explicit step
+        # all land on step 0) can't dominate the response. Every sampled step -
+        # including the min/max boundaries - is preserved because the cap is applied
+        # independently per step.
         metrics_with_run_ids = []
         for run_id in run_ids:
-            metrics_with_run_ids.extend(
-                self.get_metric_history_bulk_interval_from_steps(
-                    run_id=run_id,
-                    metric_key=metric_key,
-                    steps=steps,
-                    max_results=MAX_RESULTS_GET_METRIC_HISTORY,
-                )
+            run_metrics = sorted(
+                (m for m in self.get_metric_history(run_id, metric_key) if m.step in steps_set),
+                key=lambda metric: (metric.step, metric.timestamp),
             )
+            per_step_counts = {}
+            for metric in run_metrics:
+                count = per_step_counts.get(metric.step, 0)
+                if count < max_results:
+                    per_step_counts[metric.step] = count + 1
+                    metrics_with_run_ids.append(MetricWithRunId(run_id=run_id, metric=metric))
         return metrics_with_run_ids
 
     def search_runs(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -118,7 +118,6 @@ from mlflow.store.artifact.artifact_repository_registry import get_artifact_repo
 from mlflow.store.db.db_types import MSSQL, MYSQL
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import (
-    MAX_RESULTS_GET_METRIC_HISTORY,
     MAX_RESULTS_QUERY_TRACE_METRICS,
     MAX_TRACE_LINKS_PER_REQUEST,
     SEARCH_ISSUES_DEFAULT_MAX_RESULTS,
@@ -1674,17 +1673,54 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
             steps = sorted(sampled_steps.union(all_mins_and_maxes))
 
-        metrics_with_run_ids = []
-        for run_id in run_ids:
-            metrics_with_run_ids.extend(
-                self.get_metric_history_bulk_interval_from_steps(
-                    run_id=run_id,
-                    metric_key=metric_key,
-                    steps=steps,
-                    max_results=MAX_RESULTS_GET_METRIC_HISTORY,
+        # Bound the number of rows returned per (run, step) at ``max_results`` so a
+        # single step that accumulates many values (e.g. metrics logged without an
+        # explicit step all land on step 0) can't return tens of thousands of rows.
+        # A row_number() window applies the cap in SQL, so every sampled step -
+        # including the min/max boundaries - is preserved while no single step can
+        # dominate the response.
+        with self.ManagedSessionMaker() as session:
+            step_rank = (
+                func
+                .row_number()
+                .over(
+                    partition_by=[SqlMetric.run_uuid, SqlMetric.step],
+                    order_by=[SqlMetric.timestamp, SqlMetric.value],
                 )
+                .label("step_rank")
             )
-        return metrics_with_run_ids
+            ranked = (
+                session
+                .query(SqlMetric, step_rank)
+                .filter(
+                    SqlMetric.key == metric_key,
+                    SqlMetric.run_uuid.in_(run_ids),
+                    SqlMetric.step.in_(steps),
+                )
+                .subquery()
+            )
+            ranked_metric = aliased(SqlMetric, ranked)
+            metrics = (
+                session
+                .query(ranked_metric)
+                .filter(ranked.c.step_rank <= max_results)
+                .order_by(
+                    ranked_metric.step,
+                    ranked_metric.timestamp,
+                    ranked_metric.value,
+                )
+                .all()
+            )
+            # Group by run and emit runs in the caller-provided ``run_ids`` order;
+            # the query can't be ordered by run because that would sort by uuid.
+            metrics_by_run = defaultdict(list)
+            for metric in metrics:
+                metrics_by_run[metric.run_uuid].append(metric)
+            return [
+                MetricWithRunId(run_id=run_id, metric=metric.to_mlflow_entity())
+                for run_id in run_ids
+                for metric in metrics_by_run[run_id]
+            ]
 
     def _search_datasets(self, experiment_ids):
         """

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
@@ -2820,6 +2820,36 @@ def test_get_metric_history_bulk_interval_with_step_range(store: SqlAlchemyStore
     assert returned_steps == set(range(20, 31))
 
 
+def test_get_metric_history_bulk_interval_many_values_same_step(store: SqlAlchemyStore):
+    # Metrics logged without an explicit step all land on step 0. Step-based
+    # downsampling collapses to a single step, so the final per-run fetch must
+    # still honor max_results instead of returning every row for that step.
+    run = _run_factory(store)
+    run_id = run.info.run_id
+
+    metric_key = "test_metric"
+    for i in range(5000):
+        store.log_metric(
+            run_id,
+            models.SqlMetric(
+                key=metric_key, value=float(i), timestamp=1000 + i, step=0
+            ).to_mlflow_entity(),
+        )
+
+    max_results = 320
+    result = store.get_metric_history_bulk_interval(
+        run_ids=[run_id],
+        metric_key=metric_key,
+        max_results=max_results,
+        start_step=None,
+        end_step=None,
+    )
+
+    # The single collapsed step must not blow past the requested budget.
+    assert len(result) == max_results
+    assert all(m.step == 0 for m in result)
+
+
 def test_insert_large_text_in_dataset_table(store: SqlAlchemyStore):
     with store.engine.begin() as conn:
         # cursor = conn.cursor()

--- a/tests/store/tracking/test_abstract_store.py
+++ b/tests/store/tracking/test_abstract_store.py
@@ -260,6 +260,19 @@ def test_get_sampled_steps_from_steps(start_step, end_step, max_results, steps, 
 # Tests for get_metric_history_bulk_interval_from_steps
 
 
+def test_get_metric_history_bulk_interval_many_values_same_step(store):
+    # Metrics logged without an explicit step all land on step 0. Step-based
+    # downsampling collapses to a single step, so the final per-run fetch must
+    # still honor max_results instead of returning every row for that step.
+    max_results = 50
+    store.metrics = [Metric("accuracy", float(i), 1000 + i, 0, run_id="run1") for i in range(1000)]
+
+    result = store.get_metric_history_bulk_interval(["run1"], "accuracy", max_results, None, None)
+
+    assert len(result) == max_results
+    assert all(r.step == 0 for r in result)
+
+
 def test_get_metric_history_bulk_interval_from_steps_empty_steps(store):
     store.metrics = [Metric("accuracy", 0.8, 1000, 5, run_id="run1")]
     result = store.get_metric_history_bulk_interval_from_steps("run1", "accuracy", [], 10)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24169

### What changes are proposed in this pull request?

`GetMetricHistoryBulkInterval` samples a set of steps to honor `max_results`, but the final per-run fetch was hardcoded to `MAX_RESULTS_GET_METRIC_HISTORY` (25000) instead of the requested limit. When many values share a step the step sampling collapses to a single step, so that one fetch returns up to 25000 rows for it. This is the common case: `log_metric` without an explicit `step` writes step 0, so a run that logs metrics that way accumulates all its values on step 0. The chart UI asks for a few hundred points but the tracking server materializes the whole history, spiking memory.

This caps the rows returned per `(run, step)` at `max_results`:

- `SqlAlchemyStore.get_metric_history_bulk_interval` now applies the cap in SQL with a `row_number()` window partitioned by `(run_uuid, step)`, so it no longer loads every row for a hot step. Run order from the request is preserved by grouping the result and emitting runs in the caller-provided `run_ids` order.
- `AbstractStore.get_metric_history_bulk_interval` mirrors the per-step cap in Python.

Every sampled step, including the min/max boundary steps, is still returned because the cap is applied independently per step. The previously unused `MAX_RESULTS_GET_METRIC_HISTORY` imports are removed.

Repro from the issue (one run, 25k values all on step 0, `max_results=320`): before this change the endpoint returns 25000 points (~48 MiB peak); after, it returns 320.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added regression tests in `tests/store/tracking/test_abstract_store.py` and `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py` that log many values at a single step and assert the result is bounded by `max_results`. The existing `tests/tracking/test_rest_tracking.py::test_get_metric_history_bulk_interval_respects_max_results` (boundary steps, multiple runs, multiple values per step) still passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a memory spike in the metric-history bulk-interval endpoint where a metric with many values on a single step could return far more points than `max_results` requested.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
