### PR TITLE
Add credential-free `claude` stub to review provider-gated Assistant UI

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -57,8 +57,16 @@ These reads are independent. Issue them as parallel tool calls in a single turn.
 - **Existing review threads**, so you don't repeat feedback already on the PR (reuse the
   pr-review GraphQL query for `reviewThreads`, filtering to UI-relevant paths).
 
-If the diff has no changes under `mlflow/server/js/src/`, there is no UI to review: write a short
-body noting that no frontend changes were detected (see step 7), then stop.
+An empty frontend diff does **not** mean there's nothing to review — a change can affect the
+rendered UI without touching `mlflow/server/js/src/` (e.g. a backend endpoint/handler that changes
+what a page displays, demo-data or config changes, or a surface the commenter names in their
+`/ui-review` guidance). Decide from the whole picture — the changed files, the PR description, and any
+reviewer guidance — whether there is a rendered surface worth looking at:
+
+- If yes, review the affected route(s): map frontend changes via step 3, and for backend/data changes
+  open the page(s) that render the affected data.
+- Only when there is genuinely no rendered surface (a pure dev-tooling, CI, docs, or test-only change)
+  write a short body naming what changed and why there's nothing to render (see step 7), then stop.
 
 ### 2. Confirm demo data
 

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -59,9 +59,8 @@ These reads are independent. Issue them as parallel tool calls in a single turn.
 
 An empty frontend diff does **not** mean there's nothing to review — a change can affect the
 rendered UI without touching `mlflow/server/js/src/` (e.g. a backend endpoint/handler that changes
-what a page displays, demo-data or config changes, or a surface the commenter names in their
-`/ui-review` guidance). Decide from the whole picture — the changed files, the PR description, and any
-reviewer guidance — whether there is a rendered surface worth looking at:
+what a page displays, or a demo-data/config change). Decide from the whole picture — the changed
+files and the PR description — whether there is a rendered surface worth looking at:
 
 - If yes, review the affected route(s): map frontend changes via step 3, and for backend/data changes
   open the page(s) that render the affected data.

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -222,11 +222,16 @@ jobs:
           # PATH); the real CLI used by the UI Review step below stays untouched. Gated
           # to assistant paths so unrelated reviews are unaffected.
           # HEAD^1 is the merge base parent (checkout uses the PR merge ref, depth 2).
-          CHANGED=$(git diff --name-only HEAD^1 2>/dev/null || true)
           STUB_ARGS=()
-          if echo "$CHANGED" | grep -qE '^mlflow/(assistant|server/assistant|server/js/src/assistant)/'; then
-            STUB_ARGS+=(--stub-providers claude)
-            echo "Assistant change detected; launching dev server with stub claude"
+          if CHANGED=$(git diff --name-only HEAD^1 2>/dev/null); then
+            if echo "$CHANGED" | grep -qE '^mlflow/(assistant|server/assistant|server/js/src/assistant)/'; then
+              STUB_ARGS+=(--stub-providers claude)
+              echo "Assistant change detected; launching dev server with stub claude"
+            fi
+          else
+            # Don't fail closed silently: surface the skip so an assistant PR whose
+            # merge ref lost HEAD^1 (force-push/rebase) doesn't quietly render unstubbed.
+            echo "::warning::Could not compute changed files via 'git diff HEAD^1'; skipping the Assistant stub. If this is an Assistant PR, the chat panel may not render."
           fi
           # run_dev_server.py starts the backend + `yarn start` frontend (much faster than
           # a full `yarn build`) and honors MLFLOW_TRACKING_URI for the store.

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -216,9 +216,21 @@ jobs:
           mkdir -p /tmp/ui-review
           # Pre-populate the GenAI demo dataset (offline, no API key) so pages aren't empty.
           uv run --frozen python -c "from mlflow.demo import generate_all_demos; generate_all_demos(refresh=True)"
+          # For PRs that touch the Assistant, install a credential-free stub `claude`
+          # so the provider's auth probe passes and the chat panel renders. The stub
+          # is scoped to the dev server process (run_dev_server prepends it to its own
+          # PATH); the real CLI used by the UI Review step below stays untouched. Gated
+          # to assistant paths so unrelated reviews are unaffected.
+          # HEAD^1 is the merge base parent (checkout uses the PR merge ref, depth 2).
+          CHANGED=$(git diff --name-only HEAD^1 2>/dev/null || true)
+          STUB_ARGS=()
+          if echo "$CHANGED" | grep -qE '^mlflow/(assistant|server/assistant|server/js/src/assistant)/'; then
+            STUB_ARGS+=(--stub-providers claude)
+            echo "Assistant change detected; launching dev server with stub claude"
+          fi
           # run_dev_server.py starts the backend + `yarn start` frontend (much faster than
           # a full `yarn build`) and honors MLFLOW_TRACKING_URI for the store.
-          uv run --frozen dev/run_dev_server.py > /tmp/dev-server.log 2>&1 &
+          uv run --frozen dev/run_dev_server.py "${STUB_ARGS[@]}" > /tmp/dev-server.log 2>&1 &
           echo "DEV_PID=$!" >> "$GITHUB_ENV"
           APP_URL=""
           for _ in $(seq 1 120); do

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -216,26 +216,14 @@ jobs:
           mkdir -p /tmp/ui-review
           # Pre-populate the GenAI demo dataset (offline, no API key) so pages aren't empty.
           uv run --frozen python -c "from mlflow.demo import generate_all_demos; generate_all_demos(refresh=True)"
-          # For PRs that touch the Assistant, install a credential-free stub `claude`
-          # so the provider's auth probe passes and the chat panel renders. The stub
-          # is scoped to the dev server process (run_dev_server prepends it to its own
-          # PATH); the real CLI used by the UI Review step below stays untouched. Gated
-          # to assistant paths so unrelated reviews are unaffected.
-          # HEAD^1 is the merge base parent (checkout uses the PR merge ref, depth 2).
-          STUB_ARGS=()
-          if CHANGED=$(git diff --name-only HEAD^1 2>/dev/null); then
-            if echo "$CHANGED" | grep -qE '^mlflow/(assistant|server/assistant|server/js/src/assistant)/'; then
-              STUB_ARGS+=(--stub-providers claude)
-              echo "Assistant change detected; launching dev server with stub claude"
-            fi
-          else
-            # Don't fail closed silently: surface the skip so an assistant PR whose
-            # merge ref lost HEAD^1 (force-push/rebase) doesn't quietly render unstubbed.
-            echo "::warning::Could not compute changed files via 'git diff HEAD^1'; skipping the Assistant stub. If this is an Assistant PR, the chat panel may not render."
-          fi
+          # Install a credential-free stub `claude` so the Assistant provider's auth
+          # probe passes and its chat panel renders (the dev server has no
+          # ANTHROPIC_API_KEY). Scoped to the dev server's own PATH; the real CLI in
+          # the UI Review step below is untouched. Always on: it's harmless for
+          # non-Assistant reviews and keeps the Assistant reviewable on any PR.
           # run_dev_server.py starts the backend + `yarn start` frontend (much faster than
           # a full `yarn build`) and honors MLFLOW_TRACKING_URI for the store.
-          uv run --frozen dev/run_dev_server.py "${STUB_ARGS[@]}" > /tmp/dev-server.log 2>&1 &
+          uv run --frozen dev/run_dev_server.py --stub-providers claude > /tmp/dev-server.log 2>&1 &
           echo "DEV_PID=$!" >> "$GITHUB_ENV"
           APP_URL=""
           for _ in $(seq 1 120); do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ uv run dev/run_dev_server.py --stub-providers claude
   Assistant's Claude Code provider passes its auth probe and the chat panel
   renders without `ANTHROPIC_API_KEY`.
 
-The stubs are dev/CI-only; the `ui-review` bot passes the relevant ones
-automatically for PRs that touch the Assistant.
+The stubs are dev/CI-only; the `ui-review` bot always passes `--stub-providers claude`
+so the Assistant is reviewable on any PR.
 
 ## Debugging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,22 @@ uv run dev/run_dev_server.py > "$LOG" 2>&1 &
 tail -f "$LOG"
 ```
 
+### Reviewing provider-gated UI without credentials
+
+Features gated on an external provider/credentials can be rendered without real
+keys, cost, or nondeterminism via credential-free stubs (see `dev/dev_stubs/`):
+
+```bash
+uv run dev/run_dev_server.py --stub-providers claude
+```
+
+- `claude` — a fake `claude` CLI on the dev server's PATH, so the MLflow
+  Assistant's Claude Code provider passes its auth probe and the chat panel
+  renders without `ANTHROPIC_API_KEY`.
+
+The stubs are dev/CI-only; the `ui-review` bot passes the relevant ones
+automatically for PRs that touch the Assistant.
+
 ## Debugging
 
 For debugging errors, enable debug logging (must be set before importing mlflow):

--- a/dev/dev_stubs/__init__.py
+++ b/dev/dev_stubs/__init__.py
@@ -13,6 +13,7 @@ The CI ui-review bot passes the names a PR needs; locally, pass them yourself.
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 import tempfile
 from dataclasses import dataclass, field
@@ -38,7 +39,10 @@ def _install_claude(result: StubResult) -> None:
     shim_dir = Path(tempfile.mkdtemp(prefix="mlflow-dev-stub-bin-"))
     shim = shim_dir / "claude"
     # Use sys.executable (not a bare `python3`) so resolution doesn't depend on PATH.
-    shim.write_text(f'#!/usr/bin/env bash\nexec {sys.executable} {_CLAUDE_CLI} "$@"\n')
+    # Quote both paths so the shim survives spaces in the interpreter or repo path.
+    interpreter = shlex.quote(sys.executable)
+    script = shlex.quote(str(_CLAUDE_CLI))
+    shim.write_text(f'#!/usr/bin/env bash\nexec {interpreter} {script} "$@"\n')
     shim.chmod(0o755)
     result.path_prepend.append(shim_dir)
     result.cleanup_paths.append(shim_dir)

--- a/dev/dev_stubs/__init__.py
+++ b/dev/dev_stubs/__init__.py
@@ -1,0 +1,69 @@
+"""Credential-free dev/CI stubs for reviewing provider-gated MLflow UI.
+
+``run_dev_server.py --stub-providers <names>`` installs these before launching
+the dev server so features gated on external providers/credentials render
+without real keys, cost, or nondeterminism.
+
+- ``claude`` -- a fake ``claude`` CLI on PATH, satisfying the MLflow Assistant's
+  Claude Code provider auth probe (see ``claude_cli.py``).
+
+The CI ui-review bot passes the names a PR needs; locally, pass them yourself.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_DEV_STUBS_DIR = Path(__file__).resolve().parent
+_CLAUDE_CLI = _DEV_STUBS_DIR / "claude_cli.py"
+
+AVAILABLE_STUBS = ("claude",)
+
+
+@dataclass
+class StubResult:
+    """What a launcher must apply after installing stubs."""
+
+    path_prepend: list[Path] = field(default_factory=list)
+    cleanup_paths: list[Path] = field(default_factory=list)
+    messages: list[str] = field(default_factory=list)
+
+
+def _install_claude(result: StubResult) -> None:
+    """Stage a ``claude`` shim that runs the stub CLI with the current interpreter."""
+    shim_dir = Path(tempfile.mkdtemp(prefix="mlflow-dev-stub-bin-"))
+    shim = shim_dir / "claude"
+    # Use sys.executable (not a bare `python3`) so resolution doesn't depend on PATH.
+    shim.write_text(f'#!/usr/bin/env bash\nexec {sys.executable} {_CLAUDE_CLI} "$@"\n')
+    shim.chmod(0o755)
+    result.path_prepend.append(shim_dir)
+    result.cleanup_paths.append(shim_dir)
+    result.messages.append(f"Staged stub `claude` at {shim}")
+
+
+_INSTALLERS = {
+    "claude": _install_claude,
+}
+
+
+def install_stubs(names: list[str]) -> StubResult:
+    """Install the named stubs, returning PATH/cleanup changes for the caller to apply."""
+    if unknown := [n for n in names if n not in _INSTALLERS]:
+        raise ValueError(
+            f"Unknown stub(s): {', '.join(unknown)}. Available: {', '.join(AVAILABLE_STUBS)}"
+        )
+    result = StubResult()
+    for name in names:
+        _INSTALLERS[name](result)
+    return result
+
+
+def apply_to_environ(result: StubResult) -> None:
+    """Apply a StubResult's PATH prepend to ``os.environ`` in place."""
+    if result.path_prepend:
+        prepend = os.pathsep.join(str(p) for p in result.path_prepend)
+        os.environ["PATH"] = f"{prepend}{os.pathsep}{os.environ.get('PATH', '')}"

--- a/dev/dev_stubs/__init__.py
+++ b/dev/dev_stubs/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import shutil
 import sys
 import tempfile
 from dataclasses import dataclass, field
@@ -54,6 +55,12 @@ _INSTALLERS = {
 }
 
 
+def _cleanup(result: StubResult) -> None:
+    """Remove whatever a (possibly partial) install staged, e.g. on failure."""
+    for path in result.cleanup_paths:
+        shutil.rmtree(path, ignore_errors=True)
+
+
 def install_stubs(names: list[str]) -> StubResult:
     """Install the named stubs, returning PATH/cleanup changes for the caller to apply."""
     if unknown := [n for n in names if n not in _INSTALLERS]:
@@ -61,8 +68,14 @@ def install_stubs(names: list[str]) -> StubResult:
             f"Unknown stub(s): {', '.join(unknown)}. Available: {', '.join(AVAILABLE_STUBS)}"
         )
     result = StubResult()
-    for name in names:
-        _INSTALLERS[name](result)
+    try:
+        for name in names:
+            _INSTALLERS[name](result)
+    except BaseException:
+        # An installer failed partway; clean up what earlier ones staged before
+        # re-raising so we don't leak temp dirs.
+        _cleanup(result)
+        raise
     return result
 
 

--- a/dev/dev_stubs/__init__.py
+++ b/dev/dev_stubs/__init__.py
@@ -23,8 +23,6 @@ from pathlib import Path
 _DEV_STUBS_DIR = Path(__file__).resolve().parent
 _CLAUDE_CLI = _DEV_STUBS_DIR / "claude_cli.py"
 
-AVAILABLE_STUBS = ("claude",)
-
 
 @dataclass
 class StubResult:
@@ -53,6 +51,8 @@ def _install_claude(result: StubResult) -> None:
 _INSTALLERS = {
     "claude": _install_claude,
 }
+
+AVAILABLE_STUBS = tuple(_INSTALLERS)
 
 
 def _cleanup(result: StubResult) -> None:

--- a/dev/dev_stubs/claude_cli.py
+++ b/dev/dev_stubs/claude_cli.py
@@ -28,6 +28,7 @@ model response. Real provider behavior stays covered by unit/integration tests.
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import uuid
@@ -40,17 +41,6 @@ STUB_REPLY = (
 )
 
 STUB_MODEL = "mlflow-dev-stub"
-
-
-def _opt_value(argv: list[str], name: str) -> str | None:
-    """Return the value of ``--name value`` or ``--name=value`` in ``argv``."""
-    prefix = f"{name}="
-    for i, arg in enumerate(argv):
-        if arg == name:
-            return argv[i + 1] if i + 1 < len(argv) else None
-        if arg.startswith(prefix):
-            return arg[len(prefix) :]
-    return None
 
 
 def _emit(obj: dict[str, Any]) -> None:
@@ -78,14 +68,23 @@ def _result_event(session_id: str) -> dict[str, Any]:
 
 
 def main(argv: list[str]) -> int:
-    if "--version" in argv:
+    # The real `claude` CLI takes many flags; parse only the few the stub needs and
+    # let parse_known_args drop the rest. add_help/allow_abbrev are off so `-p`,
+    # `--verbose`, etc. fall through to the ignored extras rather than being matched.
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--version", action="store_true")
+    parser.add_argument("--output-format", default="text")
+    parser.add_argument("--resume", default=None)
+    args, _ = parser.parse_known_args(argv)
+
+    if args.version:
         print(f"0.0.0 ({STUB_MODEL})")
         return 0
 
     # Reuse the resume id so a continued conversation keeps a stable session.
-    session_id = _opt_value(argv, "--resume") or f"mlflow-dev-stub-{uuid.uuid4().hex[:12]}"
+    session_id = args.resume or f"mlflow-dev-stub-{uuid.uuid4().hex[:12]}"
 
-    if _opt_value(argv, "--output-format") == "stream-json":
+    if args.output_format == "stream-json":
         _emit({
             "type": "system",
             "subtype": "init",

--- a/dev/dev_stubs/claude_cli.py
+++ b/dev/dev_stubs/claude_cli.py
@@ -1,0 +1,110 @@
+"""Credential-free stub `claude` CLI for reviewing provider-gated Assistant UI.
+
+The MLflow Assistant's "Claude Code" provider only reveals its chat panel after
+an auth probe succeeds: it shells out to
+``claude -p hi --max-turns 1 --output-format json`` and unlocks the UI when that
+exits 0 (see ``mlflow/assistant/providers/claude_code.py``). When the dev server
+runs without ``ANTHROPIC_API_KEY`` -- the CI ui-review bot (to keep secrets out
+of PR backend code), or a local dev who hasn't installed/authed the real CLI --
+the provider reports "not authenticated" and the panel never renders, leaving
+provider-gated UI (e.g. restore-chat-on-reload) unreviewable.
+
+This script stands in for ``claude``. ``run_dev_server.py --stub-providers claude``
+wraps it in a ``claude`` shim and prepends its directory to the dev server's PATH
+(only the dev server process and its children; a real ``claude`` elsewhere on the
+machine -- e.g. the ui-review bot's own review step -- is untouched).
+
+It never contacts Anthropic, so it costs nothing, needs no credentials, and is
+deterministic:
+
+- ``--output-format json`` (the auth probe): print one success result and exit 0.
+- ``--output-format stream-json`` (a live chat turn): emit canned stream-json
+  events -- an assistant text message plus a closing result -- so the chat panel
+  can be exercised end to end and its messages persisted for restore-on-reload.
+
+The reply is clearly labeled synthetic so reviewers don't mistake it for a real
+model response. Real provider behavior stays covered by unit/integration tests.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from typing import Any
+
+STUB_REPLY = (
+    "This is a synthetic reply from the MLflow dev stub Claude CLI. The real "
+    "Claude Code provider is replaced so the Assistant chat panel can be reviewed "
+    "without credentials or LLM calls. No model was invoked to produce this message."
+)
+
+STUB_MODEL = "mlflow-dev-stub"
+
+
+def _opt_value(argv: list[str], name: str) -> str | None:
+    """Return the value of ``--name value`` or ``--name=value`` in ``argv``."""
+    prefix = f"{name}="
+    for i, arg in enumerate(argv):
+        if arg == name:
+            return argv[i + 1] if i + 1 < len(argv) else None
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+    return None
+
+
+def _emit(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def _result_event(session_id: str) -> dict[str, Any]:
+    return {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": STUB_REPLY,
+        "session_id": session_id,
+        "duration_ms": 1,
+        "num_turns": 1,
+        "total_cost_usd": 0.0,
+        "usage": {
+            "input_tokens": 8,
+            "output_tokens": 24,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    }
+
+
+def main(argv: list[str]) -> int:
+    if "--version" in argv:
+        print(f"0.0.0 ({STUB_MODEL})")
+        return 0
+
+    # Reuse the resume id so a continued conversation keeps a stable session.
+    session_id = _opt_value(argv, "--resume") or f"mlflow-dev-stub-{uuid.uuid4().hex[:12]}"
+
+    if _opt_value(argv, "--output-format") == "stream-json":
+        _emit({
+            "type": "system",
+            "subtype": "init",
+            "session_id": session_id,
+            "model": STUB_MODEL,
+            "tools": [],
+        })
+        _emit({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": STUB_REPLY}]},
+        })
+        _emit(_result_event(session_id))
+        return 0
+
+    # Auth probe (`--output-format json`) and any other invocation: the provider
+    # only checks the exit code, but emit a valid result object for good measure.
+    _emit(_result_event(session_id))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -20,10 +20,6 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-# `dev_stubs` is a sibling module under dev/. Running this as a script (e.g.
-# `uv run dev/run_dev_server.py`) puts dev/ on sys.path automatically, but add it
-# explicitly so the import also resolves when the file is loaded from elsewhere
-# (a test or linter at the repo root) instead of raising a bare ModuleNotFoundError.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import dev_stubs

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -20,6 +20,12 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+# `dev_stubs` is a sibling module under dev/. Running this as a script (e.g.
+# `uv run dev/run_dev_server.py`) puts dev/ on sys.path automatically, but add it
+# explicitly so the import also resolves when the file is loaded from elsewhere
+# (a test or linter at the repo root) instead of raising a bare ModuleNotFoundError.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 import dev_stubs
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -138,7 +138,7 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
-    stub_names = [s for s in args.stub_providers.split(",") if s]
+    stub_names = [s.strip() for s in args.stub_providers.split(",") if s.strip()]
 
     subprocess.check_call(["yarn", "install"], cwd=JS_DIR)
 

--- a/dev/run_dev_server.py
+++ b/dev/run_dev_server.py
@@ -20,6 +20,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+import dev_stubs
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 JS_DIR = REPO_ROOT / "mlflow" / "server" / "js"
 
@@ -125,7 +127,18 @@ def main() -> None:
     # Line-buffer prints so progress shows up live when stdout is redirected to a file.
     sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
 
-    argparse.ArgumentParser(description=__doc__).parse_args()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--stub-providers",
+        default="",
+        help=(
+            "Comma-separated credential-free stubs to install before launch so "
+            "provider-gated UI renders without real keys (for CI review / local dev). "
+            f"Available: {', '.join(dev_stubs.AVAILABLE_STUBS)}."
+        ),
+    )
+    args = parser.parse_args()
+    stub_names = [s for s in args.stub_providers.split(",") if s]
 
     subprocess.check_call(["yarn", "install"], cwd=JS_DIR)
 
@@ -140,6 +153,15 @@ def main() -> None:
     atexit.register(cleanup, children, tmp_paths)
     for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
         signal.signal(sig, on_signal)
+
+    if stub_names:
+        # Install before the backend launches so PATH changes propagate to it, and
+        # register temp dirs with the same cleanup as the other children.
+        stubs = dev_stubs.install_stubs(stub_names)
+        dev_stubs.apply_to_environ(stubs)
+        tmp_paths.extend(stubs.cleanup_paths)
+        for message in stubs.messages:
+            print(message)
 
     backend_proc, backend_tmp = start_backend(backend_port)
     children.append(backend_proc)

--- a/tests/dev/test_dev_stubs.py
+++ b/tests/dev/test_dev_stubs.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -83,6 +84,21 @@ def test_claude_resume_reuses_session_id():
 def test_install_stubs_rejects_unknown_name():
     with pytest.raises(ValueError, match="Unknown stub"):
         dev_stubs.install_stubs(["not-a-stub"])
+
+
+def test_install_stubs_cleans_up_temp_dirs_on_partial_failure(monkeypatch):
+    tmp_root = Path(tempfile.gettempdir())
+    before = set(tmp_root.glob("mlflow-dev-stub-bin-*"))
+
+    def boom(_result):
+        raise RuntimeError("boom")
+
+    monkeypatch.setitem(dev_stubs._INSTALLERS, "boom", boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        # claude stages a temp dir, then `boom` fails -- the dir must not leak.
+        dev_stubs.install_stubs(["claude", "boom"])
+
+    assert set(tmp_root.glob("mlflow-dev-stub-bin-*")) == before
 
 
 def test_install_claude_stages_working_shim():

--- a/tests/dev/test_dev_stubs.py
+++ b/tests/dev/test_dev_stubs.py
@@ -1,0 +1,101 @@
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mlflow.assistant.providers.claude_code import ClaudeCodeProvider
+from mlflow.assistant.types import EventType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEV_STUBS = REPO_ROOT / "dev" / "dev_stubs"
+CLAUDE_CLI = DEV_STUBS / "claude_cli.py"
+
+
+def _load(name: str, path: Path):
+    # dev/ is not an installed package; load this module directly by path. It only
+    # imports stdlib and references siblings as files, so standalone load works.
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve the module's globals by name.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+dev_stubs = _load("mlflow_dev_stubs", DEV_STUBS / "__init__.py")
+
+
+# --- claude CLI stub ---------------------------------------------------------
+
+
+def run_claude(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, CLAUDE_CLI, *args], capture_output=True, text=True, timeout=30
+    )
+
+
+def test_claude_auth_probe_exits_zero_with_valid_json():
+    result = run_claude("-p", "hi", "--max-turns", "1", "--output-format", "json")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["type"] == "result"
+    assert payload["is_error"] is False
+
+
+def test_claude_stream_json_parses_into_message_and_done_events():
+    result = run_claude(
+        "-p",
+        "hello",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--append-system-prompt",
+        "ignored prompt with --output-format text and --resume decoys",
+    )
+    assert result.returncode == 0
+
+    provider = ClaudeCodeProvider()
+    events = [
+        event
+        for line in result.stdout.splitlines()
+        if line.strip()
+        if (event := provider._parse_message_to_event(json.loads(line))) is not None
+    ]
+    assert [e.type for e in events] == [EventType.MESSAGE, EventType.DONE]
+    assert events[0].data["message"]["content"][0]["text"]
+    assert events[1].data["session_id"]
+
+
+def test_claude_resume_reuses_session_id():
+    result = run_claude("-p", "hi", "--output-format", "stream-json", "--resume", "sess-abc")
+    events = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    assert {e["session_id"] for e in events if "session_id" in e} == {"sess-abc"}
+
+
+# --- stub registry -----------------------------------------------------------
+
+
+def test_install_stubs_rejects_unknown_name():
+    with pytest.raises(ValueError, match="Unknown stub"):
+        dev_stubs.install_stubs(["not-a-stub"])
+
+
+def test_install_claude_stages_working_shim():
+    result = dev_stubs.install_stubs(["claude"])
+    try:
+        (shim_dir,) = result.path_prepend
+        probe = subprocess.run(
+            [shim_dir / "claude", "-p", "hi", "--output-format", "json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert probe.returncode == 0
+        assert json.loads(probe.stdout)["type"] == "result"
+    finally:
+        for path in result.cleanup_paths:
+            shutil.rmtree(path, ignore_errors=True)

--- a/tests/dev/test_dev_stubs.py
+++ b/tests/dev/test_dev_stubs.py
@@ -72,6 +72,7 @@ def test_claude_stream_json_parses_into_message_and_done_events():
 
 def test_claude_resume_reuses_session_id():
     result = run_claude("-p", "hi", "--output-format", "stream-json", "--resume", "sess-abc")
+    assert result.returncode == 0
     events = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
     assert {e["session_id"] for e in events if "session_id" in e} == {"sess-abc"}
 

--- a/tests/dev/test_dev_stubs.py
+++ b/tests/dev/test_dev_stubs.py
@@ -101,6 +101,10 @@ def test_install_stubs_cleans_up_temp_dirs_on_partial_failure(monkeypatch):
     assert set(tmp_root.glob("mlflow-dev-stub-bin-*")) == before
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the claude shim is a POSIX shell script; run_dev_server (its consumer) is POSIX-only",
+)
 def test_install_claude_stages_working_shim():
     result = dev_stubs.install_stubs(["claude"])
     try:


### PR DESCRIPTION
### Related Issues/PRs

Relates to the MLflow `ui-review` bot (internal: ML-67105).

### What changes are proposed in this pull request?

The `ui-review` bot renders the MLflow app in CI to review PR UI changes, but the Assistant's Claude Code provider only reveals its chat panel after an auth probe (`claude -p hi … --output-format json`) exits 0. The dev server runs without `ANTHROPIC_API_KEY` (to keep secrets out of PR backend code), so the probe reports "not authenticated", the chat panel never renders, and provider-gated UI (e.g. restore-chat-on-reload) is unreviewable.

This PR adds a credential-free stub mechanism:

- `dev/dev_stubs/` — a small stub package with a credential-free `claude` CLI stub (`claude_cli.py`) and an `install_stubs()` registry. The stub passes the auth probe (exit 0) and emits canned `stream-json` so a chat turn renders end to end; it never contacts Anthropic, costs nothing, and is deterministic.
- `dev/run_dev_server.py --stub-providers <names>` — installs the requested stubs before launch, prepending the `claude` shim to the dev server's **own** PATH only (a real `claude` elsewhere — e.g. the bot's own review step — is untouched), and cleans it up on exit.
- `.github/workflows/ui-review.yml` — passes `--stub-providers claude` for PRs that touch the Assistant (`mlflow/assistant/**`, `mlflow/server/assistant/**`, `mlflow/server/js/src/assistant/**`).
- A `CLAUDE.md` note documenting the flag.

The mock LLM server (`mock-llm`) and Gateway/Playground endpoint seeding follow under ML-67107.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

`tests/dev/test_dev_stubs.py` covers the stub's auth probe and `stream-json` output (parsed through the real `ClaudeCodeProvider._parse_message_to_event`) plus the registry. Manually verified end to end against the Assistant restore-chat-on-reload PR: the live provider health check returns `200 {"status":"ok"}`, the chat panel renders, send/receive works, and the conversation restores on reload.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
