### PR TITLE
Fix Postgres deadlock between `start_trace()` and `log_spans()` on trace metadata

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3483,7 +3483,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 is_deadlock = (
                     e.error_code == temporarily_unavailable and "deadlock" in str(e).lower()
                 )
-                if not is_deadlock or attempt == _TRACE_WRITE_MAX_DEADLOCK_RETRIES:
+                if not is_deadlock or attempt >= _TRACE_WRITE_MAX_DEADLOCK_RETRIES:
                     raise
                 # Exponential backoff with jitter, matching `_try_insert_tags`.
                 sleep_duration = (2**attempt) - 1

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -111,6 +111,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_STATE,
     RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
+    TEMPORARILY_UNAVAILABLE,
     ErrorCode,
 )
 from mlflow.store.analytics import trace_correlation
@@ -266,6 +267,11 @@ from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 _T = TypeVar("_T")
 
 _logger = logging.getLogger(__name__)
+
+# Max number of times start_trace()/log_spans() retry their transaction when the DB
+# kills it with a deadlock (issue #24332). Deterministic key ordering (see the sorted
+# metadata/metrics writes) is the primary defense; this bounded retry is a safety net.
+_TRACE_WRITE_MAX_DEADLOCK_RETRIES = 3
 
 # For each database table, fetch its columns and define an appropriate attribute for each column
 # on the table's associated object representation (Mapper). This is necessary to ensure that
@@ -3459,6 +3465,31 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         )
         return SqlTraceTag(request_id=trace_id, key=MLFLOW_ARTIFACT_LOCATION, value=artifact_uri)
 
+    def _run_with_deadlock_retry(self, fn, *args, **kwargs):
+        """Run a trace-write operation, retrying on DB deadlocks (issue #24332).
+
+        The managed session (see ``mlflow/store/db/utils.py``) surfaces a psycopg2
+        DeadlockDetected / SQLAlchemy OperationalError as an ``MlflowException`` with
+        ``error_code == TEMPORARILY_UNAVAILABLE``. We gate on that error code AND the
+        ``deadlock`` substring so only deadlocks are retried and other transient errors are
+        not masked. Each attempt re-invokes ``fn`` from scratch (opening a fresh managed
+        session) rather than retrying on a rolled-back session.
+        """
+        temporarily_unavailable = ErrorCode.Name(TEMPORARILY_UNAVAILABLE)
+        for attempt in range(_TRACE_WRITE_MAX_DEADLOCK_RETRIES + 1):
+            try:
+                return fn(*args, **kwargs)
+            except MlflowException as e:
+                is_deadlock = (
+                    e.error_code == temporarily_unavailable and "deadlock" in str(e).lower()
+                )
+                if not is_deadlock or attempt == _TRACE_WRITE_MAX_DEADLOCK_RETRIES:
+                    raise
+                # Exponential backoff with jitter, matching `_try_insert_tags`.
+                sleep_duration = (2**attempt) - 1
+                sleep_duration += random.uniform(0, 1)
+                time.sleep(sleep_duration)
+
     def start_trace(self, trace_info: "TraceInfo") -> TraceInfo:
         """
         Create a trace using the V3 API format with a complete Trace object.
@@ -3469,6 +3500,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         Returns:
             The created TraceInfo object from the backend.
         """
+        # Retry on DB deadlocks so a concurrent log_spans()/start_trace() race does not
+        # drop the trace (issue #24332). Each attempt opens a fresh managed session.
+        return self._run_with_deadlock_retry(self._start_trace_once, trace_info)
+
+    def _start_trace_once(self, trace_info: "TraceInfo") -> TraceInfo:
         with self.ManagedSessionMaker(read_only=False) as session:
             experiment = self.get_experiment(trace_info.experiment_id)
             self._check_experiment_is_active(experiment)
@@ -3525,14 +3561,17 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             sql_trace_info.assessments = sql_assessments
 
             try:
-                # Happy path: attach metadata/metrics via cascade for a single flush
+                # Happy path: attach metadata/metrics via cascade for a single flush.
+                # Emit rows in sorted key order so concurrent writers acquire the
+                # trace_request_metadata / trace_metrics PK-index locks in a consistent
+                # order across transactions and cannot deadlock (issue #24332).
                 sql_trace_info.request_metadata = [
                     SqlTraceMetadata(request_id=trace_id, key=k, value=v)
-                    for k, v in request_metadata.items()
+                    for k, v in sorted(request_metadata.items())
                 ]
                 sql_trace_info.metrics = [
                     SqlTraceMetrics(request_id=trace_id, key=k, value=v)
-                    for k, v in trace_metrics.items()
+                    for k, v in sorted(trace_metrics.items())
                 ]
                 session.add(sql_trace_info)
                 session.flush()
@@ -3601,9 +3640,11 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
                 # Upsert metadata and metrics individually so the complete data
                 # from start_trace() overwrites any partial values from log_spans().
-                for k, v in request_metadata.items():
+                # Merge in sorted key order to keep PK-index lock acquisition consistent
+                # across transactions and avoid deadlocks (issue #24332).
+                for k, v in sorted(request_metadata.items()):
                     session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v))
-                for k, v in trace_metrics.items():
+                for k, v in sorted(trace_metrics.items()):
                     session.merge(SqlTraceMetrics(request_id=trace_id, key=k, value=v))
                 session.flush()
                 sql_trace_info = self._get_sql_trace_info(
@@ -4941,6 +4982,13 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         Returns:
             List of logged Span entities.
         """
+        # Retry on DB deadlocks so a concurrent start_trace()/log_spans() race does not
+        # drop metadata (issue #24332). Each attempt opens a fresh managed session.
+        return self._run_with_deadlock_retry(
+            self._log_spans_once, location, spans, tracking_uri=tracking_uri
+        )
+
+    def _log_spans_once(self, location: str, spans: list[Span], tracking_uri=None) -> list[Span]:
         if not spans:
             return []
 
@@ -5199,12 +5247,20 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 }
 
             # --- Phase 5: Per-trace updates (UPDATE + merges) ---
-            for trace_id in all_trace_ids:
+            # Iterate trace_ids in sorted order, and within each trace emit
+            # trace_request_metadata / trace_metrics merges in sorted key order, so that
+            # concurrent start_trace()/log_spans() transactions acquire the PK-index locks
+            # in a consistent order and cannot deadlock (issue #24332).
+            for trace_id in sorted(all_trace_ids):
                 agg = trace_aggregates[trace_id]
                 sql_trace_info = existing_traces[trace_id]
                 min_start_ms = agg.min_start_ms
                 max_end_ms = agg.max_end_ms
                 root_span_status = agg.root_span_status
+                # Collect metadata/metrics rows for this trace, then merge them below in
+                # sorted key order (see comment above).
+                metadata_writes: dict[str, str] = {}
+                metric_writes: dict[str, float] = {}
 
                 # Atomic update of trace time range using SQLAlchemy's case expressions.
                 # This is necessary to handle concurrent span additions from multiple
@@ -5258,20 +5314,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                             existing_record.value if existing_record else {},
                             aggregated_token_usage,
                         )
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.TOKEN_USAGE,
-                                value=json.dumps(trace_token_usage),
-                            )
+                        metadata_writes[TraceMetadataKey.TOKEN_USAGE] = json.dumps(
+                            trace_token_usage
                         )
                         for key in TokenUsageKey.all_keys():
                             if (value := trace_token_usage.get(key)) is not None:
-                                session.merge(
-                                    SqlTraceMetrics(
-                                        request_id=trace_id, key=key, value=float(value)
-                                    )
-                                )
+                                metric_writes[key] = float(value)
 
                 # Cost metadata — skip only if start_trace() has already written the
                 # authoritative value (flag set AND existing record present). If the flag
@@ -5282,13 +5330,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         recorded_cost = update_cost(
                             existing_record.value if existing_record else {}, aggregated_cost
                         )
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.COST,
-                                value=json.dumps(recorded_cost),
-                            )
-                        )
+                        metadata_writes[TraceMetadataKey.COST] = json.dumps(recorded_cost)
 
                 # Session ID metadata
                 if (
@@ -5296,13 +5338,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     and trace_id not in existing_sessions
                     and trace_id not in finalized_trace_ids
                 ):
-                    session.merge(
-                        SqlTraceMetadata(
-                            request_id=trace_id,
-                            key=TraceMetadataKey.TRACE_SESSION,
-                            value=agg.session_id,
-                        )
-                    )
+                    metadata_writes[TraceMetadataKey.TRACE_SESSION] = agg.session_id
 
                 # User ID metadata
                 if agg.user_id:
@@ -5316,13 +5352,14 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         .one_or_none()
                     )
                     if not existing_user_id:
-                        session.merge(
-                            SqlTraceMetadata(
-                                request_id=trace_id,
-                                key=TraceMetadataKey.TRACE_USER,
-                                value=agg.user_id,
-                            )
-                        )
+                        metadata_writes[TraceMetadataKey.TRACE_USER] = agg.user_id
+
+                # Emit the collected metadata/metrics merges in sorted key order so
+                # PK-index lock acquisition is deterministic across transactions (#24332).
+                for key, value in sorted(metadata_writes.items()):
+                    session.merge(SqlTraceMetadata(request_id=trace_id, key=key, value=value))
+                for key, value in sorted(metric_writes.items()):
+                    session.merge(SqlTraceMetrics(request_id=trace_id, key=key, value=value))
 
                 if update_dict:
                     # `trace_id` was selected through workspace-scoped reads earlier in this
@@ -7486,8 +7523,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             trace_info.tags = [SqlTraceTag(key=k, value=v) for k, v in tags.items()]
             trace_info.tags.append(self._get_trace_artifact_location_tag(experiment, request_id))
 
+            # Emit metadata rows in sorted key order to keep PK-index lock acquisition
+            # consistent with the other trace-metadata writers and avoid deadlocks (#24332).
             trace_info.request_metadata = [
-                SqlTraceMetadata(key=k, value=v) for k, v in request_metadata.items()
+                SqlTraceMetadata(key=k, value=v) for k, v in sorted(request_metadata.items())
             ]
             session.add(trace_info)
 
@@ -7526,7 +7565,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             sql_trace_info.execution_time_ms = execution_time_ms
             sql_trace_info.status = status
             session.merge(sql_trace_info)
-            for k, v in request_metadata.items():
+            # Merge metadata in sorted key order so concurrent writers acquire the
+            # trace_request_metadata PK-index locks in a consistent order and cannot
+            # deadlock (issue #24332).
+            for k, v in sorted(request_metadata.items()):
                 session.merge(SqlTraceMetadata(request_id=request_id, key=k, value=v))
             for k, v in tags.items():
                 session.merge(SqlTraceTag(request_id=request_id, key=k, value=v))

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -269,9 +269,9 @@ _T = TypeVar("_T")
 _logger = logging.getLogger(__name__)
 
 # Max number of times start_trace()/log_spans() retry their transaction when the DB
-# kills it with a deadlock (issue #24332). Deterministic key ordering (see the sorted
+# kills it with a deadlock. Deterministic key ordering (see the sorted
 # metadata/metrics writes) is the primary defense; this bounded retry is a safety net.
-_TRACE_WRITE_MAX_DEADLOCK_RETRIES = 3
+_TRACE_WRITE_MAX_DEADLOCK_RETRIES = 2
 
 # For each database table, fetch its columns and define an appropriate attribute for each column
 # on the table's associated object representation (Mapper). This is necessary to ensure that
@@ -3466,7 +3466,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         return SqlTraceTag(request_id=trace_id, key=MLFLOW_ARTIFACT_LOCATION, value=artifact_uri)
 
     def _run_with_deadlock_retry(self, fn, *args, **kwargs):
-        """Run a trace-write operation, retrying on DB deadlocks (issue #24332).
+        """Run a trace-write operation, retrying on DB deadlocks.
 
         The managed session (see ``mlflow/store/db/utils.py``) surfaces a psycopg2
         DeadlockDetected / SQLAlchemy OperationalError as an ``MlflowException`` with
@@ -3501,7 +3501,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             The created TraceInfo object from the backend.
         """
         # Retry on DB deadlocks so a concurrent log_spans()/start_trace() race does not
-        # drop the trace (issue #24332). Each attempt opens a fresh managed session.
+        # drop the trace. Each attempt opens a fresh managed session.
         return self._run_with_deadlock_retry(self._start_trace_once, trace_info)
 
     def _start_trace_once(self, trace_info: "TraceInfo") -> TraceInfo:
@@ -3564,7 +3564,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 # Happy path: attach metadata/metrics via cascade for a single flush.
                 # Emit rows in sorted key order so concurrent writers acquire the
                 # trace_request_metadata / trace_metrics PK-index locks in a consistent
-                # order across transactions and cannot deadlock (issue #24332).
+                # order across transactions and cannot deadlock.
                 sql_trace_info.request_metadata = [
                     SqlTraceMetadata(request_id=trace_id, key=k, value=v)
                     for k, v in sorted(request_metadata.items())
@@ -3641,7 +3641,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 # Upsert metadata and metrics individually so the complete data
                 # from start_trace() overwrites any partial values from log_spans().
                 # Merge in sorted key order to keep PK-index lock acquisition consistent
-                # across transactions and avoid deadlocks (issue #24332).
+                # across transactions and avoid deadlocks.
                 for k, v in sorted(request_metadata.items()):
                     session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v))
                 for k, v in sorted(trace_metrics.items()):
@@ -4983,7 +4983,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             List of logged Span entities.
         """
         # Retry on DB deadlocks so a concurrent start_trace()/log_spans() race does not
-        # drop metadata (issue #24332). Each attempt opens a fresh managed session.
+        # drop metadata. Each attempt opens a fresh managed session.
         return self._run_with_deadlock_retry(
             self._log_spans_once, location, spans, tracking_uri=tracking_uri
         )
@@ -5250,7 +5250,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             # Iterate trace_ids in sorted order, and within each trace emit
             # trace_request_metadata / trace_metrics merges in sorted key order, so that
             # concurrent start_trace()/log_spans() transactions acquire the PK-index locks
-            # in a consistent order and cannot deadlock (issue #24332).
+            # in a consistent order and cannot deadlock
             for trace_id in sorted(all_trace_ids):
                 agg = trace_aggregates[trace_id]
                 sql_trace_info = existing_traces[trace_id]
@@ -7567,7 +7567,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             session.merge(sql_trace_info)
             # Merge metadata in sorted key order so concurrent writers acquire the
             # trace_request_metadata PK-index locks in a consistent order and cannot
-            # deadlock (issue #24332).
+            # deadlock.
             for k, v in sorted(request_metadata.items()):
                 session.merge(SqlTraceMetadata(request_id=request_id, key=k, value=v))
             for k, v in tags.items():

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -9665,10 +9665,15 @@ def _extract_metadata_write_pairs(statement, parameters):
     else:
         param_rows = [parameters]
 
-    # Determine positional column order from the INSERT (…cols…) VALUES clause.
+    # Determine positional column order from the INSERT (…cols…) VALUES clause. The table
+    # name may be quoted or schema-qualified by the dialect (e.g. "trace_request_metadata",
+    # `trace_request_metadata`, [dbo].[trace_request_metadata]), so match the bare identifier
+    # via a word boundary and allow any quoting/qualifier around it.
     col_order = None
     if m := re.search(
-        r"insert\s+into\s+trace_request_metadata\s*\(([^)]*)\)", statement, re.IGNORECASE
+        r"insert\s+into\s+[^(]*\btrace_request_metadata\b[^(]*\(([^)]*)\)",
+        statement,
+        re.IGNORECASE,
     ):
         col_order = [c.strip().strip('"').strip("`").strip("[]") for c in m.group(1).split(",")]
 
@@ -9825,6 +9830,32 @@ def test_log_spans_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
         keys_by_request.setdefault(rid, []).append(key)
     for rid, keys in keys_by_request.items():
         assert keys == sorted(keys), f"keys for {rid} not sorted: {keys}"
+
+
+@pytest.mark.parametrize(
+    "table_ref",
+    [
+        "trace_request_metadata",
+        '"trace_request_metadata"',
+        "`trace_request_metadata`",
+        "[trace_request_metadata]",
+        "[dbo].[trace_request_metadata]",
+        'public."trace_request_metadata"',
+    ],
+)
+def test_extract_metadata_write_pairs_parses_quoted_and_qualified_table_names(table_ref):
+    """The INSERT column-list parser must recover positional (request_id, key) tuples
+    regardless of how the dialect quotes or schema-qualifies the table name. If the
+    column order can't be parsed, tuple-param writes are silently dropped and the
+    sorted-order assertions become vacuous across backends.
+    """
+    statement = f"INSERT INTO {table_ref} (request_id, key, value) VALUES (?, ?, ?)"
+    # Positional tuple params (executemany-style), two rows.
+    parameters = [("tr-1", "alpha", "v1"), ("tr-1", "beta", "v2")]
+
+    pairs = _extract_metadata_write_pairs(statement, parameters)
+
+    assert pairs == [("tr-1", "alpha"), ("tr-1", "beta")]
 
 
 def _make_deadlock_exception() -> MlflowException:

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -4,6 +4,7 @@ import random
 import re
 import time
 import uuid
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
@@ -47,6 +48,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     INVALID_STATE,
     RESOURCE_DOES_NOT_EXIST,
+    TEMPORARILY_UNAVAILABLE,
     ErrorCode,
 )
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
@@ -9633,3 +9635,287 @@ def test_archive_traces_rejects_unsupported_resolved_root_override(store: SqlAlc
                 default_retention="1d",
             )
     assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+def _extract_metadata_write_pairs(statement, parameters):
+    """Extract (request_id, key) pairs written to trace_request_metadata, in order.
+
+    Handles both dict-bound params (named placeholders) and positional tuple params
+    (executemany), across dialects, by parsing the INSERT column list to locate the
+    `key` and `request_id` positions.
+    """
+    if not re.search(r"\btrace_request_metadata\b", statement, re.IGNORECASE):
+        return []
+    if not re.search(r"\b(insert|update)\b", statement, re.IGNORECASE):
+        return []
+
+    # Normalize params into a list of rows. SQLAlchemy passes either a single dict,
+    # a single positional tuple (one row), or a list of dicts/tuples (executemany).
+    if isinstance(parameters, dict):
+        param_rows = [parameters]
+    elif (
+        isinstance(parameters, (list, tuple))
+        and parameters
+        and isinstance(parameters[0], (dict, list, tuple))
+    ):
+        param_rows = list(parameters)
+    elif isinstance(parameters, (list, tuple)):
+        # A flat single row of scalar values, e.g. ("key", "value", "request_id").
+        param_rows = [parameters]
+    else:
+        param_rows = [parameters]
+
+    # Determine positional column order from the INSERT (…cols…) VALUES clause.
+    col_order = None
+    if m := re.search(
+        r"insert\s+into\s+trace_request_metadata\s*\(([^)]*)\)", statement, re.IGNORECASE
+    ):
+        col_order = [c.strip().strip('"').strip("`").strip("[]") for c in m.group(1).split(",")]
+
+    pairs = []
+    for row in param_rows:
+        if isinstance(row, dict):
+            if "key" in row and "request_id" in row:
+                # Single-row named params: {"key": ..., "value": ..., "request_id": ...}
+                pairs.append((row["request_id"], row["key"]))
+            elif any(k.startswith("key__") for k in row):
+                # Multi-row cascade INSERT flattened into one dict with suffixed keys:
+                # {"key__0": ..., "request_id__0": ..., "key__1": ..., ...}. Preserve N order.
+                indices = sorted(
+                    int(k.split("__", 1)[1]) for k in row if re.fullmatch(r"key__\d+", k)
+                )
+                pairs.extend(
+                    (row[f"request_id__{i}"], row[f"key__{i}"])
+                    for i in indices
+                    if f"request_id__{i}" in row
+                )
+        elif isinstance(row, (list, tuple)) and col_order:
+            try:
+                key_idx = col_order.index("key")
+                rid_idx = col_order.index("request_id")
+            except ValueError:
+                continue
+            if len(row) > max(key_idx, rid_idx):
+                pairs.append((row[rid_idx], row[key_idx]))
+    return pairs
+
+
+def _capture_trace_metadata_write_keys(
+    store: SqlAlchemyStore,
+) -> tuple[list[str], Callable[[], None]]:
+    """Capture, in execution order, the `key` values written to trace_request_metadata."""
+    captured: list[str] = []
+
+    def _listener(_conn, _cursor, statement, parameters, _context, _executemany):
+        captured.extend(key for _rid, key in _extract_metadata_write_pairs(statement, parameters))
+
+    sqlalchemy.event.listen(store.engine, "before_cursor_execute", _listener)
+    return captured, lambda: sqlalchemy.event.remove(
+        store.engine, "before_cursor_execute", _listener
+    )
+
+
+def test_start_trace_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
+    """start_trace() must write trace_request_metadata rows in a deterministic, sorted
+    key order so that two concurrent transactions acquire the PK-index locks in the same
+    order and cannot deadlock (issue #24332).
+    """
+    experiment_id = store.create_experiment("sorted-order-start-trace")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    # Deliberately supply metadata whose natural dict order is NOT sorted.
+    trace_metadata = {
+        "mlflow.trace.tokenUsage": json.dumps({"input_tokens": 10}),
+        "mlflow.traceInputs": "in",
+        "mlflow.trace.cost": json.dumps({"total": 0.1}),
+        "mlflow.traceOutputs": "out",
+    }
+    captured, remove = _capture_trace_metadata_write_keys(store)
+    try:
+        _create_trace(store, trace_id, experiment_id, trace_metadata=trace_metadata)
+    finally:
+        remove()
+
+    metadata_keys = [k for k in captured if k in trace_metadata]
+    assert metadata_keys, "expected trace_request_metadata writes to be captured"
+    assert metadata_keys == sorted(metadata_keys)
+
+
+def test_deprecated_start_trace_v2_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
+    """The legacy V2 start-trace path must also write metadata in sorted key order, so it
+    keeps a consistent PK-index lock order with the other writers (issue #24332).
+    """
+    experiment_id = store.create_experiment("sorted-order-v2")
+    # Metadata whose natural dict order is NOT sorted.
+    request_metadata = {"rq_z": "z", "rq_a": "a", "rq_m": "m"}
+    captured, remove = _capture_trace_metadata_write_keys(store)
+    try:
+        store.deprecated_start_trace_v2(
+            experiment_id=experiment_id,
+            timestamp_ms=1234,
+            request_metadata=request_metadata,
+            tags={},
+        )
+    finally:
+        remove()
+
+    metadata_keys = [k for k in captured if k in request_metadata]
+    assert metadata_keys, "expected trace_request_metadata writes to be captured"
+    assert metadata_keys == sorted(metadata_keys)
+
+
+def test_log_spans_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
+    """log_spans() must write trace_request_metadata rows in a deterministic, sorted
+    key order (both across trace_ids and across keys within a trace) so concurrent
+    log_spans/start_trace transactions cannot deadlock (issue #24332).
+    """
+    experiment_id = store.create_experiment("sorted-order-log-spans")
+    # Two trace_ids in a single batch, deliberately in non-sorted order, each carrying
+    # token-usage + session so multiple metadata keys are written per trace.
+    trace_id_b = "tr-bbbb" + uuid.uuid4().hex
+    trace_id_a = "tr-aaaa" + uuid.uuid4().hex
+
+    def _usage_span(trace_id, span_id_num, session_id):
+        otel_span = create_test_otel_span(
+            trace_id=trace_id,
+            name="llm_call",
+            trace_id_num=span_id_num,
+            span_id_num=span_id_num,
+        )
+        otel_span._attributes = {
+            "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+            SpanAttributeKey.SESSION_ID: json.dumps(session_id, cls=TraceJSONEncoder),
+            SpanAttributeKey.CHAT_USAGE: json.dumps({
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }),
+        }
+        return create_mlflow_span(otel_span, trace_id, "LLM")
+
+    # Pass trace_id_b's span first so the defaultdict order is [b, a] (not sorted).
+    spans = [
+        _usage_span(trace_id_b, 222, "sess-b"),
+        _usage_span(trace_id_a, 111, "sess-a"),
+    ]
+
+    captured_pairs: list[tuple[str, str]] = []
+
+    def _listener(_conn, _cursor, statement, parameters, _context, _executemany):
+        captured_pairs.extend(_extract_metadata_write_pairs(statement, parameters))
+
+    sqlalchemy.event.listen(store.engine, "before_cursor_execute", _listener)
+    try:
+        store.log_spans(experiment_id, spans)
+    finally:
+        sqlalchemy.event.remove(store.engine, "before_cursor_execute", _listener)
+
+    assert captured_pairs, "expected trace_request_metadata writes to be captured"
+    captured_request_ids = [rid for rid, _key in captured_pairs]
+
+    # Both traces must actually have been written, else the ordering assertions are vacuous.
+    assert {trace_id_a, trace_id_b} <= set(captured_request_ids)
+
+    # request_ids must be written in a deterministic (sorted) order across traces.
+    seen_request_ids = list(dict.fromkeys(captured_request_ids))
+    assert seen_request_ids == sorted(seen_request_ids)
+
+    # Within each trace_id, keys must be written in sorted order.
+    keys_by_request: dict[str, list[str]] = {}
+    for rid, key in captured_pairs:
+        keys_by_request.setdefault(rid, []).append(key)
+    for rid, keys in keys_by_request.items():
+        assert keys == sorted(keys), f"keys for {rid} not sorted: {keys}"
+
+
+def _make_deadlock_exception() -> MlflowException:
+    # Mirrors exactly what mlflow.store.db.utils re-raises a psycopg2 DeadlockDetected /
+    # sqlalchemy OperationalError as when a transaction is killed by the DB:
+    # MlflowException(message=..., error_code=TEMPORARILY_UNAVAILABLE) (int error code).
+    return MlflowException(
+        "(psycopg2.errors.DeadlockDetected) deadlock detected",
+        error_code=TEMPORARILY_UNAVAILABLE,
+    )
+
+
+def test_start_trace_retries_on_deadlock(store: SqlAlchemyStore):
+    """start_trace() must retry (not silently drop the trace) when the DB kills its
+    transaction with a deadlock, and ultimately persist the trace (#24332).
+    """
+    experiment_id = store.create_experiment("start-trace-deadlock-retry")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=0,
+        execution_duration=1,
+        state=TraceState.OK,
+        tags={},
+        trace_metadata={},
+    )
+
+    real_start_trace = SqlAlchemyStore._start_trace_once
+    calls = {"n": 0}
+
+    def _flaky(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _make_deadlock_exception()
+        return real_start_trace(self, *args, **kwargs)
+
+    with (
+        mock.patch.object(SqlAlchemyStore, "_start_trace_once", _flaky),
+        mock.patch("mlflow.store.tracking.sqlalchemy_store.time.sleep"),
+    ):
+        result = store.start_trace(trace_info)
+
+    assert calls["n"] == 2  # one deadlock, one successful retry
+    assert result.trace_id == trace_id
+    assert store.get_trace_info(trace_id).trace_id == trace_id
+
+
+def test_start_trace_gives_up_after_max_deadlock_retries(store: SqlAlchemyStore):
+    # A persistent deadlock must eventually surface (bounded retry), not loop forever.
+    experiment_id = store.create_experiment("start-trace-deadlock-giveup")
+    trace_info = TraceInfo(
+        trace_id=f"tr-{uuid.uuid4().hex}",
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=0,
+        execution_duration=1,
+        state=TraceState.OK,
+        tags={},
+        trace_metadata={},
+    )
+
+    with (
+        mock.patch.object(
+            SqlAlchemyStore, "_start_trace_once", side_effect=_make_deadlock_exception()
+        ),
+        mock.patch("mlflow.store.tracking.sqlalchemy_store.time.sleep"),
+        pytest.raises(MlflowException, match="deadlock"),
+    ):
+        store.start_trace(trace_info)
+
+
+def test_log_spans_retries_on_deadlock(store: SqlAlchemyStore):
+    # log_spans() must retry when the DB kills its transaction with a deadlock (#24332).
+    experiment_id = store.create_experiment("log-spans-deadlock-retry")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    span = create_test_span(trace_id, name="llm_call", span_id=111, span_type="LLM")
+
+    real_log_spans = SqlAlchemyStore._log_spans_once
+    calls = {"n": 0}
+
+    def _flaky(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _make_deadlock_exception()
+        return real_log_spans(self, *args, **kwargs)
+
+    with (
+        mock.patch.object(SqlAlchemyStore, "_log_spans_once", _flaky),
+        mock.patch("mlflow.store.tracking.sqlalchemy_store.time.sleep"),
+    ):
+        store.log_spans(experiment_id, [span])
+
+    assert calls["n"] == 2
+    assert store.get_trace_info(trace_id).trace_id == trace_id

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -57,6 +57,7 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlSpan,
     SqlSpanMetrics,
     SqlTraceInfo,
+    SqlTraceMetadata,
     SqlTraceMetrics,
     SqlTraceTag,
 )
@@ -9832,6 +9833,83 @@ def test_log_spans_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
         assert keys == sorted(keys), f"keys for {rid} not sorted: {keys}"
 
 
+def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_order(
+    store: SqlAlchemyStore,
+):
+    """The IntegrityError conflict path is where the reported start_trace()/log_spans()
+    race actually occurs (issue #24332): log_spans() creates the trace first, then
+    start_trace() hits IntegrityError and upserts metadata/metrics via per-row
+    session.merge(). This test forces that branch and asserts BOTH merge loops emit keys
+    in sorted order — the happy-path tests never execute these lines, so a regression
+    that dropped the sort there would otherwise pass CI silently.
+
+    We spy on Session.merge (the ORM operation the conflict branch actually uses) rather
+    than the SQL cursor, because the merges here emit UPDATE statements (the keys were
+    already inserted by log_spans) whose positional params carry no parseable column list.
+    """
+    experiment_id = store.create_experiment("sorted-order-conflict-path")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    # 1. Create the trace via log_spans() first so start_trace() below collides on the PK
+    # and takes the IntegrityError conflict path.
+    otel_span = create_test_otel_span(
+        trace_id=trace_id, name="llm_call", trace_id_num=111, span_id_num=111
+    )
+    otel_span._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps({
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+        }),
+    }
+    store.log_spans(experiment_id, [create_mlflow_span(otel_span, trace_id, "LLM")])
+
+    # 2. Record the key order of every metadata/metric row merged during start_trace().
+    merged_metadata_keys: list[str] = []
+    merged_metric_keys: list[str] = []
+    real_merge = sqlalchemy.orm.Session.merge
+
+    def _spy_merge(self, instance, *args, **kwargs):
+        if isinstance(instance, SqlTraceMetadata) and instance.request_id == trace_id:
+            merged_metadata_keys.append(instance.key)
+        elif isinstance(instance, SqlTraceMetrics) and instance.request_id == trace_id:
+            merged_metric_keys.append(instance.key)
+        return real_merge(self, instance, *args, **kwargs)
+
+    # Metadata whose natural dict order is NOT sorted; token usage yields several
+    # trace_metrics rows (input/output/total_tokens) so metric ordering is observable.
+    # Values differ from the log_spans write above so the metric merges are real upserts.
+    trace_metadata = {
+        "mlflow.traceOutputs": "out",
+        "mlflow.trace.tokenUsage": json.dumps({
+            "input_tokens": 200,
+            "output_tokens": 70,
+            "total_tokens": 270,
+        }),
+        "mlflow.traceInputs": "in",
+    }
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=0,
+        execution_duration=1,
+        state=TraceState.OK,
+        tags={},
+        trace_metadata=trace_metadata,
+    )
+
+    with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
+        store.start_trace(trace_info)
+
+    # Both loops must actually have merged multiple keys, else the ordering assertions
+    # are vacuous (e.g. if start_trace took the happy path instead of the conflict path).
+    assert len(merged_metadata_keys) >= 2, merged_metadata_keys
+    assert len(merged_metric_keys) >= 2, merged_metric_keys
+    assert merged_metadata_keys == sorted(merged_metadata_keys)
+    assert merged_metric_keys == sorted(merged_metric_keys)
+
+
 @pytest.mark.parametrize(
     "table_ref",
     [
@@ -9871,6 +9949,13 @@ def _make_deadlock_exception() -> MlflowException:
 def test_start_trace_retries_on_deadlock(store: SqlAlchemyStore):
     """start_trace() must retry (not silently drop the trace) when the DB kills its
     transaction with a deadlock, and ultimately persist the trace (#24332).
+
+    A genuine ``sqlalchemy.exc.OperationalError`` is raised from inside the managed
+    session (via ``Session.flush``) rather than a pre-built ``MlflowException``, so the
+    full production seam is exercised end-to-end: ``make_managed_session`` wraps it to
+    ``TEMPORARILY_UNAVAILABLE`` (`db/utils.py`), then ``_run_with_deadlock_retry`` matches
+    the error code + "deadlock" substring and retries. If either half of that seam drifts,
+    the safety net silently stops retrying and this test fails.
     """
     experiment_id = store.create_experiment("start-trace-deadlock-retry")
     trace_id = f"tr-{uuid.uuid4().hex}"
@@ -9884,22 +9969,26 @@ def test_start_trace_retries_on_deadlock(store: SqlAlchemyStore):
         trace_metadata={},
     )
 
-    real_start_trace = SqlAlchemyStore._start_trace_once
-    calls = {"n": 0}
+    real_flush = sqlalchemy.orm.Session.flush
+    flush_calls = {"n": 0}
 
-    def _flaky(self, *args, **kwargs):
-        calls["n"] += 1
-        if calls["n"] == 1:
-            raise _make_deadlock_exception()
-        return real_start_trace(self, *args, **kwargs)
+    def _flaky_flush(self, *args, **kwargs):
+        flush_calls["n"] += 1
+        if flush_calls["n"] == 1:
+            raise sqlalchemy.exc.OperationalError(
+                "INSERT INTO trace_request_metadata ...",
+                {},
+                Exception("deadlock detected"),
+            )
+        return real_flush(self, *args, **kwargs)
 
     with (
-        mock.patch.object(SqlAlchemyStore, "_start_trace_once", _flaky),
+        mock.patch.object(sqlalchemy.orm.Session, "flush", _flaky_flush),
         mock.patch("mlflow.store.tracking.sqlalchemy_store.time.sleep"),
     ):
         result = store.start_trace(trace_info)
 
-    assert calls["n"] == 2  # one deadlock, one successful retry
+    assert flush_calls["n"] >= 2  # first flush deadlocked, retry re-ran and succeeded
     assert result.trace_id == trace_id
     assert store.get_trace_info(trace_id).trace_id == trace_id
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24332

### What changes are proposed in this pull request?

`start_trace()` and `log_spans()` both `session.merge()` overlapping rows into `trace_request_metadata` / `trace_metrics` for the same `request_id`, in unsynchronized key order, on separate threads of the async export pool. 

On Postgres this is a lock-order inversion on `trace_request_metadata_pk`: two transactions each hold an index-tuple lock the other needs, Postgres kills one with `DeadlockDetected`, and — with no retry — the killed transaction's metadata (e.g. `mlflow.trace.tokenUsage`) is silently dropped. 

Fix, in two parts:

1. **Deterministic key ordering (primary fix).** Every writer of `SqlTraceMetadata` / `SqlTraceMetrics` now emits rows sorted by key, and `log_spans()` iterates its `trace_id`s in sorted order. A consistent lock-acquisition order makes the circular wait impossible. This matches the existing "consistent locking order across transactions" convention already used for latest-metric and trace-deletion writes. I'm assuming that the metadata keys tend to be small, so `O(n log n)` shouldn't result in a big performance degradation here. 


4. **Bounded deadlock retry (safety net).** `start_trace()` / `log_spans()` re-run the whole operation on a fresh managed session when the DB kills the transaction with a deadlock (bounded retries, exponential backoff + jitter, matching `_try_insert_tags`). Going with 2 retries first just to be safe with potential latency and in case the check is too wide, happy to increase. Added private helper methods to help encapsulate this logic.

Why not atomic upsert?

The transaction would still have to acquire the lock on a per row level. It merely makes the update to the row atomic. However, if two transactions, both performing atomic operations, will still run into a deadlock if the order of acquisition is not conducive, eg if its acquired in reverse order. 


For future extensions, we may consider making the metadata merge a helper function that does the sorting, so we don't run into similar deadlocks for new code branches. However, holding off on this for now to avoid premature optimization.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New regression tests assert sorted emission order for every writer (`start_trace` happy + conflict paths, `log_spans`, and the deprecated V2 path) and that both methods retry-then-recover on a deadlock and surface it after the bounded retries are exhausted.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a Postgres deadlock between concurrent `start_trace()` and `log_spans()` calls that could silently drop trace metadata such as token usage.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release