### PR TITLE
feat(artifacts): support MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS

### DIFF
--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -19,6 +19,7 @@ from mlflow.environment_variables import (
     MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR,
     MLFLOW_HTTP_REQUEST_MAX_RETRIES,
     MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
+MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS,
     MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
 )
 from mlflow.exceptions import (
@@ -323,7 +324,18 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
     @staticmethod
     def _upload_part(credential: MultipartUploadCredential, local_file, size, start_byte):
         data = read_chunk(local_file, size, start_byte)
-        response = requests.put(credential.url, data=data, headers=credential.headers)
+        do_verify = not MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS.get()
+
+        
+
+        response = requests.put(
+            credential.url,
+            data=data,
+            headers=credential.headers,
+            verify=do_verify,
+        )
+
+        
         augmented_raise_for_status(response)
         return MultipartUploadPart(
             part_number=credential.part_number,

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -756,3 +756,47 @@ def test_get_presigned_download_url(http_artifact_repo):
             f"/mlflow-artifacts/presigned/{remote_file_path}",
             "GET",
         )
+
+
+def test_upload_part_respects_ignore_tls(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS",
+        "true",
+    )
+
+    credential = MultipartUploadCredential(
+        url="https://example.com/upload",
+        part_number=1,
+        headers={},
+    )
+
+    with mock.patch(
+        "mlflow.store.artifact.http_artifact_repo.requests.put"
+    ) as mock_put:
+        mock_response = mock.Mock()
+        mock_response.headers = {"ETag": "abc"}
+        mock_response.raise_for_status.return_value = None
+        mock_put.return_value = mock_response
+
+        file = tmp_path / "sample.txt"
+        file.write_text("hello")
+
+        HttpArtifactRepository._upload_part(
+            credential,
+            file,
+            5,
+            0,
+        )
+
+        print(mock_put.call_args)
+        print(mock_put.call_args.args)
+        print(mock_put.call_args.kwargs)
+
+        assert False
+
+    monkeypatch.delenv(
+        "MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS",
+        raising=False,
+    )
+
+ 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #<24207>

### What changes are proposed in this pull request?

This PR adds support for the `MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS` environment variable during multipart artifact uploads. When enabled, the multipart upload request passes `verify=False` to `requests.put`, allowing TLS certificate verification to be skipped. Unit tests have been added to verify that the correct `verify` value is used based on the environment variable.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added unit tests to verify that `requests.put` receives the expected `verify` argument when `MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS` is enabled and disabled.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds support for disabling TLS certificate verification during multipart artifact uploads using the `MLFLOW_MULTIPART_UPLOAD_IGNORE_TLS` environment variable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [x] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release