### PR TITLE
Fix sklearn-flavor cross-version model tests broken by the skops default

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,6 +1,6 @@
 ## Dependencies required to run tests
 ## Test-only dependencies
-pytest
+pytest==9.0.2
 pytest-asyncio
 pytest-repeat
 pytest-cov

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -456,7 +456,10 @@ def test_pyfunc_serve_and_score_sklearn(reg_model):
 
     with mlflow.start_run():
         model_info = mlflow.sklearn.log_model(
-            model, name="model", input_example=inference_dataframe.head(3)
+            model,
+            name="model",
+            input_example=inference_dataframe.head(3),
+            skops_trusted_types=["catboost.core.CatBoostRegressor"],
         )
 
     inference_payload = load_serving_example(model_info.model_uri)

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -434,7 +434,16 @@ def test_pyfunc_serve_and_score_sklearn(model):
     model.fit(X, y)
 
     with mlflow.start_run():
-        model_info = mlflow.sklearn.log_model(model, name="model", input_example=X.head(3))
+        model_info = mlflow.sklearn.log_model(
+            model,
+            name="model",
+            input_example=X.head(3),
+            skops_trusted_types=[
+                "collections.OrderedDict",
+                "lightgbm.basic.Booster",
+                "lightgbm.sklearn.LGBMClassifier",
+            ],
+        )
 
     inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -469,7 +469,12 @@ def test_pyfunc_serve_and_score_sklearn(model):
     model.fit(X, y)
 
     with mlflow.start_run():
-        model_info = mlflow.sklearn.log_model(model, name="model", input_example=X.head(3))
+        model_info = mlflow.sklearn.log_model(
+            model,
+            name="model",
+            input_example=X.head(3),
+            skops_trusted_types=["xgboost.core.Booster", "xgboost.sklearn.XGBClassifier"],
+        )
 
     inference_payload = load_serving_example(model_info.model_uri)
     resp = pyfunc_serve_and_score_model(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23987

### What changes are proposed in this pull request?

The `mlflow.sklearn` default `serialization_format` was changed from `cloudpickle` to `skops` in #23987, which broke the `*/models/*` cross-version jobs for `xgboost`, `lightgbm`, and `catboost`. Two distinct problems, both rooted in that change:

1. **Untrusted types.** `test_pyfunc_serve_and_score_sklearn` logs a non-sklearn estimator (`XGBClassifier`, `LGBMClassifier`, `CatBoostRegressor`) through the sklearn flavor, so skops rejects those third-party types on load. Fixed by declaring them via the existing `skops_trusted_types` parameter.

2. **pytest leaking into model requirements.** Loading a skops model imports `skops.io` -> `sklearn.utils._testing` -> `pytest`, so `pytest` gets captured into the logged model's `requirements.txt`. The test env had an unpinned `pytest==9.1.1`, which conflicts with the `pytest==9.0.2` constraint when pyfunc serving builds a fresh env (`ResolutionImpossible`, "scoring process died"). Fixed by pinning `pytest` in `test-requirements.txt` to match `constraints.txt`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)