### PR TITLE
Disclose Databricks scorer versioning gap and wrap duplicate-name `ValueError`

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/versioning.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/versioning.mdx
@@ -5,6 +5,32 @@ import TabItem from "@theme/TabItem";
 
 Scorers can be registered to MLflow experiments for version control and team collaboration.
 
+:::note[Backend support differs for versioning]
+
+SDK-based scorer versioning (re-registering the same name to create a new version)
+is supported on the OSS MLflow tracking backend (file-based, SQL-backed, or
+self-hosted tracking servers). The **Databricks** tracking backend doesn't
+currently support scorer versioning through the SDK. On Databricks, calling
+`Scorer.register()` with a name that already exists raises a `ValueError` from
+the underlying `databricks-rag-eval` package. If you're on a Databricks tracking
+URI, use one of the following:
+
+- **Update in place:** call `Scorer.update(...)` instead of calling
+  `Scorer.register()` again. This replaces the existing scorer's configuration.
+  No version history.
+- **Replace:** call `delete_scorer(name=..., experiment_id=..., version=None)`
+  and then re-register. No version history.
+- **Version the instructions:** version the instruction template through
+  [MLflow Prompt Registry](/genai/prompt-registry) and reference it from a
+  single judge. This preserves history of the instruction content while keeping
+  one scorer entry on the Databricks backend. It's the recommended approach when
+  you want to keep a record of how the judge has evolved.
+
+The UI-based "Edit" flow on Databricks does create a new version per the UI tab
+above.
+
+:::
+
 ## Supported Scorers
 
 | Scorer Type                                                              | Supported                                                         |
@@ -55,7 +81,8 @@ from mlflow.genai.judges import make_judge
 quality_judge = make_judge(
     name="response_quality",
     instructions=("Evaluate if {{ outputs }} is high quality for {{ inputs }}."),
-    model="anthropic:/claude-opus-4-1-20250805",
+    # `model` omitted to use the default judge model. On a Databricks tracking URI,
+    # registration requires either the default model or a `databricks:/` model URI.
     feedback_value_type=str,
 )
 ```
@@ -83,7 +110,8 @@ quality_judge_v2 = make_judge(
         "Evaluate if {{ outputs }} is high quality, accurate, and complete "
         "for the question in {{ inputs }}."
     ),
-    model="anthropic:/claude-3.5-sonnet-20241022",  # Updated model
+    # `model` omitted to use the default judge model. See the Backend support
+    # note above for the Databricks tracking URI behavior on re-registration.
     feedback_value_type=str,
 )
 

--- a/docs/docs/genai/eval-monitor/scorers/versioning.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/versioning.mdx
@@ -11,9 +11,10 @@ SDK-based scorer versioning (re-registering the same name to create a new versio
 is supported on the OSS MLflow tracking backend (file-based, SQL-backed, or
 self-hosted tracking servers). The **Databricks** tracking backend doesn't
 currently support scorer versioning through the SDK. On Databricks, calling
-`Scorer.register()` with a name that already exists raises a `ValueError` from
-the underlying `databricks-rag-eval` package. If you're on a Databricks tracking
-URI, use one of the following:
+`Scorer.register()` with a name that already exists raises an `MlflowException`
+with error code `RESOURCE_ALREADY_EXISTS` (the underlying `ValueError` from
+`databricks-rag-eval` is chained as the cause for traceback fidelity). If
+you're on a Databricks tracking URI, use one of the following:
 
 - **Update in place:** call `Scorer.update(...)` instead of calling
   `Scorer.register()` again. This replaces the existing scorer's configuration.

--- a/mlflow/genai/scorers/registry.py
+++ b/mlflow/genai/scorers/registry.py
@@ -433,14 +433,33 @@ class DatabricksStore(AbstractScorerStore):
         return DatabricksStore._scheduled_scorer_to_scorer(scheduled_scorer)
 
     def register_scorer(self, experiment_id: str | None, scorer: Scorer) -> int | None:
-        # Add the scorer to the server with sample_rate=0 (not actively sampling)
-        DatabricksStore.add_registered_scorer(
-            name=scorer.name,
-            scorer=scorer,
-            sample_rate=0.0,
-            filter_string=None,
-            experiment_id=experiment_id,
-        )
+        # Add the scorer to the server with sample_rate=0 (not actively sampling).
+        # The Databricks backend doesn't support scorer versioning. When the name
+        # already exists, the underlying `databricks-rag-eval` package raises a
+        # `ValueError` (see `databricks/rag_eval/monitoring/scheduled_scorers.py`).
+        # Wrap the duplicate-name case in `MlflowException` so the MLflow API
+        # surface returns a consistent exception type and the message points at
+        # the workarounds the Databricks backend supports.
+        try:
+            DatabricksStore.add_registered_scorer(
+                name=scorer.name,
+                scorer=scorer,
+                sample_rate=0.0,
+                filter_string=None,
+                experiment_id=experiment_id,
+            )
+        except ValueError as e:
+            if "has already been registered" in str(e):
+                raise MlflowException(
+                    f"Cannot register a new version of scorer '{scorer.name}' "
+                    f"on a Databricks tracking URI. The Databricks scorer "
+                    f"backend doesn't support versioning. To update the scorer "
+                    f"in place, call `Scorer.update(...)`. To replace it, call "
+                    f"`delete_scorer(name='{scorer.name}', experiment_id=...)` "
+                    f"and then re-register. To version the instruction "
+                    f"template, use MLflow Prompt Registry."
+                ) from e
+            raise
 
         # Set the sampling config on the new instance
         scorer._sampling_config = ScorerSamplingConfig(sample_rate=0.0, filter_string=None)

--- a/mlflow/genai/scorers/registry.py
+++ b/mlflow/genai/scorers/registry.py
@@ -6,6 +6,7 @@ evaluate traces in MLflow experiments.
 """
 
 import json
+import re
 import warnings
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Optional
@@ -331,6 +332,21 @@ class MlflowTrackingStore(AbstractScorerStore):
         return self.get_scorer(experiment_id, scorer.name)
 
 
+# Matches the duplicate-name error raised by `databricks-rag-eval` from
+# `databricks/rag_eval/monitoring/scheduled_scorers.py`. Verified against the
+# message "A scorer with name '<name>' has already been registered." Regex
+# (instead of exact substring) absorbs trivial future wording variations like
+# "is already registered" or "scorer name ... already exists".
+_DUPLICATE_SCORER_NAME_PATTERN = re.compile(
+    r"already\s+(?:been\s+)?registered|already\s+exists",
+    re.IGNORECASE,
+)
+
+
+def _is_duplicate_scorer_name_error(exc: ValueError) -> bool:
+    return bool(_DUPLICATE_SCORER_NAME_PATTERN.search(str(exc)))
+
+
 class DatabricksStore(AbstractScorerStore):
     """
     Databricks store that provides scorer functionality through the Databricks API.
@@ -433,13 +449,12 @@ class DatabricksStore(AbstractScorerStore):
         return DatabricksStore._scheduled_scorer_to_scorer(scheduled_scorer)
 
     def register_scorer(self, experiment_id: str | None, scorer: Scorer) -> int | None:
-        # Add the scorer to the server with sample_rate=0 (not actively sampling).
-        # The Databricks backend doesn't support scorer versioning. When the name
-        # already exists, the underlying `databricks-rag-eval` package raises a
-        # `ValueError` (see `databricks/rag_eval/monitoring/scheduled_scorers.py`).
-        # Wrap the duplicate-name case in `MlflowException` so the MLflow API
-        # surface returns a consistent exception type and the message points at
-        # the workarounds the Databricks backend supports.
+        # The Databricks backend does not support scorer versioning. When the
+        # name already exists, `databricks-rag-eval` raises `ValueError`. Wrap
+        # the duplicate-name case in `MlflowException` so the MLflow API
+        # surface returns a consistent exception type, and point users at the
+        # supported workarounds. See `_is_duplicate_scorer_name_error` for the
+        # upstream-message coupling contract.
         try:
             DatabricksStore.add_registered_scorer(
                 name=scorer.name,
@@ -449,15 +464,17 @@ class DatabricksStore(AbstractScorerStore):
                 experiment_id=experiment_id,
             )
         except ValueError as e:
-            if "has already been registered" in str(e):
+            if _is_duplicate_scorer_name_error(e):
                 raise MlflowException(
                     f"Cannot register a new version of scorer '{scorer.name}' "
                     f"on a Databricks tracking URI. The Databricks scorer "
-                    f"backend doesn't support versioning. To update the scorer "
-                    f"in place, call `Scorer.update(...)`. To replace it, call "
+                    f"backend does not support versioning. Use `Scorer.update(...)` "
+                    f"to update the scorer in place, or "
                     f"`delete_scorer(name='{scorer.name}', experiment_id=...)` "
-                    f"and then re-register. To version the instruction "
-                    f"template, use MLflow Prompt Registry."
+                    f"and then re-register to replace it. To version the "
+                    f"instruction template, use MLflow Prompt Registry. See "
+                    f"https://mlflow.org/docs/latest/genai/eval-monitor/scorers/versioning "
+                    f"for the full guidance."
                 ) from e
             raise
 

--- a/mlflow/genai/scorers/registry.py
+++ b/mlflow/genai/scorers/registry.py
@@ -19,6 +19,7 @@ from mlflow.genai.scorers.base import (
     Scorer,
     ScorerSamplingConfig,
 )
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking._tracking_service.utils import _get_store
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.plugins import get_entry_points
@@ -474,7 +475,8 @@ class DatabricksStore(AbstractScorerStore):
                     f"and then re-register to replace it. To version the "
                     f"instruction template, use MLflow Prompt Registry. See "
                     f"https://mlflow.org/docs/latest/genai/eval-monitor/scorers/versioning "
-                    f"for the full guidance."
+                    f"for the full guidance.",
+                    error_code=RESOURCE_ALREADY_EXISTS,
                 ) from e
             raise
 

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -17,6 +17,7 @@ from mlflow.genai.scorers.registry import (
     list_scorer_versions,
     list_scorers,
 )
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.tracking._tracking_service.utils import _get_store
 
 
@@ -224,6 +225,11 @@ def test_databricks_backend_register_duplicate_name_raises_mlflow_exception():
         assert "delete_scorer" in message
         assert "MLflow Prompt Registry" in message
         assert "mlflow.org/docs" in message
+        # Copilot review: must be RESOURCE_ALREADY_EXISTS (HTTP 400),
+        # not the MlflowException default of INTERNAL_ERROR (HTTP 500),
+        # because a duplicate-name registration is a user-actionable
+        # conflict, not an internal failure.
+        assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS)
         assert exc_info.value.__cause__ is duplicate_value_error
 
 

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -1,9 +1,12 @@
 from unittest.mock import ANY, Mock, patch
 
+import pytest
+
 import mlflow
 import mlflow.genai
 from mlflow.entities import GatewayEndpointModelConfig, GatewayModelLinkageType
 from mlflow.entities.gateway_endpoint import GatewayEndpoint
+from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import Guidelines, Scorer, scorer
 from mlflow.genai.scorers.base import ScorerSamplingConfig, ScorerStatus
 from mlflow.genai.scorers.registry import (
@@ -163,6 +166,75 @@ def test_databricks_backend_scorer_operations():
         # Test delete operation
         delete_scorer(name="test_databricks_scorer", experiment_id="exp_123")
         mock_delete.assert_called_once_with("exp_123", "test_databricks_scorer")
+
+
+def test_databricks_backend_register_duplicate_name_raises_mlflow_exception():
+    """Re-registering the same name on the Databricks backend wraps the underlying
+    ValueError from `databricks-rag-eval` into an `MlflowException` that points
+    at the supported workarounds (`Scorer.update()`, `delete_scorer()`, Prompt
+    Registry). The MLflow API surface shouldn't leak a bare `ValueError` from a
+    transitive package.
+    """
+    duplicate_value_error = ValueError(
+        "A scorer with name 'dup_scorer' has already been registered. "
+        "Update the scorer using '.update()' or choose a different name."
+    )
+
+    with (
+        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+        patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
+        patch(
+            "mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer",
+            side_effect=duplicate_value_error,
+        ),
+    ):
+        mock_get_store.return_value = DatabricksStore()
+
+        @scorer
+        def dup_scorer(outputs) -> bool:
+            return True
+
+        with pytest.raises(
+            MlflowException, match="Databricks scorer backend doesn't support versioning"
+        ) as exc_info:
+            dup_scorer.register(experiment_id="exp_456")
+
+        message = str(exc_info.value)
+        assert "dup_scorer" in message
+        assert "Scorer.update" in message
+        assert "delete_scorer" in message
+        assert "MLflow Prompt Registry" in message
+        # The original ValueError is chained via __cause__ for traceback fidelity.
+        assert exc_info.value.__cause__ is duplicate_value_error
+
+
+def test_databricks_backend_register_other_value_error_propagates():
+    """Only the duplicate-name `ValueError` is wrapped. Other `ValueError`s from
+    the underlying scheduled-scorer API propagate unchanged so callers see the
+    original error (e.g. validation failures).
+    """
+    unrelated_value_error = ValueError("some other validation failure unrelated to versioning")
+
+    with (
+        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+        patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
+        patch(
+            "mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer",
+            side_effect=unrelated_value_error,
+        ),
+    ):
+        mock_get_store.return_value = DatabricksStore()
+
+        @scorer
+        def other_scorer(outputs) -> bool:
+            return True
+
+        with pytest.raises(ValueError, match="some other validation failure") as exc_info:
+            other_scorer.register(experiment_id="exp_789")
+
+        assert exc_info.value is unrelated_value_error
 
 
 def _mock_gateway_endpoint():

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -11,6 +11,7 @@ from mlflow.genai.scorers import Guidelines, Scorer, scorer
 from mlflow.genai.scorers.base import ScorerSamplingConfig, ScorerStatus
 from mlflow.genai.scorers.registry import (
     DatabricksStore,
+    _is_duplicate_scorer_name_error,
     delete_scorer,
     get_scorer,
     list_scorer_versions,
@@ -168,13 +169,30 @@ def test_databricks_backend_scorer_operations():
         mock_delete.assert_called_once_with("exp_123", "test_databricks_scorer")
 
 
+# Upstream-contract note for the tests below: `databricks-rag-eval` raises the
+# duplicate-name `ValueError` from `databricks/rag_eval/monitoring/scheduled_scorers.py`
+# with the message "A scorer with name '<name>' has already been registered."
+# These tests fake that upstream behavior. If `databricks-rag-eval` changes the
+# wording, update `_DUPLICATE_SCORER_NAME_PATTERN` in
+# `mlflow/genai/scorers/registry.py` and adjust the parametrized cases in
+# `test_is_duplicate_scorer_name_error_pattern` below.
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("A scorer with name 'foo' has already been registered.", True),
+        ("Scorer 'foo' is already registered", True),
+        ("scorer name 'foo' already exists in workspace", True),
+        ("A scorer with name 'foo' HAS ALREADY BEEN REGISTERED.", True),
+        ("invalid filter_string for scorer 'foo'", False),
+        ("permission denied for experiment", False),
+        ("", False),
+    ],
+)
+def test_is_duplicate_scorer_name_error_pattern(message: str, expected: bool):
+    assert _is_duplicate_scorer_name_error(ValueError(message)) is expected
+
+
 def test_databricks_backend_register_duplicate_name_raises_mlflow_exception():
-    """Re-registering the same name on the Databricks backend wraps the underlying
-    ValueError from `databricks-rag-eval` into an `MlflowException` that points
-    at the supported workarounds (`Scorer.update()`, `delete_scorer()`, Prompt
-    Registry). The MLflow API surface shouldn't leak a bare `ValueError` from a
-    transitive package.
-    """
     duplicate_value_error = ValueError(
         "A scorer with name 'dup_scorer' has already been registered. "
         "Update the scorer using '.update()' or choose a different name."
@@ -196,7 +214,7 @@ def test_databricks_backend_register_duplicate_name_raises_mlflow_exception():
             return True
 
         with pytest.raises(
-            MlflowException, match="Databricks scorer backend doesn't support versioning"
+            MlflowException, match="Databricks scorer backend does not support versioning"
         ) as exc_info:
             dup_scorer.register(experiment_id="exp_456")
 
@@ -205,15 +223,11 @@ def test_databricks_backend_register_duplicate_name_raises_mlflow_exception():
         assert "Scorer.update" in message
         assert "delete_scorer" in message
         assert "MLflow Prompt Registry" in message
-        # The original ValueError is chained via __cause__ for traceback fidelity.
+        assert "mlflow.org/docs" in message
         assert exc_info.value.__cause__ is duplicate_value_error
 
 
 def test_databricks_backend_register_other_value_error_propagates():
-    """Only the duplicate-name `ValueError` is wrapped. Other `ValueError`s from
-    the underlying scheduled-scorer API propagate unchanged so callers see the
-    original error (e.g. validation failures).
-    """
     unrelated_value_error = ValueError("some other validation failure unrelated to versioning")
 
     with (


### PR DESCRIPTION
### Related Issues/PRs

Closes #24174

### What changes are proposed in this pull request?

The Registering and Versioning Scorers docs page describes versioning behavior that only works on the OSS MLflow tracking backend. On the Databricks tracking backend, scorer versioning is not supported. Re-registering a scorer with the same name raises a `ValueError` from `databricks-rag-eval`, and the page's SDK example uses `anthropic:/...` model URIs that the Databricks registration path rejects (`_check_can_be_registered` in `mlflow/genai/scorers/base.py`).

This change:

- **Docs.** Adds a note to [`docs/docs/genai/eval-monitor/scorers/versioning.mdx`](https://github.com/mlflow/mlflow/blob/main/docs/docs/genai/eval-monitor/scorers/versioning.mdx) that discloses the Databricks-backend limitation and lists three workarounds: `Scorer.update(...)`, `delete_scorer(...)` + re-register, and versioning the instruction template through MLflow Prompt Registry. Also removes the `anthropic:/...` model URIs from the two SDK code examples on the same page so the snippets run on Databricks tracking URIs (the default judge model is used instead).
- **Code.** Wraps the duplicate-name `ValueError` from `databricks-rag-eval` inside `DatabricksStore.register_scorer()` ([`mlflow/genai/scorers/registry.py`](https://github.com/mlflow/mlflow/blob/main/mlflow/genai/scorers/registry.py)) into an `MlflowException` so the MLflow API surface returns a consistent exception type and the message points at the workarounds the Databricks backend supports. The original `ValueError` is chained via `__cause__` for traceback fidelity. Other `ValueError`s from the underlying scheduled-scorer API propagate unchanged.
- **Tests.** Adds two tests in `tests/genai/scorers/test_scorer_CRUD.py`:
  - `test_databricks_backend_register_duplicate_name_raises_mlflow_exception` — verifies the wrap behavior and the `__cause__` chaining.
  - `test_databricks_backend_register_other_value_error_propagates` — verifies non-duplicate `ValueError`s propagate without being wrapped.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
$ pytest tests/genai/scorers/test_scorer_CRUD.py -v
============================== 9 passed in 7.21s ===============================
```

Manual repro of the original `ValueError` on a Databricks tracking URI reproduced as described in #24174. After the change, the duplicate-name path raises `MlflowException` with the guidance message; other `ValueError`s from the underlying API are unaffected.

Lint:

```
$ ruff check mlflow/genai/scorers/registry.py tests/genai/scorers/test_scorer_CRUD.py
All checks passed!
$ ruff format --check mlflow/genai/scorers/registry.py tests/genai/scorers/test_scorer_CRUD.py
2 files already formatted
```

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Documents the Databricks-backend limitation on `Scorer.register()` versioning, fixes broken model URIs in the docs examples, and improves the error users see when re-registering an existing scorer name on Databricks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [x] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [x] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
