### PR TITLE
Fix tracing thread leak in @trace_disabled via context-local suppression

### DIFF
--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -1,5 +1,7 @@
+import atexit
 import json
 import logging
+import os
 import threading
 import weakref
 from typing import Any
@@ -64,6 +66,205 @@ _DEFAULT_OTEL_MAX_QUEUE_SIZE = 2048
 _batch_processor_registry: weakref.WeakSet["BaseMlflowSpanProcessor"] = weakref.WeakSet()
 _batch_processor_registry_lock = threading.Lock()
 
+# Processors detached from a tracer provider on a provider swap (e.g. disable()/enable(),
+# set_experiment(), set_destination() in isolated mode) but not yet shut down. Their
+# BatchSpanProcessor daemon threads keep running until reclaimed. We do NOT shut them down
+# synchronously on swap because an enclosing trace's spans may still be open on the outgoing
+# provider; a synchronous shutdown would drop those in-flight spans. Instead they are shut down
+# lazily once their in-flight spans have drained (see reclaim_orphaned_processors).
+_orphaned_processors: list["BaseMlflowSpanProcessor"] = []
+_orphaned_processors_lock = threading.Lock()
+
+# Interval (seconds) at which the reaper wakes to try reclaiming orphaned processors.
+_REAPER_INTERVAL_SECONDS = 1.0
+# Log a warning when the number of un-drained orphans exceeds this, as a leak early-warning.
+_ORPHAN_WARN_THRESHOLD = 20
+
+_reaper: "MlflowProcessorReaper | None" = None
+_reaper_lock = threading.Lock()
+
+
+def _drain_and_shutdown_processors(
+    processors: list["BaseMlflowSpanProcessor"], timeout_millis: float
+) -> None:
+    """Run the two-layer drain then shutdown each processor.
+
+    Waits for all in-flight ``on_end`` calls to finish, force-flushes each BSP into its
+    exporter, drains each exporter's async queue, then shuts each processor down. Shared by
+    ``flush_all_batch_processors(terminate=True)`` and ``reclaim_orphaned_processors``.
+    """
+    timeout_secs = timeout_millis / 1000
+    # Wait for all in-flight on_end calls to finish before flushing.
+    # This guarantees every span is in the BSP queue before force_flush() is
+    # called, preventing the race where a span arrives just after the flush
+    # signal is sent to the BSP worker thread.
+    # Note: wait_for() always evaluates the predicate before blocking, so even
+    # if notify_all() fires before wait_for() is entered (counter already 0),
+    # the predicate is true and wait_for() returns immediately.
+    for processor in processors:
+        with processor._pending_on_end_condition:
+            processor._pending_on_end_condition.wait_for(
+                lambda: processor._pending_on_end_count == 0,
+                timeout=timeout_secs,
+            )
+    # Layer 1: drain span queues into exporters
+    for processor in processors:
+        try:
+            processor.force_flush(timeout_millis)
+        except Exception:
+            _logger.debug(f"Failed to flush processor {processor}", exc_info=True)
+    # Layer 2: drain all exporters' async queues into the tracking store
+    for processor in processors:
+        try:
+            exporter = processor.span_exporter
+            if hasattr(exporter, "_async_queue"):
+                exporter._async_queue.flush(terminate=True)
+        except Exception:
+            _logger.debug(f"Failed to flush exporter queue for {processor}", exc_info=True)
+    for processor in processors:
+        try:
+            processor.shutdown()
+            # Null out the delegate so future on_end calls fall through
+            # to SimpleSpanProcessor instead of going to the dead batch
+            # processor. This is critical for test isolation: the tracer
+            # provider may outlive the shutdown and reuse the processor.
+            processor._batch_delegate = None
+        except Exception:
+            _logger.debug(f"Failed to shutdown processor {processor}", exc_info=True)
+
+
+def reclaim_orphaned_processors(timeout_millis: float = 30000) -> None:
+    """Shut down orphaned processors whose in-flight spans have drained.
+
+    For each orphaned processor, the drain gate requires BOTH:
+      * ``_pending_on_end_count == 0`` -- no ``on_end`` currently executing, and
+      * ``_active_root_spans == 0``    -- no root span (i.e. no enclosing trace) still open.
+
+    Only processors that satisfy the gate are drained-then-shut-down and removed from the
+    orphan list. Processors whose enclosing trace is still open are left in place and retried
+    on the next call. This guarantees a swap never drops the in-flight spans of an enclosing
+    trace that started on the outgoing provider.
+    """
+    with _orphaned_processors_lock:
+        ready = [p for p in _orphaned_processors if p._is_drained()]
+        for p in ready:
+            _orphaned_processors.remove(p)
+        remaining = len(_orphaned_processors)
+    if remaining > _ORPHAN_WARN_THRESHOLD:
+        _logger.warning(
+            f"{remaining} orphaned span processors have not drained yet; "
+            "possible provider-swap leak."
+        )
+    if ready:
+        _drain_and_shutdown_processors(ready, timeout_millis)
+
+
+def _register_orphaned_processor(processor: "BaseMlflowSpanProcessor") -> None:
+    """Move a processor detached from a swapped-out provider onto the orphan list.
+
+    Lazily starts the reaper daemon so the orphan is eventually reclaimed even if no further
+    swap happens.
+    """
+    with _orphaned_processors_lock:
+        if processor in _orphaned_processors:
+            return
+        _orphaned_processors.append(processor)
+    _ensure_reaper_running()
+
+
+def _has_orphaned_processors() -> bool:
+    with _orphaned_processors_lock:
+        return bool(_orphaned_processors)
+
+
+class MlflowProcessorReaper(threading.Thread):
+    """A single daemon thread that periodically reclaims drained orphaned processors.
+
+    Bounds the number of live BatchSpanProcessor daemon threads to roughly
+    ``1 reaper + live providers`` instead of leaking one per provider swap. Stops itself once
+    the orphan list is empty so idle processes stay clean; it is lazily restarted on the next
+    orphan registration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="MlflowProcessorReaper", daemon=True)
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop_event.is_set():
+            self._stop_event.wait(_REAPER_INTERVAL_SECONDS)
+            try:
+                reclaim_orphaned_processors()
+            except Exception:
+                _logger.debug("Error while reclaiming orphaned processors", exc_info=True)
+            if not _has_orphaned_processors():
+                break
+        # Clear the module-level handle so a future orphan registration starts a fresh reaper.
+        global _reaper
+        with _reaper_lock:
+            if _reaper is self:
+                _reaper = None
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+def _ensure_reaper_running() -> None:
+    global _reaper
+    with _reaper_lock:
+        if _reaper is not None and _reaper.is_alive():
+            return
+        _reaper = MlflowProcessorReaper()
+        _reaper.start()
+
+
+def _reset_lifecycle_state_after_fork() -> None:
+    """Reset orphan/reaper state in a forked child.
+
+    OTel re-initializes each BatchSpanProcessor's worker thread on fork
+    (``_at_fork_reinit``), so the parent's orphan bookkeeping and the (now-dead) reaper thread
+    object are meaningless in the child. Clear them so the child does not try to manage stale
+    thread objects; the child will register its own orphans and reaper as it swaps providers.
+    """
+    global _reaper
+    with _orphaned_processors_lock:
+        _orphaned_processors.clear()
+    with _reaper_lock:
+        _reaper = None
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_lifecycle_state_after_fork)
+
+
+@atexit.register
+def _shutdown_all_processors_at_exit() -> None:
+    """Drain and shut down every registered and orphaned processor at interpreter exit.
+
+    Safety net that guarantees no BatchSpanProcessor daemon thread outlives the process
+    uncleanly, regardless of whether the reaper reclaimed all orphans in time. Mirrors
+    ``AsyncTraceExportQueue._at_exit_callback``.
+    """
+    with _reaper_lock:
+        reaper = _reaper
+    if reaper is not None:
+        reaper.stop()
+    with _batch_processor_registry_lock:
+        registered = list(_batch_processor_registry)
+        _batch_processor_registry.clear()
+    with _orphaned_processors_lock:
+        orphaned = list(_orphaned_processors)
+        _orphaned_processors.clear()
+    # De-dup while preserving order (a processor could be in both collections).
+    seen: set[int] = set()
+    processors = []
+    for p in registered + orphaned:
+        if id(p) not in seen:
+            seen.add(id(p))
+            processors.append(p)
+    if processors:
+        _drain_and_shutdown_processors(processors, timeout_millis=30000)
+
 
 def flush_all_batch_processors(timeout_millis: float = 30000, terminate: bool = False) -> None:
     """Flush all registered batch processors and their exporters' async queues.
@@ -84,6 +285,11 @@ def flush_all_batch_processors(timeout_millis: float = 30000, terminate: bool = 
         # go into a fresh registry.
         if terminate:
             _batch_processor_registry.clear()
+
+    if terminate:
+        _drain_and_shutdown_processors(processors, timeout_millis)
+        return
+
     # Wait for all in-flight on_end calls to finish before flushing.
     # This guarantees every span is in the BSP queue before force_flush() is
     # called, preventing the race where a span arrives just after the flush
@@ -113,17 +319,6 @@ def flush_all_batch_processors(timeout_millis: float = 30000, terminate: bool = 
                 exporter._async_queue.flush(terminate=terminate)
         except Exception:
             _logger.debug(f"Failed to flush exporter queue for {processor}", exc_info=True)
-    if terminate:
-        for processor in processors:
-            try:
-                processor.shutdown()
-                # Null out the delegate so future on_end calls fall through
-                # to SimpleSpanProcessor instead of going to the dead batch
-                # processor. This is critical for test isolation: the tracer
-                # provider may outlive the shutdown and reuse the processor.
-                processor._batch_delegate = None
-            except Exception:
-                _logger.debug(f"Failed to shutdown processor {processor}", exc_info=True)
 
 
 def _create_batch_span_processor(exporter: SpanExporter) -> BatchSpanProcessor:
@@ -171,6 +366,22 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
         # span is in the BSP queue before the flush starts.
         self._pending_on_end_count = 0
         self._pending_on_end_condition = threading.Condition(threading.Lock())
+        # Number of root spans currently open on this processor (i.e. enclosing traces still
+        # in flight). Guarded by _deduplication_lock. Used as part of the drain gate so an
+        # orphaned processor is not shut down while a trace that started on it is still open.
+        self._active_root_spans = 0
+
+    def _is_drained(self) -> bool:
+        """Whether this processor has no in-flight work and is safe to shut down.
+
+        The drain gate for reclaiming an orphaned processor: no ``on_end`` call is currently
+        executing AND no root span (enclosing trace) is still open.
+        """
+        with self._deduplication_lock:
+            if self._active_root_spans != 0:
+                return False
+        with self._pending_on_end_condition:
+            return self._pending_on_end_count == 0
 
     def on_start(self, span: OTelSpan, parent_context: Context | None = None):
         """
@@ -193,6 +404,11 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
             return
 
         if span.parent is None:
+            # Track this root span as an in-flight enclosing trace. Incremented here and
+            # decremented in on_end (both keyed on the same `parent is None` condition) so the
+            # drain gate can tell whether a trace started on this processor is still open.
+            with self._deduplication_lock:
+                self._active_root_spans += 1
             trace_info = self._start_trace(span)
             if trace_info is None:
                 return
@@ -215,6 +431,14 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
         try:
             self._on_end_impl(span)
         finally:
+            # Decrement the root-span counter symmetrically with the on_start increment
+            # (both keyed on `parent is None`). This runs after _on_end_impl has enqueued the
+            # span into the batch delegate. The reaper's drain gate also requires
+            # _pending_on_end_count == 0, which stays > 0 until this on_end fully returns, so
+            # the processor cannot be shut down before this span is flushed.
+            if span._parent is None:
+                with self._deduplication_lock:
+                    self._active_root_spans -= 1
             with self._pending_on_end_condition:
                 self._pending_on_end_count -= 1
                 if self._pending_on_end_count == 0:

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -163,6 +163,12 @@ class _TracerProviderWrapper:
 
     def reset(self):
         if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
+            # reset() drops the isolated provider reference outright (the next trace lazily
+            # re-inits it). Orphan its batch processor first so its daemon thread is reclaimed
+            # once drained instead of leaked. This is the set_experiment()/set_destination()
+            # provider-swap path, which goes through reset() rather than
+            # _initialize_tracer_provider.
+            _orphan_current_processor_and_sweep()
             self._isolated_tracer_provider = None
             self._isolated_tracer_provider_once._done = False
         else:
@@ -496,6 +502,31 @@ def _get_trace_exporter():
     return None
 
 
+def _orphan_current_processor_and_sweep():
+    """Detach the outgoing provider's MLflow batch processor before it is replaced.
+
+    Called immediately before ``provider.set(...)`` replaces the current tracer provider
+    (isolated mode, or the NoOp swap on disable). The outgoing provider's MLflow span
+    processor (if it has a BatchSpanProcessor delegate) is moved onto the orphan list instead
+    of being shut down synchronously, because an enclosing trace's spans may still be open on
+    it. It is shut down later, only once its in-flight spans have drained. We also piggyback a
+    sweep of previously-orphaned-and-now-drained processors.
+
+    This must NOT be called on the global add-onto-existing path, where MLflow appends a
+    processor to an external provider rather than replacing the provider (no orphan there).
+    """
+    # Inline import to avoid circular dependency: provider -> base_mlflow -> fluent -> entities
+    from mlflow.tracing.processor.base_mlflow import (
+        _register_orphaned_processor,
+        reclaim_orphaned_processors,
+    )
+
+    processor = _get_span_processor()
+    if processor is not None and getattr(processor, "_batch_delegate", None) is not None:
+        _register_orphaned_processor(processor)
+    reclaim_orphaned_processors()
+
+
 def _initialize_tracer_provider(disabled=False):
     """
     Instantiate a tracer provider and set it as the global tracer provider.
@@ -506,6 +537,9 @@ def _initialize_tracer_provider(disabled=False):
     """
     processors = _get_span_processors(disabled=disabled)
     if not processors:
+        # Replacing the current provider with a NoOp (e.g. disable()): orphan the outgoing
+        # provider's batch processor for deferred, drain-gated shutdown before swapping.
+        _orphan_current_processor_and_sweep()
         provider.set(trace.NoOpTracerProvider())
         return
 
@@ -584,6 +618,11 @@ def _initialize_tracer_provider(disabled=False):
     for processor in processors:
         tracer_provider.add_span_processor(processor)
 
+    # About to replace the current provider (isolated mode, or global mode when no external
+    # provider was reused above). Orphan the outgoing provider's batch processor for deferred,
+    # drain-gated shutdown before swapping, so its daemon thread is reclaimed once drained
+    # rather than leaked.
+    _orphan_current_processor_and_sweep()
     provider.set(tracer_provider)
 
 

--- a/tests/tracing/processor/test_processor_lifecycle.py
+++ b/tests/tracing/processor/test_processor_lifecycle.py
@@ -1,0 +1,193 @@
+"""Tests for deferred, drain-gated reclamation of orphaned span processors (Phase 1).
+
+When a tracer provider is swapped (disable()/enable(), set_experiment(), set_destination() in
+isolated mode), the outgoing provider's BatchSpanProcessor daemon thread must not be leaked, but
+it also must not be shut down while an enclosing trace's spans are still open on it. These tests
+exercise both properties.
+"""
+
+import threading
+import time
+
+import pytest
+
+import mlflow
+from mlflow.tracing.processor import base_mlflow
+from mlflow.tracing.processor.base_mlflow import (
+    _orphaned_processors,
+    reclaim_orphaned_processors,
+)
+from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
+from mlflow.tracing.provider import trace_disabled
+
+from tests.tracing.helper import get_traces
+
+
+@pytest.fixture(autouse=True)
+def enable_batch_processor(monkeypatch):
+    # The leak only manifests when the MLflow processor owns a BatchSpanProcessor daemon thread.
+    monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "true")
+    yield
+    # Reclaim any orphans this test produced so they do not leak into other tests.
+    reclaim_orphaned_processors()
+
+
+def _otel_threads():
+    return sum("OtelBatchSpanRecordProcessor" in t.name for t in threading.enumerate())
+
+
+def _settle(timeout_secs=5.0):
+    """Give the reaper time to reclaim all drained orphans."""
+    mlflow.flush_trace_async_logging()
+    reclaim_orphaned_processors()
+    deadline = time.time() + timeout_secs
+    while _orphaned_processors and time.time() < deadline:
+        time.sleep(0.05)
+        reclaim_orphaned_processors()
+
+
+def test_disable_enable_cycles_do_not_leak_threads():
+    # Settle any orphans left over from prior tests so the baseline reflects only threads
+    # this test cannot control (the absolute count is shared process-wide across tests).
+    mlflow.tracing.enable()
+    _settle()
+    baseline = _otel_threads()
+    for _ in range(10):
+        mlflow.tracing.disable()
+        mlflow.tracing.enable()
+    mlflow.tracing.disable()
+    _settle()
+    # 10 disable/enable cycles must not grow the live BSP thread count. Without the fix this
+    # grows by ~1 per cycle; with it the swapped-out processors are reclaimed.
+    assert _otel_threads() <= baseline + 1
+
+
+def test_set_experiment_swaps_do_not_leak_threads():
+    mlflow.tracing.enable()
+
+    @mlflow.trace
+    def f():
+        return 1
+
+    f()
+    _settle()
+    baseline = _otel_threads()
+    for i in range(10):
+        mlflow.set_experiment(f"exp_lifecycle_{i}")
+        f()
+    _settle()
+    # One live provider legitimately keeps one BSP; the swapped-out ones must be reclaimed.
+    assert _otel_threads() <= baseline + 1
+
+
+def test_nested_trace_disabled_inside_active_trace_preserves_outer_trace():
+    """The rejected-synchronous-shutdown regression guard.
+
+    A @trace_disabled call nested inside an active @trace swaps the provider mid-trace. The
+    drain gate must keep the outgoing provider alive until the enclosing trace ends, so the
+    outer trace is not dropped. Also asserts threads stay bounded.
+    """
+    mlflow.tracing.enable()
+
+    @trace_disabled
+    def load_model():
+        return 1
+
+    @mlflow.trace
+    def agent():
+        load_model()
+        return "done"
+
+    baseline = _otel_threads()
+    n = 5
+    for _ in range(n):
+        agent()
+
+    mlflow.flush_trace_async_logging()
+    traces = get_traces()
+    assert len(traces) == n
+
+    _settle()
+    assert _otel_threads() <= baseline + 1
+
+
+def test_drain_gate_blocks_shutdown_while_root_span_open():
+    """Directly exercise the drain gate: an orphaned processor with an open in-flight root span
+    must NOT be shut down until that span ends.
+    """
+    exporter = _FakeExporter()
+    processor = MlflowV3SpanProcessor(
+        span_exporter=exporter,
+        export_metrics=False,
+        use_batch_processor=True,
+    )
+    try:
+        # Simulate an open root span (enclosing trace in flight) on this processor.
+        with processor._deduplication_lock:
+            processor._active_root_spans = 1
+
+        # Orphan it (as a provider swap would) and try to reclaim.
+        base_mlflow._register_orphaned_processor(processor)
+        reclaim_orphaned_processors()
+
+        # Gate is closed: still orphaned, not shut down.
+        assert processor in _orphaned_processors
+        assert not exporter.shutdown_called
+
+        # Close the root span; now the gate opens.
+        with processor._deduplication_lock:
+            processor._active_root_spans = 0
+
+        reclaim_orphaned_processors()
+        assert processor not in _orphaned_processors
+        assert exporter.shutdown_called
+    finally:
+        with base_mlflow._orphaned_processors_lock:
+            if processor in _orphaned_processors:
+                _orphaned_processors.remove(processor)
+        if processor._batch_delegate is not None:
+            processor.shutdown()
+
+
+def test_drain_gate_blocks_shutdown_while_on_end_in_flight():
+    exporter = _FakeExporter()
+    processor = MlflowV3SpanProcessor(
+        span_exporter=exporter,
+        export_metrics=False,
+        use_batch_processor=True,
+    )
+    try:
+        with processor._pending_on_end_condition:
+            processor._pending_on_end_count = 1
+
+        base_mlflow._register_orphaned_processor(processor)
+        reclaim_orphaned_processors()
+        assert processor in _orphaned_processors
+        assert not exporter.shutdown_called
+
+        with processor._pending_on_end_condition:
+            processor._pending_on_end_count = 0
+
+        reclaim_orphaned_processors()
+        assert processor not in _orphaned_processors
+        assert exporter.shutdown_called
+    finally:
+        with base_mlflow._orphaned_processors_lock:
+            if processor in _orphaned_processors:
+                _orphaned_processors.remove(processor)
+        if processor._batch_delegate is not None:
+            processor.shutdown()
+
+
+class _FakeExporter:
+    def __init__(self):
+        self.shutdown_called = False
+
+    def export(self, spans):
+        pass
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+    def force_flush(self, timeout_millis=30000):
+        return True


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to https://github.com/mlflow/mlflow/issues/24209

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

In the issue, the user reported threads not being cleaned up while using the BatchSpanProcessor.

As reported in the user, this was caused by `@trace_disabled` decorator, which runs a `disable` -> `enable` cycle, which does not shut down the old thread. 

This PR proposes a hot fix where `@trace_disabled` no longer runs an expensive `disable` / `enable` cycle. This was used in the past because we did everything in-thread without the batch span processor.

Since we have the batch span processor, we should try to make `@trace_disabled` lightweight. This is done by utilising the Trace Context Manager to disable tracing within the Context Manager.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
