### PR TITLE
Fix broken Issue Detection link on the GenAI Live Demo docs page

### DIFF
--- a/docs/docs/genai/demo.mdx
+++ b/docs/docs/genai/demo.mdx
@@ -29,13 +29,13 @@ The demo environment includes sample data across four areas:
     title="Evaluation"
     headerRight={<FlaskConical />}
     description="Browse pre-configured judges, datasets, and evaluation runs with judge-scored quality metrics across sample traces."
-    link="https://demo.mlflow.org/#/experiments/1/evaluation-runs?selectedRunUuid=4bacc57345684766ac7371c523a97fa7"
+    link="https://demo.mlflow.org/#/experiments/1/evaluation-runs"
   />
   <TitleCard
     title="Issue Detection"
     headerRight={<ShieldAlert />}
     description="See automatically detected issues surfaced from trace data and an issue detection run, showing how MLflow flags quality and reliability problems in production."
-    link="https://demo.mlflow.org/#/experiments/1/evaluation-runs/e50e393c385c4c9cb8b30e09cbb6f141/issues"
+    link="https://demo.mlflow.org/#/experiments/1/evaluation-runs/1e66d099f5f34d4db3a34aa6537782a3/issues"
   />
   <TitleCard
     title="Prompts"


### PR DESCRIPTION
### Related Issues/PRs

Relates to Jira ML-67046

### What changes are proposed in this pull request?

The Live Demo docs page (`docs/docs/genai/demo.mdx`, rendered at https://mlflow.org/docs/latest/genai/demo/) had a broken **Issue Detection** card. It linked to an evaluation-run UUID (`e50e393c385c4c9cb8b30e09cbb6f141`) that no longer exists on the redeployed `demo.mlflow.org` server, so clicking it landed on "Page Not Found — Run ID ... does not exist".

This PR:

- Repoints the **Issue Detection** card to the current valid run UUID (`1e66d099f5f34d4db3a34aa6537782a3`).
- Drops the ephemeral `?selectedRunUuid=...` query param from the **Evaluation** card so it points at the stable `/evaluation-runs` list, which won't break when the demo is redeployed.

The **Observability** (`/experiments/1`) and **Prompts** (`/experiments/1/prompts`) links are left unchanged — they already resolve correctly (`/experiments/1` auto-redirects to the overview page with app-generated time-window params).

### How is this PR tested?

- [x] Manual tests

Verified each link in a browser against the live `demo.mlflow.org`:

- Issue Detection → loads "Demo Issue Detection → Issues" ✅
- Evaluation → loads the evaluation runs list ✅
- Observability / Prompts → unchanged, still resolve ✅

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.