### PR TITLE
Fix Vertex AI Gemini multi-turn tool calling

### DIFF
--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -175,6 +175,10 @@ class VertexAIProvider(GeminiProvider):
 
     @property
     def adapter_class(self):
+        # Claude/MaaS models are formatted by their delegate's adapter; only Gemini
+        # models use the Gemini adapter (stripped for Vertex).
+        if self._delegate is not None:
+            return self._delegate.adapter_class
         return _VertexGeminiAdapter
 
     def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -27,7 +27,7 @@ from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.anthropic import AnthropicProvider
 from mlflow.gateway.providers.base import BaseProvider
-from mlflow.gateway.providers.gemini import GeminiProvider
+from mlflow.gateway.providers.gemini import GeminiAdapter, GeminiProvider
 from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
 
 _DEFAULT_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -38,6 +38,29 @@ _VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
 # No-slash model name prefixes that belong to the MaaS (OpenAI-compatible) type
 # rather than the Google (Gemini API) type.
 _MAAS_PREFIXES = ("mistral", "codestral", "jamba")
+
+
+class _VertexGeminiAdapter(GeminiAdapter):
+    """GeminiAdapter for Gemini models on Vertex AI.
+
+    The shared GeminiAdapter targets the Developer Gemini API
+    (generativelanguage.googleapis.com), which uses ``functionCall``/``functionResponse``
+    ``id`` to correlate parallel tool calls. Vertex AI's generateContent proto rejects
+    that field with ``400 INVALID_ARGUMENT`` at ``contents[].parts[].function_call.id``,
+    so strip it from the translated request while leaving ``name`` and
+    ``thoughtSignature`` intact.
+    """
+
+    @classmethod
+    def chat_to_model(cls, payload, config):
+        model_payload = super().chat_to_model(payload, config)
+        for content in model_payload.get("contents", []):
+            for part in content.get("parts", []):
+                if function_call := part.get("functionCall"):
+                    function_call.pop("id", None)
+                if function_response := part.get("functionResponse"):
+                    function_response.pop("id", None)
+        return model_payload
 
 
 def _classify_model(model_name: str) -> str:
@@ -143,6 +166,10 @@ class VertexAIProvider(GeminiProvider):
 
     def get_provider_name(self) -> str:
         return "vertex_ai"
+
+    @property
+    def adapter_class(self):
+        return _VertexGeminiAdapter
 
     def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:
         if not isinstance(config.model.config, VertexAIConfig):

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -43,15 +43,15 @@ _MAAS_PREFIXES = ("mistral", "codestral", "jamba")
 def _strip_function_call_ids(gemini_payload: dict[str, Any]) -> dict[str, Any]:
     """Remove ``id`` from functionCall/functionResponse parts of a Gemini request body.
 
-    The shared GeminiAdapter and the Gemini passthrough route both target the Developer
-    Gemini API (generativelanguage.googleapis.com), which uses ``functionCall``/
-    ``functionResponse`` ``id`` to correlate parallel tool calls. Vertex AI's
-    generateContent proto rejects that field with ``400 INVALID_ARGUMENT`` at
-    ``contents[].parts[].function_call.id``, so strip it while leaving ``name`` and
-    ``thoughtSignature`` intact. Mutates and returns ``gemini_payload``.
+    The shared GeminiAdapter targets the Developer Gemini API
+    (generativelanguage.googleapis.com), which uses ``functionCall``/``functionResponse``
+    ``id`` to correlate parallel tool calls. Vertex AI's generateContent proto rejects
+    that field with ``400 INVALID_ARGUMENT`` at ``contents[].parts[].function_call.id``,
+    so strip it while leaving ``name`` and ``thoughtSignature`` intact. Mutates and
+    returns ``gemini_payload``.
     """
-    for content in gemini_payload.get("contents", []):
-        for part in content.get("parts", []):
+    for content in gemini_payload.get("contents") or []:
+        for part in content.get("parts") or []:
             if function_call := part.get("functionCall"):
                 function_call.pop("id", None)
             if function_response := part.get("functionResponse"):
@@ -297,8 +297,3 @@ class VertexAIProvider(GeminiProvider):
             )
         async for chunk in super()._completions_stream(payload):
             yield chunk
-
-    async def _passthrough(self, action, payload, headers=None):
-        # Raw Gemini-native bodies bypass chat_to_model, so strip the Vertex-illegal
-        # functionCall/functionResponse id here too before forwarding.
-        return await super()._passthrough(action, _strip_function_call_ids(payload), headers)

--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -40,27 +40,33 @@ _VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
 _MAAS_PREFIXES = ("mistral", "codestral", "jamba")
 
 
-class _VertexGeminiAdapter(GeminiAdapter):
-    """GeminiAdapter for Gemini models on Vertex AI.
+def _strip_function_call_ids(gemini_payload: dict[str, Any]) -> dict[str, Any]:
+    """Remove ``id`` from functionCall/functionResponse parts of a Gemini request body.
 
-    The shared GeminiAdapter targets the Developer Gemini API
-    (generativelanguage.googleapis.com), which uses ``functionCall``/``functionResponse``
-    ``id`` to correlate parallel tool calls. Vertex AI's generateContent proto rejects
-    that field with ``400 INVALID_ARGUMENT`` at ``contents[].parts[].function_call.id``,
-    so strip it from the translated request while leaving ``name`` and
-    ``thoughtSignature`` intact.
+    The shared GeminiAdapter and the Gemini passthrough route both target the Developer
+    Gemini API (generativelanguage.googleapis.com), which uses ``functionCall``/
+    ``functionResponse`` ``id`` to correlate parallel tool calls. Vertex AI's
+    generateContent proto rejects that field with ``400 INVALID_ARGUMENT`` at
+    ``contents[].parts[].function_call.id``, so strip it while leaving ``name`` and
+    ``thoughtSignature`` intact. Mutates and returns ``gemini_payload``.
+    """
+    for content in gemini_payload.get("contents", []):
+        for part in content.get("parts", []):
+            if function_call := part.get("functionCall"):
+                function_call.pop("id", None)
+            if function_response := part.get("functionResponse"):
+                function_response.pop("id", None)
+    return gemini_payload
+
+
+class _VertexGeminiAdapter(GeminiAdapter):
+    """GeminiAdapter for Gemini models on Vertex AI, which strips the Vertex-illegal
+    ``functionCall``/``functionResponse`` ``id`` from the translated request.
     """
 
     @classmethod
     def chat_to_model(cls, payload, config):
-        model_payload = super().chat_to_model(payload, config)
-        for content in model_payload.get("contents", []):
-            for part in content.get("parts", []):
-                if function_call := part.get("functionCall"):
-                    function_call.pop("id", None)
-                if function_response := part.get("functionResponse"):
-                    function_response.pop("id", None)
-        return model_payload
+        return _strip_function_call_ids(super().chat_to_model(payload, config))
 
 
 def _classify_model(model_name: str) -> str:
@@ -287,3 +293,8 @@ class VertexAIProvider(GeminiProvider):
             )
         async for chunk in super()._completions_stream(payload):
             yield chunk
+
+    async def _passthrough(self, action, payload, headers=None):
+        # Raw Gemini-native bodies bypass chat_to_model, so strip the Vertex-illegal
+        # functionCall/functionResponse id here too before forwarding.
+        return await super()._passthrough(action, _strip_function_call_ids(payload), headers)

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -10,7 +10,6 @@ from mlflow.environment_variables import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS
 from mlflow.gateway.exceptions import AIGatewayException
-from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.vertex_ai import VertexAIProvider
 from mlflow.gateway.schemas import chat, completions
 
@@ -229,75 +228,49 @@ def test_adapter_class_matches_the_active_delegate():
     )
 
 
-def _passthrough_tool_body():
-    # A raw Gemini-native generateContent body a client posts to the passthrough
-    # route, already carrying the function-call id that Vertex rejects.
-    return {
-        "contents": [
-            {"role": "user", "parts": [{"text": "What's the weather in Santiago?"}]},
-            {
-                "role": "model",
-                "parts": [
-                    {
-                        "functionCall": {
-                            "id": "call_001",
-                            "name": "get_weather",
-                            "args": {"city": "Santiago"},
-                        }
-                    }
-                ],
-            },
-            {
-                "role": "user",
-                "parts": [
-                    {
-                        "functionResponse": {
-                            "id": "call_001",
-                            "name": "get_weather",
-                            "response": {"temp": 14},
-                        }
-                    }
-                ],
-            },
+@pytest.mark.asyncio
+async def test_chat_parallel_tool_calls_omit_all_function_call_ids():
+    # Two parallel tool calls in one turn — the case `id` exists for on the Dev API.
+    # Proves the strip loop covers every functionCall part, not just the first.
+    provider = _make_provider()
+    payload = _tool_calling_second_turn_payload()
+    payload["messages"][1]["tool_calls"].append({
+        "id": "call_002",
+        "function": {"arguments": '{"location": "Tokyo"}', "name": "get_weather"},
+        "type": "function",
+    })
+    payload["messages"].append({
+        "role": "tool",
+        "tool_call_id": "call_002",
+        "content": '{"temperature": 18.0, "condition": "cloudy"}',
+    })
+    resp = {
+        "candidates": [
+            {"content": {"parts": [{"text": "Sunny and cloudy."}]}, "finishReason": "stop"}
         ]
     }
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        await provider.chat(chat.RequestPayload(**payload))
 
-
-@pytest.mark.asyncio
-async def test_passthrough_generate_content_strips_function_call_id():
-    # Regression test for #24127 on the passthrough route: raw generateContent bodies
-    # bypass chat_to_model, so the id must be stripped here too before reaching Vertex.
-    provider = _make_provider()
-    mock_client = mock_http_client(MockAsyncResponse({"candidates": []}))
-
-    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-        await provider.passthrough(
-            PassthroughAction.GEMINI_GENERATE_CONTENT, _passthrough_tool_body()
-        )
-
-    contents = mock_client.post.call_args[1]["json"]["contents"]
-    function_call = _find_part(contents, "functionCall")
-    function_response = _find_part(contents, "functionResponse")
-    assert "id" not in function_call
-    assert "id" not in function_response
-    assert function_call["name"] == "get_weather"
-    assert function_call["args"] == {"city": "Santiago"}
-
-
-@pytest.mark.asyncio
-async def test_passthrough_stream_generate_content_strips_function_call_id():
-    provider = _make_provider()
-    mock_client = mock_http_client(MockAsyncStreamingResponse([b'data: {"candidates": []}\n\n']))
-
-    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
-        result = await provider.passthrough(
-            PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, _passthrough_tool_body()
-        )
-        _ = [chunk async for chunk in result]
-
-    contents = mock_client.post.call_args[1]["json"]["contents"]
-    assert "id" not in _find_part(contents, "functionCall")
-    assert "id" not in _find_part(contents, "functionResponse")
+    contents = mock_post.call_args[1]["json"]["contents"]
+    function_calls = [
+        part["functionCall"]
+        for c in contents
+        for part in c.get("parts", [])
+        if "functionCall" in part
+    ]
+    function_responses = [
+        part["functionResponse"]
+        for c in contents
+        for part in c.get("parts", [])
+        if "functionResponse" in part
+    ]
+    assert len(function_calls) == 2
+    assert len(function_responses) == 2
+    assert all("id" not in fc for fc in function_calls)
+    assert all("id" not in fr for fr in function_responses)
 
 
 def test_basic_config():

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -10,6 +10,7 @@ from mlflow.environment_variables import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS
 from mlflow.gateway.exceptions import AIGatewayException
+from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.vertex_ai import VertexAIProvider
 from mlflow.gateway.schemas import chat, completions
 
@@ -207,6 +208,77 @@ async def test_chat_stream_tool_calling_omits_function_call_id():
     with mock.patch("aiohttp.ClientSession", return_value=mock_client):
         stream = provider.chat_stream(chat.RequestPayload(**payload))
         _ = [chunk async for chunk in stream]
+
+    contents = mock_client.post.call_args[1]["json"]["contents"]
+    assert "id" not in _find_part(contents, "functionCall")
+    assert "id" not in _find_part(contents, "functionResponse")
+
+
+def _passthrough_tool_body():
+    # A raw Gemini-native generateContent body a client posts to the passthrough
+    # route, already carrying the function-call id that Vertex rejects.
+    return {
+        "contents": [
+            {"role": "user", "parts": [{"text": "What's the weather in Santiago?"}]},
+            {
+                "role": "model",
+                "parts": [
+                    {
+                        "functionCall": {
+                            "id": "call_001",
+                            "name": "get_weather",
+                            "args": {"city": "Santiago"},
+                        }
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "functionResponse": {
+                            "id": "call_001",
+                            "name": "get_weather",
+                            "response": {"temp": 14},
+                        }
+                    }
+                ],
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_passthrough_generate_content_strips_function_call_id():
+    # Regression test for #24127 on the passthrough route: raw generateContent bodies
+    # bypass chat_to_model, so the id must be stripped here too before reaching Vertex.
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse({"candidates": []}))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        await provider.passthrough(
+            PassthroughAction.GEMINI_GENERATE_CONTENT, _passthrough_tool_body()
+        )
+
+    contents = mock_client.post.call_args[1]["json"]["contents"]
+    function_call = _find_part(contents, "functionCall")
+    function_response = _find_part(contents, "functionResponse")
+    assert "id" not in function_call
+    assert "id" not in function_response
+    assert function_call["name"] == "get_weather"
+    assert function_call["args"] == {"city": "Santiago"}
+
+
+@pytest.mark.asyncio
+async def test_passthrough_stream_generate_content_strips_function_call_id():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncStreamingResponse([b'data: {"candidates": []}\n\n']))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        result = await provider.passthrough(
+            PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, _passthrough_tool_body()
+        )
+        _ = [chunk async for chunk in result]
 
     contents = mock_client.post.call_args[1]["json"]["contents"]
     assert "id" not in _find_part(contents, "functionCall")

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -214,6 +214,21 @@ async def test_chat_stream_tool_calling_omits_function_call_id():
     assert "id" not in _find_part(contents, "functionResponse")
 
 
+def test_adapter_class_matches_the_active_delegate():
+    # adapter_class must follow the delegate: Claude/MaaS models are formatted by their
+    # own adapters (get_endpoint_url points at the delegate's endpoint), not the Gemini one.
+    from mlflow.gateway.providers.anthropic import AnthropicAdapter
+    from mlflow.gateway.providers.openai_compatible import OpenAICompatibleAdapter
+    from mlflow.gateway.providers.vertex_ai import _VertexGeminiAdapter
+
+    assert _make_provider().adapter_class is _VertexGeminiAdapter
+    assert _make_claude_provider().adapter_class is AnthropicAdapter
+    assert (
+        _make_maas_provider("meta/llama-3.1-405b-instruct-maas").adapter_class
+        is OpenAICompatibleAdapter
+    )
+
+
 def _passthrough_tool_body():
     # A raw Gemini-native generateContent body a client posts to the passthrough
     # route, already carrying the function-call id that Vertex rejects.

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -98,6 +98,121 @@ async def test_chat():
     assert result["usage"]["completion_tokens"] == 20
 
 
+def _tool_calling_second_turn_payload():
+    return {
+        "messages": [
+            {"role": "user", "content": "What's the weather like in Singapore today?"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_001",
+                        "function": {
+                            "arguments": '{"location": "Singapore"}',
+                            "name": "get_weather",
+                        },
+                        "type": "function",
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_001",
+                "content": '{"temperature": 31.2, "condition": "sunny"}',
+            },
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current temperature for a given location.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {"type": "string", "description": "The name of a city"}
+                        },
+                        "required": ["location"],
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _find_part(contents, key):
+    return next(
+        part[key] for content in contents for part in content.get("parts", []) if key in part
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_calling_omits_function_call_id():
+    # Regression test for #24127: Vertex AI rejects `id` on functionCall/functionResponse
+    # parts with 400 INVALID_ARGUMENT, unlike the Developer Gemini API which requires it.
+    provider = _make_provider()
+    resp = {
+        "candidates": [
+            {"content": {"parts": [{"text": "Sunny, 31.2 degrees."}]}, "finishReason": "stop"}
+        ]
+    }
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        await provider.chat(chat.RequestPayload(**_tool_calling_second_turn_payload()))
+
+    contents = mock_post.call_args[1]["json"]["contents"]
+    function_call = _find_part(contents, "functionCall")
+    function_response = _find_part(contents, "functionResponse")
+
+    assert "id" not in function_call
+    assert "id" not in function_response
+    # The function name must survive — Gemini requires it on both parts.
+    assert function_call["name"] == "get_weather"
+    assert function_response["name"] == "get_weather"
+    assert function_call["args"] == {"location": "Singapore"}
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_calling_preserves_thought_signature():
+    provider = _make_provider()
+    payload = _tool_calling_second_turn_payload()
+    payload["messages"][1]["tool_calls"][0]["thought_signature"] = "opaque_thought_sig_token"
+    resp = {
+        "candidates": [
+            {"content": {"parts": [{"text": "Sunny, 31.2 degrees."}]}, "finishReason": "stop"}
+        ]
+    }
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        await provider.chat(chat.RequestPayload(**payload))
+
+    function_call = _find_part(mock_post.call_args[1]["json"]["contents"], "functionCall")
+    assert "id" not in function_call
+    assert function_call["thoughtSignature"] == "opaque_thought_sig_token"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_tool_calling_omits_function_call_id():
+    provider = _make_provider()
+    stream_resp = [
+        b'data: {"candidates": [{"content": {"parts": [{"text": "Sunny."}]}, '
+        b'"finishReason": "stop"}]}\n\n',
+    ]
+    mock_client = mock_http_client(MockAsyncStreamingResponse(stream_resp))
+    payload = _tool_calling_second_turn_payload()
+    payload["stream"] = True
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        stream = provider.chat_stream(chat.RequestPayload(**payload))
+        _ = [chunk async for chunk in stream]
+
+    contents = mock_client.post.call_args[1]["json"]["contents"]
+    assert "id" not in _find_part(contents, "functionCall")
+    assert "id" not in _find_part(contents, "functionResponse")
+
+
 def test_basic_config():
     config = VertexAIConfig(vertex_project="my-project")
     assert config.vertex_project == "my-project"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24127

### What changes are proposed in this pull request?

VertexAIProvider subclasses GeminiProvider and reused the shared GeminiAdapter.chat_to_model(), which emits an `id` on functionCall/ functionResponse parts. The Developer Gemini API
(generativelanguage.googleapis.com) uses that id to correlate parallel tool calls, but the Vertex AI generateContent proto rejects it with 400 INVALID_ARGUMENT at contents[].parts[].function_call.id, breaking any follow-up turn that replays prior tool-call history.

Add a _VertexGeminiAdapter that strips id from those parts after translation (preserving name and thoughtSignature) and override adapter_class on the Vertex path only, leaving the Developer Gemini path and its parallel-call correlation untouched.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested live calls to Vertex to ensure that bug was fixed for both Gateway and Passthrough path. 

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
