### PR TITLE
Add recovery hint to deleted-experiment errors in tracking stores

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -737,7 +737,10 @@ class FileStore(AbstractStore):
             )
         if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise MlflowException(
-                f"Could not create run under non-active experiment with ID {experiment_id}.",
+                f"Could not create run under non-active experiment with ID {experiment_id}. "
+                "The experiment has been deleted; restore it with "
+                f"`MlflowClient().restore_experiment('{experiment_id}')` or use an active "
+                "experiment.",
                 databricks_pb2.INVALID_STATE,
             )
         tags = tags or []

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -738,9 +738,8 @@ class FileStore(AbstractStore):
         if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise MlflowException(
                 f"Could not create run under non-active experiment with ID {experiment_id}. "
-                "The experiment has been deleted; restore it with "
-                f"`MlflowClient().restore_experiment('{experiment_id}')` or use an active "
-                "experiment.",
+                f"Restore it with `MlflowClient().restore_experiment('{experiment_id}')` "
+                "or use an active experiment.",
                 databricks_pb2.INVALID_STATE,
             )
         tags = tags or []

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1076,7 +1076,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             raise MlflowException(
                 (
                     f"The experiment {experiment.experiment_id} must be in the 'active' state. "
-                    f"Current state is {experiment.lifecycle_stage}."
+                    f"Current state is {experiment.lifecycle_stage}. Restore it with "
+                    f"`MlflowClient().restore_experiment('{experiment.experiment_id}')` or use an "
+                    "active experiment."
                 ),
                 INVALID_PARAMETER_VALUE,
             )

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
@@ -247,6 +247,17 @@ def test_create_run_with_tags(store: SqlAlchemyStore):
     assert actual.inputs.dataset_inputs == []
 
 
+def test_create_run_under_deleted_experiment_points_to_recovery(store: SqlAlchemyStore):
+    experiment_id = _create_experiments(store, "test_create_run_deleted_exp")
+    store.delete_experiment(experiment_id)
+    configs = _get_run_configs(experiment_id=experiment_id)
+    with pytest.raises(
+        MlflowException,
+        match=rf"must be in the 'active' state.*restore_experiment\('{experiment_id}'\)",
+    ):
+        store.create_run(**configs)
+
+
 def test_create_run_sets_name(store: SqlAlchemyStore):
     experiment_id = _create_experiments(store, "test_create_run_run_name")
     configs = _get_run_configs(experiment_id=experiment_id)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -957,7 +957,10 @@ def test_get_deleted_runs(store):
 def test_create_run_in_deleted_experiment(store):
     exp_id = store.create_experiment("test")
     store.delete_experiment(exp_id)
-    with pytest.raises(Exception, match="Could not create run under non-active experiment"):
+    with pytest.raises(
+        Exception,
+        match=rf"Could not create run under non-active experiment.*restore_experiment\('{exp_id}'\)",
+    ):
         store.create_run(exp_id, "user", 0, [], "name")
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #2690

### What changes are proposed in this pull request?

When an experiment has been deleted, attempting to create a run under it — or any operation gated on the experiment being active — fails with an opaque error that gives no path forward:

- **FileStore:** `Could not create run under non-active experiment with ID 0.`
- **SQLAlchemy store:** `The experiment 0 must be in the 'active' state. Current state is deleted.`

This is the core confusion reported in #2690 ("Can't start run once the default experiment has been deleted"). This PR appends an actionable hint to both messages, pointing the user to `MlflowClient().restore_experiment(...)` or to using an active experiment. In the SQLAlchemy store the hint is added in `_check_experiment_is_active`, so it benefits every operation gated on an active experiment (`create_run`, `log_*`, `set_experiment_tag`, etc.), not just run creation.

**Why this approach** (rather than blocking deletion or auto-restoring the default experiment): the SQLAlchemy store deliberately *allows* deleting the default experiment and does *not* reactivate it on store restart — this is explicitly asserted by `test_default_experiment_lifecycle` (it deletes experiment `0` and asserts it stays `DELETED` across a fresh store over the same DB). Blocking deletion or auto-restoring (the direction of the stale CLI-only #3057) would contradict that tested, intentional behavior. This PR instead makes the existing failure self-explanatory, which resolves the user's confusion while preserving the current contract.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- New `test_create_run_under_deleted_experiment_points_to_recovery` (SQLAlchemy store) asserts the recovery hint appears; passes in both `workspace-enabled` and `workspace-disabled` parametrizations.
- Updated the FileStore `test_create_run_in_deleted_experiment` to assert the hint.
- The broader experiment/run active-state suite (incl. `test_default_experiment_lifecycle`) passes locally with no behavior change (48 passed, 8 skipped).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Deleted-experiment errors (e.g. `create_run` on a deleted experiment) now include an actionable hint telling the user to restore the experiment or use an active one.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

### AI assistance

Developed with AI assistance (Claude Code, Anthropic — Opus 4.x). **AI's role:** drafted the patch and tests and ran a review pass. **My role:** reproduced the issue, confirmed the design constraint (the tested delete-allowed / no-reactivate behavior of the default experiment), reviewed and edited every line, ran the tests below, and I take responsibility for the change. **Verification:** targeted + broader SQLAlchemy tracking-store suite green locally (48 passed, 8 skipped); FileStore cases green under `MLFLOW_ALLOW_FILE_STORE=true`; DCO signed.
