### PR TITLE
Reject non-HTTP scopes in WSGI mount to fix WebSocket crash

### DIFF
--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -77,7 +77,16 @@ class _EfficientWSGIMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        assert scope["type"] == "http"
+        if scope["type"] != "http":
+            # WSGI cannot serve WebSocket (or other non-HTTP) connections. The Flask
+            # app is mounted at the catch-all "/", so any WebSocket handshake that
+            # isn't matched by a native FastAPI route reaches here. Reject it cleanly
+            # instead of crashing with AssertionError (see issue #24146). Sending
+            # websocket.close before accept is a valid ASGI rejection (server maps it
+            # to HTTP 403); other non-HTTP scopes (e.g. lifespan) are simply ignored.
+            if scope["type"] == "websocket":
+                await send({"type": "websocket.close", "code": 1000})
+            return
         responder = _EfficientWSGIResponder(self.app, scope)
         await responder(receive, send)
 

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -81,9 +81,9 @@ class _EfficientWSGIMiddleware:
             # WSGI cannot serve WebSocket (or other non-HTTP) connections. The Flask
             # app is mounted at the catch-all "/", so any WebSocket handshake that
             # isn't matched by a native FastAPI route reaches here. Reject it cleanly
-            # instead of crashing with AssertionError (see issue #24146). Sending
-            # websocket.close before accept is a valid ASGI rejection (server maps it
-            # to HTTP 403); other non-HTTP scopes (e.g. lifespan) are simply ignored.
+            # instead of crashing. Sending websocket.close before accept is a valid
+            # ASGI rejection (server maps it to HTTP 403); other non-HTTP scopes
+            # (e.g. lifespan) are simply ignored.
             if scope["type"] == "websocket":
                 await send({"type": "websocket.close", "code": 1000})
             return

--- a/tests/server/test_fastapi_app.py
+++ b/tests/server/test_fastapi_app.py
@@ -1,0 +1,24 @@
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from mlflow.server.fastapi_app import create_fastapi_app
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_fastapi_app())
+
+
+def test_websocket_to_wsgi_mount_does_not_crash(client):
+    # A WebSocket handshake routed to the catch-all WSGI mount must be rejected
+    # cleanly (close code 1000) instead of raising AssertionError. Regression for #24146.
+    with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT011
+        with client.websocket_connect("/gateway/proxy/codex/v1/models"):
+            pass
+    assert excinfo.value.code == 1000
+
+
+def test_http_to_wsgi_mount_still_served(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200

--- a/tests/server/test_fastapi_app.py
+++ b/tests/server/test_fastapi_app.py
@@ -12,7 +12,7 @@ def client():
 
 def test_websocket_to_wsgi_mount_does_not_crash(client):
     # A WebSocket handshake routed to the catch-all WSGI mount must be rejected
-    # cleanly (close code 1000) instead of raising AssertionError. Regression for #24146.
+    # cleanly (close code 1000) instead of raising AssertionError.
     with pytest.raises(WebSocketDisconnect) as excinfo:  # noqa: PT011
         with client.websocket_connect("/gateway/proxy/codex/v1/models"):
             pass


### PR DESCRIPTION
### Related Issues/PRs

Closes #24146

### What changes are proposed in this pull request?

The Flask app is mounted at the catch-all `/` via `_EfficientWSGIMiddleware`, whose `__call__` asserted `scope["type"] == "http"`. Any WebSocket handshake not matched by a native FastAPI route reaches this mount and crashes the connection handler with an uncaught `AssertionError`.

WSGI cannot serve WebSockets, so this rejects them cleanly with `websocket.close` (surfaced to the client as HTTP 403) and ignores other non-HTTP scopes, mirroring the existing idiom in `fastapi_security.py`.

Codex triggers this because it prefers a WebSocket transport for the Responses API and tries it *first*, before falling back to HTTP POST — so the crash on that first attempt breaks the integration. The separate `GET .../v1/models` 404 in the issue is a distinct discovery-route gap and is out of scope here.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Pointed Codex at a gateway endpoint on a real server built from this branch. WebSocket attempts are now cleanly rejected (403) with no crash, and Codex falls back to `POST /responses`, which is relayed upstream (401 below is the upstream rejecting a deliberately fake key):

```
"WebSocket /gateway/proxy/codex/v1/responses" 403   (x7, with backoff)
connection rejected (403 Forbidden)
...
"POST /gateway/proxy/codex/v1/responses HTTP/1.1" 401 Unauthorized
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Fixes an `AssertionError` crash when a WebSocket connection reaches the MLflow server's WSGI-mounted Flask app.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
