### PR TITLE
fix: use Base.metadata with checkfirst to prevent duplicate table creation in _initialize_tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Bug: Running `mlflow db upgrade` after updating MLflow from 3.7.0 to 3.8.x fails with `Table 'secrets' already exists` when the database already contains the tables. This happens because `_initialize_tables` uses `InitialBase.metadata.create_all(engine)` (which does not set `checkfirst` so it tries to create all tables unconditionally) followed by `_upgrade_db`, which via Alembic attempts to create the same tables again.

## Fix
Changed `_initialize_tables` to use `Base.metadata.create_all(engine, checkfirst=True)` so that existing tables are not re-created. This aligns with the fallback logic already present in `_all_tables_exist` and prevents the conflict with Alembic migrations.

Closes #19943