### PR TITLE
Fix core tracing tests broken by opentelemetry-sdk 1.43.0

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -784,13 +784,23 @@ def _bypass_attribute_guard(span: OTelSpan) -> Generator[None, None, None]:
     However, we need to set some attributes within `on_end` handler of the span processor,
     where the span is already marked as ended. This context manager is a hacky workaround
     to bypass the attribute guard.
+
+    Since opentelemetry-sdk 1.43.0, `Span.end()` additionally marks the span's
+    `BoundedAttributes` as immutable, which raises a `TypeError` on any write regardless of
+    the end time. We temporarily clear that flag as well and restore it afterwards.
     """
     original_end_time = span._end_time
     span._end_time = None
+    attributes = span._attributes
+    original_immutable = getattr(attributes, "_immutable", None)
+    if original_immutable is not None:
+        attributes._immutable = False
     try:
         yield
     finally:
         span._end_time = original_end_time
+        if original_immutable is not None:
+            attributes._immutable = original_immutable
 
 
 def parse_trace_id_v4(trace_id: str | None) -> tuple[str | None, str | None]:

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -613,7 +613,8 @@ def test_otel_resource_attributes(monkeypatch):
     }
 
     mlflow.tracing.reset()
-    # When otel attributes are set explicitly, they are merged into the resource alongside MLflow's SDK attributes.
+    # When otel attributes are set explicitly, they are merged into the resource
+    # alongside MLflow's SDK attributes.
     monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "favorite.fruit=apple,color=red")
     tracer = _get_tracer("test")
     assert resource_attributes(tracer) == {

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -597,9 +597,16 @@ def test_metrics_export_without_otlp_trace_export(monkeypatch):
 
 
 def test_otel_resource_attributes(monkeypatch):
+    def resource_attributes(tracer):
+        # opentelemetry-sdk 1.43.0+ auto-injects a random `service.instance.id` when it builds
+        # the resource from env vars. It is not deterministic, so drop it before comparing.
+        attributes = dict(tracer.resource.attributes)
+        attributes.pop("service.instance.id", None)
+        return attributes
+
     tracer = _get_tracer("test")
     # By default, only MLflow's SDK attributes are set on an empty resource
-    assert tracer.resource.attributes == {
+    assert resource_attributes(tracer) == {
         "telemetry.sdk.language": "python",
         "telemetry.sdk.name": "mlflow",
         "telemetry.sdk.version": mlflow.__version__,
@@ -609,7 +616,7 @@ def test_otel_resource_attributes(monkeypatch):
     # When otel attributes are set explicitly, MLflow's SDK attributes are not set on the resource
     monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "favorite.fruit=apple,color=red")
     tracer = _get_tracer("test")
-    assert dict(tracer.resource.attributes) == {
+    assert resource_attributes(tracer) == {
         "favorite.fruit": "apple",
         "color": "red",
         "telemetry.sdk.language": "python",
@@ -623,7 +630,7 @@ def test_otel_resource_attributes(monkeypatch):
     monkeypatch.setenv("OTEL_SERVICE_NAME", "test-service")
     monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
     tracer = _get_tracer("test")
-    assert dict(tracer.resource.attributes) == {
+    assert resource_attributes(tracer) == {
         "service.name": "test-service",
         "telemetry.sdk.language": "python",
         "telemetry.sdk.name": "mlflow",
@@ -635,7 +642,7 @@ def test_otel_resource_attributes(monkeypatch):
     monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "invalid")
     monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
     tracer = _get_tracer("test")
-    assert dict(tracer.resource.attributes) == {
+    assert resource_attributes(tracer) == {
         "service.name": "unknown_service",
         "telemetry.sdk.language": "python",
         "telemetry.sdk.name": "mlflow",

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -613,7 +613,7 @@ def test_otel_resource_attributes(monkeypatch):
     }
 
     mlflow.tracing.reset()
-    # When otel attributes are set explicitly, MLflow's SDK attributes are not set on the resource
+    # When otel attributes are set explicitly, they are merged into the resource alongside MLflow's SDK attributes.
     monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "favorite.fruit=apple,color=red")
     tracer = _get_tracer("test")
     assert resource_attributes(tracer) == {


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

All PRs are blocked due a new OTEL version

https://github.com/mlflow/mlflow/actions/runs/28576000096/job/84724592837?pr=24249

### What changes are proposed in this pull request?

[opentelemetry-sdk 1.43.0](https://github.com/open-telemetry/opentelemetry-python/pull/5298/changes) introduced two behavior changes that broke the core tracing test job:

1. Span.end() now marks the span's BoundedAttributes as immutable (_attributes._immutable = True) in addition to setting the end time. _bypass_attribute_guard only cleared _end_time, so writing user/session attributes on an ended root span in DatabricksUCTableSpanProcessor.on_end (and the strands/haystack/semantic_kernel autolog integrations) raised TypeError. The guard now also temporarily clears the immutable flag and restores it, guarded with getattr so it no-ops on older SDK versions.

2. Building a resource from OTEL_RESOURCE_ATTRIBUTES/OTEL_SERVICE_NAME now auto-injects a random service.instance.id. test_otel_resource_attribute

IMO, this OTEL fix does have some performance benefits, so we should reconsider our hacky approach around modifying spans like that.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
