### PR TITLE
Fix empty spans.type for OTLP-ingested spans

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4993,6 +4993,17 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     span_cost = span_attributes.get(SpanAttributeKey.LLM_COST)
 
                 content_json = json.dumps(span_dict, cls=TraceJSONEncoder)
+                translated_span_type = _try_parse_json_string(
+                    span_attributes.get(SpanAttributeKey.SPAN_TYPE)
+)
+                if not translated_span_type:
+                    translated_span_type = span.span_type
+
+                if not translated_span_type:
+                    translated_span_type = "UNKNOWN"
+
+
+
 
                 # Prepare dimension attributes with model name and provider if available
                 dimension_attribute_keys = [
@@ -5004,12 +5015,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     if value := span_attributes.get(key):
                         dimension_attributes[key] = _try_parse_json_string(value)
 
-                        translated_span_type = span.span_type
-
-                        if translated_span_type is None:
-                            translated_span_type = _try_parse_json_string(
-                                span_attributes.get(SpanAttributeKey.SPAN_TYPE)
-    )
+                        
 
                 # experiment_id filled in after we resolve trace infos
                 all_span_rows.append({

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5004,6 +5004,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     if value := span_attributes.get(key):
                         dimension_attributes[key] = _try_parse_json_string(value)
 
+                        translated_span_type = span.span_type
+
+                        if translated_span_type is None:
+                            translated_span_type = _try_parse_json_string(
+                                span_attributes.get(SpanAttributeKey.SPAN_TYPE)
+    )
+
                 # experiment_id filled in after we resolve trace infos
                 all_span_rows.append({
                     "trace_id": span.trace_id,
@@ -5011,7 +5018,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     "span_id": span.span_id,
                     "parent_span_id": span.parent_id,
                     "name": span.name,
-                    "type": span.span_type,
+                    "type": translated_span_type,
                     "status": span.status.status_code,
                     "start_time_unix_nano": span.start_time_ns,
                     "end_time_unix_nano": span.end_time_ns,


### PR DESCRIPTION
### Related Issues/PRs

Closes #24237

### What changes are proposed in this pull request?

This PR fixes an issue where the `spans.type` column was left empty for OTLP-ingested spans whose MLflow span type is derived during ingestion.

Previously, `translate_span_when_storing(span)` correctly derived and stored the translated span type in the serialized span content, but the SQL `type` column was populated using the original `span.span_type`, which could remain empty. This caused an inconsistency between the serialized span content and the indexed database column.

This change updates the span insertion logic so that the translated span type is used when populating the SQL `type` column. As a result, the stored database value remains consistent with the serialized span content, allowing OTLP-ingested TOOL and LLM spans to be correctly recognized by span-level trace metrics.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual Testing**

- Verified the updated code path in `SqlAlchemyStore.log_spans`.
- Confirmed that the translated span type is used when populating the `spans.type` database column.
- Verified that the SQL `type` column remains consistent with the serialized span content generated by `translate_span_when_storing(span)`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an issue where OTLP-ingested spans could be stored with an empty `spans.type` column, preventing TOOL and LLM spans from appearing correctly in span-level trace metrics.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release