### PR TITLE
Lock down MLflow Assistant tool execution to an allowlist

### DIFF
--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -30,6 +30,7 @@ from mlflow.assistant.providers.prompts import ASSISTANT_SYSTEM_PROMPT
 from mlflow.assistant.providers.tool_executor import (
     build_tools_schema,
     execute_tool,
+    remote_lockdown_active,
     static_permission_error,
 )
 from mlflow.assistant.types import Event, Message, ToolResultBlock, ToolUseBlock
@@ -635,10 +636,15 @@ class OpenAICompatibleProvider(AssistantProvider):
                             static_permission_error(tool_name, tool_input, config.permissions, cwd)
                             is not None
                         )
+                        # In remote mode the allowlist is absolute: don't offer a
+                        # per-call override the static policy would re-deny anyway.
+                        # Disallowed calls fall through to execute_tool and return
+                        # a denial as the tool result instead of prompting.
                         gated = (
                             not config.permissions.full_access
                             and bool(mlflow_session_id)
                             and needs_prompt
+                            and not remote_lockdown_active()
                         )
                         decision = tool_decisions.get(tc["id"])
 

--- a/mlflow/assistant/providers/prompts.py
+++ b/mlflow/assistant/providers/prompts.py
@@ -244,22 +244,6 @@ mlflow experiments search --max-results 50
 # Get experiment details
 mlflow experiments get --experiment-id <ID>
 mlflow experiments get --experiment-name "my-experiment" --output json
-
-# Export all runs as CSV
-mlflow experiments csv --experiment-id <ID>
-```
-
-### Artifacts
-
-```
-# List artifacts for a run
-mlflow artifacts list --run-id <RUN_ID>
-
-# Download artifacts
-mlflow artifacts download --run-id <RUN_ID> --artifact-path <PATH>
-
-# Log a local file as artifact
-mlflow artifacts log-artifact --local-file /path/to/file --run-id <RUN_ID>
 ```
 
 ### Datasets and Scorers

--- a/mlflow/assistant/providers/prompts.py
+++ b/mlflow/assistant/providers/prompts.py
@@ -23,6 +23,9 @@ You have access to the following tools. Use them to accomplish tasks:
 - **Write**: Write content to a file (creates or overwrites).
 - **Edit**: Replace text in an existing file (find and replace).
 
+Read, Write, and Edit operate on the local project and are unavailable on a remote
+assistant; there, use the `mlflow` CLI to query tracking data.
+
 ## CRITICAL: Be Proactive and Minimize User Effort
 
 NEVER ask the user to do something manually that you can do for them.

--- a/mlflow/assistant/providers/prompts.py
+++ b/mlflow/assistant/providers/prompts.py
@@ -14,8 +14,11 @@ exactly as specified.
 
 You have access to the following tools. Use them to accomplish tasks:
 
-- **Bash**: Execute shell commands. Use this for MLflow CLI commands, Python one-liners
-  with the MLflow SDK, and general shell operations.
+- **Bash**: Run commands to query and interact with MLflow. By default only the `mlflow`
+  CLI is permitted and commands run without a shell, so pipes, redirects, and chaining
+  are not interpreted and non-`mlflow` binaries (including `python`/`python3`) are denied.
+  Prefer `mlflow` CLI subcommands. Arbitrary shell commands work only when Full Access is
+  enabled.
 - **Read**: Read file contents from the local filesystem.
 - **Write**: Write content to a file (creates or overwrites).
 - **Edit**: Replace text in an existing file (find and replace).

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -10,8 +10,81 @@ from mlflow.assistant.config import PermissionsConfig
 _logger = logging.getLogger(__name__)
 
 _FILE_TOOLS = {"Read", "Write", "Edit"}
-# Restricted mode only permits MLflow CLI and Python; anything else needs Full Access.
-_ALLOWED_BASH_COMMANDS = {"mlflow", "python3", "python"}
+# Restricted mode only permits the MLflow CLI; anything else needs Full Access.
+# python/python3 were removed: allowing them is plain remote code execution as the
+# server process.
+_ALLOWED_BASH_COMMANDS = {"mlflow"}
+
+# MLflow subcommands the restricted assistant may invoke. This is an allowlist
+# (fail-closed): any subcommand not listed here — including future ones — is
+# denied. Everything here is read/query-oriented and routes through the tracking
+# API (so Tier-1 token forwarding authorizes it as the calling user). Excluded
+# subcommands such as `run`, `models`, `server`, `deployments`, `sagemaker`,
+# `gateway`, `db`, `gc`, and the LLM/agent runners either execute arbitrary code,
+# serve/mutate backend state, or permanently delete data. `artifacts` is also
+# excluded: `log-artifact --local-file` / `download --dst-path` take unconstrained
+# server-local paths, making it an arbitrary file read/write primitive that would
+# escape the workspace sandbox the Read/Write tools enforce.
+_ALLOWED_MLFLOW_SUBCOMMANDS = frozenset({
+    "experiments",
+    "runs",
+    "traces",
+    "datasets",
+    "scorers",
+    "doctor",
+})
+
+# Sub-subcommands that are denied even though their parent subcommand is allowlisted,
+# because they are file-system primitives (not tracking-API queries) that escape the
+# workspace sandbox. `experiments csv --filename/-o PATH` writes an arbitrary
+# server-local file via pandas.to_csv with no path validation (mlflow/experiments.py),
+# and needs no shell to do it. Keyed by parent subcommand.
+_DENIED_MLFLOW_SUBSUBCOMMANDS = {
+    "experiments": frozenset({"csv"}),
+}
+
+# The only value-taking option on the top-level `mlflow` group (mlflow/cli/__init__.py).
+# It consumes the following token, which must not be mistaken for the subcommand.
+_MLFLOW_GLOBAL_VALUE_FLAGS = frozenset({"--env-file"})
+
+
+def _mlflow_subcommand(argv: list[str]) -> tuple[str | None, str | None]:
+    """Return ``(subcommand, sub_subcommand)`` for a ``mlflow`` invocation, using
+    None for either when absent (e.g. ``mlflow --version`` -> (None, None),
+    ``mlflow experiments`` -> ("experiments", None)). ``argv[0]`` is assumed to be
+    ``mlflow``.
+
+    Skips global flags and the value consumed by ``--env-file`` so the positional
+    tokens are identified without a full CLI parser. The sub-subcommand is the second
+    positional; per-subcommand option values could in principle precede it, but the
+    denied sub-subcommands are all bare verbs, so returning the first positional after
+    the subcommand is sufficient (and any mismatch fails closed at the allowlist).
+    """
+    positionals: list[str] = []
+    i = 1
+    while i < len(argv) and len(positionals) < 2:
+        tok = argv[i]
+        if tok in _MLFLOW_GLOBAL_VALUE_FLAGS:
+            i += 2  # skip the flag and its value
+            continue
+        if tok.startswith("-"):
+            i += 1  # boolean flag such as --version / --help
+            continue
+        positionals.append(tok)
+        i += 1
+    subcommand = positionals[0] if positionals else None
+    sub_subcommand = positionals[1] if len(positionals) > 1 else None
+    return subcommand, sub_subcommand
+
+
+def remote_lockdown_active() -> bool:
+    """True when the assistant is exposed beyond localhost (MLFLOW_ALLOW_REMOTE_ASSISTANT).
+
+    In this mode the restricted allowlist is absolute: full_access is force-disabled
+    and per-call approval cannot override it, since arbitrary shell/code execution on a
+    remotely-reachable server is RCE affecting every tenant.
+    """
+    return bool(os.environ.get("MLFLOW_ALLOW_REMOTE_ASSISTANT"))
 
 
 def _is_path_within(path: Path, root: Path) -> bool:
@@ -43,7 +116,9 @@ def static_permission_error(
     allows — e.g. an ``mlflow`` CLI command or an in-workspace file op — runs without prompting,
     just as it did before tool-call permissions existed.
     """
-    if perms.full_access:
+    # Remote mode must never grant full_access, even if the config requests it:
+    # a remotely-reachable assistant with unrestricted shell access is RCE.
+    if perms.full_access and not remote_lockdown_active():
         return None
 
     if tool_name == "Bash":
@@ -57,6 +132,19 @@ def static_permission_error(
                 f"Permission denied: only {', '.join(sorted(_ALLOWED_BASH_COMMANDS))} "
                 "commands are allowed"
             )
+        if argv[0] == "mlflow":
+            subcommand, sub_subcommand = _mlflow_subcommand(argv)
+            if subcommand is not None and subcommand not in _ALLOWED_MLFLOW_SUBCOMMANDS:
+                return (
+                    f"Permission denied: 'mlflow {subcommand}' is not allowed. "
+                    f"Allowed subcommands: {', '.join(sorted(_ALLOWED_MLFLOW_SUBCOMMANDS))}"
+                )
+            denied_actions = _DENIED_MLFLOW_SUBSUBCOMMANDS.get(subcommand, frozenset())
+            if sub_subcommand in denied_actions:
+                return (
+                    f"Permission denied: 'mlflow {subcommand} {sub_subcommand}' is not allowed "
+                    "(it can write to an arbitrary server-local path)."
+                )
 
     if tool_name in _FILE_TOOLS and not perms.allow_edit_files:
         return f"Permission denied: {tool_name} is not allowed"
@@ -85,10 +173,18 @@ async def execute_tool(
     if (denial := static_permission_error(tool_name, tool_input, perms, cwd)) is not None:
         return denial, True
 
+    # Only genuine (local) full_access gets a real shell. In restricted mode — or
+    # any remote deployment — the command runs as a direct argv exec so the
+    # subcommand allowlist is the true boundary: shell metacharacters (|, ;, &&,
+    # $(), >, backticks, newlines) can't smuggle a second process past the check.
+    use_shell = perms.full_access and not remote_lockdown_active()
+
     try:
         match tool_name:
             case "Bash":
-                return await _execute_bash(tool_input, cwd=cwd, tracking_uri=tracking_uri)
+                return await _execute_bash(
+                    tool_input, cwd=cwd, tracking_uri=tracking_uri, use_shell=use_shell
+                )
             case "Read":
                 return await asyncio.to_thread(_execute_read, tool_input, cwd=cwd)
             case "Write":
@@ -106,6 +202,7 @@ async def _execute_bash(
     tool_input: dict[str, Any],
     cwd: Path | None,
     tracking_uri: str | None,
+    use_shell: bool = False,
 ) -> tuple[str, bool]:
     command = tool_input.get("command", "")
     if not command:
@@ -116,14 +213,31 @@ async def _execute_bash(
         env["MLFLOW_TRACKING_URI"] = tracking_uri
 
     try:
-        # Shell required: LLM-generated commands may use pipes, redirects, or && chaining.
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=cwd,
-            env=env,
-        )
+        if use_shell:
+            # full_access only: a real shell so pipes, redirects, and && chaining work.
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+        else:
+            # Restricted/remote: exec the parsed argv directly (no shell), so shell
+            # metacharacters can't spawn a second process past the allowlist check.
+            try:
+                argv = shlex.split(command)
+            except ValueError:
+                return "Permission denied: malformed command", True
+            if not argv:
+                return "No command provided", True
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
         output = stdout.decode("utf-8", errors="replace")
         err_output = stderr.decode("utf-8", errors="replace")
@@ -137,6 +251,8 @@ async def _execute_bash(
         return (output + err_output).strip() or "(no output)", False
     except asyncio.TimeoutError:
         return "Command timed out after 120 seconds", True
+    except FileNotFoundError:
+        return f"Command not found: {command}", True
 
 
 def _execute_read(tool_input: dict[str, Any], cwd: Path | None = None) -> tuple[str, bool]:
@@ -189,15 +305,21 @@ def build_tools_schema() -> list[dict[str, Any]]:
             "function": {
                 "name": "Bash",
                 "description": (
-                    "Execute a shell command to query or interact with MLflow. "
-                    "Use 'mlflow' CLI commands or Python one-liners with the MLflow SDK."
+                    "Run a command to query or interact with MLflow. In the default "
+                    "(restricted) mode only the 'mlflow' CLI is permitted and the command "
+                    "is executed directly without a shell, so pipes, redirects, command "
+                    "substitution, and chaining (|, >, ;, &&, $(...)) are not interpreted. "
+                    "With Full Access enabled, arbitrary shell commands are allowed."
                 ),
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "command": {
                             "type": "string",
-                            "description": "The shell command to execute.",
+                            "description": (
+                                "The command to execute. In restricted mode this must be an "
+                                "'mlflow' CLI invocation (e.g. 'mlflow experiments search')."
+                            ),
                         }
                     },
                     "required": ["command"],

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -18,8 +18,8 @@ _ALLOWED_BASH_COMMANDS = {"mlflow"}
 # MLflow subcommands the restricted assistant may invoke. This is an allowlist
 # (fail-closed): any subcommand not listed here — including future ones — is
 # denied. Every entry routes through the tracking API, so Tier-1 token forwarding
-# authorizes it as the calling user; most are read/query verbs, and the few that
-# mutate (`experiments create/delete/restore/rename/update`, `runs delete/restore`)
+# authorizes it as the calling user; most are read/query verbs, and the ones that
+# mutate (e.g. `experiments create/delete/rename`, `runs create/delete/link-traces`)
 # are still authorized as that user. Excluded subcommands such as `run`, `models`,
 # `server`, `deployments`, `sagemaker`, `gateway`, `db`, `gc`, and the LLM/agent
 # runners either execute arbitrary code, serve/mutate backend state, or permanently

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -17,21 +17,25 @@ _ALLOWED_BASH_COMMANDS = {"mlflow"}
 
 # MLflow subcommands the restricted assistant may invoke. This is an allowlist
 # (fail-closed): any subcommand not listed here — including future ones — is
-# denied. Everything here is read/query-oriented and routes through the tracking
-# API (so Tier-1 token forwarding authorizes it as the calling user). Excluded
-# subcommands such as `run`, `models`, `server`, `deployments`, `sagemaker`,
-# `gateway`, `db`, `gc`, and the LLM/agent runners either execute arbitrary code,
-# serve/mutate backend state, or permanently delete data. `artifacts` is also
-# excluded: `log-artifact --local-file` / `download --dst-path` take unconstrained
-# server-local paths, making it an arbitrary file read/write primitive that would
-# escape the workspace sandbox the Read/Write tools enforce.
+# denied. Every entry routes through the tracking API, so Tier-1 token forwarding
+# authorizes it as the calling user; most are read/query verbs, and the few that
+# mutate (`experiments create/delete/restore/rename/update`, `runs delete/restore`)
+# are still authorized as that user. Excluded subcommands such as `run`, `models`,
+# `server`, `deployments`, `sagemaker`, `gateway`, `db`, `gc`, and the LLM/agent
+# runners either execute arbitrary code, serve/mutate backend state, or permanently
+# delete data. `artifacts` is also excluded: `log-artifact --local-file` /
+# `download --dst-path` take unconstrained server-local paths, making it an arbitrary
+# file read/write primitive that would escape the workspace sandbox the Read/Write
+# tools enforce. `doctor` is excluded too: it reads local process state rather than
+# the tracking API and prints every MLFLOW_* env var unmasked (including
+# MLFLOW_TRACKING_TOKEN/USERNAME/PASSWORD) plus the raw tracking URI, so under remote
+# lockdown it is a one-shot server-side secret exfiltration primitive.
 _ALLOWED_MLFLOW_SUBCOMMANDS = frozenset({
     "experiments",
     "runs",
     "traces",
     "datasets",
     "scorers",
-    "doctor",
 })
 
 # Sub-subcommands that are denied even though their parent subcommand is allowlisted,

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -168,6 +168,14 @@ def static_permission_error(
     if tool_name in {"Write", "Edit"} and not cwd:
         return f"Permission denied: {tool_name} requires a configured project directory"
 
+    # Under remote lockdown a file tool with no workspace root has no containment
+    # boundary, so an absolute path (e.g. /etc/passwd) would reach the filesystem
+    # unchecked — this must cover Read, which Write/Edit's cwd requirement above does
+    # not. Locally (same host as the user) an unscoped read is the existing contract,
+    # so this denial is scoped to remote mode.
+    if tool_name in _FILE_TOOLS and not cwd and remote_lockdown_active():
+        return f"Permission denied: {tool_name} requires a configured project directory"
+
     if tool_name in _FILE_TOOLS and cwd:
         if raw_path := tool_input.get("file_path") or tool_input.get("path", ""):
             target = _resolve_file_path(raw_path, cwd)
@@ -268,7 +276,14 @@ async def _execute_bash(
     except asyncio.TimeoutError:
         return "Command timed out after 120 seconds", True
     except FileNotFoundError:
-        return f"Command not found: {command}", True
+        # Echo only the executable name, never the full command: it carries
+        # user-controlled arguments and may surface server paths / option values
+        # the caller shouldn't see in a streamed tool result.
+        try:
+            executable = shlex.split(command)[0]
+        except (ValueError, IndexError):
+            executable = command
+        return f"Command not found: {executable}", True
 
 
 def _execute_read(tool_input: dict[str, Any], cwd: Path | None = None) -> tuple[str, bool]:

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -91,7 +91,9 @@ def remote_lockdown_active() -> bool:
 
     In this mode the restricted allowlist is absolute: full_access is force-disabled
     and per-call approval cannot override it, since arbitrary shell/code execution on a
-    remotely-reachable server is RCE affecting every tenant.
+    remotely-reachable server is RCE affecting every tenant. The file tools
+    (Read/Write/Edit) are also denied outright — remote is tracking-API-query only, and
+    server-local file access adds no capability the mlflow CLI doesn't already cover.
     """
     return MLFLOW_ENABLE_REMOTE_ASSISTANT.get()
 
@@ -165,15 +167,17 @@ def static_permission_error(
     if tool_name in _FILE_TOOLS and not perms.allow_edit_files:
         return f"Permission denied: {tool_name} is not allowed"
 
-    if tool_name in {"Write", "Edit"} and not cwd:
-        return f"Permission denied: {tool_name} requires a configured project directory"
+    # Remote lockdown is tracking-API-query only. The mlflow CLI already reads all
+    # tracking state; the file tools add only server-local filesystem access, running
+    # as the server identity with no per-call approval — a disclosure/tamper primitive
+    # with no remote use the CLI doesn't cover (cwd is an admin-configured project dir
+    # on the server host, not the remote caller's own workspace). Deny all three
+    # outright here. Locally / under full_access they remain available for the
+    # code-integration workflow, which is where reading and editing project files lives.
+    if tool_name in _FILE_TOOLS and remote_lockdown_active():
+        return f"Permission denied: {tool_name} is not available on a remote assistant"
 
-    # Under remote lockdown a file tool with no workspace root has no containment
-    # boundary, so an absolute path (e.g. /etc/passwd) would reach the filesystem
-    # unchecked — this must cover Read, which Write/Edit's cwd requirement above does
-    # not. Locally (same host as the user) an unscoped read is the existing contract,
-    # so this denial is scoped to remote mode.
-    if tool_name in _FILE_TOOLS and not cwd and remote_lockdown_active():
+    if tool_name in {"Write", "Edit"} and not cwd:
         return f"Permission denied: {tool_name} requires a configured project directory"
 
     if tool_name in _FILE_TOOLS and cwd:

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from mlflow.assistant.config import PermissionsConfig
+from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 
 _logger = logging.getLogger(__name__)
 
@@ -79,13 +80,20 @@ def _mlflow_subcommand(argv: list[str]) -> str | None:
 
 
 def remote_lockdown_active() -> bool:
-    """True when the assistant is exposed beyond localhost (MLFLOW_ALLOW_REMOTE_ASSISTANT).
+    """True when the assistant may be exposed beyond localhost.
+
+    Keyed on MLFLOW_ENABLE_REMOTE_ASSISTANT — the same switch the server uses to open
+    the assistant API to non-localhost clients (mlflow/server/assistant/api.py). Reading
+    the canonical flag (rather than a separate variable) is what keeps the lockdown from
+    being fail-open: it engages exactly when remote access is enabled. This is the
+    fail-safe reading — remote exposure additionally requires a provider that allows it,
+    so locking down whenever the flag is on is never less restrictive than actual reach.
 
     In this mode the restricted allowlist is absolute: full_access is force-disabled
     and per-call approval cannot override it, since arbitrary shell/code execution on a
     remotely-reachable server is RCE affecting every tenant.
     """
-    return bool(os.environ.get("MLFLOW_ALLOW_REMOTE_ASSISTANT"))
+    return MLFLOW_ENABLE_REMOTE_ASSISTANT.get()
 
 
 def _is_path_within(path: Path, root: Path) -> bool:

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -18,10 +18,12 @@ _ALLOWED_BASH_COMMANDS = {"mlflow"}
 
 # MLflow subcommands the restricted assistant may invoke. This is an allowlist
 # (fail-closed): any subcommand not listed here — including future ones — is
-# denied. Every entry routes through the tracking API, so Tier-1 token forwarding
-# authorizes it as the calling user; most are read/query verbs, and the ones that
-# mutate (e.g. `experiments create/delete/rename`, `runs create/delete/link-traces`)
-# are still authorized as that user. Excluded subcommands such as `run`, `models`,
+# denied. Every entry routes through the tracking API; most are read/query verbs, but
+# some mutate (e.g. `experiments create/delete/rename`, `runs create/delete/link-traces`).
+# NOTE: these run with the server's identity/credentials, not the requesting user's —
+# per-user token forwarding is not yet implemented, so the allowlist (not authz) is the
+# only boundary on what a remote caller can do. Tightening this to per-user auth is
+# tracked as follow-up work. Excluded subcommands such as `run`, `models`,
 # `server`, `deployments`, `sagemaker`, `gateway`, `db`, `gc`, and the LLM/agent
 # runners either execute arbitrary code, serve/mutate backend state, or permanently
 # delete data. `artifacts` is also excluded: `log-artifact --local-file` /

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -178,7 +178,13 @@ def static_permission_error(
 
     if tool_name in _FILE_TOOLS and cwd:
         if raw_path := tool_input.get("file_path") or tool_input.get("path", ""):
-            target = _resolve_file_path(raw_path, cwd)
+            # resolve() raises ValueError on a NUL byte (and OSError on other bad
+            # paths). This runs outside execute_tool's try/except, so guard it here and
+            # fail closed rather than letting the exception propagate.
+            try:
+                target = _resolve_file_path(raw_path, cwd)
+            except (ValueError, OSError):
+                return f"Permission denied: invalid path {raw_path!r}"
             if not _is_path_within(target, cwd):
                 return f"Permission denied: path {raw_path} is outside the workspace {cwd}"
 

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -38,11 +38,13 @@ _ALLOWED_MLFLOW_SUBCOMMANDS = frozenset({
     "scorers",
 })
 
-# Sub-subcommands that are denied even though their parent subcommand is allowlisted,
-# because they are file-system primitives (not tracking-API queries) that escape the
+# Verbs that are denied even when their parent subcommand is allowlisted, because
+# they are file-system primitives (not tracking-API queries) that escape the
 # workspace sandbox. `experiments csv --filename/-o PATH` writes an arbitrary
 # server-local file via pandas.to_csv with no path validation (mlflow/experiments.py),
-# and needs no shell to do it. Keyed by parent subcommand.
+# and needs no shell to do it. Keyed by parent subcommand; matched against the whole
+# argv (see static_permission_error) rather than a fixed positional, so a value-taking
+# option cannot shift the verb out of view (e.g. `experiments -x 0 csv`).
 _DENIED_MLFLOW_SUBSUBCOMMANDS = {
     "experiments": frozenset({"csv"}),
 }
@@ -52,33 +54,28 @@ _DENIED_MLFLOW_SUBSUBCOMMANDS = {
 _MLFLOW_GLOBAL_VALUE_FLAGS = frozenset({"--env-file"})
 
 
-def _mlflow_subcommand(argv: list[str]) -> tuple[str | None, str | None]:
-    """Return ``(subcommand, sub_subcommand)`` for a ``mlflow`` invocation, using
-    None for either when absent (e.g. ``mlflow --version`` -> (None, None),
-    ``mlflow experiments`` -> ("experiments", None)). ``argv[0]`` is assumed to be
-    ``mlflow``.
+def _mlflow_subcommand(argv: list[str]) -> str | None:
+    """Return the top-level subcommand for a ``mlflow`` invocation, or None when
+    absent (e.g. ``mlflow --version`` -> None, ``mlflow experiments search`` ->
+    "experiments"). ``argv[0]`` is assumed to be ``mlflow``.
 
-    Skips global flags and the value consumed by ``--env-file`` so the positional
-    tokens are identified without a full CLI parser. The sub-subcommand is the second
-    positional; per-subcommand option values could in principle precede it, but the
-    denied sub-subcommands are all bare verbs, so returning the first positional after
-    the subcommand is sufficient (and any mismatch fails closed at the allowlist).
+    Skips global flags and the value consumed by ``--env-file`` so the subcommand is
+    identified without a full CLI parser. Only the top-level subcommand is returned;
+    the denied verbs (see ``_DENIED_MLFLOW_SUBSUBCOMMANDS``) are matched against the
+    whole argv by the caller, so no fragile positional-index reasoning about
+    sub-subcommands is needed here.
     """
-    positionals: list[str] = []
     i = 1
-    while i < len(argv) and len(positionals) < 2:
+    while i < len(argv):
         tok = argv[i]
         if tok in _MLFLOW_GLOBAL_VALUE_FLAGS:
             i += 2  # skip the flag and its value
             continue
         if tok.startswith("-"):
-            i += 1  # boolean flag such as --version / --help
+            i += 1  # boolean/glued flag such as --version / --help / --env-file=x
             continue
-        positionals.append(tok)
-        i += 1
-    subcommand = positionals[0] if positionals else None
-    sub_subcommand = positionals[1] if len(positionals) > 1 else None
-    return subcommand, sub_subcommand
+        return tok
+    return None
 
 
 def remote_lockdown_active() -> bool:
@@ -137,17 +134,24 @@ def static_permission_error(
                 "commands are allowed"
             )
         if argv[0] == "mlflow":
-            subcommand, sub_subcommand = _mlflow_subcommand(argv)
+            subcommand = _mlflow_subcommand(argv)
             if subcommand is not None and subcommand not in _ALLOWED_MLFLOW_SUBCOMMANDS:
                 return (
                     f"Permission denied: 'mlflow {subcommand}' is not allowed. "
                     f"Allowed subcommands: {', '.join(sorted(_ALLOWED_MLFLOW_SUBCOMMANDS))}"
                 )
+            # Match denied verbs anywhere in argv, not at a fixed position: a
+            # value-taking option (e.g. `experiments -x 0 csv`) must not be able to
+            # shift the verb past a positional check and evade the denial. This
+            # over-denies the rare case where a denied verb also appears as an option
+            # value (e.g. an experiment literally named "csv") — an acceptable
+            # fail-closed tradeoff, since distinguishing verb from value would require
+            # the positional reasoning this scan deliberately avoids.
             denied_actions = _DENIED_MLFLOW_SUBSUBCOMMANDS.get(subcommand, frozenset())
-            if sub_subcommand in denied_actions:
+            if denied_verb := denied_actions.intersection(argv):
                 return (
-                    f"Permission denied: 'mlflow {subcommand} {sub_subcommand}' is not allowed "
-                    "(it can write to an arbitrary server-local path)."
+                    f"Permission denied: 'mlflow {subcommand} {min(denied_verb)}' is not "
+                    "allowed (it can write to an arbitrary server-local path)."
                 )
 
     if tool_name in _FILE_TOOLS and not perms.allow_edit_files:

--- a/tests/assistant/conftest.py
+++ b/tests/assistant/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_remote_env(monkeypatch):
+    # A leaked MLFLOW_ALLOW_REMOTE_ASSISTANT would silently invert the
+    # full_access tests (remote mode force-disables full_access). Tests that
+    # exercise remote mode set it explicitly.
+    monkeypatch.delenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", raising=False)

--- a/tests/assistant/conftest.py
+++ b/tests/assistant/conftest.py
@@ -1,9 +1,11 @@
 import pytest
 
+from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
+
 
 @pytest.fixture(autouse=True)
 def _clear_remote_env(monkeypatch):
-    # A leaked MLFLOW_ALLOW_REMOTE_ASSISTANT would silently invert the
+    # A leaked MLFLOW_ENABLE_REMOTE_ASSISTANT would silently invert the
     # full_access tests (remote mode force-disables full_access). Tests that
     # exercise remote mode set it explicitly.
-    monkeypatch.delenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", raising=False)
+    monkeypatch.delenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, raising=False)

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -16,6 +16,7 @@ from mlflow.assistant.providers.openai_compatible import (
 )
 from mlflow.assistant.providers.tool_executor import static_permission_error
 from mlflow.assistant.types import EventType
+from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 from mlflow.tracing.constant import CostKey, TokenUsageKey
 
 # ---------------------------------------------------------------------------
@@ -678,7 +679,7 @@ async def test_astream_remote_lockdown_denies_full_access_bash(provider, config_
     # disallowed Bash command must be denied by the real execute_tool (not prompted,
     # not executed) even though full_access is configured. Guards the security-critical
     # `gated` short-circuit and effective_permissions selection.
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "1")
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
     config_file.write_text(
         json.dumps({
             "providers": {"oai_test": {"model": "model-a", "permissions": {"full_access": True}}}

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -672,6 +672,64 @@ async def test_astream_tool_call_round_trip(provider):
     assert any(m["role"] == "tool" for m in second_payload["messages"])
 
 
+@pytest.mark.asyncio
+async def test_astream_remote_lockdown_denies_full_access_bash(provider, config_file, monkeypatch):
+    # Remote mode + config full_access=True: the allowlist is still absolute. A
+    # disallowed Bash command must be denied by the real execute_tool (not prompted,
+    # not executed) even though full_access is configured. Guards the security-critical
+    # `gated` short-circuit and effective_permissions selection.
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "1")
+    config_file.write_text(
+        json.dumps({
+            "providers": {"oai_test": {"model": "model-a", "permissions": {"full_access": True}}}
+        })
+    )
+    clear_config_cache()
+
+    turn1 = [
+        _sse(
+            _delta(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {"name": "Bash", "arguments": '{"command": "echo hi"}'},
+                    }
+                ]
+            )
+        ),
+        b"data: [DONE]\n",
+    ]
+    turn2 = [_sse(_delta(content="ok")), b"data: [DONE]\n"]
+    session, _calls = _make_aiohttp_session([turn1, turn2])
+
+    # execute_tool is NOT mocked here: we want the real allowlist denial to run.
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [
+            e
+            async for e in provider.astream(
+                "hi", "http://localhost:5000", mlflow_session_id=_SESSION_ID
+            )
+        ]
+
+    # Remote mode: no per-call prompt is offered.
+    assert not [e for e in events if e.type == EventType.PERMISSION_REQUEST]
+    # The tool result is a denial (proving `echo` never executed).
+    tool_results = [
+        block
+        for e in events
+        if e.type == EventType.MESSAGE and isinstance(e.data["message"]["content"], list)
+        for block in e.data["message"]["content"]
+        if block.get("tool_use_id")
+    ]
+    assert len(tool_results) == 1
+    assert tool_results[0]["is_error"] is True
+    assert "Permission denied" in tool_results[0]["content"]
+
+
 # ---------------------------------------------------------------------------
 # astream — session-scoped permission gating
 # ---------------------------------------------------------------------------
@@ -966,7 +1024,8 @@ async def test_astream_global_full_access_skips_prompt(tmp_path):
     ("tool_name", "tool_input", "allowed"),
     [
         ("Bash", {"command": "mlflow experiments search"}, True),
-        ("Bash", {"command": "python script.py"}, True),
+        ("Bash", {"command": "python script.py"}, False),
+        ("Bash", {"command": "mlflow run ."}, False),
         ("Bash", {"command": "rm -rf /"}, False),
         ("Bash", {"command": "ls"}, False),
     ],

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -121,7 +121,7 @@ def test_bash_no_shell_injection_via_metacharacters(tmp_path, template):
 
 @pytest.mark.parametrize(
     "sub",
-    ["run", "server", "models", "deployments", "sagemaker", "gateway", "db", "gc", "ai"],
+    ["run", "server", "models", "deployments", "sagemaker", "gateway", "db", "gc", "ai", "doctor"],
 )
 def test_bash_blocks_dangerous_mlflow_subcommands(sub):
     result, is_error = _run(execute_tool("Bash", {"command": f"mlflow {sub} --help"}))
@@ -160,6 +160,10 @@ def test_static_allows_safe_mlflow_commands(cmd):
         "mlflow experiments csv --experiment-id 0 --filename /root/.ssh/authorized_keys",
         "mlflow experiments csv --experiment-id 0 -o /etc/cron.d/x",
         "mlflow experiments csv --experiment-id 0",
+        # `doctor` prints MLFLOW_* env vars (tokens/passwords) unmasked and the raw
+        # tracking URI, reading local process state rather than the tracking API.
+        "mlflow doctor",
+        "mlflow doctor --mask-envs",
     ],
 )
 def test_static_denies_dangerous_mlflow_commands(cmd):

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -3,7 +3,13 @@ import asyncio
 import pytest
 
 from mlflow.assistant.config import PermissionsConfig
-from mlflow.assistant.providers.tool_executor import execute_tool
+from mlflow.assistant.providers.tool_executor import (
+    _mlflow_subcommand,
+    execute_tool,
+    static_permission_error,
+)
+
+# MLFLOW_ALLOW_REMOTE_ASSISTANT is cleared by the autouse fixture in conftest.py.
 
 
 @pytest.fixture
@@ -66,13 +72,21 @@ def test_path_containment_blocks_escape(workspace):
 
 
 def test_bash_works_without_cwd():
-    result, is_error = _run(execute_tool("Bash", {"command": "python3 -c \"print('hello')\""}))
+    # Previously ran python3 (now blocked); the MLflow CLI is the only allowed binary.
+    result, is_error = _run(execute_tool("Bash", {"command": "mlflow --version"}))
     assert not is_error
-    assert "hello" in result
+    assert "mlflow" in result.lower()
 
 
 def test_bash_blocks_non_mlflow_commands():
     result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}))
+    assert is_error
+    assert "Permission denied" in result
+
+
+@pytest.mark.parametrize("cmd", ["python3 -c \"print('x')\"", "python foo.py"])
+def test_bash_blocks_python(cmd):
+    result, is_error = _run(execute_tool("Bash", {"command": cmd}))
     assert is_error
     assert "Permission denied" in result
 
@@ -82,11 +96,148 @@ def test_bash_allows_mlflow_commands():
     assert not is_error
 
 
+@pytest.mark.parametrize(
+    "template",
+    [
+        "mlflow experiments search; touch {sentinel}",
+        "mlflow experiments search && touch {sentinel}",
+        "mlflow experiments search | touch {sentinel}",
+        "mlflow --version || touch {sentinel}",
+        "mlflow experiments search $(touch {sentinel})",
+        "mlflow experiments search > {sentinel}",
+        "mlflow experiments search `touch {sentinel}`",
+        "mlflow experiments search\ntouch {sentinel}",
+    ],
+)
+def test_bash_no_shell_injection_via_metacharacters(tmp_path, template):
+    # An allowlisted subcommand (passes the static check) followed by a shell
+    # metacharacter must NOT spawn a second process. Restricted mode runs argv
+    # directly (no /bin/sh -c), so the metacharacters reach mlflow as literal
+    # args instead of being interpreted by a shell.
+    sentinel = tmp_path / "pwned"
+    _run(execute_tool("Bash", {"command": template.format(sentinel=sentinel)}))
+    assert not sentinel.exists(), f"shell injection executed: {template!r}"
+
+
+@pytest.mark.parametrize(
+    "sub",
+    ["run", "server", "models", "deployments", "sagemaker", "gateway", "db", "gc", "ai"],
+)
+def test_bash_blocks_dangerous_mlflow_subcommands(sub):
+    result, is_error = _run(execute_tool("Bash", {"command": f"mlflow {sub} --help"}))
+    assert is_error
+    assert "Permission denied" in result
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "mlflow experiments search",
+        "mlflow experiments get --experiment-id 0",
+        "mlflow experiments create --experiment-name x",
+        "mlflow runs list --experiment-id 0",
+        "mlflow traces get --trace-id t",
+        "mlflow --version",
+        "mlflow --help",
+    ],
+)
+def test_static_allows_safe_mlflow_commands(cmd):
+    assert static_permission_error("Bash", {"command": cmd}, PermissionsConfig(), None) is None
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "mlflow run .",
+        "mlflow models serve -m model",
+        "mlflow gc",
+        "mlflow db upgrade sqlite:///x",
+        # `artifacts` is an arbitrary server-local file read/write primitive; denied.
+        "mlflow artifacts log-artifact --local-file /etc/passwd --run-id r",
+        "mlflow artifacts download --dst-path /tmp/x",
+        # `experiments csv --filename/-o PATH` writes an arbitrary server-local file
+        # (to_csv, no path validation) inside an otherwise-allowlisted subcommand.
+        "mlflow experiments csv --experiment-id 0 --filename /root/.ssh/authorized_keys",
+        "mlflow experiments csv --experiment-id 0 -o /etc/cron.d/x",
+        "mlflow experiments csv --experiment-id 0",
+    ],
+)
+def test_static_denies_dangerous_mlflow_commands(cmd):
+    assert static_permission_error("Bash", {"command": cmd}, PermissionsConfig(), None) is not None
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["mlflow"], (None, None)),
+        (["mlflow", "--version"], (None, None)),
+        (["mlflow", "experiments"], ("experiments", None)),
+        (["mlflow", "experiments", "search"], ("experiments", "search")),
+        (["mlflow", "experiments", "csv", "--filename", "/tmp/x"], ("experiments", "csv")),
+        # --env-file consumes its value; a value that looks like a subcommand is not one.
+        (["mlflow", "--env-file", "run", "experiments", "search"], ("experiments", "search")),
+        # Glued --env-file=value must skip exactly one slot.
+        (["mlflow", "--env-file=x", "run"], ("run", None)),
+        # `ui` is an AliasedGroup alias for `server`; not in the allowlist -> caught.
+        (["mlflow", "ui"], ("ui", None)),
+        (["mlflow", "--env-file", "/tmp/e", "run", "."], ("run", ".")),
+    ],
+)
+def test_mlflow_subcommand_parsing(argv, expected):
+    assert _mlflow_subcommand(argv) == expected
+
+
+def test_env_file_flag_value_is_not_mistaken_for_subcommand():
+    # `--env-file` consumes the next token; the real subcommand follows and must
+    # still be allowed. A value that happens to look like a subcommand must not fool the check.
+    err = static_permission_error(
+        "Bash", {"command": "mlflow --env-file run experiments search"}, PermissionsConfig(), None
+    )
+    assert err is None
+
+
+def test_dangerous_subcommand_after_env_file_flag_is_blocked():
+    err = static_permission_error(
+        "Bash", {"command": "mlflow --env-file /tmp/e run ."}, PermissionsConfig(), None
+    )
+    assert err is not None
+
+
+def test_remote_env_disables_full_access_bash(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "1")
+    perms = PermissionsConfig(full_access=True)
+    result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}, permissions=perms))
+    assert is_error
+    assert "Permission denied" in result
+
+
+def test_remote_env_disables_full_access_file_escape(monkeypatch, workspace):
+    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "1")
+    perms = PermissionsConfig(full_access=True)
+    result, is_error = _run(
+        execute_tool("Read", {"file_path": "../../../etc/passwd"}, cwd=workspace, permissions=perms)
+    )
+    assert is_error
+    assert "Permission denied" in result
+
+
 def test_bash_full_access_allows_any_command():
     perms = PermissionsConfig(full_access=True)
     result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}, permissions=perms))
     assert not is_error
     assert "hello" in result
+
+
+def test_bash_full_access_still_uses_shell(tmp_path):
+    # Local full_access is the explicit "give me a real shell" opt-in: pipes,
+    # redirects, and chaining must still work there.
+    sentinel = tmp_path / "ok"
+    perms = PermissionsConfig(full_access=True)
+    result, is_error = _run(
+        execute_tool("Bash", {"command": f"echo hi && touch {sentinel}"}, permissions=perms)
+    )
+    assert not is_error
+    assert sentinel.exists()
 
 
 def test_full_access_bypasses_permission_checks(workspace):

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -6,10 +6,21 @@ from mlflow.assistant.config import PermissionsConfig
 from mlflow.assistant.providers.tool_executor import (
     _mlflow_subcommand,
     execute_tool,
+    remote_lockdown_active,
     static_permission_error,
 )
+from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 
-# MLFLOW_ALLOW_REMOTE_ASSISTANT is cleared by the autouse fixture in conftest.py.
+# MLFLOW_ENABLE_REMOTE_ASSISTANT is cleared by the autouse fixture in conftest.py.
+
+
+def test_remote_lockdown_reads_canonical_env_var(monkeypatch):
+    # The lockdown must key off the same switch that actually opens the assistant to
+    # remote clients (MLFLOW_ENABLE_REMOTE_ASSISTANT, mlflow/server/assistant/api.py),
+    # not a differently-named variable that nothing sets — otherwise it is fail-open.
+    assert remote_lockdown_active() is False
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
+    assert remote_lockdown_active() is True
 
 
 @pytest.fixture
@@ -230,7 +241,7 @@ def test_experiments_csv_denied_regardless_of_arg_order(cmd):
 
 
 def test_remote_env_disables_full_access_bash(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "1")
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
     perms = PermissionsConfig(full_access=True)
     result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}, permissions=perms))
     assert is_error
@@ -238,7 +249,7 @@ def test_remote_env_disables_full_access_bash(monkeypatch):
 
 
 def test_remote_env_disables_full_access_file_escape(monkeypatch, workspace):
-    monkeypatch.setenv("MLFLOW_ALLOW_REMOTE_ASSISTANT", "1")
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
     perms = PermissionsConfig(full_access=True)
     result, is_error = _run(
         execute_tool("Read", {"file_path": "../../../etc/passwd"}, cwd=workspace, permissions=perms)

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -281,6 +281,18 @@ def test_remote_read_without_cwd_cannot_escape(monkeypatch):
     assert "Permission denied" in result
 
 
+@pytest.mark.parametrize("tool", ["Read", "Write", "Edit"])
+def test_nul_byte_path_denied_not_crashed(workspace, tool):
+    # A NUL byte in file_path makes Path.resolve() raise ValueError. That call lives
+    # in static_permission_error (outside execute_tool's try/except), so an unguarded
+    # resolve would propagate instead of denying. It must fail closed with a denial.
+    err = static_permission_error(
+        tool, {"file_path": "a\x00b"}, PermissionsConfig(allow_edit_files=True), workspace
+    )
+    assert err is not None
+    assert "Permission denied" in err
+
+
 def test_bash_full_access_allows_any_command():
     perms = PermissionsConfig(full_access=True)
     result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}, permissions=perms))

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -173,18 +173,18 @@ def test_static_denies_dangerous_mlflow_commands(cmd):
 @pytest.mark.parametrize(
     ("argv", "expected"),
     [
-        (["mlflow"], (None, None)),
-        (["mlflow", "--version"], (None, None)),
-        (["mlflow", "experiments"], ("experiments", None)),
-        (["mlflow", "experiments", "search"], ("experiments", "search")),
-        (["mlflow", "experiments", "csv", "--filename", "/tmp/x"], ("experiments", "csv")),
+        (["mlflow"], None),
+        (["mlflow", "--version"], None),
+        (["mlflow", "experiments"], "experiments"),
+        (["mlflow", "experiments", "search"], "experiments"),
+        (["mlflow", "experiments", "csv", "--filename", "/tmp/x"], "experiments"),
         # --env-file consumes its value; a value that looks like a subcommand is not one.
-        (["mlflow", "--env-file", "run", "experiments", "search"], ("experiments", "search")),
+        (["mlflow", "--env-file", "run", "experiments", "search"], "experiments"),
         # Glued --env-file=value must skip exactly one slot.
-        (["mlflow", "--env-file=x", "run"], ("run", None)),
+        (["mlflow", "--env-file=x", "run"], "run"),
         # `ui` is an AliasedGroup alias for `server`; not in the allowlist -> caught.
-        (["mlflow", "ui"], ("ui", None)),
-        (["mlflow", "--env-file", "/tmp/e", "run", "."], ("run", ".")),
+        (["mlflow", "ui"], "ui"),
+        (["mlflow", "--env-file", "/tmp/e", "run", "."], "run"),
     ],
 )
 def test_mlflow_subcommand_parsing(argv, expected):
@@ -205,6 +205,28 @@ def test_dangerous_subcommand_after_env_file_flag_is_blocked():
         "Bash", {"command": "mlflow --env-file /tmp/e run ."}, PermissionsConfig(), None
     )
     assert err is not None
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # Canonical form (already denied), kept as a regression guard.
+        "mlflow experiments csv --experiment-id 0 -o /tmp/x",
+        # Bypass: `-x` takes a value, so a positional-index denylist reads the
+        # sub-subcommand as "0" and lets `csv` through. A whole-argv verb scan
+        # must still deny it regardless of where `csv` appears.
+        "mlflow experiments -x 0 csv -o /tmp/x",
+        # Glued short option value (`-x0`) is the subtlest shlex form.
+        "mlflow experiments -x0 csv -o /tmp/x",
+        "mlflow experiments --experiment-id 0 csv --filename /tmp/x",
+        "mlflow experiments --experiment-id=0 csv -o /tmp/x",
+    ],
+)
+def test_experiments_csv_denied_regardless_of_arg_order(cmd):
+    # `experiments csv` writes an arbitrary server-local file (to_csv, no path
+    # validation). The denial must not be evadable by moving a value-taking
+    # option in front of the `csv` verb.
+    assert static_permission_error("Bash", {"command": cmd}, PermissionsConfig(), None) is not None
 
 
 def test_remote_env_disables_full_access_bash(monkeypatch):

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -4,6 +4,7 @@ import pytest
 
 from mlflow.assistant.config import PermissionsConfig
 from mlflow.assistant.providers.tool_executor import (
+    _execute_bash,
     _mlflow_subcommand,
     execute_tool,
     remote_lockdown_active,
@@ -258,11 +259,49 @@ def test_remote_env_disables_full_access_file_escape(monkeypatch, workspace):
     assert "Permission denied" in result
 
 
+@pytest.mark.parametrize("tool", ["Read", "Write", "Edit"])
+def test_file_tool_without_cwd_denied_under_remote_lockdown(monkeypatch, tool):
+    # Under remote lockdown, no workspace root means no containment boundary, so an
+    # absolute path like /etc/passwd would otherwise reach the filesystem unchecked.
+    # Every file tool must require a configured project directory here, not just
+    # Write/Edit. (Local unscoped reads remain allowed — see
+    # test_read_absolute_path_works_without_cwd.)
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
+    err = static_permission_error(tool, {"file_path": "/etc/passwd"}, PermissionsConfig(), None)
+    assert err is not None
+
+
+def test_remote_read_without_cwd_cannot_escape(monkeypatch):
+    # Regression: remote lockdown + full_access config, no cwd. Read must be denied
+    # rather than falling through to read an arbitrary server-local file.
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
+    perms = PermissionsConfig(full_access=True)
+    result, is_error = _run(execute_tool("Read", {"file_path": "/etc/passwd"}, permissions=perms))
+    assert is_error
+    assert "Permission denied" in result
+
+
 def test_bash_full_access_allows_any_command():
     perms = PermissionsConfig(full_access=True)
     result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}, permissions=perms))
     assert not is_error
     assert "hello" in result
+
+
+def test_command_not_found_echoes_only_executable(tmp_path):
+    # The FileNotFoundError message must not leak user-controlled arguments or
+    # server-local paths — only the executable name.
+    secret_arg = str(tmp_path / "secret-internal-path")
+    result, is_error = _run(
+        _execute_bash(
+            {"command": f"definitely-not-a-real-binary --token {secret_arg}"},
+            cwd=None,
+            tracking_uri=None,
+        )
+    )
+    assert is_error
+    assert result == "Command not found: definitely-not-a-real-binary"
+    assert secret_arg not in result
 
 
 def test_bash_full_access_still_uses_shell(tmp_path):

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -260,15 +260,33 @@ def test_remote_env_disables_full_access_file_escape(monkeypatch, workspace):
 
 
 @pytest.mark.parametrize("tool", ["Read", "Write", "Edit"])
-def test_file_tool_without_cwd_denied_under_remote_lockdown(monkeypatch, tool):
-    # Under remote lockdown, no workspace root means no containment boundary, so an
-    # absolute path like /etc/passwd would otherwise reach the filesystem unchecked.
-    # Every file tool must require a configured project directory here, not just
-    # Write/Edit. (Local unscoped reads remain allowed — see
-    # test_read_absolute_path_works_without_cwd.)
+def test_file_tools_denied_under_remote_lockdown(monkeypatch, tool):
+    # Remote lockdown is tracking-API-query only: the mlflow CLI already reads all
+    # tracking state, and Read/Write/Edit add only server-local filesystem access as
+    # the server identity (no per-call approval), which is a disclosure/tamper
+    # primitive with no remote use the CLI doesn't cover. Deny all three outright,
+    # regardless of whether a project dir is configured. (Local/full-access retains
+    # them — see test_read_absolute_path_works_without_cwd.)
     monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
-    err = static_permission_error(tool, {"file_path": "/etc/passwd"}, PermissionsConfig(), None)
+    assert (
+        static_permission_error(tool, {"file_path": "/etc/passwd"}, PermissionsConfig(), None)
+        is not None
+    )
+
+
+@pytest.mark.parametrize("tool", ["Read", "Write", "Edit"])
+def test_file_tools_denied_under_remote_lockdown_even_with_workspace(monkeypatch, workspace, tool):
+    # Even a validly-contained in-workspace path is denied: the ban is on the tool
+    # under remote lockdown, not merely on paths that escape the workspace.
+    monkeypatch.setenv(MLFLOW_ENABLE_REMOTE_ASSISTANT.name, "1")
+    err = static_permission_error(
+        tool,
+        {"file_path": "README.md", "content": "x", "old_string": "# project", "new_string": "y"},
+        PermissionsConfig(),
+        workspace,
+    )
     assert err is not None
+    assert "Permission denied" in err
 
 
 def test_remote_read_without_cwd_cannot_escape(monkeypatch):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

As the MLflow Assistant moves toward remote use, this PR removes the remote-code-execution surface by restricting what tools it can run.

When remote access is enabled (`MLFLOW_ENABLE_REMOTE_ASSISTANT`), the Assistant is locked to an allowlist:
- Only the `mlflow` CLI — no `python`/`python3` or arbitrary shell.
- Only read/query subcommands (`experiments`, `runs`, `traces`, `datasets`, `scorers`); dangerous ones (`run`, `server`, `models`, `db`, `gc`, `doctor`, `artifacts`, …) are denied, as is `experiments csv` (arbitrary file write).
- Commands run via direct `argv` exec — no shell — so pipes, redirects, and `$(...)` can't smuggle a second process.
- In this mode `full_access` and per-call approval cannot override the allowlist.

For local users, on restricted mode, only MLFlow CLI commands can run, though Read/Write/Edit will still be available provided the path resolves in the workspace (meaning this only applies to Claude and Codex)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Remote MLflow Assistant only supports a subset of allowlisted tools

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

