### PR TITLE
fix: make migration 1bd49d398cd23 idempotent to survive partial DDL commit

### DIFF
--- a/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
+++ b/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
@@ -9,6 +9,12 @@ import time
 import sqlalchemy as sa
 from alembic import op
 
+
+def _get_existing_tables():
+    bind = op.get_bind()
+    return set(sa.inspect(bind).get_table_names())
+
+
 # revision identifiers, used by Alembic.
 revision = "1bd49d398cd23"
 down_revision = "bf29a5ff90ea"
@@ -116,180 +122,192 @@ def _drop_immutability_trigger():
 
 
 def upgrade():
-    op.create_table(
-        "secrets",
-        sa.Column("secret_id", sa.String(length=36), nullable=False),
-        sa.Column("secret_name", sa.String(length=255), nullable=False),
-        sa.Column("encrypted_value", sa.LargeBinary(), nullable=False),
-        sa.Column("wrapped_dek", sa.LargeBinary(), nullable=False),
-        sa.Column("kek_version", sa.Integer(), nullable=False, default=1),
-        sa.Column("masked_value", sa.String(length=500), nullable=False),
-        sa.Column("provider", sa.String(length=64), nullable=True),
-        sa.Column("auth_config", sa.Text(), nullable=True),
-        sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.PrimaryKeyConstraint("secret_id", name="secrets_pk"),
-    )
-    with op.batch_alter_table("secrets", schema=None) as batch_op:
-        batch_op.create_index("unique_secret_name", ["secret_name"], unique=True)
+    existing_tables = _get_existing_tables()
 
-    op.create_table(
-        "endpoints",
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.Column("name", sa.String(length=255), nullable=True),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.PrimaryKeyConstraint("endpoint_id", name="endpoints_pk"),
-    )
-    with op.batch_alter_table("endpoints", schema=None) as batch_op:
-        batch_op.create_index("unique_endpoint_name", ["name"], unique=True)
-
-    op.create_table(
-        "model_definitions",
-        sa.Column("model_definition_id", sa.String(length=36), nullable=False),
-        sa.Column("name", sa.String(length=255), nullable=False),
-        sa.Column("secret_id", sa.String(length=36), nullable=True),
-        sa.Column("provider", sa.String(length=64), nullable=False),
-        sa.Column("model_name", sa.String(length=256), nullable=False),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.ForeignKeyConstraint(
-            ["secret_id"],
-            ["secrets.secret_id"],
-            name="fk_model_definitions_secret_id",
-            ondelete="SET NULL",
-        ),
-        sa.PrimaryKeyConstraint("model_definition_id", name="model_definitions_pk"),
-    )
-    with op.batch_alter_table("model_definitions", schema=None) as batch_op:
-        batch_op.create_index("unique_model_definition_name", ["name"], unique=True)
-        batch_op.create_index("index_model_definitions_secret_id", ["secret_id"], unique=False)
-        batch_op.create_index("index_model_definitions_provider", ["provider"], unique=False)
-
-    op.create_table(
-        "endpoint_model_mappings",
-        sa.Column("mapping_id", sa.String(length=36), nullable=False),
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.Column("model_definition_id", sa.String(length=36), nullable=False),
-        sa.Column("weight", sa.Float(), nullable=False, default=1.0),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.ForeignKeyConstraint(
-            ["endpoint_id"],
-            ["endpoints.endpoint_id"],
-            name="fk_endpoint_model_mappings_endpoint_id",
-            ondelete="CASCADE",
-        ),
-        sa.ForeignKeyConstraint(
-            ["model_definition_id"],
-            ["model_definitions.model_definition_id"],
-            name="fk_endpoint_model_mappings_model_definition_id",
-        ),
-        sa.PrimaryKeyConstraint("mapping_id", name="endpoint_model_mappings_pk"),
-    )
-    with op.batch_alter_table("endpoint_model_mappings", schema=None) as batch_op:
-        batch_op.create_index(
-            "index_endpoint_model_mappings_endpoint_id", ["endpoint_id"], unique=False
+    if "secrets" not in existing_tables:
+        op.create_table(
+            "secrets",
+            sa.Column("secret_id", sa.String(length=36), nullable=False),
+            sa.Column("secret_name", sa.String(length=255), nullable=False),
+            sa.Column("encrypted_value", sa.LargeBinary(), nullable=False),
+            sa.Column("wrapped_dek", sa.LargeBinary(), nullable=False),
+            sa.Column("kek_version", sa.Integer(), nullable=False, default=1),
+            sa.Column("masked_value", sa.String(length=500), nullable=False),
+            sa.Column("provider", sa.String(length=64), nullable=True),
+            sa.Column("auth_config", sa.Text(), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("secret_id", name="secrets_pk"),
         )
-        batch_op.create_index(
-            "index_endpoint_model_mappings_model_definition_id",
-            ["model_definition_id"],
-            unique=False,
+        with op.batch_alter_table("secrets", schema=None) as batch_op:
+            batch_op.create_index("unique_secret_name", ["secret_name"], unique=True)
+
+    if "endpoints" not in existing_tables:
+        op.create_table(
+            "endpoints",
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=True),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("endpoint_id", name="endpoints_pk"),
         )
-        batch_op.create_index(
-            "unique_endpoint_model_mapping",
-            ["endpoint_id", "model_definition_id"],
-            unique=True,
+        with op.batch_alter_table("endpoints", schema=None) as batch_op:
+            batch_op.create_index("unique_endpoint_name", ["name"], unique=True)
+
+    if "model_definitions" not in existing_tables:
+        op.create_table(
+            "model_definitions",
+            sa.Column("model_definition_id", sa.String(length=36), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("secret_id", sa.String(length=36), nullable=True),
+            sa.Column("provider", sa.String(length=64), nullable=False),
+            sa.Column("model_name", sa.String(length=256), nullable=False),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["secret_id"],
+                ["secrets.secret_id"],
+                name="fk_model_definitions_secret_id",
+                ondelete="SET NULL",
+            ),
+            sa.PrimaryKeyConstraint("model_definition_id", name="model_definitions_pk"),
+        )
+        with op.batch_alter_table("model_definitions", schema=None) as batch_op:
+            batch_op.create_index("unique_model_definition_name", ["name"], unique=True)
+            batch_op.create_index("index_model_definitions_secret_id", ["secret_id"], unique=False)
+            batch_op.create_index("index_model_definitions_provider", ["provider"], unique=False)
+
+    if "endpoint_model_mappings" not in existing_tables:
+        op.create_table(
+            "endpoint_model_mappings",
+            sa.Column("mapping_id", sa.String(length=36), nullable=False),
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.Column("model_definition_id", sa.String(length=36), nullable=False),
+            sa.Column("weight", sa.Float(), nullable=False, default=1.0),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["endpoint_id"],
+                ["endpoints.endpoint_id"],
+                name="fk_endpoint_model_mappings_endpoint_id",
+                ondelete="CASCADE",
+            ),
+            sa.ForeignKeyConstraint(
+                ["model_definition_id"],
+                ["model_definitions.model_definition_id"],
+                name="fk_endpoint_model_mappings_model_definition_id",
+            ),
+            sa.PrimaryKeyConstraint("mapping_id", name="endpoint_model_mappings_pk"),
+        )
+        with op.batch_alter_table("endpoint_model_mappings", schema=None) as batch_op:
+            batch_op.create_index(
+                "index_endpoint_model_mappings_endpoint_id", ["endpoint_id"], unique=False
+            )
+            batch_op.create_index(
+                "index_endpoint_model_mappings_model_definition_id",
+                ["model_definition_id"],
+                unique=False,
+            )
+            batch_op.create_index(
+                "unique_endpoint_model_mapping",
+                ["endpoint_id", "model_definition_id"],
+                unique=True,
+            )
+
+    if "endpoint_bindings" not in existing_tables:
+        op.create_table(
+            "endpoint_bindings",
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.Column("resource_type", sa.String(length=50), nullable=False),
+            sa.Column("resource_id", sa.String(length=255), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("created_by", sa.String(length=255), nullable=True),
+            sa.Column(
+                "last_updated_at",
+                sa.BigInteger(),
+                default=lambda: int(time.time() * 1000),
+                nullable=False,
+            ),
+            sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["endpoint_id"],
+                ["endpoints.endpoint_id"],
+                name="fk_endpoint_bindings_endpoint_id",
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint(
+                "endpoint_id", "resource_type", "resource_id", name="endpoint_bindings_pk"
+            ),
         )
 
-    op.create_table(
-        "endpoint_bindings",
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.Column("resource_type", sa.String(length=50), nullable=False),
-        sa.Column("resource_id", sa.String(length=255), nullable=False),
-        sa.Column(
-            "created_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("created_by", sa.String(length=255), nullable=True),
-        sa.Column(
-            "last_updated_at",
-            sa.BigInteger(),
-            default=lambda: int(time.time() * 1000),
-            nullable=False,
-        ),
-        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["endpoint_id"],
-            ["endpoints.endpoint_id"],
-            name="fk_endpoint_bindings_endpoint_id",
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint(
-            "endpoint_id", "resource_type", "resource_id", name="endpoint_bindings_pk"
-        ),
-    )
+    if "endpoint_tags" not in existing_tables:
+        op.create_table(
+            "endpoint_tags",
+            sa.Column("key", sa.String(length=250), nullable=False),
+            sa.Column("value", sa.String(length=5000), nullable=True),
+            sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["endpoint_id"],
+                ["endpoints.endpoint_id"],
+                name="fk_endpoint_tags_endpoint_id",
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("key", "endpoint_id", name="endpoint_tag_pk"),
+        )
+        with op.batch_alter_table("endpoint_tags", schema=None) as batch_op:
+            batch_op.create_index("index_endpoint_tags_endpoint_id", ["endpoint_id"], unique=False)
 
-    op.create_table(
-        "endpoint_tags",
-        sa.Column("key", sa.String(length=250), nullable=False),
-        sa.Column("value", sa.String(length=5000), nullable=True),
-        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["endpoint_id"],
-            ["endpoints.endpoint_id"],
-            name="fk_endpoint_tags_endpoint_id",
-            ondelete="CASCADE",
-        ),
-        sa.PrimaryKeyConstraint("key", "endpoint_id", name="endpoint_tag_pk"),
-    )
-    with op.batch_alter_table("endpoint_tags", schema=None) as batch_op:
-        batch_op.create_index("index_endpoint_tags_endpoint_id", ["endpoint_id"], unique=False)
-
+    # Drop the trigger first so re-running the migration after a partial failure is idempotent.
+    # On MySQL, DDL is auto-committed, so a failed trigger creation leaves tables created but
+    # alembic_version un-advanced. Dropping before creating ensures a clean retry.
+    _drop_immutability_trigger()
     _create_immutability_trigger()
 
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
@@ -203,6 +203,58 @@ def test_create_index_on_metrics_run_uuid_key_step(tmp_path, db_url):
         assert columns == ["run_uuid", "key", "step"]
 
 
+def test_secrets_migration_is_idempotent(tmp_path, db_url):
+    # Test for mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
+    # Simulates the MySQL partial-migration scenario: DDL is auto-committed, so tables
+    # may exist from a prior interrupted run while alembic_version was not advanced.
+    # The migration must succeed even when the tables already exist.
+    engine = sqlalchemy.create_engine(db_url)
+    InitialBase.metadata.create_all(engine)
+    config = _get_alembic_config(db_url)
+
+    # Migrate up to the revision that precedes 1bd49d398cd23.
+    command.upgrade(config, "bf29a5ff90ea")
+
+    # Simulate partial DDL commit: create the secrets table manually, as if a prior
+    # interrupted run of 1bd49d398cd23 left it behind on a MySQL-like database.
+    with engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.text(
+                "CREATE TABLE secrets ("
+                "  secret_id VARCHAR(36) NOT NULL,"
+                "  secret_name VARCHAR(255) NOT NULL,"
+                "  encrypted_value BLOB NOT NULL,"
+                "  wrapped_dek BLOB NOT NULL,"
+                "  kek_version INTEGER NOT NULL,"
+                "  masked_value VARCHAR(500) NOT NULL,"
+                "  provider VARCHAR(64),"
+                "  auth_config TEXT,"
+                "  description TEXT,"
+                "  created_by VARCHAR(255),"
+                "  created_at INTEGER NOT NULL,"
+                "  last_updated_by VARCHAR(255),"
+                "  last_updated_at INTEGER NOT NULL,"
+                "  CONSTRAINT secrets_pk PRIMARY KEY (secret_id)"
+                ")"
+            )
+        )
+
+    # Running the migration to head must not raise even though 'secrets' already exists.
+    command.upgrade(config, "1bd49d398cd23")
+
+    inspector = sqlalchemy.inspect(engine)
+    table_names = inspector.get_table_names()
+    for table in (
+        "secrets",
+        "endpoints",
+        "model_definitions",
+        "endpoint_model_mappings",
+        "endpoint_bindings",
+        "endpoint_tags",
+    ):
+        assert table in table_names, f"Expected table '{table}' to exist after migration"
+
+
 def test_index_for_dataset_tables(tmp_path, db_url):
     # Test for
     # mlflow/store/db_migrations/versions/7f2a7d5fae7d_add_datasets_inputs_input_tags_tables.py


### PR DESCRIPTION
### Related Issues/PRs
Closes #23721

### What changes are proposed in this pull request?

Migration `1bd49d398cd23` (`add_secrets_tables`) creates multiple tables and a trigger. On MySQL, DDL is auto-committed — so if the migration fails after some tables are created (e.g., during trigger creation), those tables persist but `alembic_version` remains at the prior revision `bf29a5ff90ea`. On the next server restart, the migration is retried and fails immediately with `Table 'secrets' already exists`, putting the server into a crash loop.

This PR makes the `upgrade()` function idempotent in two ways:
1. **Table creation**: checks whether each table already exists (via `sqlalchemy.inspect`) before calling `op.create_table()`. If the table is already present from a prior interrupted run, the step is skipped.
2. **Trigger creation**: calls `_drop_immutability_trigger()` (which uses `DROP TRIGGER IF EXISTS`) before `_create_immutability_trigger()`, ensuring a clean, repeatable trigger installation on all dialects.

### How is this PR tested?
- [x] New unit/integration tests

Added `test_secrets_migration_is_idempotent` in `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py`. The test:
1. Migrates a fresh SQLite DB up to the revision preceding `1bd49d398cd23`
2. Manually creates the `secrets` table (simulating the partial-DDL-commit scenario)
3. Runs `command.upgrade(config, "1bd49d398cd23")` and asserts it succeeds
4. Verifies all expected tables exist after the migration

### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the MLflow Skills repository?
- [x] No.

### Release Notes
#### Is this a user-facing change?
- [x] Yes. Fixes a crash loop on MySQL when MLflow server restarts after a partially-applied `add_secrets_tables` migration.

#### What component(s) does this PR affect?
- [x] area/tracking

#### Release note classification:
- [x] rn/bug-fix

#### Patch release?
- [x] Critical — needs patch release