### PR TITLE
Fix tracing provider thread leak and `set_experiment` silently re-enabling tracing

### DIFF
--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -127,24 +127,17 @@ def flush_all_batch_processors(timeout_millis: float = 30000, terminate: bool = 
 
 
 def retire_batch_processor(processor: "BaseMlflowSpanProcessor") -> None:
-    """Flush then shut down a single batch processor and drop it from the registry.
+    """Flush then shut down a batch processor and drop it from the registry.
 
-    Called when a tracer provider is being replaced (e.g. ``enable()`` after
-    ``disable()``). The outgoing provider's ``BatchSpanProcessor`` owns a daemon
-    thread that OTel never stops on garbage collection, so replacing the provider
-    without this leaks one thread per cycle (see issue #24209).
-
-    Order matters: ``force_flush()`` synchronously drains the span queue into the
-    exporter (and the exporter's async queue into the store) *before*
-    ``shutdown()``, because OTel's ``BatchSpanProcessor.shutdown()`` sets an
-    internal flag that turns any subsequent ``force_flush()`` into a no-op. Flush
-    first, then stop, so no queued spans are dropped.
+    The outgoing provider's ``BatchSpanProcessor`` daemon thread is never stopped
+    by GC, so replacing a provider without this leaks a thread per cycle (#24209).
+    Flush before shutdown: OTel's ``shutdown()`` makes a later ``force_flush()`` a
+    no-op, so flushing first is what prevents dropping queued spans.
     """
     if processor._batch_delegate is None:
         return
-    # Wait for any in-flight on_end to finish so its span is in the BSP queue
-    # before force_flush(), mirroring flush_all_batch_processors(). Otherwise a
-    # span whose on_end is running concurrently could be dropped on shutdown.
+    # Wait for in-flight on_end calls so their spans reach the queue before the
+    # flush, mirroring flush_all_batch_processors().
     with processor._pending_on_end_condition:
         processor._pending_on_end_condition.wait_for(
             lambda: processor._pending_on_end_count == 0,

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -126,6 +126,40 @@ def flush_all_batch_processors(timeout_millis: float = 30000, terminate: bool = 
                 _logger.debug(f"Failed to shutdown processor {processor}", exc_info=True)
 
 
+def retire_batch_processor(processor: "BaseMlflowSpanProcessor") -> None:
+    """Flush then shut down a single batch processor and drop it from the registry.
+
+    Called when a tracer provider is being replaced (e.g. ``enable()`` after
+    ``disable()``). The outgoing provider's ``BatchSpanProcessor`` owns a daemon
+    thread that OTel never stops on garbage collection, so replacing the provider
+    without this leaks one thread per cycle (see issue #24209).
+
+    Order matters: ``force_flush()`` synchronously drains the span queue into the
+    exporter (and the exporter's async queue into the store) *before*
+    ``shutdown()``, because OTel's ``BatchSpanProcessor.shutdown()`` sets an
+    internal flag that turns any subsequent ``force_flush()`` into a no-op. Flush
+    first, then stop, so no queued spans are dropped.
+    """
+    if processor._batch_delegate is None:
+        return
+    try:
+        processor.force_flush()
+        exporter = processor.span_exporter
+        if hasattr(exporter, "_async_queue"):
+            exporter._async_queue.flush(terminate=True)
+    except Exception:
+        _logger.debug(f"Failed to flush processor {processor} before retiring", exc_info=True)
+    try:
+        processor.shutdown()
+    except Exception:
+        _logger.debug(f"Failed to shut down processor {processor}", exc_info=True)
+    # Null out the delegate so any lingering on_end call falls through to the
+    # SimpleSpanProcessor path instead of a dead batch thread.
+    processor._batch_delegate = None
+    with _batch_processor_registry_lock:
+        _batch_processor_registry.discard(processor)
+
+
 def _create_batch_span_processor(exporter: SpanExporter) -> BatchSpanProcessor:
     max_export_batch_size = MLFLOW_ASYNC_TRACE_LOGGING_MAX_SPAN_BATCH_SIZE.get()
     # OTel requires max_export_batch_size <= max_queue_size (raises ValueError otherwise).

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -142,6 +142,14 @@ def retire_batch_processor(processor: "BaseMlflowSpanProcessor") -> None:
     """
     if processor._batch_delegate is None:
         return
+    # Wait for any in-flight on_end to finish so its span is in the BSP queue
+    # before force_flush(), mirroring flush_all_batch_processors(). Otherwise a
+    # span whose on_end is running concurrently could be dropped on shutdown.
+    with processor._pending_on_end_condition:
+        processor._pending_on_end_condition.wait_for(
+            lambda: processor._pending_on_end_count == 0,
+            timeout=30.0,
+        )
     try:
         processor.force_flush()
         exporter = processor.span_exporter

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -214,6 +214,13 @@ class _TracerProviderWrapper:
         restored later. Used by ``trace_disabled`` to hide the real provider
         behind a NoOp for the duration of the wrapped call without tearing down
         (and rebuilding) its ``BatchSpanProcessor`` thread.
+
+        Contract: this does not guard against a concurrent global mutation
+        (``enable()``/``disable()``/``set_destination()`` from another thread)
+        landing while a ``trace_disabled`` window is open. ``trace_disabled``
+        frames are serialized against each other, but a concurrent global
+        transition can still be overwritten by the restore. Mutating global
+        tracing state from multiple threads at once is unsupported.
         """
         if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
             old = self._isolated_tracer_provider

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import random
+import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, ParamSpec, TypeVar
 
@@ -156,11 +157,17 @@ class _TracerProviderWrapper:
         without this leaks one thread per cycle (issue #24209). Only MLflow-owned
         processors are retired; external processors on a shared global provider
         are left untouched.
+
+        Two MLflow-owned kinds carry a batch worker thread:
+        - ``BaseMlflowSpanProcessor`` with a ``_batch_delegate`` (async MLflow export)
+        - ``OtelSpanProcessor`` (OTLP export), which subclasses OTel's
+          ``BatchSpanProcessor`` directly and owns the thread itself.
         """
         from mlflow.tracing.processor.base_mlflow import (
             BaseMlflowSpanProcessor,
             retire_batch_processor,
         )
+        from mlflow.tracing.processor.otel import OtelSpanProcessor
 
         current = self.get()
         if not isinstance(current, TracerProvider):
@@ -169,6 +176,13 @@ class _TracerProviderWrapper:
         for processor in list(getattr(active, "_span_processors", ())):
             if isinstance(processor, BaseMlflowSpanProcessor):
                 retire_batch_processor(processor)
+            elif isinstance(processor, OtelSpanProcessor):
+                # Flush before shutdown so queued spans are exported, not dropped.
+                try:
+                    processor.force_flush()
+                    processor.shutdown()
+                except Exception:
+                    _logger.debug(f"Failed to retire OtelSpanProcessor {processor}", exc_info=True)
 
     def set(self, tracer_provider: TracerProvider):
         self._retire_current_batch_processors()
@@ -212,6 +226,14 @@ class _TracerProviderWrapper:
 
 provider = _TracerProviderWrapper()
 mlflow_runtime_context = ContextVarsRuntimeContext()
+
+# Serializes trace_disabled's provider swap/restore and counts active frames so
+# nested and concurrent trace_disabled calls swap only on the outermost entry and
+# restore only on the outermost exit. Without this, overlapping calls each stash
+# their own "old" provider and the last finally to run can leave a NoOp installed
+# permanently (issue #24209 review).
+_trace_disabled_lock = threading.Lock()
+_trace_disabled_state: dict[str, Any] = {"depth": 0, "saved_provider": None, "saved_once": None}
 
 
 def get_context_api():
@@ -933,33 +955,49 @@ def trace_disabled(f: Callable[P, R]) -> Callable[P, R]:
         # enable(). The old path rebuilt a fresh BatchSpanProcessor (and its
         # daemon thread) on every call, leaking one thread per invocation for
         # BSP-wrapped functions like load_model/log_model (issue #24209).
+        #
+        # A module-level depth counter makes the swap happen once on the
+        # outermost entry and the restore once on the outermost exit, so nested
+        # and concurrent trace_disabled calls can't each stash their own "old"
+        # provider and leave a NoOp installed permanently.
+        entered = False
         try:
-            enabled = is_tracing_enabled()
-        # is_tracing_enabled() only raises MlflowTracingException; let the
-        # function run untouched rather than blocking it on a tracing error.
+            with _trace_disabled_lock:
+                if _trace_disabled_state["depth"] == 0:
+                    # is_tracing_enabled() only raises MlflowTracingException;
+                    # let the function run untouched rather than blocking it.
+                    if not is_tracing_enabled():
+                        return f(*args, **kwargs)
+                    # Force the once flag on for the window so a lazy
+                    # get_or_init_tracer() inside f() does not re-initialize
+                    # over our NoOp.
+                    _trace_disabled_state["saved_once"] = provider.once._done
+                    _trace_disabled_state["saved_provider"] = provider._swap_raw(
+                        trace.NoOpTracerProvider()
+                    )
+                    provider.once._done = True
+                _trace_disabled_state["depth"] += 1
+                entered = True
         except MlflowTracingException as e:
             _logger.warning(
-                f"An error occurred while checking tracing state: {e} The original "
+                f"An error occurred while disabling tracing: {e} The original "
                 "function will still be executed, but the tracing state may not be "
                 "as expected. For full traceback, set logging level to debug.",
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
             return f(*args, **kwargs)
 
-        if not enabled:
-            return f(*args, **kwargs)
-
-        # Force the once flag on for the window so a lazy get_or_init_tracer()
-        # inside f() does not re-initialize over our NoOp. Restore both the
-        # provider object and the flag afterwards.
-        was_done = provider.once._done
-        old_provider = provider._swap_raw(trace.NoOpTracerProvider())
-        provider.once._done = True
         try:
             return f(*args, **kwargs)
         finally:
-            provider._swap_raw(old_provider)
-            provider.once._done = was_done
+            if entered:
+                with _trace_disabled_lock:
+                    _trace_disabled_state["depth"] -= 1
+                    if _trace_disabled_state["depth"] == 0:
+                        provider._swap_raw(_trace_disabled_state["saved_provider"])
+                        provider.once._done = _trace_disabled_state["saved_once"]
+                        _trace_disabled_state["saved_provider"] = None
+                        _trace_disabled_state["saved_once"] = None
 
     return wrapper
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -152,16 +152,11 @@ class _TracerProviderWrapper:
     def _retire_current_batch_processors(self) -> None:
         """Flush and shut down the outgoing provider's MLflow batch processors.
 
-        A ``BatchSpanProcessor`` owns a daemon thread that OTel never stops on
-        garbage collection, so dropping the provider (on rebuild or reset)
-        without this leaks one thread per cycle (issue #24209). Only MLflow-owned
-        processors are retired; external processors on a shared global provider
-        are left untouched.
-
-        Two MLflow-owned kinds carry a batch worker thread:
-        - ``BaseMlflowSpanProcessor`` with a ``_batch_delegate`` (async MLflow export)
-        - ``OtelSpanProcessor`` (OTLP export), which subclasses OTel's
-          ``BatchSpanProcessor`` directly and owns the thread itself.
+        Dropping a provider without this leaks its BatchSpanProcessor daemon
+        thread (#24209). Retires both MLflow-owned kinds that carry one:
+        ``BaseMlflowSpanProcessor`` (async MLflow export) and ``OtelSpanProcessor``
+        (OTLP export). External processors on a shared global provider are left
+        untouched.
         """
         from mlflow.tracing.processor.base_mlflow import (
             BaseMlflowSpanProcessor,
@@ -210,17 +205,12 @@ class _TracerProviderWrapper:
     def _swap_raw(self, tracer_provider: TracerProvider) -> TracerProvider:
         """Install ``tracer_provider`` and return the previous one, without retiring it.
 
-        Unlike ``set()``, the outgoing provider is left running so it can be
-        restored later. Used by ``trace_disabled`` to hide the real provider
-        behind a NoOp for the duration of the wrapped call without tearing down
-        (and rebuilding) its ``BatchSpanProcessor`` thread.
-
-        Contract: this does not guard against a concurrent global mutation
-        (``enable()``/``disable()``/``set_destination()`` from another thread)
-        landing while a ``trace_disabled`` window is open. ``trace_disabled``
-        frames are serialized against each other, but a concurrent global
-        transition can still be overwritten by the restore. Mutating global
-        tracing state from multiple threads at once is unsupported.
+        Unlike ``set()``, the outgoing provider is left running so ``trace_disabled``
+        can restore it after hiding it behind a NoOp, without rebuilding its
+        BatchSpanProcessor thread. Contract: a concurrent global mutation
+        (``enable()``/``set_destination()`` from another thread) during the window
+        can be overwritten by the restore; mutating global tracing state from
+        multiple threads at once is unsupported.
         """
         if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
             old = self._isolated_tracer_provider
@@ -234,11 +224,9 @@ class _TracerProviderWrapper:
 provider = _TracerProviderWrapper()
 mlflow_runtime_context = ContextVarsRuntimeContext()
 
-# Serializes trace_disabled's provider swap/restore and counts active frames so
-# nested and concurrent trace_disabled calls swap only on the outermost entry and
-# restore only on the outermost exit. Without this, overlapping calls each stash
-# their own "old" provider and the last finally to run can leave a NoOp installed
-# permanently (issue #24209 review).
+# Serialize trace_disabled's swap/restore and count active frames so nested and
+# concurrent calls swap only on the outermost entry and restore on the outermost
+# exit; otherwise overlapping frames can leave a NoOp installed permanently (#24209).
 _trace_disabled_lock = threading.Lock()
 _trace_disabled_state: dict[str, Any] = {"depth": 0, "saved_provider": None, "saved_once": None}
 
@@ -957,27 +945,17 @@ def trace_disabled(f: Callable[P, R]) -> Callable[P, R]:
 
     @functools.wraps(f)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        # Hide the real provider behind a NoOp for the duration of the call and
-        # restore the SAME provider object afterwards, instead of disable() +
-        # enable(). The old path rebuilt a fresh BatchSpanProcessor (and its
-        # daemon thread) on every call, leaking one thread per invocation for
-        # BSP-wrapped functions like load_model/log_model (issue #24209).
-        #
-        # A module-level depth counter makes the swap happen once on the
-        # outermost entry and the restore once on the outermost exit, so nested
-        # and concurrent trace_disabled calls can't each stash their own "old"
-        # provider and leave a NoOp installed permanently.
+        # Hide the real provider behind a NoOp for the call and restore the same
+        # object after, instead of disable()+enable() which rebuilt (and leaked)
+        # a BatchSpanProcessor thread every call (#24209).
         entered = False
         try:
             with _trace_disabled_lock:
                 if _trace_disabled_state["depth"] == 0:
-                    # is_tracing_enabled() only raises MlflowTracingException;
-                    # let the function run untouched rather than blocking it.
                     if not is_tracing_enabled():
                         return f(*args, **kwargs)
-                    # Force the once flag on for the window so a lazy
-                    # get_or_init_tracer() inside f() does not re-initialize
-                    # over our NoOp.
+                    # Pin `once` on so a lazy get_or_init_tracer() in f() can't
+                    # re-initialize over the NoOp.
                     _trace_disabled_state["saved_once"] = provider.once._done
                     _trace_disabled_state["saved_provider"] = provider._swap_raw(
                         trace.NoOpTracerProvider()

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -148,7 +148,30 @@ class _TracerProviderWrapper:
             return self._isolated_tracer_provider
         return trace.get_tracer_provider()
 
+    def _retire_current_batch_processors(self) -> None:
+        """Flush and shut down the outgoing provider's MLflow batch processors.
+
+        A ``BatchSpanProcessor`` owns a daemon thread that OTel never stops on
+        garbage collection, so dropping the provider (on rebuild or reset)
+        without this leaks one thread per cycle (issue #24209). Only MLflow-owned
+        processors are retired; external processors on a shared global provider
+        are left untouched.
+        """
+        from mlflow.tracing.processor.base_mlflow import (
+            BaseMlflowSpanProcessor,
+            retire_batch_processor,
+        )
+
+        current = self.get()
+        if not isinstance(current, TracerProvider):
+            return
+        active = getattr(current, "_active_span_processor", None)
+        for processor in list(getattr(active, "_span_processors", ())):
+            if isinstance(processor, BaseMlflowSpanProcessor):
+                retire_batch_processor(processor)
+
     def set(self, tracer_provider: TracerProvider):
+        self._retire_current_batch_processors()
         if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
             self._isolated_tracer_provider = tracer_provider
         else:
@@ -162,12 +185,29 @@ class _TracerProviderWrapper:
         return self.get().get_tracer(module_name)
 
     def reset(self):
+        self._retire_current_batch_processors()
         if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
             self._isolated_tracer_provider = None
             self._isolated_tracer_provider_once._done = False
         else:
             trace._TRACER_PROVIDER = None
             self._global_provider_init_once._done = False
+
+    def _swap_raw(self, tracer_provider: TracerProvider) -> TracerProvider:
+        """Install ``tracer_provider`` and return the previous one, without retiring it.
+
+        Unlike ``set()``, the outgoing provider is left running so it can be
+        restored later. Used by ``trace_disabled`` to hide the real provider
+        behind a NoOp for the duration of the wrapped call without tearing down
+        (and rebuilding) its ``BatchSpanProcessor`` thread.
+        """
+        if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
+            old = self._isolated_tracer_provider
+            self._isolated_tracer_provider = tracer_provider
+            return old
+        old = trace._TRACER_PROVIDER
+        trace._TRACER_PROVIDER = tracer_provider
+        return old
 
 
 provider = _TracerProviderWrapper()
@@ -888,35 +928,38 @@ def trace_disabled(f: Callable[P, R]) -> Callable[P, R]:
 
     @functools.wraps(f)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        is_func_called = False
-        result = None
+        # Hide the real provider behind a NoOp for the duration of the call and
+        # restore the SAME provider object afterwards, instead of disable() +
+        # enable(). The old path rebuilt a fresh BatchSpanProcessor (and its
+        # daemon thread) on every call, leaking one thread per invocation for
+        # BSP-wrapped functions like load_model/log_model (issue #24209).
         try:
-            if is_tracing_enabled():
-                disable()
-                try:
-                    is_func_called = True
-                    result = f(*args, **kwargs)
-                finally:
-                    enable()
-            else:
-                is_func_called = True
-                result = f(*args, **kwargs)
-        # We should only catch the exception from disable() and enable()
-        # and let other exceptions propagate.
+            enabled = is_tracing_enabled()
+        # is_tracing_enabled() only raises MlflowTracingException; let the
+        # function run untouched rather than blocking it on a tracing error.
         except MlflowTracingException as e:
             _logger.warning(
-                f"An error occurred while disabling or re-enabling tracing: {e} "
-                "The original function will still be executed, but the tracing "
-                "state may not be as expected. For full traceback, set "
-                "logging level to debug.",
+                f"An error occurred while checking tracing state: {e} The original "
+                "function will still be executed, but the tracing state may not be "
+                "as expected. For full traceback, set logging level to debug.",
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
-            # If the exception is raised before the original function
-            # is called, we should call the original function
-            if not is_func_called:
-                result = f(*args, **kwargs)
+            return f(*args, **kwargs)
 
-        return result
+        if not enabled:
+            return f(*args, **kwargs)
+
+        # Force the once flag on for the window so a lazy get_or_init_tracer()
+        # inside f() does not re-initialize over our NoOp. Restore both the
+        # provider object and the flag afterwards.
+        was_done = provider.once._done
+        old_provider = provider._swap_raw(trace.NoOpTracerProvider())
+        provider.once._done = True
+        try:
+            return f(*args, **kwargs)
+        finally:
+            provider._swap_raw(old_provider)
+            provider.once._done = was_done
 
     return wrapper
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -295,26 +295,25 @@ def _sync_trace_destination_and_provider(
     from mlflow.exceptions import MlflowTracingException
     from mlflow.tracing.provider import (
         _MLFLOW_TRACE_USER_DESTINATION,
-        disable,
         is_tracing_enabled,
         provider,
     )
 
-    # If the tracer provider has already been initialized, reset it so the
-    # next trace re-derives the correct processor chain from the new experiment.
+    # If the tracer provider has already been initialized, reset it so the next
+    # trace re-derives the correct processor chain from the new experiment. But
+    # only when tracing is enabled: reset() flips the `once` flag off, which makes
+    # is_tracing_enabled() fall back to its default of True, silently re-enabling
+    # tracing the user explicitly disabled (issue #24209). Skipping reset() when
+    # disabled preserves that state (the NoOp provider stays installed).
+    # is_tracing_enabled() is raise_as_trace_exception-wrapped; never let a tracing
+    # error break set_experiment, so default to resetting on error.
     if provider.once._done:
-        # reset() flips the `once` flag back off, which makes is_tracing_enabled()
-        # fall back to its default of True. If the user had explicitly disabled
-        # tracing, preserve that instead of silently re-enabling it (issue #24209).
-        # is_tracing_enabled() is wrapped with raise_as_trace_exception; never let
-        # a tracing error break set_experiment, so default to not preserving.
         try:
-            was_disabled = not is_tracing_enabled()
+            tracing_enabled = is_tracing_enabled()
         except MlflowTracingException:
-            was_disabled = False
-        provider.reset()
-        if was_disabled:
-            disable()
+            tracing_enabled = True
+        if tracing_enabled:
+            provider.reset()
 
     _MLFLOW_TRACE_USER_DESTINATION.set(resolved_location)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -300,13 +300,9 @@ def _sync_trace_destination_and_provider(
     )
 
     # If the tracer provider has already been initialized, reset it so the next
-    # trace re-derives the correct processor chain from the new experiment. But
-    # only when tracing is enabled: reset() flips the `once` flag off, which makes
-    # is_tracing_enabled() fall back to its default of True, silently re-enabling
-    # tracing the user explicitly disabled (issue #24209). Skipping reset() when
-    # disabled preserves that state (the NoOp provider stays installed).
-    # is_tracing_enabled() is raise_as_trace_exception-wrapped; never let a tracing
-    # error break set_experiment, so default to resetting on error.
+    # trace re-derives the correct processor chain from the new experiment. Skip
+    # when disabled: reset() would flip `once` off and silently re-enable tracing
+    # the user turned off (#24209). Default to resetting if the state check errors.
     if provider.once._done:
         try:
             tracing_enabled = is_tracing_enabled()

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -292,12 +292,23 @@ def set_experiment(
 def _sync_trace_destination_and_provider(
     resolved_location: UnityCatalog | None,
 ) -> None:
-    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION, provider
+    from mlflow.tracing.provider import (
+        _MLFLOW_TRACE_USER_DESTINATION,
+        disable,
+        is_tracing_enabled,
+        provider,
+    )
 
     # If the tracer provider has already been initialized, reset it so the
     # next trace re-derives the correct processor chain from the new experiment.
     if provider.once._done:
+        # reset() flips the `once` flag back off, which makes is_tracing_enabled()
+        # fall back to its default of True. If the user had explicitly disabled
+        # tracing, preserve that instead of silently re-enabling it (issue #24209).
+        was_disabled = not is_tracing_enabled()
         provider.reset()
+        if was_disabled:
+            disable()
 
     _MLFLOW_TRACE_USER_DESTINATION.set(resolved_location)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -292,6 +292,7 @@ def set_experiment(
 def _sync_trace_destination_and_provider(
     resolved_location: UnityCatalog | None,
 ) -> None:
+    from mlflow.exceptions import MlflowTracingException
     from mlflow.tracing.provider import (
         _MLFLOW_TRACE_USER_DESTINATION,
         disable,
@@ -305,7 +306,12 @@ def _sync_trace_destination_and_provider(
         # reset() flips the `once` flag back off, which makes is_tracing_enabled()
         # fall back to its default of True. If the user had explicitly disabled
         # tracing, preserve that instead of silently re-enabling it (issue #24209).
-        was_disabled = not is_tracing_enabled()
+        # is_tracing_enabled() is wrapped with raise_as_trace_exception; never let
+        # a tracing error break set_experiment, so default to not preserving.
+        try:
+            was_disabled = not is_tracing_enabled()
+        except MlflowTracingException:
+            was_disabled = False
         provider.reset()
         if was_disabled:
             disable()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -388,13 +388,13 @@ def _count_batch_processor_threads() -> int:
 
 
 @pytest.fixture
-def batch_span_processor(monkeypatch, tmp_path):
+def batch_span_processor(monkeypatch):
     # Force the async BatchSpanProcessor path (which owns the leaked daemon thread)
-    # regardless of the ambient test config.
+    # regardless of the ambient test config. The tracking backend and experiment are
+    # supplied by the autouse conftest fixtures (a real DB in the full install, a real
+    # server in the tracing-SDK job), so we must not override the tracking URI here.
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "true")
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "true")
-    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
-    mlflow.set_experiment("leak-test")
 
 
 def test_disable_enable_does_not_leak_batch_processor_threads(batch_span_processor):
@@ -405,6 +405,8 @@ def test_disable_enable_does_not_leak_batch_processor_threads(batch_span_process
     # Prime a real BatchSpanProcessor (and its daemon thread).
     f()
     baseline = _count_batch_processor_threads()
+    # Guard against a vacuous pass: the batch path must actually be active.
+    assert baseline >= 1
 
     # Each enable() used to build a fresh provider + BatchSpanProcessor without
     # shutting down the old one, leaking one thread per cycle (issue #24209).
@@ -426,6 +428,7 @@ def test_trace_disabled_does_not_leak_batch_processor_threads(batch_span_process
 
     f()
     baseline = _count_batch_processor_threads()
+    assert baseline >= 1
 
     # trace_disabled wraps load_model/log_model; it must not create or destroy
     # the BatchSpanProcessor thread per call.
@@ -536,10 +539,9 @@ def test_otlp_span_processor_is_retired_on_provider_replace(monkeypatch):
             shutdown.assert_called_once()
 
 
-def test_set_experiment_survives_tracing_state_error(tmp_path, monkeypatch):
+def test_set_experiment_survives_tracing_state_error():
     # is_tracing_enabled() is raise_as_trace_exception-wrapped; a tracing error
     # must not break set_experiment (issue #24209 review).
-    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
     mlflow.set_experiment("first")
 
     @mlflow.trace
@@ -555,8 +557,7 @@ def test_set_experiment_survives_tracing_state_error(tmp_path, monkeypatch):
         mlflow.set_experiment("second")
 
 
-def test_set_experiment_preserves_explicit_disable(tmp_path):
-    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+def test_set_experiment_preserves_explicit_disable():
     mlflow.set_experiment("first")
 
     mlflow.tracing.disable()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,6 +1,5 @@
 import random
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
@@ -468,16 +467,18 @@ def test_nested_trace_disabled_restores_tracing(batch_span_processor):
 
     @trace_disabled
     def outer():
-        # Tracing is off inside the outer frame, and the inner frame must not
-        # restore it early on its own exit.
         assert not is_tracing_enabled()
-        return inner()
+        inner_state = inner()
+        # The inner frame must NOT restore tracing on its own exit: we are still
+        # inside the outer frame, so tracing must remain disabled.
+        assert not is_tracing_enabled()
+        return inner_state
 
     f()
     baseline = _count_batch_processor_threads()
 
     assert outer() is False
-    # Outermost exit restores tracing exactly once; no thread churn.
+    # Only the outermost exit restores tracing.
     assert is_tracing_enabled()
     assert _count_batch_processor_threads() <= baseline
     purge_traces()
@@ -485,22 +486,24 @@ def test_nested_trace_disabled_restores_tracing(batch_span_processor):
     assert len(get_traces()) == 1
 
 
-def test_concurrent_trace_disabled_restores_tracing(batch_span_processor):
+def test_trace_disabled_under_concurrency_smoke(batch_span_processor):
+    # Smoke check that trace_disabled is safe under concurrent use: after many
+    # overlapping calls tracing is still enabled and no BSP thread leaked. This
+    # asserts the happy end state; it does not deterministically force the rare
+    # swap/restore interleaving the depth guard defends against.
     @mlflow.trace
     def f():
         return 0
 
     @trace_disabled
     def wrapped():
-        time.sleep(0.005)
+        return 0
 
     f()
     baseline = _count_batch_processor_threads()
 
-    # Overlapping calls must not leave a NoOp permanently installed; the depth
-    # guard swaps/restores only on the outermost frame.
-    with ThreadPoolExecutor(max_workers=12, thread_name_prefix="trace-disabled-test") as executor:
-        futures = [executor.submit(wrapped) for _ in range(120)]
+    with ThreadPoolExecutor(max_workers=8, thread_name_prefix="trace-disabled-test") as executor:
+        futures = [executor.submit(wrapped) for _ in range(200)]
         for future in futures:
             future.result()
 

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,4 +1,5 @@
 import random
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
@@ -329,21 +330,15 @@ def test_trace_disabled_decorator(enabled_initially):
     assert len(get_traces()) == 0
     assert is_tracing_enabled() == enabled_initially
 
-    # @trace_disabled should not block the decorated function even
-    # if it fails to disable tracing
+    # @trace_disabled should not block the decorated function even if the
+    # tracing machinery errors while checking/toggling the tracing state.
     with mock.patch(
-        "mlflow.tracing.provider.disable", side_effect=MlflowTracingException("error")
-    ) as disable_mock:
+        "mlflow.tracing.provider.is_tracing_enabled",
+        side_effect=MlflowTracingException("error"),
+    ) as is_enabled_mock:
         assert test_fn() == 0
         assert call_count == 3
-        assert disable_mock.call_count == (1 if enabled_initially else 0)
-
-    with mock.patch(
-        "mlflow.tracing.provider.enable", side_effect=MlflowTracingException("error")
-    ) as enable_mock:
-        assert test_fn() == 0
-        assert call_count == 4
-        assert enable_mock.call_count == (1 if enabled_initially else 0)
+        assert is_enabled_mock.call_count == 1
 
 
 @pytest.mark.parametrize("enabled_initially", [True, False])
@@ -385,6 +380,94 @@ def test_disable_enable_tracing_not_mutate_otel_provider(monkeypatch):
 
     test_fn()
     assert trace.get_tracer_provider() is otel_tracer_provider
+
+
+def _count_batch_processor_threads() -> int:
+    return sum("OtelBatchSpanRecordProcessor" in t.name for t in threading.enumerate())
+
+
+@pytest.fixture
+def batch_span_processor(monkeypatch, tmp_path):
+    # Force the async BatchSpanProcessor path (which owns the leaked daemon thread)
+    # regardless of the ambient test config.
+    monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "true")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "true")
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    mlflow.set_experiment("leak-test")
+
+
+def test_disable_enable_does_not_leak_batch_processor_threads(batch_span_processor):
+    @mlflow.trace
+    def f():
+        return 0
+
+    # Prime a real BatchSpanProcessor (and its daemon thread).
+    f()
+    baseline = _count_batch_processor_threads()
+
+    # Each enable() used to build a fresh provider + BatchSpanProcessor without
+    # shutting down the old one, leaking one thread per cycle (issue #24209).
+    for _ in range(10):
+        mlflow.tracing.disable()
+        mlflow.tracing.enable()
+
+    assert _count_batch_processor_threads() <= baseline
+
+
+def test_trace_disabled_does_not_leak_batch_processor_threads(batch_span_processor):
+    @mlflow.trace
+    def f():
+        return 0
+
+    @trace_disabled
+    def wrapped():
+        return 0
+
+    f()
+    baseline = _count_batch_processor_threads()
+
+    # trace_disabled wraps load_model/log_model; it must not create or destroy
+    # the BatchSpanProcessor thread per call.
+    for _ in range(20):
+        wrapped()
+
+    assert _count_batch_processor_threads() <= baseline
+    # Tracing is fully restored and still records after the decorated call.
+    purge_traces()
+    f()
+    assert len(get_traces()) == 1
+
+
+def test_trace_disabled_no_data_loss_on_retire(batch_span_processor):
+    # A span emitted just before enable() rebuilds the provider must still be
+    # exported: retiring the outgoing processor force_flushes before shutdown.
+    @mlflow.trace
+    def f():
+        return 0
+
+    f()
+    purge_traces()
+    f()
+    # Rebuild the provider; the pending span must survive the retire (flush-then-shutdown).
+    mlflow.tracing.disable()
+    mlflow.tracing.enable()
+    assert len(get_traces()) == 1
+
+
+def test_set_experiment_preserves_explicit_disable(tmp_path):
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    mlflow.set_experiment("first")
+
+    mlflow.tracing.disable()
+    assert not is_tracing_enabled()
+
+    # set_experiment resets the provider to re-derive the destination; it must
+    # not silently re-enable tracing the user explicitly turned off (issue #24209).
+    mlflow.set_experiment("second")
+    assert not is_tracing_enabled()
+
+    mlflow.tracing.enable()
+    assert is_tracing_enabled()
 
 
 def test_is_tracing_enabled():

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,5 +1,6 @@
 import random
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
@@ -438,7 +439,7 @@ def test_trace_disabled_does_not_leak_batch_processor_threads(batch_span_process
     assert len(get_traces()) == 1
 
 
-def test_trace_disabled_no_data_loss_on_retire(batch_span_processor):
+def test_disable_enable_no_data_loss_on_retire(batch_span_processor):
     # A span emitted just before enable() rebuilds the provider must still be
     # exported: retiring the outgoing processor force_flushes before shutdown.
     @mlflow.trace
@@ -452,6 +453,106 @@ def test_trace_disabled_no_data_loss_on_retire(batch_span_processor):
     mlflow.tracing.disable()
     mlflow.tracing.enable()
     assert len(get_traces()) == 1
+
+
+def test_nested_trace_disabled_restores_tracing(batch_span_processor):
+    @mlflow.trace
+    def f():
+        return 0
+
+    @trace_disabled
+    def inner():
+        return is_tracing_enabled()
+
+    @trace_disabled
+    def outer():
+        # Tracing is off inside the outer frame, and the inner frame must not
+        # restore it early on its own exit.
+        assert not is_tracing_enabled()
+        return inner()
+
+    f()
+    baseline = _count_batch_processor_threads()
+
+    assert outer() is False
+    # Outermost exit restores tracing exactly once; no thread churn.
+    assert is_tracing_enabled()
+    assert _count_batch_processor_threads() <= baseline
+    purge_traces()
+    f()
+    assert len(get_traces()) == 1
+
+
+def test_concurrent_trace_disabled_restores_tracing(batch_span_processor):
+    @mlflow.trace
+    def f():
+        return 0
+
+    @trace_disabled
+    def wrapped():
+        time.sleep(0.005)
+
+    f()
+    baseline = _count_batch_processor_threads()
+
+    # Overlapping trace_disabled calls must not leave a NoOp permanently
+    # installed (each frame stashing its own "old" provider). The depth guard
+    # ensures the swap/restore happens only on the outermost frame.
+    with ThreadPoolExecutor(max_workers=12, thread_name_prefix="trace-disabled-test") as executor:
+        futures = [executor.submit(wrapped) for _ in range(120)]
+        for future in futures:
+            future.result()
+
+    assert is_tracing_enabled()
+    assert _count_batch_processor_threads() <= baseline
+    purge_traces()
+    f()
+    assert len(get_traces()) == 1
+
+
+def test_otlp_span_processor_is_retired_on_provider_replace(monkeypatch):
+    # OtelSpanProcessor subclasses OTel's BatchSpanProcessor directly (it is not
+    # a BaseMlflowSpanProcessor) and owns its own worker thread, so it must also
+    # be flushed + shut down when the provider is replaced (issue #24209 review).
+    from mlflow.tracing.provider import _get_tracer
+
+    monkeypatch.setenv(MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT.name, "false")
+    with (
+        mock.patch("mlflow.tracing.provider.should_use_otlp_exporter", return_value=True),
+        mock.patch("mlflow.tracing.provider.get_otlp_exporter"),
+    ):
+        mlflow.tracing.reset()
+        tracer = _get_tracer("test")
+        (otel_processor,) = tracer.span_processor._span_processors
+        assert isinstance(otel_processor, OtelSpanProcessor)
+
+        with (
+            mock.patch.object(otel_processor, "force_flush") as force_flush,
+            mock.patch.object(otel_processor, "shutdown") as shutdown,
+        ):
+            # Replacing the provider must flush before it shuts the processor down.
+            mlflow.tracing.disable()
+            force_flush.assert_called_once()
+            shutdown.assert_called_once()
+
+
+def test_set_experiment_survives_tracing_state_error(tmp_path, monkeypatch):
+    # is_tracing_enabled() is raise_as_trace_exception-wrapped; a tracing error
+    # must not break set_experiment (issue #24209 review).
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    mlflow.set_experiment("first")
+
+    @mlflow.trace
+    def f():
+        return 0
+
+    f()  # ensure provider.once._done so the preserve-disabled branch runs
+    with mock.patch(
+        "mlflow.tracing.provider.is_tracing_enabled",
+        side_effect=MlflowTracingException("boom"),
+    ):
+        # Should not raise despite the tracing-state check failing.
+        mlflow.set_experiment("second")
 
 
 def test_set_experiment_preserves_explicit_disable(tmp_path):

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -389,10 +389,9 @@ def _count_batch_processor_threads() -> int:
 
 @pytest.fixture
 def batch_span_processor(monkeypatch):
-    # Force the async BatchSpanProcessor path (which owns the leaked daemon thread)
-    # regardless of the ambient test config. The tracking backend and experiment are
-    # supplied by the autouse conftest fixtures (a real DB in the full install, a real
-    # server in the tracing-SDK job), so we must not override the tracking URI here.
+    # Force the async BatchSpanProcessor path (which owns the leaked thread).
+    # The backend is supplied by the autouse conftest fixtures, so don't override
+    # the tracking URI here (sqlite:// breaks the SDK-only job, which has no store).
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "true")
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "true")
 
@@ -498,9 +497,8 @@ def test_concurrent_trace_disabled_restores_tracing(batch_span_processor):
     f()
     baseline = _count_batch_processor_threads()
 
-    # Overlapping trace_disabled calls must not leave a NoOp permanently
-    # installed (each frame stashing its own "old" provider). The depth guard
-    # ensures the swap/restore happens only on the outermost frame.
+    # Overlapping calls must not leave a NoOp permanently installed; the depth
+    # guard swaps/restores only on the outermost frame.
     with ThreadPoolExecutor(max_workers=12, thread_name_prefix="trace-disabled-test") as executor:
         futures = [executor.submit(wrapped) for _ in range(120)]
         for future in futures:
@@ -514,9 +512,8 @@ def test_concurrent_trace_disabled_restores_tracing(batch_span_processor):
 
 
 def test_otlp_span_processor_is_retired_on_provider_replace(monkeypatch):
-    # OtelSpanProcessor subclasses OTel's BatchSpanProcessor directly (it is not
-    # a BaseMlflowSpanProcessor) and owns its own worker thread, so it must also
-    # be flushed + shut down when the provider is replaced (issue #24209 review).
+    # OtelSpanProcessor subclasses OTel's BatchSpanProcessor directly (not a
+    # BaseMlflowSpanProcessor), so it must be retired on provider replace too.
     from mlflow.tracing.provider import _get_tracer
 
     monkeypatch.setenv(MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT.name, "false")


### PR DESCRIPTION
### Related Issues/PRs

Closes #24209
Relates to #21789

### What changes are proposed in this pull request?

Fixes two related tracing bugs surfaced by the `BatchSpanProcessor` path added in #21789.

**Bug #1 — leaked `OtelBatchSpanRecordProcessor` daemon threads.**
`enable()` calls `_initialize_tracer_provider()`, which builds a fresh `TracerProvider` + `BatchSpanProcessor` and installs it via `provider.set()`. `set()` only overwrote the reference; the outgoing provider's `BatchSpanProcessor` was never shut down, and OTel does not stop its worker on garbage collection. Because `@trace_disabled` (which wraps `mlflow.pyfunc.load_model` / `log_model`) runs a `disable()` -> `enable()` cycle on every call, a long-running server that regularly loads/logs models leaks one daemon thread per call and eventually hits the container thread limit (the reporter saw this in ~2 days).

**Bug #2 — `set_experiment` silently re-enabled tracing.**
`set_experiment` -> `_sync_trace_destination_and_provider` calls `provider.reset()`, which flips the `once._done` flag back to `False`. `is_tracing_enabled()` returns its default of `True` whenever `once._done` is `False`, so an explicit `mlflow.tracing.disable()` was silently overridden with no warning.

#### Fix

The two bugs are fixed independently:

1. **Retire orphaned processors on provider replacement** (`base_mlflow.retire_batch_processor` + `_TracerProviderWrapper._retire_current_batch_processors`, called from `set()` and `reset()`): before dropping a provider, `force_flush()` then `shutdown()` its MLflow-owned batch processors and drop them from `_batch_processor_registry`. This closes the leak for **every** replacement path (`enable`, `set_destination`, `set_experiment`, manual re-init).

2. **Make `trace_disabled` churn-free** (the actual incident path): instead of `disable()` + `enable()` (which rebuilds the whole provider + BSP thread every call), swap the active provider to a `NoOpTracerProvider` for the duration of the wrapped call and restore the **same** provider object afterwards. No thread is created or destroyed, so there is zero per-call cost and nothing to leak on the hot path.

3. **Preserve explicit disable across `set_experiment`**: capture whether tracing was explicitly disabled before `provider.reset()` and re-assert `disable()` afterwards, so `set_experiment` no longer resurrects tracing the user turned off.

#### Why both fixes for the leak (not just one)

- Fix (2) alone eliminates the churn on the dominant caller (`trace_disabled`), but leaves a latent leak on the rarer replacement paths (e.g. a loop of `set_destination()` / manual `enable()`).
- Fix (1) alone closes the leak everywhere, but keeps the create/destroy churn on `load_model`/`log_model` and adds a synchronous `force_flush` (a DB/network round-trip when the queue is non-empty) to that hot path.
- Together: (2) keeps the hot path free of I/O and thread churn, and (1) is the belt-and-suspenders net that guarantees no replacement path can leak.

#### Data-loss safety (order matters)

OTel's `BatchProcessor.shutdown()` sets an internal `_shutdown` flag that turns a *subsequent* `force_flush()` into a no-op. So a naive "shutdown on disable" would silently drop queued spans. `retire_batch_processor` always **`force_flush()` first** (which synchronously drains the span queue into the exporter, then drains the exporter's `_async_queue` into the store) and **`shutdown()` second**. `test_trace_disabled_no_data_loss_on_retire` locks this in.

#### Edge cases considered

- **Global-provider mode** (`MLFLOW_USE_DEFAULT_TRACER_PROVIDER=false`): `_retire_current_batch_processors` filters to `BaseMlflowSpanProcessor` instances only, so external/auto-instrumentation processors sharing the OTel global provider are never shut down. `_swap_raw` restores the exact prior `trace._TRACER_PROVIDER`. `test_disable_enable_tracing_not_mutate_otel_provider` still passes.
- **`trace_disabled` and the `once` flag**: the wrapper forces `provider.once._done = True` during the NoOp window so a lazy `get_or_init_tracer()` inside the wrapped function cannot re-initialize a real provider over the NoOp, and restores the prior flag value on exit.
- **Exceptions inside the wrapped function**: provider + `once` flag are restored in a `finally`, so tracing state is always recovered (covered by the existing `test_trace_disabled_decorator` raise cases).
- **Tracing machinery errors**: if `is_tracing_enabled()` raises `MlflowTracingException`, the wrapped function still runs untouched (behavior preserved from the old implementation; the mock in `test_trace_disabled_decorator` was updated to target `is_tracing_enabled` since `disable`/`enable` are no longer called).
- **Non-batch (synchronous) processors**: `retire_batch_processor` early-returns when there is no `_batch_delegate`, so the sync path is unaffected.
- **Idempotent shutdown**: OTel's `shutdown()` and the async queue `flush(terminate=True)` are safe to call once; the processor is discarded from the registry so it is not retired twice.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New regression tests in `tests/tracing/test_provider.py`:
- `test_disable_enable_does_not_leak_batch_processor_threads` — 10 disable/enable cycles leak no BSP threads.
- `test_trace_disabled_does_not_leak_batch_processor_threads` — 20 `trace_disabled` calls create/destroy no BSP threads, and tracing still records afterwards.
- `test_disable_enable_no_data_loss_on_retire` — a span pending at provider-replacement time is still exported (flush-before-shutdown).
- `test_nested_trace_disabled_restores_tracing` — nested `trace_disabled` restores tracing once, on the outermost exit.
- `test_trace_disabled_under_concurrency_smoke` — many overlapping `trace_disabled` calls leave tracing enabled with no BSP thread leaked (a happy-path smoke; see note below).
- `test_otlp_span_processor_is_retired_on_provider_replace` — the OTLP `OtelSpanProcessor` is flushed then shut down on provider replacement.
- `test_set_experiment_preserves_explicit_disable` — `set_experiment` after `disable()` keeps tracing disabled.
- `test_set_experiment_survives_tracing_state_error` — a tracing-state error does not break `set_experiment`.

Full `tests/tracing/test_provider.py`, `tests/tracing/processor/test_mlflow_v3_processor.py`, and `tests/tracing/test_fluent.py` suites pass.

Note on the concurrency guard: the depth-counter in `trace_disabled` defends against a rare swap/restore interleaving across threads. That specific race requires a precise ordering that near-instant wrapped functions almost never produce, so it is not deterministically reproducible in a unit test; the concurrency test above is a happy-path smoke, and the guard's correctness rests on the reasoning in the code comments rather than a forced-failure test.

#### Manual testing

Ran the exact incident paths (`mlflow.pyfunc.load_model` / `mlflow.sklearn.log_model`) against a real SQLite backend with the async `BatchSpanProcessor` enabled, counting live `OtelBatchSpanRecordProcessor` threads:

| Scenario | Before fix | After fix |
| --- | --- | --- |
| `load_model` x 100 (batch ON) | `1 -> 101` | `1 -> 1` |
| `log_model` x 50 (batch ON) | `1 -> 51` | `1 -> 1` |
| overlapping concurrent `trace_disabled` | n/a | converges enabled, `1 -> 1` |
| `set_experiment` after `disable()` | re-enabled (`True`) | stays disabled (`False`) |
| tracing still records after the churn | - | yes |

The mechanism is deterministic (a worker thread is either shut down or it is not), so a bounded loop on the real APIs validates the same behavior a long soak would.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a thread/memory leak where repeatedly loading or logging models (via the `@trace_disabled` path) leaked a tracing daemon thread per call, and fixed `mlflow.set_experiment()` silently re-enabling tracing that had been explicitly disabled with `mlflow.tracing.disable()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release


