### PR TITLE
[BUG] Fix #24170: surface direct (per-resource) permissions in Admin UI

### DIFF
--- a/mlflow/server/js/src/account/hooks.test.tsx
+++ b/mlflow/server/js/src/account/hooks.test.tsx
@@ -134,7 +134,10 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
     expect(mockedApi.listUserRoles).toHaveBeenCalledWith('pat');
   });
 
-  it('drops synthetic __user_<id>__ roles from the response', async () => {
+  it('retains synthetic __user_<id>__ roles in the response', async () => {
+    // The hook intentionally returns roles unfiltered. Synthetic roles back
+    // direct grants; consumers (PermissionsSection, EditAccessModal pre-fill)
+    // need them, while the human-facing Roles tables filter them out locally.
     const namedRole = {
       id: 7,
       name: 'editors',
@@ -153,7 +156,7 @@ describe('useUserRolesQuery (gated on truthy username)', () => {
 
     const { result } = renderHook(() => useUserRolesQuery('pat'), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.roles).toEqual([namedRole]);
+    expect(result.current.data?.roles).toEqual([namedRole, syntheticRole]);
   });
 });
 

--- a/mlflow/server/js/src/account/hooks.ts
+++ b/mlflow/server/js/src/account/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useMutation, useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { AccountApi } from './api';
-import { isSyntheticUserRole, isWorkspaceAdminRole } from './types';
+import { isWorkspaceAdminRole } from './types';
 import type { UpdatePasswordRequest } from './types';
 
 export const useCurrentUserQuery = () => {
@@ -104,13 +104,12 @@ export const useUpdatePassword = () => {
 export const useUserRolesQuery = (username: string, options: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: AccountQueryKeys.userRoles(username),
-    queryFn: async () => {
-      const data = await AccountApi.listUserRoles(username);
-      // Synthetic ``__user_<id>__`` roles back direct grants and are not
-      // human-facing. Drop them so the per-user roles list never leaks
-      // its own bookkeeping row.
-      return { ...data, roles: data.roles.filter((r) => !isSyntheticUserRole(r.name)) };
-    },
+    // Return roles unfiltered — including the synthetic ``__user_<id>__`` role
+    // that backs direct grants. Consumers filter synthetic roles out of their
+    // own human-facing Roles tables (via ``displayRoles``); PermissionsSection
+    // and the EditAccessModal pre-fill need the synthetic role to surface /
+    // edit direct grants.
+    queryFn: () => AccountApi.listUserRoles(username),
     retry: false,
     refetchOnWindowFocus: false,
     // Callers pass ``enabled: false`` to skip a fetch they know will 403.

--- a/mlflow/server/js/src/admin/pages/UserDetailPage.test.tsx
+++ b/mlflow/server/js/src/admin/pages/UserDetailPage.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+
+import UserDetailPage from './UserDetailPage';
+
+// Per-test override for ``useUserRolesQuery`` and the active tab, so each case
+// can pick its own role payload and land on the Roles or Permissions tab.
+const mockUseUserRolesQuery = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock('../hooks', () => ({
+  useCurrentUserIsAdmin: () => true,
+  useUserRolesQuery: (username: string) => mockUseUserRolesQuery(username),
+  useUsersQuery: () => ({
+    data: { users: [{ id: 1, username: 'alice', is_admin: false, roles: [] }] },
+    isLoading: false,
+    error: null,
+  }),
+  useWithSettingsReturnTo: () => (route: string) => route,
+}));
+
+jest.mock('../../workspaces/utils/WorkspaceUtils', () => ({
+  useActiveWorkspace: () => null,
+}));
+
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useWorkspacesEnabled: () => ({ workspacesEnabled: false }),
+}));
+
+// The modal drags in its own query stack; it's irrelevant to the roles/
+// permissions split under test, so stub it out.
+jest.mock('../components/EditAccessModal', () => ({
+  EditAccessModal: () => null,
+}));
+
+jest.mock('../../common/utils/RoutingUtils', () => ({
+  // Keep ``createMLflowRoutePath`` et al. real so ``admin/routes`` still
+  // builds; only stub the router hooks and Link (no Router provider here).
+  ...jest.requireActual<typeof import('../../common/utils/RoutingUtils')>('../../common/utils/RoutingUtils'),
+  useParams: () => ({ username: 'alice' }),
+  useSearchParams: () => [mockSearchParams, jest.fn()],
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+const syntheticOnlyRoles = {
+  roles: [
+    {
+      id: 19,
+      name: '__user_1__',
+      workspace: 'default',
+      description: null,
+      permissions: [{ id: 1, role_id: 19, resource_type: 'experiment', resource_pattern: '19', permission: 'MANAGE' }],
+    },
+  ],
+};
+
+describe('UserDetailPage — synthetic role wiring (#24170)', () => {
+  beforeEach(() => {
+    mockUseUserRolesQuery.mockReset();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("surfaces a synthetic-only user's direct grant on the Permissions tab", () => {
+    // Regression guard for #24170: the page must hand the *unfiltered* role
+    // list (including the synthetic ``__user_<id>__`` role that backs direct
+    // grants) to PermissionsSection, not the synthetic-filtered ``displayRoles``.
+    mockSearchParams = new URLSearchParams('tab=permissions');
+    mockUseUserRolesQuery.mockReturnValue({ data: syntheticOnlyRoles, isLoading: false, error: null });
+
+    renderWithDesignSystem(<UserDetailPage />);
+
+    expect(screen.getByText(/experiment:19/)).toBeInTheDocument();
+    expect(screen.getByText('MANAGE')).toBeInTheDocument();
+    // Rendered under the localized "Direct" source, never the raw role name.
+    expect(screen.getByText('Direct')).toBeInTheDocument();
+    expect(screen.queryByText('__user_1__')).not.toBeInTheDocument();
+    expect(screen.queryByText('No resource permissions to show.')).not.toBeInTheDocument();
+  });
+
+  it('hides the synthetic role from the human-facing Roles tab', () => {
+    // The flip side of the split: the synthetic role must stay out of the
+    // Roles table, so a synthetic-only user reads as having no named roles.
+    mockUseUserRolesQuery.mockReturnValue({ data: syntheticOnlyRoles, isLoading: false, error: null });
+
+    renderWithDesignSystem(<UserDetailPage />);
+
+    expect(screen.queryByText('__user_1__')).not.toBeInTheDocument();
+    expect(screen.getByText('This user has not been assigned to any roles.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Related Issues/PRs

Closes #24170

### What changes are proposed in this pull request?

In the Admin UI, the Permissions section on both the User Detail page (`/admin/users/:username`) and the self-service Account page rendered empty for any user whose access comes only from direct per-resource grants (grants stored in the reserved synthetic `__user_<id>__` role). The data was returned by the REST endpoint and received by the browser, but never displayed — a regression from #23578.

**Root cause:** the shared `useUserRolesQuery` React Query hook filtered synthetic roles inside its `queryFn`, i.e. before any component received the data. The Roles table (which should hide synthetic roles) and `PermissionsSection` (whose entire purpose is to display those direct grants) consumed the same already-filtered list, so `PermissionsSection` was starved of its source data and rendered the "No resource permissions to show." empty state.

**Fix:** return roles unfiltered from `useUserRolesQuery`. Every consumer already filters synthetic roles out of its own human-facing Roles table locally (via `displayRoles` / `isSyntheticUserRole`), so the Roles tables keep hiding the synthetic role while the Permissions tab and the Edit-access pre-fill regain their direct-grant data.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `hooks.test`: inverted to assert `useUserRolesQuery` retains synthetic `__user_<id>__` roles.
- `PermissionsSection.test`: existing coverage that synthetic grants render under the localized "Direct" source.
- `UserDetailPage.test` (new): page-level guard that a synthetic-only user shows their direct grant on the Permissions tab (source "Direct", not the empty state) yet reads as having no named roles on the Roles tab — covering the exact wiring seam where the regression lived.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Direct (per-resource) permissions now correctly render in the Admin UI Permissions section for users whose access comes only from direct grants.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)