### PR TITLE
Update omnigent install command to use `uv`

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/omnigent.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/omnigent.mdx
@@ -38,7 +38,7 @@ Omnigent ships MLflow as an optional dependency. Install the tracing extra and c
 <StepHeader number={1} title="Install the Tracing Extra" />
 
 ```bash
-pip install 'omnigent[tracing]'
+uv pip install 'omnigent[tracing]'
 ```
 
 This installs `mlflow` and `opentelemetry` SDK packages. If the tracing extra is not installed, Omnigent degrades gracefully to a no-op — the server continues to run without emitting traces.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #N/A

### What changes are proposed in this pull request?

Updates the `pip install` command in the Omnigent tracing integration docs to use `uv pip install` for consistency with the rest of the MLflow documentation.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release