### PR TITLE
feat: Add native FastAPI artifact upload/download endpoints with streaming support

### DIFF
--- a/mlflow/server/artifact_router.py
+++ b/mlflow/server/artifact_router.py
@@ -1,0 +1,181 @@
+"""
+Native FastAPI artifact upload and download endpoints.
+
+When MLflow runs under uvicorn/FastAPI (the default), these endpoints handle
+artifact upload and download requests directly via ASGI, bypassing the WSGI
+bridge and avoiding full-body buffering. This enables true streaming for large
+artifact transfers.
+
+When MLflow runs under gunicorn/waitress (Flask-only), the Flask handlers in
+handlers.py serve these same URL patterns as the natural fallback.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import posixpath
+import tempfile
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
+
+from mlflow.exceptions import MlflowException
+from mlflow.store.artifact.artifact_repo import ARTIFACT_STREAM_CHUNK_SIZE, StreamUploadMixin
+from mlflow.utils.mime_type_utils import _guess_mime_type
+from mlflow.utils.uri import validate_path_is_safe
+
+_logger = logging.getLogger(__name__)
+
+artifact_router = APIRouter()
+
+
+def _is_serving_proxied_artifacts() -> bool:
+    from mlflow.server import SERVE_ARTIFACTS_ENV_VAR
+
+    return os.environ.get(SERVE_ARTIFACTS_ENV_VAR, "false") == "true"
+
+
+def _get_artifact_repo():
+    from mlflow.server import ARTIFACTS_DESTINATION_ENV_VAR
+    from mlflow.server.handlers import _get_artifact_repo_mlflow_artifacts
+
+    if ARTIFACTS_DESTINATION_ENV_VAR not in os.environ:
+        raise HTTPException(status_code=503, detail="Artifact serving is not configured.")
+    return _get_artifact_repo_mlflow_artifacts()
+
+
+def _get_workspace_scoped_path(artifact_path: str) -> str:
+    from mlflow.server.handlers import _get_workspace_scoped_repo_path_if_enabled
+
+    return _get_workspace_scoped_repo_path_if_enabled(artifact_path)
+
+
+def _content_disposition(filename: str) -> str:
+    from mlflow.server.handlers import _content_disposition_attachment
+
+    return _content_disposition_attachment(filename)
+
+
+@artifact_router.get("/api/2.0/mlflow-artifacts/artifacts/{artifact_path:path}")
+@artifact_router.get("/ajax-api/2.0/mlflow-artifacts/artifacts/{artifact_path:path}")
+async def download_artifact(artifact_path: str):
+    if not _is_serving_proxied_artifacts():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Artifact serving is disabled. "
+                "Run `mlflow server` with `--serve-artifacts` to enable."
+            ),
+        )
+
+    try:
+        artifact_path = validate_path_is_safe(artifact_path)
+        artifact_path = _get_workspace_scoped_path(artifact_path)
+        artifact_repo = _get_artifact_repo()
+
+        if (local_path := artifact_repo.get_local_path(artifact_path)) is not None:
+            abs_path = os.path.abspath(local_path)
+            if os.path.isdir(abs_path):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Artifact path refers to a directory, not a file: '{artifact_path}'",
+                )
+            filename = os.path.basename(artifact_path)
+            mime_type = _guess_mime_type(abs_path)
+            return FileResponse(
+                abs_path,
+                headers={
+                    "Content-Type": mime_type,
+                    "Content-Disposition": _content_disposition(filename),
+                    "X-Content-Type-Options": "nosniff",
+                },
+            )
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        try:
+            dst = os.path.abspath(
+                await asyncio.to_thread(
+                    artifact_repo.download_artifacts, artifact_path, tmp_dir.name
+                )
+            )
+        except Exception:
+            tmp_dir.cleanup()
+            raise
+
+        mime_type = _guess_mime_type(dst)
+        filename = os.path.basename(artifact_path)
+
+        def _stream_file():
+            """Sync generator — Starlette iterates it in a threadpool automatically."""
+            try:
+                with open(dst, "rb") as f:
+                    while chunk := f.read(ARTIFACT_STREAM_CHUNK_SIZE):
+                        yield chunk
+            finally:
+                tmp_dir.cleanup()
+
+        return StreamingResponse(
+            _stream_file(),
+            headers={
+                "Content-Type": mime_type,
+                "Content-Disposition": _content_disposition(filename),
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+    except HTTPException:
+        raise
+    except MlflowException as e:
+        return JSONResponse(
+            status_code=e.get_http_status_code(),
+            content=json.loads(e.serialize_as_json()),
+        )
+
+
+@artifact_router.put("/api/2.0/mlflow-artifacts/artifacts/{artifact_path:path}")
+@artifact_router.put("/ajax-api/2.0/mlflow-artifacts/artifacts/{artifact_path:path}")
+async def upload_artifact(artifact_path: str, request: Request):
+    if not _is_serving_proxied_artifacts():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Artifact serving is disabled. "
+                "Run `mlflow server` with `--serve-artifacts` to enable."
+            ),
+        )
+
+    try:
+        artifact_path = validate_path_is_safe(artifact_path)
+        artifact_path = _get_workspace_scoped_path(artifact_path)
+        head, tail = posixpath.split(artifact_path)
+
+        if not tail:
+            raise HTTPException(
+                status_code=400,
+                detail="Artifact path must include a filename (cannot end with '/').",
+            )
+
+        artifact_repo = _get_artifact_repo()
+
+        if isinstance(artifact_repo, StreamUploadMixin):
+            await artifact_repo.log_artifact_from_async_stream(
+                request.stream(),
+                tail,
+                artifact_path=head or None,
+            )
+        else:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                tmp_path = os.path.join(tmp_dir, tail)
+                with open(tmp_path, "wb") as f:
+                    async for chunk in request.stream():
+                        await asyncio.to_thread(f.write, chunk)
+                await asyncio.to_thread(
+                    artifact_repo.log_artifact, tmp_path, artifact_path=head or None
+                )
+
+        return Response(status_code=200)
+    except MlflowException as e:
+        return JSONResponse(
+            status_code=e.get_http_status_code(),
+            content=json.loads(e.serialize_as_json()),
+        )

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -9,6 +9,7 @@ Usage
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import functools
 import hmac
@@ -39,6 +40,7 @@ from flask import (
     request,
 )
 from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
 from werkzeug.datastructures import Authorization
 
 from mlflow import MlflowException
@@ -820,7 +822,10 @@ def _get_experiment_id_from_view_args():
 
 
 def _get_permission_from_experiment_id_artifact_proxy() -> Permission:
-    username = authenticate_request().username
+    # Flask artifact proxy routes have already authenticated in `_before_request`.
+    # Reuse that username so custom auth functions are not invoked twice on
+    # Flask-served list/delete/presigned/MPU requests.
+    username = getattr(g, "mlflow_authenticated_user", None) or authenticate_request().username
 
     if experiment_id := _get_experiment_id_from_view_args():
         return _get_role_permission_or_default(
@@ -2905,6 +2910,21 @@ WEBHOOK_BEFORE_REQUEST_VALIDATORS = {
 _AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
 
 
+def _is_native_fastapi_proxy_artifact_path(path: str, method: str) -> bool:
+    # Only artifact download/upload routes are served natively by FastAPI. List,
+    # delete, presigned, and MPU routes still fall through to Flask and must
+    # rely on Flask's existing auth flow to avoid double-invoking custom auth
+    # functions.
+    if method not in {"GET", "PUT"}:
+        return False
+
+    prefixes = [
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/artifacts/",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/artifacts/",
+    ]
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
 def _is_proxy_artifact_path(path: str) -> bool:
     # MlflowArtifactsService endpoints are registered at both /api/2.0/... and /ajax-api/2.0/...
     # paths (see handlers._get_paths), so we need to check both prefixes for auth validation.
@@ -4454,6 +4474,73 @@ def _authenticate_fastapi_request(request: StarletteRequest) -> User | None:
         return None
 
 
+def _authenticate_custom_for_fastapi(
+    request: StarletteRequest,
+) -> User | StarletteResponse | None:
+    """Bridge custom authorization_function into the FastAPI middleware path.
+
+    Custom auth functions (configured via ``authorization_function`` in auth config)
+    are written against Flask's request context (``flask.request``). This function
+    creates a synthetic Flask request context from the Starlette request, invokes the
+    custom function within it, and translates the result back.
+
+    Returns:
+        - A ``User`` if authentication succeeds.
+        - A Starlette ``Response`` if the custom auth function returned a Flask Response
+          (converted to preserve status code, headers, and body).
+        - ``None`` if authentication fails (no username / unknown user).
+
+    Raises:
+        MlflowException: If the custom auth function returns an unsupported type,
+            matching Flask ``_before_request`` failure semantics.
+    """
+    headers = dict(request.headers)
+    with app.test_request_context(
+        path=request.url.path,
+        method=request.method,
+        headers=headers,
+        query_string=request.url.query or "",
+    ):
+        authorization = authenticate_request()
+        if isinstance(authorization, Response):
+            return _flask_response_to_starlette(authorization)
+        if not isinstance(authorization, Authorization):
+            # Match Flask `_before_request`: unsupported plugin return types are an
+            # internal misconfiguration, not an authentication failure (401).
+            raise MlflowException(
+                f"Unsupported result type from {auth_config.authorization_function}: "
+                f"'{type(authorization).__name__}'",
+                INTERNAL_ERROR,
+            )
+        username = authorization.username
+        if not username:
+            return None
+        try:
+            return store.get_user(username)
+        except Exception:
+            return None
+
+
+def _flask_response_to_starlette(flask_resp: Response) -> StarletteResponse:
+    """Convert a Flask/Werkzeug Response to a Starlette Response.
+
+    Preserves status code, headers (including multi-value headers like Set-Cookie),
+    and body so custom auth functions can return meaningful error responses
+    (e.g., 403 with a custom message, or a redirect) that get forwarded to the
+    client unchanged.
+    """
+    _hop_by_hop_headers = {"content-length", "transfer-encoding"}
+    response = StarletteResponse(
+        content=flask_resp.get_data(),
+        status_code=flask_resp.status_code,
+    )
+    for key, value in flask_resp.headers:
+        if key.lower() in _hop_by_hop_headers:
+            continue
+        response.headers.append(key, value)
+    return response
+
+
 def _extract_gateway_endpoint_name(path: str, body: dict[str, Any] | None) -> str | None:
     """Extract endpoint name from gateway routes."""
     # Pattern 1: /gateway/{endpoint_name}/mlflow/invocations
@@ -4772,7 +4859,85 @@ def _get_otel_validator(
     return validator
 
 
-def _find_fastapi_validator(path: str) -> Callable[[str, StarletteRequest], Awaitable[bool]] | None:
+def _extract_experiment_id_from_artifact_proxy_path(
+    path: str, query_path: str | None = None
+) -> str | None:
+    # Mirror Flask view_args extraction for both simple artifact routes and MPU
+    # control-plane routes (create/complete/abort). FastAPI permission middleware
+    # claims all `_is_proxy_artifact_path` URLs, so experiment ids must be parsed
+    # from /mpu/... as well as /artifacts/....
+    prefixes = (
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/artifacts/",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/artifacts/",
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/mpu/create/",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/mpu/create/",
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/mpu/complete/",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/mpu/complete/",
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/mpu/abort/",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/mpu/abort/",
+    )
+    prefix = next((prefix for prefix in prefixes if path.startswith(prefix)), None)
+    if prefix is not None:
+        artifact_path = path.removeprefix(prefix)
+        if m := _EXPERIMENT_ID_PATTERN.match(f"{artifact_path}/"):
+            return m.group(1)
+
+    # List-artifacts uses GET .../artifacts?path=<experiment_id>/... (Flask parity).
+    if query_path and (m := _EXPERIMENT_ID_PATTERN.match(query_path)):
+        return m.group(1)
+    return None
+
+
+def _get_proxy_artifact_permission(
+    path: str, username: str, query_path: str | None = None
+) -> Permission:
+    if experiment_id := _extract_experiment_id_from_artifact_proxy_path(path, query_path):
+        return _get_role_permission_or_default(
+            _role_permission_for(
+                username=username,
+                resource_type="experiment",
+                resource_key=experiment_id,
+                workspace_lookup_id=experiment_id,
+                workspace_fetcher=_get_tracking_store().get_experiment,
+                workspace_label="experiment",
+            ),
+        )
+
+    if MLFLOW_ENABLE_WORKSPACES.get():
+        if workspace_name := workspace_context.get_request_workspace():
+            user = store.get_user(username)
+            perm = store.get_role_permission_for_resource(user.id, "workspace", "*", workspace_name)
+            if perm is not None:
+                return perm
+            # Honor the default-workspace auto-grant when configured.
+            if _user_inherits_default_workspace_grant(workspace_name):
+                return get_permission(auth_config.default_permission)
+        return NO_PERMISSIONS
+
+    return get_permission(auth_config.default_permission)
+
+
+def _get_fastapi_proxy_artifact_validator(
+    path: str, method: str
+) -> Callable[[str, StarletteRequest], Awaitable[bool]]:
+    async def validator(username: str, request: StarletteRequest) -> bool:
+        query_path = request.query_params.get("path")
+        permission = await asyncio.to_thread(
+            _get_proxy_artifact_permission, path, username, query_path
+        )
+        return {
+            "GET": permission.can_read,
+            "PUT": permission.can_update,
+            "DELETE": permission.can_manage,
+            "POST": permission.can_update,
+        }.get(method, False)
+
+    return validator
+
+
+def _find_fastapi_validator(
+    path: str, method: str
+) -> Callable[[str, StarletteRequest], Awaitable[bool]] | None:
     """
     Find the validator for a FastAPI route that bypasses Flask.
 
@@ -4797,6 +4962,9 @@ def _find_fastapi_validator(path: str) -> Callable[[str, StarletteRequest], Awai
 
     if path.startswith("/ajax-api/3.0/mlflow/assistant"):
         return _get_require_authentication_validator()
+
+    if _is_native_fastapi_proxy_artifact_path(path, method):
+        return _get_fastapi_proxy_artifact_validator(path, method)
 
     if is_mcp_server_api_path(path):
         return _get_mcp_server_validator(path)
@@ -4895,18 +5063,22 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
     Add permission middleware to FastAPI app for routes not handled by Flask.
 
     This middleware mirrors the high-level logic of ``_before_request`` for routes that are
-    served directly by FastAPI (e.g., ``/gateway/`` routes) and thus bypass Flask's
-    ``before_request`` hooks. It follows the same authorization flow:
+    served directly by FastAPI (e.g., ``/gateway/`` and native artifact routes) and thus
+    bypass Flask's ``before_request`` hooks. It follows the same authorization flow:
 
     1. Skip unprotected routes
     2. Find the appropriate validator for the route
-    3. Reject if custom authorization_function is configured (not supported for FastAPI routes)
-    4. Authenticate the request
-    5. Resolve workspace context (needed for validators and workspace-scoped after-handlers)
-    6. Allow admins to skip validators (full access) while still running after-handlers
-    7. Run the validator for non-admins
-    8. Run after-request handlers on successful responses (including for admins)
-    9. Apply response filters for non-admins
+    3. Authenticate the request (via custom authorization_function bridge or Basic Auth)
+    4. Resolve workspace context before validator execution
+    5. Allow admins to skip validators while still running after-request handlers
+    6. Run the validator for non-admins
+    7. Run after-request handlers on successful responses
+    8. Apply response filters for non-admins
+
+    When a custom ``authorization_function`` is configured, requests are authenticated by
+    constructing a Flask request context and invoking the custom function within it.
+    This bridges Flask-based auth functions into the ASGI middleware path without requiring
+    users to rewrite their auth plugins.
 
     Args:
         app: The FastAPI application instance.
@@ -4921,22 +5093,28 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
             return await call_next(request)
 
         # Find validator for this route
-        validator = _find_fastapi_validator(path)
+        validator = _find_fastapi_validator(path, request.method)
         if validator is None:
             return await call_next(request)
 
-        # Check for custom authorization_function (only affects routes with validators)
-        if auth_config.authorization_function != DEFAULT_AUTHORIZATION_FUNCTION:
-            return PlainTextResponse(
-                f"Custom authorization_function '{auth_config.authorization_function}' is not "
-                f"supported for FastAPI routes (e.g., /gateway/ endpoints). Only the default "
-                f"Basic Auth function is supported. Please use "
-                f"'{DEFAULT_AUTHORIZATION_FUNCTION}' or disable the AI Gateway feature.",
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        # Authenticate using either the custom authorization_function (via Flask
+        # request context bridge) or the native FastAPI Basic Auth path.
+        try:
+            if auth_config.authorization_function != DEFAULT_AUTHORIZATION_FUNCTION:
+                auth_result = _authenticate_custom_for_fastapi(request)
+                if isinstance(auth_result, StarletteResponse):
+                    return auth_result
+                user = auth_result
+            else:
+                user = _authenticate_fastapi_request(request)
+        except MlflowException as e:
+            # Preserve Flask semantics for misconfigured custom auth plugins
+            # (e.g. unsupported return types) instead of collapsing to 401.
+            # Match Flask `catch_mlflow_exception` wire format (JSON body).
+            return JSONResponse(
+                status_code=e.get_http_status_code(),
+                content=json.loads(e.serialize_as_json()),
             )
-
-        # Authenticate user
-        user = _authenticate_fastapi_request(request)
         if user is None:
             return PlainTextResponse(
                 "You are not authenticated. Please see "

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -23,6 +23,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER, MLFLOW_GATEWAY_OVERHEAD_HEADER
 from mlflow.gateway.providers.utils import provider_call_duration_ms
 from mlflow.server import app as flask_app
+from mlflow.server.artifact_router import artifact_router
 from mlflow.server.asgi_utils import get_routed_asgi_path
 from mlflow.server.assistant.api import assistant_router
 from mlflow.server.fastapi_security import init_fastapi_security
@@ -205,8 +206,8 @@ def create_fastapi_app(flask_app: Flask = flask_app):
         title="MLflow Tracking Server",
         description="MLflow Tracking Server API",
         version=VERSION,
-        # TODO: Enable API documentation when we have native FastAPI endpoints
-        # For now, disable docs since we only have Flask routes via WSGI
+        # Docs/OpenAPI remain disabled intentionally even though several native
+        # FastAPI routers are mounted (otel, jobs, gateway, assistant, artifacts).
         docs_url=None,
         redoc_url=None,
         openapi_url=None,
@@ -232,13 +233,16 @@ def create_fastapi_app(flask_app: Flask = flask_app):
     # This provides /ajax-api/3.0/mlflow/assistant/* endpoints (localhost only)
     fastapi_app.include_router(assistant_router)
 
+    # Include native artifact upload/download router for ASGI streaming
+    # This provides /api/2.0/mlflow-artifacts/artifacts/* and /ajax-api/2.0/... routes
+    fastapi_app.include_router(artifact_router)
+
     add_mcp_exception_handlers(fastapi_app)
     for route_prefix in get_mcp_server_api_route_prefixes():
         fastapi_app.include_router(mcp_server_router, prefix=route_prefix)
 
-    # Mount the entire Flask application at the root path
-    # This ensures compatibility with existing APIs
-    # NOTE: This must come AFTER include_router to avoid Flask catching all requests
+    # Mount the entire Flask application at the root path.
+    # Must come AFTER include_router so native FastAPI routes take precedence.
     fastapi_app.mount("/", _EfficientWSGIMiddleware(flask_app))
 
     return fastapi_app

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -10,7 +10,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING, Any, AsyncIterable, BinaryIO
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.entities.multipart_upload import (
@@ -741,6 +741,24 @@ class StreamUploadMixin(ABC):
 
         Args:
             stream: Readable binary stream containing the artifact contents.
+            artifact_file_name: Artifact filename to log. Any directory components are
+                ignored; use ``artifact_path`` to specify the destination directory.
+            artifact_path: Directory within the run's artifact directory in which to log
+                the artifact.
+        """
+
+    @abstractmethod
+    async def log_artifact_from_async_stream(
+        self,
+        chunks: AsyncIterable[bytes],
+        artifact_file_name: str,
+        artifact_path: str | None = None,
+    ) -> None:
+        """
+        Log artifact contents from an async chunk stream.
+
+        Args:
+            chunks: Async iterable yielding binary chunks containing the artifact contents.
             artifact_file_name: Artifact filename to log. Any directory components are
                 ignored; use ``artifact_path`` to specify the destination directory.
             artifact_path: Directory within the run's artifact directory in which to log

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -1,9 +1,10 @@
+import asyncio
 import os
 import shutil
 import tempfile
 import threading
 from contextlib import suppress
-from typing import Any, BinaryIO, Callable
+from typing import Any, AsyncIterable, BinaryIO, Callable
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
@@ -96,6 +97,31 @@ class LocalArtifactRepository(ArtifactRepository, StreamUploadMixin):
         validate_path_within_directory(self.artifact_dir, destination_file_path)
         return artifact_dir, destination_file_path
 
+    def _create_staging_artifact(
+        self, artifact_file_name: str, artifact_path: str | None = None
+    ) -> tuple[int, str, str]:
+        artifact_dir, destination_file_path = self._get_destination_artifact_path(
+            artifact_file_name, artifact_path
+        )
+        temp_file_descriptor, temp_file_path = tempfile.mkstemp(
+            dir=artifact_dir, prefix=_TEMP_ARTIFACT_PREFIX
+        )
+        return temp_file_descriptor, temp_file_path, destination_file_path
+
+    def _publish_staged_artifact(
+        self,
+        temp_file_path: str,
+        destination_file_path: str,
+        finalize_temp_path: Callable[[str], None] | None = None,
+    ) -> None:
+        if finalize_temp_path is not None:
+            finalize_temp_path(temp_file_path)
+        os.replace(temp_file_path, destination_file_path)
+
+    def _cleanup_staged_artifact(self, temp_file_path: str) -> None:
+        with suppress(FileNotFoundError):
+            os.remove(temp_file_path)
+
     def _write_to_destination_path(
         self,
         artifact_file_name: str,
@@ -103,13 +129,10 @@ class LocalArtifactRepository(ArtifactRepository, StreamUploadMixin):
         artifact_path: str | None = None,
         finalize_temp_path: Callable[[str], None] | None = None,
     ) -> None:
-        artifact_dir, destination_file_path = self._get_destination_artifact_path(
-            artifact_file_name, artifact_path
-        )
         # Write to a hidden temp file in the destination directory, then atomically
         # replace the target path so readers never see a partially-written artifact.
-        temp_file_descriptor, temp_file_path = tempfile.mkstemp(
-            dir=artifact_dir, prefix=_TEMP_ARTIFACT_PREFIX
+        temp_file_descriptor, temp_file_path, destination_file_path = self._create_staging_artifact(
+            artifact_file_name, artifact_path
         )
         published = False
         try:
@@ -117,16 +140,13 @@ class LocalArtifactRepository(ArtifactRepository, StreamUploadMixin):
             temp_file_descriptor = None
             with temp_file:
                 writer(temp_file)
-            if finalize_temp_path is not None:
-                finalize_temp_path(temp_file_path)
-            os.replace(temp_file_path, destination_file_path)
+            self._publish_staged_artifact(temp_file_path, destination_file_path, finalize_temp_path)
             published = True
         finally:
             if temp_file_descriptor is not None:
                 os.close(temp_file_descriptor)
             if not published:
-                with suppress(FileNotFoundError):
-                    os.remove(temp_file_path)
+                self._cleanup_staged_artifact(temp_file_path)
 
     def log_artifact(self, local_file, artifact_path=None):
         _, destination_file_path = self._get_destination_artifact_path(local_file, artifact_path)
@@ -164,6 +184,37 @@ class LocalArtifactRepository(ArtifactRepository, StreamUploadMixin):
             artifact_path,
             finalize_temp_path=_set_default_file_mode,
         )
+
+    async def log_artifact_from_async_stream(
+        self,
+        chunks: AsyncIterable[bytes],
+        artifact_file_name: str,
+        artifact_path: str | None = None,
+    ) -> None:
+        temp_file_descriptor = None
+        temp_file_path = None
+        published = False
+        try:
+            temp_file_descriptor, temp_file_path, destination_file_path = await asyncio.to_thread(
+                self._create_staging_artifact, artifact_file_name, artifact_path
+            )
+            temp_file = os.fdopen(temp_file_descriptor, "wb")
+            temp_file_descriptor = None
+            with temp_file:
+                async for chunk in chunks:
+                    await asyncio.to_thread(temp_file.write, chunk)
+            await asyncio.to_thread(
+                self._publish_staged_artifact,
+                temp_file_path,
+                destination_file_path,
+                _set_default_file_mode,
+            )
+            published = True
+        finally:
+            if temp_file_descriptor is not None:
+                os.close(temp_file_descriptor)
+            if not published and temp_file_path is not None:
+                await asyncio.to_thread(self._cleanup_staged_artifact, temp_file_path)
 
     def _is_directory(self, artifact_path):
         # NOTE: The path is expected to be in posix format.

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -132,6 +132,11 @@ def fastapi_client(request, tmp_path):
     extra_env[MLFLOW_FLASK_SERVER_SECRET_KEY.name] = "my-secret-key"
     # Set _MLFLOW_SGI_NAME to "uvicorn" so auth module returns FastAPI app
     extra_env["_MLFLOW_SGI_NAME"] = "uvicorn"
+    if extra_env.get("_MLFLOW_SERVER_SERVE_ARTIFACTS") == "true":
+        extra_env.setdefault(
+            "_MLFLOW_SERVER_ARTIFACT_DESTINATION",
+            str(tmp_path / "served_artifacts"),
+        )
 
     with _init_server(
         backend_uri=backend_uri,
@@ -346,6 +351,47 @@ def test_proxy_artifact_mpu_path_detection():
     assert not auth_module._is_proxy_artifact_path("/api/2.0/mlflow/experiments/get")
 
 
+def test_extract_experiment_id_from_artifact_proxy_path():
+    assert (
+        auth_module._extract_experiment_id_from_artifact_proxy_path(
+            "/api/2.0/mlflow-artifacts/artifacts/42/run-id/artifacts/model.pkl"
+        )
+        == "42"
+    )
+    assert (
+        auth_module._extract_experiment_id_from_artifact_proxy_path(
+            "/ajax-api/2.0/mlflow-artifacts/artifacts/workspaces/team-a/7/run-id/artifacts/f"
+        )
+        == "7"
+    )
+    for action in ("create", "complete", "abort"):
+        assert (
+            auth_module._extract_experiment_id_from_artifact_proxy_path(
+                f"/api/2.0/mlflow-artifacts/mpu/{action}/99/run-id/artifacts/model"
+            )
+            == "99"
+        )
+        assert (
+            auth_module._extract_experiment_id_from_artifact_proxy_path(
+                f"/ajax-api/2.0/mlflow-artifacts/mpu/{action}/workspaces/ws/3/run/artifacts/x"
+            )
+            == "3"
+        )
+    assert (
+        auth_module._extract_experiment_id_from_artifact_proxy_path(
+            "/api/2.0/mlflow-artifacts/artifacts",
+            query_path="55/models/m-abc123/artifacts",
+        )
+        == "55"
+    )
+    assert (
+        auth_module._extract_experiment_id_from_artifact_proxy_path(
+            "/api/2.0/mlflow/experiments/get"
+        )
+        is None
+    )
+
+
 def test_proxy_artifact_mpu_validator_returns_update_for_post():
     validator = auth_module._get_proxy_artifact_validator(
         "POST", {"artifact_path": "1/run-id/artifacts/model"}
@@ -418,6 +464,69 @@ def test_proxy_artifact_authorization_required(client, monkeypatch):
         auth=(username2, password2),
     )
     assert response.status_code == 403
+
+
+def test_proxy_artifact_authorization_required_fastapi(fastapi_client, monkeypatch):
+    username1, password1 = create_user(fastapi_client.tracking_uri)
+    username2, password2 = create_user(fastapi_client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = fastapi_client.create_experiment("proxy-artifact-authz-test-fastapi")
+
+    response = requests.put(
+        url=(
+            fastapi_client.tracking_uri
+            + f"/ajax-api/2.0/mlflow-artifacts/artifacts/{experiment_id}/test.txt"
+        ),
+        data=b"forbidden",
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/api/2.0/mlflow-artifacts/artifacts/1/run-id/artifacts/model.pkl", "GET"),
+        ("/ajax-api/2.0/mlflow-artifacts/artifacts/1/run-id/artifacts/model.pkl", "GET"),
+        ("/api/2.0/mlflow-artifacts/artifacts/1/run-id/artifacts/model.pkl", "PUT"),
+        ("/ajax-api/2.0/mlflow-artifacts/artifacts/1/run-id/artifacts/model.pkl", "PUT"),
+    ],
+)
+def test_fastapi_validator_matches_native_artifact_routes(path, method):
+    assert _find_fastapi_validator(path, method) is not None
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/api/2.0/mlflow-artifacts/artifacts", "GET"),
+        ("/ajax-api/2.0/mlflow-artifacts/artifacts", "GET"),
+        ("/api/2.0/mlflow-artifacts/artifacts/1/run-id/artifacts/model.pkl", "DELETE"),
+        ("/ajax-api/2.0/mlflow-artifacts/artifacts/1/run-id/artifacts/model.pkl", "DELETE"),
+        ("/api/2.0/mlflow-artifacts/mpu/create/1/run-id/artifacts/model.pkl", "POST"),
+        ("/ajax-api/2.0/mlflow-artifacts/mpu/abort/1/run-id/artifacts/model.pkl", "POST"),
+    ],
+)
+def test_fastapi_validator_skips_flask_fallback_artifact_routes(path, method):
+    assert _find_fastapi_validator(path, method) is None
+
+
+def test_proxy_artifact_permission_reuses_authenticated_flask_user(monkeypatch):
+    permission = SimpleNamespace(can_read=True, can_update=True, can_manage=False)
+    authenticate_request = mock.Mock(side_effect=AssertionError("should not re-authenticate"))
+
+    monkeypatch.setattr(auth_module, "authenticate_request", authenticate_request)
+    monkeypatch.setattr(auth_module, "_get_experiment_id_from_view_args", lambda: "123")
+    monkeypatch.setattr(auth_module, "_role_permission_for", lambda **_: permission)
+    monkeypatch.setattr(auth_module, "_get_role_permission_or_default", lambda perm: perm)
+
+    with auth_module.app.test_request_context("/api/2.0/mlflow-artifacts/artifacts"):
+        auth_module.g.mlflow_authenticated_user = "alice"
+        result = auth_module._get_permission_from_experiment_id_artifact_proxy()
+
+    assert result is permission
+    authenticate_request.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -510,6 +619,56 @@ def test_proxy_artifact_list_query_param_uses_experiment_permission(client, monk
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize(
+    "fastapi_client",
+    [
+        {
+            "MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini",
+            "_MLFLOW_SERVER_SERVE_ARTIFACTS": "true",
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("list_path", "query_path_template"),
+    [
+        ("/api/2.0/mlflow-artifacts/artifacts", "{experiment_id}/models/m-abc123/artifacts"),
+        ("/ajax-api/2.0/mlflow-artifacts/artifacts", "{experiment_id}/models/m-abc123/artifacts"),
+        (
+            "/api/2.0/mlflow-artifacts/artifacts",
+            "workspaces/default/{experiment_id}/models/m-abc123/artifacts",
+        ),
+    ],
+)
+def test_proxy_artifact_list_query_param_uses_experiment_permission_on_fastapi_server(
+    fastapi_client, monkeypatch, list_path, query_path_template
+):
+    # List-artifacts is still served by Flask on the FastAPI server, so this
+    # exercises the fallback auth path rather than the native FastAPI router.
+    username1, password1 = create_user(fastapi_client.tracking_uri)
+    username2, password2 = create_user(fastapi_client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = fastapi_client.create_experiment(
+            "proxy-artifact-list-query-param-test-fastapi"
+        )
+
+    query_path = query_path_template.format(experiment_id=experiment_id)
+    response = requests.get(
+        url=fastapi_client.tracking_uri + list_path,
+        params={"path": query_path},
+        auth=(username1, password1),
+    )
+    assert response.status_code == 200
+
+    response = requests.get(
+        url=fastapi_client.tracking_uri + list_path,
+        params={"path": query_path},
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+
+
 @pytest.mark.parametrize("mpu_action", ["create", "complete", "abort"])
 def test_mpu_authorization_required(client, monkeypatch, mpu_action):
     username1, password1 = create_user(client.tracking_uri)
@@ -564,6 +723,46 @@ def test_presigned_download_url_authorization_required(client, monkeypatch):
         auth=(username1, password1),
     )
     assert response.status_code == 501
+
+
+@pytest.mark.parametrize(
+    "fastapi_client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+@pytest.mark.parametrize("mpu_action", ["create", "complete", "abort"])
+def test_mpu_authorization_required_via_flask_fallback_on_fastapi_server(
+    fastapi_client, monkeypatch, mpu_action
+):
+    username1, password1 = create_user(fastapi_client.tracking_uri)
+    username2, password2 = create_user(fastapi_client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = fastapi_client.create_experiment(f"mpu-authz-fastapi-{mpu_action}")
+
+    # MPU routes are still handled by Flask on the FastAPI server, so both
+    # assertions here exercise the Flask fallback auth path.
+    response = requests.post(
+        url=(
+            fastapi_client.tracking_uri
+            + f"/api/2.0/mlflow-artifacts/mpu/{mpu_action}/{experiment_id}/artifacts/model"
+        ),
+        json={"path": "python_model.pkl", "num_parts": 1},
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+
+    # If middleware failed to parse the experiment id, owner would also get 403
+    # from default_permission=NO_PERMISSIONS.
+    response = requests.post(
+        url=(
+            fastapi_client.tracking_uri
+            + f"/api/2.0/mlflow-artifacts/mpu/{mpu_action}/{experiment_id}/artifacts/model"
+        ),
+        json={"path": "python_model.pkl", "num_parts": 1},
+        auth=(username1, password1),
+    )
+    assert response.status_code != 403
 
 
 def _mlflow_search_experiments_rest(base_uri, headers):
@@ -627,6 +826,241 @@ def test_authenticate_jwt(client):
     with pytest.raises(requests.HTTPError, match=r"401 Client Error: UNAUTHORIZED") as e:
         _mlflow_search_experiments_rest(client.tracking_uri, headers)
     assert e.value.response.status_code == 401  # Unauthorized
+
+
+@pytest.fixture
+def jwt_fastapi_artifact_client(tmp_path):
+    path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+    backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
+    artifact_dest = str(tmp_path / "jwt_artifacts")
+    extra_env = _isolate_auth_config({"MLFLOW_AUTH_CONFIG_PATH": "fixtures/jwt_auth.ini"}, tmp_path)
+    extra_env[MLFLOW_FLASK_SERVER_SECRET_KEY.name] = "my-secret-key"
+    extra_env["_MLFLOW_SGI_NAME"] = "uvicorn"
+    extra_env["PYTHONPATH"] = str(Path.cwd() / "examples" / "jwt_auth")
+    extra_env["_MLFLOW_SERVER_SERVE_ARTIFACTS"] = "true"
+    extra_env["_MLFLOW_SERVER_ARTIFACT_DESTINATION"] = artifact_dest
+
+    with _init_server(
+        backend_uri=backend_uri,
+        root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
+        extra_env=extra_env,
+        app="mlflow.server.auth:create_app",
+        server_type="fastapi",
+    ) as url:
+        yield MlflowClient(url)
+
+
+def _write_counting_custom_auth_setup(tmp_path: Path):
+    counter_path = tmp_path / "auth_count.txt"
+    counter_path.write_text("0")
+    (tmp_path / "counting_auth.py").write_text(
+        "from pathlib import Path\n"
+        "from werkzeug.datastructures import Authorization\n\n"
+        f"_COUNTER_PATH = Path({str(counter_path)!r})\n\n"
+        "def authenticate_request():\n"
+        "    _COUNTER_PATH.write_text(str(int(_COUNTER_PATH.read_text()) + 1))\n"
+        f'    return Authorization("basic", {{"username": {ADMIN_USERNAME!r}}})\n'
+    )
+    config_path = tmp_path / "counting_auth.ini"
+    config_path.write_text(
+        "[mlflow]\n"
+        "default_permission = READ\n"
+        f"database_uri = sqlite:///{tmp_path / 'basic_auth.db'}\n"
+        f"admin_username = {ADMIN_USERNAME}\n"
+        f"admin_password = {ADMIN_PASSWORD}\n"
+        "authorization_function = counting_auth:authenticate_request\n"
+        "grant_default_workspace_access = false\n"
+    )
+    return counter_path, {
+        "MLFLOW_AUTH_CONFIG_PATH": str(config_path),
+        MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key",
+        "PYTHONPATH": str(tmp_path),
+        "_MLFLOW_SERVER_SERVE_ARTIFACTS": "true",
+        "_MLFLOW_SERVER_ARTIFACT_DESTINATION": str(tmp_path / "served_artifacts"),
+    }
+
+
+@pytest.fixture
+def counting_custom_auth_fastapi_client(tmp_path):
+    tmp_path = tmp_path / "fastapi"
+    tmp_path.mkdir()
+    path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+    backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
+    counter_path, extra_env = _write_counting_custom_auth_setup(tmp_path)
+    extra_env["_MLFLOW_SGI_NAME"] = "uvicorn"
+
+    with _init_server(
+        backend_uri=backend_uri,
+        root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
+        extra_env=extra_env,
+        app="mlflow.server.auth:create_app",
+        server_type="fastapi",
+    ) as url:
+        yield MlflowClient(url), counter_path
+
+
+@pytest.fixture
+def counting_custom_auth_flask_client(tmp_path):
+    tmp_path = tmp_path / "flask"
+    tmp_path.mkdir()
+    path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+    backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
+    counter_path, extra_env = _write_counting_custom_auth_setup(tmp_path)
+
+    with _init_server(
+        backend_uri=backend_uri,
+        root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
+        extra_env=extra_env,
+        app="mlflow.server.auth:create_app",
+        server_type="flask",
+    ) as url:
+        yield MlflowClient(url), counter_path
+
+
+def _count_custom_auth_calls_for_artifact_list(client, counter_path):
+    experiment_id = client.create_experiment(f"counting-auth-fallback-{random_str()}")
+    counter_path.write_text("0")
+    response = requests.get(
+        f"{client.tracking_uri}/api/2.0/mlflow-artifacts/artifacts",
+        params={"path": f"{experiment_id}/models/m-abc123/artifacts"},
+    )
+    return response, int(counter_path.read_text())
+
+
+def test_custom_auth_flask_fallback_artifact_list_matches_flask_auth_count_on_fastapi_server(
+    counting_custom_auth_flask_client,
+    counting_custom_auth_fastapi_client,
+):
+    flask_client, flask_counter_path = counting_custom_auth_flask_client
+    fastapi_client, fastapi_counter_path = counting_custom_auth_fastapi_client
+
+    flask_response, flask_count = _count_custom_auth_calls_for_artifact_list(
+        flask_client, flask_counter_path
+    )
+    fastapi_response, fastapi_count = _count_custom_auth_calls_for_artifact_list(
+        fastapi_client, fastapi_counter_path
+    )
+
+    assert flask_response.status_code == 200
+    assert fastapi_response.status_code == 200
+    assert fastapi_count == flask_count
+
+
+def test_custom_auth_artifact_upload_download_fastapi(jwt_fastapi_artifact_client):
+    client = jwt_fastapi_artifact_client
+    admin_token = jwt.encode({"username": ADMIN_USERNAME}, "secret", algorithm="HS256")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # Create experiment as admin
+    response = requests.post(
+        f"{client.tracking_uri}/api/2.0/mlflow/experiments/create",
+        headers=admin_headers,
+        json={"name": "jwt-artifact-e2e"},
+    )
+    response.raise_for_status()
+    experiment_id = response.json()["experiment_id"]
+
+    artifact_path = f"{experiment_id}/run-id/artifacts/model.pkl"
+    artifact_url = f"{client.tracking_uri}/api/2.0/mlflow-artifacts/artifacts/{artifact_path}"
+    payload = b"trained model weights v1"
+
+    # Upload artifact with valid JWT (admin has full access)
+    put_resp = requests.put(artifact_url, data=payload, headers=admin_headers)
+    assert put_resp.status_code == 200, f"Upload failed: {put_resp.status_code} {put_resp.text}"
+
+    # Download artifact with valid JWT
+    get_resp = requests.get(artifact_url, headers=admin_headers)
+    assert get_resp.status_code == 200, f"Download failed: {get_resp.status_code} {get_resp.text}"
+    assert get_resp.content == payload
+
+    # Verify non-admin user with valid JWT can also access (admins grant global read)
+    username, _ = _mlflow_create_user_rest(client.tracking_uri, admin_headers)
+    user_token = jwt.encode({"username": username}, "secret", algorithm="HS256")
+    user_headers = {"Authorization": f"Bearer {user_token}"}
+
+    get_resp = requests.get(artifact_url, headers=user_headers)
+    assert get_resp.status_code in (200, 403)  # depends on default_permission
+
+
+def test_custom_auth_artifact_rejects_invalid_token_fastapi(jwt_fastapi_artifact_client):
+    client = jwt_fastapi_artifact_client
+    base = f"{client.tracking_uri}/api/2.0/mlflow-artifacts/artifacts"
+    artifact_url = f"{base}/1/run-id/artifacts/model.pkl"
+
+    # No auth header → 401
+    resp = requests.get(artifact_url)
+    assert resp.status_code == 401
+
+    # Invalid JWT secret → 401
+    bad_token = jwt.encode({"username": "admin"}, "wrong-secret", algorithm="HS256")
+    resp = requests.get(artifact_url, headers={"Authorization": f"Bearer {bad_token}"})
+    assert resp.status_code == 401
+
+    # Malformed header → 401
+    resp = requests.get(artifact_url, headers={"Authorization": "NotBearer xyz"})
+    assert resp.status_code == 401
+
+
+def test_custom_auth_artifact_denies_unauthorized_user_fastapi(jwt_fastapi_artifact_client):
+    client = jwt_fastapi_artifact_client
+    admin_token = jwt.encode({"username": ADMIN_USERNAME}, "secret", algorithm="HS256")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # Create two users
+    user1, _ = _mlflow_create_user_rest(client.tracking_uri, admin_headers)
+    user2, _ = _mlflow_create_user_rest(client.tracking_uri, admin_headers)
+    user1_token = jwt.encode({"username": user1}, "secret", algorithm="HS256")
+    user2_token = jwt.encode({"username": user2}, "secret", algorithm="HS256")
+    user1_headers = {"Authorization": f"Bearer {user1_token}"}
+    user2_headers = {"Authorization": f"Bearer {user2_token}"}
+
+    # Create experiment as admin, grant EDIT to user1 only via roles API with JWT
+    response = requests.post(
+        f"{client.tracking_uri}/api/2.0/mlflow/experiments/create",
+        headers=admin_headers,
+        json={"name": "jwt-artifact-authz-e2e"},
+    )
+    response.raise_for_status()
+    experiment_id = response.json()["experiment_id"]
+
+    role_name = f"_test_jwt_{random_str()}"
+    resp = requests.post(
+        f"{client.tracking_uri}/api/3.0/mlflow/roles/create",
+        headers=admin_headers,
+        json={"name": role_name, "workspace": "default"},
+    )
+    resp.raise_for_status()
+    role_id = resp.json()["role"]["id"]
+
+    resp = requests.post(
+        f"{client.tracking_uri}/api/3.0/mlflow/roles/permissions/add",
+        headers=admin_headers,
+        json={
+            "role_id": role_id,
+            "resource_type": "experiment",
+            "resource_pattern": experiment_id,
+            "permission": "EDIT",
+        },
+    )
+    resp.raise_for_status()
+
+    resp = requests.post(
+        f"{client.tracking_uri}/api/3.0/mlflow/roles/assign",
+        headers=admin_headers,
+        json={"username": user1, "role_id": role_id},
+    )
+    resp.raise_for_status()
+
+    artifact_path = f"{experiment_id}/run-id/artifacts/secret.bin"
+    artifact_url = f"{client.tracking_uri}/api/2.0/mlflow-artifacts/artifacts/{artifact_path}"
+
+    # user1 can upload
+    put_resp = requests.put(artifact_url, data=b"secret data", headers=user1_headers)
+    assert put_resp.status_code == 200
+
+    # user2 cannot upload (no permission on this experiment)
+    put_resp = requests.put(artifact_url, data=b"hacked", headers=user2_headers)
+    assert put_resp.status_code == 403
 
 
 @pytest.mark.parametrize(
@@ -4570,7 +5004,7 @@ _MCP_SUBPATHS = [
     [f"{prefix}{sub}" for prefix in (_MCP_AJAX_PREFIX, _MCP_REST_PREFIX) for sub in _MCP_SUBPATHS],
 )
 def test_mcp_server_routes_have_validators(path):
-    validator = _find_fastapi_validator(path)
+    validator = _find_fastapi_validator(path, "GET")
     assert validator is not None
 
 
@@ -4581,7 +5015,7 @@ def test_mcp_server_routes_have_validators(path):
 def test_mcp_server_routes_return_validator_with_custom_auth(path):
     with mock.patch("mlflow.server.auth.auth_config") as cfg:
         cfg.authorization_function = "custom_auth:authorize"
-        validator = _find_fastapi_validator(path)
+        validator = _find_fastapi_validator(path, "GET")
     assert validator is not None
 
 
@@ -4932,7 +5366,7 @@ def test_mcp_server_root_post_enforces_workspace_create_authz(prefix, monkeypatc
         assert auth_module.validate_can_create_mcp_server(username) is False
 
     # The FastAPI validator for root POST dispatches to validate_can_create_mcp_server.
-    validator = _find_fastapi_validator(prefix)
+    validator = _find_fastapi_validator(prefix, "POST")
     assert validator is not None
 
     auth_store.engine.dispose()
@@ -5082,7 +5516,7 @@ def test_implicit_parent_create_grants_manage_despite_wildcard(fastapi_client, m
 
 @pytest.mark.parametrize("prefix", [_MCP_AJAX_PREFIX, _MCP_REST_PREFIX])
 def test_version_create_validator_stores_live_update_recheck(monkeypatch, prefix):
-    validator = _find_fastapi_validator(f"{prefix}/com.test/race-server/versions")
+    validator = _find_fastapi_validator(f"{prefix}/com.test/race-server/versions", "POST")
     assert validator is not None
 
     class _Store:

--- a/tests/server/auth/test_custom_auth_bridge.py
+++ b/tests/server/auth/test_custom_auth_bridge.py
@@ -1,0 +1,204 @@
+from unittest import mock
+
+import pytest
+from fastapi import FastAPI
+from flask import Response as FlaskResponse
+from starlette.responses import Response as StarletteResponse
+from starlette.testclient import TestClient
+from werkzeug.datastructures import Authorization
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, ErrorCode
+from mlflow.server.auth import (
+    DEFAULT_AUTHORIZATION_FUNCTION,
+    _authenticate_custom_for_fastapi,
+    _flask_response_to_starlette,
+    add_fastapi_permission_middleware,
+)
+
+
+def test_flask_response_to_starlette_preserves_status_code():
+    flask_resp = FlaskResponse("Forbidden", status=403)
+    result = _flask_response_to_starlette(flask_resp)
+    assert isinstance(result, StarletteResponse)
+    assert result.status_code == 403
+
+
+def test_flask_response_to_starlette_preserves_body():
+    flask_resp = FlaskResponse("Custom error message", status=401)
+    result = _flask_response_to_starlette(flask_resp)
+    assert result.body == b"Custom error message"
+
+
+def test_flask_response_to_starlette_preserves_custom_headers():
+    flask_resp = FlaskResponse("Unauthorized", status=401)
+    flask_resp.headers["WWW-Authenticate"] = 'Bearer realm="mlflow"'
+    flask_resp.headers["X-Custom-Header"] = "custom-value"
+    result = _flask_response_to_starlette(flask_resp)
+    assert result.headers["www-authenticate"] == 'Bearer realm="mlflow"'
+    assert result.headers["x-custom-header"] == "custom-value"
+
+
+def test_flask_response_to_starlette_excludes_hop_by_hop_headers():
+    flask_resp = FlaskResponse("OK", status=200)
+    flask_resp.headers["Transfer-Encoding"] = "chunked"
+    result = _flask_response_to_starlette(flask_resp)
+    assert "transfer-encoding" not in result.headers
+
+
+def test_flask_response_to_starlette_preserves_content_encoding():
+    flask_resp = FlaskResponse("OK", status=200)
+    flask_resp.headers["Content-Encoding"] = "gzip"
+    result = _flask_response_to_starlette(flask_resp)
+    assert result.headers["content-encoding"] == "gzip"
+
+
+def test_flask_response_to_starlette_preserves_multi_value_headers():
+    flask_resp = FlaskResponse("OK", status=200)
+    flask_resp.headers.add("Set-Cookie", "session=abc; Path=/")
+    flask_resp.headers.add("Set-Cookie", "token=xyz; Path=/api")
+    result = _flask_response_to_starlette(flask_resp)
+    cookie_values = result.headers.getlist("set-cookie")
+    assert len(cookie_values) == 2
+    assert "session=abc; Path=/" in cookie_values
+    assert "token=xyz; Path=/api" in cookie_values
+
+
+@pytest.fixture
+def mock_starlette_request():
+    request = mock.MagicMock()
+    request.url.path = "/api/2.0/mlflow-artifacts/artifacts/model.pkl"
+    request.url.query = "run_id=abc123"
+    request.method = "GET"
+    request.headers = {"Authorization": "Bearer mytoken", "Host": "localhost"}
+    return request
+
+
+def test_custom_auth_returns_user_on_successful_auth(mock_starlette_request):
+    mock_user = mock.MagicMock()
+    mock_user.username = "testuser"
+    mock_authorization = Authorization("basic", {"username": "testuser"})
+
+    with (
+        mock.patch(
+            "mlflow.server.auth.authenticate_request",
+            return_value=mock_authorization,
+        ),
+        mock.patch("mlflow.server.auth.store") as mock_store,
+    ):
+        mock_store.get_user.return_value = mock_user
+        result = _authenticate_custom_for_fastapi(mock_starlette_request)
+
+    assert result is mock_user
+    mock_store.get_user.assert_called_once_with("testuser")
+
+
+def test_custom_auth_returns_starlette_response_on_flask_response(mock_starlette_request):
+    flask_resp = FlaskResponse("Auth failed", status=401)
+    flask_resp.headers["WWW-Authenticate"] = 'Basic realm="mlflow"'
+
+    with mock.patch(
+        "mlflow.server.auth.authenticate_request",
+        return_value=flask_resp,
+    ):
+        result = _authenticate_custom_for_fastapi(mock_starlette_request)
+
+    assert isinstance(result, StarletteResponse)
+    assert result.status_code == 401
+    assert result.body == b"Auth failed"
+
+
+def test_custom_auth_raises_on_unsupported_authorization_result(mock_starlette_request):
+    with mock.patch(
+        "mlflow.server.auth.authenticate_request",
+        return_value="unexpected_type",
+    ):
+        with pytest.raises(MlflowException, match="Unsupported result type") as exc_info:
+            _authenticate_custom_for_fastapi(mock_starlette_request)
+
+    assert exc_info.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+
+def test_fastapi_middleware_returns_json_for_unsupported_custom_auth():
+    app = FastAPI()
+    add_fastapi_permission_middleware(app)
+
+    @app.get("/api/2.0/mlflow-artifacts/artifacts/{artifact_path:path}")
+    async def _download(artifact_path: str):
+        return {"ok": True}
+
+    mock_config = mock.Mock()
+    mock_config.authorization_function = "tests.server.auth.fake_auth:broken_auth"
+    with (
+        mock.patch("mlflow.server.auth.auth_config", mock_config),
+        mock.patch(
+            "mlflow.server.auth.authenticate_request",
+            return_value="unexpected_type",
+        ),
+    ):
+        assert mock_config.authorization_function != DEFAULT_AUTHORIZATION_FUNCTION
+        response = TestClient(app, raise_server_exceptions=False).get(
+            "/api/2.0/mlflow-artifacts/artifacts/1/run/artifacts/model.pkl"
+        )
+
+    assert response.status_code == 500
+    assert response.headers.get("www-authenticate") is None
+    body = response.json()
+    assert body["error_code"] == ErrorCode.Name(INTERNAL_ERROR)
+    assert "Unsupported result type" in body["message"]
+
+
+def test_custom_auth_returns_none_on_missing_username(mock_starlette_request):
+    mock_authorization = Authorization("basic", {"username": None})
+
+    with mock.patch(
+        "mlflow.server.auth.authenticate_request",
+        return_value=mock_authorization,
+    ):
+        result = _authenticate_custom_for_fastapi(mock_starlette_request)
+
+    assert result is None
+
+
+def test_custom_auth_returns_none_on_user_not_found(mock_starlette_request):
+    mock_authorization = Authorization("basic", {"username": "ghost"})
+
+    with (
+        mock.patch(
+            "mlflow.server.auth.authenticate_request",
+            return_value=mock_authorization,
+        ),
+        mock.patch("mlflow.server.auth.store") as mock_store,
+    ):
+        mock_store.get_user.side_effect = Exception("User not found")
+        result = _authenticate_custom_for_fastapi(mock_starlette_request)
+
+    assert result is None
+
+
+def test_custom_auth_passes_request_context_correctly(mock_starlette_request):
+    mock_authorization = Authorization("basic", {"username": "testuser"})
+    captured_path = None
+    captured_method = None
+
+    def capture_context():
+        from flask import request as flask_request
+
+        nonlocal captured_path, captured_method
+        captured_path = flask_request.path
+        captured_method = flask_request.method
+        return mock_authorization
+
+    mock_user = mock.MagicMock()
+    with (
+        mock.patch(
+            "mlflow.server.auth.authenticate_request",
+            side_effect=capture_context,
+        ),
+        mock.patch("mlflow.server.auth.store") as mock_store,
+    ):
+        mock_store.get_user.return_value = mock_user
+        _authenticate_custom_for_fastapi(mock_starlette_request)
+
+    assert captured_path == "/api/2.0/mlflow-artifacts/artifacts/model.pkl"
+    assert captured_method == "GET"

--- a/tests/server/test_artifact_router.py
+++ b/tests/server/test_artifact_router.py
@@ -1,0 +1,281 @@
+from unittest import mock
+
+import pytest
+from starlette.testclient import TestClient
+
+from mlflow.server import ARTIFACTS_DESTINATION_ENV_VAR, SERVE_ARTIFACTS_ENV_VAR
+from mlflow.server import app as flask_app
+from mlflow.server.fastapi_app import create_fastapi_app
+from mlflow.store.artifact.artifact_repo import ARTIFACT_STREAM_CHUNK_SIZE, ArtifactRepository
+from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "/tmp/mlflow-artifacts-test")
+    monkeypatch.setenv("MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE", "true")
+    return TestClient(create_fastapi_app())
+
+
+@pytest.fixture
+def client_no_serve(monkeypatch):
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "false")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "/tmp/mlflow-artifacts-test")
+    monkeypatch.setenv("MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE", "true")
+    return TestClient(create_fastapi_app())
+
+
+def test_download_local_path_returns_file_response(client, tmp_path):
+    test_data = b"local artifact content"
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(test_data)
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock()
+        mock_repo.get_local_path.return_value = str(test_file)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.get("/api/2.0/mlflow-artifacts/artifacts/test/model.pkl")
+
+    assert resp.status_code == 200
+    assert resp.content == test_data
+    assert "attachment" in resp.headers["Content-Disposition"]
+    assert "model.pkl" in resp.headers["Content-Disposition"]
+    mock_repo.get_local_path.assert_called_once()
+    mock_repo.download_artifacts.assert_not_called()
+
+
+def test_download_remote_path_returns_streaming_response(client, tmp_path):
+    test_data = b"remote artifact content"
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(test_data)
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock()
+        mock_repo.get_local_path.return_value = None
+        mock_repo.download_artifacts.return_value = str(test_file)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.get("/api/2.0/mlflow-artifacts/artifacts/nested/model.pkl")
+
+    assert resp.status_code == 200
+    assert resp.content == test_data
+    assert "attachment" in resp.headers["Content-Disposition"]
+    mock_repo.download_artifacts.assert_called_once()
+
+
+def test_download_ajax_prefix_also_works(client, tmp_path):
+    test_file = tmp_path / "data.bin"
+    test_file.write_bytes(b"data")
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock()
+        mock_repo.get_local_path.return_value = str(test_file)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.get("/ajax-api/2.0/mlflow-artifacts/artifacts/data.bin")
+
+    assert resp.status_code == 200
+    assert resp.content == b"data"
+
+
+def test_download_directory_path_returns_400(client, tmp_path):
+    dir_path = tmp_path / "model_dir"
+    dir_path.mkdir()
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock()
+        mock_repo.get_local_path.return_value = str(dir_path)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.get("/api/2.0/mlflow-artifacts/artifacts/model_dir")
+
+    assert resp.status_code == 400
+
+
+def test_download_disabled_returns_503(client_no_serve):
+    resp = client_no_serve.get("/api/2.0/mlflow-artifacts/artifacts/model.pkl")
+    assert resp.status_code == 503
+
+
+def test_upload_with_stream_upload_mixin(client):
+    test_data = b"uploaded artifact"
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock(spec=LocalArtifactRepository)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.put(
+            "/api/2.0/mlflow-artifacts/artifacts/nested/model.pkl",
+            content=test_data,
+        )
+
+    assert resp.status_code == 200
+    mock_repo.log_artifact_from_async_stream.assert_awaited_once()
+    args, kwargs = mock_repo.log_artifact_from_async_stream.call_args
+    assert args[1] == "model.pkl"
+    assert kwargs["artifact_path"] == "nested"
+
+
+def test_upload_without_stream_mixin_uses_log_artifact(client):
+    test_data = b"uploaded artifact"
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock(spec=ArtifactRepository)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.put(
+            "/api/2.0/mlflow-artifacts/artifacts/nested/model.pkl",
+            content=test_data,
+        )
+
+    assert resp.status_code == 200
+    mock_repo.log_artifact.assert_called_once()
+    args, kwargs = mock_repo.log_artifact.call_args
+    assert args[0].endswith("model.pkl")
+    assert kwargs["artifact_path"] == "nested"
+
+
+def test_upload_preserves_content(client, tmp_path):
+    test_data = b"x" * (ARTIFACT_STREAM_CHUNK_SIZE * 2 + 500)
+    uploaded_content = None
+
+    async def capture_stream(chunks, filename, artifact_path=None):
+        nonlocal uploaded_content
+        content = bytearray()
+        async for chunk in chunks:
+            content.extend(chunk)
+        uploaded_content = bytes(content)
+
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock(spec=LocalArtifactRepository)
+        mock_repo.log_artifact_from_async_stream.side_effect = capture_stream
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.put(
+            "/api/2.0/mlflow-artifacts/artifacts/big_model.bin",
+            content=test_data,
+        )
+
+    assert resp.status_code == 200
+    assert uploaded_content == test_data
+
+
+def test_upload_ajax_prefix(client):
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock(spec=ArtifactRepository)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.put(
+            "/ajax-api/2.0/mlflow-artifacts/artifacts/model.pkl",
+            content=b"data",
+        )
+
+    assert resp.status_code == 200
+
+
+def test_upload_disabled_returns_503(client_no_serve):
+    resp = client_no_serve.put(
+        "/api/2.0/mlflow-artifacts/artifacts/model.pkl",
+        content=b"data",
+    )
+    assert resp.status_code == 503
+
+
+def test_download_does_not_hit_flask_handler(client, tmp_path):
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(b"test")
+
+    with (
+        mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo,
+        mock.patch("mlflow.server.handlers._download_artifact") as mock_flask_handler,
+    ):
+        mock_repo = mock.MagicMock()
+        mock_repo.get_local_path.return_value = str(test_file)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.get("/api/2.0/mlflow-artifacts/artifacts/model.pkl")
+
+    assert resp.status_code == 200
+    mock_flask_handler.assert_not_called()
+
+
+def test_upload_does_not_hit_flask_handler(client):
+    with (
+        mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo,
+        mock.patch("mlflow.server.handlers._upload_artifact") as mock_flask_handler,
+    ):
+        mock_repo = mock.MagicMock(spec=ArtifactRepository)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.put(
+            "/api/2.0/mlflow-artifacts/artifacts/model.pkl",
+            content=b"test",
+        )
+
+    assert resp.status_code == 200
+    mock_flask_handler.assert_not_called()
+
+
+def test_path_traversal_rejected(client):
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock()
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.get("/api/2.0/mlflow-artifacts/artifacts/../../../etc/passwd")
+
+    assert resp.status_code != 200
+
+
+def test_upload_trailing_slash_rejected(client):
+    with mock.patch("mlflow.server.artifact_router._get_artifact_repo") as mock_get_repo:
+        mock_repo = mock.MagicMock(spec=ArtifactRepository)
+        mock_get_repo.return_value = mock_repo
+
+        resp = client.put(
+            "/api/2.0/mlflow-artifacts/artifacts/nested/",
+            content=b"data",
+        )
+
+    assert resp.status_code == 400
+    assert "filename" in resp.json()["detail"].lower()
+
+
+@pytest.fixture
+def flask_client(monkeypatch):
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "/tmp/mlflow-artifacts-test")
+    return flask_app.test_client()
+
+
+def test_flask_fallback_download(flask_client, tmp_path):
+    test_data = b"flask fallback content"
+    test_file = tmp_path / "model.pkl"
+    test_file.write_bytes(test_data)
+
+    with mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_get_repo:
+        mock_repo = mock.MagicMock()
+        mock_repo.get_local_path.return_value = str(test_file)
+        mock_get_repo.return_value = mock_repo
+
+        resp = flask_client.get("/api/2.0/mlflow-artifacts/artifacts/test/model.pkl")
+
+    assert resp.status_code == 200
+    assert resp.data == test_data
+
+
+def test_flask_fallback_upload(flask_client, tmp_path):
+    test_data = b"flask upload content"
+
+    with mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_get_repo:
+        mock_repo = mock.MagicMock(spec=LocalArtifactRepository)
+        mock_get_repo.return_value = mock_repo
+
+        resp = flask_client.put(
+            "/api/2.0/mlflow-artifacts/artifacts/nested/model.pkl",
+            data=test_data,
+        )
+
+    assert resp.status_code == 200
+    mock_repo.log_artifact_from_stream.assert_called_once()

--- a/tests/store/artifact/test_local_artifact_repo.py
+++ b/tests/store/artifact/test_local_artifact_repo.py
@@ -261,6 +261,25 @@ def test_log_artifact_from_stream_writes_file_atomically(local_artifact_repo):
     assert list(artifact_dir.glob(".artifact.uploading.*")) == []
 
 
+@pytest.mark.asyncio
+async def test_log_artifact_from_async_stream_writes_file_atomically(local_artifact_repo):
+    artifact_contents = b"hello world!"
+
+    async def chunk_stream():
+        yield artifact_contents[:5]
+        yield artifact_contents[5:]
+
+    await local_artifact_repo.log_artifact_from_async_stream(
+        chunk_stream(),
+        "test.txt",
+        artifact_path="nested",
+    )
+
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    assert (artifact_dir / "test.txt").read_bytes() == artifact_contents
+    assert list(artifact_dir.glob(".artifact.uploading.*")) == []
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX-only permission semantics")
 def test_log_artifact_from_stream_preserves_default_file_mode(local_artifact_repo):
     artifact_contents = b"hello world!"
@@ -275,6 +294,34 @@ def test_log_artifact_from_stream_preserves_default_file_mode(local_artifact_rep
 
     local_artifact_repo.log_artifact_from_stream(
         io.BytesIO(artifact_contents),
+        "test.txt",
+        artifact_path="nested",
+    )
+
+    final_path = artifact_dir / "test.txt"
+    assert stat.S_IMODE(final_path.stat().st_mode) == expected_mode
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only permission semantics")
+async def test_log_artifact_from_async_stream_preserves_default_file_mode(
+    local_artifact_repo,
+):
+    artifact_contents = b"hello world!"
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    artifact_dir.mkdir()
+
+    reference_path = artifact_dir / "reference.txt"
+    with open(reference_path, "wb"):
+        pass
+    expected_mode = stat.S_IMODE(reference_path.stat().st_mode)
+    reference_path.unlink()
+
+    async def chunk_stream():
+        yield artifact_contents
+
+    await local_artifact_repo.log_artifact_from_async_stream(
+        chunk_stream(),
         "test.txt",
         artifact_path="nested",
     )
@@ -310,6 +357,30 @@ def test_log_artifact_from_stream_cleans_up_temp_file_on_failure(local_artifact_
     assert list(artifact_dir.glob(".artifact.uploading.*")) == []
 
 
+@pytest.mark.asyncio
+async def test_log_artifact_from_async_stream_cleans_up_temp_file_on_failure(
+    local_artifact_repo,
+):
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    artifact_dir.mkdir()
+    final_path = artifact_dir / "test.txt"
+    final_path.write_bytes(b"existing-content")
+
+    async def failing_chunk_stream():
+        yield b"new-content"
+        raise RuntimeError("stream failed")
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        await local_artifact_repo.log_artifact_from_async_stream(
+            failing_chunk_stream(),
+            "test.txt",
+            artifact_path="nested",
+        )
+
+    assert final_path.read_bytes() == b"existing-content"
+    assert list(artifact_dir.glob(".artifact.uploading.*")) == []
+
+
 def test_log_artifact_from_stream_closes_fd_when_fdopen_fails(local_artifact_repo):
     artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
     artifact_dir.mkdir()
@@ -331,6 +402,39 @@ def test_log_artifact_from_stream_closes_fd_when_fdopen_fails(local_artifact_rep
         with pytest.raises(OSError, match="fdopen failed"):
             local_artifact_repo.log_artifact_from_stream(
                 io.BytesIO(b"hello world!"),
+                "test.txt",
+                artifact_path="nested",
+            )
+
+    close_mock.assert_called_once_with(123)
+    remove_mock.assert_called_once_with(str(temp_artifact_path))
+
+
+@pytest.mark.asyncio
+async def test_log_artifact_from_async_stream_closes_fd_when_fdopen_fails(local_artifact_repo):
+    artifact_dir = pathlib.Path(local_artifact_repo.artifact_dir) / "nested"
+    artifact_dir.mkdir()
+    temp_artifact_path = artifact_dir / ".artifact.uploading.mock"
+    temp_artifact_path.touch()
+
+    async def chunk_stream():
+        yield b"hello world!"
+
+    with (
+        mock.patch(
+            "mlflow.store.artifact.local_artifact_repo.tempfile.mkstemp",
+            return_value=(123, str(temp_artifact_path)),
+        ),
+        mock.patch(
+            "mlflow.store.artifact.local_artifact_repo.os.fdopen",
+            side_effect=OSError("fdopen failed"),
+        ),
+        mock.patch("mlflow.store.artifact.local_artifact_repo.os.close") as close_mock,
+        mock.patch("mlflow.store.artifact.local_artifact_repo.os.remove") as remove_mock,
+    ):
+        with pytest.raises(OSError, match="fdopen failed"):
+            await local_artifact_repo.log_artifact_from_async_stream(
+                chunk_stream(),
                 "test.txt",
                 artifact_path="nested",
             )


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24325

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The WSGI bridge (`_EfficientWSGIMiddleware`) fully buffers request bodies into memory before passing them to Flask artifact handlers. For large artifact uploads this causes per-request memory spikes equal to the file size. This PR adds native FastAPI endpoints for artifact upload and download that bypass the WSGI bridge entirely, enabling true streaming under uvicorn.

Changes:
- Add `mlflow/server/artifact_router.py` with native async GET/PUT endpoints for `/api/2.0/mlflow-artifacts/artifacts/{path}` and `/ajax-api/2.0/mlflow-artifacts/artifacts/{path}`. Uploads use `request.stream()` to write chunks to a temp file; downloads use `FileResponse` for local paths or `StreamingResponse` for remote backends.
- Register `artifact_router` in `mlflow/server/fastapi_app.py` before the WSGI mount so FastAPI handles these paths natively. Flask handlers remain as fallback for non-uvicorn deployments.
- Add `_authenticate_custom_for_fastapi()` and `_flask_response_to_starlette()` in `mlflow/server/auth/__init__.py` to bridge custom `authorization_function` plugins into the FastAPI middleware path via a synthetic Flask request context.
- Update `add_fastapi_permission_middleware` to dispatch through the bridge when a custom auth function is configured, instead of rejecting with HTTP 500.
- Add `_is_proxy_artifact_path()` and `_get_fastapi_proxy_artifact_validator()` to enforce experiment-scoped permissions on native artifact routes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

- `tests/server/test_artifact_router.py`: 13 unit tests covering download (FileResponse/StreamingResponse), upload (StreamUploadMixin and fallback), ajax prefix routing, path traversal rejection, 503 when disabled, and explicit routing verification (Flask handler not called).
- `tests/server/auth/test_custom_auth_bridge.py`: 10 unit tests for the Flask-to-Starlette response conversion and the custom auth bridge function.
- `tests/server/auth/test_auth.py`: 3 end-to-end integration tests that spin up a real uvicorn server with JWT custom auth (`examples/jwt_auth`) and artifact serving enabled, then exercise PUT/GET with valid tokens, invalid tokens, and permission denial.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release