### PR TITLE
fix(db): Avoid 'Table already exists' error during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Running `mlflow db upgrade` from 3.7.0 to 3.8.x fails with pymysql.err.OperationalError: (1050, "Table 'secrets' already exists") because `InitialBase.metadata.create_all(engine)` tries to recreate tables that already exist.

## Fix
Add `checkfirst=True` to the `create_all` call so that SQLAlchemy skips creation of existing tables instead of raising an error. This is the standard way to safely initialize tables without conflicts.

Closes #19943