### PR TITLE
Add span links display to trace explorer UI

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1908,6 +1908,7 @@ module.exports = {
   "mlflow.model_trace_explorer.header.session_id_link": "",
   "mlflow.model_trace_explorer.header_details.tag-session-id": "",
   "mlflow.model_trace_explorer.linked_prompts.prompt_link": "",
+  "mlflow.model_trace_explorer.span_link": "",
   "mlflow.model_trace_explorer.timeline.gateway_trace_link": "",
 
   // -- mlflow.node-level-metric-charts --

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1909,6 +1909,7 @@ module.exports = {
   "mlflow.model_trace_explorer.header_details.tag-session-id": "",
   "mlflow.model_trace_explorer.linked_prompts.prompt_link": "",
   "mlflow.model_trace_explorer.span_link": "",
+  "mlflow.model_trace_explorer.span_link.tooltip": "",
   "mlflow.model_trace_explorer.timeline.gateway_trace_link": "",
 
   // -- mlflow.node-level-metric-charts --

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3975,6 +3975,10 @@
     "defaultMessage": "Does the assistant follow the provided guidelines throughout the conversation?",
     "description": "Hint for ConversationalGuidelines template"
   },
+  "Hg5XD1": {
+    "defaultMessage": "No links found",
+    "description": "Empty state for the links tab in the model trace explorer. Links connect spans across different traces."
+  },
   "Hk0RSH": {
     "defaultMessage": "Y-axis:",
     "description": "Label text for Y-axis in box plot comparison in MLflow"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -144,7 +144,7 @@ export type ModelTraceEvent = {
 export type ModelTraceSpanLink = {
   trace_id: string;
   span_id: string;
-  attributes?: Record<string, any>;
+  attributes?: Record<string, any> | null;
 };
 
 export type ModelTraceData = {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -345,7 +345,7 @@ export type ModelTraceExplorerTab = 'chat' | 'content' | 'attributes' | 'events'
 
 export type SearchMatch = {
   span: ModelTraceSpanNode;
-  section: 'inputs' | 'outputs' | 'attributes' | 'events';
+  section: 'inputs' | 'outputs' | 'attributes' | 'events' | 'links';
   key: string;
   isKeyMatch: boolean;
   matchIndex: number;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -81,6 +81,7 @@ export type ModelTraceSpanV2 = {
   outputs?: any;
   attributes?: Record<string, any>;
   events?: ModelTraceEvent[];
+  links?: ModelTraceSpanLink[];
   /* metadata for ui usage logging */
   type?: ModelSpanType;
 };
@@ -101,6 +102,7 @@ export type ModelTraceSpanV3 = {
   };
   attributes: Record<string, any>;
   events?: ModelTraceEvent[];
+  links?: ModelTraceSpanLink[];
   /* metadata for ui usage logging */
   type?: ModelSpanType;
 };
@@ -124,6 +126,7 @@ export type ModelTraceSpanV4 = {
   }>;
   status: { code: ModelSpanStatusCode };
   events?: ModelTraceEvent[];
+  links?: ModelTraceSpanLink[];
   /* metadata for ui usage logging */
   type?: ModelSpanType;
 };
@@ -135,6 +138,12 @@ export type ModelTraceEvent = {
   /* deprecated as of v3, migrated to `time_unix_nano` */
   timestamp?: number;
   time_unix_nano?: number;
+  attributes?: Record<string, any>;
+};
+
+export type ModelTraceSpanLink = {
+  trace_id: string;
+  span_id: string;
   attributes?: Record<string, any>;
 };
 
@@ -312,7 +321,8 @@ export interface SpanCostInfo {
 /**
  * Represents a single node in the model trace tree.
  */
-export interface ModelTraceSpanNode extends TimelineTreeNode, Pick<ModelTraceSpan, 'attributes' | 'type' | 'events'> {
+export interface ModelTraceSpanNode
+  extends TimelineTreeNode, Pick<ModelTraceSpan, 'attributes' | 'type' | 'events' | 'links'> {
   assessments: Assessment[];
   inputs?: any;
   outputs?: any;
@@ -331,7 +341,7 @@ export interface ModelTraceSpanNode extends TimelineTreeNode, Pick<ModelTraceSpa
   logLevel?: SpanLogLevel;
 }
 
-export type ModelTraceExplorerTab = 'chat' | 'content' | 'attributes' | 'events';
+export type ModelTraceExplorerTab = 'chat' | 'content' | 'attributes' | 'events' | 'links';
 
 export type SearchMatch = {
   span: ModelTraceSpanNode;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test-utils.ts
@@ -5,6 +5,7 @@ import type {
   ModelTraceChatTool,
   ModelTraceInfo,
   ModelTraceInfoV3,
+  ModelTraceSpanLink,
   ModelTraceSpanNode,
   ModelTraceSpanV2,
   ModelTraceSpanV3,
@@ -582,6 +583,31 @@ export const MOCK_TRACE_INFO_V2: ModelTraceInfo = {
     },
   ],
   tags: [],
+};
+
+export const MOCK_SPAN_LINKS: ModelTraceSpanLink[] = [
+  {
+    trace_id: 'tr-abc123def456',
+    span_id: 'aabbccddeeff0011',
+    attributes: { relationship: 'triggered_by' },
+  },
+  {
+    trace_id: 'tr-789xyz000111',
+    span_id: '1122334455667788',
+  },
+];
+
+export const MOCK_LINKS_SPAN: ModelTraceSpanNode = {
+  key: 'links_span',
+  type: ModelSpanType.FUNCTION,
+  start: 0,
+  end: 1000,
+  inputs: undefined,
+  outputs: undefined,
+  attributes: {},
+  assessments: [],
+  traceId: 'tr-test',
+  links: MOCK_SPAN_LINKS,
 };
 
 export const MOCK_OTEL_TRACE: ModelTrace = {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -527,6 +527,7 @@ export const normalizeNewSpanData = (
     (value) => tryDeserializeAttribute(value),
   );
   const events = span.events;
+  const links = span.links;
   const start = (Number(getModelTraceSpanStartTime(span)) - rootStartTime) / 1000;
   const end = (Number(getModelTraceSpanEndTime(span) ?? rootEndTime) - rootStartTime) / 1000;
 
@@ -548,6 +549,7 @@ export const normalizeNewSpanData = (
     outputs,
     attributes,
     events,
+    links,
     chatMessageFormat: messageFormat,
     chatMessages,
     chatTools,
@@ -1387,6 +1389,7 @@ export const convertOtelAttributesToMap = (modelTraceSpan: ModelTraceSpan): Mode
         attributes: convertAttributes(event.attributes),
       })),
     }),
+    ...(modelTraceSpan.links && { links: modelTraceSpan.links }),
   };
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -238,6 +238,43 @@ export const getMatchesFromEvent = (span: ModelTraceSpanNode, searchFilter: stri
   return matches;
 };
 
+export const getLinkFieldKey = (index: number, field: string): string => {
+  return `link-${index}-${field}`;
+};
+
+const getMatchesFromLinks = (span: ModelTraceSpanNode, searchFilter: string): SearchMatch[] => {
+  const links = span.links;
+  if (!links) {
+    return [];
+  }
+
+  const matches: SearchMatch[] = [];
+  links.forEach((link, index) => {
+    const fields: Record<string, string> = {
+      span_id: JSON.stringify(link.span_id),
+      ...(link.attributes && Object.keys(link.attributes).length > 0
+        ? { attributes: JSON.stringify(link.attributes, null, 2) }
+        : {}),
+    };
+
+    Object.entries(fields).forEach(([field, value]) => {
+      const key = getLinkFieldKey(index, field);
+      const numValueMatches = value.toLowerCase().split(searchFilter).length - 1;
+      for (let i = 0; i < numValueMatches; i++) {
+        matches.push({
+          span,
+          section: 'links',
+          key,
+          isKeyMatch: false,
+          matchIndex: i,
+        });
+      }
+    });
+  });
+
+  return matches;
+};
+
 /**
  * This function extracts all the matches from a span based on the search filter,
  * and appends some necessary metadata that is necessary for the jump-to-search
@@ -257,11 +294,16 @@ export const getMatchesFromSpan = (span: ModelTraceSpanNode, searchFilter: strin
     outputs: span?.outputs,
     attributes: span?.attributes,
     events: span?.events,
+    links: span?.links,
   };
 
-  map(sections, (section: any, label: 'inputs' | 'outputs' | 'attributes' | 'events') => {
+  map(sections, (section: any, label: 'inputs' | 'outputs' | 'attributes' | 'events' | 'links') => {
     if (label === 'events') {
       matches.push(...getMatchesFromEvent(span, searchFilter));
+      return;
+    }
+    if (label === 'links') {
+      matches.push(...getMatchesFromLinks(span, searchFilter));
       return;
     }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -250,14 +250,14 @@ const getMatchesFromLinks = (span: ModelTraceSpanNode, searchFilter: string): Se
 
   const matches: SearchMatch[] = [];
   links.forEach((link, index) => {
-    const fields: Record<string, string> = {
-      span_id: JSON.stringify(link.span_id),
+    const fields = [
+      { field: 'span_id', value: JSON.stringify(link.span_id) },
       ...(link.attributes && Object.keys(link.attributes).length > 0
-        ? { attributes: JSON.stringify(link.attributes, null, 2) }
-        : {}),
-    };
+        ? [{ field: 'attributes', value: JSON.stringify(link.attributes, null, 2) }]
+        : []),
+    ];
 
-    Object.entries(fields).forEach(([field, value]) => {
+    fields.forEach(({ field, value }) => {
       const key = getLinkFieldKey(index, field);
       const numValueMatches = value.toLowerCase().split(searchFilter).length - 1;
       for (let i = 0; i < numValueMatches; i++) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -87,6 +87,7 @@ import {
   SPAN_ATTRIBUTE_MODEL_KEY,
   TOKEN_USAGE_METADATA_KEY,
 } from './constants';
+import { getExperimentPageTracesTabRoute } from './routes';
 
 export const FETCH_TRACE_INFO_QUERY_KEY = 'model-trace-info-v3';
 
@@ -250,24 +251,20 @@ const getMatchesFromLinks = (span: ModelTraceSpanNode, searchFilter: string): Se
 
   const matches: SearchMatch[] = [];
   links.forEach((link, index) => {
-    const fields = [
-      { field: 'span_id', value: JSON.stringify(link.span_id) },
-      ...(link.attributes && Object.keys(link.attributes).length > 0
-        ? [{ field: 'attributes', value: JSON.stringify(link.attributes, null, 2) }]
-        : []),
-    ];
+    const attributes = link.attributes;
+    if (!attributes || Object.keys(attributes).length === 0) return;
 
-    fields.forEach(({ field, value }) => {
-      const key = getLinkFieldKey(index, field);
-      const numValueMatches = value.toLowerCase().split(searchFilter).length - 1;
+    Object.entries(attributes).forEach(([attrKey, attrValue]) => {
+      const key = getLinkFieldKey(index, attrKey);
+      const isKeyMatch = attrKey.toLowerCase().includes(searchFilter);
+      if (isKeyMatch) {
+        matches.push({ span, section: 'links', key, isKeyMatch: true, matchIndex: 0 });
+      }
+
+      const value = JSON.stringify(attrValue, null, 2).toLowerCase();
+      const numValueMatches = value.split(searchFilter).length - 1;
       for (let i = 0; i < numValueMatches; i++) {
-        matches.push({
-          span,
-          section: 'links',
-          key,
-          isKeyMatch: false,
-          matchIndex: i,
-        });
+        matches.push({ span, section: 'links', key, isKeyMatch: false, matchIndex: i });
       }
     });
   });
@@ -651,6 +648,22 @@ export function isV3ModelTraceInfo(
 
   return 'trace_location' in info;
 }
+
+export const getTraceHref = (traceId: string, traceInfo: ModelTrace['info'] | undefined): string | undefined => {
+  if (!traceInfo) return undefined;
+
+  let experimentId: string | undefined;
+  if (isV3ModelTraceInfo(traceInfo)) {
+    if (traceInfo.trace_location?.type === 'MLFLOW_EXPERIMENT') {
+      experimentId = traceInfo.trace_location.mlflow_experiment?.experiment_id;
+    }
+  } else {
+    experimentId = traceInfo.experiment_id;
+  }
+
+  if (!experimentId) return undefined;
+  return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${traceId}`;
+};
 
 export function isV4ModelTraceSpan(span: ModelTraceSpan): span is ModelTraceSpanV4 {
   return 'start_time_unix_nano' in span && Array.isArray(span.attributes);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts
@@ -40,6 +40,13 @@ export const createAssessment = ({
 export const fetchTraceInfoV3 = ({ traceId }: { traceId: string }) =>
   fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${traceId}`));
 
+export const fetchBatchTraceInfosV3 = async ({
+  traceIds,
+}: {
+  traceIds: string[];
+}): Promise<{ trace_infos: ModelTraceInfoV3[] }> =>
+  fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/traces/batchGetInfos'), 'POST', { trace_ids: traceIds });
+
 export type UpdateAssessmentPayload = {
   // we only support updating these fields
   assessment: {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useGatewayTraceLink.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useGatewayTraceLink.tsx
@@ -1,17 +1,10 @@
-import { useMemo } from 'react';
-
 import { useQuery } from '../../query-client/queryClient';
 
-import { isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
+import { getTraceHref } from '../ModelTraceExplorer.utils';
 import { fetchTraceInfoV3 } from '../api';
-import { getExperimentPageTracesTabRoute } from '../routes';
 
 const GATEWAY_TRACE_INFO_QUERY_KEY = 'GATEWAY_TRACE_INFO';
 
-/**
- * Fetches trace info for a linked gateway trace and returns a navigable href.
- * Returns undefined while loading or if the experiment ID cannot be resolved.
- */
 export const useGatewayTraceLink = (linkedTraceId: string | undefined): string | undefined => {
   const { data } = useQuery({
     queryKey: [GATEWAY_TRACE_INFO_QUERY_KEY, linkedTraceId],
@@ -21,27 +14,6 @@ export const useGatewayTraceLink = (linkedTraceId: string | undefined): string |
     retry: false,
   });
 
-  return useMemo(() => {
-    if (!linkedTraceId || !data?.trace) {
-      return undefined;
-    }
-
-    let experimentId: string | undefined;
-
-    if (isV3ModelTraceInfo(data?.trace?.trace_info)) {
-      // V3 format: trace info at root with trace_location
-      if (data?.trace?.trace_info?.trace_location?.type === 'MLFLOW_EXPERIMENT') {
-        experimentId = data?.trace?.trace_info?.trace_location.mlflow_experiment?.experiment_id;
-      }
-    } else {
-      // V2 format: nested under data.trace.trace_info
-      experimentId = data?.trace?.trace_info?.experiment_id;
-    }
-
-    if (!experimentId) {
-      return undefined;
-    }
-
-    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${linkedTraceId}`;
-  }, [linkedTraceId, data?.trace]);
+  if (!linkedTraceId || !data?.trace?.trace_info) return undefined;
+  return getTraceHref(linkedTraceId, data.trace.trace_info);
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useModelTraceSearch.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useModelTraceSearch.tsx
@@ -46,6 +46,8 @@ const getTabForMatch = (match: SearchMatch): ModelTraceExplorerTab => {
       return 'attributes';
     case 'events':
       return 'events';
+    case 'links':
+      return 'links';
     default:
       // shouldn't happen
       return 'content';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
@@ -2,23 +2,25 @@ import { useMemo } from 'react';
 
 import { useQuery } from '../../query-client/queryClient';
 
-import { isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
+import { isV3ModelTraceInfo, parseV4TraceIdToObject } from '../ModelTraceExplorer.utils';
 import { fetchTraceInfoV3 } from '../api';
 import { getExperimentPageTracesTabRoute } from '../routes';
 
 const SPAN_LINK_TRACE_INFO_QUERY_KEY = 'SPAN_LINK_TRACE_INFO';
 
-/**
- * Fetches trace info for a span link target and returns a navigable href.
- * Returns undefined while loading or if the experiment ID cannot be resolved.
- */
 export const useSpanLinkHref = (traceId: string | undefined): string | undefined => {
+  const resolvedTraceId = useMemo(() => {
+    if (!traceId) return undefined;
+    return parseV4TraceIdToObject(traceId)?.trace_id ?? traceId;
+  }, [traceId]);
+
   const { data } = useQuery({
-    queryKey: [SPAN_LINK_TRACE_INFO_QUERY_KEY, traceId],
-    queryFn: () => fetchTraceInfoV3({ traceId: traceId ?? '' }),
-    enabled: Boolean(traceId),
+    queryKey: [SPAN_LINK_TRACE_INFO_QUERY_KEY, resolvedTraceId],
+    queryFn: () => fetchTraceInfoV3({ traceId: resolvedTraceId ?? '' }),
+    enabled: Boolean(resolvedTraceId),
     refetchOnWindowFocus: false,
     retry: false,
+    staleTime: Infinity,
   });
 
   return useMemo(() => {
@@ -40,6 +42,6 @@ export const useSpanLinkHref = (traceId: string | undefined): string | undefined
       return undefined;
     }
 
-    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${traceId}`;
-  }, [traceId, data?.trace]);
+    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${resolvedTraceId}`;
+  }, [traceId, resolvedTraceId, data?.trace]);
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
@@ -2,22 +2,19 @@ import { useMemo } from 'react';
 
 import { useQuery } from '../../query-client/queryClient';
 
-import { isV3ModelTraceInfo, parseV4TraceIdToObject } from '../ModelTraceExplorer.utils';
+import { isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
 import { fetchTraceInfoV3 } from '../api';
 import { getExperimentPageTracesTabRoute } from '../routes';
 
 const SPAN_LINK_TRACE_INFO_QUERY_KEY = 'SPAN_LINK_TRACE_INFO';
 
+// Only supports V3 trace IDs (tr-...). V4/UC traces skip link materialization
+// in the Python layer, so trace:/<location>/<hex> IDs won't appear here.
 export const useSpanLinkHref = (traceId: string | undefined): string | undefined => {
-  const resolvedTraceId = useMemo(() => {
-    if (!traceId) return undefined;
-    return parseV4TraceIdToObject(traceId)?.trace_id ?? traceId;
-  }, [traceId]);
-
   const { data } = useQuery({
-    queryKey: [SPAN_LINK_TRACE_INFO_QUERY_KEY, resolvedTraceId],
-    queryFn: () => fetchTraceInfoV3({ traceId: resolvedTraceId ?? '' }),
-    enabled: Boolean(resolvedTraceId),
+    queryKey: [SPAN_LINK_TRACE_INFO_QUERY_KEY, traceId],
+    queryFn: () => fetchTraceInfoV3({ traceId: traceId ?? '' }),
+    enabled: Boolean(traceId),
     refetchOnWindowFocus: false,
     retry: false,
     staleTime: Infinity,
@@ -42,6 +39,6 @@ export const useSpanLinkHref = (traceId: string | undefined): string | undefined
       return undefined;
     }
 
-    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${resolvedTraceId}`;
-  }, [traceId, resolvedTraceId, data?.trace]);
+    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${traceId}`;
+  }, [traceId, data?.trace]);
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '../../query-client/queryClient';
+
+import { isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
+import { fetchTraceInfoV3 } from '../api';
+import { getExperimentPageTracesTabRoute } from '../routes';
+
+const SPAN_LINK_TRACE_INFO_QUERY_KEY = 'SPAN_LINK_TRACE_INFO';
+
+/**
+ * Fetches trace info for a span link target and returns a navigable href.
+ * Returns undefined while loading or if the experiment ID cannot be resolved.
+ */
+export const useSpanLinkHref = (traceId: string | undefined): string | undefined => {
+  const { data } = useQuery({
+    queryKey: [SPAN_LINK_TRACE_INFO_QUERY_KEY, traceId],
+    queryFn: () => fetchTraceInfoV3({ traceId: traceId ?? '' }),
+    enabled: Boolean(traceId),
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  return useMemo(() => {
+    if (!traceId || !data?.trace) {
+      return undefined;
+    }
+
+    let experimentId: string | undefined;
+
+    if (isV3ModelTraceInfo(data?.trace?.trace_info)) {
+      if (data?.trace?.trace_info?.trace_location?.type === 'MLFLOW_EXPERIMENT') {
+        experimentId = data?.trace?.trace_info?.trace_location.mlflow_experiment?.experiment_id;
+      }
+    } else {
+      experimentId = data?.trace?.trace_info?.experiment_id;
+    }
+
+    if (!experimentId) {
+      return undefined;
+    }
+
+    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${traceId}`;
+  }, [traceId, data?.trace]);
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
@@ -1,10 +1,7 @@
-import { useMemo } from 'react';
-
 import { useQuery } from '../../query-client/queryClient';
 
-import { isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
+import { getTraceHref } from '../ModelTraceExplorer.utils';
 import { fetchTraceInfoV3 } from '../api';
-import { getExperimentPageTracesTabRoute } from '../routes';
 
 const SPAN_LINK_TRACE_INFO_QUERY_KEY = 'SPAN_LINK_TRACE_INFO';
 
@@ -20,25 +17,6 @@ export const useSpanLinkHref = (traceId: string | undefined): string | undefined
     staleTime: Infinity,
   });
 
-  return useMemo(() => {
-    if (!traceId || !data?.trace) {
-      return undefined;
-    }
-
-    let experimentId: string | undefined;
-
-    if (isV3ModelTraceInfo(data?.trace?.trace_info)) {
-      if (data?.trace?.trace_info?.trace_location?.type === 'MLFLOW_EXPERIMENT') {
-        experimentId = data?.trace?.trace_info?.trace_location.mlflow_experiment?.experiment_id;
-      }
-    } else {
-      experimentId = data?.trace?.trace_info?.experiment_id;
-    }
-
-    if (!experimentId) {
-      return undefined;
-    }
-
-    return `${getExperimentPageTracesTabRoute(experimentId)}?selectedEvaluationId=${traceId}`;
-  }, [traceId, data?.trace]);
+  if (!traceId || !data?.trace?.trace_info) return undefined;
+  return getTraceHref(traceId, data.trace.trace_info);
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useSpanLinkHref.tsx
@@ -1,22 +1,33 @@
+import { useMemo } from 'react';
+
 import { useQuery } from '../../query-client/queryClient';
 
 import { getTraceHref } from '../ModelTraceExplorer.utils';
-import { fetchTraceInfoV3 } from '../api';
+import { fetchBatchTraceInfosV3 } from '../api';
 
-const SPAN_LINK_TRACE_INFO_QUERY_KEY = 'SPAN_LINK_TRACE_INFO';
+const SPAN_LINK_TRACE_INFOS_QUERY_KEY = 'SPAN_LINK_TRACE_INFOS';
 
 // Only supports V3 trace IDs (tr-...). V4/UC traces skip link materialization
 // in the Python layer, so trace:/<location>/<hex> IDs won't appear here.
-export const useSpanLinkHref = (traceId: string | undefined): string | undefined => {
+export const useSpanLinkHrefs = (traceIds: string[]): Record<string, string | undefined> => {
+  const sortedIds = useMemo(() => [...new Set(traceIds)].sort(), [traceIds]);
+
   const { data } = useQuery({
-    queryKey: [SPAN_LINK_TRACE_INFO_QUERY_KEY, traceId],
-    queryFn: () => fetchTraceInfoV3({ traceId: traceId ?? '' }),
-    enabled: Boolean(traceId),
+    queryKey: [SPAN_LINK_TRACE_INFOS_QUERY_KEY, sortedIds],
+    queryFn: () => fetchBatchTraceInfosV3({ traceIds: sortedIds }),
+    enabled: sortedIds.length > 0,
     refetchOnWindowFocus: false,
     retry: false,
     staleTime: Infinity,
   });
 
-  if (!traceId || !data?.trace?.trace_info) return undefined;
-  return getTraceHref(traceId, data.trace.trace_info);
+  return useMemo(() => {
+    if (!data?.trace_infos) return {};
+
+    const hrefMap: Record<string, string | undefined> = {};
+    for (const info of data.trace_infos) {
+      hrefMap[info.trace_id] = getTraceHref(info.trace_id, info);
+    }
+    return hrefMap;
+  }, [data?.trace_infos]);
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -12,9 +12,13 @@ import type { ModelTraceSpanNode } from '../ModelTrace.types';
 import { ModelSpanType } from '../ModelTrace.types';
 import { MOCK_LINKS_SPAN, MOCK_SPAN_LINKS } from '../ModelTraceExplorer.test-utils';
 
-jest.mock('../hooks/useSpanLinkHref', () => ({
-  useSpanLinkHref: (traceId: string | undefined) =>
+const mockUseSpanLinkHref = jest.fn(
+  (traceId: string | undefined) =>
     traceId ? `/experiments/1/traces?selectedEvaluationId=${traceId}` : undefined,
+);
+
+jest.mock('../hooks/useSpanLinkHref', () => ({
+  useSpanLinkHref: (...args: any[]) => mockUseSpanLinkHref(...args),
 }));
 
 const queryClient = new QueryClient();
@@ -90,6 +94,18 @@ describe('ModelTraceExplorerLinksTab', () => {
 
     expect(screen.getByText('tr-with-attrs')).toBeInTheDocument();
     expect(screen.getByText('attributes')).toBeInTheDocument();
+  });
+
+  it('renders trace_id as plain text when href is unavailable', () => {
+    mockUseSpanLinkHref.mockReturnValue(undefined);
+    const span = createMockSpanNode({
+      links: [{ trace_id: 'tr-unresolved', span_id: 'eeff000000000000' }],
+    });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('tr-unresolved')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    mockUseSpanLinkHref.mockRestore();
   });
 
   it('does not render attributes section when link has no attributes', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import { QueryClient, QueryClientProvider } from '../../query-client/queryClient';
+
+import { ModelTraceExplorerLinksTab } from './ModelTraceExplorerLinksTab';
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
+import { MOCK_LINKS_SPAN, MOCK_SPAN_LINKS } from '../ModelTraceExplorer.test-utils';
+
+jest.mock('../hooks/useSpanLinkHref', () => ({
+  useSpanLinkHref: (traceId: string | undefined) =>
+    traceId ? `/experiments/1/traces?selectedEvaluationId=${traceId}` : undefined,
+}));
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <IntlProvider locale="en">
+    <DesignSystemProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    </DesignSystemProvider>
+  </IntlProvider>
+);
+
+const createMockSpanNode = (overrides: Partial<ModelTraceSpanNode> = {}): ModelTraceSpanNode => ({
+  key: 'test-span',
+  title: 'Test Span',
+  start: 0,
+  end: 1000,
+  inputs: undefined,
+  outputs: undefined,
+  attributes: {},
+  type: ModelSpanType.FUNCTION,
+  assessments: [],
+  traceId: 'tr-test',
+  ...overrides,
+});
+
+describe('ModelTraceExplorerLinksTab', () => {
+  it('renders empty state when span has no links', () => {
+    const span = createMockSpanNode();
+    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('No links found')).toBeInTheDocument();
+  });
+
+  it('renders empty state when links array is empty', () => {
+    const span = createMockSpanNode({ links: [] });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('No links found')).toBeInTheDocument();
+  });
+
+  it('renders link entries with trace_id and span_id', () => {
+    render(<ModelTraceExplorerLinksTab activeSpan={MOCK_LINKS_SPAN} />, { wrapper: Wrapper });
+
+    expect(screen.getByText(MOCK_SPAN_LINKS[0].trace_id)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_SPAN_LINKS[1].trace_id)).toBeInTheDocument();
+  });
+
+  it('renders navigation links for each span link', () => {
+    render(<ModelTraceExplorerLinksTab activeSpan={MOCK_LINKS_SPAN} />, { wrapper: Wrapper });
+
+    const navLinks = screen.getAllByRole('link');
+    expect(navLinks).toHaveLength(2);
+    expect(navLinks[0]).toHaveAttribute(
+      'href',
+      `/experiments/1/traces?selectedEvaluationId=${MOCK_SPAN_LINKS[0].trace_id}`,
+    );
+  });
+
+  it('renders link attributes when present', () => {
+    const span = createMockSpanNode({
+      links: [
+        {
+          trace_id: 'tr-with-attrs',
+          span_id: 'aabb000000000000',
+          attributes: { relationship: 'caused_by', priority: 'high' },
+        },
+      ],
+    });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('tr-with-attrs')).toBeInTheDocument();
+    expect(screen.getByText('attributes')).toBeInTheDocument();
+  });
+
+  it('does not render attributes section when link has no attributes', () => {
+    const span = createMockSpanNode({
+      links: [{ trace_id: 'tr-no-attrs', span_id: 'ccdd000000000000' }],
+    });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+
+    expect(screen.getByText('tr-no-attrs')).toBeInTheDocument();
+    expect(screen.queryByText('attributes')).not.toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -21,7 +21,7 @@ const mockUseSpanLinkHrefs = jest.fn((traceIds: string[]) => {
 });
 
 jest.mock('../hooks/useSpanLinkHref', () => ({
-  useSpanLinkHrefs: (...args: any[]) => mockUseSpanLinkHrefs(...args),
+  useSpanLinkHrefs: (traceIds: string[]) => mockUseSpanLinkHrefs(traceIds),
 }));
 
 const queryClient = new QueryClient();

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -12,12 +12,16 @@ import type { ModelTraceSpanNode } from '../ModelTrace.types';
 import { ModelSpanType } from '../ModelTrace.types';
 import { MOCK_LINKS_SPAN, MOCK_SPAN_LINKS } from '../ModelTraceExplorer.test-utils';
 
-const mockUseSpanLinkHref = jest.fn((traceId: string | undefined) =>
-  traceId ? `/experiments/1/traces?selectedEvaluationId=${traceId}` : undefined,
-);
+const mockUseSpanLinkHrefs = jest.fn((traceIds: string[]) => {
+  const map: Record<string, string> = {};
+  for (const id of traceIds) {
+    map[id] = `/experiments/1/traces?selectedEvaluationId=${id}`;
+  }
+  return map;
+});
 
 jest.mock('../hooks/useSpanLinkHref', () => ({
-  useSpanLinkHref: (...args: any[]) => mockUseSpanLinkHref(...args),
+  useSpanLinkHrefs: (...args: any[]) => mockUseSpanLinkHrefs(...args),
 }));
 
 const queryClient = new QueryClient();
@@ -47,6 +51,16 @@ const createMockSpanNode = (overrides: Partial<ModelTraceSpanNode> = {}): ModelT
 });
 
 describe('ModelTraceExplorerLinksTab', () => {
+  afterEach(() => {
+    mockUseSpanLinkHrefs.mockImplementation((traceIds: string[]) => {
+      const map: Record<string, string> = {};
+      for (const id of traceIds) {
+        map[id] = `/experiments/1/traces?selectedEvaluationId=${id}`;
+      }
+      return map;
+    });
+  });
+
   it('renders empty state when span has no links', () => {
     const span = createMockSpanNode();
     render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, { wrapper: Wrapper });
@@ -101,7 +115,7 @@ describe('ModelTraceExplorerLinksTab', () => {
   });
 
   it('renders trace_id as plain text when href is unavailable', () => {
-    mockUseSpanLinkHref.mockReturnValue(undefined);
+    mockUseSpanLinkHrefs.mockReturnValue({});
     const span = createMockSpanNode({
       links: [{ trace_id: 'tr-unresolved', span_id: 'eeff000000000000' }],
     });
@@ -109,7 +123,6 @@ describe('ModelTraceExplorerLinksTab', () => {
 
     expect(screen.getByText('tr-unresolved')).toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
-    mockUseSpanLinkHref.mockRestore();
   });
 
   it('does not render attribute snippets when link has no attributes', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -12,9 +12,8 @@ import type { ModelTraceSpanNode } from '../ModelTrace.types';
 import { ModelSpanType } from '../ModelTrace.types';
 import { MOCK_LINKS_SPAN, MOCK_SPAN_LINKS } from '../ModelTraceExplorer.test-utils';
 
-const mockUseSpanLinkHref = jest.fn(
-  (traceId: string | undefined) =>
-    traceId ? `/experiments/1/traces?selectedEvaluationId=${traceId}` : undefined,
+const mockUseSpanLinkHref = jest.fn((traceId: string | undefined) =>
+  traceId ? `/experiments/1/traces?selectedEvaluationId=${traceId}` : undefined,
 );
 
 jest.mock('../hooks/useSpanLinkHref', () => ({

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -49,27 +49,31 @@ const createMockSpanNode = (overrides: Partial<ModelTraceSpanNode> = {}): ModelT
 describe('ModelTraceExplorerLinksTab', () => {
   it('renders empty state when span has no links', () => {
     const span = createMockSpanNode();
-    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, { wrapper: Wrapper });
 
     expect(screen.getByText('No links found')).toBeInTheDocument();
   });
 
   it('renders empty state when links array is empty', () => {
     const span = createMockSpanNode({ links: [] });
-    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, { wrapper: Wrapper });
 
     expect(screen.getByText('No links found')).toBeInTheDocument();
   });
 
-  it('renders link entries with trace_id and span_id', () => {
-    render(<ModelTraceExplorerLinksTab activeSpan={MOCK_LINKS_SPAN} />, { wrapper: Wrapper });
+  it('renders link entries with trace_id', () => {
+    render(<ModelTraceExplorerLinksTab activeSpan={MOCK_LINKS_SPAN} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
 
     expect(screen.getByText(MOCK_SPAN_LINKS[0].trace_id)).toBeInTheDocument();
     expect(screen.getByText(MOCK_SPAN_LINKS[1].trace_id)).toBeInTheDocument();
   });
 
-  it('renders navigation links for each span link', () => {
-    render(<ModelTraceExplorerLinksTab activeSpan={MOCK_LINKS_SPAN} />, { wrapper: Wrapper });
+  it('renders navigation links with correct href', () => {
+    render(<ModelTraceExplorerLinksTab activeSpan={MOCK_LINKS_SPAN} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
 
     const navLinks = screen.getAllByRole('link');
     expect(navLinks).toHaveLength(2);
@@ -79,7 +83,7 @@ describe('ModelTraceExplorerLinksTab', () => {
     );
   });
 
-  it('renders link attributes when present', () => {
+  it('renders each attribute key as a separate snippet', () => {
     const span = createMockSpanNode({
       links: [
         {
@@ -89,10 +93,11 @@ describe('ModelTraceExplorerLinksTab', () => {
         },
       ],
     });
-    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, { wrapper: Wrapper });
 
     expect(screen.getByText('tr-with-attrs')).toBeInTheDocument();
-    expect(screen.getByText('attributes')).toBeInTheDocument();
+    expect(screen.getByText('relationship')).toBeInTheDocument();
+    expect(screen.getByText('priority')).toBeInTheDocument();
   });
 
   it('renders trace_id as plain text when href is unavailable', () => {
@@ -100,20 +105,20 @@ describe('ModelTraceExplorerLinksTab', () => {
     const span = createMockSpanNode({
       links: [{ trace_id: 'tr-unresolved', span_id: 'eeff000000000000' }],
     });
-    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, { wrapper: Wrapper });
 
     expect(screen.getByText('tr-unresolved')).toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
     mockUseSpanLinkHref.mockRestore();
   });
 
-  it('does not render attributes section when link has no attributes', () => {
+  it('does not render attribute snippets when link has no attributes', () => {
     const span = createMockSpanNode({
       links: [{ trace_id: 'tr-no-attrs', span_id: 'ccdd000000000000' }],
     });
-    render(<ModelTraceExplorerLinksTab activeSpan={span} />, { wrapper: Wrapper });
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, { wrapper: Wrapper });
 
     expect(screen.getByText('tr-no-attrs')).toBeInTheDocument();
-    expect(screen.queryByText('attributes')).not.toBeInTheDocument();
+    expect(screen.queryByText('relationship')).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { afterEach, describe, it, expect, jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -1,4 +1,4 @@
-import { Empty, LinkIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Empty, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import type { ModelTraceSpanLink, ModelTraceSpanNode } from '../ModelTrace.types';
@@ -12,29 +12,28 @@ function SpanLinkEntry({ link, index }: { link: ModelTraceSpanLink; index: numbe
   const { theme } = useDesignSystemTheme();
   const href = useSpanLinkHref(link.trace_id);
 
-  const title = (
-    <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-      <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {link.trace_id}
-      </Typography.Text>
-      {href && (
-        <Link
-          componentId="mlflow.model_trace_explorer.span_link"
-          to={href}
-          target="_blank"
-          rel="noreferrer"
-          onClick={(e: React.MouseEvent) => e.stopPropagation()}
-          css={{
-            flexShrink: 0,
-            display: 'flex',
-            alignItems: 'center',
-            color: theme.colors.actionPrimaryBackgroundDefault,
-          }}
-        >
-          <LinkIcon css={{ fontSize: 14 }} />
-        </Link>
-      )}
-    </div>
+  const title = href ? (
+    <Link
+      componentId="mlflow.model_trace_explorer.span_link"
+      to={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      css={{
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        fontWeight: theme.typography.typographyBoldFontWeight,
+        color: theme.colors.actionPrimaryBackgroundDefault,
+        '&:hover': { textDecoration: 'underline' },
+      }}
+    >
+      {link.trace_id}
+    </Link>
+  ) : (
+    <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+      {link.trace_id}
+    </Typography.Text>
   );
 
   const hasAttributes = link.attributes && Object.keys(link.attributes).length > 0;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -1,0 +1,103 @@
+import { Empty, LinkIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import type { ModelTraceSpanLink, ModelTraceSpanNode } from '../ModelTrace.types';
+import { CodeSnippetRenderMode } from '../ModelTrace.types';
+import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
+import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { Link } from '../RoutingUtils';
+import { useSpanLinkHref } from '../hooks/useSpanLinkHref';
+
+function SpanLinkEntry({ link, index }: { link: ModelTraceSpanLink; index: number }) {
+  const { theme } = useDesignSystemTheme();
+  const href = useSpanLinkHref(link.trace_id);
+
+  const title = (
+    <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+      <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {link.trace_id}
+      </Typography.Text>
+      {href && (
+        <Link
+          componentId="mlflow.model_trace_explorer.span_link"
+          to={href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          css={{
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            color: theme.colors.actionPrimaryBackgroundDefault,
+          }}
+        >
+          <LinkIcon css={{ fontSize: 14 }} />
+        </Link>
+      )}
+    </div>
+  );
+
+  const hasAttributes = link.attributes && Object.keys(link.attributes).length > 0;
+
+  return (
+    <ModelTraceExplorerCollapsibleSection
+      key={`link-${index}`}
+      css={{
+        marginBottom: theme.spacing.sm,
+        '& > div:first-of-type': { borderTop: 'none' },
+      }}
+      sectionKey={`link-${index}`}
+      title={title}
+      withBorder
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+        <ModelTraceExplorerCodeSnippet
+          title="span_id"
+          data={JSON.stringify(link.span_id)}
+          searchFilter=""
+          activeMatch={null}
+          containsActiveMatch={false}
+          initialRenderMode={CodeSnippetRenderMode.TEXT}
+        />
+        {hasAttributes && (
+          <ModelTraceExplorerCodeSnippet
+            title="attributes"
+            data={JSON.stringify(link.attributes, null, 2)}
+            searchFilter=""
+            activeMatch={null}
+            containsActiveMatch={false}
+            initialRenderMode={CodeSnippetRenderMode.JSON}
+          />
+        )}
+      </div>
+    </ModelTraceExplorerCollapsibleSection>
+  );
+}
+
+export function ModelTraceExplorerLinksTab({ activeSpan }: { activeSpan: ModelTraceSpanNode }) {
+  const { theme } = useDesignSystemTheme();
+  const { links } = activeSpan;
+
+  if (!Array.isArray(links) || links.length === 0) {
+    return (
+      <div css={{ marginTop: theme.spacing.sm }}>
+        <Empty
+          description={
+            <FormattedMessage
+              defaultMessage="No links found"
+              description="Empty state for the links tab in the model trace explorer. Links connect spans across different traces."
+            />
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ marginTop: theme.spacing.sm }}>
+      {links.map((link, index) => (
+        <SpanLinkEntry key={`${link.trace_id}-${link.span_id}-${index}`} link={link} index={index} />
+      ))}
+    </div>
+  );
+}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -1,14 +1,29 @@
+import { isNil } from 'lodash';
+
 import { Empty, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
-import type { ModelTraceSpanLink, ModelTraceSpanNode } from '../ModelTrace.types';
+import type { ModelTraceSpanLink, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { CodeSnippetRenderMode } from '../ModelTrace.types';
+import { getLinkFieldKey } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
 import { Link } from '../RoutingUtils';
 import { useSpanLinkHref } from '../hooks/useSpanLinkHref';
 
-function SpanLinkEntry({ link, index }: { link: ModelTraceSpanLink; index: number }) {
+function SpanLinkEntry({
+  link,
+  index,
+  searchFilter,
+  activeMatch,
+  isActiveMatchSpan,
+}: {
+  link: ModelTraceSpanLink;
+  index: number;
+  searchFilter: string;
+  activeMatch: SearchMatch | null;
+  isActiveMatchSpan: boolean;
+}) {
   const { theme } = useDesignSystemTheme();
   const href = useSpanLinkHref(link.trace_id);
 
@@ -53,18 +68,26 @@ function SpanLinkEntry({ link, index }: { link: ModelTraceSpanLink; index: numbe
         <ModelTraceExplorerCodeSnippet
           title="span_id"
           data={JSON.stringify(link.span_id)}
-          searchFilter=""
-          activeMatch={null}
-          containsActiveMatch={false}
+          searchFilter={searchFilter}
+          activeMatch={activeMatch}
+          containsActiveMatch={
+            isActiveMatchSpan &&
+            activeMatch?.section === 'links' &&
+            activeMatch.key === getLinkFieldKey(index, 'span_id')
+          }
           initialRenderMode={CodeSnippetRenderMode.TEXT}
         />
         {hasAttributes && (
           <ModelTraceExplorerCodeSnippet
             title="attributes"
             data={JSON.stringify(link.attributes, null, 2)}
-            searchFilter=""
-            activeMatch={null}
-            containsActiveMatch={false}
+            searchFilter={searchFilter}
+            activeMatch={activeMatch}
+            containsActiveMatch={
+              isActiveMatchSpan &&
+              activeMatch?.section === 'links' &&
+              activeMatch.key === getLinkFieldKey(index, 'attributes')
+            }
             initialRenderMode={CodeSnippetRenderMode.JSON}
           />
         )}
@@ -73,9 +96,18 @@ function SpanLinkEntry({ link, index }: { link: ModelTraceSpanLink; index: numbe
   );
 }
 
-export function ModelTraceExplorerLinksTab({ activeSpan }: { activeSpan: ModelTraceSpanNode }) {
+export function ModelTraceExplorerLinksTab({
+  activeSpan,
+  searchFilter,
+  activeMatch,
+}: {
+  activeSpan: ModelTraceSpanNode;
+  searchFilter: string;
+  activeMatch: SearchMatch | null;
+}) {
   const { theme } = useDesignSystemTheme();
   const { links } = activeSpan;
+  const isActiveMatchSpan = !isNil(activeMatch) && activeMatch.span.key === activeSpan.key;
 
   if (!Array.isArray(links) || links.length === 0) {
     return (
@@ -95,7 +127,14 @@ export function ModelTraceExplorerLinksTab({ activeSpan }: { activeSpan: ModelTr
   return (
     <div css={{ marginTop: theme.spacing.sm }}>
       {links.map((link, index) => (
-        <SpanLinkEntry key={`${link.trace_id}-${link.span_id}-${index}`} link={link} index={index} />
+        <SpanLinkEntry
+          key={`${link.trace_id}-${link.span_id}-${index}`}
+          link={link}
+          index={index}
+          searchFilter={searchFilter}
+          activeMatch={activeMatch}
+          isActiveMatchSpan={isActiveMatchSpan}
+        />
       ))}
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -1,6 +1,6 @@
 import { isNil } from 'lodash';
 
-import { Empty, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Empty, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import type { ModelTraceSpanLink, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
@@ -8,7 +8,6 @@ import { CodeSnippetRenderMode } from '../ModelTrace.types';
 import { getLinkFieldKey } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
-import { Link } from '../RoutingUtils';
 import { useSpanLinkHref } from '../hooks/useSpanLinkHref';
 
 function SpanLinkEntry({
@@ -27,31 +26,30 @@ function SpanLinkEntry({
   const { theme } = useDesignSystemTheme();
   const href = useSpanLinkHref(link.trace_id);
 
-  const title = href ? (
-    <Link
-      componentId="mlflow.model_trace_explorer.span_link"
-      to={href}
-      target="_blank"
-      rel="noreferrer"
-      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-      css={{
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        fontWeight: theme.typography.typographyBoldFontWeight,
-        color: theme.colors.actionPrimaryBackgroundDefault,
-        '&:hover': { textDecoration: 'underline' },
-      }}
+  const title = (
+    <Tooltip
+      componentId="mlflow.model_trace_explorer.span_link.tooltip"
+      content={`span_id: ${link.span_id}`}
     >
-      {link.trace_id}
-    </Link>
-  ) : (
-    <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-      {link.trace_id}
-    </Typography.Text>
+      {href ? (
+        <Typography.Link
+          componentId="mlflow.model_trace_explorer.span_link"
+          href={href}
+          openInNewTab
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {link.trace_id}
+        </Typography.Link>
+      ) : (
+        <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {link.trace_id}
+        </Typography.Text>
+      )}
+    </Tooltip>
   );
 
-  const hasAttributes = link.attributes && Object.keys(link.attributes).length > 0;
+  const attributes = link.attributes && Object.keys(link.attributes).length > 0 ? link.attributes : null;
 
   return (
     <ModelTraceExplorerCollapsibleSection
@@ -64,34 +62,25 @@ function SpanLinkEntry({
       title={title}
       withBorder
     >
-      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-        <ModelTraceExplorerCodeSnippet
-          title="span_id"
-          data={JSON.stringify(link.span_id)}
-          searchFilter={searchFilter}
-          activeMatch={activeMatch}
-          containsActiveMatch={
-            isActiveMatchSpan &&
-            activeMatch?.section === 'links' &&
-            activeMatch.key === getLinkFieldKey(index, 'span_id')
-          }
-          initialRenderMode={CodeSnippetRenderMode.TEXT}
-        />
-        {hasAttributes && (
-          <ModelTraceExplorerCodeSnippet
-            title="attributes"
-            data={JSON.stringify(link.attributes, null, 2)}
-            searchFilter={searchFilter}
-            activeMatch={activeMatch}
-            containsActiveMatch={
-              isActiveMatchSpan &&
-              activeMatch?.section === 'links' &&
-              activeMatch.key === getLinkFieldKey(index, 'attributes')
-            }
-            initialRenderMode={CodeSnippetRenderMode.JSON}
-          />
-        )}
-      </div>
+      {attributes && (
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          {Object.entries(attributes).map(([key, value]) => (
+            <ModelTraceExplorerCodeSnippet
+              key={key}
+              title={key}
+              data={JSON.stringify(value, null, 2)}
+              searchFilter={searchFilter}
+              activeMatch={activeMatch}
+              containsActiveMatch={
+                isActiveMatchSpan &&
+                activeMatch?.section === 'links' &&
+                activeMatch.key === getLinkFieldKey(index, key)
+              }
+              initialRenderMode={CodeSnippetRenderMode.TEXT}
+            />
+          ))}
+        </div>
+      )}
     </ModelTraceExplorerCollapsibleSection>
   );
 }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -73,9 +73,7 @@ function SpanLinkEntry({
               searchFilter={searchFilter}
               activeMatch={activeMatch}
               containsActiveMatch={
-                isActiveMatchSpan &&
-                activeMatch?.section === 'links' &&
-                activeMatch.key === getLinkFieldKey(index, key)
+                isActiveMatchSpan && activeMatch?.section === 'links' && activeMatch.key === getLinkFieldKey(index, key)
               }
               initialRenderMode={CodeSnippetRenderMode.TEXT}
             />

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -30,7 +30,7 @@ function SpanLinkEntry({
   const { theme } = useDesignSystemTheme();
 
   const title = (
-    <Tooltip componentId="mlflow.model_trace_explorer.span_link.tooltip" content={`span_id: ${link.span_id}`}>
+    <Tooltip componentId="mlflow.model_trace_explorer.span_link.tooltip" content={`Destination span: ${link.span_id}`}>
       {href ? (
         <Link
           componentId="mlflow.model_trace_explorer.span_link"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -9,6 +9,7 @@ import { CodeSnippetRenderMode } from '../ModelTrace.types';
 import { getLinkFieldKey } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { Link } from '../RoutingUtils';
 import { useSpanLinkHrefs } from '../hooks/useSpanLinkHref';
 
 function SpanLinkEntry({
@@ -31,15 +32,16 @@ function SpanLinkEntry({
   const title = (
     <Tooltip componentId="mlflow.model_trace_explorer.span_link.tooltip" content={`span_id: ${link.span_id}`}>
       {href ? (
-        <Typography.Link
+        <Link
           componentId="mlflow.model_trace_explorer.span_link"
-          href={href}
-          openInNewTab
+          to={href}
+          target="_blank"
+          rel="noreferrer"
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
           css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
         >
           {link.trace_id}
-        </Typography.Link>
+        </Link>
       ) : (
         <Typography.Text bold css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {link.trace_id}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -1,4 +1,5 @@
 import { isNil } from 'lodash';
+import { useMemo } from 'react';
 
 import { Empty, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
@@ -8,29 +9,27 @@ import { CodeSnippetRenderMode } from '../ModelTrace.types';
 import { getLinkFieldKey } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
-import { useSpanLinkHref } from '../hooks/useSpanLinkHref';
+import { useSpanLinkHrefs } from '../hooks/useSpanLinkHref';
 
 function SpanLinkEntry({
   link,
   index,
+  href,
   searchFilter,
   activeMatch,
   isActiveMatchSpan,
 }: {
   link: ModelTraceSpanLink;
   index: number;
+  href: string | undefined;
   searchFilter: string;
   activeMatch: SearchMatch | null;
   isActiveMatchSpan: boolean;
 }) {
   const { theme } = useDesignSystemTheme();
-  const href = useSpanLinkHref(link.trace_id);
 
   const title = (
-    <Tooltip
-      componentId="mlflow.model_trace_explorer.span_link.tooltip"
-      content={`span_id: ${link.span_id}`}
-    >
+    <Tooltip componentId="mlflow.model_trace_explorer.span_link.tooltip" content={`span_id: ${link.span_id}`}>
       {href ? (
         <Typography.Link
           componentId="mlflow.model_trace_explorer.span_link"
@@ -98,6 +97,9 @@ export function ModelTraceExplorerLinksTab({
   const { links } = activeSpan;
   const isActiveMatchSpan = !isNil(activeMatch) && activeMatch.span.key === activeSpan.key;
 
+  const traceIds = useMemo(() => (links ?? []).map((link) => link.trace_id), [links]);
+  const hrefMap = useSpanLinkHrefs(traceIds);
+
   if (!Array.isArray(links) || links.length === 0) {
     return (
       <div css={{ marginTop: theme.spacing.sm }}>
@@ -120,6 +122,7 @@ export function ModelTraceExplorerLinksTab({
           key={`${link.trace_id}-${link.span_id}-${index}`}
           link={link}
           index={index}
+          href={hrefMap[link.trace_id]}
           searchFilter={searchFilter}
           activeMatch={activeMatch}
           isActiveMatchSpan={isActiveMatchSpan}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -9,6 +9,7 @@ import { ModelTraceExplorerAttributesTab } from './ModelTraceExplorerAttributesT
 import { ModelTraceExplorerChatTab } from './ModelTraceExplorerChatTab';
 import { ModelTraceExplorerContentTab } from './ModelTraceExplorerContentTab';
 import { ModelTraceExplorerEventsTab } from './ModelTraceExplorerEventsTab';
+import { ModelTraceExplorerLinksTab } from './ModelTraceExplorerLinksTab';
 import { SimplifiedAssessmentView } from './SimplifiedAssessmentView';
 import type { ModelTraceExplorerTab, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { SpanModelCostBadge } from './SpanModelCostBadge';
@@ -129,6 +130,11 @@ function ModelTraceExplorerRightPaneTabsImpl({
         <Tabs.Trigger value="events">
           Events {hasException && <ModelTraceExplorerBadge count={exceptionCount} />}
         </Tabs.Trigger>
+        {activeSpan.links && activeSpan.links.length > 0 && (
+          <Tabs.Trigger value="links">
+            Links <ModelTraceExplorerBadge count={activeSpan.links.length} />
+          </Tabs.Trigger>
+        )}
         {displayReadOnlyAssessments && (
           <Tabs.Trigger value="assessments">
             <FormattedMessage
@@ -155,6 +161,9 @@ function ModelTraceExplorerRightPaneTabsImpl({
       </Tabs.Content>
       <Tabs.Content css={contentStyle} value="events">
         <ModelTraceExplorerEventsTab activeSpan={activeSpan} searchFilter={searchFilter} activeMatch={activeMatch} />
+      </Tabs.Content>
+      <Tabs.Content css={contentStyle} value="links">
+        <ModelTraceExplorerLinksTab activeSpan={activeSpan} />
       </Tabs.Content>
       {displayReadOnlyAssessments && (
         <Tabs.Content css={contentStyle} value="assessments">

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -163,7 +163,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
         <ModelTraceExplorerEventsTab activeSpan={activeSpan} searchFilter={searchFilter} activeMatch={activeMatch} />
       </Tabs.Content>
       <Tabs.Content css={contentStyle} value="links">
-        <ModelTraceExplorerLinksTab activeSpan={activeSpan} />
+        <ModelTraceExplorerLinksTab activeSpan={activeSpan} searchFilter={searchFilter} activeMatch={activeMatch} />
       </Tabs.Content>
       {displayReadOnlyAssessments && (
         <Tabs.Content css={contentStyle} value="assessments">

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -130,9 +130,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
         <Tabs.Trigger value="events">
           Events {hasException && <ModelTraceExplorerBadge count={exceptionCount} />}
         </Tabs.Trigger>
-        {activeSpan.links && activeSpan.links.length > 0 && (
-          <Tabs.Trigger value="links">Links</Tabs.Trigger>
-        )}
+        <Tabs.Trigger value="links">Links</Tabs.Trigger>
         {displayReadOnlyAssessments && (
           <Tabs.Trigger value="assessments">
             <FormattedMessage

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -131,9 +131,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
           Events {hasException && <ModelTraceExplorerBadge count={exceptionCount} />}
         </Tabs.Trigger>
         {activeSpan.links && activeSpan.links.length > 0 && (
-          <Tabs.Trigger value="links">
-            Links <ModelTraceExplorerBadge count={activeSpan.links.length} />
-          </Tabs.Trigger>
+          <Tabs.Trigger value="links">Links</Tabs.Trigger>
         )}
         {displayReadOnlyAssessments && (
           <Tabs.Trigger value="assessments">


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23251

### What changes are proposed in this pull request?

Adds a **Links** tab to the trace explorer right pane that displays [OpenTelemetry Span Links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) on spans. This is the UI counterpart to #23251 which added the `links` parameter to Python span-creation APIs.

**New files:**
- `ModelTraceExplorerLinksTab.tsx` — Links tab component with collapsible link entries, navigation, and empty state
- `useSpanLinkHref.tsx` — Hook that resolves a linked trace ID to a navigable URL
- `ModelTraceExplorerLinksTab.test.tsx` — 6 tests covering rendering, navigation, attributes, and empty state

**Modified files:**
- `ModelTrace.types.ts` — `ModelTraceSpanLink` type, `links` on span types and `ModelTraceSpanNode`, `'links'` in tab union
- `ModelTraceExplorer.utils.tsx` — Wire `links` through `normalizeNewSpanData` and `convertOtelAttributesToMap`
- `ModelTraceExplorerRightPaneTabs.tsx` — Conditional Links tab with badge count
- `ModelTraceExplorer.test-utils.ts` — Mock link fixtures

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

6 new tests in `ModelTraceExplorerLinksTab.test.tsx`. All existing trace explorer tests (118 tests) pass without regressions.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Span links are now displayed in the trace explorer UI as a "Links" tab, allowing users to view and navigate to linked spans across traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release