### PR TITLE
fix(artifact): convert Windows absolute paths to file URIs before urlparse

### DIFF
--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -79,6 +79,13 @@ def _get_root_uri_and_artifact_path(artifact_uri):
         else:  # if we're dealing with nt-based systems, we need to utilize pathname2url to encode.
             artifact_uri = path_to_local_file_uri(artifact_uri)
 
+    # On Windows, absolute paths (e.g. "C:\path\to\artifact") that don't yet
+    # exist on disk bypass the os.path.exists() branch above and reach urlparse
+    # directly. urlparse incorrectly interprets the drive letter as a URL scheme
+    # (e.g. scheme='c'), causing a "Could not find a registered artifact
+    # repository" error. Convert to a file:// URI before parsing.
+    if is_windows() and pathlib.PureWindowsPath(str(artifact_uri)).drive:
+        artifact_uri = path_to_local_file_uri(str(artifact_uri))
     parsed_uri = urllib.parse.urlparse(str(artifact_uri))
     prefix = ""
     if parsed_uri.scheme and not parsed_uri.path.startswith("/"):

--- a/tests/tracking/test_artifact_utils.py
+++ b/tests/tracking/test_artifact_utils.py
@@ -148,3 +148,30 @@ def test_upload_artifacts_to_uri(tmp_path):
     )
     with open(downloaded_artifact_path) as f:
         assert f.read() == artifact_text
+
+
+def test_get_root_uri_and_artifact_path_with_windows_absolute_path_not_on_disk():
+    """
+    Regression test for https://github.com/mlflow/mlflow/issues/2783.
+    On Windows, absolute paths that don't exist on disk (e.g. "C:\\path\\to\\artifact")
+    bypass the os.path.exists() branch and reach urlparse directly. urlparse incorrectly
+    treats the drive letter as a URL scheme (e.g. scheme='c'), causing a
+    "Could not find a registered artifact repository" error.
+    """
+    from mlflow.tracking.artifact_utils import _get_root_uri_and_artifact_path
+
+    windows_path = "C:\\Users\\test\\artifacts\\model"
+    expected_file_uri = "file:///C:/Users/test/artifacts/model"
+
+    with (
+        mock.patch("mlflow.tracking.artifact_utils.is_windows", return_value=True),
+        mock.patch("os.path.exists", return_value=False),
+        mock.patch(
+            "mlflow.tracking.artifact_utils.path_to_local_file_uri",
+            return_value=expected_file_uri,
+        ),
+    ):
+        root_uri, artifact_path = _get_root_uri_and_artifact_path(windows_path)
+
+    assert root_uri == "file:///C:/Users/test/artifacts"
+    assert artifact_path == "model"


### PR DESCRIPTION
Closes #2783

### What changes are proposed in this pull request?

When a Windows absolute path (e.g. `C:\Users\test\artifacts\model`) does not exist on disk yet, it bypasses the `os.path.exists()` branch in `_get_root_uri_and_artifact_path` and reaches `urlparse` directly. `urlparse` incorrectly interprets the drive letter as a URL scheme (e.g. `scheme='c'`), causing a `MlflowException: Could not find a registered artifact repository for: c`.

Added a check using `pathlib.PureWindowsPath.drive` to detect Windows absolute paths before calling `urlparse`, and converts them to `file://` URIs via the existing `path_to_local_file_uri` utility.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_get_root_uri_and_artifact_path_with_windows_absolute_path_not_on_disk` in `tests/tracking/test_artifact_utils.py`. The test mocks `is_windows()` and `path_to_local_file_uri` to simulate Windows behavior in a cross-platform CI environment.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a crash when passing a non-existent Windows absolute path as an artifact URI on Windows systems.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release