### PR TITLE
Fix async trace export dropping workspace context (#24093)

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -1,7 +1,7 @@
 import logging
-from contextlib import nullcontext
 import threading
 from collections import defaultdict
+from contextlib import nullcontext
 from typing import Sequence
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -89,7 +89,10 @@ class MlflowV3SpanExporter(SpanExporter):
             return
 
         mlflow_spans_by_experiment_and_workspace = self._collect_mlflow_spans_for_export(spans)
-        for (experiment_id, workspace), spans_to_log in mlflow_spans_by_experiment_and_workspace.items():
+        for (
+            (experiment_id, workspace),
+            spans_to_log,
+        ) in mlflow_spans_by_experiment_and_workspace.items():
             if self._should_log_async():
                 self._async_queue.put(
                     task=Task(
@@ -217,7 +220,9 @@ class MlflowV3SpanExporter(SpanExporter):
         else:
             self._log_trace(trace, prompts=manager_trace.prompts, workspace=workspace)
 
-    def _log_spans(self, experiment_id: str, spans: list[Span], workspace: str | None = None) -> None:
+    def _log_spans(
+        self, experiment_id: str, spans: list[Span], workspace: str | None = None
+    ) -> None:
         """
         Helper method to log spans with error handling.
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -28,7 +28,7 @@ from mlflow.tracing.utils import (
 )
 from mlflow.utils.databricks_utils import is_in_databricks_notebook
 from mlflow.utils.uri import is_databricks_uri
-from mlflow.utils.workspace_context import ServerWorkspaceContext, get_request_workspace
+from mlflow.utils.workspace_context import ServerWorkspaceContext
 
 _logger = logging.getLogger(__name__)
 
@@ -88,8 +88,8 @@ class MlflowV3SpanExporter(SpanExporter):
             )
             return
 
-        mlflow_spans_by_target = self._collect_mlflow_spans_for_export(spans)
-        for (experiment_id, workspace), spans_to_log in mlflow_spans_by_target.items():
+        mlflow_spans_by_experiment_and_workspace = self._collect_mlflow_spans_for_export(spans)
+        for (experiment_id, workspace), spans_to_log in mlflow_spans_by_experiment_and_workspace.items():
             if self._should_log_async():
                 self._async_queue.put(
                     task=Task(
@@ -118,7 +118,7 @@ class MlflowV3SpanExporter(SpanExporter):
             Dictionary mapping (experiment_id, workspace) to list of MLflow Span objects.
         """
         manager = InMemoryTraceManager.get_instance()
-        spans_by_target = defaultdict(list)
+        spans_by_experiment_and_workspace = defaultdict(list)
 
         for span in spans:
             mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
@@ -137,15 +137,13 @@ class MlflowV3SpanExporter(SpanExporter):
                 except AttributeError:
                     # Remote/distributed traces may have trace_location=None
                     experiment_id = None
-                if trace and getattr(trace, "workspace", None) is not None:
+                if trace is not None:
                     workspace = trace.workspace
             if experiment_id is None:
                 experiment_id = get_experiment_id_for_trace(span)
-            if workspace is None:
-                workspace = get_request_workspace()
-            spans_by_target[(experiment_id, workspace)].append(mlflow_span)
+            spans_by_experiment_and_workspace[(experiment_id, workspace)].append(mlflow_span)
 
-        return spans_by_target
+        return spans_by_experiment_and_workspace
 
     def _export_traces(self, spans: Sequence[ReadableSpan]) -> None:
         """
@@ -207,7 +205,7 @@ class MlflowV3SpanExporter(SpanExporter):
         if not maybe_get_request_id(is_evaluate=True):
             self._display_handler.display_traces([trace])
 
-        workspace = getattr(manager_trace, "workspace", None) or get_request_workspace()
+        workspace = manager_trace.workspace
         if self._should_log_async():
             self._async_queue.put(
                 task=Task(

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import nullcontext
 import threading
 from collections import defaultdict
 from typing import Sequence
@@ -27,6 +28,7 @@ from mlflow.tracing.utils import (
 )
 from mlflow.utils.databricks_utils import is_in_databricks_notebook
 from mlflow.utils.uri import is_databricks_uri
+from mlflow.utils.workspace_context import ServerWorkspaceContext, get_request_workspace
 
 _logger = logging.getLogger(__name__)
 
@@ -86,37 +88,37 @@ class MlflowV3SpanExporter(SpanExporter):
             )
             return
 
-        mlflow_spans_by_experiment = self._collect_mlflow_spans_for_export(spans)
-        for experiment_id, spans_to_log in mlflow_spans_by_experiment.items():
+        mlflow_spans_by_target = self._collect_mlflow_spans_for_export(spans)
+        for (experiment_id, workspace), spans_to_log in mlflow_spans_by_target.items():
             if self._should_log_async():
                 self._async_queue.put(
                     task=Task(
                         handler=self._log_spans,
-                        args=(experiment_id, spans_to_log),
+                        args=(experiment_id, spans_to_log, workspace),
                         error_msg="Failed to log spans to the trace server.",
                     )
                 )
             else:
-                self._log_spans(experiment_id, spans_to_log)
+                self._log_spans(experiment_id, spans_to_log, workspace=workspace)
 
     def _collect_mlflow_spans_for_export(
         self, spans: Sequence[ReadableSpan]
-    ) -> dict[str, list[Span]]:
+    ) -> dict[tuple[str, str | None], list[Span]]:
         """
-        Collect MLflow spans from ReadableSpans for export, grouped by experiment_id.
+        Collect MLflow spans from ReadableSpans for export, grouped by (experiment_id, workspace).
 
-        The experiment_id is resolved from the trace info (set during on_start in the
-        originating thread) rather than from get_experiment_id_for_trace(), which reads
-        thread-local ContextVars that are unavailable in the batch processor's worker thread.
+        The experiment_id and workspace are resolved from the trace (set during on_start in the
+        originating thread) rather than from thread-local ContextVars that are unavailable in the
+        batch processor's worker thread.
 
         Args:
             spans: Sequence of ReadableSpan objects.
 
         Returns:
-            Dictionary mapping experiment_id to list of MLflow Span objects.
+            Dictionary mapping (experiment_id, workspace) to list of MLflow Span objects.
         """
         manager = InMemoryTraceManager.get_instance()
-        spans_by_experiment = defaultdict(list)
+        spans_by_target = defaultdict(list)
 
         for span in spans:
             mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
@@ -126,19 +128,24 @@ class MlflowV3SpanExporter(SpanExporter):
             mlflow_span = manager.get_span_from_id(mlflow_trace_id, span_id)
             if mlflow_span is None:
                 continue
-            # Get experiment_id from trace info (resolved at on_start time in the
+            # Get experiment_id and workspace from trace info (resolved at on_start time in the
             # originating thread) to survive BatchSpanProcessor thread hops.
+            workspace = None
             with manager.get_trace(mlflow_trace_id) as trace:
                 try:
                     experiment_id = trace.info.experiment_id if trace else None
                 except AttributeError:
                     # Remote/distributed traces may have trace_location=None
                     experiment_id = None
+                if trace and getattr(trace, "workspace", None) is not None:
+                    workspace = trace.workspace
             if experiment_id is None:
                 experiment_id = get_experiment_id_for_trace(span)
-            spans_by_experiment[experiment_id].append(mlflow_span)
+            if workspace is None:
+                workspace = get_request_workspace()
+            spans_by_target[(experiment_id, workspace)].append(mlflow_span)
 
-        return spans_by_experiment
+        return spans_by_target
 
     def _export_traces(self, spans: Sequence[ReadableSpan]) -> None:
         """
@@ -200,96 +207,114 @@ class MlflowV3SpanExporter(SpanExporter):
         if not maybe_get_request_id(is_evaluate=True):
             self._display_handler.display_traces([trace])
 
+        workspace = getattr(manager_trace, "workspace", None) or get_request_workspace()
         if self._should_log_async():
             self._async_queue.put(
                 task=Task(
                     handler=self._log_trace,
-                    args=(trace, manager_trace.prompts),
+                    args=(trace, manager_trace.prompts, workspace),
                     error_msg="Failed to log trace to the trace server.",
                 )
             )
         else:
-            self._log_trace(trace, prompts=manager_trace.prompts)
+            self._log_trace(trace, prompts=manager_trace.prompts, workspace=workspace)
 
-    def _log_spans(self, experiment_id: str, spans: list[Span]) -> None:
+    def _log_spans(self, experiment_id: str, spans: list[Span], workspace: str | None = None) -> None:
         """
         Helper method to log spans with error handling.
 
         Args:
             experiment_id: The experiment ID to log spans to.
             spans: List of spans to log.
+            workspace: Optional workspace name captured on the originating thread.
+                When provided, a ServerWorkspaceContext is applied so that HTTP calls
+                on the async worker thread include the correct X-MLFLOW-WORKSPACE header
+                without mutating process-wide environment variables.
         """
-        try:
-            self._client.log_spans(experiment_id, spans)
-        except NotImplementedError:
-            # Silently skip if the store doesn't support log_spans. This is expected for stores that
-            # don't implement span-level logging, and we don't want to spam warnings for every span.
-            self._store_supports_log_spans = False
-        except RestException as e:
-            # When the FileStore is behind the tracking server, it returns 501 exception.
-            # However, the OTLP endpoint returns general HTTP error, not MlflowException, which does
-            # not include error_code in the body and handled as a general server side error. Hence,
-            # we need to check the message to handle this case.
-            if "REST OTLP span logging is not supported" in e.message:
+        with ServerWorkspaceContext(workspace) if workspace else nullcontext():
+            try:
+                self._client.log_spans(experiment_id, spans)
+            except NotImplementedError:
+                # Silently skip if the store doesn't support log_spans. This is expected for stores
+                # that don't implement span-level logging, and we don't want to spam warnings for
+                # every span.
                 self._store_supports_log_spans = False
-            else:
+            except RestException as e:
+                # When the FileStore is behind the tracking server, it returns 501 exception.
+                # However, the OTLP endpoint returns general HTTP error, not MlflowException, which
+                # does not include error_code in the body and handled as a general server side
+                # error. Hence, we need to check the message to handle this case.
+                if "REST OTLP span logging is not supported" in e.message:
+                    self._store_supports_log_spans = False
+                else:
+                    _logger.debug(f"Failed to log span to MLflow backend: {e}")
+            except Exception as e:
                 _logger.debug(f"Failed to log span to MLflow backend: {e}")
-        except Exception as e:
-            _logger.debug(f"Failed to log span to MLflow backend: {e}")
 
-    def _log_trace(self, trace: Trace, prompts: Sequence[PromptVersion]) -> None:
+    def _log_trace(
+        self, trace: Trace, prompts: Sequence[PromptVersion], workspace: str | None = None
+    ) -> None:
         """
         Handles exporting a trace to MLflow using the V3 API and blob storage.
         Steps:
         1. Create the trace in MLflow
         2. Upload the trace data to blob storage using the returned trace info.
+
+        Args:
+            trace: The trace to export.
+            prompts: Prompt versions to link to the trace.
+            workspace: Optional workspace name captured on the originating thread.
+                When provided, a ServerWorkspaceContext is applied so that HTTP calls
+                on the async worker thread include the correct X-MLFLOW-WORKSPACE header
+                without mutating process-wide environment variables.
         """
-        returned_trace_info = None
-        try:
-            if trace:
-                add_size_stats_to_trace_metadata(trace)
-                returned_trace_info = self._client.start_trace(trace.info)
+        with ServerWorkspaceContext(workspace) if workspace else nullcontext():
+            returned_trace_info = None
+            try:
+                if trace:
+                    add_size_stats_to_trace_metadata(trace)
+                    returned_trace_info = self._client.start_trace(trace.info)
 
-                if self._should_log_spans_to_artifacts(returned_trace_info):
-                    self._client._upload_trace_data(returned_trace_info, trace.data)
-            else:
-                _logger.warning("No trace or trace info provided, unable to export")
-        except Exception as e:
-            _logger.warning(
-                f"Failed to send trace to MLflow backend: {e}",
-                exc_info=_logger.isEnabledFor(logging.DEBUG),
-            )
+                    if self._should_log_spans_to_artifacts(returned_trace_info):
+                        self._client._upload_trace_data(returned_trace_info, trace.data)
+                else:
+                    _logger.warning("No trace or trace info provided, unable to export")
+            except Exception as e:
+                _logger.warning(
+                    f"Failed to send trace to MLflow backend: {e}",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
 
-        # Upload attachments in a separate try-except so trace data still lands
-        # even if attachment upload fails. Runs regardless of span storage mode —
-        # in TRACKING_STORE mode, spans are in the DB but attachments still go
-        # to the artifact repo via the mlflow.artifactLocation tag.
-        try:
-            if trace and returned_trace_info:
-                attachments = {}
-                for span in trace.data.spans:
-                    attachments.update(span._attachments)
-                if attachments:
-                    self._client._upload_attachments(returned_trace_info, attachments)
-        except Exception as e:
-            _logger.warning(
-                f"Failed to upload trace attachments: {e}",
-                exc_info=_logger.isEnabledFor(logging.DEBUG),
-            )
+            # Upload attachments in a separate try-except so trace data still lands
+            # even if attachment upload fails. Runs regardless of span storage mode —
+            # in TRACKING_STORE mode, spans are in the DB but attachments still go
+            # to the artifact repo via the mlflow.artifactLocation tag.
+            try:
+                if trace and returned_trace_info:
+                    attachments = {}
+                    for span in trace.data.spans:
+                        attachments.update(span._attachments)
+                    if attachments:
+                        self._client._upload_attachments(returned_trace_info, attachments)
+            except Exception as e:
+                _logger.warning(
+                    f"Failed to upload trace attachments: {e}",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
 
-        try:
-            # Always run prompt linking asynchronously since (1) prompt linking API calls
-            # would otherwise add latency to the export procedure and (2) prompt linking is not
-            # critical for trace export (if the prompt fails to link, the user's workflow is
-            # minorly affected), so we don't have to await successful linking
-            try_link_prompts_to_trace(
-                client=self._client,
-                trace_id=trace.info.trace_id,
-                prompts=prompts,
-                synchronous=False,
-            )
-        except Exception as e:
-            _logger.warning(f"Failed to link prompts to trace: {e}")
+            try:
+                # Always run prompt linking asynchronously since (1) prompt linking API calls
+                # would otherwise add latency to the export procedure and (2) prompt linking is
+                # not critical for trace export (if the prompt fails to link, the user's workflow
+                # is minorly affected), so we don't have to await successful linking
+                try_link_prompts_to_trace(
+                    client=self._client,
+                    trace_id=trace.info.trace_id,
+                    prompts=prompts,
+                    synchronous=False,
+                )
+            except Exception as e:
+                _logger.warning(f"Failed to link prompts to trace: {e}")
 
     def _should_enable_async_logging(self) -> bool:
         if is_in_databricks_notebook():

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -11,6 +11,7 @@ from mlflow.tracing.constant import TraceTagKey
 from mlflow.tracing.utils.prompt import update_linked_prompts_tag
 from mlflow.tracing.utils.timeout import get_trace_cache_with_timeout
 from mlflow.tracing.utils.truncation import set_request_response_preview
+from mlflow.utils.workspace_context import get_request_workspace
 
 _logger = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ class _Trace:
     span_dict: dict[str, LiveSpan] = field(default_factory=dict)
     prompts: list[PromptVersion] = field(default_factory=list)
     is_remote_trace: bool = False
+    workspace: str | None = None
 
     def to_mlflow_trace(self) -> Trace:
         trace_data = TraceData()
@@ -49,6 +51,7 @@ class ManagerTrace:
     trace: Trace
     prompts: Sequence[PromptVersion]
     is_remote_trace: bool = False
+    workspace: str | None = None
 
 
 class InMemoryTraceManager:
@@ -89,7 +92,11 @@ class InMemoryTraceManager:
         # Check for a new timeout setting whenever a new trace is created.
         self._check_timeout_update()
         with self._lock:
-            self._traces[trace_info.trace_id] = _Trace(trace_info, is_remote_trace=is_remote_trace)
+            self._traces[trace_info.trace_id] = _Trace(
+                trace_info,
+                is_remote_trace=is_remote_trace,
+                workspace=get_request_workspace(),
+            )
             self._otel_id_to_mlflow_trace_id[otel_trace_id] = trace_info.trace_id
 
     def register_span(self, span: LiveSpan):
@@ -199,6 +206,7 @@ class InMemoryTraceManager:
                 trace=internal_trace.to_mlflow_trace(),
                 prompts=internal_trace.prompts,
                 is_remote_trace=internal_trace.is_remote_trace,
+                workspace=internal_trace.workspace,
             )
 
     def _check_timeout_update(self):

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -798,8 +798,6 @@ def test_async_export_preserves_workspace_context(monkeypatch):
 
     trace_manager = InMemoryTraceManager.get_instance()
     trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
-    trace_manager.register_trace(otel_span.context.trace_id, trace_info)
-    trace_manager.register_span(span)
 
     with (
         mock.patch(
@@ -815,13 +813,18 @@ def test_async_export_preserves_workspace_context(monkeypatch):
     ):
         exporter = MlflowV3SpanExporter()
 
-        # Set a workspace on the originating thread, then export.
-        # The workspace must survive the async hop to the worker thread.
+        # Capture workspace on the originating thread at trace registration time.
         with WorkspaceContext("test-workspace"):
-            exporter.export([otel_span])
+            trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+            trace_manager.register_span(span)
 
-        # After exiting WorkspaceContext, the workspace is cleared on this thread.
-        # The async worker thread should still see "test-workspace".
+        # Context exited: the originating thread no longer has a workspace.
+        assert get_request_workspace() is None
+
+        # Export the span — the async queue dispatches to a worker thread.
+        exporter.export([otel_span])
+
+        # Flush the async queue to ensure the worker thread has completed.
         exporter._async_queue.flush(terminate=True)
 
     # start_trace (called inside _log_trace) should see the workspace on the worker thread
@@ -845,22 +848,27 @@ def test_async_export_preserves_workspace_context(monkeypatch):
 
 def test_bsp_export_preserves_workspace_context(monkeypatch):
     """
-    Regression test verifying that BatchSpanProcessor (BSP) thread hops preserve
+    Regression test verifying that BatchSpanProcessor (BSP) daemon thread hops preserve
     the workspace context captured on the originating thread at trace creation time.
+
+    Uses a real BatchSpanProcessor so the export runs on the BSP's own daemon worker
+    thread, not the originating thread.
     """
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
     from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
 
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
 
-    captured_log_spans_workspace = []
     captured_start_trace_workspace = []
-
-    def mock_log_spans(*args, **kwargs):
-        captured_log_spans_workspace.append(get_request_workspace())
+    captured_log_spans_workspace = []
 
     def mock_start_trace(*args, **kwargs):
         captured_start_trace_workspace.append(get_request_workspace())
         return trace_info
+
+    def mock_log_spans(*args, **kwargs):
+        captured_log_spans_workspace.append(get_request_workspace())
 
     now_ns = int(time.time() * 1e9)
     otel_span = create_mock_otel_span(
@@ -877,29 +885,42 @@ def test_bsp_export_preserves_workspace_context(monkeypatch):
     trace_manager = InMemoryTraceManager.get_instance()
     trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
 
-    with WorkspaceContext("bsp-workspace"):
-        trace_manager.register_trace(otel_span.context.trace_id, trace_info)
-        trace_manager.register_span(span)
-
-    exporter = MlflowV3SpanExporter()
-
     with (
-        mock.patch(
-            "mlflow.tracing.client.TracingClient.log_spans",
-            side_effect=mock_log_spans,
-        ),
         mock.patch(
             "mlflow.tracing.client.TracingClient.start_trace",
             side_effect=mock_start_trace,
         ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.log_spans",
+            side_effect=mock_log_spans,
+        ),
         mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
         mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
     ):
-        exporter.export([otel_span])
+        exporter = MlflowV3SpanExporter()
+        bsp = BatchSpanProcessor(exporter, max_export_batch_size=1)
 
+        # Capture workspace on the originating thread at trace registration time.
+        with WorkspaceContext("bsp-workspace"):
+            trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+            trace_manager.register_span(span)
+
+        # Context exited: the originating thread no longer has a workspace.
+        assert get_request_workspace() is None
+
+        # Enqueue the span — BSP daemon thread picks it up and calls
+        # exporter.export([span]) on its own thread.
+        bsp.on_end(otel_span)
+
+        # Deterministically drain: shutdown() joins the worker thread after it
+        # has exported everything queued.
+        bsp.shutdown()
+
+    # Assert workspace survived the BSP daemon thread hop
     assert len(captured_start_trace_workspace) == 1
     assert captured_start_trace_workspace[0] == "bsp-workspace"
     assert len(captured_log_spans_workspace) == 1
     assert captured_log_spans_workspace[0] == "bsp-workspace"
+
 
 

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -758,3 +758,148 @@ def test_deferred_root_span_export(monkeypatch):
         exporter.export([child_otel_span_closed])
         mock_start_trace.assert_called_once()
         mock_upload_trace_data.assert_called_once()
+
+
+def test_async_export_preserves_workspace_context(monkeypatch):
+    """
+    Regression test for #24093: async trace export must carry the workspace
+    set on the originating thread through to the worker thread so that
+    http_request() includes the correct X-MLFLOW-WORKSPACE header.
+    """
+    from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
+
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "true")
+    # Disable batch span processor — this test verifies exporter-level async logging
+    monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "false")
+
+    # Captured workspace values seen inside the client methods on the worker thread.
+    # These methods execute *inside* the WorkspaceContext wrapper applied by _log_spans/_log_trace.
+    captured_log_spans_workspace = []
+    captured_start_trace_workspace = []
+
+    def mock_log_spans(*args, **kwargs):
+        captured_log_spans_workspace.append(get_request_workspace())
+
+    def mock_start_trace(*args, **kwargs):
+        captured_start_trace_workspace.append(get_request_workspace())
+        return trace_info
+
+    now_ns = int(time.time() * 1e9)
+    otel_span = create_mock_otel_span(
+        name="root",
+        trace_id=99999,
+        span_id=1,
+        parent_id=None,
+        start_time=now_ns - 1_000_000,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+    trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+    trace_manager.register_span(span)
+
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.log_spans",
+            side_effect=mock_log_spans,
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.start_trace",
+            side_effect=mock_start_trace,
+        ),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+    ):
+        exporter = MlflowV3SpanExporter()
+
+        # Set a workspace on the originating thread, then export.
+        # The workspace must survive the async hop to the worker thread.
+        with WorkspaceContext("test-workspace"):
+            exporter.export([otel_span])
+
+        # After exiting WorkspaceContext, the workspace is cleared on this thread.
+        # The async worker thread should still see "test-workspace".
+        exporter._async_queue.flush(terminate=True)
+
+    # start_trace (called inside _log_trace) should see the workspace on the worker thread
+    assert len(captured_start_trace_workspace) == 1, (
+        f"Expected start_trace to be called once, got {len(captured_start_trace_workspace)}"
+    )
+    assert captured_start_trace_workspace[0] == "test-workspace", (
+        f"Expected workspace 'test-workspace' on worker thread, "
+        f"got '{captured_start_trace_workspace[0]}'"
+    )
+
+    # log_spans (called inside _log_spans) should see the workspace on the worker thread
+    assert len(captured_log_spans_workspace) == 1, (
+        f"Expected log_spans to be called once, got {len(captured_log_spans_workspace)}"
+    )
+    assert captured_log_spans_workspace[0] == "test-workspace", (
+        f"Expected workspace 'test-workspace' on worker thread, "
+        f"got '{captured_log_spans_workspace[0]}'"
+    )
+
+
+def test_bsp_export_preserves_workspace_context(monkeypatch):
+    """
+    Regression test verifying that BatchSpanProcessor (BSP) thread hops preserve
+    the workspace context captured on the originating thread at trace creation time.
+    """
+    from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
+
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+
+    captured_log_spans_workspace = []
+    captured_start_trace_workspace = []
+
+    def mock_log_spans(*args, **kwargs):
+        captured_log_spans_workspace.append(get_request_workspace())
+
+    def mock_start_trace(*args, **kwargs):
+        captured_start_trace_workspace.append(get_request_workspace())
+        return trace_info
+
+    now_ns = int(time.time() * 1e9)
+    otel_span = create_mock_otel_span(
+        name="root",
+        trace_id=88888,
+        span_id=1,
+        parent_id=None,
+        start_time=now_ns - 1_000_000,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+
+    with WorkspaceContext("bsp-workspace"):
+        trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+        trace_manager.register_span(span)
+
+    exporter = MlflowV3SpanExporter()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.log_spans",
+            side_effect=mock_log_spans,
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.start_trace",
+            side_effect=mock_start_trace,
+        ),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+    ):
+        exporter.export([otel_span])
+
+    assert len(captured_start_trace_workspace) == 1
+    assert captured_start_trace_workspace[0] == "bsp-workspace"
+    assert len(captured_log_spans_workspace) == 1
+    assert captured_log_spans_workspace[0] == "bsp-workspace"
+
+

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -21,7 +21,6 @@ from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import generate_trace_id_v3
-
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info
 
 _EXPERIMENT_ID = "dummy-experiment-id"

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -21,6 +21,7 @@ from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import generate_trace_id_v3
+
 from tests.tracing.helper import create_mock_otel_span, create_test_trace_info
 
 _EXPERIMENT_ID = "dummy-experiment-id"

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -921,6 +921,3 @@ def test_bsp_export_preserves_workspace_context(monkeypatch):
     assert captured_start_trace_workspace[0] == "bsp-workspace"
     assert len(captured_log_spans_workspace) == 1
     assert captured_log_spans_workspace[0] == "bsp-workspace"
-
-
-


### PR DESCRIPTION
When workspaces are enabled and async trace logging is active (default), `AsyncTraceExportQueue` dispatches export tasks to `ThreadPoolExecutor` worker threads that start with a fresh `contextvars` context. The `_WORKSPACE` ContextVar set by `WorkspaceContext` on the originating thread was invisible to them, causing traces to land in the default workspace.

Fix: capture `get_request_workspace()` at task-creation time (on the originating thread) and pass it through `Task.args`. Apply `WorkspaceContext(workspace)` on the worker thread before making HTTP calls. This follows the same pattern already used for `experiment_id`.

The sync path is unchanged: `workspace` defaults to `None`, `nullcontext()` is used as a no-op wrapper.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24093

### What changes are proposed in this pull request?

- **`mlflow/tracing/export/mlflow_v3.py`**:
  - Added imports: `nullcontext` from `contextlib`, `WorkspaceContext` and `get_request_workspace` from `mlflow.utils.workspace_context`
  - `_export_spans_incrementally`: capture `get_request_workspace()` on the originating thread and pass it as a 3rd arg in `Task.args`
  - `_do_export_trace`: same — capture workspace and thread it through `Task.args`
  - `_log_spans`: accept optional `workspace` param; wrap body with `WorkspaceContext(workspace) if workspace else nullcontext()`
  - `_log_trace`: same pattern
- Sync path is completely unaffected (`workspace=None` → `nullcontext()` → no-op)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_async_export_preserves_workspace_context` in `tests/tracing/export/test_mlflow_v3_exporter.py` — sets `WorkspaceContext("test-workspace")` on the originating thread, exports a span via the async queue, flushes, and asserts that both `TracingClient.start_trace` and `TracingClient.log_spans` see `"test-workspace"` via `get_request_workspace()` on the worker thread. All 16 existing tests continue to pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Async trace export now correctly preserves the workspace context, so traces land in the intended workspace instead of the default one when `MLFLOW_ENABLE_WORKSPACES=true`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
