### PR TITLE
Forward tags to registered ModelVersion in Model.log()

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1043,6 +1043,7 @@ class Model:
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
+                    
                 )
 
             model_info = mlflow_model.get_model_info()
@@ -1369,6 +1370,7 @@ class Model:
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
+                    tags=tags,
                 )
             model_info = mlflow_model.get_model_info(model)
             if registered_model is not None:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -257,6 +257,22 @@ def test_model_info_with_model_version(tmp_path):
         model_info = Model.log("model", TestFlavor)
         assert model_info.registered_model_version is None
 
+def test_model_log_tags_propagated_to_registered_model_version(tmp_path):
+    experiment_id = mlflow.create_experiment("test_tags", artifact_location=str(tmp_path))
+    tags = {"stage": "training", "framework": "test"}
+    with mlflow.start_run(experiment_id=experiment_id):
+        model_info = Model.log(
+            "model",
+            TestFlavor,
+            registered_model_name="model_with_tags",
+            tags=tags,
+        )
+
+    client = mlflow.MlflowClient()
+    model_version = client.get_model_version(
+        "model_with_tags", model_info.registered_model_version
+    )
+    assert model_version.tags == tags
 
 def test_model_metadata():
     with TempDir(chdr=True) as tmp:


### PR DESCRIPTION
## Related Issues/PRs

Fixes #24101

## What changes are proposed in this pull request?

When calling `log_model(..., tags={...}, registered_model_name=...)`, the tags were dropped from the registered ModelVersion. `Model.log()` called `_register_model(...)` without forwarding the `tags` argument, so the tags only reached the LoggedModel and never propagated to the ModelVersion.

This forwards `tags=tags` to the `_register_model(...)` call in `Model.log()`, so tags passed at logging time now correctly appear on the registered ModelVersion.

## How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a regression test in `tests/models/test_model.py` (`test_model_log_tags_propagated_to_registered_model_version`) that logs a model with both `tags` and `registered_model_name`, then asserts the resulting ModelVersion carries the tags. Verified passing locally along with the existing model-version and model-log tests.

## Does this PR require documentation updates?

- [x] No. You can skip the rest of this section.

## Release Notes

### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where tags passed to `log_model(..., registered_model_name=...)` were not propagated to the registered model version.

### What component(s) does this PR affect?

- [x] `area/model-registry`: Model registry, model registry APIs, and the fluent client calls for model registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors