### PR TITLE
Forward tags to the registered ModelVersion in `log_model`

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1369,6 +1369,7 @@ class Model:
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
+                    tags=tags,
                 )
             model_info = mlflow_model.get_model_info(model)
             if registered_model is not None:

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -226,6 +226,24 @@ def test_set_model_version_tag():
     assert mv.tags == {"key": "value"}
 
 
+def test_log_model_forwards_tags_to_registered_model_version():
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input):
+            return model_input
+
+    tags = {"stage": "training", "framework": "pyfunc"}
+    model_info = mlflow.pyfunc.log_model(
+        name="model",
+        python_model=TestModel(),
+        registered_model_name="Model 1",
+        tags=tags,
+    )
+
+    # Tags must land on the registered ModelVersion, not only on the LoggedModel.
+    mv = MlflowClient().get_model_version("Model 1", str(model_info.registered_model_version))
+    assert mv.tags == tags
+
+
 def test_register_model_with_2_x_model(tmp_path: Path):
     tracking_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
     artifact_location = (tmp_path / "artifacts").as_uri()


### PR DESCRIPTION
### Related Issues/PRs

Closes #24101

### What changes are proposed in this pull request?

When you log a model and register it in one call while passing `tags`, the tags don't make it onto the resulting `ModelVersion`:

```python
info = mlflow.sklearn.log_model(
    model,
    name="my-model",
    registered_model_name="my-model",
    tags={"stage": "training", "framework": "sklearn"},
)

client = mlflow.MlflowClient()
client.get_logged_model(info.model_id).tags                       # {'stage': 'training', 'framework': 'sklearn'}
client.get_model_version("my-model", info.registered_model_version).tags  # {}  <- expected the tags
```

The tags land on the `LoggedModel` entity but are silently dropped from the registered `ModelVersion`, which is the thing most people are actually inspecting in the registry.

**Root cause:** In `Model.log()` (`mlflow/models/model.py`), the `models:/` registration path calls `_register_model(...)` without forwarding `tags`. `_register_model` already accepts a `tags` keyword and forwards it on to `_create_model_version`, so the entity-level plumbing was already there — `Model.log()` just wasn't using it.

**The fix:** one line — forward `tags=tags` on the `models:/` registration call so they reach the `ModelVersion`.

The other `_register_model` call site in this file lives in `_log_v2()`, which has no `tags` parameter in its signature, so it is intentionally left untouched. This is the only call path where a user-supplied `tags` value is in scope.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a regression test in `tests/tracking/_model_registry/test_model_registry_fluent.py` that logs a model with both `registered_model_name` and `tags`, then asserts the tags are present on the registered `ModelVersion`. It fails on `master` (`{} != {...}`) and passes with this change.

```
$ pytest tests/tracking/_model_registry/test_model_registry_fluent.py -q
16 passed

$ ruff check mlflow/models/model.py tests/tracking/_model_registry/test_model_registry_fluent.py
All checks passed!
$ ruff format --check mlflow/models/model.py tests/tracking/_model_registry/test_model_registry_fluent.py
2 files already formatted
```

Existing behavioral tests in the same module (`test_set_model_version_tag`, `test_register_model_with_tags`, etc.) still pass, so this doesn't change any documented behavior beyond fixing the dropped tags.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.<flavor>.log_model(..., registered_model_name=..., tags=...)` now correctly applies the supplied `tags` to the registered `ModelVersion`, not just the `LoggedModel`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
