### PR TITLE
Authenticate OpenAI-protocol coding agents through the RBAC gateway

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/coding-agents/codex.mdx
+++ b/docs/docs/genai/governance/ai-gateway/coding-agents/codex.mdx
@@ -31,10 +31,30 @@ codex --config 'openai_base_url="http://localhost:5000/gateway/proxy/codex/v1"'
 For a persistent setup, add the same value to `~/.codex/config.toml`:
 
 ```toml title="~/.codex/config.toml"
-openai_base_url = "http://localhost:5000/gateway/proxy/codex/v1
+openai_base_url = "http://localhost:5000/gateway/proxy/codex/v1"
 ```
 
 Note that you need to authenticate with your API key instead of ChatGPT subscription.
+
+## Authenticated Gateways (RBAC / basic auth)
+
+If your MLflow server has [authentication](/self-hosting/security/basic-http-auth) enabled, Codex
+must also send your MLflow credentials. Codex already uses the `Authorization` header for your own
+OpenAI key (which the gateway forwards upstream), so MLflow reads its credentials from a dedicated
+`X-MLflow-Authorization` header instead. Set it via Codex's `env_http_headers`:
+
+```toml title="~/.codex/config.toml"
+openai_base_url = "http://localhost:5000/gateway/proxy/codex/v1"
+env_http_headers = { "X-MLflow-Authorization" = "MLFLOW_AUTH" }
+```
+
+```bash
+# Base64-encode your MLflow "username:password" as an HTTP Basic credential.
+export MLFLOW_AUTH="Basic $(printf '%s' 'my-user:my-password' | base64)"
+```
+
+MLflow honors `X-MLflow-Authorization` only on `/gateway/` routes and never forwards it to the
+upstream provider.
 
 ## What You Get
 

--- a/docs/docs/genai/governance/ai-gateway/coding-agents/codex.mdx
+++ b/docs/docs/genai/governance/ai-gateway/coding-agents/codex.mdx
@@ -50,7 +50,7 @@ env_http_headers = { "X-MLflow-Authorization" = "MLFLOW_AUTH" }
 
 ```bash
 # Base64-encode your MLflow "username:password" as an HTTP Basic credential.
-export MLFLOW_AUTH="Basic $(printf '%s' 'my-user:my-password' | base64)"
+export MLFLOW_AUTH="Basic $(printf '%s' 'my-user:my-password' | base64 | tr -d '\n')"
 ```
 
 MLflow honors `X-MLflow-Authorization` only on `/gateway/` routes and never forwards it to the

--- a/mlflow/gateway/constants.py
+++ b/mlflow/gateway/constants.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 MLFLOW_GATEWAY_CALLER_HEADER = "X-MLflow-Gateway-Caller"
+MLFLOW_GATEWAY_AUTH_HEADER = "X-MLflow-Authorization"
 MLFLOW_GATEWAY_DURATION_HEADER = "X-MLflow-Gateway-Duration-Ms"
 MLFLOW_GATEWAY_OVERHEAD_HEADER = "X-MLflow-Gateway-Overhead-Duration-Ms"
 

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -23,7 +23,14 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
 
     # Drop any client Accept-Encoding (any casing) so we send only one value; otherwise
     # aiohttp may send both and upstream can respond with Brotli, which is not supported.
-    request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
+    # Also drop X-MLflow-Authorization (MLflow's own RBAC credential on gateway routes) so
+    # it is never forwarded to the upstream provider. This is the single egress choke point
+    # all proxy/passthrough paths funnel through.
+    request_headers = {
+        k: v
+        for k, v in headers.items()
+        if k.lower() not in ("accept-encoding", "x-mlflow-authorization")
+    }
     request_headers["Accept-Encoding"] = SUPPORTED_ACCEPT_ENCODING
     url = append_to_uri_path(base_url, path)
     # Raise the aiohttp stream read buffer to tolerate large SSE `data:` lines

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -5,7 +5,10 @@ from typing import Any, AsyncGenerator
 from urllib.parse import urlparse, urlunparse
 
 from mlflow.environment_variables import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
+from mlflow.gateway.constants import MLFLOW_GATEWAY_AUTH_HEADER
 from mlflow.utils.uri import append_to_uri_path
+
+_STRIPPED_HEADERS = frozenset({"accept-encoding", MLFLOW_GATEWAY_AUTH_HEADER.lower()})
 
 # Accumulates the total time (ms) spent waiting for provider HTTP responses in the current
 # request context. Reset to 0.0 at the start of each request by the gateway timing middleware
@@ -26,11 +29,7 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
     # Also drop X-MLflow-Authorization (MLflow's own RBAC credential on gateway routes) so
     # it is never forwarded to the upstream provider. This is the single egress choke point
     # all proxy/passthrough paths funnel through.
-    request_headers = {
-        k: v
-        for k, v in headers.items()
-        if k.lower() not in ("accept-encoding", "x-mlflow-authorization")
-    }
+    request_headers = {k: v for k, v in headers.items() if k.lower() not in _STRIPPED_HEADERS}
     request_headers["Accept-Encoding"] = SUPPORTED_ACCEPT_ENCODING
     url = append_to_uri_path(base_url, path)
     # Raise the aiohttp stream read buffer to tolerate large SSE `data:` lines

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -4300,6 +4300,8 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
     # does not shadow a valid Authorization header.
     if not auth:
         auth = request.headers.get("Authorization")
+
+    # Neither header present — unauthenticated.
     if not auth:
         return None
     try:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -392,12 +392,7 @@ def _auth_cache_key(username: str, password: str) -> tuple[str, bytes]:
     return (username, digest)
 
 
-# Dedicated header carrying MLflow RBAC credentials on /gateway/ routes, so an
-# OpenAI-protocol coding agent (Codex, Claude Code, Gemini CLI) can keep its own provider
-# key in the standard ``Authorization`` header (which MLflow forwards upstream) while still
-# authenticating to MLflow. Honored ONLY on /gateway/ routes so it can never act as a
-# master credential elsewhere, and stripped before forwarding upstream (see _aiohttp_post).
-_MLFLOW_GATEWAY_AUTH_HEADER = "X-MLflow-Authorization"
+from mlflow.gateway.constants import MLFLOW_GATEWAY_AUTH_HEADER
 
 
 def _authenticate_cached(username: str, password: str) -> User | None:
@@ -4295,7 +4290,7 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
     # header. Prefer it there; fall back to Authorization for backward compat.
     auth = None
     if request_path.startswith("/gateway/"):
-        auth = request.headers.get(_MLFLOW_GATEWAY_AUTH_HEADER)
+        auth = request.headers.get(MLFLOW_GATEWAY_AUTH_HEADER)
     # Treat a missing OR empty header as absent so an empty X-MLflow-Authorization
     # does not shadow a valid Authorization header.
     if not auth:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -392,6 +392,14 @@ def _auth_cache_key(username: str, password: str) -> tuple[str, bytes]:
     return (username, digest)
 
 
+# Dedicated header carrying MLflow RBAC credentials on /gateway/ routes, so an
+# OpenAI-protocol coding agent (Codex, Claude Code, Gemini CLI) can keep its own provider
+# key in the standard ``Authorization`` header (which MLflow forwards upstream) while still
+# authenticating to MLflow. Honored ONLY on /gateway/ routes so it can never act as a
+# master credential elsewhere, and stripped before forwarding upstream (see _aiohttp_post).
+_MLFLOW_GATEWAY_AUTH_HEADER = "X-MLflow-Authorization"
+
+
 def _authenticate_cached(username: str, password: str) -> User | None:
     """Run basic-auth verification with the credential cache in front of it.
 
@@ -4280,11 +4288,20 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
     Returns:
         User object if authentication succeeds, None otherwise.
     """
-    if "Authorization" not in request.headers:
-        return None
-
     request_path = get_routed_asgi_path(request)
-    auth = request.headers["Authorization"]
+
+    # On /gateway/ routes, a coding agent's own provider key occupies the standard
+    # Authorization header (forwarded upstream), so MLflow credentials ride in a dedicated
+    # header. Prefer it there; fall back to Authorization for backward compat.
+    auth = None
+    if request_path.startswith("/gateway/"):
+        auth = request.headers.get(_MLFLOW_GATEWAY_AUTH_HEADER)
+    # Treat a missing OR empty header as absent so an empty X-MLflow-Authorization
+    # does not shadow a valid Authorization header.
+    if not auth:
+        auth = request.headers.get("Authorization")
+    if not auth:
+        return None
     try:
         scheme, credentials = auth.split()
         if scheme.lower() != "basic":

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -1427,6 +1427,27 @@ async def test_proxy_non_streaming():
 
 
 @pytest.mark.asyncio
+async def test_proxy_strips_mlflow_auth_header_but_preserves_client_key():
+    provider = OpenAIProvider(EndpointConfig(**chat_config()))
+    mock_client = mock_http_client(MockAsyncResponse(chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session:
+        await provider.proxy(
+            path="v1/responses",
+            payload={"messages": [{"role": "user", "content": "Hello"}]},
+            headers={
+                "authorization": "Bearer client-key",
+                "x-mlflow-authorization": "Basic dXNlcjpwYXNz",
+                "user-agent": "codex_cli_rs/1.0",
+            },
+        )
+
+    sent_headers = mock_session.call_args.kwargs["headers"]
+    assert sent_headers["authorization"] == "Bearer client-key"
+    assert "x-mlflow-authorization" not in {k.lower() for k in sent_headers}
+
+
+@pytest.mark.asyncio
 async def test_proxy_streaming():
     provider = OpenAIProvider(EndpointConfig(**chat_config()))
     chunk_data = (

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -1448,6 +1448,31 @@ async def test_proxy_strips_mlflow_auth_header_but_preserves_client_key():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header_name",
+    ["X-MLflow-Authorization", "X-MLFLOW-AUTHORIZATION", "x-Mlflow-authorization"],
+)
+async def test_proxy_strips_mlflow_auth_header_mixed_case(header_name):
+    provider = OpenAIProvider(EndpointConfig(**chat_config()))
+    mock_client = mock_http_client(MockAsyncResponse(chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session:
+        await provider.proxy(
+            path="v1/responses",
+            payload={"messages": [{"role": "user", "content": "Hello"}]},
+            headers={
+                "authorization": "Bearer client-key",
+                header_name: "Basic dXNlcjpwYXNz",
+                "user-agent": "codex_cli_rs/1.0",
+            },
+        )
+
+    sent_headers = mock_session.call_args.kwargs["headers"]
+    assert sent_headers["authorization"] == "Bearer client-key"
+    assert "x-mlflow-authorization" not in {k.lower() for k in sent_headers}
+
+
+@pytest.mark.asyncio
 async def test_proxy_streaming():
     provider = OpenAIProvider(EndpointConfig(**chat_config()))
     chunk_data = (

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -2214,6 +2214,107 @@ def test_gateway_endpoint_use_permission(fastapi_client, monkeypatch):
         ).raise_for_status()
 
 
+def test_gateway_proxy_authenticates_via_mlflow_auth_header(fastapi_client, monkeypatch):
+    user1, password1 = create_user(fastapi_client.tracking_uri)
+    user2, password2 = create_user(fastapi_client.tracking_uri)
+
+    with User(user1, password1, monkeypatch):
+        response = requests.post(
+            url=fastapi_client.tracking_uri + "/api/3.0/mlflow/gateway/secrets/create",
+            json={
+                "secret_name": "proxy_secret",
+                "secret_value": {"api_key": "test-key"},
+                "provider": "openai",
+            },
+            auth=(user1, password1),
+        )
+        response.raise_for_status()
+        secret_id = response.json()["secret"]["secret_id"]
+
+        response = requests.post(
+            url=fastapi_client.tracking_uri + "/api/3.0/mlflow/gateway/model-definitions/create",
+            json={
+                "name": "proxy_model_def",
+                "secret_id": secret_id,
+                "provider": "openai",
+                "model_name": "gpt-4",
+            },
+            auth=(user1, password1),
+        )
+        response.raise_for_status()
+        model_definition_id = response.json()["model_definition"]["model_definition_id"]
+
+        response = requests.post(
+            url=fastapi_client.tracking_uri + "/api/3.0/mlflow/gateway/endpoints/create",
+            json={
+                "name": "proxy_endpoint",
+                "model_configs": [
+                    {"model_definition_id": model_definition_id, "linkage_type": "PRIMARY"}
+                ],
+            },
+            auth=(user1, password1),
+        )
+        response.raise_for_status()
+        endpoint_id = response.json()["endpoint"]["endpoint_id"]
+        endpoint_name = response.json()["endpoint"]["name"]
+
+    with User(user1, password1, monkeypatch):
+        grant_role_permission(
+            fastapi_client.tracking_uri,
+            user2,
+            "gateway_endpoint",
+            endpoint_id,
+            "USE",
+        )
+
+    mlflow_auth = "Basic " + base64.b64encode(f"{user2}:{password2}".encode()).decode("ascii")
+    proxy_url = fastapi_client.tracking_uri + f"/gateway/proxy/{endpoint_name}/v1/responses"
+
+    # The coding agent's own provider key occupies Authorization; MLflow creds ride in
+    # X-MLflow-Authorization. Auth must clear the middleware (the upstream call then fails
+    # on the fake key, but that is NOT the middleware's 401/403).
+    response = requests.post(
+        proxy_url,
+        json={"messages": [{"role": "user", "content": "hi"}]},
+        headers={
+            "Authorization": "Bearer sk-decoy-provider-key",
+            "X-MLflow-Authorization": mlflow_auth,
+            "User-Agent": "codex_cli_rs/1.0",
+        },
+    )
+    assert "You are not authenticated" not in response.text
+    assert response.text != "Permission denied"
+
+    # Without the MLflow auth header, the decoy Bearer alone must be rejected by the middleware.
+    response = requests.post(
+        proxy_url,
+        json={"messages": [{"role": "user", "content": "hi"}]},
+        headers={
+            "Authorization": "Bearer sk-decoy-provider-key",
+            "User-Agent": "codex_cli_rs/1.0",
+        },
+    )
+    assert response.status_code == 401
+    assert "You are not authenticated" in response.text
+
+    with User(user1, password1, monkeypatch):
+        requests.delete(
+            url=fastapi_client.tracking_uri + "/api/3.0/mlflow/gateway/endpoints/delete",
+            json={"endpoint_id": endpoint_id},
+            auth=(user1, password1),
+        ).raise_for_status()
+        requests.delete(
+            url=fastapi_client.tracking_uri + "/api/3.0/mlflow/gateway/model-definitions/delete",
+            json={"model_definition_id": model_definition_id},
+            auth=(user1, password1),
+        ).raise_for_status()
+        requests.delete(
+            url=fastapi_client.tracking_uri + "/api/3.0/mlflow/gateway/secrets/delete",
+            json={"secret_id": secret_id},
+            auth=(user1, password1),
+        ).raise_for_status()
+
+
 def test_gateway_model_definition_requires_secret_use_permission(client, monkeypatch):
     user1, password1 = create_user(client.tracking_uri)
     user2, password2 = create_user(client.tracking_uri)
@@ -3180,13 +3281,15 @@ def enable_auth_cache():
         yield cache
 
 
-def _make_request(path, authorization=None, *, scope_path=None):
+def _make_request(path, authorization=None, mlflow_authorization=None, *, scope_path=None):
     request = mock.Mock()
     request.scope = {"path": scope_path or path}
     request.url.path = path
     request.headers = {}
     if authorization:
         request.headers["Authorization"] = authorization
+    if mlflow_authorization:
+        request.headers["X-MLflow-Authorization"] = mlflow_authorization
     return request
 
 
@@ -3303,6 +3406,117 @@ def test_basic_auth_no_internal_token_uses_normal_auth(
     monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
     credentials = base64.b64encode(b"alice:password123").decode("ascii")
     request = _make_request("/gateway/mlflow/v1/chat", f"Basic {credentials}")
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
+# -- X-MLflow-Authorization header for gateway routes (OpenAI-protocol coding agents) --
+
+
+def test_gateway_auth_header_authenticates(mock_auth_store, mock_auth_config, monkeypatch):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request(
+        "/gateway/proxy/my-endpoint/v1/responses",
+        mlflow_authorization=f"Basic {credentials}",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
+def test_gateway_auth_header_takes_precedence_over_bearer(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request(
+        "/gateway/proxy/my-endpoint/v1/responses",
+        authorization="Bearer sk-provider-key",
+        mlflow_authorization=f"Basic {credentials}",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
+def test_gateway_auth_header_ignored_on_non_gateway_route(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request(
+        "/api/3.0/mlflow/experiments/list",
+        authorization="Bearer sk-provider-key",
+        mlflow_authorization=f"Basic {credentials}",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user is None
+    mock_auth_store.authenticate_user.assert_not_called()
+
+
+def test_gateway_basic_auth_still_works_without_new_header(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request(
+        "/gateway/proxy/my-endpoint/v1/responses",
+        authorization=f"Basic {credentials}",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
+
+
+def test_gateway_auth_header_honors_internal_token(mock_auth_store, mock_auth_config, monkeypatch):
+    monkeypatch.setenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, "internal-secret")
+    credentials = base64.b64encode(b"alice:internal-secret").decode("ascii")
+    request = _make_request(
+        "/gateway/proxy/my-endpoint/v1/responses",
+        mlflow_authorization=f"Basic {credentials}",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user.username == "alice"
+    mock_auth_store.get_user.assert_called_once_with("alice")
+    mock_auth_store.authenticate_user.assert_not_called()
+
+
+def test_gateway_auth_header_malformed_returns_none(mock_auth_store, mock_auth_config):
+    request = _make_request(
+        "/gateway/proxy/my-endpoint/v1/responses",
+        mlflow_authorization="garbage-not-basic",
+    )
+
+    user = _authenticate_fastapi_request(request)
+
+    assert user is None
+
+
+def test_gateway_empty_auth_header_falls_back_to_authorization(
+    mock_auth_store, mock_auth_config, monkeypatch
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    credentials = base64.b64encode(b"alice:password123").decode("ascii")
+    request = _make_request(
+        "/gateway/proxy/my-endpoint/v1/responses",
+        authorization=f"Basic {credentials}",
+    )
+    # A present-but-empty X-MLflow-Authorization must not shadow a valid Authorization.
+    request.headers["X-MLflow-Authorization"] = ""
 
     user = _authenticate_fastapi_request(request)
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -2283,7 +2283,7 @@ def test_gateway_proxy_authenticates_via_mlflow_auth_header(fastapi_client, monk
         },
     )
     assert "You are not authenticated" not in response.text
-    assert response.text != "Permission denied"
+    assert "Permission denied" not in response.text
 
     # Without the MLflow auth header, the decoy Bearer alone must be rejected by the middleware.
     response = requests.post(


### PR DESCRIPTION
### Related Issues/PRs

Closes #24281 

### What changes are proposed in this pull request?

With MLflow basic-auth/RBAC enabled, OpenAI-protocol coding agents (Codex, Claude Code, Gemini CLI) could not reach `/gateway/proxy/...`. The RBAC middleware (added in 2023, #8102/#8130) assumes the `Authorization` header always carries an MLflow Basic credential. The raw gateway proxy (added in 2026, #23330) assumes the same header carries the upstream provider key and forwards it verbatim. These two features were built by different teams years apart and use the same header so when both are enabled, the agent's `Bearer sk-...` is rejected by RBAC before it ever reaches the provider layer.

Add a dedicated `X-MLflow-Authorization` header carrying the MLflow Basic credential. It is:

- Honored **only on `/gateway/` routes** (gated on `get_routed_asgi_path`, consistent with the #23685 hardening)
- Falls back to `Authorization` for backward compat
- Stripped at the single HTTP egress choke point (`_aiohttp_post`) so it is never forwarded to any upstream provider

The agent's own `Authorization: Bearer` key is untouched and still forwarded upstream. Docs updated with the client-wiring (`env_http_headers`) and the unterminated-quote typo in the codex example fixed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Unit tests: header authenticates, precedence over Bearer, ignored on non-gateway route, backward-compat plain Basic, internal-token via new header, malformed → None, empty → fallback. Provider test: strip preserves client key. E2E RBAC test: full endpoint provisioning + proxy call with both headers.

Manual: started a real MLflow server with `--app-name basic-auth` from this branch, provisioned a `codex` gateway endpoint, and verified the three auth scenarios:

```
# Bearer alone → MLflow RBAC rejects (the original bug)
$ curl -X POST -H "Authorization: Bearer sk-FAKE-not-real" .../gateway/proxy/codex/v1/responses
"You are not authenticated."  HTTP 401

# X-MLflow-Authorization + Bearer → passes RBAC, reaches upstream
$ curl -X POST -H "Authorization: Bearer sk-FAKE-not-real" \
       -H "X-MLflow-Authorization: Basic <admin creds>" .../gateway/proxy/codex/v1/responses
"Incorrect API key provided: sk-FAKE-..."  HTTP 401  (upstream OpenAI rejection, NOT MLflow auth)

# Plain Basic in Authorization → backward compat still works
$ curl -X POST -H "Authorization: Basic <admin creds>" .../gateway/proxy/codex/v1/responses
"Incorrect API key provided: sk-FAKE-..."  HTTP 401  (same upstream rejection)
```

Then drove real Codex 0.140 with `env_http_headers = { "X-MLflow-Authorization" = "MLFLOW_AUTH" }` against the RBAC server:

```
provider: mlflowrbac
...
user
say hi in one word
ERROR: unexpected status 401 Unauthorized: {"detail":"{\"error\":{\"message\":\"Incorrect API key
provided: sk-FAKE-****real. ..."}}"}, url: http://127.0.0.1:5199/gateway/proxy/codex/v1/responses
```

Codex's request passed the RBAC middleware (no "not authenticated" rejection) and reached the real OpenAI upstream (which rejected the deliberately fake key). With a real key this would be a working completion.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Add `X-MLflow-Authorization` header support so OpenAI-protocol coding agents can authenticate to the RBAC-protected gateway while keeping their own provider key in the standard `Authorization` header.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
