### PR TITLE
Fix duplicate full-trace fetch for `TRACKING_STORE` traces in the trace UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.test.ts
@@ -8,7 +8,7 @@ import {
   getTrace,
 } from './TraceUtils';
 import type { ModelTrace, ModelTraceSpanV2, ModelTraceSpanV3 } from '@databricks/web-shared/model-trace-explorer';
-import { getExperimentTraceV3, TracesServiceV3, TracesServiceV4 } from '@databricks/web-shared/model-trace-explorer';
+import { getExperimentTraceV3, TracesServiceV3 } from '@databricks/web-shared/model-trace-explorer';
 import { getSpansLocation, TRACKING_STORE_SPANS_LOCATION } from '@databricks/web-shared/genai-traces-table';
 
 jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
@@ -1100,7 +1100,6 @@ describe('extractRetrievalContext', () => {
 describe('getTrace', () => {
   const mockGetExperimentTraceV3 = jest.mocked(getExperimentTraceV3);
   const mockGetTraceV3 = jest.mocked(TracesServiceV3.getTraceV3);
-  const mockGetTraceV4 = jest.mocked(TracesServiceV4.getTraceV4);
   const mockGetSpansLocation = jest.mocked(getSpansLocation);
 
   beforeEach(() => {
@@ -1119,9 +1118,20 @@ describe('getTrace', () => {
 
     const result = await getTrace('tr-1', { trace_id: 'tr-1' } as any);
 
-    expect(mockGetExperimentTraceV3).toHaveBeenCalledTimes(1);
+    expect(mockGetExperimentTraceV3).toHaveBeenCalledWith({ traceId: 'tr-1' });
     expect(mockGetTraceV3).not.toHaveBeenCalled();
     expect(result).toEqual({ info: { trace_id: 'tr-1' }, data: { spans } });
+  });
+
+  it('falls back to getTraceV3 when get-trace returns no trace for a TRACKING_STORE trace', async () => {
+    mockGetSpansLocation.mockReturnValue(TRACKING_STORE_SPANS_LOCATION);
+    mockGetExperimentTraceV3.mockResolvedValue({ trace: null } as any);
+    mockGetTraceV3.mockResolvedValue({ info: {}, data: { spans: [] } } as any);
+
+    await getTrace('tr-1', { trace_id: 'tr-1' } as any);
+
+    expect(mockGetExperimentTraceV3).toHaveBeenCalledWith({ traceId: 'tr-1' });
+    expect(mockGetTraceV3).toHaveBeenCalledWith('tr-1');
   });
 
   it('falls back to getTraceV3 for a non-TRACKING_STORE v3 trace', async () => {

--- a/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.test.ts
@@ -1,6 +1,27 @@
-import { describe, it, expect } from '@jest/globals';
-import { isRootSpan, getRootSpan, extractInputs, extractOutputs, extractRetrievalContext } from './TraceUtils';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import {
+  isRootSpan,
+  getRootSpan,
+  extractInputs,
+  extractOutputs,
+  extractRetrievalContext,
+  getTrace,
+} from './TraceUtils';
 import type { ModelTrace, ModelTraceSpanV2, ModelTraceSpanV3 } from '@databricks/web-shared/model-trace-explorer';
+import { getExperimentTraceV3, TracesServiceV3, TracesServiceV4 } from '@databricks/web-shared/model-trace-explorer';
+import { getSpansLocation, TRACKING_STORE_SPANS_LOCATION } from '@databricks/web-shared/genai-traces-table';
+
+jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  ...jest.requireActual<any>('@databricks/web-shared/model-trace-explorer'),
+  getExperimentTraceV3: jest.fn(),
+  TracesServiceV3: { getTraceV3: jest.fn() },
+  TracesServiceV4: { getTraceV4: jest.fn() },
+}));
+
+jest.mock('@databricks/web-shared/genai-traces-table', () => ({
+  ...jest.requireActual<any>('@databricks/web-shared/genai-traces-table'),
+  getSpansLocation: jest.fn(),
+}));
 
 describe('isRootSpan', () => {
   describe('Golden Path - Successful Operations', () => {
@@ -1073,5 +1094,43 @@ describe('extractRetrievalContext', () => {
         ],
       });
     });
+  });
+});
+
+describe('getTrace', () => {
+  const mockGetExperimentTraceV3 = jest.mocked(getExperimentTraceV3);
+  const mockGetTraceV3 = jest.mocked(TracesServiceV3.getTraceV3);
+  const mockGetTraceV4 = jest.mocked(TracesServiceV4.getTraceV4);
+  const mockGetSpansLocation = jest.mocked(getSpansLocation);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches a TRACKING_STORE trace via get-trace only, without the artifact request', async () => {
+    // Regression test for the duplicate full-trace fetch: the get-trace response is
+    // { trace: { trace_info, spans } }, so the branch must consume trace.spans and return
+    // instead of falling through to getTraceV3 (which issues get-trace-artifact).
+    mockGetSpansLocation.mockReturnValue(TRACKING_STORE_SPANS_LOCATION);
+    const spans = [{ span_id: 's1' }, { span_id: 's2' }] as any;
+    mockGetExperimentTraceV3.mockResolvedValue({
+      trace: { trace_info: { trace_id: 'tr-1' }, spans },
+    } as any);
+
+    const result = await getTrace('tr-1', { trace_id: 'tr-1' } as any);
+
+    expect(mockGetExperimentTraceV3).toHaveBeenCalledTimes(1);
+    expect(mockGetTraceV3).not.toHaveBeenCalled();
+    expect(result).toEqual({ info: { trace_id: 'tr-1' }, data: { spans } });
+  });
+
+  it('falls back to getTraceV3 for a non-TRACKING_STORE v3 trace', async () => {
+    mockGetSpansLocation.mockReturnValue(undefined);
+    mockGetTraceV3.mockResolvedValue({ info: {}, data: { spans: [] } } as any);
+
+    await getTrace('tr-1', { trace_id: 'tr-1' } as any);
+
+    expect(mockGetExperimentTraceV3).not.toHaveBeenCalled();
+    expect(mockGetTraceV3).toHaveBeenCalledWith('tr-1');
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/TraceUtils.ts
@@ -33,10 +33,14 @@ export async function getTrace(
   // only set when the backend is OSS SQLAlchemyStore.
   if (getSpansLocation(traceInfo as ModelTraceInfoV3) === TRACKING_STORE_SPANS_LOCATION) {
     const traceResp = await getExperimentTraceV3({ traceId });
-    if (traceResp?.trace && traceResp.trace.data) {
+    // The get-trace response is { trace: { trace_info, spans } } (see GetTrace.Response),
+    // so the spans live under trace.spans. Reshape into the { info, data: { spans } } shape
+    // the UI expects, mirroring getTraceV4. Returning here avoids falling through to the
+    // artifact route, which would issue a second full-trace request for the same trace.
+    if (traceResp?.trace) {
       return {
         info: traceResp.trace.trace_info || {},
-        data: traceResp.trace.data,
+        data: { spans: traceResp.trace.spans ?? [] },
       };
     }
   }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24312

### What changes are proposed in this pull request?

`TraceUtils.getTrace()` checks the `mlflow.trace.spansLocation` tag and, for `TRACKING_STORE` traces, fetches the trace via `GET /traces/get`. But the early-return was guarded on `traceResp.trace.data`:

```ts
const traceResp = await getExperimentTraceV3({ traceId });
if (traceResp?.trace && traceResp.trace.data) {  // <- never truthy
  return { info: traceResp.trace.trace_info || {}, data: traceResp.trace.data };
}
```

The `GetTrace` response shape is `{ trace: { trace_info, spans } }` (see `GetTrace.Response` / the `Trace` proto message) — there is no `data` field. So `traceResp.trace.data` is always `undefined`, the guard never passes, and execution falls through to `TracesServiceV3.getTraceV3(traceId)`, which issues `GET /get-trace-artifact` for the same trace via its internal `Promise.all([info, data])`.

Net effect for every `TRACKING_STORE` trace: the full trace payload is fetched twice — once via `traces/get` (result discarded) and again via `get-trace-artifact`. On large traces both requests are expensive and the UI appears to hang.

This PR consumes the actual response shape (`traceResp.trace.spans`) and reshapes it into the `{ info, data: { spans } }` form the UI expects, mirroring how `getTraceV4` reshapes the same proto shape. The branch now returns after the single `traces/get` call and never reaches the `get-trace-artifact` fallthrough.

Note: this fixes the duplicate request. Large `TRACKING_STORE` traces still fully materialize all spans server-side in a single request (tracked separately in #24314); this change halves the load by removing the redundant fetch but does not by itself resolve the large-trace cost.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added two tests in `TraceUtils.test.ts`:
- a `TRACKING_STORE` trace fetches via `getExperimentTraceV3` (`traces/get`) only and does **not** call `getTraceV3` (the `get-trace-artifact` path), and returns the `{ info, data: { spans } }` shape;
- a non-`TRACKING_STORE` v3 trace still falls back to `getTraceV3`.

Verified the new test fails against the previous (`traceResp.trace.data`) guard and passes with the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the trace UI issuing a redundant full-trace request (`get-trace-artifact` in addition to `traces/get`) when opening tracking-store-backed traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
