### PR TITLE
Fix Summary ignoring valid=False Assessments

### DIFF
--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -470,7 +470,16 @@ def _apply_view_initial_join(query: Query, view_type: MetricViewType) -> Query:
         case MetricViewType.SPANS:
             query = query.join(SqlSpan, SqlSpan.trace_id == SqlTraceInfo.request_id)
         case MetricViewType.ASSESSMENTS:
-            query = query.join(SqlAssessments, SqlAssessments.trace_id == SqlTraceInfo.request_id)
+            # Only aggregate valid assessments. When an assessment is overridden via
+            # mlflow.override_feedback(), the superseded assessment is marked valid=False,
+            # and should be excluded from counts/values so override chains aren't double-counted.
+            query = query.join(
+                SqlAssessments,
+                and_(
+                    SqlAssessments.trace_id == SqlTraceInfo.request_id,
+                    SqlAssessments.valid.is_(True),
+                ),
+            )
     return query
 
 

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -2,7 +2,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, Float, and_, case, distinct, exists, func, literal_column
+from sqlalchemy import Column, Float, and_, case, distinct, exists, func, literal_column, true
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.query import Query
 
@@ -477,7 +477,7 @@ def _apply_view_initial_join(query: Query, view_type: MetricViewType) -> Query:
                 SqlAssessments,
                 and_(
                     SqlAssessments.trace_id == SqlTraceInfo.request_id,
-                    SqlAssessments.valid.is_(True),
+                    SqlAssessments.valid == true(),
                 ),
             )
     return query

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
@@ -3239,6 +3239,91 @@ def test_query_assessment_metrics_across_multiple_traces(store: SqlAlchemyStore)
     }
 
 
+def test_query_assessment_metrics_excludes_overridden_assessments(store: SqlAlchemyStore):
+    # Regression test for https://github.com/mlflow/mlflow/issues/24132. Assessments in an
+    # override chain (marked valid=False) must not be counted or bucketed, otherwise the
+    # Quality Overview over-counts superseded feedback.
+    exp_id = store.create_experiment("test_assessment_excludes_overridden")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    store.start_trace(
+        TraceInfo(
+            trace_id=trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+            request_time=get_current_time_millis(),
+            execution_duration=100,
+            state=TraceStatus.OK,
+            tags={TraceTagKey.TRACE_NAME: "demo"},
+        )
+    )
+
+    source = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="reviewer")
+    # yes -> override to no -> override to yes; only the final assessment stays valid.
+    fb1 = store.create_assessment(
+        Feedback(trace_id=trace_id, name="user_satisfaction", value="yes", source=source)
+    )
+    fb2 = store.create_assessment(
+        Feedback(
+            trace_id=trace_id,
+            name="user_satisfaction",
+            value="no",
+            source=source,
+            overrides=fb1.assessment_id,
+        )
+    )
+    store.create_assessment(
+        Feedback(
+            trace_id=trace_id,
+            name="user_satisfaction",
+            value="yes",
+            source=source,
+            overrides=fb2.assessment_id,
+        )
+    )
+
+    count_result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_COUNT,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.COUNT)],
+    )
+    assert len(count_result) == 1
+    assert asdict(count_result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_COUNT,
+        "dimensions": {},
+        "values": {"COUNT": 1},
+    }
+
+    histogram_result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_COUNT,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.COUNT)],
+        dimensions=[AssessmentMetricDimensionKey.ASSESSMENT_VALUE],
+    )
+    assert len(histogram_result) == 1
+    assert asdict(histogram_result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_COUNT,
+        "dimensions": {AssessmentMetricDimensionKey.ASSESSMENT_VALUE: json.dumps("yes")},
+        "values": {"COUNT": 1},
+    }
+
+    # The overridden "no" (0.0) must not drag down the average of the valid "yes" (1.0).
+    value_result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+        dimensions=[AssessmentMetricDimensionKey.ASSESSMENT_NAME],
+    )
+    assert len(value_result) == 1
+    assert asdict(value_result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {AssessmentMetricDimensionKey.ASSESSMENT_NAME: "user_satisfaction"},
+        "values": {"AVG": 1.0},
+    }
+
+
 def test_query_assessment_value_avg_by_name(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_assessment_value_avg_by_name")
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes https://github.com/mlflow/mlflow/issues/24132

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR fixes a bug where override chains were all included in the Summary query. We should just take the latest feedback (with `valid=True`) for the summary to avoid double counting.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
