### PR TITLE
Add MCP icon validation

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1363,24 +1363,24 @@ _MLFLOW_WEBHOOK_ALLOWED_SCHEMES = _EnvironmentVariable(
 )
 
 
-#: Allowed schemes for MCP icon URLs.
+#: Allowed schemes for icon URLs.
 #: Defaults to ``https``. Set to ``http,https`` for local development.
-MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES = _EnvironmentVariable(
-    "MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", _split_strip, ["https"]
+MLFLOW_ICON_URL_ALLOWED_SCHEMES = _EnvironmentVariable(
+    "MLFLOW_ICON_URL_ALLOWED_SCHEMES", _split_strip, ["https"]
 )
 
-#: Whether to allow MCP icon URLs that target private or loopback hosts.
+#: Whether to allow icon URLs that target private or loopback hosts.
 #: Intended for local development and testing only.
-MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
-    "MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", False
+MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
+    "MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS", False
 )
 
-#: Optional allowlist of domains that MCP icon URLs may target.
+#: Optional allowlist of domains that icon URLs may target.
 #: Supports exact hosts and wildcard patterns like ``*.example.com``.
 #: When unset, icon URLs may use any public host allowed by the scheme/private-IP
 #: policy.
-MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS = _EnvironmentVariable(
-    "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", _split_strip, None
+MLFLOW_ICON_URL_ALLOWED_DOMAINS = _EnvironmentVariable(
+    "MLFLOW_ICON_URL_ALLOWED_DOMAINS", _split_strip, None
 )
 
 #: Specifies the secret key used to encrypt webhook secrets in MLflow.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1363,6 +1363,26 @@ _MLFLOW_WEBHOOK_ALLOWED_SCHEMES = _EnvironmentVariable(
 )
 
 
+#: Allowed schemes for MCP icon URLs.
+#: Defaults to ``https``. Set to ``http,https`` for local development.
+MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES = _EnvironmentVariable(
+    "MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", _split_strip, ["https"]
+)
+
+#: Whether to allow MCP icon URLs that target private or loopback hosts.
+#: Intended for local development and testing only.
+MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
+    "MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", False
+)
+
+#: Optional allowlist of domains that MCP icon URLs may target.
+#: Supports exact hosts and wildcard patterns like ``*.example.com``.
+#: When unset, icon URLs may use any public host allowed by the scheme/private-IP
+#: policy.
+MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS = _EnvironmentVariable(
+    "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", _split_strip, None
+)
+
 #: Specifies the secret key used to encrypt webhook secrets in MLflow.
 MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY = _EnvironmentVariable(
     "MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY", str, None

--- a/mlflow/server/mcp_server_api.py
+++ b/mlflow/server/mcp_server_api.py
@@ -6,7 +6,14 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, Query, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, ConfigDict, Field, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from mlflow.entities.mcp_access_binding import MCPAccessBinding
 from mlflow.entities.mcp_server import (
@@ -18,6 +25,7 @@ from mlflow.entities.mcp_server import (
 )
 from mlflow.entities.mcp_server_version import MCPServerVersion
 from mlflow.exceptions import MlflowException
+from mlflow.utils.validation import _validate_mcp_icon_url
 
 if TYPE_CHECKING:
     from mlflow.store.tracking.mcp_server_registry.abstract_mixin import MCPIcon
@@ -42,7 +50,7 @@ def is_mcp_server_api_path(path: str) -> bool:
     )
 
 
-class MCPIconPayload(BaseModel):
+class _BaseMCPIconPayload(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     src: str
@@ -63,6 +71,31 @@ class MCPIconPayload(BaseModel):
         return icon
 
 
+class MCPIconRequestPayload(_BaseMCPIconPayload):
+    @field_validator("src")
+    @classmethod
+    def _validate_src(cls, value: str) -> str:
+        _validate_mcp_icon_url(value)
+        return value
+
+    @field_validator("mimeType")
+    @classmethod
+    def _validate_mime_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        normalized = value.strip().lower()
+        if not normalized.startswith("image/") or normalized == "image/":
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid icon mimeType {value!r}. Allowed values must use the 'image/*' "
+                "media type."
+            )
+        return normalized
+
+
+class MCPIconResponsePayload(_BaseMCPIconPayload):
+    pass
+
+
 class ServerJSONRepositoryPayload(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -79,6 +112,7 @@ class ServerJSONPayload(BaseModel):
     version: str
     title: str | None = None
     description: str | None = None
+    icons: list[MCPIconRequestPayload] | None = None
     packages: list[ServerJSONPackagePayload] | None = None
     remotes: list[ServerJSONRemotePayload] | None = None
     repository: ServerJSONRepositoryPayload | None = None
@@ -113,27 +147,38 @@ class ServerJSONRemotePayload(BaseModel):
     url: str
 
 
-class MCPToolPayload(BaseModel):
+class MCPToolRequestPayload(BaseModel):
     name: str
     title: str | None = None
     description: str | None = None
     inputSchema: dict[str, Any] | None = None
     outputSchema: dict[str, Any] | None = None
     annotations: dict[str, Any] | None = None
-    icons: list[MCPIconPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = None
+    execution: dict[str, Any] | None = None
+
+
+class MCPToolResponsePayload(BaseModel):
+    name: str
+    title: str | None = None
+    description: str | None = None
+    inputSchema: dict[str, Any] | None = None
+    outputSchema: dict[str, Any] | None = None
+    annotations: dict[str, Any] | None = None
+    icons: list[MCPIconResponsePayload] | None = None
     execution: dict[str, Any] | None = None
 
 
 class CreateMCPServerRequest(BaseModel):
     name: str
     description: str | None = None
-    icons: list[MCPIconPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = None
 
 
 class UpdateMCPServerRequest(BaseModel):
     display_name: str | None = None
     description: str | None = None
-    icons: list[MCPIconPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -151,13 +196,13 @@ class CreateMCPServerVersionRequest(BaseModel):
     display_name: str | None = None
     status: str = "draft"
     source: str | None = None
-    tools: list[MCPToolPayload] | None = None
+    tools: list[MCPToolRequestPayload] | None = None
 
 
 class UpdateMCPServerVersionRequest(BaseModel):
     display_name: str | None = None
     status: str | None = None
-    tools: list[MCPToolPayload] | None = None
+    tools: list[MCPToolRequestPayload] | None = None
 
 
 class CreateMCPAccessBindingRequest(BaseModel):
@@ -229,7 +274,7 @@ class MCPServerResponse(BaseModel):
     name: str
     display_name: str | None = None
     description: str | None = None
-    icons: list[MCPIconPayload] | None = None
+    icons: list[MCPIconResponsePayload] | None = None
     workspace: str | None = None
     status: str | None = None
     access_bindings: list[MCPAccessBindingSummaryResponse] = Field(default_factory=list)
@@ -270,7 +315,7 @@ class MCPServerVersionResponse(BaseModel):
     display_name: str | None = None
     workspace: str | None = None
     status: str = "draft"
-    tools: list[MCPToolPayload] = Field(default_factory=list)
+    tools: list[MCPToolResponsePayload] = Field(default_factory=list)
     aliases: list[str] = Field(default_factory=list)
     tags: dict[str, str] = Field(default_factory=dict)
     source: str | None = None
@@ -289,7 +334,7 @@ class MCPServerVersionResponse(BaseModel):
             workspace=entity.workspace,
             status=str(entity.status),
             # Normalize unset tools to [] so clients can iterate without null guards.
-            tools=[MCPToolPayload(**t.to_dict()) for t in (entity.tools or [])],
+            tools=[MCPToolResponsePayload(**t.to_dict()) for t in (entity.tools or [])],
             aliases=entity.aliases,
             tags=entity.tags,
             source=entity.source,
@@ -306,7 +351,7 @@ class MCPAccessBindingResponse(BaseModel):
     endpoint_url: str
     transport_type: str = "streamable-http"
     workspace: str | None = None
-    tools: list[MCPToolPayload] | None = None
+    tools: list[MCPToolResponsePayload] | None = None
     server_version: str | None = None
     server_alias: str | None = None
     resolved_version: MCPServerVersionResponse | None = None
@@ -319,7 +364,7 @@ class MCPAccessBindingResponse(BaseModel):
     def from_entity(cls, entity: MCPAccessBinding) -> MCPAccessBindingResponse:
         tools = None
         if entity.resolved_version is not None and entity.resolved_version.tools is not None:
-            tools = [MCPToolPayload(**t.to_dict()) for t in entity.resolved_version.tools]
+            tools = [MCPToolResponsePayload(**t.to_dict()) for t in entity.resolved_version.tools]
         return cls(
             binding_id=entity.binding_id,
             server_name=entity.server_name,
@@ -399,14 +444,14 @@ def _request_validation_error_response(exc: RequestValidationError) -> JSONRespo
     )
 
 
-def _tool_payloads_to_entities(tools: list[MCPToolPayload] | None) -> list[MCPTool] | None:
+def _tool_payloads_to_entities(tools: list[MCPToolRequestPayload] | None) -> list[MCPTool] | None:
     if tools is None:
         return None
     return [MCPTool.from_dict(t.model_dump(exclude_none=True)) for t in tools]
 
 
 def _icon_payloads_to_entities(
-    icons: list[MCPIconPayload] | None,
+    icons: list[MCPIconRequestPayload] | None,
 ) -> list[MCPIcon] | None:
     if icons is None:
         return None

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -10,6 +10,7 @@ import posixpath
 import re
 import socket
 import urllib.parse
+from fnmatch import fnmatch
 from typing import Any
 
 from mlflow.entities import Dataset, DatasetInput, InputTag, Param, RunTag
@@ -19,6 +20,9 @@ from mlflow.environment_variables import (
     _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS,
     _MLFLOW_WEBHOOK_ALLOWED_SCHEMES,
     MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
+    MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS,
+    MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS,
+    MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES,
     MLFLOW_TRUNCATE_LONG_VALUES,
 )
 from mlflow.exceptions import MlflowException
@@ -883,6 +887,104 @@ def _validate_webhook_name(name: str) -> None:
             f"Webhook name {name!r} is invalid. It must start and end with a letter or digit, "
             "be less than 63 characters long, and contain only letters, digits, dots (.), "
             "underscores (_), and hyphens (-)."
+        )
+
+
+def _validate_public_https_url(
+    url: str,
+    field_name: str = "URL",
+    allowed_schemes: list[str] | tuple[str, ...] | set[str] = ("https",),
+    allow_private_ips: bool = False,
+) -> None:
+    if not isinstance(url, str):
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} must be a string, got {type(url).__name__!r}"
+        )
+
+    if not url.strip():
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} cannot be empty or just whitespace: {url!r}"
+        )
+
+    try:
+        parsed_url = urllib.parse.urlparse(url)
+    except ValueError as e:
+        raise MlflowException.invalid_parameter_value(f"Invalid {field_name} {url!r}: {e!r}") from e
+
+    normalized_allowed_schemes = {scheme.lower() for scheme in allowed_schemes}
+    if parsed_url.scheme not in normalized_allowed_schemes:
+        scheme_list = ", ".join(f"{scheme!r}" for scheme in sorted(normalized_allowed_schemes))
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid {field_name} scheme: {parsed_url.scheme!r}. Allowed schemes are: "
+            f"{scheme_list}."
+        )
+
+    if parsed_url.username or parsed_url.password:
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} must not include embedded credentials: {url!r}"
+        )
+
+    hostname = parsed_url.hostname
+    if not hostname:
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} must include a hostname: {url!r}"
+        )
+
+    if allow_private_ips:
+        return
+
+    if hostname.lower() == "localhost":
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} must not target localhost: {url!r}"
+        )
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return
+
+    if not ip.is_global:
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} must not resolve to a non-public IP address: {ip}."
+        )
+
+
+def _validate_mcp_icon_url(url: str) -> None:
+    """Validate an MCP icon URL on write/update requests.
+
+    Default behavior accepts only public HTTPS targets. This follows the
+    existing webhook pattern for scheme and private-IP controls, with an
+    optional hostname allowlist layered on top for stricter deployments.
+
+    Operators can further configure:
+    - ``MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES`` to allow schemes like ``http``
+    - ``MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS=true`` to allow localhost /
+      loopback / private-network targets
+    - ``MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS`` for a strict hostname allowlist
+    """
+    allowed_schemes = MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES.get()
+    allow_private_ips = MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS.get()
+    _validate_public_https_url(
+        url,
+        field_name="Icon URL",
+        allowed_schemes=allowed_schemes,
+        allow_private_ips=allow_private_ips,
+    )
+
+    allowed_domains = MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS.get()
+    if not allowed_domains:
+        return
+
+    hostname = urllib.parse.urlparse(url).hostname
+    if not hostname:
+        raise MlflowException.invalid_parameter_value(f"Icon URL must include a hostname: {url!r}")
+
+    normalized_hostname = hostname.lower()
+    normalized_allowed_domains = [pattern.lower() for pattern in allowed_domains]
+    if not any(fnmatch(normalized_hostname, pattern) for pattern in normalized_allowed_domains):
+        raise MlflowException.invalid_parameter_value(
+            f"Icon URL host {hostname!r} is not in the allowed domain list: "
+            f"{', '.join(allowed_domains)}."
         )
 
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -20,9 +20,9 @@ from mlflow.environment_variables import (
     _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS,
     _MLFLOW_WEBHOOK_ALLOWED_SCHEMES,
     MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
-    MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS,
-    MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS,
-    MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES,
+    MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS,
+    MLFLOW_ICON_URL_ALLOWED_DOMAINS,
+    MLFLOW_ICON_URL_ALLOWED_SCHEMES,
     MLFLOW_TRUNCATE_LONG_VALUES,
 )
 from mlflow.exceptions import MlflowException
@@ -890,6 +890,28 @@ def _validate_webhook_name(name: str) -> None:
         )
 
 
+def _validate_hostname_resolves_to_public_ips(hostname: str, field_name: str) -> None:
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise MlflowException.invalid_parameter_value(
+            f"Cannot resolve {field_name} hostname {hostname!r}: {e}"
+        ) from e
+
+    for addr_info in addr_infos:
+        try:
+            ip = ipaddress.ip_address(addr_info[4][0])
+        except ValueError as e:
+            raise MlflowException.invalid_parameter_value(
+                f"{field_name} hostname {hostname!r} resolved to an invalid IP address: {e}"
+            ) from e
+        if not ip.is_global:
+            raise MlflowException.invalid_parameter_value(
+                f"{field_name} must not resolve to a non-public IP address. "
+                f"{hostname!r} resolves to {ip}."
+            )
+
+
 def _validate_public_https_url(
     url: str,
     field_name: str = "URL",
@@ -930,23 +952,8 @@ def _validate_public_https_url(
             f"{field_name} must include a hostname: {url!r}"
         )
 
-    if allow_private_ips:
-        return
-
-    if hostname.lower() == "localhost":
-        raise MlflowException.invalid_parameter_value(
-            f"{field_name} must not target localhost: {url!r}"
-        )
-
-    try:
-        ip = ipaddress.ip_address(hostname)
-    except ValueError:
-        return
-
-    if not ip.is_global:
-        raise MlflowException.invalid_parameter_value(
-            f"{field_name} must not resolve to a non-public IP address: {ip}."
-        )
+    if not allow_private_ips:
+        _validate_hostname_resolves_to_public_ips(hostname, field_name)
 
 
 def _validate_mcp_icon_url(url: str) -> None:
@@ -957,13 +964,13 @@ def _validate_mcp_icon_url(url: str) -> None:
     optional hostname allowlist layered on top for stricter deployments.
 
     Operators can further configure:
-    - ``MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES`` to allow schemes like ``http``
-    - ``MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS=true`` to allow localhost /
+    - ``MLFLOW_ICON_URL_ALLOWED_SCHEMES`` to allow schemes like ``http``
+    - ``MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS=true`` to allow localhost /
       loopback / private-network targets
-    - ``MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS`` for a strict hostname allowlist
+    - ``MLFLOW_ICON_URL_ALLOWED_DOMAINS`` for a strict hostname allowlist
     """
-    allowed_schemes = MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES.get()
-    allow_private_ips = MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS.get()
+    allowed_schemes = MLFLOW_ICON_URL_ALLOWED_SCHEMES.get()
+    allow_private_ips = MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS.get()
     _validate_public_https_url(
         url,
         field_name="Icon URL",
@@ -971,7 +978,7 @@ def _validate_mcp_icon_url(url: str) -> None:
         allow_private_ips=allow_private_ips,
     )
 
-    allowed_domains = MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS.get()
+    allowed_domains = MLFLOW_ICON_URL_ALLOWED_DOMAINS.get()
     if not allowed_domains:
         return
 
@@ -1017,25 +1024,7 @@ def _validate_webhook_url(url: str) -> None:
         )
 
     if not _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS.get():
-        try:
-            addr_infos = socket.getaddrinfo(hostname, None)
-        except socket.gaierror as e:
-            raise MlflowException.invalid_parameter_value(
-                f"Cannot resolve webhook URL hostname {hostname!r}: {e}"
-            ) from e
-
-        for addr_info in addr_infos:
-            try:
-                ip = ipaddress.ip_address(addr_info[4][0])
-            except ValueError as e:
-                raise MlflowException.invalid_parameter_value(
-                    f"Webhook URL hostname {hostname!r} resolved to an invalid IP address: {e}"
-                ) from e
-            if not ip.is_global:
-                raise MlflowException.invalid_parameter_value(
-                    f"Webhook URL must not resolve to a non-public IP address. "
-                    f"{hostname!r} resolves to {ip}."
-                )
+        _validate_hostname_resolves_to_public_ips(hostname, "Webhook URL")
 
 
 def _validate_webhook_events(events: list[WebhookEvent]) -> None:

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -54,6 +54,21 @@ def client(store):
         yield TestClient(_create_registry_fastapi_app())
 
 
+@pytest.fixture(autouse=True)
+def mock_icon_url_dns_resolution():
+    def _resolve(host, port, *a, **kw):
+        if host == "localhost":
+            ip = "127.0.0.1"
+        elif host == "example.com" or host.endswith(".example.com"):
+            ip = "8.8.8.8"
+        else:
+            ip = host
+        return [(None, None, None, None, (ip, 0))]
+
+    with mock.patch("mlflow.utils.validation.socket.getaddrinfo", side_effect=_resolve):
+        yield
+
+
 def test_create_server(client):
     r = client.post(PREFIX, json={"name": "com.example/my-server", "description": "A test server"})
     assert r.status_code == 200
@@ -102,7 +117,7 @@ def test_create_server_rejects_risky_icon_urls(client, icons):
 
 def test_create_server_rejects_icon_url_outside_allowlist(client, monkeypatch):
     monkeypatch.setenv(
-        "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS",
+        "MLFLOW_ICON_URL_ALLOWED_DOMAINS",
         "assets.example.com,*.cdn.example.com",
     )
     r = client.post(
@@ -118,7 +133,7 @@ def test_create_server_rejects_icon_url_outside_allowlist(client, monkeypatch):
 
 def test_create_server_accepts_icon_url_inside_allowlist(client, monkeypatch):
     monkeypatch.setenv(
-        "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS",
+        "MLFLOW_ICON_URL_ALLOWED_DOMAINS",
         "assets.example.com,*.cdn.example.com",
     )
     r = client.post(
@@ -132,7 +147,7 @@ def test_create_server_accepts_icon_url_inside_allowlist(client, monkeypatch):
 
 
 def test_create_server_accepts_public_http_icon_url_when_scheme_enabled(client, monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_SCHEMES", "http,https")
     r = client.post(
         PREFIX,
         json={
@@ -144,7 +159,7 @@ def test_create_server_accepts_public_http_icon_url_when_scheme_enabled(client, 
 
 
 def test_create_server_accepts_local_icon_url_when_private_ips_enabled(client, monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS", "true")
     r = client.post(
         PREFIX,
         json={
@@ -158,8 +173,8 @@ def test_create_server_accepts_local_icon_url_when_private_ips_enabled(client, m
 def test_create_server_accepts_local_http_icon_when_scheme_and_private_flags_enabled(
     client, monkeypatch
 ):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS", "true")
     r = client.post(
         PREFIX,
         json={

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -86,6 +86,128 @@ def test_create_server_with_icons_preserves_extra_fields(client):
     assert r.json()["icons"] == icons
 
 
+@pytest.mark.parametrize(
+    "icons",
+    [
+        [{"src": "http://example.com/icon.png"}],
+        [{"src": "https://127.0.0.1/icon.png"}],
+        [{"src": "https://user:pass@example.com/icon.png"}],
+    ],
+)
+def test_create_server_rejects_risky_icon_urls(client, icons):
+    r = client.post(PREFIX, json={"name": "com.example/icon-server", "icons": icons})
+    assert r.status_code == 400
+    assert "Icon URL" in r.text
+
+
+def test_create_server_rejects_icon_url_outside_allowlist(client, monkeypatch):
+    monkeypatch.setenv(
+        "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS",
+        "assets.example.com,*.cdn.example.com",
+    )
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-allowlist-server",
+            "icons": [{"src": "https://other.example.com/icon.png"}],
+        },
+    )
+    assert r.status_code == 400
+    assert "allowed domain list" in r.text
+
+
+def test_create_server_accepts_icon_url_inside_allowlist(client, monkeypatch):
+    monkeypatch.setenv(
+        "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS",
+        "assets.example.com,*.cdn.example.com",
+    )
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-allowlist-accepted",
+            "icons": [{"src": "https://foo.cdn.example.com/icon.png"}],
+        },
+    )
+    assert r.status_code == 200
+
+
+def test_create_server_accepts_public_http_icon_url_when_scheme_enabled(client, monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-http-public",
+            "icons": [{"src": "http://example.com/icon.png"}],
+        },
+    )
+    assert r.status_code == 200
+
+
+def test_create_server_accepts_local_icon_url_when_private_ips_enabled(client, monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-private-localhost",
+            "icons": [{"src": "https://localhost/icon.png"}],
+        },
+    )
+    assert r.status_code == 200
+
+
+def test_create_server_accepts_local_http_icon_when_scheme_and_private_flags_enabled(
+    client, monkeypatch
+):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-http-localhost",
+            "icons": [{"src": "http://localhost/icon.png"}],
+        },
+    )
+    assert r.status_code == 200
+
+
+def test_create_server_rejects_invalid_icon_mime_type(client):
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-bad-mime",
+            "icons": [
+                {
+                    "src": "https://example.com/icon.bin",
+                    "mimeType": "application/octet-stream",
+                }
+            ],
+        },
+    )
+    assert r.status_code == 400
+    assert "Invalid icon mimeType" in r.text
+
+
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        "image/png",
+        "image/svg+xml",
+        "image/heic",
+        "IMAGE/PNG",
+    ],
+)
+def test_create_server_accepts_reasonable_icon_mime_types(client, mime_type):
+    r = client.post(
+        PREFIX,
+        json={
+            "name": f"com.example/icon-mime-{mime_type.replace('/', '-').replace('+', '-')}",
+            "icons": [{"src": "https://example.com/icon", "mimeType": mime_type}],
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["icons"][0]["mimeType"] == mime_type.lower()
+
+
 def test_create_duplicate_server(client):
     client.post(PREFIX, json={"name": "com.example/dup"})
     r = client.post(PREFIX, json={"name": "com.example/dup"})
@@ -194,6 +316,16 @@ def test_update_server(client):
     data = r.json()
     assert data["description"] == "updated"
     assert data["display_name"] == "Upd"
+
+
+def test_update_server_rejects_risky_icon_urls(client):
+    client.post(PREFIX, json={"name": "com.example/upd-icons"})
+    r = client.patch(
+        f"{PREFIX}/{_encode_path_param('com.example/upd-icons')}",
+        json={"icons": [{"src": "https://127.0.0.1/icon.png"}]},
+    )
+    assert r.status_code == 400
+    assert "Icon URL" in r.text
 
 
 def test_update_server_rejects_latest_version_field(client):
@@ -409,6 +541,31 @@ def test_create_version_with_tool_icons_preserves_extra_fields(client):
     assert r.status_code == 200
     assert r.json()["tools"][0]["name"] == "web_search"
     assert r.json()["tools"][0]["icons"] == tools[0]["icons"]
+
+
+def test_create_version_rejects_risky_tool_icon_urls(client):
+    sj = _server_json("com.example/tool-icons-invalid", "1.0.0")
+    tools = [{"name": "web_search", "icons": [{"src": "https://127.0.0.1/icon.png"}]}]
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/tool-icons-invalid')}/versions",
+        json={"server_json": sj, "tools": tools, "status": "active"},
+    )
+    assert r.status_code == 400
+    assert "Icon URL" in r.text
+
+
+def test_create_version_rejects_risky_server_json_icon_urls(client):
+    sj = _server_json(
+        "com.example/server-json-icons-invalid",
+        "1.0.0",
+        icons=[{"src": "http://example.com/icon.png"}],
+    )
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/server-json-icons-invalid')}/versions",
+        json={"server_json": sj, "status": "active"},
+    )
+    assert r.status_code == 400
+    assert "Icon URL" in r.text
 
 
 def test_create_version_preserves_empty_tools_list(client):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -1241,6 +1241,14 @@ def test_search_mcp_servers_filter_by_name_like(store):
     assert names == {"io.github.test/alpha", "io.github.test/beta"}
 
 
+def test_search_mcp_servers_filter_by_display_name(store):
+    store.create_mcp_server("io.github.test/alpha")
+    store.update_mcp_server("io.github.test/alpha", display_name="Pretty Alpha")
+    result = store.search_mcp_servers(filter_string="display_name ILIKE '%pretty%'")
+    assert len(result) == 1
+    assert result[0].name == "io.github.test/alpha"
+
+
 def test_search_mcp_servers_filter_by_tag(store):
     store.create_mcp_server("io.github.test/server1")
     store.create_mcp_server("io.github.test/server2")

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -460,6 +460,15 @@ def _mock_getaddrinfo(ip_str):
     return lambda host, port, *a, **kw: [(None, None, None, None, (ip_str, 0))]
 
 
+def _mock_getaddrinfo_by_host(host_to_ip: dict[str, str]):
+    def _resolve(host, port, *a, **kw):
+        if host not in host_to_ip:
+            raise socket.gaierror("Name or service not known")
+        return [(None, None, None, None, (host_to_ip[host], 0))]
+
+    return _resolve
+
+
 @pytest.mark.parametrize(
     ("url", "expected_match"),
     [
@@ -504,7 +513,7 @@ def test_validate_webhook_url_rejects_unresolvable_hostname():
         "mlflow.utils.validation.socket.getaddrinfo",
         side_effect=socket.gaierror("Name or service not known"),
     ):
-        with pytest.raises(MlflowException, match="Cannot resolve webhook URL hostname"):
+        with pytest.raises(MlflowException, match="Cannot resolve Webhook URL hostname"):
             _validate_webhook_url("https://does-not-exist.invalid/hook")
 
 
@@ -547,7 +556,7 @@ def test_validate_webhook_url_allow_private_ips_env_var(monkeypatch):
         ("data:image/png;base64,abc", "Invalid Icon URL scheme"),
         ("https://", "Icon URL must include a hostname"),
         ("https://user:pass@example.com/icon.png", "must not include embedded credentials"),
-        ("https://localhost/icon.png", "must not target localhost"),
+        ("https://localhost/icon.png", "must not resolve to a non-public IP address"),
         ("https://127.0.0.1/icon.png", "must not resolve to a non-public IP address"),
         ("https://[::1]/icon.png", "must not resolve to a non-public IP address"),
         ("https://192.168.1.10/icon.png", "must not resolve to a non-public IP address"),
@@ -558,17 +567,31 @@ def test_validate_public_https_url_rejects_invalid_input(url, expected_match):
         _validate_public_https_url(url, field_name="Icon URL")
 
 
-@pytest.mark.parametrize("url", ["https://example.com/icon.png", "https://8.8.8.8/icon.png"])
-def test_validate_public_https_url_accepts_public_targets(url):
-    _validate_public_https_url(url, field_name="Icon URL")
+@pytest.mark.parametrize(
+    ("url", "resolved_ip"),
+    [
+        ("https://example.com/icon.png", "8.8.8.8"),
+        ("https://8.8.8.8/icon.png", "8.8.8.8"),
+    ],
+)
+def test_validate_public_https_url_accepts_public_targets(url, resolved_ip):
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo(resolved_ip),
+    ):
+        _validate_public_https_url(url, field_name="Icon URL")
 
 
 def test_validate_public_https_url_allowed_schemes_accepts_http():
-    _validate_public_https_url(
-        "http://example.com/icon.png",
-        field_name="Icon URL",
-        allowed_schemes=("http", "https"),
-    )
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("8.8.8.8"),
+    ):
+        _validate_public_https_url(
+            "http://example.com/icon.png",
+            field_name="Icon URL",
+            allowed_schemes=("http", "https"),
+        )
 
 
 @pytest.mark.parametrize(
@@ -599,52 +622,100 @@ def test_validate_public_https_url_allow_private_ips_accepts_local_targets(url):
     _validate_public_https_url(url, field_name="Icon URL", allow_private_ips=True)
 
 
+def test_validate_public_https_url_rejects_unresolvable_hostname():
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=socket.gaierror("Name or service not known"),
+    ):
+        with pytest.raises(MlflowException, match="Cannot resolve Icon URL hostname"):
+            _validate_public_https_url(
+                "https://does-not-exist.invalid/icon.png", field_name="Icon URL"
+            )
+
+
+def test_validate_public_https_url_rejects_if_any_resolved_address_is_private():
+    def multi_resolve(host, port, *a, **kw):
+        return [
+            (None, None, None, None, ("8.8.8.8", 0)),
+            (None, None, None, None, ("10.0.0.1", 0)),
+        ]
+
+    with patch("mlflow.utils.validation.socket.getaddrinfo", side_effect=multi_resolve):
+        with pytest.raises(MlflowException, match="must not resolve to a non-public"):
+            _validate_public_https_url("https://internal.corp/icon.png", field_name="Icon URL")
+
+
 def test_validate_mcp_icon_url_allowlist_accepts_exact_match(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "example.com")
-    _validate_mcp_icon_url("https://example.com/icon.png")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_DOMAINS", "example.com")
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo_by_host({"example.com": "8.8.8.8"}),
+    ):
+        _validate_mcp_icon_url("https://example.com/icon.png")
 
 
 def test_validate_mcp_icon_url_allowlist_accepts_wildcard_match(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "*.example.com")
-    _validate_mcp_icon_url("https://cdn.example.com/icon.png")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_DOMAINS", "*.example.com")
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo_by_host({"cdn.example.com": "8.8.8.8"}),
+    ):
+        _validate_mcp_icon_url("https://cdn.example.com/icon.png")
 
 
 def test_validate_mcp_icon_url_allowlist_rejects_unlisted_host(monkeypatch):
     monkeypatch.setenv(
-        "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS",
+        "MLFLOW_ICON_URL_ALLOWED_DOMAINS",
         "assets.example.com,*.cdn.example.com",
     )
-    with pytest.raises(MlflowException, match="not in the allowed domain list"):
-        _validate_mcp_icon_url("https://evil.example.com/icon.png")
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo_by_host({"evil.example.com": "8.8.8.8"}),
+    ):
+        with pytest.raises(MlflowException, match="not in the allowed domain list"):
+            _validate_mcp_icon_url("https://evil.example.com/icon.png")
 
 
 def test_validate_mcp_icon_url_allow_private_ips_accepts_localhost(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS", "true")
     _validate_mcp_icon_url("https://localhost/icon.png")
 
 
 def test_validate_mcp_icon_url_allowed_schemes_accepts_public_http(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
-    _validate_mcp_icon_url("http://example.com/icon.png")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("8.8.8.8"),
+    ):
+        _validate_mcp_icon_url("http://example.com/icon.png")
 
 
 def test_validate_mcp_icon_url_allow_private_ips_does_not_bypass_allowlist(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "assets.example.com")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_DOMAINS", "assets.example.com")
     with pytest.raises(MlflowException, match="allowed domain list"):
         _validate_mcp_icon_url("https://localhost/icon.png")
 
 
 def test_validate_mcp_icon_url_allow_private_ips_and_allowlist_accepts_localhost(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "localhost")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_DOMAINS", "localhost")
     _validate_mcp_icon_url("https://localhost/icon.png")
 
 
 def test_validate_mcp_icon_url_allowed_schemes_keeps_basic_shape_checks(monkeypatch):
-    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    monkeypatch.setenv("MLFLOW_ICON_URL_ALLOWED_SCHEMES", "http,https")
     with pytest.raises(MlflowException, match="must not include embedded credentials"):
         _validate_mcp_icon_url("http://user:pass@example.com/icon.png")
+
+
+def test_validate_mcp_icon_url_rejects_hostname_resolving_to_private_ip():
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("10.0.0.1"),
+    ):
+        with pytest.raises(MlflowException, match="must not resolve to a non-public"):
+            _validate_mcp_icon_url("https://internal.corp/icon.png")
 
 
 @pytest.mark.parametrize("invalid_name", ["my/model", "model:v1", "name/with:both"])

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -20,12 +20,14 @@ from mlflow.utils.validation import (
     _validate_experiment_artifact_location_length,
     _validate_experiment_name,
     _validate_list_param,
+    _validate_mcp_icon_url,
     _validate_metric_name,
     _validate_model_alias_name,
     _validate_model_alias_name_reserved,
     _validate_model_name,
     _validate_model_renaming,
     _validate_param_name,
+    _validate_public_https_url,
     _validate_run_id,
     _validate_tag_name,
     _validate_webhook_url,
@@ -533,6 +535,116 @@ def test_validate_webhook_url_allow_private_ips_env_var(monkeypatch):
         side_effect=_mock_getaddrinfo("127.0.0.1"),
     ):
         _validate_webhook_url("https://localhost/callback")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_match"),
+    [
+        (123, "Icon URL must be a string"),
+        ("", "Icon URL cannot be empty"),
+        ("   ", "Icon URL cannot be empty"),
+        ("http://example.com/icon.png", "Invalid Icon URL scheme"),
+        ("data:image/png;base64,abc", "Invalid Icon URL scheme"),
+        ("https://", "Icon URL must include a hostname"),
+        ("https://user:pass@example.com/icon.png", "must not include embedded credentials"),
+        ("https://localhost/icon.png", "must not target localhost"),
+        ("https://127.0.0.1/icon.png", "must not resolve to a non-public IP address"),
+        ("https://[::1]/icon.png", "must not resolve to a non-public IP address"),
+        ("https://192.168.1.10/icon.png", "must not resolve to a non-public IP address"),
+    ],
+)
+def test_validate_public_https_url_rejects_invalid_input(url, expected_match):
+    with pytest.raises(MlflowException, match=expected_match):
+        _validate_public_https_url(url, field_name="Icon URL")
+
+
+@pytest.mark.parametrize("url", ["https://example.com/icon.png", "https://8.8.8.8/icon.png"])
+def test_validate_public_https_url_accepts_public_targets(url):
+    _validate_public_https_url(url, field_name="Icon URL")
+
+
+def test_validate_public_https_url_allowed_schemes_accepts_http():
+    _validate_public_https_url(
+        "http://example.com/icon.png",
+        field_name="Icon URL",
+        allowed_schemes=("http", "https"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_match"),
+    [
+        ("https://user:pass@example.com/icon.png", "must not include embedded credentials"),
+        ("https://", "Icon URL must include a hostname"),
+    ],
+)
+def test_validate_public_https_url_allowed_schemes_keeps_basic_shape_checks(url, expected_match):
+    with pytest.raises(MlflowException, match=expected_match):
+        _validate_public_https_url(
+            url,
+            field_name="Icon URL",
+            allowed_schemes=("http", "https"),
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://localhost/icon.png",
+        "https://127.0.0.1/icon.png",
+        "https://192.168.1.10/icon.png",
+    ],
+)
+def test_validate_public_https_url_allow_private_ips_accepts_local_targets(url):
+    _validate_public_https_url(url, field_name="Icon URL", allow_private_ips=True)
+
+
+def test_validate_mcp_icon_url_allowlist_accepts_exact_match(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "example.com")
+    _validate_mcp_icon_url("https://example.com/icon.png")
+
+
+def test_validate_mcp_icon_url_allowlist_accepts_wildcard_match(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "*.example.com")
+    _validate_mcp_icon_url("https://cdn.example.com/icon.png")
+
+
+def test_validate_mcp_icon_url_allowlist_rejects_unlisted_host(monkeypatch):
+    monkeypatch.setenv(
+        "MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS",
+        "assets.example.com,*.cdn.example.com",
+    )
+    with pytest.raises(MlflowException, match="not in the allowed domain list"):
+        _validate_mcp_icon_url("https://evil.example.com/icon.png")
+
+
+def test_validate_mcp_icon_url_allow_private_ips_accepts_localhost(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    _validate_mcp_icon_url("https://localhost/icon.png")
+
+
+def test_validate_mcp_icon_url_allowed_schemes_accepts_public_http(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    _validate_mcp_icon_url("http://example.com/icon.png")
+
+
+def test_validate_mcp_icon_url_allow_private_ips_does_not_bypass_allowlist(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "assets.example.com")
+    with pytest.raises(MlflowException, match="allowed domain list"):
+        _validate_mcp_icon_url("https://localhost/icon.png")
+
+
+def test_validate_mcp_icon_url_allow_private_ips_and_allowlist_accepts_localhost(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS", "localhost")
+    _validate_mcp_icon_url("https://localhost/icon.png")
+
+
+def test_validate_mcp_icon_url_allowed_schemes_keeps_basic_shape_checks(monkeypatch):
+    monkeypatch.setenv("MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES", "http,https")
+    with pytest.raises(MlflowException, match="must not include embedded credentials"):
+        _validate_mcp_icon_url("http://user:pass@example.com/icon.png")
 
 
 @pytest.mark.parametrize("invalid_name", ["my/model", "model:v1", "name/with:both"])


### PR DESCRIPTION
Added MCP icon URL validation with three config options:

- `MLFLOW_MCP_ICON_URL_ALLOWED_SCHEMES`
  - default: `https`
  - possible values: comma-separated schemes such as `https` or `http,https`
  - controls whether icon URLs may use `http`, `https`, or both

- `MLFLOW_MCP_ICON_URL_ALLOW_PRIVATE_IPS`
  - default: `false`
  - possible values: `true` or `false`
  - controls whether icon URLs may target `localhost`, loopback, or other private/internal addresses

- `MLFLOW_MCP_ICON_URL_ALLOWED_DOMAINS`
  - default: unset
  - possible values: comma-separated host patterns such as `assets.example.com,*.cdn.example.com`
  - when set, icon URLs must match this allowlist in addition to the scheme/private-IP rules

Default behavior is secure: only public `https` icon URLs are allowed. For local testing, users can allow `http`, private hosts, or both via the first two env vars.

Related discussion: https://github.com/mlflow/mlflow/pull/24217#discussion_r3498982105



<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
