### PR TITLE
Add OCI source annotation to the Helm chart for GHCR repository linkage

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -4,3 +4,5 @@ description: A production-ready Helm chart for deploying MLflow on Kubernetes
 type: application
 version: 0.1.0
 appVersion: "3.14.0"
+annotations:
+  org.opencontainers.image.source: https://github.com/mlflow/mlflow


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24313

### What changes are proposed in this pull request?

Add an `org.opencontainers.image.source` annotation to `charts/Chart.yaml` pointing at `https://github.com/mlflow/mlflow`.

The chart is published to `ghcr.io/mlflow/charts/mlflow` by a workflow that lives in a separate release automation repository and authenticates with that repository's `GITHUB_TOKEN`. GHCR infers the "source repository" of a package from the token used to push it, so it currently links the published package to the release automation repository (its README and source are what show on the package page) rather than to mlflow/mlflow.

Setting `org.opencontainers.image.source` on the chart manifest overrides that token-based inference: GHCR reads this annotation from the pushed OCI manifest and links the package to the annotated repository. Helm copies annotations from `Chart.yaml` into the pushed OCI manifest annotations, so adding it here is sufficient.

Notes:

- The chart version is intentionally not bumped; nothing else is changed.
- The annotation takes effect from the next published chart version. The already-published `0.1.0` is unaffected (its manifest is immutable), so the linkage on GHCR will correct itself once a new version is published.

### How is this PR tested?

- [x] Manual tests

Verified end to end with **helm 4.2.2**, the version the release workflow runs on its runner (local helm was installed to match it):

1. Started a disposable local OCI registry.
2. `helm package charts/` with the annotated `Chart.yaml`, then `helm push` of `mlflow-0.1.0.tgz` to the registry.
3. Fetched the pushed manifest with `oras manifest fetch` and confirmed the annotation is present in the OCI manifest `annotations`:

```json
"annotations": {
  "org.opencontainers.image.created": "2026-07-07T20:08:59-07:00",
  "org.opencontainers.image.description": "A production-ready Helm chart for deploying MLflow on Kubernetes",
  "org.opencontainers.image.source": "https://github.com/mlflow/mlflow",
  "org.opencontainers.image.title": "mlflow",
  "org.opencontainers.image.version": "0.1.0"
}
```

`org.opencontainers.image.source` is not one of the annotations helm generates on its own (those are `created`, `description`, `title`, `version`), so its presence confirms the value propagated from the `Chart.yaml` change.

4. `helm lint charts/` passes clean (only the standard "icon is recommended" info message).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
