### PR TITLE
fix: prevent 'Table already exists' error during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,6 +86,12 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
+    # After creating initial tables, stamp the Alembic revision to avoid
+    # Alembic trying to re-create tables that already exist.
+    from alembic.config import Config
+    from alembic import command
+    alembic_cfg = _get_alembic_config(engine.url)
+    command.stamp(alembic_cfg, "heads")
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from 3.7.0 to 3.8.x, the upgrade fails with 'Table \'secrets\' already exists' because `_initialize_tables()` creates initial tables via `InitialBase.metadata.create_all()` and then calls `_upgrade_db()` which runs Alembic migrations. Some migrations attempt to create the 'secrets' table (or other tables) that were already created by the initial schema, leading to a conflict.

## Fix
After creating the initial tables with `InitialBase.metadata.create_all()`, we stamp the Alembic revision as 'heads' so that Alembic does not attempt to re-run migrations that would create tables already present. This ensures the database schema is up-to-date and avoids duplicate table creation errors.

Closes #19943