### PR TITLE
Fix parameter name mismatches in docstrings

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -283,7 +283,8 @@ def _upgrade_db(engine):
     we recommend taking a backup of your database before running migrations.
 
     Args:
-        url: Database URL, like sqlite:///<absolute-path-to-local-db-file>. See
+        engine: SQLAlchemy engine for the database to upgrade, created from a database URL
+            like sqlite:///<absolute-path-to-local-db-file>. See
             https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls for a full list of
             valid database URLs.
     """

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1897,7 +1897,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         Args:
             run_id: String ID of the run
             tags: List of RunTag instances to log
-            path: current json path for error messages
         """
         if not tags:
             return

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -77,7 +77,6 @@ class MlflowV3SpanExporter(SpanExporter):
 
         Args:
             spans: Sequence of ReadableSpan objects to export.
-            manager: The trace manager instance.
         """
         if is_databricks_uri(self._client.tracking_uri):
             _logger.debug(


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fixes three internal docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `mlflow/store/db/utils.py` | `_upgrade_db` | `url` | `engine` |
| `mlflow/store/tracking/sqlalchemy_store.py` | `SqlAlchemyStore._set_tags` | stale `path` arg | `run_id`, `tags` only |
| `mlflow/tracing/export/mlflow_v3.py` | `_export_spans_incrementally` | stale `manager` arg | `spans` only |

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Doc-only change; no behavior modified.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components:
- [ ] `area/docs`: MLflow documentation pages

Languages:
- [x] `language/python`: Python APIs for MLflow

<a name="release-note-category"></a>
#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section