### PR TITLE
Propagate MLflow context through `MlflowSpanHandler`

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -37,8 +37,15 @@ from mlflow.entities import LiveSpan, SpanEvent, SpanType
 from mlflow.entities.document import Document
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+from mlflow.tracing.distributed import (
+    _get_tracing_headers_from_span,
+    set_tracing_context_from_http_request_headers,
+)
 from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
+from mlflow.tracing.provider import (
+    detach_span_from_context,
+    set_span_in_context,
+)
 from mlflow.tracing.utils import set_span_chat_tools
 
 _logger = logging.getLogger(__name__)
@@ -81,6 +88,9 @@ def remove_llama_index_tracer():
     from llama_index.core.instrumentation import get_dispatcher
 
     dsp = get_dispatcher()
+    for handler in dsp.span_handlers:
+        if isinstance(handler, MlflowSpanHandler):
+            handler.close()
     dsp.span_handlers = [h for h in dsp.span_handlers if h.class_name() != "MlflowSpanHandler"]
     dsp.event_handlers = [h for h in dsp.event_handlers if h.class_name() != "MlflowEventHandler"]
 
@@ -160,6 +170,8 @@ def _extract_workflow_inputs(arguments: dict[str, Any]) -> dict[str, Any]:
 
 
 class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
+    _PROPAGATION_KEY = "mlflow"
+
     def __init__(self):
         super().__init__()
         self._span_id_to_token = {}
@@ -167,6 +179,8 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         self._pending_spans: dict[str, _LlamaSpan] = {}
         # Track workflow spans that are pending completion (WorkflowHandler returned)
         self._pending_workflow_span_ids: set[str] = set()
+        self._propagation_context_managers = []
+        self._propagated_root_span_ids: set[str] = set()
 
     @classmethod
     def class_name(cls) -> str:
@@ -175,6 +189,35 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
     def get_span_for_event(self, event: BaseEvent) -> LiveSpan:
         llama_span = self.open_spans.get(event.span_id) or self._pending_spans.get(event.span_id)
         return llama_span._mlflow_span if llama_span else None
+
+    def capture_propagation_context(self) -> dict[str, Any]:
+        span = mlflow.get_current_active_span()
+        if span is None:
+            return {}
+        headers = _get_tracing_headers_from_span(span)
+        return {self._PROPAGATION_KEY: headers} if headers else {}
+
+    def restore_propagation_context(self, context: dict[str, Any]) -> None:
+        headers = context.get(self._PROPAGATION_KEY)
+        if not headers:
+            return
+
+        context_manager = set_tracing_context_from_http_request_headers(headers)
+        context_manager.__enter__()
+        self._propagation_context_managers.append(context_manager)
+
+    def close(self) -> None:
+        while self._propagation_context_managers:
+            self._close_latest_propagation_context()
+        self._propagated_root_span_ids.clear()
+
+    def _close_latest_propagation_context(self) -> None:
+        context_manager = self._propagation_context_managers.pop()
+        context_manager.__exit__(None, None, None)
+
+    @property
+    def _has_restored_context(self) -> bool:
+        return bool(self._propagation_context_managers)
 
     def new_span(
         self,
@@ -191,10 +234,13 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
         try:
             input_args = _extract_workflow_inputs(bound_args.arguments)
-            attributes = self._get_instance_attributes(instance)
+            attributes = self._get_instance_attributes(instance) or {}
             span_type = self._get_span_type(instance) or SpanType.UNKNOWN
+            name = id_.partition("-")[0]
+            if parent_span is None and self._has_restored_context:
+                self._propagated_root_span_ids.add(id_)
             span = start_span_no_context(
-                name=id_.partition("-")[0],
+                name=name,
                 parent_span=parent_span,
                 span_type=span_type,
                 inputs=input_args,
@@ -257,10 +303,16 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
             # If a child step returns a StopEvent, close the parent workflow span
             self._try_close_workflow_span(llama_span.parent_id, result)
+            self._try_close_propagation_context(id_)
 
             return llama_span
         except BaseException as e:
             _logger.debug(f"Failed to end a span: {e}", exc_info=True)
+
+    def _try_close_propagation_context(self, id_: str | None):
+        if id_ in self._propagated_root_span_ids:
+            self._propagated_root_span_ids.discard(id_)
+            self._close_latest_propagation_context()
 
     def _try_close_workflow_span(self, parent_id: str | None, result: Any):
         """Close a pending workflow span when a child step returns a StopEvent."""
@@ -280,6 +332,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
             workflow_llama_span = self.open_spans.pop(parent_id, None)
         if workflow_llama_span:
             _end_span(span=workflow_llama_span._mlflow_span, outputs=result.result)
+            self._try_close_propagation_context(parent_id)
 
     def resolve_pending_stream_span(self, span: LiveSpan, event: Any):
         """End the pending streaming span(s)"""
@@ -303,6 +356,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
         span.add_event(SpanEvent.from_exception(err))
         _end_span(span=span, status="ERROR", token=token)
+        self._try_close_propagation_context(id_)
         return llama_span
 
     def _get_span_type(self, instance: Any) -> SpanType:

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -1,3 +1,5 @@
+import contextlib
+import contextvars
 import inspect
 import json
 import logging
@@ -12,6 +14,7 @@ from llama_index.core.base.llms.base import BaseLLM
 from llama_index.core.base.llms.types import ChatResponse, CompletionResponse
 from llama_index.core.base.response.schema import AsyncStreamingResponse, StreamingResponse
 from llama_index.core.chat_engine.types import StreamingAgentChatResponse
+from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.instrumentation.event_handlers import BaseEventHandler
 from llama_index.core.instrumentation.events import BaseEvent
 from llama_index.core.instrumentation.events.agent import AgentToolCallEvent
@@ -51,6 +54,14 @@ from mlflow.tracing.utils import set_span_chat_tools
 _logger = logging.getLogger(__name__)
 
 
+# Handoff from restore_propagation_context() to the next new_span() that opens a propagated
+# root. A ContextVar, not a shared field, so concurrent restores stay isolated per thread and
+# per async task. It can't be keyed by span id because the id doesn't exist yet at restore.
+_pending_propagation_context: contextvars.ContextVar[contextlib.AbstractContextManager | None] = (
+    contextvars.ContextVar("mlflow_llama_pending_propagation", default=None)
+)
+
+
 def _get_llama_index_version() -> Version:
     return Version(llama_index.core.__version__)
 
@@ -60,8 +71,6 @@ def set_llama_index_tracer():
     Set the MlflowSpanHandler and MlflowEventHandler to the global dispatcher.
     If the handlers are already set, skip setting.
     """
-    from llama_index.core.instrumentation import get_dispatcher
-
     dsp = get_dispatcher()
     span_handler = None
     for handler in dsp.span_handlers:
@@ -85,8 +94,6 @@ def remove_llama_index_tracer():
     """
     Remove the MlflowSpanHandler and MlflowEventHandler from the global dispatcher.
     """
-    from llama_index.core.instrumentation import get_dispatcher
-
     dsp = get_dispatcher()
     for handler in dsp.span_handlers:
         if isinstance(handler, MlflowSpanHandler):
@@ -179,8 +186,8 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         self._pending_spans: dict[str, _LlamaSpan] = {}
         # Track workflow spans that are pending completion (WorkflowHandler returned)
         self._pending_workflow_span_ids: set[str] = set()
-        self._propagation_context_managers = []
-        self._propagated_root_span_ids: set[str] = set()
+        # Entered propagation contexts keyed by root span id, so each root closes its own.
+        self._root_id_to_propagation_context: dict[str, contextlib.AbstractContextManager] = {}
 
     @classmethod
     def class_name(cls) -> str:
@@ -202,22 +209,55 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         if not headers:
             return
 
+        # An earlier restore in this context that no new_span claimed is now unreachable;
+        # close it before entering the next context so contextvars tokens unwind in order.
+        orphaned = _pending_propagation_context.get()
+        if orphaned is not None:
+            _pending_propagation_context.set(None)
+            self._exit_propagation_context(orphaned)
+
         context_manager = set_tracing_context_from_http_request_headers(headers)
-        context_manager.__enter__()
-        self._propagation_context_managers.append(context_manager)
+        try:
+            context_manager.__enter__()
+        except Exception as e:
+            _logger.debug(f"Failed to restore propagation context: {e}", exc_info=True)
+            return
+        # Ambient propagation stays attached until this restore is claimed, overwritten, or
+        # closed. Reusing the worker context for unrelated work before then can mis-parent it.
+        _pending_propagation_context.set(context_manager)
 
     def close(self) -> None:
-        while self._propagation_context_managers:
-            self._close_latest_propagation_context()
-        self._propagated_root_span_ids.clear()
+        with self.lock:
+            restored_contexts = list(self._root_id_to_propagation_context.values())
+            self._root_id_to_propagation_context.clear()
+        for restored_context in restored_contexts:
+            self._exit_propagation_context(restored_context)
+        pending = _pending_propagation_context.get()
+        if pending is not None:
+            _pending_propagation_context.set(None)
+            self._exit_propagation_context(pending)
 
-    def _close_latest_propagation_context(self) -> None:
-        context_manager = self._propagation_context_managers.pop()
-        context_manager.__exit__(None, None, None)
-
-    @property
-    def _has_restored_context(self) -> bool:
-        return bool(self._propagation_context_managers)
+    @staticmethod
+    def _exit_propagation_context(
+        context_manager: contextlib.AbstractContextManager,
+    ) -> None:
+        try:
+            # __exit__ pops the dummy remote trace, which deletes the OTel trace id ->
+            # MLflow trace id mapping from the InMemoryTraceManager. With async logging
+            # enabled (the default), the spans that just ended under this restored context
+            # are still queued in the batch span processor at this point; the exporter
+            # resolves each queued span through that mapping and silently skips spans it
+            # can't resolve, so popping before the queues drain drops the restored spans
+            # from the backend. Flush both the span queue and the exporter's async write
+            # queue while the mapping is still alive. When async logging is disabled the
+            # queues are empty and this is a no-op.
+            mlflow.flush_trace_async_logging()
+        except Exception as e:
+            _logger.debug(f"Failed to flush restored propagation context: {e}", exc_info=True)
+        try:
+            context_manager.__exit__(None, None, None)
+        except Exception as e:
+            _logger.debug(f"Failed to close propagation context: {e}", exc_info=True)
 
     def new_span(
         self,
@@ -234,11 +274,12 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
         try:
             input_args = _extract_workflow_inputs(bound_args.arguments)
-            attributes = self._get_instance_attributes(instance) or {}
+            attributes = self._get_instance_attributes(instance)
             span_type = self._get_span_type(instance) or SpanType.UNKNOWN
             name = id_.partition("-")[0]
-            if parent_span is None and self._has_restored_context:
-                self._propagated_root_span_ids.add(id_)
+            pending_context = (
+                _pending_propagation_context.get() if parent_span is None else None
+            )
             span = start_span_no_context(
                 name=name,
                 parent_span=parent_span,
@@ -249,6 +290,10 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
             token = set_span_in_context(span)
             self._span_id_to_token[span.span_id] = token
+            if pending_context is not None:
+                with self.lock:
+                    self._root_id_to_propagation_context[id_] = pending_context
+                _pending_propagation_context.set(None)
 
             # NB: The tool definition is passed to LLM via kwargs, but it is not set
             # to the LLM/Chat start event. Therefore, we need to handle it here.
@@ -286,33 +331,38 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                 if token:
                     detach_span_from_context(token)
                 return None  # Keep the span in open_spans
-            elif self._stream_resolver.is_streaming_result(result):
-                # If the result is a generator, we keep the span in progress for streaming
-                # and end it when the generator is exhausted.
-                is_pended = self._stream_resolver.register_stream_span(span, result)
-                if is_pended:
-                    self._pending_spans[id_] = llama_span
-                    # We still need to detach the span from the context, otherwise it will
-                    # be considered as "active"
-                    detach_span_from_context(token)
-                else:
-                    # If the span is not pended successfully, end it immediately
-                    _end_span(span=span, outputs=result, token=token)
-            else:
-                _end_span(span=span, outputs=result, token=token)
 
-            # If a child step returns a StopEvent, close the parent workflow span
-            self._try_close_workflow_span(llama_span.parent_id, result)
-            self._try_close_propagation_context(id_)
+            try:
+                if self._stream_resolver.is_streaming_result(result):
+                    # If the result is a generator, we keep the span in progress for streaming
+                    # and end it when the generator is exhausted.
+                    is_pended = self._stream_resolver.register_stream_span(span, result)
+                    if is_pended:
+                        self._pending_spans[id_] = llama_span
+                        # We still need to detach the span from the context, otherwise it will
+                        # be considered as "active"
+                        detach_span_from_context(token)
+                    else:
+                        # If the span is not pended successfully, end it immediately
+                        _end_span(span=span, outputs=result, token=token)
+                else:
+                    _end_span(span=span, outputs=result, token=token)
+            finally:
+                try:
+                    # If a child step returns a StopEvent, close the parent workflow span
+                    self._try_close_workflow_span(llama_span.parent_id, result)
+                finally:
+                    self._try_close_propagation_context(id_)
 
             return llama_span
         except BaseException as e:
             _logger.debug(f"Failed to end a span: {e}", exc_info=True)
 
     def _try_close_propagation_context(self, id_: str | None):
-        if id_ in self._propagated_root_span_ids:
-            self._propagated_root_span_ids.discard(id_)
-            self._close_latest_propagation_context()
+        with self.lock:
+            restored_context = self._root_id_to_propagation_context.pop(id_, None)
+        if restored_context is not None:
+            self._exit_propagation_context(restored_context)
 
     def _try_close_workflow_span(self, parent_id: str | None, result: Any):
         """Close a pending workflow span when a child step returns a StopEvent."""
@@ -346,18 +396,23 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         span = llama_span._mlflow_span
         token = self._span_id_to_token.pop(span.span_id, None)
 
-        if _get_llama_index_version() >= Version("0.10.59"):
-            # LlamaIndex determines if a workflow is terminated or not by propagating an special
-            # exception WorkflowDone. We should treat this exception as a successful termination.
-            from llama_index.core.workflow.errors import WorkflowDone
+        try:
+            if _get_llama_index_version() >= Version("0.10.59"):
+                # LlamaIndex determines if a workflow is terminated or not by propagating a
+                # special exception WorkflowDone. We should treat this exception as a
+                # successful termination.
+                from llama_index.core.workflow.errors import WorkflowDone
 
-            if err and isinstance(err, WorkflowDone):
-                return _end_span(span=span, status=SpanStatusCode.OK, token=token)
+                if err and isinstance(err, WorkflowDone):
+                    return _end_span(span=span, status=SpanStatusCode.OK, token=token)
 
-        span.add_event(SpanEvent.from_exception(err))
-        _end_span(span=span, status="ERROR", token=token)
-        self._try_close_propagation_context(id_)
-        return llama_span
+            span.add_event(SpanEvent.from_exception(err))
+            _end_span(span=span, status="ERROR", token=token)
+            return llama_span
+        finally:
+            # Close on both the WorkflowDone and error paths, so a propagated root that ends
+            # via WorkflowDone still tears down its context.
+            self._try_close_propagation_context(id_)
 
     def _get_span_type(self, instance: Any) -> SpanType:
         """

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -332,6 +332,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                     detach_span_from_context(token)
                 return None  # Keep the span in open_spans
 
+            is_pended = False
             try:
                 if self._stream_resolver.is_streaming_result(result):
                     # If the result is a generator, we keep the span in progress for streaming
@@ -352,7 +353,8 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                     # If a child step returns a StopEvent, close the parent workflow span
                     self._try_close_workflow_span(llama_span.parent_id, result)
                 finally:
-                    self._try_close_propagation_context(id_)
+                    if not is_pended:
+                        self._try_close_propagation_context(id_)
 
             return llama_span
         except BaseException as e:
@@ -386,8 +388,17 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
     def resolve_pending_stream_span(self, span: LiveSpan, event: Any):
         """End the pending streaming span(s)"""
-        self._stream_resolver.resolve(span, event)
-        self._pending_spans.pop(event.span_id, None)
+        resolved_span_ids = self._stream_resolver.resolve(span, event)
+        with self.lock:
+            resolved_llama_span_ids = [
+                id_
+                for id_, llama_span in self._pending_spans.items()
+                if llama_span._mlflow_span.span_id in resolved_span_ids
+            ]
+            for id_ in resolved_llama_span_ids:
+                self._pending_spans.pop(id_, None)
+        for id_ in resolved_llama_span_ids:
+            self._try_close_propagation_context(id_)
 
     def prepare_to_drop_span(self, id_: str, err: Exception | None, **kwargs) -> _LlamaSpan:
         """Logic for handling errors during the model execution."""
@@ -725,14 +736,14 @@ class StreamResolver:
         self._span_id_to_span_and_gen[span.span_id] = (span, stream)
         return True
 
-    def resolve(self, span: LiveSpan, event: _StreamEndEvent):
+    def resolve(self, span: LiveSpan, event: _StreamEndEvent) -> set[str]:
         """
         Finish the streaming span and recursively resolve the parent spans that
         returns the same (or derived) stream.
         """
         _, stream = self._span_id_to_span_and_gen.pop(span.span_id, (None, None))
         if not stream:
-            return
+            return set()
 
         if isinstance(event, (LLMChatEndEvent, LLMCompletionEndEvent)):
             outputs = event.response
@@ -745,6 +756,7 @@ class StreamResolver:
             raise ValueError(f"Unsupported event type to resolve streaming: {type(event)}")
 
         _end_span(span=span, status=status, outputs=outputs)
+        resolved_span_ids = {span.span_id}
 
         # Extract the complete text from the event.
         if isinstance(outputs, ChatResponse):
@@ -763,3 +775,6 @@ class StreamResolver:
                 # as token stream can be modified by callers. However, it is technically
                 # challenging to track the modified stream across multiple spans.
                 _end_span(span=span, status=status, outputs=output_text)
+                resolved_span_ids.add(span.span_id)
+
+        return resolved_span_ids

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -817,6 +817,8 @@ llama_index:
           # Required to run tests/openai/mock_openai.py
           "fastapi",
           "uvicorn",
+          # Dispatcher context propagation APIs used by mlflow.llama_index
+          "llama-index-instrumentation>=0.4.3",
         ]
     run: pytest tests/llama_index/test_llama_index_autolog.py tests/llama_index/test_llama_index_tracer.py
     test_tracing_sdk: true

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -61,6 +61,8 @@ tenacity
 # transitive conflict in the combined ML env silently backtracks llama-index to an
 # unsupported 0.10.x (pydantic v1 models), which crashes Settings serialization.
 llama-index>=0.12.38
+# Required for LlamaIndex dispatcher context propagation APIs used by mlflow.llama_index
+llama-index-instrumentation>=0.5.0
 # Required for an agent example of mlflow.llama_index
 llama-index-agent-openai
 # Required by mlflow.langchain

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -61,8 +61,6 @@ tenacity
 # transitive conflict in the combined ML env silently backtracks llama-index to an
 # unsupported 0.10.x (pydantic v1 models), which crashes Settings serialization.
 llama-index>=0.12.38
-# Required for LlamaIndex dispatcher context propagation APIs used by mlflow.llama_index
-llama-index-instrumentation>=0.5.0
 # Required for an agent example of mlflow.llama_index
 llama-index-agent-openai
 # Required by mlflow.langchain

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -117,6 +117,41 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
         }
 
 
+def test_tracer_restores_propagated_mlflow_context_for_instrumented_span():
+    from llama_index.core.instrumentation import get_dispatcher
+
+    dispatcher = get_dispatcher()
+
+    @dispatcher.span
+    def instrumented_operation(value: str) -> str:
+        result = value.upper()
+        with mlflow.start_span("manual-child") as child:
+            child.set_outputs(result)
+        return result
+
+    with mlflow.start_span("workflow-root") as root:
+        context = dispatcher.capture_propagation_context()
+        root_trace_id = root.trace_id
+        root_span_id = root.span_id
+
+    assert mlflow.get_current_active_span() is None
+
+    dispatcher.restore_propagation_context(context)
+    assert instrumented_operation("done") == "DONE"
+
+    traces = get_traces()
+    assert len(traces) == 1
+
+    spans = traces[0].data.spans
+    instrumented_span = next(span for span in spans if span.name.endswith("instrumented_operation"))
+    manual_child = next(span for span in spans if span.name == "manual-child")
+
+    assert instrumented_span.trace_id == root_trace_id
+    assert instrumented_span.parent_id == root_span_id
+    assert manual_child.trace_id == root_trace_id
+    assert manual_child.parent_id == instrumented_span.span_id
+
+
 def test_trace_llm_complete_stream():
     model_name = "gpt-3.5-turbo"
     llm = OpenAI(model=model_name)

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -166,6 +166,47 @@ def test_tracer_restores_propagated_mlflow_context_for_instrumented_span():
     not hasattr(Dispatcher, "capture_propagation_context"),
     reason="Dispatcher propagation APIs require llama-index-instrumentation>=0.4.3",
 )
+def test_tracer_keeps_restored_context_until_stream_resolves():
+    dispatcher = get_dispatcher()
+    llm = OpenAI(model="gpt-3.5-turbo")
+
+    @dispatcher.span
+    def instrumented_stream():
+        message = ChatMessage(role="system", content="Hello")
+        return llm.stream_chat([message], stream_options={"include_usage": True})
+
+    with mlflow.start_span("workflow-root") as root:
+        context = dispatcher.capture_propagation_context()
+        root_trace_id = root.trace_id
+        root_span_id = root.span_id
+
+    dispatcher.restore_propagation_context(context)
+    response_gen = instrumented_stream()
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    with trace_manager.get_trace(root_trace_id) as restored_trace:
+        assert restored_trace is not None
+
+    assert [response.message.content for response in response_gen] == ["Hello", "Hello world"]
+
+    with trace_manager.get_trace(root_trace_id) as restored_trace:
+        assert restored_trace is None
+
+    traces = get_traces()
+    assert len(traces) == 1
+    instrumented_span = next(
+        span for span in traces[0].data.spans if span.name.endswith("instrumented_stream")
+    )
+    stream_span = next(span for span in traces[0].data.spans if span.name == "OpenAI.stream_chat")
+    assert instrumented_span.trace_id == root_trace_id
+    assert instrumented_span.parent_id == root_span_id
+    assert stream_span.parent_id == instrumented_span.span_id
+
+
+@pytest.mark.skipif(
+    not hasattr(Dispatcher, "capture_propagation_context"),
+    reason="Dispatcher propagation APIs require llama-index-instrumentation>=0.4.3",
+)
 def test_tracer_exports_restored_remote_spans_before_context_cleanup(tmp_path):
     dispatcher = get_dispatcher()
     tracking_uri = f"sqlite:///{tmp_path / 'mlflow.sqlite'}"

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -1,7 +1,12 @@
 import asyncio
 import base64
 import inspect
+import json
+import os
 import random
+import subprocess
+import sys
+import threading
 from dataclasses import asdict
 from importlib import metadata
 from pathlib import Path
@@ -13,6 +18,8 @@ import openai
 import pytest
 from llama_index.core import Settings
 from llama_index.core.base.response.schema import StreamingResponse
+from llama_index.core.instrumentation import get_dispatcher
+from llama_index.core.instrumentation.dispatcher import Dispatcher
 from llama_index.core.llms import ChatMessage, ChatResponse
 from llama_index.core.llms.callbacks import llm_chat_callback
 from llama_index.core.retrievers import VectorIndexRetriever
@@ -34,6 +41,7 @@ from mlflow.llama_index.tracer import (
 )
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.provider import _get_tracer
+from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.version import IS_TRACING_SDK_ONLY
 
@@ -117,9 +125,11 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
         }
 
 
+@pytest.mark.skipif(
+    not hasattr(Dispatcher, "capture_propagation_context"),
+    reason="Dispatcher propagation APIs require llama-index-instrumentation>=0.4.3",
+)
 def test_tracer_restores_propagated_mlflow_context_for_instrumented_span():
-    from llama_index.core.instrumentation import get_dispatcher
-
     dispatcher = get_dispatcher()
 
     @dispatcher.span
@@ -150,6 +160,219 @@ def test_tracer_restores_propagated_mlflow_context_for_instrumented_span():
     assert instrumented_span.parent_id == root_span_id
     assert manual_child.trace_id == root_trace_id
     assert manual_child.parent_id == instrumented_span.span_id
+
+
+@pytest.mark.skipif(
+    not hasattr(Dispatcher, "capture_propagation_context"),
+    reason="Dispatcher propagation APIs require llama-index-instrumentation>=0.4.3",
+)
+def test_tracer_exports_restored_remote_spans_before_context_cleanup(tmp_path):
+    dispatcher = get_dispatcher()
+    tracking_uri = f"sqlite:///{tmp_path / 'mlflow.sqlite'}"
+
+    with _use_tracking_uri(tracking_uri):
+        experiment_id = mlflow.set_experiment(
+            f"llama-index-propagation-{random.random()}"
+        ).experiment_id
+
+        with mlflow.start_span("workflow-root") as root:
+            context = dispatcher.capture_propagation_context()
+            root_trace_id = root.trace_id
+            root_span_id = root.span_id
+
+        assert mlflow.get_current_active_span() is None
+        assert [trace.info.trace_id for trace in get_traces(experiment_id)] == [root_trace_id]
+
+        child_code = """
+import json
+import os
+
+import mlflow
+from llama_index.core.instrumentation import get_dispatcher
+
+from mlflow.llama_index.tracer import remove_llama_index_tracer, set_llama_index_tracer
+
+mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+mlflow.set_experiment(experiment_id=os.environ["MLFLOW_EXPERIMENT_ID"])
+set_llama_index_tracer()
+dispatcher = get_dispatcher()
+
+@dispatcher.span
+def instrumented_operation(value: str) -> str:
+    with mlflow.start_span("manual-child") as child:
+        child.set_outputs(value)
+    return value
+
+dispatcher.restore_propagation_context(json.loads(os.environ["MLFLOW_PROPAGATION_CONTEXT"]))
+assert instrumented_operation("done") == "done"
+remove_llama_index_tracer()
+"""
+        repo_root = Path(__file__).parents[2]
+        env = {
+            **os.environ,
+            "MLFLOW_EXPERIMENT_ID": experiment_id,
+            "MLFLOW_PROPAGATION_CONTEXT": json.dumps(context),
+            "MLFLOW_TRACKING_URI": tracking_uri,
+            "PYTHONPATH": os.pathsep.join(
+                [str(repo_root), *filter(None, [os.environ.get("PYTHONPATH")])]
+            ),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", child_code],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        traces = get_traces(experiment_id)
+        assert len(traces) == 1
+        assert traces[0].info.trace_id == root_trace_id
+
+    spans = traces[0].data.spans
+    instrumented_span = next(span for span in spans if span.name.endswith("instrumented_operation"))
+    manual_child = next(span for span in spans if span.name == "manual-child")
+
+    assert instrumented_span.parent_id == root_span_id
+    assert manual_child.parent_id == instrumented_span.span_id
+
+
+@pytest.mark.skipif(
+    not hasattr(Dispatcher, "capture_propagation_context"),
+    reason="Dispatcher propagation APIs require llama-index-instrumentation>=0.4.3",
+)
+def test_tracer_replaces_unclaimed_propagation_context():
+    dispatcher = get_dispatcher()
+
+    @dispatcher.span
+    def instrumented_operation(value: str) -> str:
+        return value.upper()
+
+    roots = {}
+    for key in ("a", "b"):
+        with mlflow.start_span(f"root-{key}") as root:
+            roots[key] = {
+                "context": dispatcher.capture_propagation_context(),
+                "trace_id": root.trace_id,
+                "span_id": root.span_id,
+            }
+
+    assert mlflow.get_current_active_span() is None
+
+    dispatcher.restore_propagation_context(roots["a"]["context"])
+    dispatcher.restore_propagation_context(roots["b"]["context"])
+    assert instrumented_operation("b") == "B"
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    for key in ("a", "b"):
+        with trace_manager.get_trace(roots[key]["trace_id"]) as leaked_trace:
+            assert leaked_trace is None
+
+    traces = {trace.info.trace_id: trace for trace in get_traces()}
+    instrumented_spans = [
+        (trace, span)
+        for trace in traces.values()
+        for span in trace.data.spans
+        if span.name.endswith("instrumented_operation")
+    ]
+    assert len(instrumented_spans) == 1
+
+    trace, instrumented_span = instrumented_spans[0]
+    assert trace.info.trace_id == roots["b"]["trace_id"]
+    assert instrumented_span.parent_id == roots["b"]["span_id"]
+    assert all(
+        not span.name.endswith("instrumented_operation")
+        for span in traces[roots["a"]["trace_id"]].data.spans
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(Dispatcher, "capture_propagation_context"),
+    reason="Dispatcher propagation APIs require llama-index-instrumentation>=0.4.3",
+)
+def test_tracer_restores_concurrent_propagated_contexts_independently():
+    dispatcher = get_dispatcher()
+
+    @dispatcher.span
+    def instrumented_operation(value: str) -> str:
+        result = value.upper()
+        with mlflow.start_span("manual-child") as child:
+            child.set_outputs(result)
+        return result
+
+    roots = {}
+    for key in ("a", "b"):
+        with mlflow.start_span(f"root-{key}") as root:
+            roots[key] = {
+                "context": dispatcher.capture_propagation_context(),
+                "trace_id": root.trace_id,
+                "span_id": root.span_id,
+            }
+
+    assert mlflow.get_current_active_span() is None
+
+    # Force the interleaving that exposes the bug deterministically: worker "a"
+    # restores first, worker "b" restores second, then worker "a" finishes its
+    # operation while worker "b"'s context is still the most recently restored one.
+    a_restored = threading.Event()
+    b_restored = threading.Event()
+    a_finished = threading.Event()
+    errors: dict[str, BaseException] = {}
+    results: dict[str, str] = {}
+
+    def run_a():
+        try:
+            dispatcher.restore_propagation_context(roots["a"]["context"])
+            a_restored.set()
+            assert b_restored.wait(10)
+            results["a"] = instrumented_operation("a")
+        except BaseException as e:
+            errors["a"] = e
+        finally:
+            a_finished.set()
+
+    def run_b():
+        try:
+            assert a_restored.wait(10)
+            dispatcher.restore_propagation_context(roots["b"]["context"])
+            b_restored.set()
+            assert a_finished.wait(10)
+            results["b"] = instrumented_operation("b")
+        except BaseException as e:
+            errors["b"] = e
+
+    threads = [
+        threading.Thread(target=run_a, name="propagation-worker-a"),
+        threading.Thread(target=run_b, name="propagation-worker-b"),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert errors == {}
+    assert results == {"a": "A", "b": "B"}
+
+    # Each root must have torn down its own restored propagation context. A leaked remote
+    # trace here means one root's completion closed the other's context (e.g. a regression
+    # back to stack-ordered teardown), which the tree assertions below cannot catch: child
+    # spans parent through open_spans, and leaked dummies never reach get_traces().
+    trace_manager = InMemoryTraceManager.get_instance()
+    for key in ("a", "b"):
+        with trace_manager.get_trace(roots[key]["trace_id"]) as leaked_trace:
+            assert leaked_trace is None
+
+    # Both restored operations must land back in their own trace tree.
+    traces = {trace.info.trace_id: trace for trace in get_traces()}
+    for key in ("a", "b"):
+        root = roots[key]
+        trace = traces[root["trace_id"]]
+        instrumented_span = next(
+            span for span in trace.data.spans if span.name.endswith("instrumented_operation")
+        )
+        assert instrumented_span.trace_id == root["trace_id"]
+        assert instrumented_span.parent_id == root["span_id"]
 
 
 def test_trace_llm_complete_stream():


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/run-llama/llama-agents/issues/707

### What changes are proposed in this pull request?

MLflow's LlamaIndex span handler follows only MLflow's process-local active span stack. When a runtime serializes the LlamaIndex dispatcher context and resumes work in another task or process, LlamaIndex preserves its context but MLflow loses the trace ancestry. Each resumed operation then starts a separate MLflow trace.

This teaches `MlflowSpanHandler` to participate in dispatcher propagation:

- `capture_propagation_context()` stores W3C trace headers under the `mlflow` propagation key. `restore_propagation_context()` restores those headers before the next root LlamaIndex span starts.
- A `ContextVar` hands the restored context to the next root span, and the handler keys claimed contexts by root span ID. Concurrent tasks close their own context instead of whichever context was restored most recently.
- The handler flushes async trace export before removing the OpenTelemetry-to-MLflow trace mapping. Streaming roots keep that mapping until the stream resolver ends all pending spans, including parent spans it resolves recursively.
- Removing the LlamaIndex tracer closes any outstanding restored contexts.
- The LlamaIndex autologging matrix installs `llama-index-instrumentation>=0.4.3`, where dispatcher propagation is available. Older runtime versions continue to behave as before because they do not call these hooks.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

The regression coverage restores context across task and process boundaries, interleaves concurrent restores, and consumes a nested LLM stream before checking trace ancestry and cleanup.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow now preserves trace nesting for LlamaIndex instrumentation when dispatcher propagation context is serialized and restored across task or process boundaries.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, new features and non-critical bug fixes should target a minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are reserved for critical regressions or security fixes that need to ship before the next minor release.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release