### PR TITLE
Fix FileStore.get_experiment_by_name for experiment names with filter-DSL special characters

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -69,7 +69,6 @@ from mlflow.tracing.utils import (
     generate_assessment_id,
     generate_request_id_v2,
 )
-from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.file_utils import (
     append_to,
     exists,
@@ -372,6 +371,17 @@ class FileStore(AbstractStore):
                 INVALID_PARAMETER_VALUE,
             )
 
+        experiments = self._list_experiments(view_type)
+        filtered = SearchExperimentsUtils.filter(experiments, filter_string)
+        sorted_experiments = SearchExperimentsUtils.sort(
+            filtered, order_by or ["creation_time DESC", "experiment_id ASC"]
+        )
+        experiments, next_page_token = SearchUtils.paginate(
+            sorted_experiments, page_token, max_results
+        )
+        return PagedList(experiments, next_page_token)
+
+    def _list_experiments(self, view_type=ViewType.ACTIVE_ONLY):
         self._check_root_dir()
         experiment_ids = []
         if view_type in (ViewType.ACTIVE_ONLY, ViewType.ALL):
@@ -391,30 +401,18 @@ class FileStore(AbstractStore):
                     f"Malformed experiment '{exp_id}'. Detailed error {e}",
                     exc_info=True,
                 )
-        filtered = SearchExperimentsUtils.filter(experiments, filter_string)
-        sorted_experiments = SearchExperimentsUtils.sort(
-            filtered, order_by or ["creation_time DESC", "experiment_id ASC"]
-        )
-        experiments, next_page_token = SearchUtils.paginate(
-            sorted_experiments, page_token, max_results
-        )
-        return PagedList(experiments, next_page_token)
+        return experiments
 
     def get_experiment_by_name(self, experiment_name):
-        def pagination_wrapper_func(number_to_get, next_page_token):
-            return self.search_experiments(
-                view_type=ViewType.ALL,
-                max_results=number_to_get,
-                filter_string=f"name = '{experiment_name}'",
-                page_token=next_page_token,
-            )
-
-        experiments = get_results_from_paginated_fn(
-            paginated_fn=pagination_wrapper_func,
-            max_results_per_page=SEARCH_MAX_RESULTS_THRESHOLD,
-            max_results=None,
-        )
-        return experiments[0] if len(experiments) > 0 else None
+        # Look up the experiment by name directly rather than constructing a
+        # `filter_string` for `search_experiments`. Interpolating the name into a
+        # filter expression breaks for names containing characters that are
+        # significant to the filter DSL (e.g. a single quote), which made such
+        # experiments impossible to create or retrieve.
+        for experiment in self._list_experiments(view_type=ViewType.ALL):
+            if experiment.name == experiment_name:
+                return experiment
+        return None
 
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri, tags):
         if not artifact_uri:

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -736,6 +736,34 @@ def test_get_experiment_by_name(store):
     assert store.get_experiment_by_name(exp_data[exp_id]["name"]).experiment_id == exp_id
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "o'brien",
+        "experiment ' with quote",
+        "name = 'x'",
+        "' OR '1'='1",
+    ],
+)
+def test_get_experiment_by_name_with_filter_special_characters(store, name):
+    # Names containing characters that are significant to the search filter DSL
+    # (e.g. a single quote) must still be createable and retrievable by name.
+    # Previously ``get_experiment_by_name`` interpolated the name into a
+    # ``filter_string``, so such names raised a parse error or, in the worst
+    # case, matched a different experiment.
+    exp_id = store.create_experiment(name)
+    exp = store.get_experiment_by_name(name)
+    assert exp is not None
+    assert exp.experiment_id == exp_id
+    assert exp.name == name
+
+
+def test_get_experiment_by_name_no_spurious_match(store):
+    # A crafted name must not match a different, legitimately-named experiment.
+    store.create_experiment("real")
+    assert store.get_experiment_by_name("nonexistent' OR name = 'real") is None
+
+
 def test_create_additional_experiment_generates_random_fixed_length_id(store):
     store._get_active_experiments = mock.Mock(return_value=[])
     store._get_deleted_experiments = mock.Mock(return_value=[])

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -747,7 +747,7 @@ def test_get_experiment_by_name(store):
 )
 def test_get_experiment_by_name_with_filter_special_characters(store, name):
     # Names containing characters that are significant to the search filter DSL
-    # (e.g. a single quote) must still be createable and retrievable by name.
+    # (e.g. a single quote) must still be creatable and retrievable by name.
     # Previously ``get_experiment_by_name`` interpolated the name into a
     # ``filter_string``, so such names raised a parse error or, in the worst
     # case, matched a different experiment.


### PR DESCRIPTION
### Related Issues/PRs

Resolve #12785

Supersedes the stale #12816 (which @serena-ruan noted was irrelevant and was never updated) — courtesy cc @sourabhx003.

### What changes are proposed in this pull request?

`FileStore.get_experiment_by_name` looked the experiment up by constructing a search filter string:

```python
filter_string=f"name = '{experiment_name}'"
```

and round-tripping it through `search_experiments`. Any name containing a character that is significant to the search-filter DSL (most commonly a single quote) breaks the predicate. In practice this means:

- An experiment whose name contains a `'` (e.g. `o'brien`) **cannot be created or retrieved** — `create_experiment` itself fails because it calls `get_experiment_by_name` during validation, raising `Invalid clause(s) in filter string`.
- More subtly, a crafted name could parse into a *different* predicate and match the wrong experiment, violating name-uniqueness.

The SQLAlchemy store is unaffected because it queries by name through the ORM (parameterized), so this was a FileStore-only inconsistency.

This PR makes `get_experiment_by_name` match by name directly instead of going through the filter DSL. The experiment-gathering loop is extracted into a small `_list_experiments` helper that `search_experiments` already needed, so the two share one implementation. The now-unused `get_results_from_paginated_fn` import is dropped.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`tests/store/tracking/test_file_store.py`: 143 passed, 16 skipped. New tests cover names with quotes/DSL metacharacters round-tripping through create + lookup, and that a crafted name does not match a different experiment.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `FileStore.get_experiment_by_name` so experiments whose names contain characters significant to the search-filter DSL (e.g. a single quote) can be created and retrieved.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)


### AI assistance

Developed with AI assistance (Claude Code, Anthropic — Opus 4.x). **AI's role:** drafted the patch, extracted the shared `_list_experiments` helper, wrote the regression tests, and ran a review pass. **My role:** reproduced the bug (an apostrophe in an experiment name made the experiment uncreatable via the `get_experiment_by_name` filter round-trip), validated the diagnosis, reviewed/edited every line, and I take responsibility. **Verification:** the FileStore suite in `tests/store/tracking/test_file_store.py` is green locally under `MLFLOW_ALLOW_FILE_STORE=true` (new special-character cases pass); `ruff` clean; DCO signed.
