### PR TITLE
Match any non-zero exit code in `test_host_invalid_value`

### DIFF
--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -783,7 +783,7 @@ def test_host_invalid_value():
         "mlflow.models.cli.get_flavor_backend",
         return_value=PyFuncBackend({}, env_manager=_EnvManager.VIRTUALENV),
     ):
-        with pytest.raises(ShellCommandException, match=r"Non-zero exit code: 1"):
+        with pytest.raises(ShellCommandException, match=r"Non-zero exit code: -?[1-9]\d*"):
             CliRunner().invoke(
                 models_cli.serve,
                 ["--model-uri", model_info.model_uri, "--host", "localhost & echo BUG"],


### PR DESCRIPTION
### Related Issues/PRs

Unblocks CI

### What changes are proposed in this pull request?

`test_host_invalid_value` hard-codes `Non-zero exit code: 1`, but since uvicorn was unpinned in #23588 (0.46.0 → 0.49.0), a malformed `--host` fails at socket bind and uvicorn exits with `STARTUP_FAILURE` (3) instead of 1. The test now fails deterministically on master.

The test's purpose is to confirm the injected host string (`localhost & echo BUG`) stays quoted and the command exits non-zero — the specific exit code is an incidental uvicorn internal. Match any non-zero code (`\d+`) instead of `1`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
