### PR TITLE
fix: store OpenAI agent Generation span attributes under correct SpanAttributeKey constants

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -12,7 +12,7 @@ from agents.tracing.setup import get_trace_provider
 from mlflow.entities.span import LiveSpan, SpanType
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatus, SpanStatusCode
-from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import (
     get_current_active_span,
     start_span,
@@ -238,8 +238,9 @@ def _parse_span_data(span_data: oai.SpanData) -> tuple[Any, Any, dict[str, Any]]
         attributes = {
             "model": span_data.model,
             "model_config": span_data.model_config,
-            "usage": span_data.usage,
         }
+        if usage := _parse_generation_usage(span_data.usage):
+            attributes[SpanAttributeKey.CHAT_USAGE] = usage
 
     elif span_data.type == OpenAISpanType.RESPONSE:
         inputs, outputs, attributes = _parse_response_span_data(span_data)
@@ -255,6 +256,24 @@ def _parse_span_data(span_data: oai.SpanData) -> tuple[Any, Any, dict[str, Any]]
         outputs = {"triggered": span_data.triggered}
 
     return inputs, outputs, attributes
+
+
+def _parse_generation_usage(usage: dict[str, int] | None) -> dict[str, int] | None:
+    if not usage:
+        return None
+    try:
+        result = {}
+        for key in (
+            TokenUsageKey.INPUT_TOKENS,
+            TokenUsageKey.OUTPUT_TOKENS,
+            TokenUsageKey.TOTAL_TOKENS,
+        ):
+            if (v := usage.get(key)) is not None:
+                result[key] = v
+        return result or None
+    except Exception:
+        _logger.debug("Failed to parse generation span usage", exc_info=True)
+        return None
 
 
 def _parse_response_span_data(span_data: oai.ResponseSpanData) -> tuple[Any, Any, dict[str, Any]]:

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -263,9 +263,18 @@ def _parse_generation_usage(usage: dict[str, int] | None) -> dict[str, int] | No
         return None
     try:
         result = {}
-        for key in TokenUsageKey.all_keys():
+        for key in [
+            TokenUsageKey.INPUT_TOKENS,
+            TokenUsageKey.OUTPUT_TOKENS,
+            TokenUsageKey.TOTAL_TOKENS,
+        ]:
             if (v := usage.get(key)) is not None:
                 result[key] = v
+        if details := usage.get("input_tokens_details"):
+            if (v := details.get("cached_tokens")) is not None:
+                result[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = v
+            if (v := details.get("cache_write_tokens")) is not None:
+                result[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = v
         return result or None
     except Exception:
         _logger.debug("Failed to parse generation span usage", exc_info=True)

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -263,11 +263,7 @@ def _parse_generation_usage(usage: dict[str, int] | None) -> dict[str, int] | No
         return None
     try:
         result = {}
-        for key in (
-            TokenUsageKey.INPUT_TOKENS,
-            TokenUsageKey.OUTPUT_TOKENS,
-            TokenUsageKey.TOTAL_TOKENS,
-        ):
+        for key in TokenUsageKey.all_keys():
             if (v := usage.get(key)) is not None:
                 result[key] = v
         return result or None

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -236,7 +236,7 @@ def _parse_span_data(span_data: oai.SpanData) -> tuple[Any, Any, dict[str, Any]]
         inputs = span_data.input
         outputs = span_data.output
         attributes = {
-            "model": span_data.model,
+            SpanAttributeKey.MODEL: span_data.model,
             "model_config": span_data.model_config,
         }
         if usage := _parse_generation_usage(span_data.usage):

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -534,7 +534,7 @@ def test_autolog_disable_openai_agent_tracer():
     assert isinstance(processors[0], MlflowOpenAgentTracingProcessor)
 
 
-def test_generation_span_token_usage_stored_under_chat_usage_key():
+def test_generation_span_attributes_stored_under_span_attribute_keys():
     from agents.tracing import GenerationSpanData
 
     from mlflow.openai._agent_tracer import _parse_span_data
@@ -555,6 +555,8 @@ def test_generation_span_token_usage_stored_under_chat_usage_key():
 
     _, _, attributes = _parse_span_data(span_data)
 
+    assert attributes.get(SpanAttributeKey.MODEL) == "gpt-4o-mini"
+    assert "model" not in attributes
     assert attributes.get(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 10,
         TokenUsageKey.OUTPUT_TOKENS: 20,
@@ -584,25 +586,6 @@ def test_parse_generation_usage(usage, expected):
     assert _parse_generation_usage(usage) == expected
 
 
-def test_generation_span_model_stored_under_span_attribute_key():
-    from agents.tracing import GenerationSpanData
-
-    from mlflow.openai._agent_tracer import _parse_span_data
-    from mlflow.tracing.constant import SpanAttributeKey
-
-    span_data = mock.MagicMock(spec=GenerationSpanData)
-    span_data.type = "generation"
-    span_data.input = [{"role": "user", "content": "hello"}]
-    span_data.output = [{"role": "assistant", "content": "hi"}]
-    span_data.model = "gpt-4o-mini"
-    span_data.model_config = {}
-    span_data.usage = None
-
-    _, _, attributes = _parse_span_data(span_data)
-
-    assert attributes.get(SpanAttributeKey.MODEL) == "gpt-4o-mini"
-    assert "model" not in attributes
-
 
 def test_calculate_span_cost_uses_generation_span_model_attribute():
     from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
@@ -614,14 +597,19 @@ def test_calculate_span_cost_uses_generation_span_model_attribute():
         TokenUsageKey.TOTAL_TOKENS: 30,
     }
     attribute_store = {
-        SpanAttributeKey.MODEL: "gpt-4o-mini",
+        SpanAttributeKey.MODEL: "some-model",
         SpanAttributeKey.CHAT_USAGE: usage,
         SpanAttributeKey.MODEL_PROVIDER: None,
     }
     mock_span = mock.MagicMock()
     mock_span.get_attribute.side_effect = attribute_store.get
 
-    result = calculate_span_cost(mock_span)
+    expected_cost = {"input_cost": 0.01, "output_cost": 0.02, "total_cost": 0.03}
+    with mock.patch(
+        "mlflow.tracing.utils.calculate_cost_by_model_and_token_usage",
+        return_value=expected_cost,
+    ) as mock_cost:
+        result = calculate_span_cost(mock_span)
 
-    assert result is not None
-    assert result["total_cost"] > 0
+    mock_cost.assert_called_once_with("some-model", usage, None)
+    assert result == expected_cost

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -576,6 +576,37 @@ def test_generation_span_attributes_stored_under_span_attribute_keys():
             {"input_tokens": 5, "output_tokens": 10},
             {"input_tokens": 5, "output_tokens": 10},
         ),
+        # cached tokens are nested inside input_tokens_details
+        (
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "input_tokens_details": {"cached_tokens": 4, "cache_write_tokens": 2},
+            },
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "cache_read_input_tokens": 4,
+                "cache_creation_input_tokens": 2,
+            },
+        ),
+        # partial cache details — only cached_tokens present
+        (
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "input_tokens_details": {"cached_tokens": 3},
+            },
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15,
+                "cache_read_input_tokens": 3,
+            },
+        ),
         (None, None),
         ({}, None),
     ],

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -586,7 +586,6 @@ def test_parse_generation_usage(usage, expected):
     assert _parse_generation_usage(usage) == expected
 
 
-
 def test_calculate_span_cost_uses_generation_span_model_attribute():
     from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
     from mlflow.tracing.utils import calculate_span_cost

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -532,3 +532,53 @@ def test_autolog_disable_openai_agent_tracer():
     processors = _get_processors()
     assert len(processors) == 1
     assert isinstance(processors[0], MlflowOpenAgentTracingProcessor)
+
+
+def test_generation_span_token_usage_stored_under_chat_usage_key():
+    from agents.tracing import GenerationSpanData
+
+    from mlflow.openai._agent_tracer import _parse_span_data
+    from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+
+    usage = {
+        TokenUsageKey.INPUT_TOKENS: 10,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 30,
+    }
+    span_data = mock.MagicMock(spec=GenerationSpanData)
+    span_data.type = "generation"
+    span_data.input = [{"role": "user", "content": "hello"}]
+    span_data.output = [{"role": "assistant", "content": "hi"}]
+    span_data.model = "gpt-4o-mini"
+    span_data.model_config = {}
+    span_data.usage = usage
+
+    _, _, attributes = _parse_span_data(span_data)
+
+    assert attributes.get(SpanAttributeKey.CHAT_USAGE) == {
+        TokenUsageKey.INPUT_TOKENS: 10,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 30,
+    }
+    assert "usage" not in attributes
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        (
+            {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
+            {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
+        ),
+        (
+            {"input_tokens": 5, "output_tokens": 10},
+            {"input_tokens": 5, "output_tokens": 10},
+        ),
+        (None, None),
+        ({}, None),
+    ],
+)
+def test_parse_generation_usage(usage, expected):
+    from mlflow.openai._agent_tracer import _parse_generation_usage
+
+    assert _parse_generation_usage(usage) == expected

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -582,3 +582,46 @@ def test_parse_generation_usage(usage, expected):
     from mlflow.openai._agent_tracer import _parse_generation_usage
 
     assert _parse_generation_usage(usage) == expected
+
+
+def test_generation_span_model_stored_under_span_attribute_key():
+    from agents.tracing import GenerationSpanData
+
+    from mlflow.openai._agent_tracer import _parse_span_data
+    from mlflow.tracing.constant import SpanAttributeKey
+
+    span_data = mock.MagicMock(spec=GenerationSpanData)
+    span_data.type = "generation"
+    span_data.input = [{"role": "user", "content": "hello"}]
+    span_data.output = [{"role": "assistant", "content": "hi"}]
+    span_data.model = "gpt-4o-mini"
+    span_data.model_config = {}
+    span_data.usage = None
+
+    _, _, attributes = _parse_span_data(span_data)
+
+    assert attributes.get(SpanAttributeKey.MODEL) == "gpt-4o-mini"
+    assert "model" not in attributes
+
+
+def test_calculate_span_cost_uses_generation_span_model_attribute():
+    from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+    from mlflow.tracing.utils import calculate_span_cost
+
+    usage = {
+        TokenUsageKey.INPUT_TOKENS: 10,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 30,
+    }
+    attribute_store = {
+        SpanAttributeKey.MODEL: "gpt-4o-mini",
+        SpanAttributeKey.CHAT_USAGE: usage,
+        SpanAttributeKey.MODEL_PROVIDER: None,
+    }
+    mock_span = mock.MagicMock()
+    mock_span.get_attribute.side_effect = attribute_store.get
+
+    result = calculate_span_cost(mock_span)
+
+    assert result is not None
+    assert result["total_cost"] > 0


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->
Closes #24059 


### What changes are proposed in this pull request?

`MlflowOpenAgentTracingProcessor._parse_span_data()` wrote token usage for `GENERATION` spans under the plain key `"usage"`. However, `aggregate_usage_from_spans()` and `calculate_span_cost()` both read `SpanAttributeKey.CHAT_USAGE` (`"mlflow.chat.tokenUsage"`). The key mismatch silently dropped all token counts from `trace.info.token_usage`. Streaming calls were hit hardest since the Agents SDK is the only source of usage data for those spans.

Two fixes in this PR:

1. Added `_parse_generation_usage()` helper that maps the Agents SDK usage dict to `TokenUsageKey`-keyed values and sets the result under `SpanAttributeKey.CHAT_USAGE` inside `_parse_span_data()`. Matches the existing pattern in `mlflow/groq/_groq_autolog.py` and `mlflow/anthropic/autolog.py`.

2. `_parse_span_data()` now sets `SpanAttributeKey.MODEL` (not plain `"model"`) for `GENERATION` spans, so `calculate_span_cost()` can read the model name and compute cost correctly.

No API changes are needed.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`test_generation_span_attributes_stored_under_span_attribute_keys`: mocks a `GenerationSpanData`, calls `_parse_span_data()`, asserts attributes contain both `SpanAttributeKey.MODEL` and `SpanAttributeKey.CHAT_USAGE` with correct values, and that neither plain `"model"` nor `"usage"` keys exist.

`test_parse_generation_usage`: parametrized over full dict, partial dict, nested `input_tokens_details` with both cache keys, partial cache details (only one key present), `None`, and empty dict.

`test_calculate_span_cost_uses_generation_span_model_attribute`: verifies cost calculation reads the model from `SpanAttributeKey.MODEL` and not the plain `"model"` key.

<img width="1548" height="745" alt="image" src="https://github.com/user-attachments/assets/d72403c3-5129-4d21-9852-0de31ce4d866" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Token usage from OpenAI Agents SDK `GENERATION` spans (including streamed runs) now correctly rolls up into `trace.info.token_usage` and is used by `calculate_span_cost()`. Cached token counts (read and creation) are now captured from the nested `input_tokens_details` field. Model name is now stored under the correct attribute key so span cost is no longer silently skipped.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
