### PR TITLE
feat(ts-sdk): add `MLFLOW_TRACKING_AUTH=kubernetes`/`kubernetes-namespaced` support

### DIFF
--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -48,7 +48,11 @@
     "bignumber.js": "^9.0.0",
     "ini": "^5.0.0"
   },
+  "optionalDependencies": {
+    "@kubernetes/client-node": "^1.0.0"
+  },
   "devDependencies": {
+    "@kubernetes/client-node": "^1.0.0",
     "@types/ini": "^4.1.1",
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.5",

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -23,7 +23,12 @@
  * For HTTP(S) URIs, authentication is resolved in order:
  * 1. Basic Auth (MLFLOW_TRACKING_USERNAME + MLFLOW_TRACKING_PASSWORD)
  * 2. Bearer Token (MLFLOW_TRACKING_TOKEN)
- * 3. No authentication
+ * 3. Kubernetes auth (MLFLOW_TRACKING_AUTH=kubernetes or kubernetes-namespaced)
+ * 4. No authentication
+ *
+ * Kubernetes auth support:
+ * - MLFLOW_TRACKING_AUTH=kubernetes: reads bearer token from the pod's ServiceAccount mount
+ * - MLFLOW_TRACKING_AUTH=kubernetes-namespaced: same, plus sets X-MLFLOW-WORKSPACE from the namespace
  *
  * Workspace support (servers with workspaces enabled):
  * - MLFLOW_WORKSPACE: sets the `X-MLFLOW-WORKSPACE` header for workspace-scoped requests
@@ -35,6 +40,32 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { Config } from '@databricks/sdk-experimental';
+
+const SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+const SA_NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
+const CACHE_TTL_MS = 60_000;
+
+/**
+ * Returns a function that reads a file and caches the result for CACHE_TTL_MS.
+ * Used to read ServiceAccount token/namespace files without hitting disk on
+ * every HTTP request, while still picking up rotated tokens within 60 seconds.
+ */
+function createCachedFileReader(filePath: string): () => string | undefined {
+  let cached: string | undefined;
+  let cachedAt = 0;
+  return () => {
+    const now = Date.now();
+    if (cached === undefined || now - cachedAt > CACHE_TTL_MS) {
+      cachedAt = now;
+      try {
+        cached = fs.readFileSync(filePath, 'utf-8').trim() || undefined;
+      } catch {
+        cached = undefined;
+      }
+    }
+    return cached;
+  };
+}
 
 /**
  * Function that provides HTTP headers for authenticated requests.
@@ -254,18 +285,37 @@ function createDatabricksAuth(options: AuthOptions): AuthProvider {
 /**
  * Create authentication for self-hosted (OSS) MLflow.
  *
- * Resolution order:
- * 1. Explicit options (username/password or token)
- * 2. Environment variables (MLFLOW_TRACKING_*)
- * 3. No authentication
+ * Resolution order (explicit credentials win over MLFLOW_TRACKING_AUTH):
+ * 1. Basic Auth (username/password from options or MLFLOW_TRACKING_USERNAME/PASSWORD)
+ * 2. Bearer Token (token from options or MLFLOW_TRACKING_TOKEN)
+ * 3. Kubernetes auth (MLFLOW_TRACKING_AUTH=kubernetes or kubernetes-namespaced)
+ * 4. No authentication
  */
 function createOssAuth(options: AuthOptions): AuthProvider {
   const host = options.trackingUri;
 
-  // Resolve credentials from options or environment
+  // Resolve explicit credentials from options or environment
   const username = options.trackingServerUsername || process.env.MLFLOW_TRACKING_USERNAME;
   const password = options.trackingServerPassword || process.env.MLFLOW_TRACKING_PASSWORD;
   const token = options.trackingServerToken || process.env.MLFLOW_TRACKING_TOKEN;
+
+  // Explicit credentials take precedence over MLFLOW_TRACKING_AUTH,
+  // matching Python SDK where KubernetesAuth skips if Authorization
+  // header is already set by username/password or token.
+  const hasExplicitCredentials = (username && password) || token;
+  const trackingAuth = process.env.MLFLOW_TRACKING_AUTH;
+  if (
+    (trackingAuth === 'kubernetes' || trackingAuth === 'kubernetes-namespaced') &&
+    !hasExplicitCredentials
+  ) {
+    return createKubernetesAuth(
+      host,
+      trackingAuth === 'kubernetes-namespaced',
+      SA_TOKEN_PATH,
+      SA_NAMESPACE_PATH,
+      options.workspace,
+    );
+  }
 
   // Pre-compute auth header since credentials don't change
   let authHeader: string | undefined;
@@ -288,6 +338,135 @@ function createOssAuth(options: AuthOptions): AuthProvider {
     if (workspace) {
       headers['X-MLFLOW-WORKSPACE'] = workspace;
     }
+    return headers;
+  };
+
+  return {
+    getHost: () => host,
+    getHeadersProvider: () => headersProvider,
+    getDatabricksToken: () => undefined,
+  };
+}
+
+/**
+ * Try to load token and namespace from kubeconfig (~/.kube/config).
+ * Requires @kubernetes/client-node.
+ * Returns null if the package is unavailable or kubeconfig cannot be loaded.
+ */
+async function loadFromKubeconfig(): Promise<{ token?: string; namespace?: string } | null> {
+  let k8s: typeof import('@kubernetes/client-node');
+  try {
+    k8s = await import('@kubernetes/client-node');
+  } catch {
+    console.warn(
+      '[mlflow] @kubernetes/client-node is not installed. ' +
+        'Kubeconfig fallback is disabled. ' +
+        'Install it with: npm install @kubernetes/client-node',
+    );
+    return null;
+  }
+
+  try {
+    const kc = new k8s.KubeConfig();
+    kc.loadFromDefault();
+
+    const currentContext = kc.getCurrentContext();
+    const context = kc.getContextObject(currentContext);
+
+    // Resolve token through the full auth pipeline (exec, OIDC, cloud providers)
+    // using applyToFetchOptions which is the public API for credential resolution
+    const fetchOpts = await kc.applyToFetchOptions({} as any);
+    const resolvedHeaders = new Headers(fetchOpts.headers as HeadersInit);
+
+    let token: string | undefined;
+    const authHeader = resolvedHeaders.get('Authorization') || resolvedHeaders.get('authorization');
+    if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
+      token = authHeader.substring(7).trim() || undefined;
+    }
+
+    return {
+      token,
+      namespace: context?.namespace || undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create authentication for Kubernetes environments.
+ *
+ * Resolution order (mirrors Python SDK):
+ * 1. ServiceAccount mount: reads token/namespace from
+ *    /var/run/secrets/kubernetes.io/serviceaccount/ with 60s TTL caching
+ * 2. Kubeconfig fallback: reads ~/.kube/config via @kubernetes/client-node
+ *    (via @kubernetes/client-node)
+ *
+ * When enableWorkspaces is true, also reads the namespace and sets
+ * the X-MLFLOW-WORKSPACE header.
+ */
+export function createKubernetesAuth(
+  host: string,
+  enableWorkspaces: boolean,
+  tokenPath: string = SA_TOKEN_PATH,
+  namespacePath: string = SA_NAMESPACE_PATH,
+  workspace?: string,
+  kubeconfigLoader: () => Promise<{ token?: string; namespace?: string } | null> = loadFromKubeconfig,
+): AuthProvider {
+  const getTokenFromFile = createCachedFileReader(tokenPath);
+  const getNamespaceFromFile = enableWorkspaces
+    ? createCachedFileReader(namespacePath)
+    : undefined;
+
+  // Kubeconfig result cached with TTL to pick up context switches and token rotation
+  let kubeconfigResult: { token?: string; namespace?: string } | null | undefined;
+  let kubeconfigCachedAt = 0;
+  async function getKubeconfig() {
+    const now = Date.now();
+    if (kubeconfigResult === undefined || now - kubeconfigCachedAt > CACHE_TTL_MS) {
+      kubeconfigCachedAt = now;
+      kubeconfigResult = await kubeconfigLoader();
+    }
+    return kubeconfigResult;
+  }
+
+  const headersProvider: HeadersProvider = async () => {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+    // Token: try SA file first, then kubeconfig, otherwise throw error
+    let token = getTokenFromFile();
+    if (!token) {
+      token = (await getKubeconfig())?.token;
+    }
+    if (!token) {
+      throw new Error(
+        'Could not determine Kubernetes credentials. ' +
+          'Ensure you are running in a Kubernetes pod with a service account ' +
+          'or have a valid kubeconfig with credentials set.',
+      );
+    }
+    headers['Authorization'] = `Bearer ${token}`;
+
+    // Workspace: explicit MLFLOW_WORKSPACE if provided will take precedence.
+    // For kubernetes-namespaced, also auto-discover from SA file or kubeconfig.
+    const explicitWorkspace = process.env.MLFLOW_WORKSPACE ?? workspace;
+    if (explicitWorkspace) {
+      headers['X-MLFLOW-WORKSPACE'] = explicitWorkspace;
+    } else if (enableWorkspaces) {
+      let namespace = getNamespaceFromFile?.();
+      if (!namespace) {
+        namespace = (await getKubeconfig())?.namespace;
+      }
+      if (!namespace) {
+        throw new Error(
+          'Could not determine Kubernetes namespace. ' +
+            'Ensure you are running in a Kubernetes pod with a service account ' +
+            'or have a valid kubeconfig with a namespace set in the active context.',
+        );
+      }
+      headers['X-MLFLOW-WORKSPACE'] = namespace;
+    }
+
     return headers;
   };
 

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -285,11 +285,21 @@ function createDatabricksAuth(options: AuthOptions): AuthProvider {
 /**
  * Create authentication for self-hosted (OSS) MLflow.
  *
- * Resolution order (explicit credentials win over MLFLOW_TRACKING_AUTH):
- * 1. Basic Auth (username/password from options or MLFLOW_TRACKING_USERNAME/PASSWORD)
- * 2. Bearer Token (token from options or MLFLOW_TRACKING_TOKEN)
- * 3. Kubernetes auth (MLFLOW_TRACKING_AUTH=kubernetes or kubernetes-namespaced)
+ * Authorization header resolution:
+ * 1. Basic Auth (MLFLOW_TRACKING_USERNAME/PASSWORD or programmatic options)
+ * 2. Bearer Token (MLFLOW_TRACKING_TOKEN or programmatic options)
+ * 3. MLFLOW_TRACKING_AUTH=kubernetes|kubernetes-namespaced → resolve from
+ *    Pod ServiceAccount mount or kubeconfig
  * 4. No authentication
+ *
+ * Workspace header (X-MLFLOW-WORKSPACE) resolution:
+ * 1. Explicit MLFLOW_WORKSPACE env var or programmatic `workspace` option
+ * 2. MLFLOW_TRACKING_AUTH=kubernetes-namespaced → auto-discover from
+ *    Pod namespace file or kubeconfig active context
+ *
+ * Authorization and workspace are resolved independently: kubernetes-namespaced
+ * still auto-discovers the workspace even when explicit credentials (token or
+ * username/password) supply the Authorization header.
  */
 function createOssAuth(options: AuthOptions): AuthProvider {
   const host = options.trackingUri;
@@ -299,22 +309,35 @@ function createOssAuth(options: AuthOptions): AuthProvider {
   const password = options.trackingServerPassword || process.env.MLFLOW_TRACKING_PASSWORD;
   const token = options.trackingServerToken || process.env.MLFLOW_TRACKING_TOKEN;
 
-  // Explicit credentials take precedence over MLFLOW_TRACKING_AUTH,
-  // matching Python SDK where KubernetesAuth skips if Authorization
-  // header is already set by username/password or token.
-  const hasExplicitCredentials = (username && password) || token;
   const trackingAuth = process.env.MLFLOW_TRACKING_AUTH;
-  if (
-    (trackingAuth === 'kubernetes' || trackingAuth === 'kubernetes-namespaced') &&
-    !hasExplicitCredentials
-  ) {
-    return createKubernetesAuth(
-      host,
-      trackingAuth === 'kubernetes-namespaced',
-      SA_TOKEN_PATH,
-      SA_NAMESPACE_PATH,
-      options.workspace,
-    );
+  if (trackingAuth === 'kubernetes' || trackingAuth === 'kubernetes-namespaced') {
+    const isNamespaced = trackingAuth === 'kubernetes-namespaced';
+
+    let explicitAuthHeader: string | undefined;
+    if (username && password) {
+      const encoded = Buffer.from(`${username}:${password}`).toString('base64');
+      explicitAuthHeader = `Basic ${encoded}`;
+    } else if (token) {
+      explicitAuthHeader = `Bearer ${token}`;
+    }
+
+    // When to enter the k8s auth path:
+    //   - No explicit creds: always (resolve token from Pod SA mount / kubeconfig)
+    //   - Explicit creds + kubernetes-namespaced: still needed for workspace
+    //     auto-discovery (token comes from explicit creds, namespace from k8s)
+    // NOTE : if  Explicit creds + plain kubernetes: since k8s only adds a token,
+    //     and we prioritize token from explicit creds. so the k8s path is skipped.
+    if (isNamespaced || !explicitAuthHeader) {
+      return createKubernetesAuth(
+        host,
+        isNamespaced,
+        SA_TOKEN_PATH,
+        SA_NAMESPACE_PATH,
+        options.workspace,
+        loadFromKubeconfig,
+        explicitAuthHeader,
+      );
+    }
   }
 
   // Pre-compute auth header since credentials don't change
@@ -386,7 +409,7 @@ async function loadFromKubeconfig(): Promise<{ token?: string; namespace?: strin
 
     return {
       token,
-      namespace: context?.namespace || undefined,
+      namespace: context?.namespace?.trim() || undefined,
     };
   } catch {
     return null;
@@ -411,12 +434,14 @@ export function createKubernetesAuth(
   tokenPath: string = SA_TOKEN_PATH,
   namespacePath: string = SA_NAMESPACE_PATH,
   workspace?: string,
-  kubeconfigLoader: () => Promise<{ token?: string; namespace?: string } | null> = loadFromKubeconfig,
+  kubeconfigLoader: () => Promise<{
+    token?: string;
+    namespace?: string;
+  } | null> = loadFromKubeconfig,
+  explicitAuthHeader?: string,
 ): AuthProvider {
   const getTokenFromFile = createCachedFileReader(tokenPath);
-  const getNamespaceFromFile = enableWorkspaces
-    ? createCachedFileReader(namespacePath)
-    : undefined;
+  const getNamespaceFromFile = enableWorkspaces ? createCachedFileReader(namespacePath) : undefined;
 
   // Kubeconfig result cached with TTL to pick up context switches and token rotation
   let kubeconfigResult: { token?: string; namespace?: string } | null | undefined;
@@ -433,19 +458,25 @@ export function createKubernetesAuth(
   const headersProvider: HeadersProvider = async () => {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
-    // Token: try SA file first, then kubeconfig, otherwise throw error
-    let token = getTokenFromFile();
-    if (!token) {
-      token = (await getKubeconfig())?.token;
+    // Authorization: use explicit header if provided (mirrors Python where
+    // rest_utils.py pre-sets Authorization and KubernetesAuth.__call__ skips
+    // re-setting it). Otherwise resolve from SA file / kubeconfig.
+    if (explicitAuthHeader) {
+      headers['Authorization'] = explicitAuthHeader;
+    } else {
+      let token = getTokenFromFile();
+      if (!token) {
+        token = (await getKubeconfig())?.token;
+      }
+      if (!token) {
+        throw new Error(
+          'Could not determine Kubernetes credentials. ' +
+            'Ensure you are running in a Kubernetes pod with a service account ' +
+            'or have a valid kubeconfig with credentials set.',
+        );
+      }
+      headers['Authorization'] = `Bearer ${token}`;
     }
-    if (!token) {
-      throw new Error(
-        'Could not determine Kubernetes credentials. ' +
-          'Ensure you are running in a Kubernetes pod with a service account ' +
-          'or have a valid kubeconfig with credentials set.',
-      );
-    }
-    headers['Authorization'] = `Bearer ${token}`;
 
     // Workspace: explicit MLFLOW_WORKSPACE if provided will take precedence.
     // For kubernetes-namespaced, also auto-discover from SA file or kubeconfig.

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -285,11 +285,21 @@ function createDatabricksAuth(options: AuthOptions): AuthProvider {
 /**
  * Create authentication for self-hosted (OSS) MLflow.
  *
- * Resolution order (explicit credentials win over MLFLOW_TRACKING_AUTH):
- * 1. Basic Auth (username/password from options or MLFLOW_TRACKING_USERNAME/PASSWORD)
- * 2. Bearer Token (token from options or MLFLOW_TRACKING_TOKEN)
- * 3. Kubernetes auth (MLFLOW_TRACKING_AUTH=kubernetes or kubernetes-namespaced)
+ * Authorization header resolution:
+ * 1. Basic Auth (MLFLOW_TRACKING_USERNAME/PASSWORD or programmatic options)
+ * 2. Bearer Token (MLFLOW_TRACKING_TOKEN or programmatic options)
+ * 3. MLFLOW_TRACKING_AUTH=kubernetes|kubernetes-namespaced → resolve from
+ *    Pod ServiceAccount mount or kubeconfig
  * 4. No authentication
+ *
+ * Workspace header (X-MLFLOW-WORKSPACE) resolution:
+ * 1. Explicit MLFLOW_WORKSPACE env var or programmatic `workspace` option
+ * 2. MLFLOW_TRACKING_AUTH=kubernetes-namespaced → auto-discover from
+ *    Pod namespace file or kubeconfig active context
+ *
+ * Authorization and workspace are resolved independently: kubernetes-namespaced
+ * still auto-discovers the workspace even when explicit credentials (token or
+ * username/password) supply the Authorization header.
  */
 function createOssAuth(options: AuthOptions): AuthProvider {
   const host = options.trackingUri;
@@ -299,21 +309,22 @@ function createOssAuth(options: AuthOptions): AuthProvider {
   const password = options.trackingServerPassword || process.env.MLFLOW_TRACKING_PASSWORD;
   const token = options.trackingServerToken || process.env.MLFLOW_TRACKING_TOKEN;
 
-  // Explicit credentials take precedence over MLFLOW_TRACKING_AUTH,
-  // matching Python SDK where KubernetesAuth skips if Authorization
-  // header is already set by username/password or token.
-  const hasExplicitCredentials = (username && password) || token;
   const trackingAuth = process.env.MLFLOW_TRACKING_AUTH;
-  if (
-    (trackingAuth === 'kubernetes' || trackingAuth === 'kubernetes-namespaced') &&
-    !hasExplicitCredentials
-  ) {
+  if (trackingAuth === 'kubernetes' || trackingAuth === 'kubernetes-namespaced') {
+    const isNamespaced = trackingAuth === 'kubernetes-namespaced';
+
+    // Basic auth (username/password) doesn't overlap with Kubernetes auth —
+    // ignore it when MLFLOW_TRACKING_AUTH=kubernetes* is set. Explicit tokens
+    // are normal in k8s and pass through as the Authorization header.
+    const explicitAuthHeader = token ? `Bearer ${token}` : undefined;
+
     return createKubernetesAuth(
       host,
-      trackingAuth === 'kubernetes-namespaced',
+      isNamespaced,
       SA_TOKEN_PATH,
       SA_NAMESPACE_PATH,
       options.workspace,
+      explicitAuthHeader,
     );
   }
 
@@ -349,48 +360,78 @@ function createOssAuth(options: AuthOptions): AuthProvider {
 }
 
 /**
- * Try to load token and namespace from kubeconfig (~/.kube/config).
+ * Load token and namespace from kubeconfig (~/.kube/config).
  * Requires @kubernetes/client-node.
- * Returns null if the package is unavailable or kubeconfig cannot be loaded.
+ * Throws if the package is missing or kubeconfig cannot be loaded.
  */
-async function loadFromKubeconfig(): Promise<{ token?: string; namespace?: string } | null> {
+async function loadFromKubeconfig(): Promise<{ token?: string; namespace?: string }> {
   let k8s: typeof import('@kubernetes/client-node');
   try {
     k8s = await import('@kubernetes/client-node');
   } catch {
-    console.warn(
-      '[mlflow] @kubernetes/client-node is not installed. ' +
-        'Kubeconfig fallback is disabled. ' +
+    throw new Error(
+      '@kubernetes/client-node is not installed. ' +
+        'It is required for kubeconfig-based authentication when ' +
+        'MLFLOW_TRACKING_AUTH is set to kubernetes or kubernetes-namespaced. ' +
         'Install it with: npm install @kubernetes/client-node',
     );
-    return null;
   }
 
+  const kc = new k8s.KubeConfig();
+  kc.loadFromDefault();
+
+  const currentContext = kc.getCurrentContext();
+  const context = kc.getContextObject(currentContext);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const fetchOpts = await kc.applyToFetchOptions({} as any);
+  const resolvedHeaders = new Headers(fetchOpts.headers as HeadersInit);
+
+  let token: string | undefined;
+  const authHeader = resolvedHeaders.get('Authorization') || resolvedHeaders.get('authorization');
+  if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
+    token = authHeader.substring(7).trim() || undefined;
+  }
+
+  return {
+    token,
+    namespace: context?.namespace?.trim() || undefined,
+  };
+}
+
+// Module-level reference for kubeconfig loading — tests override via _setKubeconfigLoader
+let _kubeconfigLoader: () => Promise<{ token?: string; namespace?: string }> = loadFromKubeconfig;
+
+/** @internal Test-only override, analogous to Python's mock.patch on the module attribute. */
+export function _setKubeconfigLoader(
+  loader: (() => Promise<{ token?: string; namespace?: string }>) | null,
+): void {
+  _kubeconfigLoader = loader ?? loadFromKubeconfig;
+}
+
+/**
+ * Compute a cache key from $KUBECONFIG + active context name.
+ * Matches Python's _get_kubeconfig_cache_key() so that context switches
+ * (e.g. `oc project`, `kubectl config use-context`) invalidate immediately.
+ * Only parses kubeconfig YAML — does not run the auth pipeline.
+ */
+async function defaultGetKubeconfigCacheKey(): Promise<string> {
+  const kubeconfigPath = process.env.KUBECONFIG || 'DEFAULT';
   try {
+    const k8s = await import('@kubernetes/client-node');
     const kc = new k8s.KubeConfig();
     kc.loadFromDefault();
-
-    const currentContext = kc.getCurrentContext();
-    const context = kc.getContextObject(currentContext);
-
-    // Resolve token through the full auth pipeline (exec, OIDC, cloud providers)
-    // using applyToFetchOptions which is the public API for credential resolution
-    const fetchOpts = await kc.applyToFetchOptions({} as any);
-    const resolvedHeaders = new Headers(fetchOpts.headers as HeadersInit);
-
-    let token: string | undefined;
-    const authHeader = resolvedHeaders.get('Authorization') || resolvedHeaders.get('authorization');
-    if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
-      token = authHeader.substring(7).trim() || undefined;
-    }
-
-    return {
-      token,
-      namespace: context?.namespace || undefined,
-    };
+    return `${kubeconfigPath}:${kc.getCurrentContext() || ''}`;
   } catch {
-    return null;
+    return kubeconfigPath;
   }
+}
+
+let _kubeconfigCacheKeyFn: () => Promise<string> = defaultGetKubeconfigCacheKey;
+
+/** @internal Test-only override for the kubeconfig cache key function. */
+export function _setKubeconfigCacheKeyFn(fn: (() => Promise<string>) | null): void {
+  _kubeconfigCacheKeyFn = fn ?? defaultGetKubeconfigCacheKey;
 }
 
 /**
@@ -411,21 +452,28 @@ export function createKubernetesAuth(
   tokenPath: string = SA_TOKEN_PATH,
   namespacePath: string = SA_NAMESPACE_PATH,
   workspace?: string,
-  kubeconfigLoader: () => Promise<{ token?: string; namespace?: string } | null> = loadFromKubeconfig,
+  explicitAuthHeader?: string,
 ): AuthProvider {
   const getTokenFromFile = createCachedFileReader(tokenPath);
-  const getNamespaceFromFile = enableWorkspaces
-    ? createCachedFileReader(namespacePath)
-    : undefined;
+  const getNamespaceFromFile = enableWorkspaces ? createCachedFileReader(namespacePath) : undefined;
 
-  // Kubeconfig result cached with TTL to pick up context switches and token rotation
-  let kubeconfigResult: { token?: string; namespace?: string } | null | undefined;
+  // Kubeconfig result cached with TTL + context key (mirrors Python's
+  // _get_kubeconfig_cache_key). Context switches invalidate immediately;
+  // token rotation within the same context refreshes after CACHE_TTL_MS.
+  let kubeconfigResult: { token?: string; namespace?: string } | undefined;
   let kubeconfigCachedAt = 0;
+  let kubeconfigCachedKey = '';
   async function getKubeconfig() {
     const now = Date.now();
-    if (kubeconfigResult === undefined || now - kubeconfigCachedAt > CACHE_TTL_MS) {
+    const key = await _kubeconfigCacheKeyFn();
+    if (
+      kubeconfigResult === undefined ||
+      key !== kubeconfigCachedKey ||
+      now - kubeconfigCachedAt > CACHE_TTL_MS
+    ) {
+      kubeconfigCachedKey = key;
       kubeconfigCachedAt = now;
-      kubeconfigResult = await kubeconfigLoader();
+      kubeconfigResult = await _kubeconfigLoader();
     }
     return kubeconfigResult;
   }
@@ -433,19 +481,25 @@ export function createKubernetesAuth(
   const headersProvider: HeadersProvider = async () => {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
-    // Token: try SA file first, then kubeconfig, otherwise throw error
-    let token = getTokenFromFile();
-    if (!token) {
-      token = (await getKubeconfig())?.token;
+    // Authorization: use explicit header if provided (mirrors Python where
+    // rest_utils.py pre-sets Authorization and KubernetesAuth.__call__ skips
+    // re-setting it). Otherwise resolve from SA file / kubeconfig.
+    if (explicitAuthHeader) {
+      headers['Authorization'] = explicitAuthHeader;
+    } else {
+      let token = getTokenFromFile();
+      if (!token) {
+        token = (await getKubeconfig()).token;
+      }
+      if (!token) {
+        throw new Error(
+          'Could not determine Kubernetes credentials. ' +
+            'Ensure you are running in a Kubernetes pod with a service account ' +
+            'or have a valid kubeconfig with credentials set.',
+        );
+      }
+      headers['Authorization'] = `Bearer ${token}`;
     }
-    if (!token) {
-      throw new Error(
-        'Could not determine Kubernetes credentials. ' +
-          'Ensure you are running in a Kubernetes pod with a service account ' +
-          'or have a valid kubeconfig with credentials set.',
-      );
-    }
-    headers['Authorization'] = `Bearer ${token}`;
 
     // Workspace: explicit MLFLOW_WORKSPACE if provided will take precedence.
     // For kubernetes-namespaced, also auto-discover from SA file or kubeconfig.
@@ -455,7 +509,7 @@ export function createKubernetesAuth(
     } else if (enableWorkspaces) {
       let namespace = getNamespaceFromFile?.();
       if (!namespace) {
-        namespace = (await getKubeconfig())?.namespace;
+        namespace = (await getKubeconfig()).namespace;
       }
       if (!namespace) {
         throw new Error(

--- a/libs/typescript/core/tests/core/auth.test.ts
+++ b/libs/typescript/core/tests/core/auth.test.ts
@@ -1,10 +1,14 @@
-import { createAuthProvider } from '../../src/auth';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createAuthProvider, createKubernetesAuth } from '../../src/auth';
 
 const ENV_KEYS = [
   'MLFLOW_TRACKING_TOKEN',
   'MLFLOW_TRACKING_USERNAME',
   'MLFLOW_TRACKING_PASSWORD',
   'MLFLOW_WORKSPACE',
+  'MLFLOW_TRACKING_AUTH',
 ] as const;
 
 describe('createAuthProvider', () => {
@@ -117,6 +121,315 @@ describe('createAuthProvider', () => {
       const provider = createAuthProvider({ trackingUri: 'http://localhost:5000' });
 
       expect(provider.getDatabricksToken()).toBeUndefined();
+    });
+  });
+
+  // Tests prefixed "kubernetes:" test MLFLOW_TRACKING_AUTH=kubernetes path
+  // Tests prefixed "kubernetes-namespaced:" test MLFLOW_TRACKING_AUTH=kubernetes-namespaced path
+  describe('Kubernetes auth (MLFLOW_TRACKING_AUTH)', () => {
+    const ENABLE_WORKSPACES = true;
+    const DISABLE_WORKSPACES = false;
+
+    const savedEnv: Record<string, string | undefined> = {};
+    let tmpDir: string;
+    let nonExistentTokenPath: string;
+    let nonExistentNamespacePath: string;
+
+    beforeEach(() => {
+      for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mlflow-auth-test-'));
+      nonExistentTokenPath = path.join(tmpDir, 'no-sa-token');
+      nonExistentNamespacePath = path.join(tmpDir, 'no-sa-ns');
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key];
+        }
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    // --- Token resolution ---
+
+    it('kubernetes: reads bearer token from SA file', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'sa-token-abc123');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, tokenPath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer sa-token-abc123');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('kubernetes: throws when token file is missing and no kubeconfig', async () => {
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, nonExistentTokenPath);
+
+      await expect(provider.getHeadersProvider()()).rejects.toThrow(
+        'Could not determine Kubernetes credentials',
+      );
+    });
+
+    it('kubernetes: caches token reads within TTL (60s)', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'old-token');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, tokenPath);
+
+      const headers1 = await provider.getHeadersProvider()();
+      expect(headers1['Authorization']).toBe('Bearer old-token');
+
+      // Kubelet rotates token on disk — cached value still returned within TTL
+      fs.writeFileSync(tokenPath, 'rotated-token');
+      const headers2 = await provider.getHeadersProvider()();
+      expect(headers2['Authorization']).toBe('Bearer old-token');
+    });
+
+    it('kubernetes: strips whitespace and newlines from token file', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, '  sa-token-trimmed  \n');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, tokenPath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer sa-token-trimmed');
+    });
+
+    it('kubernetes: file-based token takes priority over MLFLOW_TRACKING_TOKEN', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'sa-file-token');
+      process.env.MLFLOW_TRACKING_TOKEN = 'static-env-token';
+
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, tokenPath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer sa-file-token');
+    });
+
+    // --- Workspace resolution ---
+
+    it('kubernetes: no workspace header when MLFLOW_WORKSPACE is not set', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'sa-token');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, tokenPath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer sa-token');
+      expect(headers['X-MLFLOW-WORKSPACE']).toBeUndefined();
+    });
+
+    it('kubernetes: honors programmatic workspace option', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'sa-token');
+
+      // namespacePath is undefined — irrelevant because enableWorkspaces is false
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000', DISABLE_WORKSPACES, tokenPath, undefined, 'options-namespace',
+      );
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('options-namespace');
+    });
+
+    it('kubernetes: honors MLFLOW_WORKSPACE even without kubernetes-namespaced', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'sa-token');
+      process.env.MLFLOW_WORKSPACE = 'explicit-namespace';
+
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, tokenPath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer sa-token');
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('explicit-namespace');
+    });
+
+    it('kubernetes-namespaced: reads namespace from SA file automatically', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      const namespacePath = path.join(tmpDir, 'namespace');
+      fs.writeFileSync(tokenPath, 'sa-token-abc123');
+      fs.writeFileSync(namespacePath, 'my-namespace');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer sa-token-abc123');
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-namespace');
+    });
+
+    it('kubernetes-namespaced: throws when namespace file is missing and no kubeconfig', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      fs.writeFileSync(tokenPath, 'sa-token-abc123');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, nonExistentNamespacePath);
+
+      await expect(provider.getHeadersProvider()()).rejects.toThrow(
+        'Could not determine Kubernetes namespace',
+      );
+    });
+
+    it('kubernetes-namespaced: strips whitespace from namespace file', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      const namespacePath = path.join(tmpDir, 'namespace');
+      fs.writeFileSync(tokenPath, 'sa-token');
+      fs.writeFileSync(namespacePath, '  my-ns  \n');
+
+      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-ns');
+    });
+
+    it('kubernetes-namespaced: MLFLOW_WORKSPACE overrides auto-discovered namespace', async () => {
+      const tokenPath = path.join(tmpDir, 'token');
+      const namespacePath = path.join(tmpDir, 'namespace');
+      fs.writeFileSync(tokenPath, 'sa-token');
+      fs.writeFileSync(namespacePath, 'auto-namespace');
+      process.env.MLFLOW_WORKSPACE = 'explicit-namespace';
+
+      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('explicit-namespace');
+    });
+
+    // --- Kubeconfig fallback ---
+    // Note: @kubernetes/client-node uses ESM which Jest can't transform directly.
+    // These tests mock the module to verify the fallback and TTL logic without
+    // requiring the real package in the test environment.
+
+    it('kubernetes-namespaced: falls back to kubeconfig when SA files are missing', async () => {
+      const mockLoader = jest.fn().mockResolvedValue({
+        token: 'kubeconfig-token',
+        namespace: 'kubeconfig-ns',
+      });
+
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        nonExistentTokenPath,
+        nonExistentNamespacePath,
+        undefined,
+        mockLoader,
+      );
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer kubeconfig-token');
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('kubeconfig-ns');
+      expect(mockLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('kubernetes-namespaced: picks up kubeconfig context changes after TTL', async () => {
+      const mockLoader = jest.fn()
+        .mockResolvedValueOnce({ token: 'token-a', namespace: 'namespace-a' })
+        .mockResolvedValueOnce({ token: 'token-b', namespace: 'namespace-b' });
+
+      jest.useFakeTimers();
+      try {
+        const provider = createKubernetesAuth(
+          'http://mlflow:5000',
+          ENABLE_WORKSPACES,
+          nonExistentTokenPath,
+          nonExistentNamespacePath,
+          undefined,
+          mockLoader,
+        );
+
+        // First call reads context A
+        const headers1 = await provider.getHeadersProvider()();
+        expect(headers1['Authorization']).toBe('Bearer token-a');
+        expect(headers1['X-MLFLOW-WORKSPACE']).toBe('namespace-a');
+
+        // Still within TTL — returns cached context A
+        const headers2 = await provider.getHeadersProvider()();
+        expect(headers2['Authorization']).toBe('Bearer token-a');
+        expect(mockLoader).toHaveBeenCalledTimes(1);
+
+        // Advance past 60s TTL
+        jest.advanceTimersByTime(61_000);
+
+        // Now picks up context B
+        const headers3 = await provider.getHeadersProvider()();
+        expect(headers3['Authorization']).toBe('Bearer token-b');
+        expect(headers3['X-MLFLOW-WORKSPACE']).toBe('namespace-b');
+        expect(mockLoader).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    // --- Provider metadata ---
+
+    it('returns the tracking URI as host and undefined for databricksToken', () => {
+      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES);
+
+      expect(provider.getHost()).toBe('http://mlflow:5000');
+      expect(provider.getDatabricksToken()).toBeUndefined();
+    });
+  });
+
+  // Tests that verify createAuthProvider routes correctly and that
+  // explicit credentials (token, username/password) take precedence
+  // over MLFLOW_TRACKING_AUTH, matching Python SDK behavior.
+  describe('Auth precedence (createAuthProvider)', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key];
+        }
+      }
+    });
+
+    it('MLFLOW_TRACKING_TOKEN takes precedence over MLFLOW_TRACKING_AUTH', async () => {
+      process.env.MLFLOW_TRACKING_TOKEN = 'explicit-token';
+      process.env.MLFLOW_TRACKING_AUTH = 'kubernetes';
+
+      const provider = createAuthProvider({ trackingUri: 'http://mlflow:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer explicit-token');
+    });
+
+    it('username/password takes precedence over MLFLOW_TRACKING_AUTH', async () => {
+      process.env.MLFLOW_TRACKING_USERNAME = 'admin';
+      process.env.MLFLOW_TRACKING_PASSWORD = 'secret';
+      process.env.MLFLOW_TRACKING_AUTH = 'kubernetes';
+
+      const provider = createAuthProvider({ trackingUri: 'http://mlflow:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      const expected = `Basic ${Buffer.from('admin:secret').toString('base64')}`;
+      expect(headers['Authorization']).toBe(expected);
+    });
+
+    it('programmatic trackingServerToken skips kubernetes auth', async () => {
+      process.env.MLFLOW_TRACKING_AUTH = 'kubernetes';
+
+      const provider = createAuthProvider({
+        trackingUri: 'http://mlflow:5000',
+        trackingServerToken: 'code-token',
+      });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer code-token');
     });
   });
 });

--- a/libs/typescript/core/tests/core/auth.test.ts
+++ b/libs/typescript/core/tests/core/auth.test.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { createAuthProvider, createKubernetesAuth } from '../../src/auth';
+import {
+  createAuthProvider,
+  createKubernetesAuth,
+  _setKubeconfigLoader,
+  _setKubeconfigCacheKeyFn,
+} from '../../src/auth';
 
 const ENV_KEYS = [
   'MLFLOW_TRACKING_TOKEN',
@@ -146,6 +151,8 @@ describe('createAuthProvider', () => {
     });
 
     afterEach(() => {
+      _setKubeconfigLoader(null);
+      _setKubeconfigCacheKeyFn(null);
       for (const key of ENV_KEYS) {
         if (savedEnv[key] === undefined) {
           delete process.env[key];
@@ -169,12 +176,19 @@ describe('createAuthProvider', () => {
       expect(headers['Content-Type']).toBe('application/json');
     });
 
-    it('kubernetes: throws when token file is missing and no kubeconfig', async () => {
-      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, nonExistentTokenPath);
+    it('kubernetes: propagates kubeconfig error when SA token file is missing', async () => {
+      _setKubeconfigLoader(() => {
+        throw new Error('kubeconfig not found');
+      });
 
-      await expect(provider.getHeadersProvider()()).rejects.toThrow(
-        'Could not determine Kubernetes credentials',
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        DISABLE_WORKSPACES,
+        nonExistentTokenPath,
+        nonExistentNamespacePath,
       );
+
+      await expect(provider.getHeadersProvider()()).rejects.toThrow('kubeconfig not found');
     });
 
     it('kubernetes: caches token reads within TTL (60s)', async () => {
@@ -232,7 +246,11 @@ describe('createAuthProvider', () => {
 
       // namespacePath is undefined — irrelevant because enableWorkspaces is false
       const provider = createKubernetesAuth(
-        'http://mlflow:5000', DISABLE_WORKSPACES, tokenPath, undefined, 'options-namespace',
+        'http://mlflow:5000',
+        DISABLE_WORKSPACES,
+        tokenPath,
+        undefined,
+        'options-namespace',
       );
       const headers = await provider.getHeadersProvider()();
 
@@ -257,22 +275,34 @@ describe('createAuthProvider', () => {
       fs.writeFileSync(tokenPath, 'sa-token-abc123');
       fs.writeFileSync(namespacePath, 'my-namespace');
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        namespacePath,
+      );
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['Authorization']).toBe('Bearer sa-token-abc123');
       expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-namespace');
     });
 
-    it('kubernetes-namespaced: throws when namespace file is missing and no kubeconfig', async () => {
+    it('kubernetes-namespaced: propagates kubeconfig error when SA namespace file is missing', async () => {
+      _setKubeconfigLoader(() => {
+        throw new Error('kubeconfig not found');
+      });
+
       const tokenPath = path.join(tmpDir, 'token');
       fs.writeFileSync(tokenPath, 'sa-token-abc123');
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, nonExistentNamespacePath);
-
-      await expect(provider.getHeadersProvider()()).rejects.toThrow(
-        'Could not determine Kubernetes namespace',
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        nonExistentNamespacePath,
       );
+
+      await expect(provider.getHeadersProvider()()).rejects.toThrow('kubeconfig not found');
     });
 
     it('kubernetes-namespaced: strips whitespace from namespace file', async () => {
@@ -281,7 +311,12 @@ describe('createAuthProvider', () => {
       fs.writeFileSync(tokenPath, 'sa-token');
       fs.writeFileSync(namespacePath, '  my-ns  \n');
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        namespacePath,
+      );
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-ns');
@@ -294,7 +329,12 @@ describe('createAuthProvider', () => {
       fs.writeFileSync(namespacePath, 'auto-namespace');
       process.env.MLFLOW_WORKSPACE = 'explicit-namespace';
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        namespacePath,
+      );
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['X-MLFLOW-WORKSPACE']).toBe('explicit-namespace');
@@ -310,14 +350,13 @@ describe('createAuthProvider', () => {
         token: 'kubeconfig-token',
         namespace: 'kubeconfig-ns',
       });
+      _setKubeconfigLoader(mockLoader);
 
       const provider = createKubernetesAuth(
         'http://mlflow:5000',
         ENABLE_WORKSPACES,
         nonExistentTokenPath,
         nonExistentNamespacePath,
-        undefined,
-        mockLoader,
       );
       const headers = await provider.getHeadersProvider()();
 
@@ -326,10 +365,52 @@ describe('createAuthProvider', () => {
       expect(mockLoader).toHaveBeenCalledTimes(1);
     });
 
-    it('kubernetes-namespaced: picks up kubeconfig context changes after TTL', async () => {
-      const mockLoader = jest.fn()
+    it('kubernetes-namespaced: picks up kubeconfig context changes immediately via cache key', async () => {
+      const mockLoader = jest
+        .fn()
         .mockResolvedValueOnce({ token: 'token-a', namespace: 'namespace-a' })
         .mockResolvedValueOnce({ token: 'token-b', namespace: 'namespace-b' });
+      _setKubeconfigLoader(mockLoader);
+
+      // eslint-disable-next-line require-await, @typescript-eslint/require-await
+      _setKubeconfigCacheKeyFn(async () => 'DEFAULT:context-a');
+
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        nonExistentTokenPath,
+        nonExistentNamespacePath,
+      );
+
+      // First call reads context A
+      const headers1 = await provider.getHeadersProvider()();
+      expect(headers1['Authorization']).toBe('Bearer token-a');
+      expect(headers1['X-MLFLOW-WORKSPACE']).toBe('namespace-a');
+
+      // Same cache key — returns cached context A
+      const headers2 = await provider.getHeadersProvider()();
+      expect(headers2['Authorization']).toBe('Bearer token-a');
+      expect(mockLoader).toHaveBeenCalledTimes(1);
+
+      // Simulate context switch (oc project / kubectl config use-context)
+      // eslint-disable-next-line require-await, @typescript-eslint/require-await
+      _setKubeconfigCacheKeyFn(async () => 'DEFAULT:context-b');
+
+      // Invalidates immediately without waiting for TTL
+      const headers3 = await provider.getHeadersProvider()();
+      expect(headers3['Authorization']).toBe('Bearer token-b');
+      expect(headers3['X-MLFLOW-WORKSPACE']).toBe('namespace-b');
+      expect(mockLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('kubernetes-namespaced: refreshes kubeconfig after TTL within same context', async () => {
+      const mockLoader = jest
+        .fn()
+        .mockResolvedValueOnce({ token: 'token-v1', namespace: 'ns' })
+        .mockResolvedValueOnce({ token: 'token-v2', namespace: 'ns' });
+      _setKubeconfigLoader(mockLoader);
+      // eslint-disable-next-line require-await, @typescript-eslint/require-await
+      _setKubeconfigCacheKeyFn(async () => 'DEFAULT:same-context');
 
       jest.useFakeTimers();
       try {
@@ -338,27 +419,21 @@ describe('createAuthProvider', () => {
           ENABLE_WORKSPACES,
           nonExistentTokenPath,
           nonExistentNamespacePath,
-          undefined,
-          mockLoader,
         );
 
-        // First call reads context A
         const headers1 = await provider.getHeadersProvider()();
-        expect(headers1['Authorization']).toBe('Bearer token-a');
-        expect(headers1['X-MLFLOW-WORKSPACE']).toBe('namespace-a');
+        expect(headers1['Authorization']).toBe('Bearer token-v1');
 
-        // Still within TTL — returns cached context A
+        // 10s later, still under 60s TTL — cached
+        jest.advanceTimersByTime(10_000);
         const headers2 = await provider.getHeadersProvider()();
-        expect(headers2['Authorization']).toBe('Bearer token-a');
+        expect(headers2['Authorization']).toBe('Bearer token-v1');
         expect(mockLoader).toHaveBeenCalledTimes(1);
 
-        // Advance past 60s TTL
+        // Advance past TTL — token rotation picked up
         jest.advanceTimersByTime(61_000);
-
-        // Now picks up context B
         const headers3 = await provider.getHeadersProvider()();
-        expect(headers3['Authorization']).toBe('Bearer token-b');
-        expect(headers3['X-MLFLOW-WORKSPACE']).toBe('namespace-b');
+        expect(headers3['Authorization']).toBe('Bearer token-v2');
         expect(mockLoader).toHaveBeenCalledTimes(2);
       } finally {
         jest.useRealTimers();
@@ -375,9 +450,10 @@ describe('createAuthProvider', () => {
     });
   });
 
-  // Tests that verify createAuthProvider routes correctly and that
-  // explicit credentials (token, username/password) take precedence
-  // over MLFLOW_TRACKING_AUTH, matching Python SDK behavior.
+  // Tests that verify createAuthProvider routes correctly when
+  // MLFLOW_TRACKING_AUTH=kubernetes* is combined with explicit credentials.
+  // Tokens pass through; username/password are ignored (basic auth doesn't
+  // overlap with kubernetes auth).
   describe('Auth precedence (createAuthProvider)', () => {
     const savedEnv: Record<string, string | undefined> = {};
 
@@ -389,6 +465,8 @@ describe('createAuthProvider', () => {
     });
 
     afterEach(() => {
+      _setKubeconfigLoader(null);
+      _setKubeconfigCacheKeyFn(null);
       for (const key of ENV_KEYS) {
         if (savedEnv[key] === undefined) {
           delete process.env[key];
@@ -408,7 +486,9 @@ describe('createAuthProvider', () => {
       expect(headers['Authorization']).toBe('Bearer explicit-token');
     });
 
-    it('username/password takes precedence over MLFLOW_TRACKING_AUTH', async () => {
+    it('kubernetes + username/password: basic auth ignored, k8s token used', async () => {
+      // eslint-disable-next-line require-await, @typescript-eslint/require-await
+      _setKubeconfigLoader(async () => ({ token: 'k8s-resolved-token' }));
       process.env.MLFLOW_TRACKING_USERNAME = 'admin';
       process.env.MLFLOW_TRACKING_PASSWORD = 'secret';
       process.env.MLFLOW_TRACKING_AUTH = 'kubernetes';
@@ -416,8 +496,7 @@ describe('createAuthProvider', () => {
       const provider = createAuthProvider({ trackingUri: 'http://mlflow:5000' });
       const headers = await provider.getHeadersProvider()();
 
-      const expected = `Basic ${Buffer.from('admin:secret').toString('base64')}`;
-      expect(headers['Authorization']).toBe(expected);
+      expect(headers['Authorization']).toBe('Bearer k8s-resolved-token');
     });
 
     it('programmatic trackingServerToken skips kubernetes auth', async () => {
@@ -430,6 +509,47 @@ describe('createAuthProvider', () => {
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['Authorization']).toBe('Bearer code-token');
+    });
+
+    it('kubernetes-namespaced + explicit token: uses token but still auto-discovers workspace', async () => {
+      // eslint-disable-next-line require-await, @typescript-eslint/require-await
+      _setKubeconfigLoader(async () => ({}));
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mlflow-auth-prec-'));
+      try {
+        const namespacePath = path.join(tmpDir, 'namespace');
+        fs.writeFileSync(namespacePath, 'discovered-ns');
+
+        const provider = createKubernetesAuth(
+          'http://mlflow:5000',
+          true,
+          path.join(tmpDir, 'no-token'),
+          namespacePath,
+          undefined,
+          'Bearer explicit-token',
+        );
+        const headers = await provider.getHeadersProvider()();
+
+        expect(headers['Authorization']).toBe('Bearer explicit-token');
+        expect(headers['X-MLFLOW-WORKSPACE']).toBe('discovered-ns');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('kubernetes-namespaced + username/password: basic auth ignored, k8s auth + auto workspace', async () => {
+      _setKubeconfigLoader(
+        // eslint-disable-next-line require-await, @typescript-eslint/require-await
+        async () => ({ token: 'k8s-resolved-token', namespace: 'discovered-ns' }),
+      );
+      process.env.MLFLOW_TRACKING_USERNAME = 'admin';
+      process.env.MLFLOW_TRACKING_PASSWORD = 'secret';
+      process.env.MLFLOW_TRACKING_AUTH = 'kubernetes-namespaced';
+
+      const provider = createAuthProvider({ trackingUri: 'http://mlflow:5000' });
+      const headers = await provider.getHeadersProvider()();
+
+      expect(headers['Authorization']).toBe('Bearer k8s-resolved-token');
+      expect(headers['X-MLFLOW-WORKSPACE']).toBe('discovered-ns');
     });
   });
 });

--- a/libs/typescript/core/tests/core/auth.test.ts
+++ b/libs/typescript/core/tests/core/auth.test.ts
@@ -170,7 +170,11 @@ describe('createAuthProvider', () => {
     });
 
     it('kubernetes: throws when token file is missing and no kubeconfig', async () => {
-      const provider = createKubernetesAuth('http://mlflow:5000', DISABLE_WORKSPACES, nonExistentTokenPath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        DISABLE_WORKSPACES,
+        nonExistentTokenPath,
+      );
 
       await expect(provider.getHeadersProvider()()).rejects.toThrow(
         'Could not determine Kubernetes credentials',
@@ -232,7 +236,11 @@ describe('createAuthProvider', () => {
 
       // namespacePath is undefined — irrelevant because enableWorkspaces is false
       const provider = createKubernetesAuth(
-        'http://mlflow:5000', DISABLE_WORKSPACES, tokenPath, undefined, 'options-namespace',
+        'http://mlflow:5000',
+        DISABLE_WORKSPACES,
+        tokenPath,
+        undefined,
+        'options-namespace',
       );
       const headers = await provider.getHeadersProvider()();
 
@@ -257,7 +265,12 @@ describe('createAuthProvider', () => {
       fs.writeFileSync(tokenPath, 'sa-token-abc123');
       fs.writeFileSync(namespacePath, 'my-namespace');
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        namespacePath,
+      );
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['Authorization']).toBe('Bearer sa-token-abc123');
@@ -268,7 +281,12 @@ describe('createAuthProvider', () => {
       const tokenPath = path.join(tmpDir, 'token');
       fs.writeFileSync(tokenPath, 'sa-token-abc123');
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, nonExistentNamespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        nonExistentNamespacePath,
+      );
 
       await expect(provider.getHeadersProvider()()).rejects.toThrow(
         'Could not determine Kubernetes namespace',
@@ -281,7 +299,12 @@ describe('createAuthProvider', () => {
       fs.writeFileSync(tokenPath, 'sa-token');
       fs.writeFileSync(namespacePath, '  my-ns  \n');
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        namespacePath,
+      );
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['X-MLFLOW-WORKSPACE']).toBe('my-ns');
@@ -294,7 +317,12 @@ describe('createAuthProvider', () => {
       fs.writeFileSync(namespacePath, 'auto-namespace');
       process.env.MLFLOW_WORKSPACE = 'explicit-namespace';
 
-      const provider = createKubernetesAuth('http://mlflow:5000', ENABLE_WORKSPACES, tokenPath, namespacePath);
+      const provider = createKubernetesAuth(
+        'http://mlflow:5000',
+        ENABLE_WORKSPACES,
+        tokenPath,
+        namespacePath,
+      );
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['X-MLFLOW-WORKSPACE']).toBe('explicit-namespace');
@@ -327,7 +355,8 @@ describe('createAuthProvider', () => {
     });
 
     it('kubernetes-namespaced: picks up kubeconfig context changes after TTL', async () => {
-      const mockLoader = jest.fn()
+      const mockLoader = jest
+        .fn()
         .mockResolvedValueOnce({ token: 'token-a', namespace: 'namespace-a' })
         .mockResolvedValueOnce({ token: 'token-b', namespace: 'namespace-b' });
 
@@ -430,6 +459,55 @@ describe('createAuthProvider', () => {
       const headers = await provider.getHeadersProvider()();
 
       expect(headers['Authorization']).toBe('Bearer code-token');
+    });
+
+    it('kubernetes-namespaced + explicit token: uses token but still auto-discovers workspace', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mlflow-auth-prec-'));
+      try {
+        const namespacePath = path.join(tmpDir, 'namespace');
+        fs.writeFileSync(namespacePath, 'discovered-ns');
+
+        const provider = createKubernetesAuth(
+          'http://mlflow:5000',
+          true,
+          path.join(tmpDir, 'no-token'),
+          namespacePath,
+          undefined,
+          async () => null,
+          'Bearer explicit-token',
+        );
+        const headers = await provider.getHeadersProvider()();
+
+        expect(headers['Authorization']).toBe('Bearer explicit-token');
+        expect(headers['X-MLFLOW-WORKSPACE']).toBe('discovered-ns');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('kubernetes-namespaced + username/password: uses Basic auth but still auto-discovers workspace', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mlflow-auth-prec-'));
+      try {
+        const namespacePath = path.join(tmpDir, 'namespace');
+        fs.writeFileSync(namespacePath, 'discovered-ns');
+
+        const encoded = Buffer.from('admin:secret').toString('base64');
+        const provider = createKubernetesAuth(
+          'http://mlflow:5000',
+          true,
+          path.join(tmpDir, 'no-token'),
+          namespacePath,
+          undefined,
+          async () => null,
+          `Basic ${encoded}`,
+        );
+        const headers = await provider.getHeadersProvider()();
+
+        expect(headers['Authorization']).toBe(`Basic ${encoded}`);
+        expect(headers['X-MLFLOW-WORKSPACE']).toBe('discovered-ns');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -32,6 +32,7 @@
         "mlflow-trace-daemon": "bundle/daemon.cjs"
       },
       "devDependencies": {
+        "@kubernetes/client-node": "^1.0.0",
         "@types/ini": "^4.1.1",
         "@types/jest": "^29.5.3",
         "@types/node": "^20.4.5",
@@ -49,6 +50,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@kubernetes/client-node": "^1.0.0"
       }
     },
     "integrations/anthropic": {
@@ -1629,6 +1633,69 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.13.2",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mlflow/anthropic": {
       "resolved": "integrations/anthropic",
       "link": true
@@ -2494,6 +2561,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -2509,7 +2582,6 @@
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
@@ -2529,6 +2601,15 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -2965,8 +3046,21 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3084,6 +3178,98 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3392,7 +3578,6 @@
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3552,7 +3737,6 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3673,6 +3857,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "dev": true,
@@ -3719,7 +3912,6 @@
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -3977,6 +4169,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
@@ -4136,6 +4337,12 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4359,7 +4566,6 @@
     "node_modules/form-data": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4731,7 +4937,6 @@
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4764,6 +4969,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/html-escaper": {
@@ -5028,6 +5242,15 @@
       "version": "2.0.0",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -5679,6 +5902,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "dev": true,
@@ -5745,6 +5977,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jwa": {
@@ -5966,7 +6216,6 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5974,7 +6223,6 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6109,7 +6357,6 @@
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6152,6 +6399,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -6250,6 +6506,19 @@
       "version": "5.26.5",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6583,6 +6852,16 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -6790,6 +7069,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -7073,6 +7358,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.2.0",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -7120,6 +7452,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/strict-event-emitter": {
@@ -7209,6 +7561,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "dev": true,
@@ -7240,6 +7627,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -7288,8 +7684,7 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -7616,8 +8011,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
@@ -7627,7 +8021,6 @@
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -7689,7 +8082,6 @@
       "version": "8.18.3",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -32,6 +32,7 @@
         "mlflow-trace-daemon": "bundle/daemon.cjs"
       },
       "devDependencies": {
+        "@kubernetes/client-node": "^1.0.0",
         "@types/ini": "^4.1.1",
         "@types/jest": "^29.5.3",
         "@types/node": "^20.4.5",
@@ -49,6 +50,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@kubernetes/client-node": "^1.0.0"
       }
     },
     "integrations/anthropic": {
@@ -2030,6 +2034,69 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.13.2",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mlflow/anthropic": {
       "resolved": "integrations/anthropic",
       "link": true
@@ -2895,6 +2962,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -2910,7 +2983,6 @@
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
@@ -2930,6 +3002,15 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -3366,8 +3447,21 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3485,6 +3579,98 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3793,7 +3979,6 @@
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3953,7 +4138,6 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4074,6 +4258,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "dev": true,
@@ -4120,7 +4313,6 @@
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4379,6 +4571,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
@@ -4538,6 +4739,12 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4761,7 +4968,6 @@
     "node_modules/form-data": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5133,7 +5339,6 @@
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5166,6 +5371,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/html-escaper": {
@@ -5430,6 +5644,15 @@
       "version": "2.0.0",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6081,6 +6304,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "dev": true,
@@ -6147,6 +6379,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jwa": {
@@ -6368,7 +6618,6 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6376,7 +6625,6 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6511,7 +6759,6 @@
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6554,6 +6801,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -6652,6 +6908,19 @@
       "version": "5.26.5",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6985,6 +7254,16 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -7192,6 +7471,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -7475,6 +7760,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.2.0",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -7522,6 +7854,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/strict-event-emitter": {
@@ -7611,6 +7963,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "dev": true,
@@ -7642,6 +8029,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -7690,8 +8086,7 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -8018,8 +8413,7 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
@@ -8029,7 +8423,6 @@
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -8091,7 +8484,6 @@
       "version": "8.18.3",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #24141

### What changes are proposed in this pull request?

Add `MLFLOW_TRACKING_AUTH=kubernetes` and `MLFLOW_TRACKING_AUTH=kubernetes-namespaced` support to the TypeScript SDK (`libs/typescript/core/src/auth/index.ts`), achieving API parity with the Python SDK's Kubernetes auth provider (PR #21176).

**`MLFLOW_TRACKING_AUTH=kubernetes`**:
1. Token Resolution :: Reads bearer token from SA mount. Otherwise falls back to kubeconfig. And throws if neither available.
2. Workspace Resolution :: No automatic namespace discovery. `MLFLOW_WORKSPACE` can be set explicitly to target a specific workspace

**`MLFLOW_TRACKING_AUTH=kubernetes-namespaced`**:
1. Similar Token resolution
2. Workspace Resolution :: if `MLFLOW_WORKSPACE` is set, uses that. Otherwise reads namespace from SA mount → falls back to kubeconfig context → throws if none found

### How is this PR tested?
- [x] New unit/integration tests
- [x] Manual tests

**Manual tests:**
Traces exported successfully to RHOAI's mlflow Server ( workspace enabled ) in these cases : 
- Local: `MLFLOW_TRACKING_AUTH=kubernetes-namespaced` | Program Read token & namespace from `~/.kube/config`
- Local: `MLFLOW_TRACKING_AUTH=kubernetes` and `MLFLOW_WORKSPACE` set explicitly | Program Read token from `~/.kube/config` and namespace from `MLFLOW_WORKSPACE`

- In-pod (OpenShift): `MLFLOW_TRACKING_AUTH=kubernetes-namespaced` | Program read SA token and namespace from pod mounted secrets

### Does this PR require documentation update?

- [x ] No. 
But Module docstring in `auth/index.ts` was modified.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The TypeScript SDK now supports `MLFLOW_TRACKING_AUTH=kubernetes` and `MLFLOW_TRACKING_AUTH=kubernetes-namespaced` as env. variables.  

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release