### PR TITLE
Fix incorrect comparator list in numeric-attribute filter error message

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -654,7 +654,7 @@ class SearchUtils:
             if comparator not in cls.VALID_NUMERIC_ATTRIBUTE_COMPARATORS:
                 raise MlflowException(
                     f"Invalid comparator '{comparator}' not one of "
-                    f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}",
+                    f"'{cls.VALID_NUMERIC_ATTRIBUTE_COMPARATORS}'",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             return True

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -273,6 +273,17 @@ def test_bad_comparators(entity_type, bad_comparators, key, entity_value):
             SearchUtils.filter([run], bad_filter)
 
 
+def test_numeric_attribute_bad_comparator_message_lists_numeric_comparators():
+    # The error for an invalid comparator on a numeric attribute must list the
+    # numeric comparators (not the string ones) and be a well-formed message.
+    with pytest.raises(MlflowException, match="Invalid comparator") as exc_info:
+        SearchUtils.is_numeric_attribute(SearchUtils._ATTRIBUTE_IDENTIFIER, "start_time", "LIKE")
+    valid_set = str(exc_info.value).split("not one of", 1)[1]
+    assert "<=" in valid_set  # numeric comparators are listed
+    assert "LIKE" not in valid_set  # string-only comparators are not
+    assert str(exc_info.value).count("'") % 2 == 0  # balanced quotes
+
+
 @pytest.mark.parametrize(
     ("filter_string", "matching_runs"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Relates to the numeric-attribute search-filter error message. No tracking issue — small, self-contained bug fix.

### What changes are proposed in this pull request?

`SearchUtils.is_numeric_attribute` (`mlflow/utils/search_utils.py`) validates a comparator against `VALID_NUMERIC_ATTRIBUTE_COMPARATORS`, but its error message printed `VALID_STRING_ATTRIBUTE_COMPARATORS` **and** dropped the closing quote:

```python
if comparator not in cls.VALID_NUMERIC_ATTRIBUTE_COMPARATORS:
    raise MlflowException(
        f"Invalid comparator '{comparator}' not one of "
        f"'{cls.VALID_STRING_ATTRIBUTE_COMPARATORS}",   # wrong set + missing "'"
        error_code=INVALID_PARAMETER_VALUE,
    )
```

So filtering a **numeric** run attribute (`start_time`, `end_time`) with an unsupported comparator reported the *string*-attribute operators — the ones that are **invalid** for numeric attributes — in a malformed (unbalanced-quote) message. It is a copy-paste slip from the sibling `is_string_attribute`, which correctly uses the string set. Reached at runtime via `sqlalchemy_store` run-search filtering, so the message is user-facing.

Before → After:
```
Invalid comparator 'LIKE' not one of '{'=', 'ILIKE', 'IN', 'LIKE', '!=', 'NOT IN'}
Invalid comparator 'LIKE' not one of '{'>=', '<', '!=', '<=', '>', '='}'
```

Fix: print `VALID_NUMERIC_ATTRIBUTE_COMPARATORS` and balance the quote.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Extended `tests/utils/test_search_utils.py` to assert the numeric-attribute error lists numeric comparators (e.g. `<=`), not string-only ones (`LIKE`), with balanced quotes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The error message shown when filtering a numeric run attribute (e.g. `start_time`) with an unsupported comparator now lists the correct (numeric) comparators and is well-formed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
