### PR TITLE
fix: avoid recreating existing tables during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -103,7 +103,11 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
         if not _all_tables_exist(engine):
-            _initialize_tables(engine)
+            if _is_empty_database(engine):
+                _initialize_tables(engine)
+            else:
+                # If some tables exist but not all, run upgrade only
+                _upgrade_db(engine)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `Table 'secrets' already exists` because `_initialize_tables` attempts to create all tables from `InitialBase.metadata` even if some already exist (from a previous partial migration or upgrade). This causes duplicate table creation and crashes the upgrade process.

## Fix
Modify `_safe_initialize_tables` to check whether the database is empty before calling `_initialize_tables`. If the database already contains some tables (but not all), we now call `_upgrade_db` directly instead of trying to create tables again. This avoids the duplicate table creation error and allows migrations to proceed correctly.

Closes #19943