### PR TITLE
Forward tags to registered ModelVersion in Model.log()

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1043,6 +1043,7 @@ class Model:
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
+                    
                 )
 
             model_info = mlflow_model.get_model_info()
@@ -1369,6 +1370,7 @@ class Model:
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
+                    tags=tags,
                 )
             model_info = mlflow_model.get_model_info(model)
             if registered_model is not None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1043,7 +1043,6 @@ class Model:
                     registered_model_name,
                     await_registration_for=await_registration_for,
                     local_model_path=local_path,
-                    
                 )
 
             model_info = mlflow_model.get_model_info()

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -257,6 +257,22 @@ def test_model_info_with_model_version(tmp_path):
         model_info = Model.log("model", TestFlavor)
         assert model_info.registered_model_version is None
 
+def test_model_log_tags_propagated_to_registered_model_version(tmp_path):
+    experiment_id = mlflow.create_experiment("test_tags", artifact_location=str(tmp_path))
+    tags = {"stage": "training", "framework": "test"}
+    with mlflow.start_run(experiment_id=experiment_id):
+        model_info = Model.log(
+            "model",
+            TestFlavor,
+            registered_model_name="model_with_tags",
+            tags=tags,
+        )
+
+    client = mlflow.MlflowClient()
+    model_version = client.get_model_version(
+        "model_with_tags", model_info.registered_model_version
+    )
+    assert model_version.tags == tags
 
 def test_model_metadata():
     with TempDir(chdr=True) as tmp:

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -257,6 +257,7 @@ def test_model_info_with_model_version(tmp_path):
         model_info = Model.log("model", TestFlavor)
         assert model_info.registered_model_version is None
 
+
 def test_model_log_tags_propagated_to_registered_model_version(tmp_path):
     experiment_id = mlflow.create_experiment("test_tags", artifact_location=str(tmp_path))
     tags = {"stage": "training", "framework": "test"}
@@ -269,10 +270,9 @@ def test_model_log_tags_propagated_to_registered_model_version(tmp_path):
         )
 
     client = mlflow.MlflowClient()
-    model_version = client.get_model_version(
-        "model_with_tags", model_info.registered_model_version
-    )
+    model_version = client.get_model_version("model_with_tags", model_info.registered_model_version)
     assert model_version.tags == tags
+
 
 def test_model_metadata():
     with TempDir(chdr=True) as tmp:


### PR DESCRIPTION
### Related Issues/PRs
Closes #24101

### What changes are proposed in this pull request?
When calling `log_model(..., tags={...}, registered_model_name=...)`, the tags were dropped from the registered ModelVersion. `Model.log()` called `_register_model(...)` without forwarding the `tags` argument, so the tags only reached the LoggedModel and never propagated to the ModelVersion. This forwards `tags=tags` to the `_register_model(...)` call in `Model.log()`.

### How is this PR tested?
- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a regression test in `tests/models/test_model.py` (`test_model_log_tags_propagated_to_registered_model_version`) that logs a model with both `tags` and `registered_model_name`, then asserts the resulting ModelVersion carries the tags. Verified passing locally along with the existing model-version and model-log tests.

### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?
- [x] No.

### Release Notes
#### Is this a user-facing change?
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where tags passed to `log_model(..., registered_model_name=...)` were not propagated to the registered model version.

#### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>
#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
<details>
<summary>What is a minor/patch release?</summary>
- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.
</details>
- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release