### PR TITLE
feat: stream trace attachments and data from disk instead of memory

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -13,13 +13,16 @@ import unicodedata
 import urllib
 from functools import partial, wraps
 from typing import Any, Callable
+from zlib import adler32
 
 import requests
 from cachetools import TTLCache
 from flask import Request, Response, current_app, g, jsonify, request, send_file
 from google.protobuf import descriptor
 from google.protobuf.json_format import ParseError
+from werkzeug.exceptions import RequestedRangeNotSatisfiable
 from werkzeug.http import quote_header_value
+from werkzeug.wsgi import wrap_file
 
 import mlflow
 from mlflow.client import MlflowClient
@@ -322,6 +325,7 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartUploadMixin,
     PresignedUploadMixin,
     StreamUploadMixin,
+    _validate_attachment_path,
 )
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES
@@ -1161,6 +1165,72 @@ def _create_artifact_file_response(file_path: str, artifact_name: str) -> Respon
     return _response_with_file_attachment_headers(file_path, file_sender_response)
 
 
+def _create_temp_artifact_file_response(
+    file_path: str, artifact_name: str, cleanup: Callable[[], None]
+) -> Response:
+    """Serve a temporary file and clean it up when the WSGI iterator closes."""
+    if os.path.isdir(file_path):
+        raise MlflowException.invalid_parameter_value(
+            f"Artifact path refers to a directory, not a file: '{artifact_name}'"
+        )
+
+    try:
+        file_handle = open(file_path, "rb")  # noqa: SIM115
+        file_stat = os.fstat(file_handle.fileno())
+        file_size = file_stat.st_size
+    except Exception:
+        cleanup()
+        raise
+
+    class _CleanupFileWrapper:
+        def __init__(self, handle, cleanup_callback: Callable[[], None]) -> None:
+            self._handle = handle
+            self._cleanup_callback = cleanup_callback
+            self._closed = False
+
+        def close(self) -> None:
+            if self._closed:
+                return
+            self._closed = True
+            self._handle.close()
+            self._cleanup_callback()
+
+        def __getattr__(self, name: str):
+            return getattr(self._handle, name)
+
+    wrapped_file = _CleanupFileWrapper(file_handle, cleanup)
+
+    try:
+        response = current_app.response_class(
+            wrap_file(
+                request.environ,
+                wrapped_file,
+                buffer_size=ARTIFACT_STREAM_CHUNK_SIZE,
+            ),
+            mimetype=_guess_mime_type(file_path),
+            direct_passthrough=True,
+        )
+        response.content_length = file_size
+        response.last_modified = file_stat.st_mtime
+        check = adler32(file_path.encode()) & 0xFFFFFFFF
+        response.set_etag(f"{file_stat.st_mtime}-{file_size}-{check}")
+        response.cache_control.no_cache = True
+        response = response.make_conditional(
+            request.environ, accept_ranges=True, complete_length=file_size
+        )
+    except RequestedRangeNotSatisfiable:
+        wrapped_file.close()
+        raise
+    except Exception:
+        wrapped_file.close()
+        raise
+
+    response.headers["Content-Disposition"] = _content_disposition_attachment(
+        pathlib.Path(artifact_name).name
+    )
+    return _response_with_file_attachment_headers(file_path, response)
+
+
 def _send_artifact(artifact_repository, path):
     # Always send artifacts as attachments to prevent the browser from displaying them on our web
     # server's domain, which might enable XSS.
@@ -1172,9 +1242,7 @@ def _send_artifact(artifact_repository, path):
         file_path = os.path.abspath(
             artifact_repository.download_artifacts(path, dst_path=tmp_dir.name)
         )
-        response = _create_artifact_file_response(file_path, path)
-        response.call_on_close(tmp_dir.cleanup)
-        return response
+        return _create_temp_artifact_file_response(file_path, path, tmp_dir.cleanup)
     except Exception:
         tmp_dir.cleanup()
         raise
@@ -3585,22 +3653,10 @@ def _download_artifact(artifact_path):
     tmp_dir = tempfile.TemporaryDirectory()
     try:
         dst = os.path.abspath(artifact_repo.download_artifacts(artifact_path, tmp_dir.name))
-
-        # Ref: https://stackoverflow.com/a/24613980/6943581
-        file_handle = open(dst, "rb")  # noqa: SIM115
+        return _create_temp_artifact_file_response(dst, artifact_path, tmp_dir.cleanup)
     except Exception:
         tmp_dir.cleanup()
         raise
-
-    def stream_and_remove_file():
-        while chunk := file_handle.read(ARTIFACT_STREAM_CHUNK_SIZE):
-            yield chunk
-        file_handle.close()
-        tmp_dir.cleanup()
-
-    file_sender_response = current_app.response_class(stream_and_remove_file())
-
-    return _response_with_file_attachment_headers(artifact_path, file_sender_response)
 
 
 @catch_mlflow_exception
@@ -4333,6 +4389,7 @@ def get_trace_artifact_handler() -> Response:
 
     if path:
         path = validate_path_is_safe(path)
+        _validate_attachment_path(path)
         trace_info = store.get_trace_info(request_id)
         if trace_info is None:
             raise MlflowException(
@@ -4340,11 +4397,26 @@ def get_trace_artifact_handler() -> Response:
                 error_code=RESOURCE_DOES_NOT_EXIST,
             )
         repo = _get_trace_artifact_repo(trace_info)
+        attachment_artifact_path = posixpath.join("attachments", path)
+
         try:
-            content_bytes = repo.download_trace_attachment(path)
+            local_path = repo.get_local_path(attachment_artifact_path)
         except MlflowException:
+            local_path = None
+
+        if local_path is not None:
+            return _create_artifact_file_response(os.path.abspath(local_path), path)
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        try:
+            dst = pathlib.Path(tmp_dir.name, path)
+            repo.download_trace_attachment_to_file(path, dst)
+            return _create_temp_artifact_file_response(str(dst), path, tmp_dir.cleanup)
+        except MlflowException:
+            tmp_dir.cleanup()
             raise
         except Exception:
+            tmp_dir.cleanup()
             _logger.warning(
                 "Failed to download attachment '%s' for trace '%s'",
                 path,
@@ -4355,14 +4427,6 @@ def get_trace_artifact_handler() -> Response:
                 f"Failed to download attachment '{path}' for trace '{request_id}'.",
                 error_code=INTERNAL_ERROR,
             )
-        buf = io.BytesIO(content_bytes)
-        file_sender_response = send_file(
-            buf,
-            mimetype="application/octet-stream",
-            as_attachment=True,
-            download_name=path,
-        )
-        return _response_with_file_attachment_headers(path, file_sender_response)
 
     trace_data = _fetch_trace_data_from_store(store, request_id)
     if trace_data is None:
@@ -4372,9 +4436,29 @@ def get_trace_artifact_handler() -> Response:
                 _get_trace_archive_repo(trace_info).download_archived_trace_data().to_dict()
             )
         else:
-            trace_data = _get_trace_artifact_repo(trace_info).download_trace_data()
+            repo = _get_trace_artifact_repo(trace_info)
 
-    # Write data to a BytesIO buffer instead of needing to save a temp file
+            try:
+                local_path = repo.get_local_path(TRACE_DATA_FILE_NAME)
+            except MlflowException:
+                local_path = None
+
+            if local_path is not None:
+                return _create_artifact_file_response(
+                    os.path.abspath(local_path), TRACE_DATA_FILE_NAME
+                )
+
+            tmp_dir = tempfile.TemporaryDirectory()
+            try:
+                dst = pathlib.Path(tmp_dir.name, TRACE_DATA_FILE_NAME)
+                repo.download_trace_data_to_file(dst)
+                return _create_temp_artifact_file_response(
+                    str(dst), TRACE_DATA_FILE_NAME, tmp_dir.cleanup
+                )
+            except Exception:
+                tmp_dir.cleanup()
+                raise
+
     buf = io.BytesIO()
     buf.write(json.dumps(trace_data).encode())
     buf.seek(0)

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -479,6 +479,25 @@ class ArtifactRepository:
         num_cpus = os.cpu_count() or _NUM_DEFAULT_CPUS
         return min(num_cpus * _NUM_MAX_THREADS_PER_CPU, _NUM_MAX_THREADS)
 
+    def download_trace_data_to_file(self, dst_path: Path) -> Path:
+        """
+        Download the trace data file to the specified local path without parsing it.
+
+        Args:
+            dst_path: Local filesystem path to write the trace data file to.
+
+        Returns:
+            The ``dst_path`` argument, for convenience.
+
+        Raises:
+            - `MlflowTraceDataNotFound`: The trace data is not found.
+        """
+        try:
+            self._download_file(TRACE_DATA_FILE_NAME, dst_path)
+        except Exception as e:
+            raise MlflowTraceDataNotFound(artifact_path=TRACE_DATA_FILE_NAME) from e
+        return dst_path
+
     def download_trace_data(self) -> dict[str, Any]:
         """
         Download the trace data.
@@ -492,12 +511,7 @@ class ArtifactRepository:
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_file = Path(temp_dir, TRACE_DATA_FILE_NAME)
-            try:
-                self._download_file(TRACE_DATA_FILE_NAME, temp_file)
-            except Exception as e:
-                # `MlflowTraceDataNotFound` is caught in `TrackingServiceClient.search_traces` and
-                # is used to filter out traces with failed trace data download.
-                raise MlflowTraceDataNotFound(artifact_path=TRACE_DATA_FILE_NAME) from e
+            self.download_trace_data_to_file(temp_file)
             return try_read_trace_data(temp_file)
 
     def download_archived_trace_data(self) -> TraceData:
@@ -523,11 +537,26 @@ class ArtifactRepository:
                 return TraceData(spans=[])
             return TraceData(spans=_try_read_trace_data_pb(temp_file))
 
+    def download_trace_attachment_to_file(self, path: str, dst_path: Path) -> Path:
+        """
+        Download a trace attachment to the specified local path.
+
+        Args:
+            path: The attachment identifier (UUID).
+            dst_path: Local filesystem path to write the attachment to.
+
+        Returns:
+            The ``dst_path`` argument, for convenience.
+        """
+        _validate_attachment_path(path)
+        self._download_file(posixpath.join("attachments", path), dst_path)
+        return dst_path
+
     def download_trace_attachment(self, path: str) -> bytes:
         _validate_attachment_path(path)
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_file = Path(temp_dir, path)
-            self._download_file(posixpath.join("attachments", path), temp_file)
+            self.download_trace_attachment_to_file(path, temp_file)
             return temp_file.read_bytes()
 
     def upload_trace_data(self, trace_data: str) -> None:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -87,6 +87,8 @@ from mlflow.utils.uri import (
 
 _logger = logging.getLogger(__name__)
 _MAX_CREDENTIALS_REQUEST_SIZE = 2000  # Max number of artifact paths in a single credentials request
+_TRACE_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+_TRACE_DOWNLOAD_MAX_STREAM_ATTEMPTS = 2
 _SERVICE_AND_METHOD_TO_INFO = {
     service: extract_api_info_for_service(service, _REST_API_PATH_PREFIX)
     for service in [MlflowService, DatabricksMlflowArtifactsService]
@@ -252,20 +254,94 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         ]
         return self._get_credential_infos(_CredentialType.WRITE, relative_remote_paths)
 
-    def download_trace_data(self) -> dict[str, Any]:
+    def _validate_streamed_trace_download(
+        self, response: requests.Response, expected_length: str | None, bytes_written: int
+    ) -> None:
+        if expected_length is None:
+            return
+
+        try:
+            expected_length_int = int(expected_length)
+        except ValueError:
+            return
+
+        actual_length = None
+        raw_tell = getattr(getattr(response, "raw", None), "tell", None)
+        if callable(raw_tell):
+            try:
+                actual_length = raw_tell()
+            except Exception:
+                actual_length = None
+
+        if actual_length is None and not response.headers.get("Content-Encoding"):
+            actual_length = bytes_written
+
+        if actual_length is not None and actual_length < expected_length_int:
+            raise requests.ConnectionError(
+                f"Incomplete download: read {actual_length} of {expected_length_int} bytes"
+            )
+
+    def _stream_trace_response_to_path(self, response: requests.Response, dst_path: Path) -> Path:
+        partial_path = Path(f"{dst_path}.part")
+        bytes_written = 0
+        try:
+            with partial_path.open("wb") as output_file:
+                for chunk in response.iter_content(chunk_size=_TRACE_DOWNLOAD_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    output_file.write(chunk)
+                    bytes_written += len(chunk)
+
+            self._validate_streamed_trace_download(
+                response, response.headers.get("Content-Length"), bytes_written
+            )
+            os.replace(partial_path, dst_path)
+            return dst_path
+        except Exception:
+            partial_path.unlink(missing_ok=True)
+            raise
+
+    def _download_trace_file_to_path(
+        self, signed_uri: str, dst_path: Path, headers: dict[str, str]
+    ) -> Path:
+        try:
+            for attempt in range(1, _TRACE_DOWNLOAD_MAX_STREAM_ATTEMPTS + 1):
+                with cloud_storage_http_request(
+                    "get", signed_uri, stream=True, headers=headers
+                ) as response:
+                    augmented_raise_for_status(response)
+                    try:
+                        return self._stream_trace_response_to_path(response, dst_path)
+                    except requests.RequestException as e:
+                        if attempt == _TRACE_DOWNLOAD_MAX_STREAM_ATTEMPTS:
+                            raise
+                        _logger.warning(
+                            "Retrying streamed trace artifact download after attempt %s/%s: %s",
+                            attempt,
+                            _TRACE_DOWNLOAD_MAX_STREAM_ATTEMPTS,
+                            e,
+                        )
+        except requests.RequestException:
+            dst_path.unlink(missing_ok=True)
+            raise
+
+    def download_trace_data_to_file(self, dst_path: Path) -> Path:
         [cred], _ = self.resource.get_credentials(cred_type=_CredentialType.READ)
         signed_uri = cred.signed_uri
         headers = self._extract_headers_from_credentials(cred.headers)
-        with cloud_storage_http_request("get", signed_uri, headers=headers) as resp:
-            try:
-                augmented_raise_for_status(resp)
-            except requests.HTTPError as e:
-                if e.response.status_code == 404:
-                    raise MlflowTraceDataNotFound(request_id=self.resource.id) from e
-                raise
+        try:
+            return self._download_trace_file_to_path(signed_uri, dst_path, headers)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                raise MlflowTraceDataNotFound(request_id=self.resource.id) from e
+            raise
 
+    def download_trace_data(self) -> dict[str, Any]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dst = Path(temp_dir, "traces.json")
+            self.download_trace_data_to_file(dst)
             try:
-                return json.loads(resp.content)
+                return json.loads(dst.read_text(encoding="utf-8"))
             except json.JSONDecodeError as e:
                 raise MlflowTraceDataCorrupted(request_id=self.resource.id) from e
 
@@ -323,7 +399,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
         )
         return cred
 
-    def download_trace_attachment(self, path: str) -> bytes:
+    def download_trace_attachment_to_file(self, path: str, dst_path: Path) -> Path:
         _validate_attachment_path(path)
         artifact_path = posixpath.join("attachments", path)
         [cred], _ = self.resource.get_credentials(
@@ -331,17 +407,22 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             artifact_path=artifact_path,
         )
         headers = self._extract_headers_from_credentials(cred.headers)
-        with cloud_storage_http_request("get", cred.signed_uri, headers=headers) as resp:
-            try:
-                augmented_raise_for_status(resp)
-            except requests.HTTPError as e:
-                if e.response.status_code == 404:
-                    raise MlflowException(
-                        f"Attachment '{path}' not found.",
-                        error_code=RESOURCE_DOES_NOT_EXIST,
-                    ) from e
-                raise
-            return resp.content
+        try:
+            return self._download_trace_file_to_path(cred.signed_uri, dst_path, headers)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                raise MlflowException(
+                    f"Attachment '{path}' not found.",
+                    error_code=RESOURCE_DOES_NOT_EXIST,
+                ) from e
+            raise
+
+    def download_trace_attachment(self, path: str) -> bytes:
+        _validate_attachment_path(path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dst = Path(temp_dir, path)
+            self.download_trace_attachment_to_file(path, dst)
+            return dst.read_bytes()
 
     def upload_attachment(self, attachment_id: str, content_bytes: bytes) -> None:
         _validate_attachment_path(attachment_id)

--- a/mlflow/store/artifact/databricks_tracking_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_tracking_artifact_repo.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
@@ -84,6 +85,11 @@ class DatabricksTrackingArtifactRepository(ArtifactRepository, ABC):
                 exc_info=True,
             )
             return self.databricks_artifact_repo.list_artifacts(path)
+
+    def download_trace_attachment_to_file(self, path: str, dst_path: Path) -> Path:
+        # Bypass the SDK repo — attachment operations require path-scoped credentials
+        # which are only supported by DatabricksArtifactRepository.get_credentials.
+        return self.databricks_artifact_repo.download_trace_attachment_to_file(path, dst_path)
 
     def download_trace_attachment(self, path: str) -> bytes:
         # Bypass the SDK repo — attachment operations require path-scoped credentials

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -6,8 +6,9 @@ from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
-from flask import Response
+from flask import Response, request
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
+from werkzeug.exceptions import RequestedRangeNotSatisfiable
 
 import mlflow
 from mlflow.entities import (
@@ -166,6 +167,7 @@ from mlflow.server.handlers import (
     _create_prompt_optimization_job,
     _create_registered_model,
     _create_review_queue,
+    _create_temp_artifact_file_response,
     _create_workspace_handler,
     _delete_artifact_mlflow_artifacts,
     _delete_dataset_handler,
@@ -3559,9 +3561,14 @@ def test_get_trace_artifact_handler_fallback_to_artifact_repo(mock_tracking_stor
     )
     mock_tracking_store.get_trace_info.return_value = trace_info
 
-    # Mock the artifact repo
     mock_artifact_repo = mock.MagicMock()
-    mock_artifact_repo.download_trace_data.return_value = trace_data
+    mock_artifact_repo.get_local_path.return_value = None
+
+    def fake_download_to_file(dst_path):
+        dst_path.write_text(json.dumps(trace_data))
+        return dst_path
+
+    mock_artifact_repo.download_trace_data_to_file.side_effect = fake_download_to_file
 
     with mock.patch(
         "mlflow.server.handlers._get_trace_artifact_repo", return_value=mock_artifact_repo
@@ -3573,7 +3580,8 @@ def test_get_trace_artifact_handler_fallback_to_artifact_repo(mock_tracking_stor
     mock_tracking_store.get_trace.assert_called_once_with(trace_id, allow_partial=True)
     mock_tracking_store.batch_get_traces.assert_called_once_with([trace_id], None)
     mock_tracking_store.get_trace_info.assert_called_once_with(trace_id)
-    mock_artifact_repo.download_trace_data.assert_called_once()
+    args, _ = mock_artifact_repo.download_trace_data_to_file.call_args
+    assert args[0].name == "traces.json"
 
     # Verify successful response
     assert response is not None
@@ -3581,7 +3589,50 @@ def test_get_trace_artifact_handler_fallback_to_artifact_repo(mock_tracking_stor
     assert response.headers["Content-Disposition"] == "attachment; filename=traces.json"
 
 
-def test_get_trace_artifact_handler_with_attachment_path(mock_tracking_store):
+def test_get_trace_artifact_handler_fallback_to_artifact_repo_local_path(
+    mock_tracking_store, tmp_path
+):
+    trace_id = "test-trace-artifact-repo-local"
+
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=EntityTraceLocation.from_experiment_id("3"),
+        request_time=1234567890,
+        execution_duration=4000,
+        state=TraceState.OK,
+    )
+
+    trace_data = {"spans": [{"name": "local_span"}]}
+
+    mock_tracking_store.get_trace.side_effect = MlflowNotImplementedException(
+        "get_trace is not implemented"
+    )
+    mock_tracking_store.batch_get_traces.side_effect = MlflowNotImplementedException(
+        "batch_get_traces is not implemented"
+    )
+    mock_tracking_store.get_trace_info.return_value = trace_info
+
+    trace_file = tmp_path / "traces.json"
+    trace_file.write_text(json.dumps(trace_data))
+
+    mock_artifact_repo = mock.MagicMock()
+    mock_artifact_repo.get_local_path.return_value = str(trace_file)
+
+    with mock.patch(
+        "mlflow.server.handlers._get_trace_artifact_repo", return_value=mock_artifact_repo
+    ):
+        with app.test_request_context(method="GET", query_string={"request_id": trace_id}):
+            response = get_trace_artifact_handler()
+
+    mock_artifact_repo.get_local_path.assert_called_once_with("traces.json")
+    mock_artifact_repo.download_trace_data_to_file.assert_not_called()
+
+    assert response is not None
+    assert response.status_code == 200
+    assert response.headers["Content-Disposition"] == "attachment; filename=traces.json"
+
+
+def test_get_trace_artifact_handler_with_attachment_path(mock_tracking_store, tmp_path):
     trace_id = "tr-test-attachment-123"
     attachment_id = "a1b2c3d4-e5f6-4890-abcd-ef1234567890"
 
@@ -3596,7 +3647,14 @@ def test_get_trace_artifact_handler_with_attachment_path(mock_tracking_store):
     mock_tracking_store.get_trace_info.return_value = trace_info
 
     mock_artifact_repo = mock.MagicMock()
-    mock_artifact_repo.download_trace_attachment.return_value = b"\x89PNG fake image"
+    # get_local_path returns None to exercise the *_to_file fallback
+    mock_artifact_repo.get_local_path.return_value = None
+
+    def fake_download_to_file(path, dst_path):
+        dst_path.write_bytes(b"\x89PNG fake image")
+        return dst_path
+
+    mock_artifact_repo.download_trace_attachment_to_file.side_effect = fake_download_to_file
 
     with mock.patch(
         "mlflow.server.handlers._get_trace_artifact_repo", return_value=mock_artifact_repo
@@ -3606,11 +3664,48 @@ def test_get_trace_artifact_handler_with_attachment_path(mock_tracking_store):
             response = get_trace_artifact_handler()
 
     mock_tracking_store.get_trace_info.assert_called_once_with(trace_id)
-    mock_artifact_repo.download_trace_attachment.assert_called_once_with(attachment_id)
+    mock_artifact_repo.download_trace_attachment_to_file.assert_called_once_with(
+        attachment_id, mock.ANY
+    )
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/octet-stream"
     assert response.headers["Content-Disposition"] == f"attachment; filename={attachment_id}"
     assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_get_trace_artifact_handler_with_attachment_local_path(mock_tracking_store, tmp_path):
+    trace_id = "tr-test-attachment-local"
+    attachment_id = "a1b2c3d4-e5f6-4890-abcd-ef1234567890"
+
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=EntityTraceLocation.from_experiment_id("3"),
+        request_time=1234567890,
+        execution_duration=4000,
+        state=TraceState.OK,
+    )
+
+    mock_tracking_store.get_trace_info.return_value = trace_info
+
+    # Write a real file for the local fast path
+    att_file = tmp_path / "attachments" / attachment_id
+    att_file.parent.mkdir(parents=True)
+    att_file.write_bytes(b"\x89PNG local image")
+
+    mock_artifact_repo = mock.MagicMock()
+    mock_artifact_repo.get_local_path.return_value = str(att_file)
+
+    with mock.patch(
+        "mlflow.server.handlers._get_trace_artifact_repo", return_value=mock_artifact_repo
+    ):
+        query = {"request_id": trace_id, "path": attachment_id}
+        with app.test_request_context(method="GET", query_string=query):
+            response = get_trace_artifact_handler()
+
+    mock_artifact_repo.get_local_path.assert_called_once_with(f"attachments/{attachment_id}")
+    mock_artifact_repo.download_trace_attachment_to_file.assert_not_called()
+    assert response.status_code == 200
+    assert response.headers["Content-Disposition"] == f"attachment; filename={attachment_id}"
 
 
 def test_get_trace_artifact_handler_falls_back_to_archive_repo(mock_tracking_store):
@@ -4637,6 +4732,91 @@ def test_create_artifact_file_response_quotes_token_unsafe_ascii_artifact_name(t
         response = _create_artifact_file_response(str(test_file), "artifacts/my model;a.txt")
 
     assert response.headers["Content-Disposition"] == 'attachment; filename="my model;a.txt"'
+
+
+def test_create_temp_artifact_file_response_cleans_up_on_iterator_close(tmp_path, monkeypatch):
+    test_file = tmp_path / "payload.txt"
+    test_file.write_text("hello")
+    cleanup = mock.MagicMock()
+    monkeypatch.setitem(app.config, "USE_X_SENDFILE", True)
+
+    with app.test_request_context(method="GET"):
+        response = _create_temp_artifact_file_response(
+            str(test_file), "artifacts/payload.txt", cleanup
+        )
+        app_iter = response.get_app_iter(request.environ)
+
+    assert "X-Sendfile" not in response.headers
+    assert response.headers["Content-Length"] == "5"
+    assert not cleanup.called
+
+    app_iter.close()
+
+    cleanup.assert_called_once()
+
+
+def test_create_temp_artifact_file_response_supports_range_requests(tmp_path):
+    test_file = tmp_path / "payload.txt"
+    test_file.write_text("0123456789")
+    cleanup = mock.MagicMock()
+
+    with app.test_request_context(method="GET", headers={"Range": "bytes=2-4"}):
+        response = _create_temp_artifact_file_response(
+            str(test_file), "artifacts/payload.txt", cleanup
+        )
+        app_iter = response.get_app_iter(request.environ)
+        body = b"".join(app_iter)
+        if hasattr(app_iter, "close"):
+            app_iter.close()
+
+    assert response.status_code == 206
+    assert response.headers["Content-Length"] == "3"
+    assert response.headers["Content-Range"] == "bytes 2-4/10"
+    assert response.headers["Accept-Ranges"] == "bytes"
+    assert body == b"234"
+    cleanup.assert_called_once()
+
+
+def test_create_temp_artifact_file_response_rejects_unsatisfiable_range(tmp_path):
+    test_file = tmp_path / "payload.txt"
+    test_file.write_text("0123456789")
+    cleanup = mock.MagicMock()
+
+    with app.test_request_context(method="GET", headers={"Range": "bytes=20-25"}):
+        with pytest.raises(RequestedRangeNotSatisfiable, match="Requested Range Not Satisfiable"):
+            _create_temp_artifact_file_response(str(test_file), "artifacts/payload.txt", cleanup)
+
+    cleanup.assert_called_once()
+
+
+def test_create_temp_artifact_file_response_supports_etag_conditionals(tmp_path):
+    test_file = tmp_path / "payload.txt"
+    test_file.write_text("hello")
+
+    with app.test_request_context(method="GET"):
+        response = _create_temp_artifact_file_response(
+            str(test_file), "artifacts/payload.txt", lambda: None
+        )
+        etag = response.headers["ETag"]
+        assert response.headers["Cache-Control"] == "no-cache"
+        assert "Last-Modified" in response.headers
+        app_iter = response.get_app_iter(request.environ)
+        if hasattr(app_iter, "close"):
+            app_iter.close()
+
+    cleanup = mock.MagicMock()
+    with app.test_request_context(method="GET", headers={"If-None-Match": etag}):
+        response = _create_temp_artifact_file_response(
+            str(test_file), "artifacts/payload.txt", cleanup
+        )
+        app_iter = response.get_app_iter(request.environ)
+        body = b"".join(app_iter)
+        if hasattr(app_iter, "close"):
+            app_iter.close()
+
+    assert response.status_code == 304
+    assert body == b""
+    cleanup.assert_called_once()
 
 
 def test_download_artifact_uses_local_path_fast_path(enable_serve_artifacts, tmp_path):

--- a/tests/store/artifact/test_artifact_repo_attachments.py
+++ b/tests/store/artifact/test_artifact_repo_attachments.py
@@ -1,8 +1,9 @@
+import json
 import uuid
 
 import pytest
 
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, MlflowTraceDataNotFound
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
 
 
@@ -31,6 +32,52 @@ def test_download_trace_attachment(tmp_path):
     assert result == b"stored bytes"
 
 
+def test_download_trace_attachment_to_file(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+
+    attachments_dir = tmp_path / "attachments"
+    attachments_dir.mkdir()
+    attachment_id = str(uuid.uuid4())
+    content = b"\x89PNG to-file test"
+    (attachments_dir / attachment_id).write_bytes(content)
+
+    dst = tmp_path / "output" / attachment_id
+    dst.parent.mkdir()
+    result = repo.download_trace_attachment_to_file(attachment_id, dst)
+
+    assert result == dst
+    assert dst.read_bytes() == content
+
+
+def test_download_trace_attachment_to_file_rejects_invalid_path(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    with pytest.raises(MlflowException, match="Invalid attachment path"):
+        repo.download_trace_attachment_to_file("../../etc/passwd", tmp_path / "out")
+
+
+def test_download_trace_data_to_file(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+
+    trace_data = {"spans": [{"name": "test"}]}
+    (tmp_path / "traces.json").write_text(json.dumps(trace_data))
+
+    dst = tmp_path / "output" / "traces.json"
+    dst.parent.mkdir()
+    result = repo.download_trace_data_to_file(dst)
+
+    assert result == dst
+    assert json.loads(dst.read_text()) == trace_data
+
+
+def test_download_trace_data_to_file_missing(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    dst = tmp_path / "output" / "traces.json"
+    dst.parent.mkdir()
+
+    with pytest.raises(MlflowTraceDataNotFound, match="traces.json"):
+        repo.download_trace_data_to_file(dst)
+
+
 def test_upload_and_download_roundtrip(tmp_path):
     repo = LocalArtifactRepository(str(tmp_path))
     attachment_id = str(uuid.uuid4())
@@ -39,6 +86,19 @@ def test_upload_and_download_roundtrip(tmp_path):
     repo.upload_attachment(attachment_id, content)
     result = repo.download_trace_attachment(attachment_id)
     assert result == content
+
+
+def test_upload_and_download_to_file_roundtrip(tmp_path):
+    repo = LocalArtifactRepository(str(tmp_path))
+    attachment_id = str(uuid.uuid4())
+    content = b"\x89PNG\r\n\x1a\n fake png header"
+
+    repo.upload_attachment(attachment_id, content)
+
+    dst = tmp_path / "downloaded" / attachment_id
+    dst.parent.mkdir()
+    repo.download_trace_attachment_to_file(attachment_id, dst)
+    assert dst.read_bytes() == content
 
 
 def test_upload_rejects_path_traversal(tmp_path):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -4,15 +4,21 @@ import posixpath
 import re
 import shutil
 import time
+from pathlib import Path
 from unittest import mock
 from unittest.mock import ANY
 
 import pytest
+import requests
 from requests.models import Response
 
 from mlflow.entities import TraceData
 from mlflow.entities.file_info import FileInfo as FileInfoEntity
-from mlflow.exceptions import MlflowException, MlflowNotImplementedException
+from mlflow.exceptions import (
+    MlflowException,
+    MlflowNotImplementedException,
+    MlflowTraceDataNotFound,
+)
 from mlflow.protos.databricks_artifacts_pb2 import (
     ArtifactCredentialInfo,
     ArtifactCredentialType,
@@ -1617,8 +1623,12 @@ def test_multipart_upload_abort(
 
 
 class MockResponse:
-    def __init__(self, content: bytes):
+    def __init__(self, content: bytes, headers: dict[str, str] | None = None):
         self.content = content
+        self.headers = headers or {}
+        self._bytes_read = len(content)
+        self.raw = mock.MagicMock()
+        self.raw.tell.return_value = self._bytes_read
 
     def iter_content(self, chunk_size):
         yield self.content
@@ -1634,6 +1644,27 @@ class MockResponse:
 
     def __exit__(self, *args):
         pass
+
+
+class MockStreamingResponse(MockResponse):
+    def __init__(
+        self,
+        chunks: list[bytes],
+        error: Exception | None = None,
+        headers: dict[str, str] | None = None,
+    ):
+        super().__init__(b"".join(chunks), headers=headers)
+        self._chunks = chunks
+        self._error = error
+        self._bytes_read = 0
+
+    def iter_content(self, chunk_size):
+        for chunk in self._chunks:
+            self._bytes_read += len(chunk)
+            self.raw.tell.return_value = self._bytes_read
+            yield chunk
+        if self._error is not None:
+            raise self._error
 
 
 @pytest.mark.parametrize(
@@ -1660,6 +1691,258 @@ def test_download_trace_data(databricks_artifact_repo_trace, cred_type):
     ):
         trace_data = databricks_artifact_repo_trace.download_trace_data()
         assert TraceData.from_dict(trace_data) == TraceData(spans=[])
+
+
+@pytest.mark.parametrize(
+    "cred_type",
+    [
+        ArtifactCredentialType.AZURE_SAS_URI,
+        ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
+        ArtifactCredentialType.AWS_PRESIGNED_URL,
+        ArtifactCredentialType.GCP_SIGNED_URL,
+    ],
+)
+def test_download_trace_data_to_file(databricks_artifact_repo_trace, cred_type, tmp_path):
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=cred_type,
+    )
+    cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.call_endpoint",
+            return_value=cred,
+        ),
+        mock.patch(
+            "requests.Session.request", return_value=MockResponse(b'{"spans": []}')
+        ) as mock_request,
+    ):
+        dst = tmp_path / "traces.json"
+        result = databricks_artifact_repo_trace.download_trace_data_to_file(dst)
+        assert result == dst
+        assert json.loads(dst.read_text()) == {"spans": []}
+    mock_request.assert_called_once_with(
+        "get",
+        MOCK_AWS_SIGNED_URI,
+        allow_redirects=True,
+        headers={},
+        stream=True,
+        timeout=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "cred_type",
+    [
+        ArtifactCredentialType.AZURE_SAS_URI,
+        ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI,
+        ArtifactCredentialType.AWS_PRESIGNED_URL,
+        ArtifactCredentialType.GCP_SIGNED_URL,
+    ],
+)
+def test_download_trace_attachment_to_file(databricks_artifact_repo_trace, cred_type, tmp_path):
+    attachment_id = "a1b2c3d4-e5f6-4890-abcd-ef1234567890"
+    cred_info = ArtifactCredentialInfo(signed_uri=MOCK_AWS_SIGNED_URI, type=cred_type)
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.get_credentials",
+            return_value=([cred_info], None),
+        ) as mock_get_creds,
+        mock.patch(
+            "requests.Session.request", return_value=MockResponse(b"\x89PNG fake image")
+        ) as mock_request,
+    ):
+        dst = tmp_path / attachment_id
+        result = databricks_artifact_repo_trace.download_trace_attachment_to_file(
+            attachment_id, dst
+        )
+    assert result == dst
+    assert dst.read_bytes() == b"\x89PNG fake image"
+    mock_get_creds.assert_called_once_with(
+        cred_type=_CredentialType.READ,
+        artifact_path=f"attachments/{attachment_id}",
+    )
+    mock_request.assert_called_once_with(
+        "get",
+        MOCK_AWS_SIGNED_URI,
+        allow_redirects=True,
+        headers={},
+        stream=True,
+        timeout=None,
+    )
+
+
+def test_download_trace_data_to_file_retries_mid_stream_failure(
+    databricks_artifact_repo_trace, tmp_path
+):
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+    )
+    cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.call_endpoint",
+            return_value=cred,
+        ),
+        mock.patch(
+            "requests.Session.request",
+            side_effect=[
+                MockStreamingResponse(
+                    [b'{"spans": [', b'{"name": "partial"}'],
+                    error=requests.ConnectionError("connection reset"),
+                ),
+                MockStreamingResponse([b'{"spans": [{"name": "complete"}]}']),
+            ],
+        ) as mock_request,
+    ):
+        dst = tmp_path / "traces.json"
+        result = databricks_artifact_repo_trace.download_trace_data_to_file(dst)
+
+    assert result == dst
+    assert json.loads(dst.read_text()) == {"spans": [{"name": "complete"}]}
+    assert mock_request.call_count == 2
+    assert not Path(f"{dst}.part").exists()
+
+
+def test_download_trace_data_to_file_cleans_partial_file_after_terminal_stream_failure(
+    databricks_artifact_repo_trace, tmp_path
+):
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+    )
+    cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+    dst = tmp_path / "traces.json"
+    dst.write_text("stale")
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.call_endpoint",
+            return_value=cred,
+        ),
+        mock.patch(
+            "requests.Session.request",
+            return_value=MockStreamingResponse(
+                [b'{"spans": ['], error=requests.ConnectionError("connection reset")
+            ),
+        ),
+    ):
+        with pytest.raises(requests.ConnectionError, match="connection reset"):
+            databricks_artifact_repo_trace.download_trace_data_to_file(dst)
+
+    assert not dst.exists()
+    assert not Path(f"{dst}.part").exists()
+
+
+def test_download_trace_data_to_file_retries_short_read(databricks_artifact_repo_trace, tmp_path):
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+    )
+    cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+    success_payload = b'{"spans": [{"name": "complete"}]}'
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.call_endpoint",
+            return_value=cred,
+        ),
+        mock.patch(
+            "requests.Session.request",
+            side_effect=[
+                MockStreamingResponse([b'{"spans": []}'], headers={"Content-Length": "32"}),
+                MockStreamingResponse(
+                    [success_payload],
+                    headers={"Content-Length": str(len(success_payload))},
+                ),
+            ],
+        ) as mock_request,
+    ):
+        dst = tmp_path / "traces.json"
+        result = databricks_artifact_repo_trace.download_trace_data_to_file(dst)
+
+    assert result == dst
+    assert json.loads(dst.read_text()) == {"spans": [{"name": "complete"}]}
+    assert mock_request.call_count == 2
+    assert not Path(f"{dst}.part").exists()
+
+
+def test_download_trace_data_to_file_request_establishment_failure_not_retried(
+    databricks_artifact_repo_trace, tmp_path
+):
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+    )
+    cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+    dst = tmp_path / "traces.json"
+    dst.write_text("stale")
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.call_endpoint",
+            return_value=cred,
+        ),
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_PACKAGE}.cloud_storage_http_request",
+            side_effect=requests.ConnectionError("connect failed"),
+        ) as mock_cloud_request,
+    ):
+        with pytest.raises(requests.ConnectionError, match="connect failed"):
+            databricks_artifact_repo_trace.download_trace_data_to_file(dst)
+
+    assert mock_cloud_request.call_count == 1
+    assert not dst.exists()
+    assert not Path(f"{dst}.part").exists()
+
+
+def test_download_trace_data_to_file_not_found(databricks_artifact_repo_trace, tmp_path):
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+    )
+    cred = GetCredentialsForTraceDataUpload.Response(credential_info=cred_info)
+    not_found = Response()
+    not_found.status_code = 404
+    not_found._content = b"not found"
+    not_found.close = lambda: None
+    dst = tmp_path / "traces.json"
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.call_endpoint",
+            return_value=cred,
+        ),
+        mock.patch("requests.Session.request", return_value=not_found),
+    ):
+        with pytest.raises(MlflowTraceDataNotFound, match="Trace data not found"):
+            databricks_artifact_repo_trace.download_trace_data_to_file(dst)
+
+    assert not dst.exists()
+
+
+def test_download_trace_attachment_to_file_not_found(databricks_artifact_repo_trace, tmp_path):
+    attachment_id = "a1b2c3d4-e5f6-4890-abcd-ef1234567890"
+    cred_info = ArtifactCredentialInfo(
+        signed_uri=MOCK_AWS_SIGNED_URI,
+        type=ArtifactCredentialType.AWS_PRESIGNED_URL,
+    )
+    not_found = Response()
+    not_found.status_code = 404
+    not_found._content = b"not found"
+    not_found.close = lambda: None
+    dst = tmp_path / attachment_id
+    with (
+        mock.patch(
+            f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Trace.get_credentials",
+            return_value=([cred_info], None),
+        ),
+        mock.patch("requests.Session.request", return_value=not_found),
+        pytest.raises(
+            MlflowException, match=f"Attachment '{attachment_id}' not found."
+        ) as exc_info,
+    ):
+        databricks_artifact_repo_trace.download_trace_attachment_to_file(attachment_id, dst)
+
+    assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+    assert not dst.exists()
 
 
 def test_download_archived_trace_data_rejects_archive_repo(databricks_artifact_repo_trace):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24320

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`get_trace_artifact_handler()` loads trace attachments and trace data into memory before responding. For trace data it also round-trips through `json.loads()`/`json.dumps()`. This PR switches both paths to serve directly from disk via `send_file()`.

Changes:
- Add `download_trace_attachment_to_file()` and `download_trace_data_to_file()` to `ArtifactRepository`. Override both in `DatabricksArtifactRepository` for credential-scoped downloads.
- Refactor existing `download_trace_attachment()` and `download_trace_data()` to delegate to the new methods internally (SDK return types unchanged).
- Update `get_trace_artifact_handler()`: local repos use `get_local_path()` + `send_file()`, remote repos download to a temp file then `send_file()` with `call_on_close()` cleanup.

DB-sourced and archive-sourced trace data paths are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

In-process handler test against a real SQLite store confirmed both trace data and attachment responses return `direct_passthrough=True` (Werkzeug streaming from disk).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release