### PR TITLE
Fix promo modal focus (aria-hidden) and show it on the empty models page

### DIFF
--- a/mlflow/server/js/src/model-registry/components/ModelListView.enzyme.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelListView.enzyme.test.tsx
@@ -8,6 +8,7 @@
 import { jest, describe, beforeEach, test, expect } from '@jest/globals';
 import React from 'react';
 import { ModelListView, ModelListViewImpl } from './ModelListView';
+import { ModelsNextUIPromoModalAuto } from './ModelsNextUIPromoModalAuto';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 import Utils from '../../common/utils/Utils';
 import configureStore from 'redux-mock-store';
@@ -67,6 +68,10 @@ describe('ModelListView', () => {
       showOnboardingHelper: false,
     });
     expect(wrapper.find("[data-testid='showOnboardingHelper']").length).toBe(0);
+  });
+  test('renders the new models UI promo modal even when there are no registered models', () => {
+    wrapper = setupModelListViewWithIntl(minimalProps);
+    expect(wrapper.find(ModelsNextUIPromoModalAuto).length).toBeGreaterThan(0);
   });
   test('Page title is set', () => {
     const mockUpdatePageTitle = jest.fn();

--- a/mlflow/server/js/src/model-registry/components/ModelListView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelListView.tsx
@@ -32,6 +32,7 @@ import { shouldShowModelsNextUI, shouldEnableWorkspaces } from '../../common/uti
 import { ModelListFilters } from './model-list/ModelListFilters';
 import { ModelListTable } from './model-list/ModelListTable';
 import { ModelsNextUIToggleSwitch } from './ModelsNextUIToggleSwitch';
+import { ModelsNextUIPromoModalAuto } from './ModelsNextUIPromoModalAuto';
 import { withNextModelsUIContext } from '../hooks/useNextModelsUI';
 import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
 
@@ -194,6 +195,7 @@ export class ModelListViewImpl extends React.Component<ModelListViewImplProps, M
 
     return (
       <>
+        {shouldShowModelsNextUI() && <ModelsNextUIPromoModalAuto />}
         <Spacer shrinks={false} />
         <PageHeader title={<ModelListPageTitle />} spacerSize="xs">
           {showCreationButtons && <CreateModelButton />}

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModal.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModal.test.tsx
@@ -1,0 +1,20 @@
+import { jest, describe, test, expect } from '@jest/globals';
+import { renderWithIntl, screen, within, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { ModelsNextUIPromoModal } from './ModelsNextUIPromoModal';
+
+describe('ModelsNextUIPromoModal', () => {
+  test('renders the promo content when visible', () => {
+    renderWithIntl(<ModelsNextUIPromoModal visible onClose={jest.fn()} onTryItNow={jest.fn()} />);
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/Flexible, governed deployments/)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /Try it now/ })).toBeInTheDocument();
+  });
+
+  // Regression for #24257: on open, focus must land on a real control (the primary button)
+  // rather than resting on the dialog's aria-hidden focus-trap sentinel.
+  test('moves focus to the primary action when opened', async () => {
+    renderWithIntl(<ModelsNextUIPromoModal visible onClose={jest.fn()} onTryItNow={jest.fn()} />);
+    const tryItNow = screen.getByRole('button', { name: /Try it now/ });
+    await waitFor(() => expect(tryItNow).toHaveFocus());
+  });
+});

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModal.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModal.tsx
@@ -1,15 +1,8 @@
+import { useCallback, useRef } from 'react';
 import { Button, Modal, Typography } from '@databricks/design-system';
 import { ReactComponent as PromoContentSvg } from '../../common/static/promo-modal-content.svg';
 import { FormattedMessage } from 'react-intl';
 import { modelStagesMigrationGuideLink } from '../../common/constants';
-
-let pendingFocus: number | undefined;
-const focusPrimaryAction = (node: HTMLButtonElement | null) => {
-  if (pendingFocus !== undefined) {
-    window.clearTimeout(pendingFocus);
-  }
-  pendingFocus = node ? window.setTimeout(() => node.focus(), 0) : undefined;
-};
 
 export const ModelsNextUIPromoModal = ({
   visible,
@@ -19,55 +12,67 @@ export const ModelsNextUIPromoModal = ({
   visible: boolean;
   onClose: () => void;
   onTryItNow: () => void;
-}) => (
-  <Modal
-    componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_15"
-    visible={visible}
-    title={
-      <FormattedMessage
-        defaultMessage="Flexible, governed deployments with the new Model Registry UI"
-        description="Model registry > OSS Promo modal for model version aliases > modal title"
-      />
+}) => {
+  const pendingFocusRef = useRef<number>();
+  // Move focus onto the primary action once the modal has mounted so it does not land on the
+  // aria-hidden focus-trap sentinel. Clear any pending focus if the ref is re-invoked or detached.
+  const focusPrimaryAction = useCallback((node: HTMLButtonElement | null) => {
+    if (pendingFocusRef.current !== undefined) {
+      window.clearTimeout(pendingFocusRef.current);
     }
-    onCancel={onClose}
-    footer={
-      <>
-        <Button
-          componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_26"
-          href={modelStagesMigrationGuideLink}
-          rel="noopener"
-          target="_blank"
-        >
-          <FormattedMessage
-            defaultMessage="Learn more"
-            description="Model registry > OSS Promo modal for model version aliases > learn more link"
-          />
-        </Button>
-        <Button
-          componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_32"
-          ref={focusPrimaryAction}
-          type="primary"
-          onClick={onTryItNow}
-        >
-          <FormattedMessage
-            defaultMessage="Try it now"
-            description="Model registry > OSS Promo modal for model version aliases > try it now button label"
-          />
-        </Button>
-      </>
-    }
-  >
-    <PromoContentSvg width="100%" />
-    <Typography.Text>
-      <FormattedMessage
-        defaultMessage={`With the latest Model Registry UI, you can use <b>Model Aliases</b> for flexible 
+    pendingFocusRef.current = node ? window.setTimeout(() => node.focus(), 0) : undefined;
+  }, []);
+
+  return (
+    <Modal
+      componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_15"
+      visible={visible}
+      title={
+        <FormattedMessage
+          defaultMessage="Flexible, governed deployments with the new Model Registry UI"
+          description="Model registry > OSS Promo modal for model version aliases > modal title"
+        />
+      }
+      onCancel={onClose}
+      footer={
+        <>
+          <Button
+            componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_26"
+            href={modelStagesMigrationGuideLink}
+            rel="noopener"
+            target="_blank"
+          >
+            <FormattedMessage
+              defaultMessage="Learn more"
+              description="Model registry > OSS Promo modal for model version aliases > learn more link"
+            />
+          </Button>
+          <Button
+            componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_32"
+            ref={focusPrimaryAction}
+            type="primary"
+            onClick={onTryItNow}
+          >
+            <FormattedMessage
+              defaultMessage="Try it now"
+              description="Model registry > OSS Promo modal for model version aliases > try it now button label"
+            />
+          </Button>
+        </>
+      }
+    >
+      <PromoContentSvg width="100%" />
+      <Typography.Text>
+        <FormattedMessage
+          defaultMessage={`With the latest Model Registry UI, you can use <b>Model Aliases</b> for flexible 
         references to specific model versions, streamlining deployment in a given environment. Use 
         <b>Model Tags</b> to annotate model versions with metadata, like the status of pre-deployment checks.`}
-        description="Model registry > OSS Promo modal for model version aliases > description paragraph body"
-        values={{
-          b: (chunks: any) => <b>{chunks}</b>,
-        }}
-      />
-    </Typography.Text>
-  </Modal>
-);
+          description="Model registry > OSS Promo modal for model version aliases > description paragraph body"
+          values={{
+            b: (chunks: any) => <b>{chunks}</b>,
+          }}
+        />
+      </Typography.Text>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModal.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModal.tsx
@@ -3,6 +3,14 @@ import { ReactComponent as PromoContentSvg } from '../../common/static/promo-mod
 import { FormattedMessage } from 'react-intl';
 import { modelStagesMigrationGuideLink } from '../../common/constants';
 
+let pendingFocus: number | undefined;
+const focusPrimaryAction = (node: HTMLButtonElement | null) => {
+  if (pendingFocus !== undefined) {
+    window.clearTimeout(pendingFocus);
+  }
+  pendingFocus = node ? window.setTimeout(() => node.focus(), 0) : undefined;
+};
+
 export const ModelsNextUIPromoModal = ({
   visible,
   onClose,
@@ -37,6 +45,7 @@ export const ModelsNextUIPromoModal = ({
         </Button>
         <Button
           componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuipromomodal.tsx_32"
+          ref={focusPrimaryAction}
           type="primary"
           onClick={onTryItNow}
         >

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModalAuto.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModalAuto.test.tsx
@@ -1,0 +1,33 @@
+import { jest, describe, test, expect } from '@jest/globals';
+import { renderWithIntl, screen, within } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { withNextModelsUIContext } from '../hooks/useNextModelsUI';
+import { ModelsNextUIPromoModalAuto } from './ModelsNextUIPromoModalAuto';
+
+jest.mock('../../common/utils/FeatureUtils', () => ({
+  shouldShowModelsNextUI: () => true,
+}));
+
+describe('ModelsNextUIPromoModalAuto', () => {
+  const renderComponent = () => {
+    const Component = withNextModelsUIContext(() => <ModelsNextUIPromoModalAuto />);
+    return renderWithIntl(<Component />);
+  };
+
+  const mockSeenPromoModal = () =>
+    jest.spyOn(window.localStorage, 'getItem').mockImplementation((key) => (key.match(/promo/) ? 'true' : ''));
+
+  const mockUnseenPromoModal = () =>
+    jest.spyOn(window.localStorage, 'getItem').mockImplementation((key) => (key.match(/promo/) ? 'false' : ''));
+
+  test('it displays the promo modal when not previously seen (independent of any models)', () => {
+    mockUnseenPromoModal();
+    renderComponent();
+    expect(within(screen.getByRole('dialog')).getByText(/Flexible, governed deployments/)).toBeInTheDocument();
+  });
+
+  test('it does not display the promo modal when already seen', () => {
+    mockSeenPromoModal();
+    renderComponent();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModalAuto.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIPromoModalAuto.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useLocalStorage } from '@databricks/web-shared/hooks';
+import { ModelsNextUIPromoModal } from './ModelsNextUIPromoModal';
+import { useNextModelsUIContext } from '../hooks/useNextModelsUI';
+
+const promoModalSeenStorageKey = '_mlflow_model_registry_promo_modal_dismissed';
+
+export const ModelsNextUIPromoModalAuto = () => {
+  const { setUsingNextModelsUI } = useNextModelsUIContext();
+  const [promoModalVisited, setPromoModalVisited] = useLocalStorage({
+    key: promoModalSeenStorageKey,
+    version: 1,
+    initialValue: false,
+  });
+  const [promoModalVisible, setPromoModalVisible] = useState(!promoModalVisited);
+
+  const dismiss = () => {
+    setPromoModalVisible(false);
+    setPromoModalVisited(true);
+  };
+
+  return (
+    <ModelsNextUIPromoModal
+      visible={promoModalVisible}
+      onClose={dismiss}
+      onTryItNow={() => {
+        setUsingNextModelsUI(true);
+        dismiss();
+      }}
+    />
+  );
+};

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIToggleSwitch.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIToggleSwitch.test.tsx
@@ -28,18 +28,11 @@ describe('ModelsNextUIToggleSwitch', () => {
   const mockUnseenPromoModal = () =>
     jest.spyOn(window.localStorage, 'getItem').mockImplementation((key) => (key.match(/promo/) ? 'false' : ''));
 
-  test('it should render the switch and display the promo modal', () => {
+  test('it should render the switch without the promo modal (promo is rendered at the page level)', () => {
     mockUnseenPromoModal();
 
     renderTestComponent();
     expect(screen.getByRole('switch', { name: /New model registry UI/ })).toBeInTheDocument();
-    expect(within(screen.getByRole('dialog')).getByText(/Flexible, governed deployments/)).toBeInTheDocument();
-  });
-
-  test("it should not render display the promo modal when it's already seen", () => {
-    mockSeenPromoModal();
-    renderTestComponent();
-    expect(screen.getByRole('switch')).toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 

--- a/mlflow/server/js/src/model-registry/components/ModelsNextUIToggleSwitch.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelsNextUIToggleSwitch.tsx
@@ -1,25 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { ModelsNextUIPromoModal } from './ModelsNextUIPromoModal';
 import { Modal, Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { useNextModelsUIContext } from '../hooks/useNextModelsUI';
-
-const promoModalSeenStorageKey = '_mlflow_model_registry_promo_modal_dismissed';
 
 export const ModelsNextUIToggleSwitch = () => {
   const { usingNextModelsUI, setUsingNextModelsUI } = useNextModelsUIContext();
 
-  // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-  const promoModalVisited = window.localStorage.getItem(promoModalSeenStorageKey) === 'true';
-
-  const [promoModalVisible, setPromoModalVisible] = useState(!promoModalVisited);
   const [confirmDisableModalVisible, setConfirmDisableModalVisible] = useState(false);
-
-  const setPromoModalVisited = useCallback(() => {
-    setPromoModalVisible(false);
-    // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-    window.localStorage.setItem(promoModalSeenStorageKey, 'true');
-  }, []);
 
   const intl = useIntl();
   const label = intl.formatMessage({
@@ -45,15 +32,6 @@ export const ModelsNextUIToggleSwitch = () => {
           onChange={switchNextUI}
         />
       </div>
-      <ModelsNextUIPromoModal
-        visible={promoModalVisible}
-        onClose={() => {
-          setPromoModalVisited();
-        }}
-        onTryItNow={() => {
-          setPromoModalVisited();
-        }}
-      />
       <Modal
         componentId="codegen_mlflow_app_src_model-registry_components_modelsnextuitoggleswitch.tsx_50"
         visible={confirmDisableModalVisible}


### PR DESCRIPTION
### Related Issues/PRs

Closes #24257

### What changes are proposed in this pull request?

Two related changes to the "new Model Registry UI" promo modal (`ModelsNextUIPromoModal`) on the model registry page:

**1. Fix focus landing on the `aria-hidden` sentinel (closes #24257).**

Opening the promo modal logs a console warning and can cause the modal to lose focus / dismiss itself:

> Blocked aria-hidden on an element because its descendant retained focus. … Consider using the `inert` attribute instead.

When the dialog opens, focus can land on the dialog's focus-trap sentinel — a hidden `<div tabindex="0" aria-hidden="true">`. Having focus rest on an `aria-hidden` element is what triggers the warning (and the focus loss). This moves focus onto the primary **"Try it now"** button once the dialog mounts, so focus no longer rests on the sentinel. The focus call is deferred (`setTimeout(…, 0)`) so it runs after the dialog's own initial focus handling, and the pending timeout is tracked/cleared via a `useRef` inside the component. No visual or copy changes.

**2. Show the promo modal on the empty models page.**

Previously the promo was rendered from `ModelsNextUIToggleSwitch`, which only mounts in the models-table pagination footer — and that footer is not rendered on the empty state. So users with no registered models never saw the promo. This moves the promo into a page-level `ModelsNextUIPromoModalAuto` component rendered from `ModelListView`, so it appears regardless of model count (including the empty state). It keeps the same once-per-browser `localStorage` gate, and **"Try it now"** now enables the new Models UI directly since there is no toggle switch to flip on the empty page.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

- `ModelsNextUIPromoModal.test.tsx` — asserts the modal renders and focus lands on the primary button when it opens.
- `ModelsNextUIPromoModalAuto.test.tsx` — asserts the page-level promo shows when unseen and stays hidden once dismissed.
- `ModelListView.enzyme.test.tsx` — asserts the promo mounts even when there are no registered models.
- `ModelsNextUIToggleSwitch.test.tsx` — updated, since the promo no longer lives in the toggle switch.

Manually, on `/#/models` the `aria-hidden` console warning is gone, the promo modal stays open, and the promo now also appears on the empty models page.
<img width="1499" height="870" alt="model_focus_fix" src="https://github.com/user-attachments/assets/ed5fd82a-354e-4ba6-913e-aba17c829a52" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes the new Model Registry UI promo modal losing focus / dismissing itself and emitting an `aria-hidden` accessibility warning on the model registry page, and shows the promo on the empty models page.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
