### PR TITLE
Bump MLflow TypeScript SDK to 0.3.0

### DIFF
--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/core",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0",
   "description": "TypeScript implementation of MLflow Tracing SDK for LLM observability",
   "repository": {
     "type": "git",

--- a/libs/typescript/integrations/anthropic/package.json
+++ b/libs/typescript/integrations/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/anthropic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Anthropic integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0",
+    "@mlflow/core": "^0.3.0",
     "@anthropic-ai/sdk": "^0.71.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/claude-code/package.json
+++ b/libs/typescript/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/claude-code",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0",
   "description": "Claude Code and Claude Agent SDK integration package for MLflow Tracing",
   "type": "module",
   "repository": {
@@ -44,7 +44,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+    "@mlflow/core": "^0.3.0"
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0"

--- a/libs/typescript/integrations/codex/package.json
+++ b/libs/typescript/integrations/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/codex",
-  "version": "0.3.0-rc.0",
+  "version": "0.3.0",
   "description": "Codex CLI integration package for MLflow Tracing",
   "type": "module",
   "repository": {
@@ -47,7 +47,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+    "@mlflow/core": "^0.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/libs/typescript/integrations/gemini/package.json
+++ b/libs/typescript/integrations/gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/gemini",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Gemini integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0",
+    "@mlflow/core": "^0.3.0",
     "@google/genai": "^1.22.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/openai/package.json
+++ b/libs/typescript/integrations/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/openai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenAI integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "format:check": "prettier --check ."
   },
   "peerDependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0",
+    "@mlflow/core": "^0.3.0",
     "openai": ">=4.0.0"
   },
   "devDependencies": {

--- a/libs/typescript/integrations/opencode/package.json
+++ b/libs/typescript/integrations/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/opencode",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenCode integration package for MLflow Tracing",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+    "@mlflow/core": "^0.3.0"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": "^1.0.0"

--- a/libs/typescript/integrations/qwen-code/package.json
+++ b/libs/typescript/integrations/qwen-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/qwen-code",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Qwen Code integration package for MLflow Tracing",
   "type": "module",
   "repository": {
@@ -44,7 +44,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+    "@mlflow/core": "^0.3.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/libs/typescript/integrations/vercel/package.json
+++ b/libs/typescript/integrations/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/vercel",
-  "version": "0.2.0-rc.1",
+  "version": "0.3.0",
   "description": "Vercel AI SDK integration for MLflow Tracing — SpanProcessor that translates AI SDK span attributes to MLflow format",
   "repository": {
     "type": "git",

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -15,7 +15,7 @@
     },
     "core": {
       "name": "@mlflow/core",
-      "version": "0.3.0-rc.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@databricks/sdk-experimental": "0.15.0",
@@ -53,7 +53,7 @@
     },
     "integrations/anthropic": {
       "name": "@mlflow/anthropic",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^29.6.2",
@@ -64,15 +64,15 @@
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.71.0",
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+        "@mlflow/core": "^0.3.0"
       }
     },
     "integrations/claude-code": {
       "name": "@mlflow/claude-code",
-      "version": "0.3.0-rc.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+        "@mlflow/core": "^0.3.0"
       },
       "bin": {
         "mlflow-claude-code": "bundle/cli.cjs"
@@ -99,10 +99,10 @@
     },
     "integrations/codex": {
       "name": "@mlflow/codex",
-      "version": "0.3.0-rc.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+        "@mlflow/core": "^0.3.0"
       },
       "bin": {
         "mlflow-codex": "bundle/cli.js"
@@ -117,7 +117,7 @@
     },
     "integrations/gemini": {
       "name": "@mlflow/gemini",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^29.6.2",
@@ -129,12 +129,12 @@
       },
       "peerDependencies": {
         "@google/genai": "^1.22.0",
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+        "@mlflow/core": "^0.3.0"
       }
     },
     "integrations/openai": {
       "name": "@mlflow/openai",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^29.6.2",
@@ -144,7 +144,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0",
+        "@mlflow/core": "^0.3.0",
         "openai": ">=4.0.0"
       }
     },
@@ -176,10 +176,10 @@
     },
     "integrations/opencode": {
       "name": "@mlflow/opencode",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+        "@mlflow/core": "^0.3.0"
       },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.1.25",
@@ -197,10 +197,10 @@
     },
     "integrations/qwen-code": {
       "name": "@mlflow/qwen-code",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mlflow/core": ">=0.2.0 || >=0.3.0-rc.0"
+        "@mlflow/core": "^0.3.0"
       },
       "bin": {
         "mlflow-qwen-code": "bundle/cli.js"
@@ -215,7 +215,7 @@
     },
     "integrations/vercel": {
       "name": "@mlflow/vercel",
-      "version": "0.2.0-rc.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/sdk-trace-base": "^2.1.0",

--- a/libs/typescript/scripts/bump-ts-version.ts
+++ b/libs/typescript/scripts/bump-ts-version.ts
@@ -1,20 +1,32 @@
 /**
  * CLI script to bump the version of MLflow TypeScript libraries.
  *
- * This script updates the version in:
- * - libs/typescript/core/package.json
- * - libs/typescript/integrations/openai/package.json (version and peerDependencies)
+ * Updates the version of the core package and every published integration
+ * package, and rewrites each integration's `@mlflow/core` constraint (declared
+ * in either `dependencies` or `peerDependencies`) to match.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
-// list of packages that contain `@mlflow/core` in peerDependencies
-const INTEGRATION_PACKAGES = ['openai', 'anthropic', 'gemini', 'vercel'];
+// Published integration packages to bump alongside `@mlflow/core`.
+// `openclaw` is intentionally omitted until its first npm publish (see #23137).
+// `helpers` is a shared test utility, not a published package.
+const INTEGRATION_PACKAGES = [
+  'openai',
+  'anthropic',
+  'gemini',
+  'vercel',
+  'claude-code',
+  'codex',
+  'opencode',
+  'qwen-code',
+];
 
 interface PackageJson {
   name: string;
   version: string;
+  dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   [key: string]: any;
 }
@@ -59,6 +71,8 @@ function bumpVersion(version: string): void {
   writeFileSync(corePackagePath, JSON.stringify(corePackage, null, 2) + '\n', 'utf-8');
   console.log(`  ✓ Updated version: ${oldCoreVersion} → ${version}`);
 
+  const coreRange = `^${version}`;
+
   for (const packageName of INTEGRATION_PACKAGES) {
     const packagePath = join(tsRoot, 'integrations', packageName, 'package.json');
     console.log(`Updating integrations/${packageName}/package.json...`);
@@ -67,16 +81,21 @@ function bumpVersion(version: string): void {
 
     const oldVersion = packageJson.version;
     packageJson.version = version;
-
-    writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
     console.log(`  ✓ Updated version: ${oldVersion} → ${version}`);
 
-    if (packageJson.peerDependencies && '@mlflow/core' in packageJson.peerDependencies) {
-      const oldPeerDep = packageJson.peerDependencies['@mlflow/core'];
-      packageJson.peerDependencies['@mlflow/core'] = `^${version}`;
-      writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
-      console.log(`  ✓ Updated peerDependency @mlflow/core: ${oldPeerDep} → ^${version}`);
+    // The `@mlflow/core` constraint may live in either `dependencies` (bundled
+    // integrations) or `peerDependencies` (host-provided core). Rewrite whichever
+    // one declares it so the integration pins the matching core release.
+    for (const depKey of ['dependencies', 'peerDependencies'] as const) {
+      const deps = packageJson[depKey];
+      if (deps && '@mlflow/core' in deps) {
+        const oldRange = deps['@mlflow/core'];
+        deps['@mlflow/core'] = coreRange;
+        console.log(`  ✓ Updated ${depKey} @mlflow/core: ${oldRange} → ${coreRange}`);
+      }
     }
+
+    writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf-8');
   }
 
   console.log(`\n✅ Successfully bumped TypeScript library versions to ${version}`);


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23729

### What changes are proposed in this pull request?

Promotes the MLflow TypeScript SDK to its `0.3.0` GA release:

- `@mlflow/core`: `0.3.0-rc.0` -> `0.3.0`
- All published integrations -> `0.3.0` (`@mlflow/openai`, `@mlflow/anthropic`, `@mlflow/gemini`, `@mlflow/vercel`, `@mlflow/claude-code`, `@mlflow/codex`, `@mlflow/opencode`, `@mlflow/qwen-code`), each pinning `@mlflow/core` to `^0.3.0`.

Also updates `bump-ts-version.ts` so it stays in sync with the current package set:

- Adds the integrations introduced since the script was written (`claude-code`, `codex`, `opencode`, `qwen-code`).
- Rewrites the `@mlflow/core` constraint whether it is declared in `dependencies` (bundled integrations) or `peerDependencies` (host-provided core).

Held back / special cases:

- `@mlflow/openclaw` is not bumped; it has not had a first npm publish yet (see #23137).
- `@mlflow/vercel` declares no `@mlflow/core` constraint (it is a pure OpenTelemetry `SpanProcessor`), so only its version is bumped.

### How is this PR tested?

- [x] Manual tests

Ran `npm run bump-version -- --version 0.3.0`; verified every package.json version and `@mlflow/core` range, confirmed `openclaw` is untouched, and that `prettier --check` and `eslint` pass on the changed files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

The individual 0.3.0 features are described in their own PRs; this PR only bumps package versions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release