### PR TITLE
Route DSPy judge optimizer Databricks models to Mosaic AI Gateway for Unity Catalog names

### DIFF
--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -41,6 +41,11 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+# OpenAI-compatible base paths for the two Databricks model surfaces. See
+# _get_databricks_api_base_key for how a model is routed to one or the other.
+_DATABRICKS_SERVING_ENDPOINTS_PATH = "serving-endpoints"
+_DATABRICKS_AI_GATEWAY_PATH = "ai-gateway/mlflow/v1"
+
 
 @contextmanager
 def suppress_verbose_logging(
@@ -132,6 +137,17 @@ def construct_dspy_lm(model: str):
         return dspy.LM(model=model_litellm)
 
 
+def _is_unity_catalog_model_name(model_name: str) -> bool:
+    """
+    Whether a Databricks model name is a Unity Catalog name (and thus served via AI Gateway).
+
+    Databricks serving endpoint names cannot contain ``.``, while Unity Catalog model names
+    are three-level (``<catalog>.<schema>.<model>``, e.g. ``system.ai.claude-haiku-4-5``) and
+    always do, so the presence of a ``.`` reliably distinguishes the two surfaces.
+    """
+    return "." in model_name
+
+
 def _get_api_base_key(model: str) -> tuple[str | None, str | None]:
     """
     Get the api_base URL and api_key for a model.
@@ -143,24 +159,34 @@ def _get_api_base_key(model: str) -> tuple[str | None, str | None]:
         Tuple of (api_base, api_key) - both None if not applicable
     """
     try:
-        scheme, _ = _parse_model_uri(model)
+        scheme, path = _parse_model_uri(model)
         if scheme in ("endpoints", "databricks"):
-            return _get_databricks_api_base_key()
+            return _get_databricks_api_base_key(path)
         return None, None
     except Exception:
         return None, None
 
 
-def _get_databricks_api_base_key() -> tuple[str | None, str | None]:
+def _get_databricks_api_base_key(model_name: str) -> tuple[str | None, str | None]:
     """
-    Get the api_base URL and api_key for Databricks serving endpoints.
+    Get the api_base URL and api_key for a Databricks-hosted model.
 
-    For Databricks endpoints with OpenAI-compatible API, the URL format is:
-    - api_base: https://host/serving-endpoints
-    - model: endpoint-name (passed in request body)
+    Databricks serves OpenAI-compatible models through two surfaces, selected by the shape
+    of ``model_name``:
 
-    LiteLLM appends /chat/completions to api_base, making the final URL:
-    https://host/serving-endpoints/chat/completions with model=endpoint-name in body.
+    * Legacy model serving (``https://<host>/serving-endpoints``) for serving endpoints
+      referenced by their simple name (e.g. ``databricks-claude-haiku-4-5``).
+    * Mosaic AI Gateway (``https://<host>/ai-gateway/mlflow/v1``) for foundation models
+      referenced by their Unity Catalog name (e.g. ``system.ai.claude-haiku-4-5``).
+
+    In both cases LiteLLM appends ``/chat/completions`` (or ``/embeddings``) to ``api_base``
+    and passes ``model_name`` in the request body, so the final URL is, e.g.,
+    ``https://<host>/ai-gateway/mlflow/v1/chat/completions`` with
+    ``model=system.ai.claude-haiku-4-5``.
+
+    Args:
+        model_name: The model/endpoint name parsed from the MLflow URI (the part after
+            ``databricks:/`` or ``endpoints:/``).
 
     Returns:
         Tuple of (api_base, api_key) - both None if credentials cannot be determined
@@ -188,10 +214,18 @@ def _get_databricks_api_base_key() -> tuple[str | None, str | None]:
             if "Authorization" in headers:
                 api_key = headers["Authorization"].replace("Bearer ", "")
 
+    if not host:
+        return None, api_key
+
     host = host.rstrip("/")
-    # Return api_base with just /serving-endpoints
-    # LiteLLM will append /chat/completions and pass the endpoint name as model
-    return f"{host}/serving-endpoints", api_key
+    # Unity Catalog models live behind the AI Gateway; everything else is a serving endpoint.
+    # LiteLLM appends /chat/completions (or /embeddings) and passes the model name in the body.
+    base_path = (
+        _DATABRICKS_AI_GATEWAY_PATH
+        if _is_unity_catalog_model_name(model_name)
+        else _DATABRICKS_SERVING_ENDPOINTS_PATH
+    )
+    return f"{host}/{base_path}", api_key
 
 
 def _to_attrdict(obj):

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -141,11 +141,19 @@ def _is_unity_catalog_model_name(model_name: str) -> bool:
     """
     Whether a Databricks model name is a Unity Catalog name (and thus served via AI Gateway).
 
-    Databricks serving endpoint names cannot contain ``.``, while Unity Catalog model names
-    are three-level (``<catalog>.<schema>.<model>``, e.g. ``system.ai.claude-haiku-4-5``) and
-    always do, so the presence of a ``.`` reliably distinguishes the two surfaces.
+    Unity Catalog model names are three-level (``<catalog>.<schema>.<model>``, e.g.
+    ``system.ai.claude-haiku-4-5``), so they contain at least two ``.`` separators. Databricks
+    serving endpoint names, by contrast, are restricted to ``^[a-zA-Z0-9_-]+$`` and cannot
+    contain ``.`` at all (see the ``name`` field in the create-serving-endpoint API reference:
+    https://docs.databricks.com/api/workspace/servingendpoints/create), so this shape check
+    reliably distinguishes the two surfaces.
+
+    Requiring two separators (rather than just any ``.``) keeps a one-dot name from being
+    misrouted to the AI Gateway. Such a name cannot be a valid serving endpoint either, but
+    leaving it on the legacy path yields a clearer "endpoint not found" error than a malformed
+    gateway URL.
     """
-    return "." in model_name
+    return model_name.count(".") >= 2
 
 
 def _get_api_base_key(model: str) -> tuple[str | None, str | None]:
@@ -215,7 +223,7 @@ def _get_databricks_api_base_key(model_name: str) -> tuple[str | None, str | Non
                 api_key = headers["Authorization"].replace("Bearer ", "")
 
     if not host:
-        return None, api_key
+        return None, None
 
     host = host.rstrip("/")
     # Unity Catalog models live behind the AI Gateway; everything else is a serving endpoint.

--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -12,6 +12,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.base import AlignmentOptimizer, Judge, JudgeField
 from mlflow.genai.judges.optimizers.dspy_utils import (
     _check_dspy_installed,
+    _get_api_base_key,
     construct_dspy_lm,
     create_dspy_signature,
     trace_to_dspy_example,
@@ -59,6 +60,28 @@ def _get_embedding_batch_size(litellm_model: str) -> int:
     if litellm_model.startswith("databricks/"):
         return _DATABRICKS_EMBEDDING_BATCH_SIZE
     return _DEFAULT_EMBEDDING_BATCH_SIZE
+
+
+def _build_embedder(embedding_model: str, embedding_dim: int) -> "dspy.Embedder":
+    """Create a ``dspy.Embedder``, routing Databricks models to the correct API surface.
+
+    Mirrors ``construct_dspy_lm`` for embeddings: for ``databricks:/`` and ``endpoints:/``
+    models we resolve the workspace ``api_base``/``api_key`` (Unity Catalog names go to the
+    AI Gateway, simple names to legacy serving), so gateway-hosted embedding models resolve
+    correctly instead of failing with ENDPOINT_NOT_FOUND.
+    """
+    import dspy
+
+    litellm_embedding_model = convert_mlflow_uri_to_litellm(embedding_model)
+    api_base, api_key = _get_api_base_key(embedding_model)
+    extra_kwargs = {"api_base": api_base, "api_key": api_key} if api_base else {}
+    return dspy.Embedder(
+        litellm_embedding_model,
+        dimensions=embedding_dim,
+        drop_params=True,
+        batch_size=_get_embedding_batch_size(litellm_embedding_model),
+        **extra_kwargs,
+    )
 
 
 def _generate_fingerprint(
@@ -193,13 +216,7 @@ class MemoryAugmentedJudge(Judge):
         effective_base_judge = base_judge or self._base_judge
 
         self._base_signature = create_dspy_signature(effective_base_judge)
-        litellm_embedding_model = convert_mlflow_uri_to_litellm(self._embedding_model)
-        self._embedder = dspy.Embedder(
-            litellm_embedding_model,
-            dimensions=self._embedding_dim,
-            drop_params=True,
-            batch_size=_get_embedding_batch_size(litellm_embedding_model),
-        )
+        self._embedder = _build_embedder(self._embedding_model, self._embedding_dim)
         self._retriever = None
 
         # Inherit memory from base_judge if it's a MemoryAugmentedJudge.
@@ -418,13 +435,7 @@ class MemoryAugmentedJudge(Judge):
 
         self._base_signature = create_dspy_signature(self._base_judge)
 
-        litellm_embedding_model = convert_mlflow_uri_to_litellm(self._embedding_model)
-        self._embedder = dspy.Embedder(
-            litellm_embedding_model,
-            dimensions=self._embedding_dim,
-            drop_params=True,
-            batch_size=_get_embedding_batch_size(litellm_embedding_model),
-        )
+        self._embedder = _build_embedder(self._embedding_model, self._embedding_dim)
 
         extended_signature = create_extended_signature(self._base_signature)
         self._predict_module = dspy.Predict(extended_signature)

--- a/tests/genai/judges/optimizers/memalign/test_optimizer.py
+++ b/tests/genai/judges/optimizers/memalign/test_optimizer.py
@@ -15,6 +15,7 @@ from mlflow.genai.judges.optimizers.memalign.optimizer import (
     _DATABRICKS_EMBEDDING_BATCH_SIZE,
     _DEFAULT_EMBEDDING_BATCH_SIZE,
     MemoryAugmentedJudge,
+    _build_embedder,
 )
 from mlflow.genai.scorers.base import Scorer, ScorerKind, SerializedScorer
 
@@ -690,6 +691,47 @@ def test_embedder_batch_size(sample_judge, sample_traces, embedding_model, expec
 
         _, kwargs = mocks["embedder_class"].call_args
         assert kwargs["batch_size"] == expected_batch_size
+
+
+@pytest.mark.parametrize(
+    ("embedding_model", "expected_api_base"),
+    [
+        (
+            "databricks:/system.ai.gte-large-en",
+            "https://my-workspace.databricks.com/ai-gateway/mlflow/v1",
+        ),
+        (
+            "endpoints:/main.default.my_embeddings",
+            "https://my-workspace.databricks.com/ai-gateway/mlflow/v1",
+        ),
+        (
+            "databricks:/databricks-gte-large-en",
+            "https://my-workspace.databricks.com/serving-endpoints",
+        ),
+    ],
+)
+def test_build_embedder_routes_databricks_models(monkeypatch, embedding_model, expected_api_base):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my-workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-test-token")
+
+    with patch("dspy.Embedder") as mock_embedder_class:
+        _build_embedder(embedding_model, 512)
+
+    _, kwargs = mock_embedder_class.call_args
+    assert kwargs["api_base"] == expected_api_base
+    assert kwargs["api_key"] == "dapi-test-token"
+
+
+def test_build_embedder_non_databricks_has_no_api_base(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my-workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-test-token")
+
+    with patch("dspy.Embedder") as mock_embedder_class:
+        _build_embedder("openai:/text-embedding-3-small", 512)
+
+    _, kwargs = mock_embedder_class.call_args
+    assert "api_base" not in kwargs
+    assert "api_key" not in kwargs
 
 
 # =============================================================================

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -16,6 +16,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.base import JudgeField
 from mlflow.genai.judges.optimizers.dspy_utils import (
     AgentEvalLM,
+    _get_api_base_key,
+    _is_unity_catalog_model_name,
     agreement_metric,
     append_input_fields_section,
     construct_dspy_lm,
@@ -391,6 +393,59 @@ def test_construct_dspy_lm_utility_method(model, expected_type):
         assert isinstance(result, dspy.LM)
         # Ensure MLflow URI format is converted (no :/ in the model)
         assert ":/" not in result.model
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("databricks-claude-haiku-4-5", False),
+        ("my-custom-endpoint", False),
+        ("system.ai.claude-haiku-4-5", True),
+        ("main.default.my_model", True),
+    ],
+)
+def test_is_unity_catalog_model_name(model_name, expected):
+    assert _is_unity_catalog_model_name(model_name) is expected
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_suffix"),
+    [
+        ("databricks:/databricks-claude-haiku-4-5", "/serving-endpoints"),
+        ("endpoints:/my-custom-endpoint", "/serving-endpoints"),
+        ("databricks:/system.ai.claude-haiku-4-5", "/ai-gateway/mlflow/v1"),
+        ("endpoints:/system.ai.gte-large-en", "/ai-gateway/mlflow/v1"),
+    ],
+)
+def test_get_api_base_key_routes_unity_catalog_models_to_ai_gateway(
+    monkeypatch, model, expected_suffix
+):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my-workspace.databricks.com/")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-test-token")
+
+    api_base, api_key = _get_api_base_key(model)
+
+    assert api_base == f"https://my-workspace.databricks.com{expected_suffix}"
+    assert api_key == "dapi-test-token"
+
+
+@pytest.mark.parametrize("model", ["openai:/gpt-4", "anthropic:/claude-3"])
+def test_get_api_base_key_non_databricks_returns_none(model):
+    assert _get_api_base_key(model) == (None, None)
+
+
+def test_construct_dspy_lm_uses_ai_gateway_for_unity_catalog_model(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://my-workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-test-token")
+
+    with patch("mlflow.genai.judges.optimizers.dspy_utils.dspy.LM") as mock_lm:
+        construct_dspy_lm("databricks:/system.ai.claude-haiku-4-5")
+
+    mock_lm.assert_called_once_with(
+        model="databricks/system.ai.claude-haiku-4-5",
+        api_base="https://my-workspace.databricks.com/ai-gateway/mlflow/v1",
+        api_key="dapi-test-token",
+    )
 
 
 def test_agent_eval_lm_uses_optimizer_session_name():

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -400,6 +400,8 @@ def test_construct_dspy_lm_utility_method(model, expected_type):
     [
         ("databricks-claude-haiku-4-5", False),
         ("my-custom-endpoint", False),
+        # A one-dot name is not a three-level UC name and must stay on serving-endpoints.
+        ("my-org.prod", False),
         ("system.ai.claude-haiku-4-5", True),
         ("main.default.my_model", True),
     ],


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The DSPy-based judge optimizers resolve `databricks:/` and `endpoints:/` model URIs to an OpenAI-compatible base URL by hardcoding the legacy model-serving path: `https://<host>/serving-endpoints`. On workspaces where foundation models have moved to the **Mosaic AI Gateway** surface — served under `https://<host>/ai-gateway/mlflow/v1` and referenced by their Unity Catalog name (e.g. `system.ai.claude-haiku-4-5`) — this fails with `ENDPOINT_NOT_FOUND`, because no serving endpoint named `system.ai.claude-haiku-4-5` exists.

This PR teaches the resolver to pick the right surface based on the model name:

- **Unity Catalog names** (which contain `.`, e.g. `system.ai.claude-haiku-4-5`) → `https://<host>/ai-gateway/mlflow/v1`
- **Serving endpoint names** (no `.`, e.g. `databricks-claude-haiku-4-5`, custom endpoints) → `https://<host>/serving-endpoints` (unchanged)

Databricks serving-endpoint names cannot contain `.`, while Unity Catalog model names are three-level (`<catalog>.<schema>.<model>`) and always do, so the presence of a `.` is a reliable discriminator and requires no extra config — `reflection_lm="databricks:/system.ai.claude-haiku-4-5"` now just works.

**Scope of the fix:**

- The LM routing fix lives in the shared `dspy_utils` helper used by `construct_dspy_lm`, so it benefits **all DSPy-based judge optimizers** — both `DSPyAlignmentOptimizer` and `MemAlignOptimizer` (including memalign's reflection/distillation LM and base-judge model).
- The embedding model resolution is **memalign-specific** (episodic-memory embeddings): the embedder was previously built with no `api_base`/`api_key` at all, so gateway-hosted embedding models also failed. It now goes through the same resolver via a shared `_build_embedder` helper.
- Non-Databricks providers (`openai:/...`, `anthropic:/...`) are unaffected, and regular (non-optimized) judge scoring does not use this path at all.

Key changes:
- `mlflow/genai/judges/optimizers/dspy_utils.py`: `_get_databricks_api_base_key` now takes the model name and selects the AI Gateway vs. serving-endpoints base path via `_is_unity_catalog_model_name`. Used by `construct_dspy_lm`, shared by all DSPy optimizers.
- `mlflow/genai/judges/optimizers/memalign/optimizer.py`: new `_build_embedder` helper routes memalign's Databricks embedding models through the same resolver; both embedder construction sites now use it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New unit tests in `tests/genai/judges/optimizers/test_dspy_utils.py` cover Unity Catalog name detection, serving-vs-gateway base-path routing for both `databricks:/` and `endpoints:/` URIs, non-Databricks pass-through, and the end-to-end `construct_dspy_lm` wiring for a UC model.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

DSPy-based judge alignment optimizers (`DSPyAlignmentOptimizer` and `MemAlignOptimizer`) now support Databricks foundation models served via Mosaic AI Gateway (Unity Catalog model names such as `system.ai.claude-haiku-4-5`); memalign additionally supports gateway-hosted embedding models.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
