### PR TITLE
Add MCP server list with card/table views, search, and pagination

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -40,10 +40,14 @@ module.exports = {
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_309": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_316": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_324": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331":
+    "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_288": "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_337": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunbox.tsx_46": "",
@@ -53,126 +57,246 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_570": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_581": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_592": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310":
+    "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricchartsaccordion.tsx_82": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_120": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_154": "",
@@ -182,96 +306,184 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_modals_createexperimentform.tsx_71": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_getlinkmodal.tsx_21": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_renameform.tsx_69": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251":
+    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288":
+    "",
   "codegen_mlflow_app_src_model-registry_components_CreateModelButton.tsx_28": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47":
+    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57":
+    "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionaliastag.tsx_23": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30":
+    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41":
+    "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_29": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_37": "",
   "codegen_mlflow_app_src_model-registry_components_createmodelform.tsx_62": "",
@@ -314,49 +526,88 @@ module.exports = {
   "codegen_mlflow_app_src_shared_building_blocks_copybox.tsx_18": "",
   "codegen_mlflow_app_src_shared_building_blocks_pageheader.tsx_54": "",
   "codegen_mlflow_app_src_shared_building_blocks_previewbadge.tsx_14": "",
-  "codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111": "",
-  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91": "",
-  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298": "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29": "",
+  codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111:
+    "",
+  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115: "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82: "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91: "",
+  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99: "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113:
+    "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366":
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298:
+    "",
+  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29:
+    "",
   "codegen_web-shared_src_copy_copyactionbutton.tsx_17": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_26": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_33": "",
@@ -365,7 +616,7 @@ module.exports = {
   // -- Other --
   "TagAssignmentKey.Default.Input": "",
   "TagAssignmentValue.Default.Input": "",
-  "account": "",
+  account: "",
   "account.change_password_button": "",
   "account.change_password_modal": "",
   "account.change_password_modal.error": "",
@@ -501,7 +752,7 @@ module.exports = {
   "admin.users.select_row.self_tooltip": "",
   "admin.users.username_header": "",
   "admin.users.username_link": "",
-  "cancel": "",
+  cancel: "",
   "categorical-aggregate-chart-more-items": "",
   "databricks-experiment-tracking-prompt-edit-tags-button": "",
   "delete-run-modal": "",
@@ -518,7 +769,7 @@ module.exports = {
   "eval-tab.delete_traces-modal": "",
   "experiment-evaluation-monitoring-end-date-picker": "",
   "experiment-evaluation-monitoring-start-date-picker": "",
-  "fullscreen_button_chartcard": "",
+  fullscreen_button_chartcard: "",
   "genai.util.markdown-copy-code-block": "",
   "graph-view-span-navigator-next": "",
   "graph-view-span-navigator-prev": "",
@@ -532,7 +783,7 @@ module.exports = {
   "graph-view-toolbar.zoom-out-button": "",
   "mlflow_header.toggle_sidebar_button": "",
   "open-modal": "",
-  "promptType": "",
+  promptType: "",
   "storybook.long-form.description": "",
   "storybook.long-form.model": "",
   "storybook.long-form.name": "",
@@ -542,7 +793,7 @@ module.exports = {
   "web-shared.genai-traces-table.evaluations-review-assessment.tooltip": "",
   "web-shared.genai-traces-table.key-value-tag.full-view-tooltip": "",
   "web-shared.time-ago": "",
-  "workspace_selector": "",
+  workspace_selector: "",
   "workspace_selector.tooltip": "",
 
   // -- mlflow.artifact_view --
@@ -1622,6 +1873,7 @@ module.exports = {
   "mlflow.mcp_registry.error": "",
   "mlflow.mcp_registry.grid.pagination": "",
   "mlflow.mcp_registry.search": "",
+  "mlflow.mcp_registry.search.help_tooltip": "",
   "mlflow.mcp_registry.table.description_tooltip": "",
   "mlflow.mcp_registry.table.empty_state.create_server": "",
   "mlflow.mcp_registry.table.header": "",
@@ -1840,7 +2092,8 @@ module.exports = {
   "mlflow.run_details.header.register-model-button.tooltip": "",
   "mlflow.run_details.header.register_model_from_logged_model.button": "",
   "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item": "",
-  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button": "",
+  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button":
+    "",
   "mlflow.run_details.overview.child_runs.load_more_button": "",
   "mlflow.run_details.overview.source.commit_hash": "",
   "mlflow.run_details.overview.source.commit_hash_popover": "",
@@ -2134,5 +2387,4 @@ module.exports = {
   "shared.model-trace-explorer.trace-too-large.force-display-button": "",
   "shared.model-trace-explorer.view-mode-toggle": "",
   "shared.model-trace-explorer.workflow-node-tooltip": "",
-
 };

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -40,14 +40,10 @@ module.exports = {
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_309": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_316": "",
   "codegen_mlflow_app_src_common_hooks_useeditkeyvaluetagsmodal.tsx_324": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331":
-    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_181": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_223": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_315": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_artifact-view-components_showartifactloggedtableview.tsx_331": "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_288": "",
   "codegen_mlflow_app_src_experiment-tracking_components_artifactview.tsx_337": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunbox.tsx_46": "",
@@ -57,246 +53,126 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_570": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_581": "",
   "codegen_mlflow_app_src_experiment-tracking_components_comparerunview.tsx_592": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310":
-    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcellevaluatebutton.tsx_59": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_144": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_85": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationcreatepromptrunoutput.tsx_99": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_112": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_118": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_143": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadercellrenderer.tsx_150": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_37": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_49": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_51": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheaderdatasetindicator.tsx_66": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_107": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationrunheadermodelindicator.tsx_115": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscellrenderer.tsx_37": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_components_evaluationtableactionscolumnrenderer.tsx_22": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_111": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_createnotebookrunmodal.tsx_117": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_358": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_414": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_433": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactcompareview.tsx_465": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationartifactviewemptystate.tsx_48": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_107": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_28": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptparameters.tsx_39": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_541": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_589": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_596": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_597": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_638": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_678": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_694": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_695": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodal.tsx_736": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_42": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_48": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_evaluationcreatepromptrunmodalexamples.tsx_90": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_57": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationaddnewinputsmodal.tsx_99": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_102": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluation-artifacts-compare_hooks_useevaluationartifactwriteback.tsx_110": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_experimentviewnotes.tsx_57": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_101": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentgetsharelinkmodal.tsx_115": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_header_experimentviewheadersharebutton.tsx_44": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_172": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_184": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_49": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_56": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_datasetscellrenderer.tsx_75": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_109": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_groupparentcellrenderer.tsx_136": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_loadmorerowrenderer.tsx_20": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_modelscellrenderer.tsx_49": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_rowactionsheadercellrenderer.tsx_52": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_cells_runnamecellrenderer.tsx_46": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_206": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetdrawer.tsx_81": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_1": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetlink.tsx_19_2": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschema.tsx_92": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_57": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetschematable.tsx_58": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetsourceurl.tsx_34": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewdatasetwithcontext.tsx_41": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_300": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrols.tsx_175": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_110": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_117": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_126": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactions.tsx_136": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_34": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_51": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsaddnewtagmodal.tsx_78": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsactionsselecttags.tsx_162": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_184": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_201": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_211": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_217": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_248": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_289": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_329": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_338": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_362": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_382": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_402": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_403": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_415": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_461": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_469": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscontrolsfilters.tsx_time_button": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsemptytable.tsx_35": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_168": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_191": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_233": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_244": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_280": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_302": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_306": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_314": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_330": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_342": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_349": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_426": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunsgroupbyselector.tsx_436": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_137": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_97": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunstableaddcolumncta.tsx_218": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_212": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_236": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_runssearchautocomplete.tsx_310": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricchartsaccordion.tsx_82": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_120": "",
   "codegen_mlflow_app_src_experiment-tracking_components_metricsplotcontrols.tsx_154": "",
@@ -306,184 +182,96 @@ module.exports = {
   "codegen_mlflow_app_src_experiment-tracking_components_modals_createexperimentform.tsx_71": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_getlinkmodal.tsx_21": "",
   "codegen_mlflow_app_src_experiment-tracking_components_modals_renameform.tsx_69": "",
-  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251":
-    "",
-  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288":
-    "",
+  "codegen_mlflow_app_src_experiment-tracking_components_parallelcoordinatesplotcontrols.tsx_84": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_16": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_70": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdatasetbox.tsx_81": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewdescriptionbox.tsx_46": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_186": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewmetricstable.tsx_312": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_213": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_244": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewparamstable.tsx_74": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewregisteredmodelsbox.tsx_40": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewsourcebox.tsx_48": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_overview_runviewstatusbox.tsx_81": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_195": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_231": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_50": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_58": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_80": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_89": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewheaderregistermodelbutton.tsx_90": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_run-page_runviewmetricchartsv2.tsx_244": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_262": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_288": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_291": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_298": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_316": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_324": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_340": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_344": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_350": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_293": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_runschartsparallelchartcard.tsx_300": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_44": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_charts_imagegridmultiplekeyplot.tsx_52": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_129": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_138": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_157": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfiguredifferencechart.tsx_98": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigureimagechart.tsx_84": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_436": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_474": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_494": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_524": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_628": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_682": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_703": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_716": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_747": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_config_runschartsconfigurelinechart.tsx_838": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_112": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_126": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_42": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_56": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_70": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_84": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsaddchartmenu.tsx_98": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_232": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsconfiguremodal.tsx_296": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfilterinput.tsx_30": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsfullscreenmodal.tsx_53": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_118": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_44": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_68": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_78": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsglobalchartsettingsdropdown.tsx_88": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsnodatafoundindicator.tsx_31": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_122": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_runschartsyaxismetricandexpressionselector.tsx_221": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_220": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_321": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_327": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_333": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_sections_runschartssectionheader.tsx_351": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-charts_hooks_userunschartstooltip.stories.tsx_42": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_cards_chartcard.common.tsx_158": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscompareaddchartmenu.tsx_19": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_259": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_282": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_runscomparetooltipbody.tsx_302": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionaccordion.tsx_405": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_246": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_251": "",
+  "codegen_mlflow_app_src_experiment-tracking_components_runs-compare_sections_runscomparesectionheader.tsx_288": "",
   "codegen_mlflow_app_src_model-registry_components_CreateModelButton.tsx_28": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47":
-    "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57":
-    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_47": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelstablealiasedversionscell.tsx_57": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionaliastag.tsx_23": "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30":
-    "",
-  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41":
-    "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_30": "",
+  "codegen_mlflow_app_src_model-registry_components_aliases_modelversiontablealiasescell.tsx_41": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_29": "",
   "codegen_mlflow_app_src_model-registry_components_aliases_modelversionviewaliaseditor.tsx_37": "",
   "codegen_mlflow_app_src_model-registry_components_createmodelform.tsx_62": "",
@@ -526,88 +314,49 @@ module.exports = {
   "codegen_mlflow_app_src_shared_building_blocks_copybox.tsx_18": "",
   "codegen_mlflow_app_src_shared_building_blocks_pageheader.tsx_54": "",
   "codegen_mlflow_app_src_shared_building_blocks_previewbadge.tsx_14": "",
-  codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111:
-    "",
-  codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115: "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82: "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91: "",
-  codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99: "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113:
-    "",
-  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366":
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298:
-    "",
-  codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29:
-    "",
+  "codegen_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_cancel": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_121": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_130": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_141": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_157": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_hooks_useunifiedtracetagsmodal_207": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_111": "",
+  "codegen_no_dynamic_js_packages_web_shared_src_model_trace_explorer_timeline_tree_timelinetreefilterbutton_83": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_115": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_82": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_91": "",
+  "codegen_no_dynamic_mlflow_web_js_src_common_hooks_usetagassignmentmodal_99": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_112": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_evaluations_evaluationruncompareselector_190": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_69": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_87": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_experimentlistviewtagsfilter_96": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_experiment_page_components_header_experimentviewheaderkindselector_113": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_components_traces_quickstart_tracetablequickstart.utils_366": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_evaluation_runs_experimentevaluationrunstablecellrenderers_284": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_page_tabs_side_nav_experimentpagesidenavsection_93": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_152": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_customcodescorerformrenderer_209": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_28": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_deletescorermodalrenderer_46": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_178": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_224": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_234": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_263": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_271": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_316": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_samplescoreroutputpanelrenderer_52": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_106": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_123": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_179": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_41": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_45": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorercardrenderer_85": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scoreremptystaterenderer_59": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_140": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_293": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorerformrenderer_298": "",
+  "codegen_no_dynamic_mlflow_web_js_src_experiment_tracking_pages_experiment_scorers_scorermodalrenderer_29": "",
   "codegen_web-shared_src_copy_copyactionbutton.tsx_17": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_26": "",
   "codegen_web-shared_src_snippet_actions_snippetactionbutton.tsx_33": "",
@@ -616,7 +365,7 @@ module.exports = {
   // -- Other --
   "TagAssignmentKey.Default.Input": "",
   "TagAssignmentValue.Default.Input": "",
-  account: "",
+  "account": "",
   "account.change_password_button": "",
   "account.change_password_modal": "",
   "account.change_password_modal.error": "",
@@ -752,7 +501,7 @@ module.exports = {
   "admin.users.select_row.self_tooltip": "",
   "admin.users.username_header": "",
   "admin.users.username_link": "",
-  cancel: "",
+  "cancel": "",
   "categorical-aggregate-chart-more-items": "",
   "databricks-experiment-tracking-prompt-edit-tags-button": "",
   "delete-run-modal": "",
@@ -769,7 +518,7 @@ module.exports = {
   "eval-tab.delete_traces-modal": "",
   "experiment-evaluation-monitoring-end-date-picker": "",
   "experiment-evaluation-monitoring-start-date-picker": "",
-  fullscreen_button_chartcard: "",
+  "fullscreen_button_chartcard": "",
   "genai.util.markdown-copy-code-block": "",
   "graph-view-span-navigator-next": "",
   "graph-view-span-navigator-prev": "",
@@ -783,7 +532,7 @@ module.exports = {
   "graph-view-toolbar.zoom-out-button": "",
   "mlflow_header.toggle_sidebar_button": "",
   "open-modal": "",
-  promptType: "",
+  "promptType": "",
   "storybook.long-form.description": "",
   "storybook.long-form.model": "",
   "storybook.long-form.name": "",
@@ -793,7 +542,7 @@ module.exports = {
   "web-shared.genai-traces-table.evaluations-review-assessment.tooltip": "",
   "web-shared.genai-traces-table.key-value-tag.full-view-tooltip": "",
   "web-shared.time-ago": "",
-  workspace_selector: "",
+  "workspace_selector": "",
   "workspace_selector.tooltip": "",
 
   // -- mlflow.artifact_view --
@@ -1867,13 +1616,18 @@ module.exports = {
   "mlflow.mcp_registry.bindings.header.transport": "",
   "mlflow.mcp_registry.bindings.header.version": "",
   "mlflow.mcp_registry.bindings.search": "",
+  "mlflow.mcp_registry.card": "",
   "mlflow.mcp_registry.create_server_button": "",
   "mlflow.mcp_registry.empty_state.create_server": "",
+  "mlflow.mcp_registry.error": "",
+  "mlflow.mcp_registry.grid.pagination": "",
   "mlflow.mcp_registry.search": "",
-  "mlflow.mcp_registry.table.header.description": "",
-  "mlflow.mcp_registry.table.header.last_modified": "",
-  "mlflow.mcp_registry.table.header.name": "",
+  "mlflow.mcp_registry.table.description_tooltip": "",
+  "mlflow.mcp_registry.table.empty_state.create_server": "",
+  "mlflow.mcp_registry.table.header": "",
+  "mlflow.mcp_registry.table.pagination": "",
   "mlflow.mcp_registry.tabs": "",
+  "mlflow.mcp_registry.tag": "",
   "mlflow.mcp_registry.view_toggle": "",
 
   // -- mlflow.model-registry --
@@ -2086,8 +1840,7 @@ module.exports = {
   "mlflow.run_details.header.register-model-button.tooltip": "",
   "mlflow.run_details.header.register_model_from_logged_model.button": "",
   "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item": "",
-  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button":
-    "",
+  "mlflow.run_details.header.register_model_from_logged_model.dropdown_menu_item.view_model_button": "",
   "mlflow.run_details.overview.child_runs.load_more_button": "",
   "mlflow.run_details.overview.source.commit_hash": "",
   "mlflow.run_details.overview.source.commit_hash_popover": "",
@@ -2381,4 +2134,5 @@ module.exports = {
   "shared.model-trace-explorer.trace-too-large.force-display-button": "",
   "shared.model-trace-explorer.view-mode-toggle": "",
   "shared.model-trace-explorer.workflow-node-tooltip": "",
+
 };

--- a/mlflow/server/js/src/common/utils/SearchUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/SearchUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildSearchFilterClause } from './SearchUtils';
+
+describe('buildSearchFilterClause', () => {
+  it('returns undefined for undefined input', () => {
+    expect(buildSearchFilterClause(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(buildSearchFilterClause('')).toBeUndefined();
+  });
+
+  it('wraps plain text in ILIKE pattern', () => {
+    expect(buildSearchFilterClause('my-server')).toBe("name ILIKE '%my-server%'");
+  });
+
+  it('escapes single quotes', () => {
+    expect(buildSearchFilterClause("it's")).toBe("name ILIKE '%it''s%'");
+  });
+
+  it('escapes percent signs', () => {
+    expect(buildSearchFilterClause('100%')).toBe("name ILIKE '%100\\%%'");
+  });
+
+  it('escapes underscores', () => {
+    expect(buildSearchFilterClause('my_server')).toBe("name ILIKE '%my\\_server%'");
+  });
+
+  it('passes through ILIKE filter syntax', () => {
+    expect(buildSearchFilterClause('name ILIKE "%test%"')).toBe('name ILIKE "%test%"');
+  });
+
+  it('passes through LIKE filter syntax', () => {
+    expect(buildSearchFilterClause('name LIKE "test%"')).toBe('name LIKE "test%"');
+  });
+
+  it('passes through equals filter syntax', () => {
+    expect(buildSearchFilterClause('tags.env = "prod"')).toBe('tags.env = "prod"');
+  });
+
+  it('passes through not-equals filter syntax', () => {
+    expect(buildSearchFilterClause('tags.status != "archived"')).toBe('tags.status != "archived"');
+  });
+
+  it('passes through comparison operators', () => {
+    expect(buildSearchFilterClause('count > 10')).toBe('count > 10');
+    expect(buildSearchFilterClause('count < 10')).toBe('count < 10');
+    expect(buildSearchFilterClause('count >= 10')).toBe('count >= 10');
+    expect(buildSearchFilterClause('count <= 10')).toBe('count <= 10');
+  });
+
+  it('passes through IN filter syntax', () => {
+    expect(buildSearchFilterClause('status IN ("active", "paused")')).toBe('status IN ("active", "paused")');
+  });
+
+  it('is case-insensitive for SQL keywords', () => {
+    expect(buildSearchFilterClause('name ilike "%test%"')).toBe('name ilike "%test%"');
+  });
+
+  it('requires whitespace before SQL keywords to avoid false positives', () => {
+    expect(buildSearchFilterClause('prompt-ILIKE-test')).toBe("name ILIKE '%prompt-ILIKE-test%'");
+    expect(buildSearchFilterClause('prompt-LIKE-test')).toBe("name ILIKE '%prompt-LIKE-test%'");
+  });
+});

--- a/mlflow/server/js/src/common/utils/SearchUtils.ts
+++ b/mlflow/server/js/src/common/utils/SearchUtils.ts
@@ -1,0 +1,20 @@
+const SQL_KEYWORD_PATTERN = /(\s+(ILIKE|LIKE|IN|IS)\s+)|=|!=|<=|>=|<|>/i;
+
+/**
+ * Builds a filter clause from a search string.
+ * If the input contains SQL-like operators (ILIKE, LIKE, IN, IS, =, !=, etc.),
+ * it is passed through as-is. Otherwise, it is treated as a plain name search
+ * with special SQL characters escaped.
+ */
+export const buildSearchFilterClause = (searchFilter?: string, fieldName = 'name'): string | undefined => {
+  if (!searchFilter) {
+    return undefined;
+  }
+
+  if (SQL_KEYWORD_PATTERN.test(searchFilter)) {
+    return searchFilter;
+  }
+
+  const escaped = searchFilter.replace(/'/g, "''").replace(/%/g, '\\%').replace(/_/g, '\\_');
+  return `${fieldName} ILIKE '%${escaped}%'`;
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/api.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/api.test.ts
@@ -34,48 +34,11 @@ describe('PromptsPage', () => {
   });
 });
 
-describe('buildSearchFilterClause', () => {
-  it('should return empty string when search filter is undefined', () => {
-    expect(buildSearchFilterClause(undefined)).toBe('');
-  });
-
-  it('should return empty string when search filter is empty string', () => {
-    expect(buildSearchFilterClause('')).toBe('');
-  });
-
-  it('should wrap simple text search in ILIKE pattern', () => {
+describe('buildSearchFilterClause (re-exported from SearchUtils)', () => {
+  it('re-exports the shared utility correctly', () => {
+    expect(buildSearchFilterClause(undefined)).toBeUndefined();
     expect(buildSearchFilterClause('my-prompt')).toBe("name ILIKE '%my-prompt%'");
-  });
-
-  it('should treat filter with ILIKE as raw SQL filter', () => {
     expect(buildSearchFilterClause('name ILIKE "%test%"')).toBe('name ILIKE "%test%"');
-  });
-
-  it('should treat filter with LIKE as raw SQL filter', () => {
-    expect(buildSearchFilterClause('name LIKE "test%"')).toBe('name LIKE "test%"');
-  });
-
-  it('should treat filter with equals sign as raw SQL filter', () => {
-    expect(buildSearchFilterClause('tags.environment = "production"')).toBe('tags.environment = "production"');
-  });
-
-  it('should treat filter with not equals as raw SQL filter', () => {
-    expect(buildSearchFilterClause('tags.status != "archived"')).toBe('tags.status != "archived"');
-  });
-
-  it('should be case insensitive for SQL keywords', () => {
-    expect(buildSearchFilterClause('name ilike "%test%"')).toBe('name ilike "%test%"');
-    expect(buildSearchFilterClause('name like "test%"')).toBe('name like "test%"');
-  });
-
-  it('should require whitespace before ILIKE/LIKE to avoid false positives', () => {
-    expect(buildSearchFilterClause('prompt-ILIKE-test')).toBe("name ILIKE '%prompt-ILIKE-test%'");
-    expect(buildSearchFilterClause('prompt-LIKE-test')).toBe("name ILIKE '%prompt-LIKE-test%'");
-  });
-
-  it('should handle complex SQL filters', () => {
-    const complexFilter = 'name ILIKE "%prompt%" AND tags.env = "prod"';
-    expect(buildSearchFilterClause(complexFilter)).toBe(complexFilter);
   });
 });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -109,32 +109,8 @@ export const parseLinkedPromptsFromRunTags = (
   return [];
 };
 
-/**
- * Builds a filter clause from a search string.
- * If the search string contains SQL-like keywords (ILIKE, LIKE, =, !=),
- * it's treated as a raw filter query. Otherwise, it's treated as a simple
- * name search and wrapped with ILIKE pattern matching.
- *
- * @param searchFilter - The search string to process
- * @returns The filter clause, or an empty string if searchFilter is empty
- */
-export const buildSearchFilterClause = (searchFilter?: string): string => {
-  if (!searchFilter) {
-    return '';
-  }
-
-  // Check if the search filter looks like a SQL-like query
-  // If so, treat it as a raw filter query; otherwise, treat it as a simple name search
-  const sqlKeywordPattern = /(\s+(ILIKE|LIKE)\s+)|=|!=/i;
-
-  if (sqlKeywordPattern.test(searchFilter)) {
-    // User provided a SQL-like filter, use it directly
-    return searchFilter;
-  } else {
-    // Simple name search
-    return `name ILIKE '%${searchFilter}%'`;
-  }
-};
+// Re-export from shared utility for backwards compatibility
+export { buildSearchFilterClause } from '@mlflow/mlflow/src/common/utils/SearchUtils';
 
 /**
  * Parse model config from tag value (JSON string).

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1671,6 +1671,10 @@
     "defaultMessage": "The retrieval groundedness LLM judge returns a binary evaluation and written rationale on whether the generated response is factually consistent with the agent's retrieved context.",
     "description": "Evaluation results > known type of evaluation result assessment > description of retrieval groundedness judge."
   },
+  "6QwDyx": {
+    "defaultMessage": "Name",
+    "description": "Header for the name column in the MCP servers table"
+  },
   "6SXoSp": {
     "defaultMessage": "Model definition",
     "description": "Label for model definition selector"
@@ -2483,6 +2487,10 @@
     "defaultMessage": "Choose from a selection of built-in LLM judges or create your own custom code based judge. {learnMore}",
     "description": "Description for the empty state when no judges exist"
   },
+  "9xfwTO": {
+    "defaultMessage": "Loading servers...",
+    "description": "Loading state for MCP servers card grid"
+  },
   "9y+yUQ": {
     "defaultMessage": "File is too large to preview",
     "description": "Label to indicate that the file is too large to preview"
@@ -2815,10 +2823,6 @@
     "defaultMessage": "One-line setup",
     "description": "Tab label for the mlflow agent setup CLI path in the agent action card"
   },
-  "BVZjOe": {
-    "defaultMessage": "Name",
-    "description": "MCP servers table header for name column"
-  },
   "BWH8UR": {
     "defaultMessage": "API key name:",
     "description": "Label for API key name input"
@@ -2874,6 +2878,10 @@
   "Bg/LgH": {
     "defaultMessage": "Instructions",
     "description": "Label for guardrail judge instructions"
+  },
+  "Bh7AL1": {
+    "defaultMessage": "Latest version",
+    "description": "Header for the latest version column in the MCP servers table"
   },
   "BkDhmT": {
     "defaultMessage": "Chat",
@@ -3575,6 +3583,10 @@
     "defaultMessage": "When enabled, all requests to this endpoint will be logged as traces. This allows you to monitor usage, debug issues, and analyze performance.",
     "description": "Tooltip explaining what usage tracking does"
   },
+  "FZe3Mu": {
+    "defaultMessage": "Last modified",
+    "description": "Header for the last modified column in the MCP servers table"
+  },
   "FZubuU": {
     "defaultMessage": "Input an experiment name",
     "description": "Input placeholder to enter experiment name for create experiment"
@@ -3730,10 +3742,6 @@
   "GKiPV1": {
     "defaultMessage": "Start Time:",
     "description": "Text for start time row header in the main table in the model comparison\n                page"
-  },
-  "GRC83e": {
-    "defaultMessage": "Create MCP server",
-    "description": "Empty state title for MCP servers tab"
   },
   "GRaplV": {
     "defaultMessage": "Context sufficiency",
@@ -3914,6 +3922,10 @@
   "HXbUkt": {
     "defaultMessage": "Child runs",
     "description": "Run page > Overview > Child runs"
+  },
+  "HXhGPv": {
+    "defaultMessage": "Tags",
+    "description": "Header for the tags column in the MCP servers table"
   },
   "HYQHVk": {
     "defaultMessage": "See more",
@@ -4611,10 +4623,6 @@
     "defaultMessage": "Latency Comparison",
     "description": "Title for the tool latency comparison chart"
   },
-  "LA4/Jy": {
-    "defaultMessage": "Create and manage MCP servers using MLflow.",
-    "description": "Empty state description for MCP servers tab"
-  },
   "LBaK9z": {
     "defaultMessage": "Open dataset",
     "description": "Text for the button that opens the dataset source URL in a new tab"
@@ -4686,10 +4694,6 @@
   "LajLDb": {
     "defaultMessage": "Move to top",
     "description": "Experiment page > compare runs tab > chart header > move to top option"
-  },
-  "LbpFi1": {
-    "defaultMessage": "Create MCP server",
-    "description": "MCP Registry empty state CTA button"
   },
   "LfggX9": {
     "defaultMessage": "Loading users…",
@@ -7599,6 +7603,10 @@
     "defaultMessage": "(unknown)",
     "description": "Filler text when run's time information is unavailable"
   },
+  "ZcWNz2": {
+    "defaultMessage": "Description",
+    "description": "Header for the description column in the MCP servers table"
+  },
   "ZfsnMj": {
     "defaultMessage": "Not grounded",
     "description": "Evaluation results > grounded assessment > negative value label. Displayed if evaluation result is considered as not grounded."
@@ -9635,6 +9643,10 @@
     "defaultMessage": "Evaluating {isTraces, select, true {traces} other {sessions}}...",
     "description": "Status text while evaluating traces or sessions"
   },
+  "ig+A10": {
+    "defaultMessage": "Create and manage MCP servers using MLflow.",
+    "description": "Empty state description for MCP servers"
+  },
   "igK5Su": {
     "defaultMessage": "Error",
     "description": "Experiment page > traces table > status label > error"
@@ -10735,6 +10747,10 @@
     "defaultMessage": "Prompt Name",
     "description": "Header for prompt name column in linked prompts table on logged model details page"
   },
+  "nrIEMg": {
+    "defaultMessage": "No servers found",
+    "description": "Empty state when MCP server search returns no results"
+  },
   "nugZSE": {
     "defaultMessage": "Show less",
     "description": "Button label to collapse conversation messages in model trace explorer"
@@ -10982,6 +10998,10 @@
   "p2po2x": {
     "defaultMessage": "Delete prompt",
     "description": "A header for the delete prompt modal"
+  },
+  "p9EISw": {
+    "defaultMessage": "Create MCP server",
+    "description": "Empty state title for MCP servers"
   },
   "p9ZErC": {
     "defaultMessage": "Start review",
@@ -12427,6 +12447,10 @@
     "defaultMessage": "Owner",
     "description": "Review queue sidebar: queue-owner column"
   },
+  "wU/MOk": {
+    "defaultMessage": "Create MCP server",
+    "description": "MCP servers empty state CTA button"
+  },
   "wY58OE": {
     "defaultMessage": "Retrieval groundedness",
     "description": "Evaluation results > known type of evaluation result assessment > retrieval groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Retrieval groundedness: moderately grounded\""
@@ -12547,10 +12571,6 @@
     "defaultMessage": "Nothing to compare!",
     "description": "Header displayed in the metrics and params compare plot when no values are selected"
   },
-  "x0yivN": {
-    "defaultMessage": "Description",
-    "description": "MCP servers table header for description column"
-  },
   "x1Lbmd": {
     "defaultMessage": "{gpuCount, plural, =0 {} one {# GPU} other {# GPUs}} selected",
     "description": "Count of selected GPUs displayed in the node level metric charts node selector"
@@ -12562,10 +12582,6 @@
   "x5IuGA": {
     "defaultMessage": "Loaded {name} v{version}",
     "description": "Success toast shown on the playground after loading a prompt version that did not include stored settings"
-  },
-  "x5RW3f": {
-    "defaultMessage": "Last modified",
-    "description": "MCP servers table header for last modified column"
   },
   "x5ukxr": {
     "defaultMessage": "Runs",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -9019,6 +9019,10 @@
     "defaultMessage": "Display points",
     "description": "Runs charts > line chart > display points > label"
   },
+  "g89D3N": {
+    "defaultMessage": "Examples:",
+    "description": "Text header for examples of MCP server search syntax"
+  },
   "gC2Kxm": {
     "defaultMessage": "Give instructions to the model. Use '{{ }}' or the \"Add new variable\" button to add variables to your prompt.",
     "description": "Experiment page > new run modal > prompt template input hint"
@@ -12278,6 +12282,10 @@
   "vbRrqF": {
     "defaultMessage": "Add question",
     "description": "Add review question modal title"
+  },
+  "vcK5wo": {
+    "defaultMessage": "To search by tags or by names and tags, use a simplified version{newline}of the SQL {whereBold} clause.",
+    "description": "Tooltip to explain how to search MCP servers in the registry"
   },
   "vedifc": {
     "defaultMessage": "Enter API key or select saved key",

--- a/mlflow/server/js/src/mcp-registry/components/MCPRegistryEmptyState.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPRegistryEmptyState.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement, ReactNode } from 'react';
+import { Button, Empty, NoIcon, PlusIcon } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { emptyCenterStyles } from '../styles';
+
+export const MCPRegistryEmptyState = ({
+  title,
+  description,
+  button,
+  image,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  button?: ReactElement;
+  image?: ReactElement;
+}) => {
+  return (
+    <div css={emptyCenterStyles}>
+      <Empty title={title} description={description ?? null} button={button} image={image} />
+    </div>
+  );
+};
+
+export const MCPServersEmptyState = ({ isFiltered, componentId }: { isFiltered?: boolean; componentId: string }) => {
+  if (isFiltered) {
+    return (
+      <MCPRegistryEmptyState
+        image={<NoIcon />}
+        title={
+          <FormattedMessage
+            defaultMessage="No servers found"
+            description="Empty state when MCP server search returns no results"
+          />
+        }
+      />
+    );
+  }
+  return (
+    <MCPRegistryEmptyState
+      title={<FormattedMessage defaultMessage="Create MCP server" description="Empty state title for MCP servers" />}
+      description={
+        <FormattedMessage
+          defaultMessage="Create and manage MCP servers using MLflow."
+          description="Empty state description for MCP servers"
+        />
+      }
+      button={
+        <Button componentId={componentId} type="primary" icon={<PlusIcon />} disabled>
+          <FormattedMessage defaultMessage="Create MCP server" description="MCP servers empty state CTA button" />
+        </Button>
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPSearchInputHelpTooltip.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPSearchInputHelpTooltip.tsx
@@ -1,0 +1,38 @@
+import { InfoSmallIcon, Popover } from '@databricks/design-system';
+import { FormattedMessage, defineMessage, useIntl } from 'react-intl';
+
+const tooltipIntroMessage = defineMessage({
+  defaultMessage:
+    'To search by tags or by names and tags, use a simplified version{newline}of the SQL {whereBold} clause.',
+  description: 'Tooltip to explain how to search MCP servers in the registry',
+});
+
+export const MCPSearchInputHelpTooltip = () => {
+  const { formatMessage } = useIntl();
+  const labelText = formatMessage(tooltipIntroMessage, { newline: ' ', whereBold: 'WHERE' });
+
+  return (
+    <Popover.Root componentId="mlflow.mcp_registry.search.help_tooltip">
+      <Popover.Trigger
+        aria-label={labelText}
+        css={{ border: 0, background: 'none', padding: 0, lineHeight: 0, cursor: 'pointer' }}
+      >
+        <InfoSmallIcon />
+      </Popover.Trigger>
+      <Popover.Content align="start">
+        <div>
+          <FormattedMessage {...tooltipIntroMessage} values={{ newline: <br />, whereBold: <b>WHERE</b> }} />
+          <br />
+          <br />
+          <FormattedMessage
+            defaultMessage="Examples:"
+            description="Text header for examples of MCP server search syntax"
+          />
+          <br />• tags.my_key = &quot;my_value&quot;
+          <br />• name ILIKE &quot;%my-mcp-server%&quot; AND tags.my_key = &quot;my_value&quot;
+        </div>
+        <Popover.Arrow />
+      </Popover.Content>
+    </Popover.Root>
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCard.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCard.test.tsx
@@ -29,10 +29,10 @@ describe('MCPServerCard', () => {
     expect(screen.getByText('io.github.test/my-server')).toBeInTheDocument();
   });
 
-  it('renders display_name when set', () => {
+  it('renders name even when display_name is set', () => {
     renderCard(createMockMCPServer({ name: 'io.github.test/raw', display_name: 'Pretty Name' }));
-    expect(screen.getByText('Pretty Name')).toBeInTheDocument();
-    expect(screen.queryByText('io.github.test/raw')).not.toBeInTheDocument();
+    expect(screen.getByText('io.github.test/raw')).toBeInTheDocument();
+    expect(screen.queryByText('Pretty Name')).not.toBeInTheDocument();
   });
 
   it('renders description when provided', () => {

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCard.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
+import { MCPServerCard } from './MCPServerCard';
+import { createMockMCPServer } from '../test-utils';
+import type { MCPServer } from '../types';
+
+const renderCard = (server: MCPServer) =>
+  render(
+    <IntlProvider locale="en">
+      <TestRouter
+        routes={[
+          testRoute(
+            <DesignSystemProvider>
+              <MCPServerCard server={server} />
+            </DesignSystemProvider>,
+            '/',
+          ),
+        ]}
+      />
+    </IntlProvider>,
+  );
+
+describe('MCPServerCard', () => {
+  it('renders server name when no display_name is set', () => {
+    renderCard(createMockMCPServer({ name: 'io.github.test/my-server' }));
+    expect(screen.getByText('io.github.test/my-server')).toBeInTheDocument();
+  });
+
+  it('renders display_name when set', () => {
+    renderCard(createMockMCPServer({ name: 'io.github.test/raw', display_name: 'Pretty Name' }));
+    expect(screen.getByText('Pretty Name')).toBeInTheDocument();
+    expect(screen.queryByText('io.github.test/raw')).not.toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    renderCard(createMockMCPServer({ description: 'A helpful tool server' }));
+    expect(screen.getByText('A helpful tool server')).toBeInTheDocument();
+  });
+
+  it('does not render description when not provided', () => {
+    renderCard(createMockMCPServer({ description: undefined }));
+    expect(screen.queryByText('A helpful tool server')).not.toBeInTheDocument();
+  });
+
+  it('renders timestamp when last_updated_timestamp is set', () => {
+    renderCard(createMockMCPServer({ last_updated_timestamp: 1620000000000 }));
+    expect(screen.getByText(/2021/)).toBeInTheDocument();
+  });
+
+  it('does not render timestamp when last_updated_timestamp is absent', () => {
+    renderCard(createMockMCPServer({ last_updated_timestamp: undefined }));
+    expect(screen.queryByText(/\d{2}\/\d{2}\/\d{4}/)).not.toBeInTheDocument();
+  });
+
+  it('renders latest_version when set', () => {
+    renderCard(createMockMCPServer({ latest_version: '2.1.0' }));
+    expect(screen.getByText('v2.1.0')).toBeInTheDocument();
+  });
+
+  it('does not render version when latest_version is absent', () => {
+    renderCard(createMockMCPServer({ latest_version: undefined }));
+    expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument();
+  });
+
+  it('renders tags when provided', () => {
+    renderCard(createMockMCPServer({ tags: { env: 'production' } }));
+    expect(screen.getByText('env: production')).toBeInTheDocument();
+  });
+
+  it('does not render tags section when tags are empty', () => {
+    renderCard(createMockMCPServer({ tags: {} }));
+    expect(screen.queryByText(/:/)).not.toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCard.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCard.tsx
@@ -1,0 +1,56 @@
+import { Card, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from 'react-intl';
+
+import type { MCPServer } from '../types';
+import { resolveDisplayName } from '../utils';
+import { textClampStyles, textEllipsisStyles, cardBodyStyles, cardHeaderRowStyles } from '../styles';
+import { MCPServerIcon } from './MCPServerIcon';
+import { MCPServerTags } from './MCPServerTags';
+import Utils from '../../common/utils/Utils';
+
+export const MCPServerCard = ({ server }: { server: MCPServer }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const displayName = resolveDisplayName(server);
+  const timestamp = server.last_updated_timestamp
+    ? Utils.formatTimestamp(server.last_updated_timestamp, intl)
+    : undefined;
+
+  return (
+    <Card
+      componentId="mlflow.mcp_registry.card"
+      width="100%"
+      role="button"
+      onClick={() => {
+        // TODO: navigate to server detail page once it exists
+      }}
+      dangerouslyAppendEmotionCSS={{ height: '100%', cursor: 'pointer' }}
+    >
+      <div css={cardBodyStyles(theme)}>
+        <div css={cardHeaderRowStyles(theme)}>
+          <MCPServerIcon icons={server.icons} name={displayName} />
+          <Typography.Text bold css={{ ...textEllipsisStyles, flex: 1 }}>
+            {displayName}
+          </Typography.Text>
+          {server.latest_version && (
+            <Typography.Text color="secondary" size="sm" css={{ flexShrink: 0 }}>
+              v{server.latest_version}
+            </Typography.Text>
+          )}
+        </div>
+        {server.description && (
+          <Typography.Text color="secondary" size="sm" css={textClampStyles(2)}>
+            {server.description}
+          </Typography.Text>
+        )}
+        {Object.keys(server.tags || {}).length > 0 && <MCPServerTags tags={server.tags || {}} />}
+        {timestamp && (
+          <Typography.Text color="secondary" size="sm">
+            {timestamp}
+          </Typography.Text>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCard.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCard.tsx
@@ -2,7 +2,6 @@ import { Card, Typography, useDesignSystemTheme } from '@databricks/design-syste
 import { useIntl } from 'react-intl';
 
 import type { MCPServer } from '../types';
-import { resolveDisplayName } from '../utils';
 import { textClampStyles, textEllipsisStyles, cardBodyStyles, cardHeaderRowStyles } from '../styles';
 import { MCPServerIcon } from './MCPServerIcon';
 import { MCPServerTags } from './MCPServerTags';
@@ -12,7 +11,6 @@ export const MCPServerCard = ({ server }: { server: MCPServer }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
 
-  const displayName = resolveDisplayName(server);
   const timestamp = server.last_updated_timestamp
     ? Utils.formatTimestamp(server.last_updated_timestamp, intl)
     : undefined;
@@ -29,9 +27,9 @@ export const MCPServerCard = ({ server }: { server: MCPServer }) => {
     >
       <div css={cardBodyStyles(theme)}>
         <div css={cardHeaderRowStyles(theme)}>
-          <MCPServerIcon icons={server.icons} name={displayName} />
+          <MCPServerIcon icons={server.icons} name={server.name} />
           <Typography.Text bold css={{ ...textEllipsisStyles, flex: 1 }}>
-            {displayName}
+            {server.name}
           </Typography.Text>
           {server.latest_version && (
             <Typography.Text color="secondary" size="sm" css={{ flexShrink: 0 }}>

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCardGrid.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCardGrid.test.tsx
@@ -49,14 +49,14 @@ describe('MCPServerCardGrid', () => {
 
   it('renders a card for each server', () => {
     const servers = [
-      createMockMCPServer({ name: 'server-a', display_name: 'Server A' }),
-      createMockMCPServer({ name: 'server-b', display_name: 'Server B' }),
-      createMockMCPServer({ name: 'server-c', display_name: 'Server C' }),
+      createMockMCPServer({ name: 'server-a' }),
+      createMockMCPServer({ name: 'server-b' }),
+      createMockMCPServer({ name: 'server-c' }),
     ];
     renderGrid({ ...defaultPaginationProps, servers });
-    expect(screen.getByText('Server A')).toBeInTheDocument();
-    expect(screen.getByText('Server B')).toBeInTheDocument();
-    expect(screen.getByText('Server C')).toBeInTheDocument();
+    expect(screen.getByText('server-a')).toBeInTheDocument();
+    expect(screen.getByText('server-b')).toBeInTheDocument();
+    expect(screen.getByText('server-c')).toBeInTheDocument();
   });
 
   it('does not render loading spinner when servers are present', () => {

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCardGrid.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCardGrid.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
+import { MCPServerCardGrid } from './MCPServerCardGrid';
+import { createMockMCPServer } from '../test-utils';
+
+const noop = () => {};
+
+const defaultPaginationProps = {
+  hasNextPage: false,
+  hasPreviousPage: false,
+  onNextPage: noop,
+  onPreviousPage: noop,
+};
+
+const renderGrid = (props: React.ComponentProps<typeof MCPServerCardGrid>) =>
+  render(
+    <IntlProvider locale="en">
+      <TestRouter
+        routes={[
+          testRoute(
+            <DesignSystemProvider>
+              <MCPServerCardGrid {...props} />
+            </DesignSystemProvider>,
+            '/',
+          ),
+        ]}
+      />
+    </IntlProvider>,
+  );
+
+describe('MCPServerCardGrid', () => {
+  it('renders loading spinner when isLoading is true', () => {
+    renderGrid({ ...defaultPaginationProps, isLoading: true });
+    expect(screen.getByText('Loading servers...')).toBeInTheDocument();
+  });
+
+  it('renders "No servers found" when filtered and no results', () => {
+    renderGrid({ ...defaultPaginationProps, servers: [], isFiltered: true });
+    expect(screen.getByText('No servers found')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no servers and not filtered', () => {
+    renderGrid({ ...defaultPaginationProps, servers: [] });
+    expect(screen.getByText('Create and manage MCP servers using MLflow.')).toBeInTheDocument();
+  });
+
+  it('renders a card for each server', () => {
+    const servers = [
+      createMockMCPServer({ name: 'server-a', display_name: 'Server A' }),
+      createMockMCPServer({ name: 'server-b', display_name: 'Server B' }),
+      createMockMCPServer({ name: 'server-c', display_name: 'Server C' }),
+    ];
+    renderGrid({ ...defaultPaginationProps, servers });
+    expect(screen.getByText('Server A')).toBeInTheDocument();
+    expect(screen.getByText('Server B')).toBeInTheDocument();
+    expect(screen.getByText('Server C')).toBeInTheDocument();
+  });
+
+  it('does not render loading spinner when servers are present', () => {
+    renderGrid({ ...defaultPaginationProps, servers: [createMockMCPServer()], isLoading: false });
+    expect(screen.queryByText('Loading servers...')).not.toBeInTheDocument();
+  });
+
+  it('renders pagination controls when servers are present', () => {
+    const servers = [createMockMCPServer()];
+    renderGrid({ ...defaultPaginationProps, servers, hasNextPage: true });
+    expect(screen.getByText('Next')).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+  });
+
+  it('calls onNextPage when Next is clicked', () => {
+    const onNextPage = jest.fn();
+    const servers = [createMockMCPServer()];
+    renderGrid({ ...defaultPaginationProps, servers, hasNextPage: true, onNextPage });
+    screen.getByText('Next').click();
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPreviousPage when Previous is clicked', () => {
+    const onPreviousPage = jest.fn();
+    const servers = [createMockMCPServer()];
+    renderGrid({ ...defaultPaginationProps, servers, hasPreviousPage: true, onPreviousPage });
+    screen.getByText('Previous').click();
+    expect(onPreviousPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders page size selector', () => {
+    const servers = [createMockMCPServer()];
+    renderGrid({
+      ...defaultPaginationProps,
+      servers,
+      pageSizeSelect: { options: [10, 25, 50], default: 25, onChange: noop },
+    });
+    expect(screen.getByText('25 / page')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerCardGrid.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerCardGrid.tsx
@@ -1,0 +1,83 @@
+import type { CursorPaginationProps } from '@databricks/design-system';
+import { CursorPagination, Spinner, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+
+import type { MCPServer } from '../types';
+import { MCPServerCard } from './MCPServerCard';
+import { MCPServersEmptyState } from './MCPRegistryEmptyState';
+import { cardGridStyles, flexColumnContainerStyles } from '../styles';
+
+export const MCPServerCardGrid = ({
+  servers,
+  isLoading,
+  isFiltered,
+  hasNextPage,
+  hasPreviousPage,
+  onNextPage,
+  onPreviousPage,
+  pageSizeSelect,
+}: {
+  servers?: MCPServer[];
+  isLoading?: boolean;
+  isFiltered?: boolean;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  pageSizeSelect?: CursorPaginationProps['pageSizeSelect'];
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: theme.spacing.sm,
+          padding: theme.spacing.lg,
+          minHeight: 200,
+        }}
+      >
+        <Spinner size="small" />
+        <FormattedMessage defaultMessage="Loading servers..." description="Loading state for MCP servers card grid" />
+      </div>
+    );
+  }
+
+  if (!servers?.length) {
+    return <MCPServersEmptyState isFiltered={isFiltered} componentId="mlflow.mcp_registry.empty_state.create_server" />;
+  }
+
+  return (
+    <div css={{ ...flexColumnContainerStyles, minHeight: 0 }}>
+      <div role="list" aria-label="MCP servers" css={cardGridStyles(theme)}>
+        {servers.map((server) => (
+          <div role="listitem" key={server.name}>
+            <MCPServerCard server={server} />
+          </div>
+        ))}
+      </div>
+      <div
+        css={{
+          flexShrink: 0,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          paddingTop: theme.spacing.sm,
+          paddingBottom: theme.spacing.sm,
+        }}
+      >
+        <CursorPagination
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
+          onNextPage={onNextPage}
+          onPreviousPage={onPreviousPage}
+          pageSizeSelect={pageSizeSelect}
+          componentId="mlflow.mcp_registry.grid.pagination"
+        />
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerIcon.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerIcon.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { MCPServerIcon } from './MCPServerIcon';
+
+const renderIcon = (props: React.ComponentProps<typeof MCPServerIcon>) =>
+  render(
+    <DesignSystemProvider>
+      <MCPServerIcon {...props} />
+    </DesignSystemProvider>,
+  );
+
+const getImg = (container: HTMLElement) => container.querySelector('img');
+const getSvg = (container: HTMLElement) => container.querySelector('svg');
+
+describe('MCPServerIcon', () => {
+  it('renders fallback McpIcon when no icons provided', () => {
+    const { container } = renderIcon({});
+    expect(getImg(container)).toBeNull();
+    expect(getSvg(container)).toBeTruthy();
+  });
+
+  it('renders img when icon src is provided', () => {
+    const { container } = renderIcon({ icons: [{ src: 'https://example.com/icon.svg' }] });
+    expect(getImg(container)).toHaveAttribute('src', 'https://example.com/icon.svg');
+  });
+
+  it('uses server name as alt text', () => {
+    renderIcon({ icons: [{ src: 'https://example.com/icon.svg' }], name: 'My Server' });
+    expect(screen.getByRole('img')).toHaveAttribute('alt', 'My Server');
+  });
+
+  it('uses empty alt when name is not provided', () => {
+    const { container } = renderIcon({ icons: [{ src: 'https://example.com/icon.svg' }] });
+    expect(getImg(container)).toHaveAttribute('alt', '');
+  });
+
+  it('falls back to McpIcon when img fails to load', () => {
+    const { container } = renderIcon({ icons: [{ src: 'https://example.com/broken.svg' }] });
+    fireEvent.error(getImg(container)!);
+    expect(getImg(container)).toBeNull();
+    expect(getSvg(container)).toBeTruthy();
+  });
+
+  it('prefers theme-agnostic icon when no theme matches', () => {
+    const { container } = renderIcon({
+      icons: [{ src: 'https://example.com/dark.svg', theme: 'dark' }, { src: 'https://example.com/universal.svg' }],
+    });
+    expect(getImg(container)).toHaveAttribute('src', 'https://example.com/universal.svg');
+  });
+
+  it('falls back to first icon when no theme-agnostic icon exists', () => {
+    const { container } = renderIcon({
+      icons: [
+        { src: 'https://example.com/dark.svg', theme: 'dark' },
+        { src: 'https://example.com/light.svg', theme: 'light' },
+      ],
+    });
+    // Default theme is light mode in tests
+    expect(getImg(container)).toHaveAttribute('src', 'https://example.com/light.svg');
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerIcon.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerIcon.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { McpIcon, useDesignSystemTheme } from '@databricks/design-system';
+import type { MCPIcon as MCPIconType } from '../types';
+import { mcpIconStyles } from '../styles';
+
+const ICON_SIZE = 16;
+
+const resolveIconSrc = (icons?: MCPIconType[], isDarkMode?: boolean): string | undefined => {
+  if (!icons?.length) return undefined;
+  const preferred = isDarkMode ? 'dark' : 'light';
+  return icons.find((i) => i.theme === preferred)?.src ?? icons.find((i) => !i.theme)?.src ?? icons[0]?.src;
+};
+
+export const MCPServerIcon = ({
+  icons,
+  name,
+  css: cssProp,
+}: {
+  icons?: MCPIconType[];
+  name?: string;
+  css?: Record<string, unknown>;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const [imgFailed, setImgFailed] = useState(false);
+  const iconSrc = resolveIconSrc(icons, theme.isDarkMode);
+
+  useEffect(() => {
+    setImgFailed(false);
+  }, [iconSrc]);
+
+  if (iconSrc && !imgFailed) {
+    return (
+      <img
+        src={iconSrc}
+        alt={name || ''}
+        onError={() => setImgFailed(true)}
+        css={{
+          width: ICON_SIZE,
+          height: ICON_SIZE,
+          objectFit: 'contain',
+          ...mcpIconStyles(theme),
+          ...cssProp,
+        }}
+      />
+    );
+  }
+
+  return <McpIcon aria-hidden css={{ width: ICON_SIZE, height: ICON_SIZE, ...mcpIconStyles(theme), ...cssProp }} />;
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerIcon.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerIcon.tsx
@@ -33,6 +33,7 @@ export const MCPServerIcon = ({
       <img
         src={iconSrc}
         alt={name || ''}
+        referrerPolicy="no-referrer"
         onError={() => setImgFailed(true)}
         css={{
           width: ICON_SIZE,

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerListFilters.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerListFilters.tsx
@@ -1,6 +1,6 @@
 import { TableFilterInput, TableFilterLayout } from '@databricks/design-system';
 import { useIntl } from 'react-intl';
-import { ModelSearchInputHelpTooltip } from '../../model-registry/components/model-list/ModelListFilters';
+import { MCPSearchInputHelpTooltip } from './MCPSearchInputHelpTooltip';
 
 export const MCPServerListFilters = ({
   searchFilter,
@@ -22,7 +22,7 @@ export const MCPServerListFilters = ({
         componentId={componentId}
         value={searchFilter}
         onChange={(e) => onSearchFilterChange(e.target.value)}
-        suffix={<ModelSearchInputHelpTooltip exampleEntityName="my-mcp-server" />}
+        suffix={<MCPSearchInputHelpTooltip />}
       />
     </TableFilterLayout>
   );

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerListFilters.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerListFilters.tsx
@@ -1,0 +1,29 @@
+import { TableFilterInput, TableFilterLayout } from '@databricks/design-system';
+import { useIntl } from 'react-intl';
+import { ModelSearchInputHelpTooltip } from '../../model-registry/components/model-list/ModelListFilters';
+
+export const MCPServerListFilters = ({
+  searchFilter,
+  onSearchFilterChange,
+  componentId,
+}: {
+  searchFilter: string;
+  onSearchFilterChange: (value: string) => void;
+  componentId: string;
+}) => {
+  const intl = useIntl();
+  return (
+    <TableFilterLayout>
+      <TableFilterInput
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Search MCP servers by name',
+          description: 'Placeholder for MCP server search filter input',
+        })}
+        componentId={componentId}
+        value={searchFilter}
+        onChange={(e) => onSearchFilterChange(e.target.value)}
+        suffix={<ModelSearchInputHelpTooltip exampleEntityName="my-mcp-server" />}
+      />
+    </TableFilterLayout>
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
+import { MCPServerListTable } from './MCPServerListTable';
+import { createMockMCPServer } from '../test-utils';
+
+const noop = () => {};
+
+const renderTable = (props: Partial<React.ComponentProps<typeof MCPServerListTable>> = {}) =>
+  render(
+    <IntlProvider locale="en">
+      <TestRouter
+        routes={[
+          testRoute(
+            <DesignSystemProvider>
+              <MCPServerListTable
+                hasNextPage={false}
+                hasPreviousPage={false}
+                onNextPage={noop}
+                onPreviousPage={noop}
+                {...props}
+              />
+            </DesignSystemProvider>,
+            '/',
+          ),
+        ]}
+      />
+    </IntlProvider>,
+  );
+
+describe('MCPServerListTable', () => {
+  it('renders all column headers', () => {
+    renderTable();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Latest version')).toBeInTheDocument();
+    expect(screen.getByText('Last modified')).toBeInTheDocument();
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+  });
+
+  it('renders server rows with display name and description', () => {
+    const servers = [
+      createMockMCPServer({
+        name: 'io.github.test/server-a',
+        display_name: 'Server A',
+        description: 'A test server',
+        last_updated_timestamp: 1620000000000,
+      }),
+      createMockMCPServer({
+        name: 'io.github.test/server-b',
+        display_name: 'Server B',
+        description: 'Another test server',
+      }),
+    ];
+    renderTable({ servers });
+    expect(screen.getByText('Server A')).toBeInTheDocument();
+    expect(screen.getByText('A test server')).toBeInTheDocument();
+    expect(screen.getByText('Server B')).toBeInTheDocument();
+    expect(screen.getByText('Another test server')).toBeInTheDocument();
+  });
+
+  it('falls back to name when display_name is absent', () => {
+    const servers = [createMockMCPServer({ name: 'io.github.test/raw-name', display_name: undefined })];
+    renderTable({ servers });
+    expect(screen.getByText('io.github.test/raw-name')).toBeInTheDocument();
+  });
+
+  it('does not render data rows when loading', () => {
+    renderTable({ isLoading: true, servers: [] });
+    expect(screen.queryByText('Server A')).not.toBeInTheDocument();
+    const allRows = screen.getAllByRole('row');
+    expect(allRows.length).toBeGreaterThan(1);
+  });
+
+  it('renders empty state when no servers and not filtered', () => {
+    renderTable({ servers: [] });
+    expect(screen.getByText('Create and manage MCP servers using MLflow.')).toBeInTheDocument();
+  });
+
+  it('renders no-results state when filtered and empty', () => {
+    renderTable({ servers: [], isFiltered: true });
+    expect(screen.getByText('No servers found')).toBeInTheDocument();
+  });
+
+  it('renders server name in the table row', () => {
+    const servers = [createMockMCPServer({ name: 'test', display_name: 'My Server' })];
+    renderTable({ servers });
+    expect(screen.getByText('My Server')).toBeInTheDocument();
+  });
+
+  it('renders pagination controls', () => {
+    const servers = [createMockMCPServer()];
+    renderTable({ servers, hasNextPage: true });
+    expect(screen.getByText('Next')).toBeInTheDocument();
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+  });
+
+  it('calls onNextPage when Next is clicked', () => {
+    const onNextPage = jest.fn();
+    const servers = [createMockMCPServer()];
+    renderTable({ servers, hasNextPage: true, onNextPage });
+    screen.getByText('Next').click();
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPreviousPage when Previous is clicked', () => {
+    const onPreviousPage = jest.fn();
+    const servers = [createMockMCPServer()];
+    renderTable({ servers, hasPreviousPage: true, onPreviousPage });
+    screen.getByText('Previous').click();
+    expect(onPreviousPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders latest version column', () => {
+    const servers = [createMockMCPServer({ latest_version: '3.2.1' })];
+    renderTable({ servers });
+    expect(screen.getByText('3.2.1')).toBeInTheDocument();
+  });
+
+  it('renders em-dash when latest version is absent', () => {
+    const servers = [createMockMCPServer({ latest_version: undefined })];
+    renderTable({ servers });
+    const cells = screen.getAllByText('—');
+    expect(cells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders tags column', () => {
+    const servers = [createMockMCPServer({ tags: { env: 'staging' } })];
+    renderTable({ servers });
+    expect(screen.getByText('env: staging')).toBeInTheDocument();
+  });
+
+  it('renders last modified column with formatted timestamp', () => {
+    const servers = [createMockMCPServer({ last_updated_timestamp: 1620000000000 })];
+    renderTable({ servers });
+    const rows = screen.getAllByRole('row');
+    const dataRow = rows[rows.length - 1];
+    expect(dataRow.textContent).toMatch(/2021/);
+  });
+
+  it('does not show tooltip on description hover when not truncated', () => {
+    const servers = [createMockMCPServer({ description: 'Short' })];
+    renderTable({ servers });
+    const descriptionCell = screen.getByText('Short');
+
+    // scrollWidth equals clientWidth means no truncation
+    Object.defineProperty(descriptionCell, 'scrollWidth', { value: 100, configurable: true });
+    Object.defineProperty(descriptionCell, 'clientWidth', { value: 100, configurable: true });
+
+    fireEvent.mouseEnter(descriptionCell);
+
+    // Only one instance of the text (no tooltip duplicate)
+    expect(screen.getAllByText('Short').length).toBe(1);
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.test.tsx
@@ -40,24 +40,22 @@ describe('MCPServerListTable', () => {
     expect(screen.getByText('Tags')).toBeInTheDocument();
   });
 
-  it('renders server rows with display name and description', () => {
+  it('renders server rows with name and description', () => {
     const servers = [
       createMockMCPServer({
         name: 'io.github.test/server-a',
-        display_name: 'Server A',
         description: 'A test server',
         last_updated_timestamp: 1620000000000,
       }),
       createMockMCPServer({
         name: 'io.github.test/server-b',
-        display_name: 'Server B',
         description: 'Another test server',
       }),
     ];
     renderTable({ servers });
-    expect(screen.getByText('Server A')).toBeInTheDocument();
+    expect(screen.getByText('io.github.test/server-a')).toBeInTheDocument();
     expect(screen.getByText('A test server')).toBeInTheDocument();
-    expect(screen.getByText('Server B')).toBeInTheDocument();
+    expect(screen.getByText('io.github.test/server-b')).toBeInTheDocument();
     expect(screen.getByText('Another test server')).toBeInTheDocument();
   });
 
@@ -85,9 +83,9 @@ describe('MCPServerListTable', () => {
   });
 
   it('renders server name in the table row', () => {
-    const servers = [createMockMCPServer({ name: 'test', display_name: 'My Server' })];
+    const servers = [createMockMCPServer({ name: 'io.github.test/my-server' })];
     renderTable({ servers });
-    expect(screen.getByText('My Server')).toBeInTheDocument();
+    expect(screen.getByText('io.github.test/my-server')).toBeInTheDocument();
   });
 
   it('renders pagination controls', () => {

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.tsx
@@ -17,7 +17,6 @@ import { flexRender, getCoreRowModel } from '@tanstack/react-table';
 import { useIntl } from 'react-intl';
 
 import type { MCPServer } from '../types';
-import { resolveDisplayName } from '../utils';
 import { MCPServersEmptyState } from './MCPRegistryEmptyState';
 import { MCPServerIcon } from './MCPServerIcon';
 import { MCPServerTags } from './MCPServerTags';
@@ -79,7 +78,7 @@ const useMCPServerTableColumns = () => {
           defaultMessage: 'Name',
           description: 'Header for the name column in the MCP servers table',
         }),
-        accessorFn: (row) => resolveDisplayName(row),
+        accessorFn: (row) => row.name,
         id: 'name',
         cell: MCPServerNameCell,
       },

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerListTable.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useReactTable_unverifiedWithReact18 as useReactTable } from '@databricks/web-shared/react-table';
+import type { CursorPaginationProps } from '@databricks/design-system';
+import {
+  CursorPagination,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableSkeletonRows,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import { flexRender, getCoreRowModel } from '@tanstack/react-table';
+import { useIntl } from 'react-intl';
+
+import type { MCPServer } from '../types';
+import { resolveDisplayName } from '../utils';
+import { MCPServersEmptyState } from './MCPRegistryEmptyState';
+import { MCPServerIcon } from './MCPServerIcon';
+import { MCPServerTags } from './MCPServerTags';
+import { textEllipsisStyles } from '../styles';
+import Utils from '../../common/utils/Utils';
+
+const coreRowModel = getCoreRowModel<MCPServer>();
+const getRowId = (row: MCPServer) => row.name;
+
+const MCPServerNameCell = ({ getValue, row }: CellContext<MCPServer, unknown>) => {
+  const { theme } = useDesignSystemTheme();
+  const value = getValue() as string;
+  return (
+    <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+      <MCPServerIcon icons={row.original.icons} name={value} />
+      {value}
+    </span>
+  );
+};
+
+const MCPServerDescriptionCell = ({ getValue }: CellContext<MCPServer, unknown>) => {
+  const value = getValue() as string | undefined;
+  const ref = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const checkTruncation = useCallback(() => {
+    if (ref.current) {
+      setIsTruncated(ref.current.scrollWidth > ref.current.clientWidth);
+    }
+  }, []);
+
+  if (!value) return '—';
+
+  const content = (
+    <span ref={ref} onMouseEnter={checkTruncation} css={{ display: 'block', ...textEllipsisStyles }}>
+      {value}
+    </span>
+  );
+
+  return isTruncated ? (
+    <Tooltip content={value} componentId="mlflow.mcp_registry.table.description_tooltip">
+      {content}
+    </Tooltip>
+  ) : (
+    content
+  );
+};
+
+const MCPServerTagsCell = ({ row: { original } }: CellContext<MCPServer, unknown>) => {
+  return <MCPServerTags tags={original.tags || {}} />;
+};
+
+const useMCPServerTableColumns = () => {
+  const intl = useIntl();
+  return useMemo(() => {
+    const columns: ColumnDef<MCPServer>[] = [
+      {
+        header: intl.formatMessage({
+          defaultMessage: 'Name',
+          description: 'Header for the name column in the MCP servers table',
+        }),
+        accessorFn: (row) => resolveDisplayName(row),
+        id: 'name',
+        cell: MCPServerNameCell,
+      },
+      {
+        header: intl.formatMessage({
+          defaultMessage: 'Description',
+          description: 'Header for the description column in the MCP servers table',
+        }),
+        accessorKey: 'description',
+        id: 'description',
+        cell: MCPServerDescriptionCell,
+      },
+      {
+        header: intl.formatMessage({
+          defaultMessage: 'Latest version',
+          description: 'Header for the latest version column in the MCP servers table',
+        }),
+        id: 'latestVersion',
+        accessorFn: (row) => row.latest_version || '—',
+      },
+      {
+        header: intl.formatMessage({
+          defaultMessage: 'Last modified',
+          description: 'Header for the last modified column in the MCP servers table',
+        }),
+        id: 'lastModified',
+        accessorFn: ({ last_updated_timestamp }) =>
+          last_updated_timestamp ? Utils.formatTimestamp(last_updated_timestamp, intl) : '',
+      },
+      {
+        header: intl.formatMessage({
+          defaultMessage: 'Tags',
+          description: 'Header for the tags column in the MCP servers table',
+        }),
+        id: 'tags',
+        cell: MCPServerTagsCell,
+      },
+    ];
+    return columns;
+  }, [intl]);
+};
+
+export const MCPServerListTable = ({
+  servers,
+  hasNextPage,
+  hasPreviousPage,
+  isLoading,
+  isFiltered,
+  onNextPage,
+  onPreviousPage,
+  pageSizeSelect,
+}: {
+  servers?: MCPServer[];
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  isLoading?: boolean;
+  isFiltered?: boolean;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  pageSizeSelect?: CursorPaginationProps['pageSizeSelect'];
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const columns = useMCPServerTableColumns();
+
+  const table = useReactTable('mlflow/server/js/src/mcp-registry/components/MCPServerListTable.tsx', {
+    data: servers ?? [],
+    columns,
+    getCoreRowModel: coreRowModel,
+    getRowId,
+  });
+
+  const isEmptyList = !isLoading && (!servers || servers.length === 0);
+  const emptyState = isEmptyList ? (
+    <MCPServersEmptyState isFiltered={isFiltered} componentId="mlflow.mcp_registry.table.empty_state.create_server" />
+  ) : null;
+
+  return (
+    <Table
+      scrollable
+      pagination={
+        <CursorPagination
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
+          onNextPage={onNextPage}
+          onPreviousPage={onPreviousPage}
+          pageSizeSelect={pageSizeSelect}
+          componentId="mlflow.mcp_registry.table.pagination"
+        />
+      }
+      empty={emptyState}
+    >
+      <TableRow isHeader>
+        {table.getLeafHeaders().map((header) => (
+          <TableHeader componentId="mlflow.mcp_registry.table.header" key={header.id}>
+            {flexRender(header.column.columnDef.header, header.getContext())}
+          </TableHeader>
+        ))}
+      </TableRow>
+      {isLoading ? (
+        <TableSkeletonRows table={table} />
+      ) : (
+        table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id} css={{ height: theme.general.buttonHeight }}>
+            {row.getAllCells().map((cell) => (
+              <TableCell key={cell.id} css={{ alignItems: 'center' }}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))
+      )}
+    </Table>
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerTags.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerTags.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { MCPServerTags } from './MCPServerTags';
+
+const renderTags = (tags: Record<string, string>) =>
+  render(
+    <DesignSystemProvider>
+      <MCPServerTags tags={tags} />
+    </DesignSystemProvider>,
+  );
+
+describe('MCPServerTags', () => {
+  it('renders em-dash when tags are empty', () => {
+    const { container } = renderTags({});
+    expect(container.textContent).toBe('—');
+  });
+
+  it('renders key-value tags', () => {
+    renderTags({ env: 'production' });
+    expect(screen.getByText('env: production')).toBeInTheDocument();
+  });
+
+  it('renders key-only tag when value is empty', () => {
+    renderTags({ featured: '' });
+    expect(screen.getByText('featured')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/components/MCPServerTags.tsx
+++ b/mlflow/server/js/src/mcp-registry/components/MCPServerTags.tsx
@@ -1,0 +1,15 @@
+import { Overflow, Tag } from '@databricks/design-system';
+
+export const MCPServerTags = ({ tags }: { tags: Record<string, string> }) => {
+  const entries = Object.entries(tags);
+  if (entries.length === 0) return <span aria-label="No tags">—</span>;
+  return (
+    <Overflow noMargin>
+      {entries.map(([key, value]) => (
+        <Tag key={key} componentId="mlflow.mcp_registry.tag">
+          {value ? `${key}: ${value}` : key}
+        </Tag>
+      ))}
+    </Overflow>
+  );
+};

--- a/mlflow/server/js/src/mcp-registry/hooks/useMCPServersListQuery.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/hooks/useMCPServersListQuery.test.tsx
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { IntlProvider } from 'react-intl';
+import { getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { setupServer } from '../../common/utils/setup-msw';
+import { useMCPServersListQuery } from './useMCPServersListQuery';
+import { createMockMCPServer } from '../test-utils';
+
+const BASE_URL = 'ajax-api/3.0/mlflow/mcp-servers';
+
+describe('useMCPServersListQuery', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const mockServer = setupServer(
+    rest.get(getAjaxUrl(BASE_URL), (_req, res, ctx) =>
+      res(ctx.json({ mcp_servers: [createMockMCPServer()], next_page_token: 'page-2-token' })),
+    ),
+  );
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: React.ReactNode }) => (
+      <IntlProvider locale="en">
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </IntlProvider>
+    );
+  };
+
+  it('returns data and pagination state on initial load', async () => {
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.hasNextPage).toBe(true);
+    expect(result.current.hasPreviousPage).toBe(false);
+  });
+
+  it('navigates to next page and back using token stack', async () => {
+    const capturedTokens: (string | null)[] = [];
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedTokens.push(req.url.searchParams.get('page_token'));
+        const token = req.url.searchParams.get('page_token');
+        if (token === 'page-2-token') {
+          return res(
+            ctx.json({ mcp_servers: [createMockMCPServer({ name: 'page2' })], next_page_token: 'page-3-token' }),
+          );
+        }
+        return res(
+          ctx.json({ mcp_servers: [createMockMCPServer({ name: 'page1' })], next_page_token: 'page-2-token' }),
+        );
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Go to page 2
+    act(() => {
+      result.current.onNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.[0]?.name).toBe('page2');
+    });
+    expect(result.current.hasPreviousPage).toBe(true);
+
+    // Go back to page 1
+    act(() => {
+      result.current.onPreviousPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.[0]?.name).toBe('page1');
+    });
+    expect(result.current.hasPreviousPage).toBe(false);
+  });
+
+  it('resets pagination when searchFilter changes', async () => {
+    const capturedTokens: (string | null)[] = [];
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedTokens.push(req.url.searchParams.get('page_token'));
+        return res(ctx.json({ mcp_servers: [createMockMCPServer()], next_page_token: 'next' }));
+      }),
+    );
+
+    let searchFilter = '';
+    const { result, rerender } = renderHook(() => useMCPServersListQuery({ searchFilter }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Navigate to page 2
+    act(() => {
+      result.current.onNextPage();
+    });
+
+    await waitFor(() => {
+      expect(capturedTokens).toContain('next');
+    });
+
+    // Change filter — should reset
+    searchFilter = 'new-filter';
+    rerender();
+
+    await waitFor(() => {
+      const lastToken = capturedTokens[capturedTokens.length - 1];
+      expect(lastToken).toBeNull();
+    });
+    expect(result.current.hasPreviousPage).toBe(false);
+  });
+
+  it('provides pageSizeSelect config with correct defaults', async () => {
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.pageSizeSelect).toBeDefined();
+    expect(result.current.pageSizeSelect!.options).toEqual([10, 25, 50, 100]);
+    expect(result.current.pageSizeSelect!.default).toBe(25);
+  });
+
+  it('resets pagination when page size changes', async () => {
+    const capturedParams: { token: string | null; maxResults: string | null }[] = [];
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedParams.push({
+          token: req.url.searchParams.get('page_token'),
+          maxResults: req.url.searchParams.get('max_results'),
+        });
+        return res(ctx.json({ mcp_servers: [createMockMCPServer()], next_page_token: 'next' }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Navigate to page 2
+    act(() => {
+      result.current.onNextPage();
+    });
+
+    await waitFor(() => {
+      expect(capturedParams.some((p) => p.token === 'next')).toBe(true);
+    });
+
+    // Change page size — should reset token and use new max_results
+    act(() => {
+      result.current.pageSizeSelect!.onChange(50);
+    });
+
+    await waitFor(() => {
+      const lastParam = capturedParams[capturedParams.length - 1];
+      expect(lastParam.token).toBeNull();
+      expect(lastParam.maxResults).toBe('50');
+    });
+  });
+
+  it('sends max_results matching default page size', async () => {
+    let capturedMaxResults: string | null = null;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedMaxResults = req.url.searchParams.get('max_results');
+        return res(ctx.json({ mcp_servers: [createMockMCPServer()], next_page_token: undefined }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(capturedMaxResults).toBe('25');
+  });
+
+  it('returns error when API fails', async () => {
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (_req, res, ctx) => res(ctx.status(500), ctx.json({ message: 'Server error' }))),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('wraps plain text search in ILIKE clause', async () => {
+    let capturedFilter: string | null = null;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter_string');
+        return res(ctx.json({ mcp_servers: [], next_page_token: undefined }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({ searchFilter: 'github' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(capturedFilter).toBe("name ILIKE '%github%'");
+  });
+
+  it('passes SQL filter syntax through without modification', async () => {
+    let capturedFilter: string | null = null;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter_string');
+        return res(ctx.json({ mcp_servers: [], next_page_token: undefined }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({ searchFilter: "tags.env = 'production'" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(capturedFilter).toBe("tags.env = 'production'");
+  });
+
+  it('escapes ILIKE wildcards in plain text search', async () => {
+    let capturedFilter: string | null = null;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter_string');
+        return res(ctx.json({ mcp_servers: [], next_page_token: undefined }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({ searchFilter: 'my_server%' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(capturedFilter).toBe("name ILIKE '%my\\_server\\%%'");
+  });
+
+  it('ignores onNextPage while query is fetching', async () => {
+    let callCount = 0;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        callCount++;
+        const token = req.url.searchParams.get('page_token');
+        if (token) {
+          // Delay page-2 response so isFetching stays true during the second click
+          return res(
+            ctx.delay(500),
+            ctx.json({ mcp_servers: [createMockMCPServer({ name: 'page2' })], next_page_token: 'page-3' }),
+          );
+        }
+        return res(ctx.json({ mcp_servers: [createMockMCPServer()], next_page_token: 'page-2' }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    const callsAfterInitialLoad = callCount;
+
+    // First click triggers fetch for page 2 (slow response)
+    act(() => {
+      result.current.onNextPage();
+    });
+    // Second click should be ignored because isFetching is true
+    act(() => {
+      result.current.onNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.[0]?.name).toBe('page2');
+    });
+
+    // Only one additional API call should have been made (the second click was ignored)
+    expect(callCount - callsAfterInitialLoad).toBe(1);
+  });
+
+  it('escapes single quotes in plain text search', async () => {
+    let capturedFilter: string | null = null;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter_string');
+        return res(ctx.json({ mcp_servers: [], next_page_token: undefined }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({ searchFilter: "O'Brien" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(capturedFilter).toBe("name ILIKE '%O''Brien%'");
+  });
+
+  it('ignores onPreviousPage while query is fetching', async () => {
+    let requestCount = 0;
+    mockServer.use(
+      rest.get(getAjaxUrl(BASE_URL), (req, res, ctx) => {
+        requestCount++;
+        const token = req.url.searchParams.get('page_token');
+        if (token === 'page-2') {
+          // Delay page 2 response so isFetching stays true
+          return res(
+            ctx.delay(500),
+            ctx.json({ mcp_servers: [createMockMCPServer({ name: 'page2' })], next_page_token: undefined }),
+          );
+        }
+        return res(ctx.json({ mcp_servers: [createMockMCPServer()], next_page_token: 'page-2' }));
+      }),
+    );
+
+    const { result } = renderHook(() => useMCPServersListQuery({}), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Navigate to page 2 (slow response)
+    act(() => {
+      result.current.onNextPage();
+    });
+
+    // Immediately try going back while page 2 is still fetching
+    act(() => {
+      result.current.onPreviousPage();
+    });
+
+    // Wait for page 2 to arrive
+    await waitFor(() => {
+      expect(result.current.data?.[0]?.name).toBe('page2');
+    });
+
+    // Should still be on page 2 (onPreviousPage was ignored)
+    expect(result.current.hasPreviousPage).toBe(true);
+  });
+});

--- a/mlflow/server/js/src/mcp-registry/hooks/useMCPServersListQuery.ts
+++ b/mlflow/server/js/src/mcp-registry/hooks/useMCPServersListQuery.ts
@@ -1,0 +1,88 @@
+import type { QueryFunctionContext } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocalStorage } from '@databricks/web-shared/hooks';
+import type { CursorPaginationProps } from '@databricks/design-system';
+import { MCPRegistryApi } from '../api';
+import type { SearchMCPServersResponse } from '../types';
+import { buildSearchFilterClause } from '../../common/utils/SearchUtils';
+
+const DEFAULT_PAGE_SIZE = 25;
+const STORE_KEY = 'mcp_registry.page_size';
+
+type MCPServersListQueryKey = ['mcp_servers_list', { searchFilter?: string; pageToken?: string; pageSize: number }];
+
+const queryFn = ({ queryKey }: QueryFunctionContext<MCPServersListQueryKey>) => {
+  const [, { searchFilter, pageToken, pageSize }] = queryKey;
+  return MCPRegistryApi.searchMCPServers({
+    filter_string: buildSearchFilterClause(searchFilter),
+    page_token: pageToken,
+    max_results: pageSize,
+  });
+};
+
+export const useMCPServersListQuery = ({
+  searchFilter,
+  enabled = true,
+}: { searchFilter?: string; enabled?: boolean } = {}) => {
+  const previousPageTokens = useRef<(string | undefined)[]>([]);
+  const [currentPageToken, setCurrentPageToken] = useState<string | undefined>(undefined);
+
+  const [pageSize, setPageSize] = useLocalStorage({
+    key: STORE_KEY,
+    version: 0,
+    initialValue: DEFAULT_PAGE_SIZE,
+  });
+
+  useEffect(() => {
+    setCurrentPageToken(undefined);
+    previousPageTokens.current = [];
+  }, [searchFilter]);
+
+  const pageSizeSelect = useMemo<CursorPaginationProps['pageSizeSelect']>(
+    () => ({
+      options: [10, 25, 50, 100],
+      default: pageSize,
+      onChange(newPageSize) {
+        setPageSize(newPageSize);
+        setCurrentPageToken(undefined);
+        previousPageTokens.current = [];
+      },
+    }),
+    [pageSize, setPageSize],
+  );
+
+  const queryResult = useQuery<SearchMCPServersResponse, Error, SearchMCPServersResponse, MCPServersListQueryKey>(
+    ['mcp_servers_list', { searchFilter, pageToken: currentPageToken, pageSize }],
+    {
+      queryFn,
+      retry: false,
+      keepPreviousData: true,
+      enabled,
+    },
+  );
+
+  const onNextPage = useCallback(() => {
+    if (queryResult.isFetching) return;
+    previousPageTokens.current.push(currentPageToken);
+    setCurrentPageToken(queryResult.data?.next_page_token ?? undefined);
+  }, [queryResult.data?.next_page_token, queryResult.isFetching, currentPageToken]);
+
+  const onPreviousPage = useCallback(() => {
+    if (queryResult.isFetching) return;
+    const previousPageToken = previousPageTokens.current.pop();
+    setCurrentPageToken(previousPageToken);
+  }, [queryResult.isFetching]);
+
+  return {
+    data: queryResult.data?.mcp_servers,
+    error: queryResult.error ?? undefined,
+    isLoading: queryResult.isLoading,
+    hasNextPage: Boolean(queryResult.data?.next_page_token),
+    hasPreviousPage: Boolean(currentPageToken),
+    onNextPage,
+    onPreviousPage,
+    pageSizeSelect,
+    refetch: queryResult.refetch,
+  };
+};

--- a/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.test.tsx
@@ -7,7 +7,13 @@ import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/util
 import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
 import { setupServer } from '../../common/utils/setup-msw';
 import MCPRegistryPage from './MCPRegistryPage';
-import { getMockedSearchMCPServersResponse } from '../test-utils';
+import { rest } from 'msw';
+import { getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import {
+  createMockMCPServer,
+  getMockedSearchMCPServersResponse,
+  getMockedSearchMCPServersErrorResponse,
+} from '../test-utils';
 
 describe('MCPRegistryPage', () => {
   const server = setupServer(getMockedSearchMCPServersResponse([]));
@@ -34,18 +40,50 @@ describe('MCPRegistryPage', () => {
     });
   };
 
-  it('renders page title', async () => {
+  it('renders page title and tabs', async () => {
     renderPage();
     await waitFor(() => {
       expect(screen.getByText('MCP Registry')).toBeInTheDocument();
     });
+    expect(screen.getByText('Servers')).toBeInTheDocument();
+    expect(screen.getByText('Access Bindings')).toBeInTheDocument();
   });
 
-  it('renders both tabs', async () => {
+  it('shows empty state on servers tab when no servers exist', async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText('Servers')).toBeInTheDocument();
-      expect(screen.getByText('Access Bindings')).toBeInTheDocument();
+      expect(screen.getByText('Create and manage MCP servers using MLflow.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders server cards when data is available', async () => {
+    const servers = [
+      createMockMCPServer({ name: 'server-1', display_name: 'My Server 1' }),
+      createMockMCPServer({ name: 'server-2', display_name: 'My Server 2' }),
+    ];
+    server.use(getMockedSearchMCPServersResponse(servers));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('My Server 1')).toBeInTheDocument();
+      expect(screen.getByText('My Server 2')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Create MCP server button when servers exist', async () => {
+    const servers = [createMockMCPServer({ name: 's1', display_name: 'Server 1' })];
+    server.use(getMockedSearchMCPServersResponse(servers));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Server 1')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Create MCP server')).toBeInTheDocument();
+  });
+
+  it('renders error alert when API fails', async () => {
+    server.use(getMockedSearchMCPServersErrorResponse(500, 'Something broke'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Something broke')).toBeInTheDocument();
     });
   });
 
@@ -56,6 +94,13 @@ describe('MCPRegistryPage', () => {
     });
   });
 
+  it('shows empty state on access bindings tab when no servers exist', async () => {
+    renderPage(['/?tab=bindings']);
+    await waitFor(() => {
+      expect(screen.getByText('Create and manage access bindings for your MCP servers.')).toBeInTheDocument();
+    });
+  });
+
   it('switches to access bindings tab', async () => {
     renderPage();
     await waitFor(() => {
@@ -63,22 +108,80 @@ describe('MCPRegistryPage', () => {
     });
 
     await userEvent.click(screen.getByText('Access Bindings'));
+
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Search access bindings')).toBeInTheDocument();
     });
   });
 
-  it('shows empty state on servers tab when no servers exist', async () => {
+  it('does not show header create button in empty state', async () => {
     renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Create and manage MCP servers using MLflow.')).toBeInTheDocument();
+    });
+    // The empty state has a title and a CTA button both saying "Create MCP server" (2 elements).
+    // The header create button is a third one that should NOT exist in empty state.
+    const createTexts = screen.getAllByText('Create MCP server');
+    expect(createTexts).toHaveLength(2);
+  });
+
+  it('shows empty state in list view when no servers exist', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('MCP Registry')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText('List view'));
+
     await waitFor(() => {
       expect(screen.getByText('Create and manage MCP servers using MLflow.')).toBeInTheDocument();
     });
   });
 
-  it('shows empty state on access bindings tab when no servers exist', async () => {
-    renderPage(['/?tab=bindings']);
+  it('filters servers via search input', async () => {
+    let capturedFilter: string | null = null;
+    server.use(
+      rest.get(getAjaxUrl('ajax-api/3.0/mlflow/mcp-servers'), (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter_string');
+        return res(ctx.json({ mcp_servers: [], next_page_token: undefined }));
+      }),
+    );
+    renderPage();
+
     await waitFor(() => {
-      expect(screen.getByText('Create and manage access bindings for your MCP servers.')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search MCP servers by name')).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByPlaceholderText('Search MCP servers by name'), 'github');
+
+    await waitFor(() => {
+      expect(capturedFilter).toBe("name ILIKE '%github%'");
+    });
+  });
+
+  it('switches between grid and list views', async () => {
+    const servers = [createMockMCPServer({ name: 's1', display_name: 'Server 1' })];
+    server.use(getMockedSearchMCPServersResponse(servers));
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Server 1')).toBeInTheDocument();
+    });
+
+    // Default is grid, switch to list
+    await userEvent.click(screen.getByLabelText('List view'));
+
+    // Table headers should appear in list view
+    await waitFor(() => {
+      expect(screen.getByText('Latest version')).toBeInTheDocument();
+      expect(screen.getByText('Last modified')).toBeInTheDocument();
+    });
+
+    // Switch back to grid
+    await userEvent.click(screen.getByLabelText('Grid view'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Latest version')).not.toBeInTheDocument();
     });
   });
 });

--- a/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.test.tsx
+++ b/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.test.tsx
@@ -57,24 +57,21 @@ describe('MCPRegistryPage', () => {
   });
 
   it('renders server cards when data is available', async () => {
-    const servers = [
-      createMockMCPServer({ name: 'server-1', display_name: 'My Server 1' }),
-      createMockMCPServer({ name: 'server-2', display_name: 'My Server 2' }),
-    ];
+    const servers = [createMockMCPServer({ name: 'server-1' }), createMockMCPServer({ name: 'server-2' })];
     server.use(getMockedSearchMCPServersResponse(servers));
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText('My Server 1')).toBeInTheDocument();
-      expect(screen.getByText('My Server 2')).toBeInTheDocument();
+      expect(screen.getByText('server-1')).toBeInTheDocument();
+      expect(screen.getByText('server-2')).toBeInTheDocument();
     });
   });
 
   it('shows Create MCP server button when servers exist', async () => {
-    const servers = [createMockMCPServer({ name: 's1', display_name: 'Server 1' })];
+    const servers = [createMockMCPServer({ name: 'server-1' })];
     server.use(getMockedSearchMCPServersResponse(servers));
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText('Server 1')).toBeInTheDocument();
+      expect(screen.getByText('server-1')).toBeInTheDocument();
     });
     expect(screen.getByText('Create MCP server')).toBeInTheDocument();
   });
@@ -160,12 +157,12 @@ describe('MCPRegistryPage', () => {
   });
 
   it('switches between grid and list views', async () => {
-    const servers = [createMockMCPServer({ name: 's1', display_name: 'Server 1' })];
+    const servers = [createMockMCPServer({ name: 'server-1' })];
     server.use(getMockedSearchMCPServersResponse(servers));
     renderPage();
 
     await waitFor(() => {
-      expect(screen.getByText('Server 1')).toBeInTheDocument();
+      expect(screen.getByText('server-1')).toBeInTheDocument();
     });
 
     // Default is grid, switch to list

--- a/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.tsx
+++ b/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import {
+  Alert,
   Button,
-  Empty,
   GridIcon,
   Header,
   ListIcon,
@@ -24,25 +24,16 @@ import { ScrollablePageWrapper } from '../../common/components/ScrollablePageWra
 import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../common/utils/ErrorUtils';
 import { useSearchParams } from '../../common/utils/RoutingUtils';
+import { useMCPServersListQuery } from '../hooks/useMCPServersListQuery';
+import { MCPServerCardGrid } from '../components/MCPServerCardGrid';
+import { MCPServerListTable } from '../components/MCPServerListTable';
+import { MCPServerListFilters } from '../components/MCPServerListFilters';
+import { MCPRegistryEmptyState } from '../components/MCPRegistryEmptyState';
+import { flexColumnContainerStyles, headerIconStyles } from '../styles';
+import { useDebounce } from 'use-debounce';
 
 type ViewMode = 'list' | 'grid';
 type ActiveTab = 'servers' | 'bindings';
-
-const emptyCenterStyles = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  height: '100%',
-  minHeight: 400,
-  width: '100%',
-  '& > div': {
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column' as const,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-};
 
 const MCPRegistryPage = () => {
   const { theme } = useDesignSystemTheme();
@@ -50,8 +41,23 @@ const MCPRegistryPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const tabFromUrl = searchParams.get('tab');
   const activeTab: ActiveTab = tabFromUrl === 'bindings' ? 'bindings' : 'servers';
-  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const [searchFilter, setSearchFilter] = useState('');
+  const [debouncedSearchFilter] = useDebounce(searchFilter, 500);
+
+  const {
+    data: servers,
+    isLoading,
+    error,
+    hasNextPage,
+    hasPreviousPage,
+    onNextPage,
+    onPreviousPage,
+    pageSizeSelect,
+  } = useMCPServersListQuery({
+    searchFilter: activeTab === 'servers' ? debouncedSearchFilter : undefined,
+    enabled: activeTab === 'servers',
+  });
 
   const handleTabChange = useCallback(
     (e: RadioChangeEvent) => {
@@ -68,9 +74,8 @@ const MCPRegistryPage = () => {
     [searchParams, setSearchParams],
   );
 
-  // TODO: show create button only when server list is non-empty (matches PromptsPage pattern)
-  const isEmptyState = true;
-  const createButton = !isEmptyState ? (
+  const hideCreateButton = !isLoading && !servers?.length && !debouncedSearchFilter;
+  const createButton = !hideCreateButton ? (
     <Button componentId="mlflow.mcp_registry.create_server_button" type="primary" disabled>
       <FormattedMessage defaultMessage="Create MCP server" description="Button to create a new MCP server" />
     </Button>
@@ -82,14 +87,7 @@ const MCPRegistryPage = () => {
       <Header
         title={
           <span css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
-            <span
-              css={{
-                display: 'flex',
-                borderRadius: theme.borders.borderRadiusSm,
-                backgroundColor: theme.colors.backgroundSecondary,
-                padding: theme.spacing.sm,
-              }}
-            >
+            <span css={headerIconStyles(theme)}>
               <WrenchIcon />
             </span>
             <FormattedMessage defaultMessage="MCP Registry" description="MCP Registry page title" />
@@ -98,7 +96,7 @@ const MCPRegistryPage = () => {
         buttons={createButton}
       />
       <Spacer shrinks={false} />
-      <div css={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <div css={flexColumnContainerStyles}>
         <SegmentedControlGroup
           name="mcp-registry-tabs"
           value={activeTab}
@@ -114,22 +112,22 @@ const MCPRegistryPage = () => {
         </SegmentedControlGroup>
 
         {activeTab === 'servers' && (
-          <>
+          <div css={flexColumnContainerStyles}>
             <div
-              css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm, paddingTop: theme.spacing.md }}
+              css={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: theme.spacing.sm,
+                paddingTop: theme.spacing.md,
+                flexShrink: 0,
+              }}
             >
               <div css={{ flex: 1 }}>
-                <TableFilterLayout>
-                  <TableFilterInput
-                    placeholder={intl.formatMessage({
-                      defaultMessage: 'Search MCP servers by name',
-                      description: 'Placeholder for MCP server search filter input',
-                    })}
-                    componentId="mlflow.mcp_registry.search"
-                    value={searchFilter}
-                    onChange={(e) => setSearchFilter(e.target.value)}
-                  />
-                </TableFilterLayout>
+                <MCPServerListFilters
+                  searchFilter={searchFilter}
+                  onSearchFilterChange={setSearchFilter}
+                  componentId="mlflow.mcp_registry.search"
+                />
               </div>
               <SegmentedControlGroup
                 name="mcp-registry-view-mode"
@@ -155,61 +153,39 @@ const MCPRegistryPage = () => {
                 />
               </SegmentedControlGroup>
             </div>
-            <Table
-              scrollable
-              empty={
-                <div css={emptyCenterStyles}>
-                  <Empty
-                    title={
-                      <FormattedMessage
-                        defaultMessage="Create MCP server"
-                        description="Empty state title for MCP servers tab"
-                      />
-                    }
-                    description={
-                      <FormattedMessage
-                        defaultMessage="Create and manage MCP servers using MLflow."
-                        description="Empty state description for MCP servers tab"
-                      />
-                    }
-                    button={
-                      <Button
-                        componentId="mlflow.mcp_registry.empty_state.create_server"
-                        type="primary"
-                        icon={<PlusIcon />}
-                        disabled
-                      >
-                        <FormattedMessage
-                          defaultMessage="Create MCP server"
-                          description="MCP Registry empty state CTA button"
-                        />
-                      </Button>
-                    }
-                  />
-                </div>
-              }
-            >
-              {viewMode === 'list' && (
-                <TableRow isHeader>
-                  <TableHeader componentId="mlflow.mcp_registry.table.header.name">
-                    <FormattedMessage defaultMessage="Name" description="MCP servers table header for name column" />
-                  </TableHeader>
-                  <TableHeader componentId="mlflow.mcp_registry.table.header.description">
-                    <FormattedMessage
-                      defaultMessage="Description"
-                      description="MCP servers table header for description column"
-                    />
-                  </TableHeader>
-                  <TableHeader componentId="mlflow.mcp_registry.table.header.last_modified">
-                    <FormattedMessage
-                      defaultMessage="Last modified"
-                      description="MCP servers table header for last modified column"
-                    />
-                  </TableHeader>
-                </TableRow>
-              )}
-            </Table>
-          </>
+            {error?.message && (
+              <Alert
+                type="error"
+                message={error.message}
+                componentId="mlflow.mcp_registry.error"
+                closable={false}
+                css={{ marginTop: theme.spacing.sm, flexShrink: 0 }}
+              />
+            )}
+            {viewMode === 'grid' ? (
+              <MCPServerCardGrid
+                servers={servers}
+                isLoading={isLoading}
+                isFiltered={Boolean(debouncedSearchFilter)}
+                hasNextPage={hasNextPage}
+                hasPreviousPage={hasPreviousPage}
+                onNextPage={onNextPage}
+                onPreviousPage={onPreviousPage}
+                pageSizeSelect={pageSizeSelect}
+              />
+            ) : (
+              <MCPServerListTable
+                servers={servers}
+                hasNextPage={hasNextPage}
+                hasPreviousPage={hasPreviousPage}
+                isLoading={isLoading}
+                isFiltered={Boolean(debouncedSearchFilter)}
+                onNextPage={onNextPage}
+                onPreviousPage={onPreviousPage}
+                pageSizeSelect={pageSizeSelect}
+              />
+            )}
+          </div>
         )}
 
         {activeTab === 'bindings' && (
@@ -230,35 +206,33 @@ const MCPRegistryPage = () => {
             <Table
               scrollable
               empty={
-                <div css={emptyCenterStyles}>
-                  <Empty
-                    title={
+                <MCPRegistryEmptyState
+                  title={
+                    <FormattedMessage
+                      defaultMessage="Create access binding"
+                      description="Empty state title for MCP access bindings tab"
+                    />
+                  }
+                  description={
+                    <FormattedMessage
+                      defaultMessage="Create and manage access bindings for your MCP servers."
+                      description="Empty state description for MCP access bindings tab"
+                    />
+                  }
+                  button={
+                    <Button
+                      componentId="mlflow.mcp_registry.bindings.empty_state.create"
+                      type="primary"
+                      icon={<PlusIcon />}
+                      disabled
+                    >
                       <FormattedMessage
                         defaultMessage="Create access binding"
-                        description="Empty state title for MCP access bindings tab"
+                        description="MCP Registry bindings empty state CTA button"
                       />
-                    }
-                    description={
-                      <FormattedMessage
-                        defaultMessage="Create and manage access bindings for your MCP servers."
-                        description="Empty state description for MCP access bindings tab"
-                      />
-                    }
-                    button={
-                      <Button
-                        componentId="mlflow.mcp_registry.bindings.empty_state.create"
-                        type="primary"
-                        icon={<PlusIcon />}
-                        disabled
-                      >
-                        <FormattedMessage
-                          defaultMessage="Create access binding"
-                          description="MCP Registry bindings empty state CTA button"
-                        />
-                      </Button>
-                    }
-                  />
-                </div>
+                    </Button>
+                  }
+                />
               }
             >
               <TableRow isHeader>

--- a/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.tsx
+++ b/mlflow/server/js/src/mcp-registry/pages/MCPRegistryPage.tsx
@@ -162,29 +162,30 @@ const MCPRegistryPage = () => {
                 css={{ marginTop: theme.spacing.sm, flexShrink: 0 }}
               />
             )}
-            {viewMode === 'grid' ? (
-              <MCPServerCardGrid
-                servers={servers}
-                isLoading={isLoading}
-                isFiltered={Boolean(debouncedSearchFilter)}
-                hasNextPage={hasNextPage}
-                hasPreviousPage={hasPreviousPage}
-                onNextPage={onNextPage}
-                onPreviousPage={onPreviousPage}
-                pageSizeSelect={pageSizeSelect}
-              />
-            ) : (
-              <MCPServerListTable
-                servers={servers}
-                hasNextPage={hasNextPage}
-                hasPreviousPage={hasPreviousPage}
-                isLoading={isLoading}
-                isFiltered={Boolean(debouncedSearchFilter)}
-                onNextPage={onNextPage}
-                onPreviousPage={onPreviousPage}
-                pageSizeSelect={pageSizeSelect}
-              />
-            )}
+            {!error &&
+              (viewMode === 'grid' ? (
+                <MCPServerCardGrid
+                  servers={servers}
+                  isLoading={isLoading}
+                  isFiltered={Boolean(debouncedSearchFilter)}
+                  hasNextPage={hasNextPage}
+                  hasPreviousPage={hasPreviousPage}
+                  onNextPage={onNextPage}
+                  onPreviousPage={onPreviousPage}
+                  pageSizeSelect={pageSizeSelect}
+                />
+              ) : (
+                <MCPServerListTable
+                  servers={servers}
+                  hasNextPage={hasNextPage}
+                  hasPreviousPage={hasPreviousPage}
+                  isLoading={isLoading}
+                  isFiltered={Boolean(debouncedSearchFilter)}
+                  onNextPage={onNextPage}
+                  onPreviousPage={onPreviousPage}
+                  pageSizeSelect={pageSizeSelect}
+                />
+              ))}
           </div>
         )}
 

--- a/mlflow/server/js/src/mcp-registry/styles.ts
+++ b/mlflow/server/js/src/mcp-registry/styles.ts
@@ -1,0 +1,75 @@
+import type { ThemeType } from '@databricks/design-system';
+
+// Omits height: '100%' from the CLAUDE.md empty-state pattern so the empty state
+// sits near the top in both grid and table views instead of centering vertically.
+export const emptyCenterStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: 400,
+  width: '100%',
+  '& > div': {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+};
+
+export const cardGridStyles = (theme: ThemeType) => ({
+  flex: '0 1 auto',
+  overflow: 'auto',
+  minHeight: 0,
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+  gap: theme.spacing.md,
+  paddingTop: theme.spacing.md,
+});
+
+export const textClampStyles = (lines: number) => ({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  display: '-webkit-box',
+  WebkitLineClamp: lines,
+  WebkitBoxOrient: 'vertical' as const,
+});
+
+export const textEllipsisStyles = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap' as const,
+};
+
+export const flexColumnContainerStyles = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column' as const,
+  overflow: 'hidden',
+};
+
+export const mcpIconStyles = (theme: ThemeType) => ({
+  flexShrink: 0,
+  color: theme.colors.textSecondary,
+});
+
+export const headerIconStyles = (theme: ThemeType) => ({
+  display: 'flex',
+  borderRadius: theme.borders.borderRadiusSm,
+  backgroundColor: theme.colors.backgroundSecondary,
+  padding: theme.spacing.sm,
+});
+
+export const cardBodyStyles = (theme: ThemeType) => ({
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: theme.spacing.xs,
+  overflow: 'hidden',
+  flex: 1,
+});
+
+export const cardHeaderRowStyles = (theme: ThemeType) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.spacing.sm,
+});

--- a/mlflow/server/js/src/mcp-registry/utils.ts
+++ b/mlflow/server/js/src/mcp-registry/utils.ts
@@ -1,0 +1,3 @@
+export const resolveDisplayName = (server: { display_name?: string; name: string }): string => {
+  return server.display_name || server.name;
+};

--- a/mlflow/server/js/src/mcp-registry/utils.ts
+++ b/mlflow/server/js/src/mcp-registry/utils.ts
@@ -1,3 +1,0 @@
-export const resolveDisplayName = (server: { display_name?: string; name: string }): string => {
-  return server.display_name || server.name;
-};


### PR DESCRIPTION

  ### Related Issues/PRs

  Relates to #24145

  ### What changes are proposed in this pull request?

  Builds on the MCP Registry UI foundation from #24145 to implement the servers tab with full data fetching, display, and interaction.

https://github.com/user-attachments/assets/242eb8ef-1ab6-4ce6-a4ef-6f539a1d2b6d


  **Server list views**
  - Card grid view with responsive auto-fill layout and cursor pagination
  - Table list view with 5 columns: Name, Description, Latest version, Last modified, Tags
  - Toggle to switch between grid and table views
  - Per-server icons with dark/light mode support and fallback to McpIcon

  **Search**
  - Debounced search input (500ms) with SQL filter syntax help tooltip
  - Plain text auto-wraps as `name ILIKE '%text%'` with proper wildcard escaping
  - SQL syntax (e.g. `tags.env = "production"`) passes through as-is

  **Pagination**
  - Cursor-based pagination with Next/Previous and configurable page size (10/25/50/100)
  - Page size persisted in localStorage
  - isFetching guard prevents pagination corruption from rapid clicks

  **Shared components**
  - `MCPServerIcon` — resolves dark/light theme icons with img fallback
  - `MCPServerTags` — renders key-value tags with Overflow
  - `MCPRegistryEmptyState` — centered empty state wrapper
  - `MCPServerListFilters` — search input with SQL help tooltip
  - `styles.ts` — shared style constants

  ### How is this PR tested?

  - [ ] Existing unit/integration tests
  - [x] New unit/integration tests
  - [x] Manual tests

  ### Does this PR require documentation update?

  - [x] No.
  - [ ] Yes. I've updated:
    - [ ] Examples
    - [ ] API references
    - [ ] Instructions

  ### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

  - [x] No.
  - [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

  ### Release Notes

  #### Is this a user-facing change?

  - [x] Yes. Adds server list views with search, pagination, and card/table display to the MCP Registry page.

  #### What component(s), interfaces, languages, and integrations does this PR affect?

  Components

  - [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
  - [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
  - [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
  - [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
  - [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
  - [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
  - [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
  - [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
  - [ ] `area/projects`: MLproject format, project running backends
  - [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
  - [ ] `area/build`: Build and test infrastructure for MLflow
  - [ ] `area/docs`: MLflow documentation pages

  <a name="release-note-category"></a>

  #### How should the PR be classified in the release notes? Choose one:

  - [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
  - [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
  - [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
  - [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
  - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

  #### Is this PR a critical bugfix or security fix that should go into the next patch release?

  - [ ] This PR is critical and needs to be in the next patch release
  - [x] This PR can wait for the next minor release