### PR TITLE
fix: prevent 'Table already exists' error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
The `mlflow db upgrade` command fails with 'Table "secrets" already exists' when upgrading from 3.7.0 to 3.8.x. This occurs because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, causing it to fail on existing tables.

## Fix
Pass `checkfirst=True` to `create_all()` so SQLAlchemy skips table creation if the table already exists. This is the standard safe pattern for initializing database tables while preserving existing data.

Closes #19943