### PR TITLE
Support Python 3.12 in cross-version test matrix

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -43,8 +43,14 @@ runs:
             else
               python_version="3.11.15"
             fi
+          elif [[ "$python_version" == "3.12" ]]; then
+            if [ "$RUNNER_OS" == "Windows" ]; then
+              python_version="3.12.10"
+            else
+              python_version="3.12.13"
+            fi
           else
-            echo "Invalid python version: '$python_version'. Must be '3.10', or '3.11'."
+            echo "Invalid python version: '$python_version'. Must be '3.10', '3.11', or '3.12'."
             exit 1
           fi
         fi

--- a/dev/flavors/src/flavors/_matrix.py
+++ b/dev/flavors/src/flavors/_matrix.py
@@ -200,7 +200,7 @@ def infer_python_version(package: Package, version: str, repo_url: str | None = 
     """
     Infer the minimum Python version required by the package.
     """
-    candidates = ("3.10", "3.11")
+    candidates = ("3.10", "3.11", "3.12")
 
     if version == DEV_VERSION:
         # `Version("dev")` would raise InvalidVersion, so resolve dev separately


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Cross-version tests fail to install packages that require Python >= 3.12 (e.g. `xgboost==3.3.0`). The matrix generator only knew about 3.10/3.11, so for such packages it fell back to Python 3.10 and the install errored with `No solution found when resolving dependencies`.

- `dev/flavors/src/flavors/_matrix.py`: add `3.12` to the Python version candidates so packages requiring Python >= 3.12 resolve to a compatible interpreter.
- `.github/actions/setup-python/action.yml`: add a `3.12` branch to the micro-version pinning (Windows `3.12.10`, Linux/macOS `3.12.13`), matching the existing convention and verified against the `actions/setup-python` manifest and Anaconda.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)