### PR TITLE
Honor declared ONNX execution providers at load time

### DIFF
--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -288,34 +288,26 @@ class _OnnxModelWrapper:
                 for key, value in extra_session_config.items():
                     sess_options.add_session_config_entry(key, value)
 
-        # NOTE: Some distributions of onnxruntime require the specification of the providers
-        # argument on calling. E.g. onnxruntime-gpu. The package import call does not differentiate
-        #  which architecture specific version has been installed, as all are imported with
-        # onnxruntime. onnxruntime documentation says that from v1.9.0 some distributions require
-        #  the providers list to be provided on calling an InferenceSession. Therefore the try
-        #  catch structure below attempts to create an inference session with just the model path
-        #  as pre v1.9.0. If that fails, it will use the providers list call.
-        # At the moment this is just CUDA and CPU, and probably should be expanded.
-        # A method of user customization has been provided by adding a variable in the save_model()
-        # function, which allows the ability to pass the list of execution providers via a
-        # optional argument e.g.
-        #
-        # mlflow.onnx.save_model(..., providers=['CUDAExecutionProvider'...])
-        #
-        # For details of the execution providers construct of onnxruntime, see:
-        # https://onnxruntime.ai/docs/execution-providers/
-        #
-        # For a information on how execution providers are used with onnxruntime InferenceSession,
-        # see the API page below:
-        # https://onnxruntime.ai/docs/api/python/api_summary.html#id8
-        #
-
-        try:
-            self.rt = onnxruntime.InferenceSession(path, sess_options=sess_options)
-        except ValueError:
-            self.rt = onnxruntime.InferenceSession(
-                path, providers=providers, sess_options=sess_options
+        # Honor the execution providers declared in the MLmodel metadata. We pass them on
+        # the InferenceSession construction directly: the previous try/except (construct
+        # without providers, retry with providers only on ValueError) was a pre-onnxruntime
+        # 1.9 relic. On onnxruntime >= 1.9 the no-providers constructor succeeds on CPU, so
+        # the retry never fired and declared GPU providers were silently dropped.
+        available = set(onnxruntime.get_available_providers())
+        usable = [p for p in providers if p in available]
+        missing = [p for p in providers if p not in available]
+        if missing:
+            _logger.warning(
+                "ONNX model declares execution providers %s but %s are unavailable in "
+                "this onnxruntime build; serving with %s. GPU acceleration will not be "
+                "used if a GPU provider is missing.",
+                providers,
+                missing,
+                usable or ["CPUExecutionProvider"],
             )
+        self.rt = onnxruntime.InferenceSession(
+            path, providers=usable or ["CPUExecutionProvider"], sess_options=sess_options
+        )
 
         assert len(self.rt.get_inputs()) >= 1
         self.inputs = [(inp.name, inp.type) for inp in self.rt.get_inputs()]

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -313,9 +313,46 @@ class _OnnxModelWrapper:
                 missing,
                 usable or ["CPUExecutionProvider"],
             )
-        self.rt = onnxruntime.InferenceSession(
-            path, providers=usable or ["CPUExecutionProvider"], sess_options=sess_options
-        )
+        requested_providers = usable or ["CPUExecutionProvider"]
+        # Some providers are compiled into onnxruntime (so they appear in
+        # get_available_providers()) but fail to initialize at runtime -- e.g. TensorRT
+        # without the TensorRT libraries installed, or CUDA with a driver/runtime mismatch.
+        # Depending on the provider, construction either raises or silently falls back to
+        # CPU. To avoid regressing a previously-loadable model into a hard load failure, we
+        # retry on CPU if the requested providers raise, and warn loudly in both cases.
+        try:
+            self.rt = onnxruntime.InferenceSession(
+                path, providers=requested_providers, sess_options=sess_options
+            )
+        except Exception as e:
+            if requested_providers == ["CPUExecutionProvider"]:
+                raise
+            _logger.warning(
+                "ONNX model requested execution providers %s but onnxruntime failed to "
+                "initialize them (%s); falling back to CPU. GPU acceleration will not be "
+                "used.",
+                requested_providers,
+                repr(e),
+            )
+            self.rt = onnxruntime.InferenceSession(
+                path, providers=["CPUExecutionProvider"], sess_options=sess_options
+            )
+
+        # Even when construction succeeds, onnxruntime may have silently dropped a requested
+        # provider that failed to initialize (activating fewer than requested). Compare
+        # requested vs actually-activated providers and warn on any drop, so a GPU model
+        # quietly running on CPU is surfaced instead of silent.
+        active_providers = self.rt.get_providers()
+        inactive_providers = [p for p in requested_providers if p not in active_providers]
+        if inactive_providers:
+            _logger.warning(
+                "ONNX model requested execution providers %s but onnxruntime activated only "
+                "%s; %s failed to initialize at runtime and were dropped. GPU acceleration "
+                "will not be used.",
+                requested_providers,
+                active_providers,
+                inactive_providers,
+            )
 
         assert len(self.rt.get_inputs()) >= 1
         self.inputs = [(inp.name, inp.type) for inp in self.rt.get_inputs()]

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -269,6 +269,14 @@ class _OnnxModelWrapper:
         else:
             providers = ONNX_EXECUTION_PROVIDERS
 
+        # Guard against malformed metadata: the providers field may have been hand-written
+        # as a single string or as null. Normalize to a non-empty list of provider names so
+        # the filtering below does not iterate over characters or fail on None.
+        if isinstance(providers, str):
+            providers = [providers]
+        elif not providers:
+            providers = ONNX_EXECUTION_PROVIDERS
+
         sess_options = onnxruntime.SessionOptions()
         if options := model_meta.flavors.get(FLAVOR_NAME).get("onnx_session_options"):
             if inter_op_num_threads := options.get("inter_op_num_threads"):

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -339,17 +339,23 @@ class _OnnxModelWrapper:
 
         # Even when construction succeeds, onnxruntime may have silently dropped a requested
         # provider that failed to initialize (activating fewer than requested). Compare
-        # requested vs actually-activated providers and warn on any drop, so a GPU model
-        # quietly running on CPU is surfaced instead of silent.
+        # requested vs actually-activated providers and warn on any drop. Whether this loses
+        # acceleration depends on which providers survived: dropping TensorRT while CUDA
+        # remains still runs on GPU, but dropping every non-CPU provider means CPU-only.
         active_providers = self.rt.get_providers()
         if inactive_providers := [p for p in requested_providers if p not in active_providers]:
+            still_accelerated = any(p != "CPUExecutionProvider" for p in active_providers)
             _logger.warning(
                 "ONNX model requested execution providers %s but onnxruntime activated only "
-                "%s; %s failed to initialize at runtime and were dropped. GPU acceleration "
-                "will not be used.",
+                "%s; %s failed to initialize at runtime and were dropped. %s",
                 requested_providers,
                 active_providers,
                 inactive_providers,
+                (
+                    "Inference will still use the remaining accelerated provider(s)."
+                    if still_accelerated
+                    else "Inference will run on CPU."
+                ),
             )
 
         assert len(self.rt.get_inputs()) >= 1

--- a/mlflow/onnx/__init__.py
+++ b/mlflow/onnx/__init__.py
@@ -303,8 +303,7 @@ class _OnnxModelWrapper:
         # the retry never fired and declared GPU providers were silently dropped.
         available = set(onnxruntime.get_available_providers())
         usable = [p for p in providers if p in available]
-        missing = [p for p in providers if p not in available]
-        if missing:
+        if missing := [p for p in providers if p not in available]:
             _logger.warning(
                 "ONNX model declares execution providers %s but %s are unavailable in "
                 "this onnxruntime build; serving with %s. GPU acceleration will not be "
@@ -343,8 +342,7 @@ class _OnnxModelWrapper:
         # requested vs actually-activated providers and warn on any drop, so a GPU model
         # quietly running on CPU is surfaced instead of silent.
         active_providers = self.rt.get_providers()
-        inactive_providers = [p for p in requested_providers if p not in active_providers]
-        if inactive_providers:
+        if inactive_providers := [p for p in requested_providers if p not in active_providers]:
             _logger.warning(
                 "ONNX model requested execution providers %s but onnxruntime activated only "
                 "%s; %s failed to initialize at runtime and were dropped. GPU acceleration "

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -735,8 +735,8 @@ def test_model_log_with_metadata(onnx_model):
 
 def _stub_session(mock_session):
     # _OnnxModelWrapper.__init__ asserts len(self.rt.get_inputs()) >= 1 and reads
-    # inp.name/inp.type and outp.name (mlflow/onnx/__init__.py:320-322). Configure the
-    # mocked InferenceSession's return value so construction completes.
+    # inp.name/inp.type and outp.name. Configure the mocked InferenceSession's return
+    # value so construction completes.
     inp = mock.Mock()
     inp.name, inp.type = "input", "tensor(float)"
     outp = mock.Mock()
@@ -785,3 +785,23 @@ def test_onnx_model_load_warns_when_declared_provider_unavailable(
     _, kwargs = mock_session.call_args
     assert kwargs["providers"] == ["CPUExecutionProvider"]
     assert "CUDAExecutionProvider" in caplog.text
+
+
+def test_onnx_model_load_coerces_string_provider_metadata(onnx_model, model_path):
+    # Malformed/legacy metadata may store a single provider as a bare string rather than a
+    # list. Without coercion the loader would iterate over its characters and silently fall
+    # back to CPU; the guard normalizes it to a one-element list.
+    mlflow.onnx.save_model(
+        onnx_model, model_path, onnx_execution_providers="CUDAExecutionProvider"
+    )
+    with (
+        mock.patch("onnxruntime.InferenceSession") as mock_session,
+        mock.patch(
+            "onnxruntime.get_available_providers",
+            return_value=["CUDAExecutionProvider", "CPUExecutionProvider"],
+        ),
+    ):
+        _stub_session(mock_session)
+        mlflow.pyfunc.load_model(model_path)
+    _, kwargs = mock_session.call_args
+    assert kwargs["providers"] == ["CUDAExecutionProvider"]

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from unittest import mock
@@ -730,3 +731,57 @@ def test_model_log_with_metadata(onnx_model):
 
     reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
+
+
+def _stub_session(mock_session):
+    # _OnnxModelWrapper.__init__ asserts len(self.rt.get_inputs()) >= 1 and reads
+    # inp.name/inp.type and outp.name (mlflow/onnx/__init__.py:320-322). Configure the
+    # mocked InferenceSession's return value so construction completes.
+    inp = mock.Mock()
+    inp.name, inp.type = "input", "tensor(float)"
+    outp = mock.Mock()
+    outp.name = "output"
+    mock_session.return_value.get_inputs.return_value = [inp]
+    mock_session.return_value.get_outputs.return_value = [outp]
+
+
+def test_onnx_model_load_honors_declared_execution_providers(onnx_model, model_path):
+    mlflow.onnx.save_model(
+        onnx_model, model_path, onnx_execution_providers=["CPUExecutionProvider"]
+    )
+    with mock.patch("onnxruntime.InferenceSession") as mock_session:
+        _stub_session(mock_session)
+        mlflow.pyfunc.load_model(model_path)
+    _, kwargs = mock_session.call_args
+    assert kwargs["providers"] == ["CPUExecutionProvider"]
+
+
+def test_onnx_model_load_warns_when_declared_provider_unavailable(
+    onnx_model, model_path, caplog
+):
+    mlflow.onnx.save_model(
+        onnx_model,
+        model_path,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+    # The "mlflow" logger sets propagate=False, so caplog's root handler does not see
+    # records. Attach caplog's handler directly to the mlflow.onnx logger
+    # (mirrors tests/server/test_security.py:84-92).
+    onnx_logger = logging.getLogger("mlflow.onnx")
+    onnx_logger.addHandler(caplog.handler)
+    try:
+        with (
+            mock.patch("onnxruntime.InferenceSession") as mock_session,
+            mock.patch(
+                "onnxruntime.get_available_providers",
+                return_value=["CPUExecutionProvider"],
+            ),
+            caplog.at_level("WARNING", logger="mlflow.onnx"),
+        ):
+            _stub_session(mock_session)
+            mlflow.pyfunc.load_model(model_path)
+    finally:
+        onnx_logger.removeHandler(caplog.handler)
+    _, kwargs = mock_session.call_args
+    assert kwargs["providers"] == ["CPUExecutionProvider"]
+    assert "CUDAExecutionProvider" in caplog.text

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -779,9 +779,7 @@ def test_onnx_model_load_honors_declared_execution_providers(onnx_model, model_p
     assert kwargs["providers"] == ["CPUExecutionProvider"]
 
 
-def test_onnx_model_load_warns_when_declared_provider_unavailable(
-    onnx_model, model_path, caplog
-):
+def test_onnx_model_load_warns_when_declared_provider_unavailable(onnx_model, model_path, caplog):
     mlflow.onnx.save_model(
         onnx_model,
         model_path,
@@ -814,9 +812,7 @@ def test_onnx_model_load_coerces_string_provider_metadata(onnx_model, model_path
     # Malformed/legacy metadata may store a single provider as a bare string rather than a
     # list. Without coercion the loader would iterate over its characters and silently fall
     # back to CPU; the guard normalizes it to a one-element list.
-    mlflow.onnx.save_model(
-        onnx_model, model_path, onnx_execution_providers="CUDAExecutionProvider"
-    )
+    mlflow.onnx.save_model(onnx_model, model_path, onnx_execution_providers="CUDAExecutionProvider")
     with (
         mock.patch("onnxruntime.InferenceSession") as mock_session,
         mock.patch(

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -733,16 +733,39 @@ def test_model_log_with_metadata(onnx_model):
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
 
 
-def _stub_session(mock_session):
-    # _OnnxModelWrapper.__init__ asserts len(self.rt.get_inputs()) >= 1 and reads
-    # inp.name/inp.type and outp.name. Configure the mocked InferenceSession's return
-    # value so construction completes.
+def _stub_session(mock_session, active_providers=None, raise_on_providers=None):
+    # _OnnxModelWrapper.__init__ asserts len(self.rt.get_inputs()) >= 1, reads
+    # inp.name/inp.type and outp.name, and calls get_providers() to detect runtime
+    # fallback. Configure the mocked InferenceSession's return value so construction
+    # completes.
+    #   - active_providers: what the constructed session reports as actually activated;
+    #     default echoes the providers the (final) session was constructed with.
+    #   - raise_on_providers: if given, an InferenceSession(...) call whose providers equal
+    #     this list raises RuntimeError (simulating a provider that fails to initialize,
+    #     e.g. TensorRT without libnvinfer); other calls return the stub session.
     inp = mock.Mock()
     inp.name, inp.type = "input", "tensor(float)"
     outp = mock.Mock()
     outp.name = "output"
-    mock_session.return_value.get_inputs.return_value = [inp]
-    mock_session.return_value.get_outputs.return_value = [outp]
+    session = mock_session.return_value
+    session.get_inputs.return_value = [inp]
+    session.get_outputs.return_value = [outp]
+
+    def _construct(*args, **kwargs):
+        if raise_on_providers is not None and kwargs.get("providers") == raise_on_providers:
+            raise RuntimeError("simulated provider init failure (e.g. missing libnvinfer)")
+        return session
+
+    mock_session.side_effect = _construct
+
+    def _get_providers():
+        if active_providers is not None:
+            return active_providers
+        # Echo whatever providers the session was last constructed with.
+        _, kwargs = mock_session.call_args
+        return kwargs.get("providers") or ["CPUExecutionProvider"]
+
+    session.get_providers.side_effect = _get_providers
 
 
 def test_onnx_model_load_honors_declared_execution_providers(onnx_model, model_path):
@@ -805,3 +828,75 @@ def test_onnx_model_load_coerces_string_provider_metadata(onnx_model, model_path
         mlflow.pyfunc.load_model(model_path)
     _, kwargs = mock_session.call_args
     assert kwargs["providers"] == ["CUDAExecutionProvider"]
+
+
+def test_onnx_model_load_warns_on_runtime_provider_fallback(onnx_model, model_path, caplog):
+    # A requested provider can be compiled into onnxruntime (so it appears in
+    # get_available_providers()) yet fail to initialize at runtime -- e.g. a CUDA
+    # driver/runtime mismatch -- causing a silent fallback to CPU. The loader compares
+    # requested vs actually-activated providers and warns on the drop.
+    mlflow.onnx.save_model(
+        onnx_model,
+        model_path,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+    onnx_logger = logging.getLogger("mlflow.onnx")
+    onnx_logger.addHandler(caplog.handler)
+    try:
+        with (
+            mock.patch("onnxruntime.InferenceSession") as mock_session,
+            mock.patch(
+                "onnxruntime.get_available_providers",
+                return_value=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            ),
+            caplog.at_level("WARNING", logger="mlflow.onnx"),
+        ):
+            # CUDA is "available" but the session activates CPU only (runtime init failed).
+            _stub_session(mock_session, active_providers=["CPUExecutionProvider"])
+            mlflow.pyfunc.load_model(model_path)
+    finally:
+        onnx_logger.removeHandler(caplog.handler)
+    _, kwargs = mock_session.call_args
+    # We still requested CUDA (it passed the available-providers filter)...
+    assert kwargs["providers"] == ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    # ...but the runtime-fallback warning fires because it was not activated.
+    assert "CUDAExecutionProvider" in caplog.text
+    assert "failed to initialize at runtime" in caplog.text
+
+
+def test_onnx_model_load_falls_back_to_cpu_when_provider_construction_raises(
+    onnx_model, model_path, caplog
+):
+    # Some providers raise during construction rather than silently dropping -- e.g.
+    # TensorRT without libnvinfer, or CUDA driver/runtime mismatch. The loader must not
+    # regress a previously-loadable model into a hard failure: it retries on CPU and warns.
+    mlflow.onnx.save_model(
+        onnx_model,
+        model_path,
+        onnx_execution_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+    )
+    onnx_logger = logging.getLogger("mlflow.onnx")
+    onnx_logger.addHandler(caplog.handler)
+    try:
+        with (
+            mock.patch("onnxruntime.InferenceSession") as mock_session,
+            mock.patch(
+                "onnxruntime.get_available_providers",
+                return_value=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            ),
+            caplog.at_level("WARNING", logger="mlflow.onnx"),
+        ):
+            # Constructing with the GPU providers raises; the CPU-only retry succeeds.
+            _stub_session(
+                mock_session,
+                active_providers=["CPUExecutionProvider"],
+                raise_on_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            )
+            mlflow.pyfunc.load_model(model_path)
+    finally:
+        onnx_logger.removeHandler(caplog.handler)
+    # Two constructions: the failing GPU attempt, then the CPU fallback.
+    assert mock_session.call_count == 2
+    _, kwargs = mock_session.call_args
+    assert kwargs["providers"] == ["CPUExecutionProvider"]
+    assert "falling back to CPU" in caplog.text

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -855,9 +855,56 @@ def test_onnx_model_load_warns_on_runtime_provider_fallback(onnx_model, model_pa
     _, kwargs = mock_session.call_args
     # We still requested CUDA (it passed the available-providers filter)...
     assert kwargs["providers"] == ["CUDAExecutionProvider", "CPUExecutionProvider"]
-    # ...but the runtime-fallback warning fires because it was not activated.
+    # ...but the runtime-fallback warning fires because it was not activated, and since
+    # nothing accelerated survived the warning says inference runs on CPU.
     assert "CUDAExecutionProvider" in caplog.text
     assert "failed to initialize at runtime" in caplog.text
+    assert "Inference will run on CPU." in caplog.text
+
+
+def test_onnx_model_load_warns_but_keeps_gpu_when_only_some_providers_drop(
+    onnx_model, model_path, caplog
+):
+    # When onnxruntime drops one requested provider (e.g. TensorRT) but a GPU provider
+    # (CUDA) survives, the model still runs on GPU. The warning must report the drop
+    # without claiming acceleration was lost.
+    mlflow.onnx.save_model(
+        onnx_model,
+        model_path,
+        onnx_execution_providers=[
+            "TensorrtExecutionProvider",
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ],
+    )
+    onnx_logger = logging.getLogger("mlflow.onnx")
+    onnx_logger.addHandler(caplog.handler)
+    try:
+        with (
+            mock.patch("onnxruntime.InferenceSession") as mock_session,
+            mock.patch(
+                "onnxruntime.get_available_providers",
+                return_value=[
+                    "TensorrtExecutionProvider",
+                    "CUDAExecutionProvider",
+                    "CPUExecutionProvider",
+                ],
+            ),
+            caplog.at_level("WARNING", logger="mlflow.onnx"),
+        ):
+            # TensorRT is dropped at runtime but CUDA survives -> still on GPU.
+            _stub_session(
+                mock_session,
+                active_providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            )
+            mlflow.pyfunc.load_model(model_path)
+    finally:
+        onnx_logger.removeHandler(caplog.handler)
+    assert "TensorrtExecutionProvider" in caplog.text
+    assert "failed to initialize at runtime" in caplog.text
+    # CUDA survived, so the message must NOT claim CPU-only.
+    assert "Inference will still use the remaining accelerated provider(s)." in caplog.text
+    assert "Inference will run on CPU." not in caplog.text
 
 
 def test_onnx_model_load_falls_back_to_cpu_when_provider_construction_raises(


### PR DESCRIPTION
### Related Issues/PRs

Relates to: no existing tracking issue. Bug surfaced when serving `mlflow.onnx`-flavor models on GPU.

### What changes are proposed in this pull request?

`_OnnxModelWrapper.__init__` resolves the model's declared ONNX execution providers from the
`MLmodel` flavor metadata, but then drops them. It first constructs the `InferenceSession`
**without** `providers` and only retries with `providers` inside an `except ValueError`. On
`onnxruntime >= 1.9` the no-providers constructor succeeds (defaulting to CPU) and never raises,
so the retry is dead code and the declared providers are silently ignored. ONNX-flavor models
therefore run on CPU even on a host with `onnxruntime-gpu` and a GPU, with no warning.

This PR:
- Passes the declared providers on the single `InferenceSession` construction, filtered to those
  reported by `onnxruntime.get_available_providers()`.
- Logs a clear `WARNING` (instead of a silent CPU fallback) when a declared provider — e.g.
  `CUDAExecutionProvider` — is unavailable in the current `onnxruntime` build.
- Removes the obsolete pre-1.9 try/except.

CPU-only deployments are unaffected: the default `["CUDAExecutionProvider", "CPUExecutionProvider"]`
resolves to `["CPUExecutionProvider"]`, with a warning that CUDA was unavailable.

**Why removing the pre-1.9 try/except is safe:** the `providers=` argument has been supported since
onnxruntime 1.4 and `get_available_providers()` since 1.0 — far below any version a modern mlflow
runs with (mlflow ships `onnx>=1.17.0`). The removed `except` branch already passed `providers=`, so
no realistically supported onnxruntime regresses. And because we now filter the declared providers
through `get_available_providers()`, an unregistered provider name is never passed to
`InferenceSession` — which is the failure mode the old "construct without providers first" attempt
was guarding against, so the new path is if anything more robust.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in `tests/onnx/test_onnx_model_export.py`: one asserts `InferenceSession` is constructed
with the declared providers; one asserts a `WARNING` naming `CUDAExecutionProvider` is emitted when
that provider is unavailable. (GPU end-to-end validation on a CUDA host is recommended but was not
run by the author.)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. ONNX-flavor models now honor their declared execution providers at load time, using the
  GPU (e.g. `CUDAExecutionProvider`) when available instead of silently falling back to CPU; a
  warning is logged when a declared provider is unavailable.

#### What component(s) does this PR affect?

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release