### PR TITLE
fix: handle existing tables gracefully during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,10 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use checkfirst=True (default) to avoid errors when tables already exist.
+    # This can happen when upgrading from an older version that already has
+    # some tables (e.g., 'secrets' table added in 3.8.0).
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Running `mlflow db upgrade` after updating to 3.8.x from 3.7.0 fails with error:
`pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`

This happens because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, which attempts to create all tables including those that already exist from previous versions.

## Fix
Set `checkfirst=True` in `create_all()` to skip creation of tables that already exist. This is the default behavior, but the issue shows that it's being overridden or the InitialBase metadata includes tables that are created by migrations in 3.8.0 (like 'secrets'). By explicitly using `checkfirst=True`, we ensure that Alembic migrations handle the creation of new tables properly without conflicting with `create_all`.

Closes #19943