### PR TITLE
Fix trace OTLP encoding for lone surrogates

### DIFF
--- a/mlflow/tracing/utils/otlp.py
+++ b/mlflow/tracing/utils/otlp.py
@@ -156,6 +156,11 @@ def _otel_proto_bytes_to_id(id_bytes: bytes) -> int:
     return int.from_bytes(id_bytes, byteorder="big", signed=False)
 
 
+def _sanitize_otel_string(value: str) -> str:
+    """Replace characters that cannot be encoded as UTF-8 for protobuf string assignment."""
+    return value.encode("utf-8", errors="replace").decode("utf-8")
+
+
 def _set_otel_proto_anyvalue(pb_any_value: AnyValue, value: Any) -> None:
     """Set a value on an OTel protobuf AnyValue message.
 
@@ -169,7 +174,7 @@ def _set_otel_proto_anyvalue(pb_any_value: AnyValue, value: Any) -> None:
     elif isinstance(value, bool):
         pb_any_value.bool_value = value
     elif isinstance(value, str):
-        pb_any_value.string_value = value
+        pb_any_value.string_value = _sanitize_otel_string(value)
     elif isinstance(value, int):
         pb_any_value.int_value = value
     elif isinstance(value, float):
@@ -187,12 +192,12 @@ def _set_otel_proto_anyvalue(pb_any_value: AnyValue, value: Any) -> None:
         kvlist_value = KeyValueList()
         for k, v in value.items():
             kv = kvlist_value.values.add()
-            kv.key = str(k)
+            kv.key = _sanitize_otel_string(str(k))
             _set_otel_proto_anyvalue(kv.value, v)
         pb_any_value.kvlist_value.CopyFrom(kvlist_value)
     else:
         # For unknown types, convert to string
-        pb_any_value.string_value = str(value)
+        pb_any_value.string_value = _sanitize_otel_string(str(value))
 
 
 def _decode_otel_proto_anyvalue(pb_any_value: AnyValue) -> Any:

--- a/tests/tracing/utils/test_otlp.py
+++ b/tests/tracing/utils/test_otlp.py
@@ -13,6 +13,7 @@ from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 from mlflow.tracing.processor.otel import OtelSpanProcessor
 from mlflow.tracing.provider import _get_trace_exporter, _get_tracer
 from mlflow.tracing.provider import provider as mlflow_provider
+from mlflow.tracing.utils.otlp import _set_otel_proto_anyvalue
 from mlflow.tracking import MlflowClient
 from mlflow.utils.os import is_windows
 
@@ -26,6 +27,7 @@ try:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
         OTLPSpanExporter as HttpExporter,
     )
+    from opentelemetry.proto.common.v1.common_pb2 import AnyValue
 except ImportError:
     pytest.skip("OTLP exporters are not installed", allow_module_level=True)
 
@@ -291,3 +293,35 @@ def test_decompress_otlp_body_valid(
 def test_decompress_otlp_body_invalid(encoding: str, invalid_data: bytes, expected_error: str):
     with pytest.raises(HTTPException, match=expected_error, check=lambda e: e.status_code == 400):
         decompress_otlp_body(invalid_data, encoding)
+
+
+def test_set_otel_proto_anyvalue_sanitizes_lone_surrogate_string():
+    value = AnyValue()
+    _set_otel_proto_anyvalue(value, "x" * 149 + "\ud83e")
+    assert value.string_value == "x" * 149 + "?"
+
+
+def test_set_otel_proto_anyvalue_sanitizes_lone_surrogate_fallback():
+    class BadStr:
+        def __str__(self):
+            return "bad\ud83e"
+
+    value = AnyValue()
+    _set_otel_proto_anyvalue(value, BadStr())
+    assert value.string_value == "bad?"
+
+
+def test_set_otel_proto_anyvalue_sanitizes_nested_lone_surrogate():
+    value = AnyValue()
+    _set_otel_proto_anyvalue(value, {"items": ["ok", {"bad": "x\ud83e"}]})
+    nested = value.kvlist_value.values[0].value.array_value.values[1]
+    assert nested.kvlist_value.values[0].value.string_value == "x?"
+
+
+def test_set_otel_proto_anyvalue_sanitizes_lone_surrogate_dict_key():
+    value = AnyValue()
+
+    _set_otel_proto_anyvalue(value, {"bad\ud83e": "ok"})
+
+    assert value.kvlist_value.values[0].key == "bad?"
+    assert value.kvlist_value.values[0].value.string_value == "ok"


### PR DESCRIPTION
### Related Issues/PRs

Closes #24123

### What changes are proposed in this pull request?
This PR fixes a `UnicodeEncodeError` in `traces/batchGet` when a span attribute contains a lone surrogate character.

The fix sanitizes string values during OTLP `AnyValue` conversion so protobuf string assignment does not fail. This covers the two conversion paths discussed in the issue:
- Direct str values
- Fallback values converted through str(value)

This PR also sanitizes dict keys converted through `str(k)` and covers nested list/dict values through the existing recursive conversion path.

Batch isolation and write-side export behavior are intentionally left out of scope, as discussed on the issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added regression coverage for:
- A direct string value containing a lone surrogate
- A fallback object whose `__str__` returns a lone surrogate
- A nested dict/list value containing a lone surrogate
- A dict key containing a lone surrogate

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a tracing issue where `traces/batchGet` could fail with a `UnicodeEncodeError` when a span attribute contained a lone surrogate character.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
