### PR TITLE
docs: update Omnigent integration page for pure OTel setup

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/omnigent.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/omnigent.mdx
@@ -55,13 +55,21 @@ docker compose up -d
 
 <StepHeader number={3} title="Configure Environment Variables" />
 
-Point Omnigent at any OTLP-compatible collector (MLflow tracking server, Jaeger, Grafana Tempo, etc.):
+Set the following environment variables on the **host machine** (the machine running `omnigent run` or `omnigent host`):
 
 ```bash
+export OMNIGENT_TELEMETRY_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:5000"
-export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"  # or "grpc" (default)
-export OTEL_EXPORTER_OTLP_HEADERS="x-mlflow-experiment-id=1"
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-mlflow-experiment-id=1"
+
+# Optional: suppress internal HTTP call spans
+export OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION=false
 ```
+
+:::note
+Tracing runs in the runner/harness process on the **host** side, not the server. Set these variables where you run `omnigent run` or `omnigent host`, not where the server is deployed.
+:::
 
 <StepHeader number={4} title="Start Omnigent" />
 
@@ -88,17 +96,15 @@ agent:<name>         (AGENT)       — user message, response, token usage
 
 Omnigent response IDs use the format `resp_<32-char hex>`. The hex suffix is reused as the W3C trace ID, so operators can look up a trace by its response ID — just strip the `resp_` prefix and paste the hex into any trace backend's search UI. No lookup table needed.
 
-### Unified Provider Mode
-
-Omnigent sets `MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false` so MLflow shares the global OpenTelemetry `TracerProvider` with raw OTel instrumentation (e.g., FastAPI auto-instrumentation). This means MLflow spans and raw OTel spans appear in the same trace tree.
-
 ## Configuration Reference
 
-| Variable                      | Purpose                                                                                                                          | Default |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint (e.g. your MLflow server URL)                                                                            | unset   |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP transport (`grpc` or `http/protobuf`)                                                                                       | `grpc`  |
-| `OTEL_EXPORTER_OTLP_HEADERS`  | Key-value headers sent with every OTLP request (e.g. `x-mlflow-experiment-id=1` to route traces to a specific MLflow experiment) | unset   |
+| Variable                                    | Purpose                                                                                                    | Default |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------- |
+| `OMNIGENT_TELEMETRY_ENABLED`                | Master opt-in — must be `true` to enable any tracing                                                       | `false` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`               | OTLP collector endpoint (e.g. your MLflow server URL)                                                      | unset   |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`               | OTLP transport (`grpc` or `http/protobuf`)                                                                 | `grpc`  |
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS`         | Headers for trace OTLP requests (e.g. `x-mlflow-experiment-id=1` to route to a specific MLflow experiment) | unset   |
+| `OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION` | Set to `false` to suppress internal HTTP call spans from appearing alongside agent traces                  | `true`  |
 
 ## Monitoring Token Usage
 
@@ -110,9 +116,10 @@ See [Token Usage and Cost Tracking](/genai/tracing/token-usage-cost) for details
 
 **Tracing not working:**
 
-- Verify that `omnigent[tracing]` is installed: `python -c "import mlflow; print(mlflow.__version__)"`
-- Check that `OTEL_EXPORTER_OTLP_ENDPOINT` or `MLFLOW_TRACKING_URI` is set in the environment that starts the Omnigent server
-- Confirm the MLflow tracking server or OTLP collector is reachable
+- Verify `OMNIGENT_TELEMETRY_ENABLED=true` is set — tracing is off by default
+- Check that `OTEL_EXPORTER_OTLP_ENDPOINT` is set on the **host machine** (not the server)
+- Confirm the MLflow tracking server is reachable from the host machine
+- Check host logs (`~/.omnigent/logs/host-runner/`) for `omnigent telemetry initialized` to confirm the OTel provider started
 
 **Missing traces:**
 

--- a/docs/docs/genai/tracing/integrations/listing/omnigent.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/omnigent.mdx
@@ -16,7 +16,7 @@ import TileCard from "@site/src/components/TileCard";
 
 # Tracing Omnigent
 
-<ImageBox src="/images/llms/tracing/omnigent-tracing.png" alt="Omnigent Traces in MLflow UI" />
+<ImageBox src="/images/llms/tracing/omnigent-trace-detail.png" alt="Omnigent Trace Detail in MLflow UI" />
 
 [MLflow Tracing](/genai/tracing) provides automatic tracing for [Omnigent](https://omnigent.ai/), a multi-harness AI agent orchestration platform. Omnigent natively emits [OpenTelemetry](https://opentelemetry.io/) traces via MLflow's tracing SDK, so after setup MLflow will automatically capture traces of your Omnigent agent sessions including:
 
@@ -80,8 +80,6 @@ omnigent run
 ```
 
 ## How It Works
-
-<ImageBox src="/images/llms/tracing/omnigent-trace-detail.png" alt="Omnigent Trace Detail in MLflow UI" />
 
 Omnigent uses MLflow's tracing SDK to emit structured spans in a hierarchy that mirrors the agent execution:
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/pull/24072

### What changes are proposed in this pull request?

Updates the Omnigent tracing integration documentation to reflect the current setup:

- Add `OMNIGENT_TELEMETRY_ENABLED=true` — a master opt-in added in omnigent-ai/omnigent#1617 that must be set for any tracing to work (off by default)
- Switch to `OTEL_EXPORTER_OTLP_TRACES_HEADERS` for experiment routing — signal-specific vars take precedence over generic `OTEL_EXPORTER_OTLP_HEADERS`, which may be overridden in environments with Databricks/other OTLP headers set globally
- Add `OMNIGENT_OTEL_HTTP_CLIENT_INSTRUMENTATION=false` opt-out (omnigent-ai/omnigent#1788) to suppress internal HTTP call spans from flooding the traces view alongside agent/tool spans
- Clarify that tracing runs on the **host machine** (where `omnigent run` or `omnigent host` is invoked), not the server
- Update troubleshooting section to reflect these requirements
- Move trace detail image to the top; remove the less informative traces list image

### How is this PR tested?

- [x] Manual tests

Verified setup works end-to-end: ran `omnigent run` with `OMNIGENT_TELEMETRY_ENABLED=true` and the listed env vars against a local MLflow server, confirmed traces appear with correct experiment routing and `OK` status.

### Does this PR require documentation update?

- [x] No.

This PR _is_ a documentation update.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Updated Omnigent tracing integration docs with required `OMNIGENT_TELEMETRY_ENABLED` env var and corrected setup instructions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release