### PR TITLE
Smoke-test ubuntu-latest-crowdstrike custom-image runner

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
   # while also verifying certain dependencies are omitted.
   python-skinny:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-crowdstrike
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## Related Issues/PRs

N/A

## What changes are proposed in this pull request?

Points the `python-skinny` job in `master.yml` at the new `ubuntu-latest-crowdstrike` hosted runner (built from enterprise custom image `5451`, `ubuntu-latest-crowdstrike-image` v1.0.0) to smoke-test the image in CI before any wider rollout.

This is a temporary, single-job change; it will be reverted (or expanded) based on the result.

## How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The `python-skinny` job itself is the test: if it provisions and passes on `ubuntu-latest-crowdstrike`, the image works.

## Does this PR require documentation update?

- [x] No.

## Release Notes

### Is this a user-facing change?

- [x] No.

N/A