### PR TITLE
fix: avoid table already exists error during database initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,12 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    from sqlalchemy import inspect as sa_inspect
+    inspector = sa_inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    for table_name, table in InitialBase.metadata.tables.items():
+        if table_name not in existing_tables:
+            table.create(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `Table 'secrets' already exists`. This happens because `_initialize_tables` uses `InitialBase.metadata.create_all(engine)` which attempts to create tables that may already exist from a previous partial upgrade or migration.

## Fix
Replaced `create_all` with individual table creation that checks for existing tables first. This ensures tables are only created if they don't already exist, preventing the duplicate table error. The change is backward compatible and maintains the same initialization logic.

Closes #19943