### PR TITLE
Fix #24170: render direct per-resource permissions in the Admin UI

### DIFF
--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -134,7 +134,10 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
     expect(mockedApi.listUserRoles).toHaveBeenCalledWith('pat');
   });
 
-  it('drops synthetic __user_<id>__ roles from the response', async () => {
+  it('retains synthetic __user_<id>__ roles in the response', async () => {
+    // The hook intentionally returns roles unfiltered. Synthetic roles back
+    // direct grants; consumers (PermissionsSection, EditAccessModal pre-fill)
+    // need them, while the human-facing Roles tables filter them out locally.
     const namedRole = {
       id: 7,
       name: 'editors',
@@ -153,7 +156,7 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
 
     const { result } = renderHook(() => useUserRolesQuery('pat'), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.roles).toEqual([namedRole]);
+    expect(result.current.data?.roles).toEqual([namedRole, syntheticRole]);
   });
 });
 

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useMutation, useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { AccountApi } from './api';
-import { isSyntheticUserRole, isWorkspaceAdminRole } from './types';
+import { isWorkspaceAdminRole } from './types';
 import type { UpdatePasswordRequest } from './types';
 
 export const useCurrentUserQuery = () => {
@@ -104,13 +104,12 @@ export const useUpdatePassword = () => {
 export const useUserRolesQuery = (username: string, options: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: AccountQueryKeys.userRoles(username),
-    queryFn: async () => {
-      const data = await AccountApi.listUserRoles(username);
-      // Synthetic ``__user_<id>__`` roles back direct grants and are not
-      // human-facing. Drop them so the per-user roles list never leaks
-      // its own bookkeeping row.
-      return { ...data, roles: data.roles.filter((r) => !isSyntheticUserRole(r.name)) };
-    },
+    // Return roles unfiltered — including the synthetic ``__user_<id>__`` role
+    // that backs direct grants. Consumers filter synthetic roles out of their
+    // own human-facing Roles tables (via ``displayRoles``); PermissionsSection
+    // and the EditAccessModal pre-fill need the synthetic role to surface /
+    // edit direct grants.
+    queryFn: () => AccountApi.listUserRoles(username),
     retry: false,
     refetchOnWindowFocus: false,
     // Callers pass ``enabled: false`` to skip a fetch they know will 403.


### PR DESCRIPTION
### Related Issues/PRs

Closes #24170

### What changes are proposed in this pull request?

The Admin UI **Permissions** tab (User Detail page and the self-service Account page) rendered empty ("No resource permissions to show.") for any user whose access came only from **direct per-resource grants**, which are stored on the reserved synthetic `__user_<id>__` role. The REST endpoint returns the synthetic role correctly, but the shared `useUserRolesQuery` React Query hook stripped synthetic roles **inside its `queryFn`** — before any component received the data. This regressed the direct-grant view introduced by #23578.

Every consumer of the hook already filters synthetic roles out of its own human-facing Roles table locally (via `displayRoles`), and `PermissionsSection` / the `EditAccessModal` direct-grant pre-fill specifically need the synthetic role to surface and edit direct grants. This PR returns the roles **unfiltered** from `useUserRolesQuery`, so:

- the Roles tables continue hiding the synthetic role (unchanged, via their local `displayRoles`),
- the Permissions tab once again lists direct grants under the **Direct** source label,
- the `EditAccessModal` once again pre-fills existing direct permissions.

The separate `useUsersQuery` / `useRolesQuery` synthetic filters (Users and Roles tables) are intentionally left untouched.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

`PermissionsSection.test.tsx` already covers rendering synthetic rows as "Direct" given unfiltered input. The `useUserRolesQuery` unit test in `account/hooks.test.tsx` was inverted to assert synthetic roles are now **retained**. `yarn test` (account hooks, `PermissionsSection`, `EditAccessModal`), `yarn type-check`, `yarn lint`, and `yarn prettier:check` all pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Admin UI Permissions tab (and the self-service Account page) now correctly displays a user's direct per-resource permissions, and the Edit-access modal pre-fills existing direct grants again.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
