### PR TITLE
Fix `SqlAlchemyStore.link_prompts_to_trace` for nonexistent traces

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4737,6 +4737,15 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         with self.ManagedSessionMaker(read_only=False) as session:
             self._validate_trace_accessible(session, trace_id)
 
+            if (
+                self._trace_query(session).filter(SqlTraceInfo.request_id == trace_id).one_or_none()
+                is None
+            ):
+                raise MlflowException(
+                    f"Trace with request_id '{trace_id}' not found",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
+
             # Build list of prompt version IDs (format: "name/version")
             prompt_ids = [f"{pv.name}/{pv.version}" for pv in prompt_versions]
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -3082,6 +3082,26 @@ def test_search_traces_with_prompts_filter_multiple_prompts(store: SqlAlchemySto
     assert traces[0].request_id == trace2_id
 
 
+def test_link_prompts_to_trace_raises_for_nonexistent_trace(
+    store: SqlAlchemyStore,
+):
+    trace_id = "tr-does-not-exist"
+
+    with pytest.raises(MlflowException) as exc_info:
+        store.link_prompts_to_trace(
+            trace_id,
+            [
+                PromptVersion(
+                    name="my-prompt",
+                    version=1,
+                    template="Hello {{name}}",
+                )
+            ],
+        )
+
+    assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
 def test_search_traces_with_span_attributute_backticks(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_span_attribute_backticks")
     trace_info_1 = _create_trace(store, "trace_1", exp_id)


### PR DESCRIPTION
### Related Issues/PRs

Closes #24067

### What changes are proposed in this pull request?

This PR fixes a bug in `SqlAlchemyStore.link_prompts_to_trace` where prompt associations could be created for a nonexistent trace in single-tenant mode.

Previously, `link_prompts_to_trace` relied on `_validate_trace_accessible`, which is a no-op in single-tenant mode. As a result, providing a nonexistent `trace_id` would silently create orphaned entity associations instead of raising an error.

This PR adds an explicit trace existence check before creating associations and raises a `RESOURCE_DOES_NOT_EXIST` `MlflowException` when the specified trace does not exist.

Additionally, a regression test has been added to verify that linking prompts to a nonexistent trace raises the expected exception.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [x] `area/prompts`
- [x] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release