### PR TITLE
fix: scale artifact images to parent frame in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,12 +86,12 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',
   },
-  imageWrapper: { display: 'inline-block' },
+  imageWrapper: { display: 'block', maxWidth: '100%' },
   image: {
     maxWidth: '100%',
     height: 'auto',


### PR DESCRIPTION
Fixes #20703

## Changes

In `ShowArtifactImageView.tsx`, artifact images were not constrained to their parent container width in the run comparison view, causing a horizontal scrollbar. The root cause was two CSS issues:

1. `imageWrapper` used `display: inline-block`, which sizes to content width. This meant the image's existing `max-width: 100%` was relative to the natural image size rather than the parent container — so images always rendered at full natural size.
2. `imageOuterContainer` used `overflow: scroll`, which always showed scrollbars even when content fit.

**Fix:**
- Changed `imageWrapper` from `{ display: 'inline-block' }` to `{ display: 'block', maxWidth: '100%' }` so the image's `max-width: 100%` is correctly relative to the container width.
- Changed `imageOuterContainer` overflow from `scroll` to `auto` to only show scrollbars when content actually overflows (e.g. very tall images).

The `image` element already had `maxWidth: '100%'` and `height: 'auto'` — no changes needed there.