### PR TITLE
fix: avoid 'table already exists' error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,12 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Create only tables that do not yet exist to avoid "table already exists" errors
+    # when a subset of tables are present (e.g., after partial migration to 3.8.x).
+    existing_tables = set(sqlalchemy.inspect(engine).get_table_names())
+    for table in InitialBase.metadata.sorted_tables:
+        if table.name not in existing_tables:
+            table.create(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Running `mlflow db upgrade` when upgrading from 3.7.0 to 3.8.x fails with:
```
pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")
```
The issue occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)`, which attempts to create all tables defined in the initial models, including the `secrets` table that was added by a later migration. When some tables already exist (e.g., from a previous version), `create_all` still tries to create the `secrets` table if it exists in the metadata, leading to a conflict.

## Fix
Modified `_initialize_tables` to check if each table already exists before creating it, using `sqlalchemy.inspect(engine).get_table_names()` to get the set of existing tables. Only tables not yet in the database are created. This avoids the "table already exists" error while still ensuring all required tables are present before running `_upgrade_db`.

Closes #19943