### PR TITLE
Fix DNS-rebinding SSRF bypass in webhook delivery

### DIFF
--- a/mlflow/webhooks/delivery.py
+++ b/mlflow/webhooks/delivery.py
@@ -20,7 +20,6 @@ import requests
 import urllib3
 from cachetools import TTLCache
 from packaging.version import Version
-from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from mlflow.entities.webhook import Webhook, WebhookEvent, WebhookTestResult
@@ -40,6 +39,7 @@ from mlflow.webhooks.constants import (
     WEBHOOK_SIGNATURE_VERSION,
     WEBHOOK_TIMESTAMP_HEADER,
 )
+from mlflow.webhooks.ssrf import SSRFProtectedHTTPAdapter
 from mlflow.webhooks.types import (
     WebhookPayload,
     get_example_payload_for_event,
@@ -88,7 +88,10 @@ def _create_webhook_session() -> requests.Session:
         **extra_kwargs,
     )
 
-    adapter = HTTPAdapter(max_retries=retry_strategy)
+    # SSRF-protected adapter validates each connection's peer IP is public at
+    # connect time, closing the DNS-rebinding TOCTOU gap between
+    # _validate_webhook_url (resolve + check) and the actual request (re-resolve).
+    adapter = SSRFProtectedHTTPAdapter(max_retries=retry_strategy)
     session = requests.Session()
     session.mount("http://", adapter)
     session.mount("https://", adapter)

--- a/mlflow/webhooks/delivery.py
+++ b/mlflow/webhooks/delivery.py
@@ -93,6 +93,9 @@ def _create_webhook_session() -> requests.Session:
     # _validate_webhook_url (resolve + check) and the actual request (re-resolve).
     adapter = SSRFProtectedHTTPAdapter(max_retries=retry_strategy)
     session = requests.Session()
+    # Disable env proxy handling: a proxy would make the validated peer the
+    # proxy rather than the webhook destination, bypassing the SSRF check.
+    session.trust_env = False
     session.mount("http://", adapter)
     session.mount("https://", adapter)
 

--- a/mlflow/webhooks/ssrf.py
+++ b/mlflow/webhooks/ssrf.py
@@ -24,7 +24,7 @@ import socket
 from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
-from urllib3.poolmanager import PoolManager
+from urllib3.poolmanager import PoolManager, ProxyManager
 
 from mlflow.environment_variables import _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS
 
@@ -42,7 +42,14 @@ def _assert_public_peer(sock: socket.socket) -> None:
         return
 
     # getpeername() returns (host, port, ...) for both IPv4 and IPv6 sockets.
-    peer_ip = sock.getpeername()[0]
+    # It can raise OSError (e.g. ENOTCONN) on an unconnected socket; fail closed.
+    try:
+        peer_ip = sock.getpeername()[0]
+    except OSError as e:
+        sock.close()
+        raise SSRFProtectionError(
+            f"Could not determine webhook connection peer address: {e}"
+        ) from e
     try:
         ip = ipaddress.ip_address(peer_ip)
     except ValueError as e:
@@ -83,19 +90,32 @@ class _SSRFProtectedHTTPSConnectionPool(HTTPSConnectionPool):
     ConnectionCls = _SSRFProtectedHTTPSConnection
 
 
+# Instance-local override installed on any (Pool|Proxy)Manager below, so only
+# pools created by these managers get the SSRF-protected connection classes.
+_SSRF_POOL_CLASSES = {
+    "http": _SSRFProtectedHTTPConnectionPool,
+    "https": _SSRFProtectedHTTPSConnectionPool,
+}
+
+
 class _SSRFProtectedPoolManager(PoolManager):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        # Instance-local override, so only pools created by this manager get the
-        # SSRF-protected connection classes.
-        self.pool_classes_by_scheme = {
-            "http": _SSRFProtectedHTTPConnectionPool,
-            "https": _SSRFProtectedHTTPSConnectionPool,
-        }
+        self.pool_classes_by_scheme = _SSRF_POOL_CLASSES
+
+
+class _SSRFProtectedProxyManager(ProxyManager):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.pool_classes_by_scheme = _SSRF_POOL_CLASSES
 
 
 class SSRFProtectedHTTPAdapter(HTTPAdapter):
-    """``HTTPAdapter`` that validates each connection's peer IP is public."""
+    """``HTTPAdapter`` that validates each connection's peer IP is public.
+
+    Both the direct pool manager and the proxy manager use SSRF-protected pools,
+    so the peer-IP check runs whether or not a proxy is configured.
+    """
 
     def init_poolmanager(
         self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs
@@ -109,3 +129,16 @@ class SSRFProtectedHTTPAdapter(HTTPAdapter):
             block=block,
             **pool_kwargs,
         )
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        if proxy not in self.proxy_manager:
+            proxy_headers = self.proxy_headers(proxy)
+            self.proxy_manager[proxy] = _SSRFProtectedProxyManager(
+                proxy,
+                proxy_headers=proxy_headers,
+                num_pools=self._pool_connections,
+                maxsize=self._pool_maxsize,
+                block=self._pool_block,
+                **proxy_kwargs,
+            )
+        return self.proxy_manager[proxy]

--- a/mlflow/webhooks/ssrf.py
+++ b/mlflow/webhooks/ssrf.py
@@ -1,0 +1,111 @@
+"""Connection-time SSRF protection for outbound webhook delivery.
+
+``_validate_webhook_url`` resolves the webhook hostname and checks that every
+resolved IP is public, but it discards the resolved IP and the subsequent
+``requests.post`` re-resolves the hostname independently. That TOCTOU gap lets a
+DNS-rebinding attacker return a public IP during validation and a private or
+link-local IP (e.g. ``169.254.169.254``) at request time, reaching cloud
+metadata or internal services.
+
+The pieces below close the gap by validating the peer IP of the *actual
+connected socket* immediately after ``connect()`` returns, before any TLS
+handshake or HTTP data is exchanged. There is no second DNS resolution between
+the check and the request, so rebinding has nothing to exploit. Because the TLS
+handshake still runs against the original hostname, certificate validation is
+unaffected (unlike pinning the URL to a resolved IP).
+
+Everything here is scoped to the webhook delivery session via
+``SSRFProtectedHTTPAdapter`` so it never alters urllib3 behavior process-wide.
+"""
+
+import ipaddress
+import socket
+
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.poolmanager import PoolManager
+
+from mlflow.environment_variables import _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS
+
+
+class SSRFProtectionError(Exception):
+    """Raised when a webhook connection resolves to a non-public IP address.
+
+    Not a urllib3 exception type, so it is never retried and propagates
+    immediately: the delivery fails closed.
+    """
+
+
+def _assert_public_peer(sock: socket.socket) -> None:
+    if _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS.get():
+        return
+
+    # getpeername() returns (host, port, ...) for both IPv4 and IPv6 sockets.
+    peer_ip = sock.getpeername()[0]
+    try:
+        ip = ipaddress.ip_address(peer_ip)
+    except ValueError as e:
+        sock.close()
+        raise SSRFProtectionError(
+            f"Webhook connection resolved to an invalid IP address: {peer_ip!r}"
+        ) from e
+
+    if not ip.is_global:
+        sock.close()
+        raise SSRFProtectionError(
+            f"Webhook connection blocked: {ip} is not a public IP address. "
+            "This may indicate a DNS rebinding attempt."
+        )
+
+
+class _SSRFProtectedHTTPConnection(HTTPConnection):
+    def _new_conn(self) -> socket.socket:
+        sock = super()._new_conn()
+        _assert_public_peer(sock)
+        return sock
+
+
+class _SSRFProtectedHTTPSConnection(HTTPSConnection):
+    def _new_conn(self) -> socket.socket:
+        # HTTPSConnection inherits _new_conn from HTTPConnection: it returns the
+        # raw TCP socket before the TLS handshake, so the IP check runs pre-TLS.
+        sock = super()._new_conn()
+        _assert_public_peer(sock)
+        return sock
+
+
+class _SSRFProtectedHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = _SSRFProtectedHTTPConnection
+
+
+class _SSRFProtectedHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _SSRFProtectedHTTPSConnection
+
+
+class _SSRFProtectedPoolManager(PoolManager):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Instance-local override, so only pools created by this manager get the
+        # SSRF-protected connection classes.
+        self.pool_classes_by_scheme = {
+            "http": _SSRFProtectedHTTPConnectionPool,
+            "https": _SSRFProtectedHTTPSConnectionPool,
+        }
+
+
+class SSRFProtectedHTTPAdapter(HTTPAdapter):
+    """``HTTPAdapter`` that validates each connection's peer IP is public."""
+
+    def init_poolmanager(
+        self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs
+    ) -> None:
+        self._pool_connections = connections
+        self._pool_maxsize = maxsize
+        self._pool_block = block
+        self.poolmanager = _SSRFProtectedPoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            **pool_kwargs,
+        )

--- a/tests/webhooks/test_ssrf.py
+++ b/tests/webhooks/test_ssrf.py
@@ -1,0 +1,85 @@
+import http.server
+import socket
+import threading
+from collections.abc import Iterator
+from unittest import mock
+
+import pytest
+
+from mlflow.webhooks.delivery import _create_webhook_session
+from mlflow.webhooks.ssrf import SSRFProtectionError
+
+
+@pytest.fixture
+def loopback_server() -> Iterator[int]:
+    """A real HTTP server on loopback, standing in for an internal/metadata endpoint."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"SECRET")
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, name="ssrf-test-loopback", daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+
+
+def _rebind_getaddrinfo(rebind_host: str, target_host: str, target_port: int):
+    """getaddrinfo that resolves rebind_host to (target_host, target_port)."""
+    orig = socket.getaddrinfo
+
+    def resolver(host, port, *args, **kwargs):
+        if host == rebind_host:
+            return orig(target_host, target_port, *args, **kwargs)
+        return orig(host, port, *args, **kwargs)
+
+    return resolver
+
+
+def test_webhook_session_uses_ssrf_protected_adapter():
+    session = _create_webhook_session()
+    for scheme in ("http://", "https://"):
+        adapter = session.get_adapter(f"{scheme}example.com")
+        assert type(adapter).__name__ == "SSRFProtectedHTTPAdapter"
+
+
+def test_dns_rebinding_to_loopback_is_blocked(loopback_server: int):
+    session = _create_webhook_session()
+    resolver = _rebind_getaddrinfo("evil.example.com", "127.0.0.1", loopback_server)
+    with mock.patch.object(socket, "getaddrinfo", side_effect=resolver):
+        with pytest.raises(SSRFProtectionError, match="not a public IP"):
+            session.get(f"http://evil.example.com:{loopback_server}/latest/meta-data/", timeout=10)
+
+
+def test_private_ip_connection_is_blocked_by_default(loopback_server: int):
+    session = _create_webhook_session()
+    with pytest.raises(SSRFProtectionError, match="not a public IP"):
+        session.get(f"http://127.0.0.1:{loopback_server}/", timeout=10)
+
+
+def test_private_ip_allowed_when_env_var_set(loopback_server: int, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    session = _create_webhook_session()
+    response = session.get(f"http://127.0.0.1:{loopback_server}/", timeout=10)
+    assert response.status_code == 200
+
+
+def test_ssrf_error_is_not_retried(loopback_server: int):
+    # SSRFProtectionError is not a urllib3 exception, so it propagates on the
+    # first connection attempt rather than being retried.
+    session = _create_webhook_session()
+    with mock.patch("mlflow.webhooks.ssrf.ipaddress.ip_address") as mock_ip:
+        mock_ip.return_value.is_global = False
+        with pytest.raises(SSRFProtectionError, match="not a public IP"):
+            session.get(f"http://127.0.0.1:{loopback_server}/", timeout=10)
+        # One check per connection attempt; no retry loop.
+        mock_ip.assert_called_once()

--- a/tests/webhooks/test_ssrf.py
+++ b/tests/webhooks/test_ssrf.py
@@ -52,6 +52,23 @@ def test_webhook_session_uses_ssrf_protected_adapter():
         assert type(adapter).__name__ == "SSRFProtectedHTTPAdapter"
 
 
+def test_webhook_session_ignores_env_proxy(loopback_server: int, monkeypatch: pytest.MonkeyPatch):
+    # With trust_env left on, an HTTP_PROXY env var would route the request
+    # through the proxy, making the validated peer the proxy (not the webhook
+    # destination) and bypassing the SSRF check entirely. The session disables
+    # env proxy handling, so the loopback "proxy" must never be reached.
+    session = _create_webhook_session()
+    assert session.trust_env is False
+    monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{loopback_server}")
+    resolver = _rebind_getaddrinfo("dest.example.com", "127.0.0.1", loopback_server)
+    with mock.patch.object(socket, "getaddrinfo", side_effect=resolver):
+        # The real destination still resolves to loopback here, so the peer
+        # check fires on the destination — proving the proxy was bypassed and
+        # the destination IP is what gets validated.
+        with pytest.raises(SSRFProtectionError, match="not a public IP"):
+            session.post("http://dest.example.com/hook", timeout=10)
+
+
 def test_dns_rebinding_to_loopback_is_blocked(loopback_server: int):
     session = _create_webhook_session()
     resolver = _rebind_getaddrinfo("evil.example.com", "127.0.0.1", loopback_server)
@@ -75,11 +92,12 @@ def test_private_ip_allowed_when_env_var_set(loopback_server: int, monkeypatch: 
 
 def test_ssrf_error_is_not_retried(loopback_server: int):
     # SSRFProtectionError is not a urllib3 exception, so it propagates on the
-    # first connection attempt rather than being retried.
+    # first connection attempt rather than being retried. Use POST to exercise
+    # the production retry config (allowed_methods=["POST"]).
     session = _create_webhook_session()
     with mock.patch("mlflow.webhooks.ssrf.ipaddress.ip_address") as mock_ip:
         mock_ip.return_value.is_global = False
         with pytest.raises(SSRFProtectionError, match="not a public IP"):
-            session.get(f"http://127.0.0.1:{loopback_server}/", timeout=10)
+            session.post(f"http://127.0.0.1:{loopback_server}/", timeout=10)
         # One check per connection attempt; no retry loop.
         mock_ip.assert_called_once()

--- a/tests/webhooks/test_ssrf.py
+++ b/tests/webhooks/test_ssrf.py
@@ -5,9 +5,11 @@ from collections.abc import Iterator
 from unittest import mock
 
 import pytest
+import requests
+from urllib3.util.retry import Retry
 
 from mlflow.webhooks.delivery import _create_webhook_session
-from mlflow.webhooks.ssrf import SSRFProtectionError
+from mlflow.webhooks.ssrf import SSRFProtectedHTTPAdapter, SSRFProtectionError
 
 
 @pytest.fixture
@@ -101,3 +103,29 @@ def test_ssrf_error_is_not_retried(loopback_server: int):
             session.post(f"http://127.0.0.1:{loopback_server}/", timeout=10)
         # One check per connection attempt; no retry loop.
         mock_ip.assert_called_once()
+
+
+def test_explicit_proxy_to_private_ip_is_blocked(loopback_server: int):
+    # An explicitly configured proxy routes through proxy_manager_for, not the
+    # direct pool manager. The adapter's proxy manager must also use protected
+    # pools so the proxy endpoint's peer IP is validated.
+    session = requests.Session()
+    adapter = SSRFProtectedHTTPAdapter(max_retries=Retry(total=0))
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.proxies = {"http": f"http://127.0.0.1:{loopback_server}"}
+
+    assert type(adapter.proxy_manager_for(f"http://127.0.0.1:{loopback_server}")).__name__ == (
+        "_SSRFProtectedProxyManager"
+    )
+    with pytest.raises(SSRFProtectionError, match="not a public IP"):
+        session.post("http://example.com/hook", timeout=10)
+
+
+def test_getpeername_oserror_fails_closed(loopback_server: int):
+    # If getpeername() raises OSError (e.g. ENOTCONN), the check must fail closed
+    # with SSRFProtectionError rather than leak an uncaught OSError.
+    session = _create_webhook_session()
+    with mock.patch.object(socket.socket, "getpeername", side_effect=OSError("ENOTCONN")):
+        with pytest.raises(SSRFProtectionError, match="peer address"):
+            session.post(f"http://127.0.0.1:{loopback_server}/", timeout=10)


### PR DESCRIPTION
### Security advisory

Fixes CVE-2026-64849 (GHSA-7gwp-5pfp-969j).

### Related Issues/PRs

Closes #24179

### What changes are proposed in this pull request?

Fixes a DNS-rebinding SSRF bypass in outbound webhook delivery (reported in #24179).

`_validate_webhook_url` resolves the webhook hostname via `socket.getaddrinfo` and checks that every resolved IP is public (`ip.is_global`), but it **discards the resolved IP**. The subsequent `session.post(webhook.url)` then **re-resolves the hostname independently**. This is a TOCTOU gap: a DNS-rebinding attacker can return a public IP at validation time (passing the check) and a private/link-local IP (e.g. `169.254.169.254`, `127.0.0.1`) at request time, reaching cloud instance-metadata endpoints or internal services.

This PR closes the gap by validating the peer IP of the **actual connected socket**, immediately after `connect()` returns and before any TLS handshake or HTTP data is exchanged. Because there is no second DNS resolution between the check and the request, rebinding has nothing to exploit.

Key design points:

- A new `SSRFProtectedHTTPAdapter` (in `mlflow/webhooks/ssrf.py`) installs urllib3 connection classes that call `sock.getpeername()` right after the TCP connect and reject non-public IPs. It is scoped **only** to the webhook delivery session, so urllib3 behavior is never altered process-wide.
- Works for both HTTP and HTTPS. For HTTPS, `_new_conn` returns the raw TCP socket before the TLS handshake, so the IP check runs pre-TLS. TLS still runs against the original hostname, so **certificate validation is unaffected** (unlike pinning the URL to a resolved IP, which the issue correctly notes breaks HTTPS).
- The check raises `SSRFProtectionError` (not a urllib3 exception type), so it is **not retried** and the delivery fails closed on the first attempt.
- The existing `MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS` escape hatch is honored at connect time for local development.

`_validate_webhook_url` is retained as defense-in-depth (it still rejects obviously-private URLs at creation and provides a clear error), but it is no longer the sole protection.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/webhooks/test_ssrf.py`:

- The webhook session uses the SSRF-protected adapter for both schemes.
- A simulated DNS-rebinding attack (hostname resolves to loopback at connect time via a patched `getaddrinfo`) is blocked with `SSRFProtectionError` — this is the core regression test for the reported vulnerability.
- Direct private-IP connections are blocked by default.
- Private IPs are allowed when `MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS=true`.
- The SSRF error is raised once per connection (not retried).

All existing `tests/webhooks/test_delivery.py` and `tests/utils/test_validation.py` tests pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Webhook delivery now validates the connected peer IP at connection time, closing a DNS-rebinding SSRF bypass that could reach private/internal or cloud-metadata endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release