### PR TITLE
fix: prevent 'table already exists' error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from 3.7.0 to 3.8.x, the database upgrade fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, attempting to create tables that already exist (e.g., `secrets` added by a migration).

## Fix
Add `checkfirst=True` to `create_all` so that SQLAlchemy checks for existing tables before creation, skipping those that already exist. This prevents the duplicate table error while still ensuring all initial tables are present.

Closes #19943