### PR TITLE
fix: use Alembic upgrade in _initialize_tables to avoid table already exists error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use Alembic upgrade to create all tables properly, handling existing tables
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
The `_initialize_tables` function calls `InitialBase.metadata.create_all(engine)` followed by `_upgrade_db(engine)`. When upgrading from MLflow 3.7.0 to 3.8.x, the 'secrets' table may already exist (e.g., created by a previous migration). The `create_all` call then fails with a "Table 'secrets' already exists" error on MySQL (pymysql).

## Fix
Replace the `create_all` call with just `_upgrade_db(engine)`. Alembic's upgrade mechanism handles table creation in a safe, idempotent manner. The `_initialize_tables` function is only called when one or more tables are missing, so we can directly run the Alembic upgrade to bring the database to the latest schema revision, creating any missing tables as needed.

Closes #19943