### PR TITLE
Extract experiment id from workspace-prefixed proxied artifact paths

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -751,7 +751,9 @@ def _get_experiment_permission(experiment_id: str, username: str) -> Permission:
     )
 
 
-_EXPERIMENT_ID_PATTERN = re.compile(r"^(\d+)/")
+# In workspace mode the proxied artifact path is prefixed with `workspaces/<ws>/`, so the
+# experiment id is not necessarily at the start. Allow an optional prefix before it.
+_EXPERIMENT_ID_PATTERN = re.compile(r"^(?:workspaces/[^/]+/)?(\d+)/")
 
 
 def _get_experiment_id_from_view_args():

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -888,6 +888,8 @@ def test_experiment_artifact_proxy_workspace_prefixed_path_uses_experiment_permi
         request.view_args = {"artifact_path": "workspaces/team-a/1/path"}
         assert auth_module.validate_can_read_experiment_artifact_proxy()
         assert auth_module.validate_can_update_experiment_artifact_proxy()
+        # EDIT has can_delete=False, confirming the path resolves to the experiment grant.
+        assert not auth_module.validate_can_delete_experiment_artifact_proxy()
 
 
 def test_experiment_artifact_proxy_without_experiment_id_uses_workspace_permissions(

--- a/tests/server/auth/test_auth_workspace.py
+++ b/tests/server/auth/test_auth_workspace.py
@@ -870,6 +870,26 @@ def test_experiment_artifact_proxy_validators_respect_permissions(workspace_perm
         assert not auth_module.validate_can_delete_experiment_artifact_proxy()
 
 
+def test_experiment_artifact_proxy_workspace_prefixed_path_uses_experiment_permission(
+    workspace_permission_setup,
+):
+    # In workspace mode the proxied artifact path is prefixed with `workspaces/<ws>/`.
+    # The experiment id must still be extracted so an experiment-tier EDIT grant authorizes
+    # the write, rather than falling through to the workspace-tier USE grant (can_update=False).
+    store = workspace_permission_setup["store"]
+    username = workspace_permission_setup["username"]
+    _set_workspace_permission(store, username, USE.name)
+    store.create_experiment_permission("1", username, EDIT.name)
+
+    with auth_module.app.test_request_context(
+        "/ajax-api/2.0/mlflow-artifacts/artifacts/workspaces/team-a/1/path",
+        method="GET",
+    ):
+        request.view_args = {"artifact_path": "workspaces/team-a/1/path"}
+        assert auth_module.validate_can_read_experiment_artifact_proxy()
+        assert auth_module.validate_can_update_experiment_artifact_proxy()
+
+
 def test_experiment_artifact_proxy_without_experiment_id_uses_workspace_permissions(
     workspace_permission_setup,
 ):


### PR DESCRIPTION
### Related Issues/PRs

Closes #24210

### What changes are proposed in this pull request?

With `--app-name basic-auth --enable-workspaces`, a non-admin user holding experiment `EDIT` gets `403 Permission denied` from `log_artifacts` / model logging when the run is in a non-`default` workspace. Metadata logging (runs/params/metrics) succeeds; only proxied artifact writes fail.

Root cause: the artifact-proxy validator resolves the experiment id from the proxied path via `_EXPERIMENT_ID_PATTERN = re.compile(r"^(\d+)/")`. In workspace mode the proxied path is prefixed with `workspaces/<ws>/`, so the pattern never matches. With no experiment id, `_get_permission_from_experiment_id_artifact_proxy` falls through to the workspace-tier grant (`workspace:* USE`, `can_update=False`) and rejects the write. The `default` workspace stores artifacts unprefixed, so it is unaffected — the bug only manifests in non-default workspaces.

This makes the `workspaces/<ws>/` prefix optional in the pattern: `re.compile(r"^(?:workspaces/[^/]+/)?(\d+)/")`, so the experiment id is extracted in both modes and the experiment-tier permission is honored.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a workspace-aware regression test (`test_experiment_artifact_proxy_workspace_prefixed_path_uses_experiment_permission`) asserting that a user with only workspace `USE` but experiment `EDIT` can update artifacts via a `workspaces/<ws>/<exp_id>/...` path. Verified it fails against the previous regex and passes with the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a `403 Permission denied` on proxied artifact uploads for users with experiment `EDIT` permission when running with workspaces enabled and the run is in a non-default workspace.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

This pull request and its description were written by Isaac.