### PR TITLE
fix: restore Artifacts tab badge for runs:/ URI model versions

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.test.tsx
@@ -1,0 +1,52 @@
+import { ArtifactViewImpl } from './ArtifactView';
+
+describe('ArtifactViewImpl#getExistingModelVersions', () => {
+  const makeInstance = (props: any, state: any) => {
+    const instance = Object.create(ArtifactViewImpl.prototype);
+    instance.props = props;
+    instance.state = state;
+    instance.getActiveNodeRealPath = () =>
+      state.activeNodeId
+        ? `${props.artifactRootUri}/${state.activeNodeId}`
+        : props.artifactRootUri;
+    return instance;
+  };
+
+  it('returns versions keyed by raw S3 path (legacy)', () => {
+    const version = [{ source: 's3://bucket/run123/artifacts/model', version: '1' }];
+    const instance = makeInstance(
+      {
+        artifactRootUri: 's3://bucket/run123/artifacts',
+        modelVersionsBySource: { 's3://bucket/run123/artifacts/model': version },
+        runUuid: 'run123',
+      },
+      { activeNodeId: 'model' },
+    );
+    expect(instance.getExistingModelVersions()).toBe(version);
+  });
+
+  it('returns versions keyed by runs:/ URI (UI registration after #18501)', () => {
+    const version = [{ source: 'runs:/run123/model', version: '1' }];
+    const instance = makeInstance(
+      {
+        artifactRootUri: 's3://bucket/run123/artifacts',
+        modelVersionsBySource: { 'runs:/run123/model': version },
+        runUuid: 'run123',
+      },
+      { activeNodeId: 'model' },
+    );
+    expect(instance.getExistingModelVersions()).toBe(version);
+  });
+
+  it('returns undefined when no matching version exists', () => {
+    const instance = makeInstance(
+      {
+        artifactRootUri: 's3://bucket/run123/artifacts',
+        modelVersionsBySource: {},
+        runUuid: 'run123',
+      },
+      { activeNodeId: 'model' },
+    );
+    expect(instance.getExistingModelVersions()).toBeUndefined();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -95,10 +95,25 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
   };
 
   getExistingModelVersions() {
-    const { modelVersionsBySource } = this.props;
-    const activeNodeRealPath = Utils.normalize(this.getActiveNodeRealPath());
+  const { modelVersionsBySource, runUuid } = this.props;
+  const activeNodeRealPath = Utils.normalize(this.getActiveNodeRealPath());
+  const activeNodeId = this.state.activeNodeId;
+
+  // Check raw S3 path (legacy)
+  if (modelVersionsBySource[activeNodeRealPath]) {
     return modelVersionsBySource[activeNodeRealPath];
   }
+
+  // Check runs:/ URI (registered via UI after #18501)
+  if (runUuid && activeNodeId) {
+    const runsUri = Utils.normalize(`runs:/${runUuid}/${activeNodeId}`);
+    if (modelVersionsBySource[runsUri]) {
+      return modelVersionsBySource[runsUri];
+    }
+  }
+
+  return undefined;
+}
 
   renderRegisterModelButton() {
     const { runUuid } = this.props;


### PR DESCRIPTION
getExistingModelVersions() previously only looked up versions by raw S3 path. After #18501, UI-registered versions store a runs:/ URI as source, so the lookup missed and the badge never rendered.

Fix: also check the runs:/<runUuid>/<path> form in addition to the legacy absolute path.

Adds unit tests covering both lookup paths and the no-match case.

Fixes #23786

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #23786

### What changes are proposed in this pull request?

getExistingModelVersions()`now also checks the runs:/<runUuid>/<path>`URI form in addition to the legacy absolute S3 path, so the registered model badge renders correctly in the Artifacts tab regardless of how the version was registered.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
