### PR TITLE
fix: stamp initial Alembic revision after creating tables to prevent 'Table already exists' error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,6 +86,12 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
+    # Stamp the database with the initial Alembic revision to prevent
+    # subsequent _upgrade_db from trying to create tables that already exist.
+    from alembic.command import stamp
+    from mlflow.store.db.utils import _get_alembic_config
+    config = _get_alembic_config(engine.url)
+    stamp(config, revision="head")
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after upgrading to MLflow 3.8.x, the migration fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` creates all tables defined in `InitialBase.metadata`, then calls `_upgrade_db`, which runs Alembic migrations that attempt to create tables like 'secrets' that were already created by the initial schema. Since there is no Alembic revision stamp, Alembic treats the database as empty and re-runs all migrations.

## Fix
After `InitialBase.metadata.create_all(engine)`, stamp the database with the current Alembic head revision using `alembic.command.stamp`. This informs Alembic that the initial schema is already in place, so subsequent migration steps only apply delta changes without attempting to re-create existing tables.

Closes #19943