### PR TITLE
Resolve experiment id from workspace-prefixed artifact paths in auth proxy

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -753,7 +753,12 @@ def _get_experiment_permission(experiment_id: str, username: str) -> Permission:
     )
 
 
-_EXPERIMENT_ID_PATTERN = re.compile(r"^(\d+)/")
+# Proxied artifact paths are ``<experiment_id>/<run_id>/artifacts/...``. When
+# workspaces are enabled, non-default workspaces prefix the path with
+# ``workspaces/<workspace>/``. Accept the optional prefix so the experiment id is
+# resolved in both layouts; otherwise the prefixed form fails to match and the
+# artifact-proxy validator falls back to the coarser workspace-tier grant.
+_EXPERIMENT_ID_PATTERN = re.compile(r"^(?:workspaces/[^/]+/)?(\d+)/")
 
 
 def _get_experiment_id_from_view_args():

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -901,6 +901,35 @@ def test_experiment_artifact_proxy_without_experiment_id_denied_without_workspac
         assert not auth_module.validate_can_read_experiment_artifact_proxy()
 
 
+def test_experiment_artifact_proxy_resolves_experiment_id_under_workspace_prefix(
+    workspace_permission_setup,
+):
+    # In a non-default workspace the proxied artifact path is prefixed with
+    # ``workspaces/<ws>/``. The experiment id must still be resolved from the path so
+    # per-experiment grants apply, instead of falling back to the workspace-tier grant
+    # (which, for a USE member, has no can_update and would wrongly reject writes).
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+
+    # "DataScientist" shape: workspace USE (member, no can_update at the workspace tier)
+    # plus an explicit experiment-level EDIT grant.
+    _set_workspace_permission(store, username, USE.name)
+    store.create_experiment_permission("1", username, EDIT.name)
+
+    prefixed_path = "workspaces/team-a/1/run-1/artifacts/plots/x.png"
+    with auth_module.app.test_request_context(
+        f"/ajax-api/2.0/mlflow-artifacts/artifacts/{prefixed_path}",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": prefixed_path}
+        # EDIT on the experiment resolves through the workspace prefix -> reads and
+        # writes are allowed even though the workspace-tier grant is only USE.
+        assert auth_module.validate_can_read_experiment_artifact_proxy()
+        assert auth_module.validate_can_update_experiment_artifact_proxy()
+        # EDIT does not confer delete.
+        assert not auth_module.validate_can_delete_experiment_artifact_proxy()
+
+
 def test_filter_experiment_ids_respects_workspace_permissions(
     workspace_permission_setup, monkeypatch
 ):


### PR DESCRIPTION
What / why
Fixes [#24210](https://github.com/moengage/fusion-ml/issues/24210).

With --enable-workspaces, proxied artifact paths in non-default workspaces are prefixed with workspaces/<ws>/. _EXPERIMENT_ID_PATTERN (^(\d+)/) doesn't match that layout, so _get_permission_from_experiment_id_artifact_proxy can't resolve the experiment and falls back to the workspace-tier grant (USE, no can_update). Result: users with experiment:* EDIT get 403 Permission denied on artifact writes (log_artifacts, model logging) in product workspaces. The default workspace stores artifacts unprefixed, so it was unaffected.

Fix
Accept an optional workspaces/<ws>/ prefix before the experiment id, so per-experiment grants are honored in both layouts. Non-experiment paths still return None (unchanged).

Testing
Added test_experiment_artifact_proxy_resolves_experiment_id_under_workspace_prefix in tests/server/auth/test_auth_workspace.py (workspace USE + experiment EDIT → prefixed-path write now allowed; fails before the fix). Ran it alongside the existing test_experiment_artifact_proxy_* tests — all pass. ruff format/ruff check clean.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
