### PR TITLE
Populate `mlflow.llm.cost` for Claude Agent SDK traces on Databricks tracking

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -461,6 +461,7 @@ def _create_llm_and_tool_spans(
                 },
                 attributes={
                     "model": msg.get("model", "unknown"),
+                    SpanAttributeKey.MODEL: msg.get("model", "unknown"),
                     SpanAttributeKey.MESSAGE_FORMAT: "anthropic",
                 },
             )
@@ -776,6 +777,7 @@ def _create_sdk_child_spans(
                     },
                     attributes={
                         "model": getattr(msg, "model", "unknown"),
+                        SpanAttributeKey.MODEL: getattr(msg, "model", "unknown"),
                         SpanAttributeKey.MESSAGE_FORMAT: "anthropic",
                     },
                 )

--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -786,6 +786,8 @@ def _create_sdk_child_spans(
                     "role": "assistant",
                     "content": [{"type": "text", "text": block.text} for block in text_blocks],
                 })
+                if usage := getattr(msg, "usage", None):
+                    _set_token_usage_attribute(llm_span, usage)
                 llm_span.end()
                 pending_messages = []
                 continue

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -259,8 +259,10 @@ def test_process_transcript_creates_spans(mock_transcript_file):
     assert tool_span.name == "tool_Bash"
 
     # Verify LLM spans have MESSAGE_FORMAT set to "anthropic" for Chat UI rendering
+    # and MODEL set so cost is computable on the client-side (Databricks) path.
     for llm_span in llm_spans:
         assert llm_span.get_attribute(SpanAttributeKey.MESSAGE_FORMAT) == "anthropic"
+        assert llm_span.get_attribute(SpanAttributeKey.MODEL) == llm_span.inputs["model"]
 
     # Verify LLM span outputs are in Anthropic response format
     first_llm = llm_spans[0]
@@ -448,6 +450,7 @@ def test_process_sdk_messages_simple_conversation():
     assert llm_spans[0].inputs["model"] == "claude-sonnet-4-20250514"
     assert llm_spans[0].inputs["messages"] == [{"role": "user", "content": "What is 2 + 2?"}]
     assert llm_spans[0].get_attribute(SpanAttributeKey.MESSAGE_FORMAT) == "anthropic"
+    assert llm_spans[0].get_attribute(SpanAttributeKey.MODEL) == "claude-sonnet-4-20250514"
 
     # Output should be in Anthropic response format
     outputs = llm_spans[0].outputs

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -479,6 +479,47 @@ def test_process_sdk_messages_simple_conversation():
     assert trace.info.response_preview == "The answer is 4."
 
 
+def test_process_sdk_messages_sets_usage_on_llm_span_for_cost():
+    # When an AssistantMessage carries per-turn usage, it must land on the LLM span
+    # alongside mlflow.llm.model. Client-side cost calculation (Databricks) reads both
+    # MODEL and CHAT_USAGE from the same span, so splitting them across spans yields no cost.
+    messages = [
+        UserMessage(content="What is 2 + 2?"),
+        AssistantMessage(
+            content=[TextBlock(text="The answer is 4.")],
+            model="claude-sonnet-4-20250514",
+            usage={"input_tokens": 150, "output_tokens": 25},
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1000,
+            duration_api_ms=800,
+            is_error=False,
+            num_turns=1,
+            session_id="sdk-cost-session",
+            usage={"input_tokens": 150, "output_tokens": 25},
+        ),
+    ]
+
+    trace = process_sdk_messages(messages, "sdk-cost-session")
+
+    assert trace is not None
+    llm_spans = [s for s in trace.search_spans() if s.span_type == SpanType.LLM]
+    assert len(llm_spans) == 1
+    llm_span = llm_spans[0]
+
+    assert llm_span.get_attribute(SpanAttributeKey.MODEL) == "claude-sonnet-4-20250514"
+    usage = llm_span.get_attribute(SpanAttributeKey.CHAT_USAGE)
+    assert usage["input_tokens"] == 150
+    assert usage["output_tokens"] == 25
+    assert usage["total_tokens"] == 175
+
+    # Trace-level usage must not double-count: DFS aggregation skips the LLM span
+    # because its ancestor (root) already carries the ResultMessage usage.
+    assert trace.info.token_usage["input_tokens"] == 150
+    assert trace.info.token_usage["output_tokens"] == 25
+
+
 def test_process_sdk_messages_multiple_tools():
     messages = [
         UserMessage(content="Read two files"),


### PR DESCRIPTION
### Related Issues/PRs

None.

### What changes are proposed in this pull request?

Claude LLM spans emitted by `mlflow/claude_code/tracing.py` were not getting `mlflow.llm.cost` on **Databricks** tracking, so the cost column stayed empty.

On Databricks, `should_compute_cost_client_side()` returns `True` and cost is computed **client-side** at span end via `calculate_span_cost()`, which reads `SpanAttributeKey.MODEL` **and** `SpanAttributeKey.CHAT_USAGE` **from the same span** (the server-side `translate_span_when_storing()` fallback that recovers the model from `inputs["model"]` does not run for Databricks). The Claude spans failed this on two counts:

1. **Model attribute missing.** LLM spans set only the literal `"model"` key (for Chat UI rendering), not `SpanAttributeKey.MODEL`. Fixed on both the transcript path (`_create_llm_and_tool_spans`) and the SDK path (`_create_sdk_child_spans`). The literal `"model"` key is kept.
2. **Usage on the wrong span (SDK path).** `_create_sdk_child_spans` put the model on the LLM span but token usage only on the parent AGENT span, so model and usage never co-located and cost still could not be computed. Now the `AssistantMessage.usage` is also set on the LLM span. DFS-based trace aggregation still avoids double-counting because the parent already carries the `ResultMessage` total.

The live consumer of the SDK path is `mlflow.anthropic.autolog()` (the Claude Agent SDK). The transcript path is the retired Python-hook path (exercised only by tests), but is kept consistent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Verified end-to-end against a real Databricks workspace (`databricks://`, `should_compute_cost_client_side()` == `True`): before the fix the LLM cost was empty; after, per-span `mlflow.llm.cost` and the aggregated trace-level cost are populated for both the transcript and SDK paths. Added `test_process_sdk_messages_sets_usage_on_llm_span_for_cost` (asserts model + usage co-locate on the LLM span and trace-level usage is not double-counted).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes empty LLM cost for Claude Agent SDK traces on Databricks tracking by setting `mlflow.llm.model` and token usage on the LLM spans so client-side cost calculation can run.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release