### PR TITLE
Add `mlflow datasets add-traces` CLI command

### DIFF
--- a/mlflow/cli/datasets.py
+++ b/mlflow/cli/datasets.py
@@ -5,6 +5,9 @@ import click
 
 from mlflow import MlflowClient
 from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID
+from mlflow.exceptions import MlflowException
+from mlflow.genai.datasets import get_dataset
+from mlflow.tracing.client import TracingClient
 from mlflow.utils.string_utils import _create_table
 from mlflow.utils.time import conv_longdate_to_str
 
@@ -136,3 +139,82 @@ def list_datasets(
 
         if datasets.token:
             click.echo(f"\nNext page token: {datasets.token}")
+
+
+@commands.command("add-traces")
+@click.option(
+    "--dataset-id",
+    type=click.STRING,
+    required=True,
+    help="ID of the evaluation dataset to add traces to.",
+)
+@click.option(
+    "--trace-ids",
+    type=click.STRING,
+    required=True,
+    help="Comma-separated list of trace IDs to add.",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format.",
+)
+def add_traces(
+    dataset_id: str,
+    trace_ids: str,
+    output: Literal["table", "json"] = "table",
+) -> None:
+    """
+    Add traces to a GenAI evaluation dataset.
+
+    Traces are merged by trace ID, so re-adding a trace already in the dataset
+    is a no-op rather than creating a duplicate. Works against both OSS MLflow
+    and Databricks-managed datasets.
+
+    \b
+    Examples:
+    # Add a single trace
+    mlflow datasets add-traces --dataset-id d-abc123 --trace-ids tr-1234567890abcdef
+
+    \b
+    # Add multiple traces
+    mlflow datasets add-traces --dataset-id d-abc123 --trace-ids tr-1,tr-2,tr-3
+
+    \b
+    # Output the updated dataset as JSON
+    mlflow datasets add-traces --dataset-id d-abc123 --trace-ids tr-1 --output json
+    """
+    ids = [t.strip() for t in trace_ids.split(",") if t.strip()]
+    if not ids:
+        raise click.UsageError("--trace-ids must contain at least one trace ID.")
+
+    try:
+        dataset = get_dataset(dataset_id=dataset_id)
+    except MlflowException as e:
+        raise click.UsageError(f"Could not load dataset {dataset_id!r}: {e.message}")
+
+    tracing_client = TracingClient()
+    traces = []
+    for trace_id in ids:
+        try:
+            traces.append(tracing_client.get_trace(trace_id))
+        except MlflowException as e:
+            raise click.UsageError(f"Could not fetch trace {trace_id!r}: {e.message}")
+
+    # merge_records mutates self on the OSS path but returns a new object on the
+    # Databricks-managed path, so reassign to reflect the post-merge state for both.
+    dataset = dataset.merge_records(traces)
+    record_count = len(dataset.to_df())
+
+    if output == "json":
+        result = {
+            "dataset_id": dataset.dataset_id,
+            "name": dataset.name,
+            "record_count": record_count,
+            "added_trace_ids": ids,
+        }
+        click.echo(json.dumps(result, indent=2))
+    else:
+        click.echo(f"Added {len(ids)} trace(s) to dataset {dataset.dataset_id} ({dataset.name}).")
+        click.echo(f"Dataset now has {record_count} record(s).")

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 import mlflow
 from mlflow.cli.datasets import commands
-from mlflow.genai.datasets import create_dataset
+from mlflow.genai.datasets import create_dataset, get_dataset
 
 
 @pytest.fixture
@@ -36,6 +36,21 @@ def dataset_b(experiment):
         experiment_id=experiment,
         tags={"env": "staging"},
     )
+
+
+@pytest.fixture
+def trace_ids(experiment):
+    mlflow.set_experiment(experiment_id=experiment)
+
+    @mlflow.trace
+    def predict(question: str) -> str:
+        return f"answer to {question}"
+
+    ids = []
+    for q in ["q1", "q2"]:
+        predict(q)
+        ids.append(mlflow.get_last_active_trace_id())
+    return ids
 
 
 def test_commands_group_exists():
@@ -182,3 +197,105 @@ def test_list_datasets_json_multiple_datasets(
 
     names = {d["name"] for d in output_json["datasets"]}
     assert names == {"dataset_a", "dataset_b"}
+
+
+def test_add_traces_command_params():
+    add_cmd = next((cmd for cmd in commands.commands.values() if cmd.name == "add-traces"), None)
+    assert add_cmd is not None
+    param_names = {p.name for p in add_cmd.params}
+    assert param_names == {"dataset_id", "trace_ids", "output"}
+
+
+def test_add_traces_table_output(runner: CliRunner, dataset_a, trace_ids):
+    result = runner.invoke(
+        commands,
+        ["add-traces", "--dataset-id", dataset_a.dataset_id, "--trace-ids", ",".join(trace_ids)],
+    )
+
+    assert result.exit_code == 0
+    assert f"Added {len(trace_ids)} trace(s)" in result.output
+    assert dataset_a.dataset_id in result.output
+    assert f"Dataset now has {len(trace_ids)} record(s)." in result.output
+
+
+def test_add_traces_json_output(runner: CliRunner, dataset_a, trace_ids):
+    result = runner.invoke(
+        commands,
+        [
+            "add-traces",
+            "--dataset-id",
+            dataset_a.dataset_id,
+            "--trace-ids",
+            ",".join(trace_ids),
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    output_json = json.loads(result.output)
+    assert output_json["dataset_id"] == dataset_a.dataset_id
+    assert output_json["added_trace_ids"] == trace_ids
+    assert output_json["record_count"] == len(trace_ids)
+
+
+def test_add_traces_merges_records(runner: CliRunner, dataset_a, trace_ids):
+    result = runner.invoke(
+        commands,
+        ["add-traces", "--dataset-id", dataset_a.dataset_id, "--trace-ids", ",".join(trace_ids)],
+    )
+
+    assert result.exit_code == 0
+    refreshed = get_dataset(dataset_id=dataset_a.dataset_id)
+    assert len(refreshed.to_df()) == len(trace_ids)
+
+
+def test_add_traces_is_idempotent(runner: CliRunner, dataset_a, trace_ids):
+    args = ["add-traces", "--dataset-id", dataset_a.dataset_id, "--trace-ids", ",".join(trace_ids)]
+    assert runner.invoke(commands, args).exit_code == 0
+    assert runner.invoke(commands, args).exit_code == 0
+
+    refreshed = get_dataset(dataset_id=dataset_a.dataset_id)
+    assert len(refreshed.to_df()) == len(trace_ids)
+
+
+def test_add_traces_single_trace(runner: CliRunner, dataset_a, trace_ids):
+    result = runner.invoke(
+        commands,
+        ["add-traces", "--dataset-id", dataset_a.dataset_id, "--trace-ids", trace_ids[0]],
+    )
+
+    assert result.exit_code == 0
+    assert "Added 1 trace(s)" in result.output
+
+
+def test_add_traces_missing_dataset_id(runner: CliRunner):
+    result = runner.invoke(commands, ["add-traces", "--trace-ids", "tr-1"])
+
+    assert result.exit_code != 0
+    assert "Missing option '--dataset-id'" in result.output
+
+
+def test_add_traces_missing_trace_ids(runner: CliRunner, dataset_a):
+    result = runner.invoke(commands, ["add-traces", "--dataset-id", dataset_a.dataset_id])
+
+    assert result.exit_code != 0
+    assert "Missing option '--trace-ids'" in result.output
+
+
+def test_add_traces_unknown_dataset(runner: CliRunner, trace_ids):
+    result = runner.invoke(
+        commands, ["add-traces", "--dataset-id", "d-missing", "--trace-ids", trace_ids[0]]
+    )
+
+    assert result.exit_code != 0
+    assert "Could not load dataset 'd-missing'" in result.output
+
+
+def test_add_traces_unknown_trace(runner: CliRunner, dataset_a):
+    result = runner.invoke(
+        commands, ["add-traces", "--dataset-id", dataset_a.dataset_id, "--trace-ids", "tr-missing"]
+    )
+
+    assert result.exit_code != 0
+    assert "Could not fetch trace 'tr-missing'" in result.output


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24181

### What changes are proposed in this pull request?

Adds a new `mlflow datasets add-traces` CLI command that adds traces to a GenAI evaluation dataset by trace ID:

```bash
mlflow datasets add-traces --dataset-id d-abc123 --trace-ids tr-1,tr-2 [--output table|json]
```

The command fetches each trace via `TracingClient.get_trace()` and merges them into the dataset with `EvaluationDataset.merge_records()`. Notable behaviors:

- **Idempotent** — `merge_records` upserts by trace ID, so re-adding a trace already in the dataset is a no-op rather than a duplicate.
- **Backend-agnostic** — works against both OSS MLflow and Databricks-managed datasets (`merge_records` branches internally; the command reassigns the return value so the reported record count is correct on the managed path, which returns a new object instead of mutating in place).
- **Clean error UX** — a missing dataset or trace ID raises a `click.UsageError` with a readable message and non-zero exit code, rather than a traceback.
- Prints the post-merge record count in `table` or `json` form.

Comma-separated `--trace-ids` and `--output table|json` follow the conventions already used by the sibling `mlflow traces` and `mlflow datasets list` commands.

> [!NOTE]
> The Databricks-managed path forwards `Trace` objects to the external `databricks-agents` `merge_records` implementation, which cannot be verified in this repo's test suite. This has been validated against the OSS backend end-to-end (CLI → store → UI); a reviewer with workspace access should confirm the managed path accepts `Trace` objects.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added `tests/cli/test_datasets.py` coverage for table/JSON output, actual record merge, idempotency (re-adding does not duplicate), single-trace, and the missing-dataset / missing-trace error paths. Manually verified end-to-end against a local SQLite tracking store: seeded traces, ran `add-traces`, and confirmed the two records render in the evaluation-datasets UI.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow CLI now supports `mlflow datasets add-traces` to add traces to a GenAI evaluation dataset by trace ID.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
