### PR TITLE
fix: handle race condition when initializing database tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,15 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    try:
+        InitialBase.metadata.create_all(engine)
+    except sqlalchemy.exc.OperationalError as e:
+        # If multiple processes attempt to initialize tables concurrently,
+        # the second one may find tables already exist. This is safe to ignore.
+        if "already exists" in str(e).lower():
+            _logger.warning("Database tables already exist, skipping creation.")
+        else:
+            raise
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When multiple MLflow processes attempt database initialization concurrently, the second process fails with an error like "Table 'secrets' already exists" because InitialBase.metadata.create_all() uses CREATE TABLE IF NOT EXISTS (which most databases support) but some databases/drivers may still raise an error if the table already exists. This leads to a failure when running `mlflow db upgrade` after upgrading to 3.8.x.

## Fix
Wrap the `InitialBase.metadata.create_all()` call in a try-except block that catches sqlalchemy.exc.OperationalError. If the error message indicates the table already exists, we log a warning and continue with the upgrade, since the tables are already present.

Closes #19943