### PR TITLE
Fix `autolog_caplog` double-counting log records on pytest >= 9.1

### DIFF
--- a/tests/spark/test_spark_autologging_stop.py
+++ b/tests/spark/test_spark_autologging_stop.py
@@ -11,15 +11,17 @@ from mlflow.spark.autologging import _stop_listen_for_spark_activity
 
 @pytest.fixture
 def autolog_caplog(caplog):
-    # The "mlflow" logger sets propagate=False, so caplog's root handler does not see
-    # records. Attach caplog's handler directly to the autologging logger.
-    logger = logging.getLogger("mlflow.spark.autologging")
-    logger.addHandler(caplog.handler)
+    # "mlflow" sets propagate=False, so its records never reach caplog's root handler.
+    # Enable propagation so caplog captures them. Don't attach caplog.handler directly:
+    # pytest >= 9.1 attaches it to non-propagating loggers, which double-counts records.
+    mlflow_logger = logging.getLogger("mlflow")
+    original_propagate = mlflow_logger.propagate
+    mlflow_logger.propagate = True
     try:
         with caplog.at_level(logging.WARNING, logger="mlflow.spark.autologging"):
             yield caplog
     finally:
-        logger.removeHandler(caplog.handler)
+        mlflow_logger.propagate = original_propagate
 
 
 def _make_spark_context(shutdown_side_effect=None):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`tests/spark/test_spark_autologging_stop.py::test_hanging_shutdown_times_out_and_logs_warning` and `test_exception_during_shutdown_logs_error_not_timeout` started failing in the `spark / models` cross-version nightly with `assert 2 == 1`: a single log record was being captured twice.

Root cause is a pytest behavior change, not MLflow code. The `autolog_caplog` fixture manually attached `caplog.handler` to the `mlflow.spark.autologging` logger to work around the `mlflow` logger's `propagate=False`. pytest >= 9.1 now attaches its capture handler to all non-propagating loggers automatically, so each record was captured twice (once on `mlflow.spark.autologging`, once on `mlflow` as it propagated up).

Fix: drop the manual attach and instead enable propagation on the `mlflow` logger for the fixture's duration, so the record reaches caplog's root handler exactly once. This works on both pytest 9.0.x (currently pinned) and 9.1.x, so unpinning later is a no-op.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Verified `tests/spark/test_spark_autologging_stop.py` passes on pytest 9.0.2, 9.1.0, and 9.1.1 (failed on 9.1.0/9.1.1 before this change).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release