### PR TITLE
Propagate MLflow trace context through LlamaIndex instrumentation

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -33,7 +33,7 @@ from llama_index.core.tools import BaseTool
 from packaging.version import Version
 
 import mlflow
-from mlflow.entities import LiveSpan, NoOpSpan, SpanEvent, SpanType
+from mlflow.entities import LiveSpan, SpanEvent, SpanType
 from mlflow.entities.document import Document
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
@@ -45,10 +45,8 @@ from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import (
     detach_span_from_context,
     set_span_in_context,
-    start_span_in_context,
 )
-from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import encode_span_id, set_span_chat_tools
+from mlflow.tracing.utils import set_span_chat_tools
 
 _logger = logging.getLogger(__name__)
 
@@ -90,6 +88,9 @@ def remove_llama_index_tracer():
     from llama_index.core.instrumentation import get_dispatcher
 
     dsp = get_dispatcher()
+    for handler in dsp.span_handlers:
+        if isinstance(handler, MlflowSpanHandler):
+            handler.close()
     dsp.span_handlers = [h for h in dsp.span_handlers if h.class_name() != "MlflowSpanHandler"]
     dsp.event_handlers = [h for h in dsp.event_handlers if h.class_name() != "MlflowEventHandler"]
 
@@ -218,27 +219,6 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
     def _has_restored_context(self) -> bool:
         return bool(self._propagation_context_managers)
 
-    def _start_span_from_current_context(
-        self,
-        name: str,
-        span_type: str,
-        inputs: dict[str, Any],
-        attributes: dict[str, Any],
-    ) -> LiveSpan | NoOpSpan:
-        otel_span = start_span_in_context(name)
-        if not otel_span.is_recording():
-            return NoOpSpan(otel_span=otel_span)
-
-        trace_manager = InMemoryTraceManager.get_instance()
-        trace_id = trace_manager.get_mlflow_trace_id_from_otel_id(otel_span.context.trace_id)
-        span = trace_manager.get_span_from_id(
-            trace_id, encode_span_id(otel_span.context.span_id)
-        )
-        span.set_span_type(span_type)
-        span.set_inputs(inputs)
-        span.set_attributes(attributes)
-        return span
-
     def new_span(
         self,
         id_: str,
@@ -258,21 +238,14 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
             span_type = self._get_span_type(instance) or SpanType.UNKNOWN
             name = id_.partition("-")[0]
             if parent_span is None and self._has_restored_context:
-                span = self._start_span_from_current_context(
-                    name=name,
-                    span_type=span_type,
-                    inputs=input_args,
-                    attributes=attributes,
-                )
                 self._propagated_root_span_ids.add(id_)
-            else:
-                span = start_span_no_context(
-                    name=name,
-                    parent_span=parent_span,
-                    span_type=span_type,
-                    inputs=input_args,
-                    attributes=attributes,
-                )
+            span = start_span_no_context(
+                name=name,
+                parent_span=parent_span,
+                span_type=span_type,
+                inputs=input_args,
+                attributes=attributes,
+            )
 
             token = set_span_in_context(span)
             self._span_id_to_token[span.span_id] = token

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -33,13 +33,22 @@ from llama_index.core.tools import BaseTool
 from packaging.version import Version
 
 import mlflow
-from mlflow.entities import LiveSpan, SpanEvent, SpanType
+from mlflow.entities import LiveSpan, NoOpSpan, SpanEvent, SpanType
 from mlflow.entities.document import Document
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+from mlflow.tracing.distributed import (
+    _get_tracing_headers_from_span,
+    set_tracing_context_from_http_request_headers,
+)
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
-from mlflow.tracing.utils import set_span_chat_tools
+from mlflow.tracing.provider import (
+    detach_span_from_context,
+    set_span_in_context,
+    start_span_in_context,
+)
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import encode_span_id, set_span_chat_tools
 
 _logger = logging.getLogger(__name__)
 
@@ -160,6 +169,8 @@ def _extract_workflow_inputs(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
+    _PROPAGATION_KEY = "mlflow"
+
     def __init__(self):
         super().__init__()
         self._span_id_to_token = {}
@@ -167,6 +178,8 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         self._pending_spans: dict[str, _LlamaSpan] = {}
         # Track workflow spans that are pending completion (WorkflowHandler returned)
         self._pending_workflow_span_ids: set[str] = set()
+        self._propagation_context_managers = []
+        self._propagated_root_span_ids: set[str] = set()
 
     @classmethod
     def class_name(cls) -> str:
@@ -175,6 +188,56 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
     def get_span_for_event(self, event: BaseEvent) -> LiveSpan:
         llama_span = self.open_spans.get(event.span_id) or self._pending_spans.get(event.span_id)
         return llama_span._mlflow_span if llama_span else None
+
+    def capture_propagation_context(self) -> dict[str, Any]:
+        span = mlflow.get_current_active_span()
+        if span is None:
+            return {}
+        headers = _get_tracing_headers_from_span(span)
+        return {self._PROPAGATION_KEY: headers} if headers else {}
+
+    def restore_propagation_context(self, context: dict[str, Any]) -> None:
+        headers = context.get(self._PROPAGATION_KEY)
+        if not headers:
+            return
+
+        context_manager = set_tracing_context_from_http_request_headers(headers)
+        context_manager.__enter__()
+        self._propagation_context_managers.append(context_manager)
+
+    def close(self) -> None:
+        while self._propagation_context_managers:
+            self._close_latest_propagation_context()
+        self._propagated_root_span_ids.clear()
+
+    def _close_latest_propagation_context(self) -> None:
+        context_manager = self._propagation_context_managers.pop()
+        context_manager.__exit__(None, None, None)
+
+    @property
+    def _has_restored_context(self) -> bool:
+        return bool(self._propagation_context_managers)
+
+    def _start_span_from_current_context(
+        self,
+        name: str,
+        span_type: str,
+        inputs: dict[str, Any],
+        attributes: dict[str, Any],
+    ) -> LiveSpan | NoOpSpan:
+        otel_span = start_span_in_context(name)
+        if not otel_span.is_recording():
+            return NoOpSpan(otel_span=otel_span)
+
+        trace_manager = InMemoryTraceManager.get_instance()
+        trace_id = trace_manager.get_mlflow_trace_id_from_otel_id(otel_span.context.trace_id)
+        span = trace_manager.get_span_from_id(
+            trace_id, encode_span_id(otel_span.context.span_id)
+        )
+        span.set_span_type(span_type)
+        span.set_inputs(inputs)
+        span.set_attributes(attributes)
+        return span
 
     def new_span(
         self,
@@ -191,15 +254,25 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
         try:
             input_args = _extract_workflow_inputs(bound_args.arguments)
-            attributes = self._get_instance_attributes(instance)
+            attributes = self._get_instance_attributes(instance) or {}
             span_type = self._get_span_type(instance) or SpanType.UNKNOWN
-            span = start_span_no_context(
-                name=id_.partition("-")[0],
-                parent_span=parent_span,
-                span_type=span_type,
-                inputs=input_args,
-                attributes=attributes,
-            )
+            name = id_.partition("-")[0]
+            if parent_span is None and self._has_restored_context:
+                span = self._start_span_from_current_context(
+                    name=name,
+                    span_type=span_type,
+                    inputs=input_args,
+                    attributes=attributes,
+                )
+                self._propagated_root_span_ids.add(id_)
+            else:
+                span = start_span_no_context(
+                    name=name,
+                    parent_span=parent_span,
+                    span_type=span_type,
+                    inputs=input_args,
+                    attributes=attributes,
+                )
 
             token = set_span_in_context(span)
             self._span_id_to_token[span.span_id] = token
@@ -257,10 +330,16 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
             # If a child step returns a StopEvent, close the parent workflow span
             self._try_close_workflow_span(llama_span.parent_id, result)
+            self._try_close_propagation_context(id_)
 
             return llama_span
         except BaseException as e:
             _logger.debug(f"Failed to end a span: {e}", exc_info=True)
+
+    def _try_close_propagation_context(self, id_: str | None):
+        if id_ in self._propagated_root_span_ids:
+            self._propagated_root_span_ids.discard(id_)
+            self._close_latest_propagation_context()
 
     def _try_close_workflow_span(self, parent_id: str | None, result: Any):
         """Close a pending workflow span when a child step returns a StopEvent."""
@@ -280,6 +359,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
             workflow_llama_span = self.open_spans.pop(parent_id, None)
         if workflow_llama_span:
             _end_span(span=workflow_llama_span._mlflow_span, outputs=result.result)
+            self._try_close_propagation_context(parent_id)
 
     def resolve_pending_stream_span(self, span: LiveSpan, event: Any):
         """End the pending streaming span(s)"""
@@ -303,6 +383,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
         span.add_event(SpanEvent.from_exception(err))
         _end_span(span=span, status="ERROR", token=token)
+        self._try_close_propagation_context(id_)
         return llama_span
 
     def _get_span_type(self, instance: Any) -> SpanType:

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -117,44 +117,39 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
         }
 
 
-@pytest.mark.skipif(
-    llama_core_version < Version("0.11.0"),
-    reason="Workflow was introduced in 0.11.0",
-)
-@pytest.mark.asyncio
-async def test_tracer_workflow_restores_propagated_mlflow_context():
+def test_tracer_restores_propagated_mlflow_context_for_instrumented_span():
     from llama_index.core.instrumentation import get_dispatcher
-    from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
 
-    class MyWorkflow(Workflow):
-        @step
-        async def my_step(self, ev: StartEvent) -> StopEvent:
-            with mlflow.start_span("manual-child") as child:
-                child.set_outputs("done")
-            return StopEvent(result="done")
+    dispatcher = get_dispatcher()
+
+    @dispatcher.span
+    def instrumented_operation(value: str) -> str:
+        result = value.upper()
+        with mlflow.start_span("manual-child") as child:
+            child.set_outputs(result)
+        return result
 
     with mlflow.start_span("workflow-root") as root:
-        context = get_dispatcher().capture_propagation_context()
+        context = dispatcher.capture_propagation_context()
         root_trace_id = root.trace_id
         root_span_id = root.span_id
 
     assert mlflow.get_current_active_span() is None
 
-    get_dispatcher().restore_propagation_context(context)
-    result = await MyWorkflow(timeout=10, verbose=False).run()
-    assert result == "done"
+    dispatcher.restore_propagation_context(context)
+    assert instrumented_operation("done") == "DONE"
 
     traces = get_traces()
     assert len(traces) == 1
 
     spans = traces[0].data.spans
+    instrumented_span = next(span for span in spans if span.name.endswith("instrumented_operation"))
     manual_child = next(span for span in spans if span.name == "manual-child")
-    workflow_parent = next(span for span in spans if span.span_id == manual_child.parent_id)
 
-    assert any(span.parent_id == root_span_id for span in spans)
-    assert workflow_parent.trace_id == root_trace_id
+    assert instrumented_span.trace_id == root_trace_id
+    assert instrumented_span.parent_id == root_span_id
     assert manual_child.trace_id == root_trace_id
-    assert manual_child.parent_id != root_span_id
+    assert manual_child.parent_id == instrumented_span.span_id
 
 
 def test_trace_llm_complete_stream():

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -28,6 +28,7 @@ from mlflow.entities.span import SpanType
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.llama_index.tracer import (
+    MlflowSpanHandler,
     StreamResolver,
     remove_llama_index_tracer,
     set_llama_index_tracer,
@@ -115,6 +116,37 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
             "output_cost": 14.0,
             "total_cost": 19.0,
         }
+
+
+def test_span_handler_propagates_mlflow_context_across_boundaries():
+    handler = MlflowSpanHandler()
+    span_id = "DemoWorkflow.step-123"
+    bound_args = inspect.signature(lambda: None).bind()
+
+    with mlflow.start_span("workflow-root") as root:
+        context = handler.capture_propagation_context()
+        root_trace_id = root.trace_id
+        root_span_id = root.span_id
+
+    assert mlflow.get_current_active_span() is None
+
+    try:
+        handler.restore_propagation_context(context)
+
+        llama_span = handler.new_span(span_id, bound_args)
+        handler.open_spans[span_id] = llama_span
+
+        assert llama_span._mlflow_span.trace_id == root_trace_id
+        assert llama_span._mlflow_span.parent_id == root_span_id
+
+        with mlflow.start_span("manual-child") as manual_child:
+            assert manual_child.trace_id == root_trace_id
+            assert manual_child.parent_id == llama_span._mlflow_span.span_id
+
+        handler.prepare_to_exit_span(span_id, result="done")
+    finally:
+        handler.open_spans.pop(span_id, None)
+        handler.close()
 
 
 def test_trace_llm_complete_stream():

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -28,7 +28,6 @@ from mlflow.entities.span import SpanType
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.llama_index.tracer import (
-    MlflowSpanHandler,
     StreamResolver,
     remove_llama_index_tracer,
     set_llama_index_tracer,
@@ -118,35 +117,44 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
         }
 
 
-def test_span_handler_propagates_mlflow_context_across_boundaries():
-    handler = MlflowSpanHandler()
-    span_id = "DemoWorkflow.step-123"
-    bound_args = inspect.signature(lambda: None).bind()
+@pytest.mark.skipif(
+    llama_core_version < Version("0.11.0"),
+    reason="Workflow was introduced in 0.11.0",
+)
+@pytest.mark.asyncio
+async def test_tracer_workflow_restores_propagated_mlflow_context():
+    from llama_index.core.instrumentation import get_dispatcher
+    from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
+
+    class MyWorkflow(Workflow):
+        @step
+        async def my_step(self, ev: StartEvent) -> StopEvent:
+            with mlflow.start_span("manual-child") as child:
+                child.set_outputs("done")
+            return StopEvent(result="done")
 
     with mlflow.start_span("workflow-root") as root:
-        context = handler.capture_propagation_context()
+        context = get_dispatcher().capture_propagation_context()
         root_trace_id = root.trace_id
         root_span_id = root.span_id
 
     assert mlflow.get_current_active_span() is None
 
-    try:
-        handler.restore_propagation_context(context)
+    get_dispatcher().restore_propagation_context(context)
+    result = await MyWorkflow(timeout=10, verbose=False).run()
+    assert result == "done"
 
-        llama_span = handler.new_span(span_id, bound_args)
-        handler.open_spans[span_id] = llama_span
+    traces = get_traces()
+    assert len(traces) == 1
 
-        assert llama_span._mlflow_span.trace_id == root_trace_id
-        assert llama_span._mlflow_span.parent_id == root_span_id
+    spans = traces[0].data.spans
+    manual_child = next(span for span in spans if span.name == "manual-child")
+    workflow_parent = next(span for span in spans if span.span_id == manual_child.parent_id)
 
-        with mlflow.start_span("manual-child") as manual_child:
-            assert manual_child.trace_id == root_trace_id
-            assert manual_child.parent_id == llama_span._mlflow_span.span_id
-
-        handler.prepare_to_exit_span(span_id, result="done")
-    finally:
-        handler.open_spans.pop(span_id, None)
-        handler.close()
+    assert any(span.parent_id == root_span_id for span in spans)
+    assert workflow_parent.trace_id == root_trace_id
+    assert manual_child.trace_id == root_trace_id
+    assert manual_child.parent_id != root_span_id
 
 
 def test_trace_llm_complete_stream():


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/run-llama/llama-agents/issues/707

### What changes are proposed in this pull request?

LlamaIndex span handlers can serialize propagation context before work crosses a task or process boundary, but the MLflow handler currently does not participate in that contract. When a runtime restores dispatcher context before starting the next instrumented span, MLflow still starts a new root trace because the handler captured no active MLflow span state.

This teaches the MLflow LlamaIndex span handler to capture and restore MLflow’s W3C trace context:

```python
context = dispatcher.capture_propagation_context()
dispatcher.restore_propagation_context(context)
```

The handler stores its payload under the `mlflow` propagation key. Capture emits the same `traceparent` headers MLflow already uses for distributed HTTP tracing. Restore enters `set_tracing_context_from_http_request_headers(...)`, so the next LlamaIndex span created with `start_span_no_context(...)` parents from the restored context instead of becoming a new root trace.

The restored context is unwound when the propagated root LlamaIndex span closes, and `remove_llama_index_tracer()` now closes existing MLflow span handlers before removing them so restored context does not leak across tracer teardown.

The regression coverage stays at the LlamaIndex instrumentation boundary: it captures dispatcher context under an active MLflow span, restores it with no active span in scope, runs a plain `@dispatcher.span` function, and verifies both the instrumented span and a manual `mlflow.start_span(...)` child stay in the original trace tree.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow now preserves trace nesting for LlamaIndex instrumentation when dispatcher propagation context is serialized and restored across task or process boundaries.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
