### PR TITLE
feat: Advertise presigned artifact capabilities via `/server-info` and auto-detect in Python client

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2900,9 +2900,6 @@ WEBHOOK_BEFORE_REQUEST_VALIDATORS = {
 _AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
 
 
-_AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
-
-
 def _is_proxy_artifact_path(path: str) -> bool:
     # MlflowArtifactsService endpoints are registered at both /api/2.0/... and /ajax-api/2.0/...
     # paths (see handlers._get_paths), so we need to check both prefixes for auth validation.
@@ -2917,6 +2914,7 @@ def _is_proxy_artifact_path(path: str) -> bool:
         f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/presigned/",
         f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/presigned/",
     ]
+    prefixes += [_add_static_prefix(prefix) for prefix in prefixes]
     return any(path.startswith(prefix) for prefix in prefixes)
 
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -322,6 +322,10 @@ from mlflow.store.artifact.artifact_repo import (
     StreamUploadMixin,
 )
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from mlflow.store.artifact.mlflow_artifacts_repo import (
+    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
+    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
+)
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.jobs.abstract_store import AbstractJobStore
 from mlflow.store.model_registry.abstract_store import AbstractStore as AbstractModelRegistryStore
@@ -6625,10 +6629,27 @@ def _get_server_info():
         store_type = "SqlStore"
     else:
         store_type = None
+
+    multipart_uploads_enabled = False
+    multipart_downloads_enabled = False
+    if _is_serving_proxied_artifacts():
+        try:
+            artifact_repo = _get_artifact_repo_mlflow_artifacts()
+            multipart_uploads_enabled = isinstance(artifact_repo, MultipartUploadMixin)
+            multipart_downloads_enabled = isinstance(artifact_repo, MultipartDownloadMixin)
+        except Exception:
+            _logger.debug(
+                "Failed to resolve artifact repo for multipart capability advertisement; "
+                "defaulting to disabled.",
+                exc_info=True,
+            )
+
     return jsonify({
         "store_type": store_type,
         "workspaces_enabled": MLFLOW_ENABLE_WORKSPACES.get(),
         "trace_archival_enabled": trace_archival_enabled,
+        SERVER_INFO_MULTIPART_UPLOADS_ENABLED: multipart_uploads_enabled,
+        SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED: multipart_downloads_enabled,
     })
 
 

--- a/mlflow/store/artifact/http_artifact_repo.py
+++ b/mlflow/store/artifact/http_artifact_repo.py
@@ -68,15 +68,19 @@ class HttpArtifactRepository(ArtifactRepository, MultipartUploadMixin):
     def _host_creds(self):
         return get_default_host_creds(self.artifact_uri)
 
+    def _is_multipart_upload_enabled(self):
+        """Whether presigned multipart upload should be attempted. Subclasses may override."""
+        return MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD.get()
+
+    def _should_multipart_upload(self, local_file):
+        return self._is_multipart_upload_enabled() and (
+            os.path.getsize(local_file) >= MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
+        )
+
     def log_artifact(self, local_file, artifact_path=None):
         verify_artifact_path(artifact_path)
 
-        # Try to perform multipart upload if the file is large.
-        # If the server does not support, or if the upload failed, revert to normal upload.
-        if (
-            MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD.get()
-            and os.path.getsize(local_file) >= MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
-        ):
+        if self._should_multipart_upload(local_file):
             try:
                 self._try_multipart_upload(local_file, artifact_path)
                 return

--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import re
+import threading
 from http import HTTPStatus
 from urllib.parse import urlparse, urlunparse
 
@@ -7,13 +9,24 @@ from requests import HTTPError
 
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD,
+    MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD,
     MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
+    MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
 from mlflow.tracking._tracking_service.utils import get_tracking_uri
+from mlflow.utils.credentials import get_default_host_creds
+from mlflow.utils.rest_utils import http_request
 
 _logger = logging.getLogger(__name__)
+
+_SERVER_INFO_ENDPOINT = "/api/3.0/mlflow/server-info"
+SERVER_INFO_MULTIPART_UPLOADS_ENABLED = "multipart_uploads_enabled"
+SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED = "multipart_downloads_enabled"
+# resolve_uri always embeds this service root; strip it to recover the deployment base URL
+# used for /server-info (which lives beside /api/2.0, not under it).
+_ARTIFACTS_SERVICE_ROOT = "/api/2.0/mlflow-artifacts/artifacts"
 
 
 def _check_if_host_is_numeric(hostname):
@@ -66,6 +79,8 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
             tracking_uri=effective_tracking_uri,
             registry_uri=registry_uri,
         )
+        self._server_capabilities: dict[str, bool] | None = None
+        self._server_capabilities_lock = threading.Lock()
 
     @classmethod
     def resolve_uri(cls, artifact_uri, tracking_uri):
@@ -106,9 +121,82 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
 
         return resolved_artifacts_uri.replace("///", "/").rstrip("/")
 
+    @property
+    def _artifact_server_host_creds(self):
+        """Credentials for the artifact-serving server root (not the artifact sub-path).
+
+        Uses the resolved artifact URI host so `mlflow-artifacts://other-host/...` probes
+        that host. Strips `/api/2.0/mlflow-artifacts/artifacts...` while preserving any tracking
+        URI path prefix (e.g. `/mlflow`) so `/server-info` is requested at the correct base.
+        """
+        uri, _, _ = self.artifact_uri.partition(_ARTIFACTS_SERVICE_ROOT)
+        return get_default_host_creds(uri.rstrip("/"))
+
+    def _fetch_server_capabilities(self):
+        """Fetch and cache multipart artifact capabilities from /server-info."""
+        if self._server_capabilities is not None:
+            return self._server_capabilities
+
+        with self._server_capabilities_lock:
+            if self._server_capabilities is not None:
+                return self._server_capabilities
+
+            try:
+                response = http_request(
+                    host_creds=self._artifact_server_host_creds,
+                    endpoint=_SERVER_INFO_ENDPOINT,
+                    method="GET",
+                    timeout=3,
+                    max_retries=0,
+                    raise_on_status=False,
+                )
+                if response.status_code == 200:
+                    data = response.json()
+                    self._server_capabilities = {
+                        SERVER_INFO_MULTIPART_UPLOADS_ENABLED: data.get(
+                            SERVER_INFO_MULTIPART_UPLOADS_ENABLED, False
+                        ),
+                        SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED: data.get(
+                            SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED, False
+                        ),
+                    }
+                else:
+                    _logger.debug(
+                        "Failed to fetch multipart capabilities from %s (status=%s); "
+                        "defaulting to disabled.",
+                        _SERVER_INFO_ENDPOINT,
+                        response.status_code,
+                    )
+                    self._server_capabilities = {}
+            except Exception:
+                _logger.debug(
+                    "Failed to fetch multipart capabilities from %s; defaulting to disabled.",
+                    _SERVER_INFO_ENDPOINT,
+                    exc_info=True,
+                )
+                self._server_capabilities = {}
+
+            return self._server_capabilities
+
+    def _should_multipart_upload(self, local_file):
+        # Check size first here so small mlflow-artifacts uploads skip the /server-info probe.
+        return (
+            os.path.getsize(local_file) >= MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE.get()
+            and self._is_multipart_upload_enabled()
+        )
+
+    def _is_multipart_upload_enabled(self):
+        if MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD.is_set():
+            return MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD.get()
+        return self._fetch_server_capabilities().get(SERVER_INFO_MULTIPART_UPLOADS_ENABLED, False)
+
+    def _is_multipart_download_enabled(self):
+        if MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD.is_set():
+            return MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD.get()
+        return self._fetch_server_capabilities().get(SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED, False)
+
     def _download_file(self, remote_file_path, local_path):
-        # Try multipart download via presigned URL if enabled (mlflow-artifacts only)
-        if MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD.get():
+        if self._is_multipart_download_enabled():
             try:
                 presigned_response = self._get_presigned_download_url(remote_file_path)
                 file_size = presigned_response.file_size
@@ -123,19 +211,23 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
                     )
                     return
             except HTTPError as e:
-                # Fall back to proxied download when server doesn't support presigned (501)
-                # or endpoint is missing (404, e.g. old server with new SDK).
-                if e.response is not None and e.response.status_code in (
-                    HTTPStatus.NOT_IMPLEMENTED,
-                    HTTPStatus.NOT_FOUND,
-                ):
-                    _logger.warning(
-                        "Multipart download was requested but the server does not support "
-                        "presigned downloads (HTTP %s). Falling back to proxied download. "
-                        "Consider setting MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD=false to "
-                        "avoid this warning and the extra presigned request on each download.",
-                        e.response.status_code,
-                    )
+                # When auto-detected via server-info, presigned failures indicate a
+                # server misconfiguration — raise immediately.
+                # When user forced via env var, fall back gracefully for legacy compat.
+                if MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD.is_set():
+                    if e.response is not None and e.response.status_code in (
+                        HTTPStatus.NOT_IMPLEMENTED,
+                        HTTPStatus.NOT_FOUND,
+                    ):
+                        _logger.warning(
+                            "Multipart download was requested but the server does not support "
+                            "presigned downloads (HTTP %s). Falling back to proxied download. "
+                            "Consider setting MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD=false to "
+                            "avoid this warning and the extra presigned request on each download.",
+                            e.response.status_code,
+                        )
+                    else:
+                        raise
                 else:
                     raise
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -302,6 +302,16 @@ def test_proxy_artifact_path_detection():
     assert auth_module._is_proxy_artifact_path("/ajax-api/2.0/mlflow-artifacts/artifacts/foo")
 
 
+def test_proxy_artifact_path_detection_with_static_prefix(monkeypatch):
+    monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/mlflow")
+
+    assert auth_module._is_proxy_artifact_path("/mlflow/api/2.0/mlflow-artifacts/artifacts/foo")
+    assert auth_module._is_proxy_artifact_path(
+        "/mlflow/ajax-api/2.0/mlflow-artifacts/presigned/1/run-id/artifacts/model.pkl"
+    )
+    assert not auth_module._is_proxy_artifact_path("/api/2.0/mlflow/experiments/get")
+
+
 def test_is_unprotected_route_handles_static_prefix(monkeypatch):
     # When ``_MLFLOW_STATIC_PREFIX`` is set, the health/static/favicon routes
     # are served from e.g. ``/mlflow/health``. Health checks must not require
@@ -433,6 +443,38 @@ def test_proxy_artifact_presigned_authorization_required(client, monkeypatch):
         client.tracking_uri + f"/api/2.0/mlflow-artifacts/presigned/{experiment_id}/test.txt"
     )
     response = requests.get(url=presigned_url, auth=(username2, password2))
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "client",
+    [
+        {
+            "MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini",
+            STATIC_PREFIX_ENV_VAR: "/mlflow",
+        }
+    ],
+    indirect=True,
+)
+def test_presigned_download_authorization_required_with_static_prefix(client, monkeypatch):
+    prefixed_tracking_uri = f"{client.tracking_uri}/mlflow"
+    prefixed_client = MlflowClient(prefixed_tracking_uri)
+    username1, password1 = create_user(prefixed_tracking_uri)
+    username2, password2 = create_user(prefixed_tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = prefixed_client.create_experiment("prefixed-presigned-download-authz-test")
+
+    response = requests.get(
+        url=(
+            client.tracking_uri
+            + (
+                f"/mlflow/api/2.0/mlflow-artifacts/presigned/"
+                f"{experiment_id}/run-id/artifacts/model.pkl"
+            )
+        ),
+        auth=(username2, password2),
+    )
     assert response.status_code == 403
 
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -251,6 +251,10 @@ from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+from mlflow.store.artifact.mlflow_artifacts_repo import (
+    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
+    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
+)
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry import (
@@ -468,6 +472,75 @@ def test_server_info_handles_unexpected_trace_archival_config_error(monkeypatch)
         assert response.status_code == 200
         data = response.get_json()
         assert data["trace_archival_enabled"] is False
+
+
+def test_server_info_multipart_capabilities_disabled_by_default():
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data[SERVER_INFO_MULTIPART_UPLOADS_ENABLED] is False
+        assert data[SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED] is False
+
+
+def test_server_info_multipart_capabilities_with_multipart_backend(monkeypatch):
+    from mlflow.store.artifact.artifact_repo import MultipartDownloadMixin, MultipartUploadMixin
+
+    class _FakeMultipartArtifactRepo(MultipartUploadMixin, MultipartDownloadMixin):
+        def create_multipart_upload(self, local_file, num_parts, artifact_path=None):
+            raise NotImplementedError
+
+        def complete_multipart_upload(self, local_file, upload_id, parts, artifact_path=None):
+            raise NotImplementedError
+
+        def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
+            raise NotImplementedError
+
+        def get_download_presigned_url(self, artifact_path, expiration=300):
+            raise NotImplementedError
+
+    monkeypatch.setattr("mlflow.server.handlers._is_serving_proxied_artifacts", lambda: True)
+    monkeypatch.setattr(
+        "mlflow.server.handlers._get_artifact_repo_mlflow_artifacts",
+        lambda: _FakeMultipartArtifactRepo(),
+    )
+
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data[SERVER_INFO_MULTIPART_UPLOADS_ENABLED] is True
+        assert data[SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED] is True
+
+
+def test_server_info_multipart_capabilities_with_local_backend(monkeypatch):
+    monkeypatch.setattr("mlflow.server.handlers._is_serving_proxied_artifacts", lambda: True)
+    monkeypatch.setattr(
+        "mlflow.server.handlers._get_artifact_repo_mlflow_artifacts",
+        lambda: mock.Mock(spec=[]),
+    )
+
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data[SERVER_INFO_MULTIPART_UPLOADS_ENABLED] is False
+        assert data[SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED] is False
+
+
+def test_server_info_multipart_capabilities_handles_repo_error(monkeypatch):
+    monkeypatch.setattr("mlflow.server.handlers._is_serving_proxied_artifacts", lambda: True)
+    monkeypatch.setattr(
+        "mlflow.server.handlers._get_artifact_repo_mlflow_artifacts",
+        mock.Mock(side_effect=KeyError("ARTIFACTS_DESTINATION")),
+    )
+
+    with app.test_client() as c:
+        response = c.get("/api/3.0/mlflow/server-info")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data[SERVER_INFO_MULTIPART_UPLOADS_ENABLED] is False
+        assert data[SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED] is False
 
 
 def test_get_endpoints():
@@ -1256,6 +1329,49 @@ def test_get_presigned_download_url_success(enable_serve_artifacts, monkeypatch)
     assert data["headers"] == {"x-custom-header": "value"}
     assert data["file_size"] == 1024
     assert artifact_repo.artifact_path == "workspaces/team-a/run_id/artifacts/model.pkl"
+
+
+def test_get_presigned_download_url_applies_workspace_scoping(enable_serve_artifacts, monkeypatch):
+    from mlflow.store.artifact.artifact_repo import MultipartDownloadMixin
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    seen_paths = []
+
+    class MockMultipartDownloadRepo(MultipartDownloadMixin):
+        def get_download_presigned_url(self, artifact_path, expiration=300):
+            seen_paths.append(artifact_path)
+            return PresignedDownloadUrlResponse(
+                url="https://storage.example.com/presigned?token=abc",
+                headers={},
+                file_size=1024,
+            )
+
+    with (
+        app.test_request_context(method="GET"),
+        WorkspaceContext("team-blue"),
+        mock.patch(
+            "mlflow.server.handlers._get_artifact_repo_mlflow_artifacts",
+            return_value=MockMultipartDownloadRepo(),
+        ),
+    ):
+        response = _get_presigned_download_url("2/new/artifact/model.pkl")
+
+    assert response.status_code == 200
+    assert seen_paths == ["workspaces/team-blue/2/new/artifact/model.pkl"]
+
+
+def test_get_presigned_download_url_rejects_cross_workspace_path(
+    enable_serve_artifacts, monkeypatch
+):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    with app.test_request_context(method="GET"), WorkspaceContext("team-a"):
+        response = _get_presigned_download_url("workspaces/team-b/secret.txt")
+
+    assert response.status_code == 400
+    json_response = json.loads(response.get_data())
+    assert json_response["error_code"] == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert "targets workspace 'team-b'" in json_response["message"]
 
 
 @pytest.mark.parametrize(

--- a/tests/store/artifact/test_http_artifact_repo.py
+++ b/tests/store/artifact/test_http_artifact_repo.py
@@ -185,6 +185,26 @@ def test_log_artifact(
         mock_abort.assert_called_once()
 
 
+def test_log_artifact_skips_size_check_when_multipart_disabled(http_artifact_repo, tmp_path):
+    file_path = tmp_path.joinpath("small.txt")
+    file_path.write_text("0")
+
+    with (
+        mock.patch.object(http_artifact_repo, "_is_multipart_upload_enabled", return_value=False),
+        mock.patch(
+            "mlflow.store.artifact.http_artifact_repo.os.path.getsize",
+            side_effect=AssertionError("getsize should not be called"),
+        ),
+        mock.patch(
+            "mlflow.store.artifact.http_artifact_repo.http_request",
+            return_value=MockResponse({}, 200),
+        ) as mock_put,
+    ):
+        http_artifact_repo.log_artifact(file_path)
+
+    mock_put.assert_called_once()
+
+
 @pytest.mark.parametrize(
     ("ignore_tls", "expected_verify"),
     [

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -1,12 +1,18 @@
 import os
 import posixpath
+import threading
+import time
 from unittest import mock
 
 import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.artifact.mlflow_artifacts_repo import MlflowArtifactsRepository
+from mlflow.store.artifact.mlflow_artifacts_repo import (
+    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
+    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
+    MlflowArtifactsRepository,
+)
 from mlflow.utils.credentials import get_default_host_creds
 
 
@@ -335,3 +341,208 @@ def test_download_artifacts(mlflow_artifact_repo, tmp_path):
         ]
         assert read_file(paths[0]) == "data_a"
         assert read_file(paths[1]) == "data_b"
+
+
+def _make_multipart_repo(artifact_uri="mlflow-artifacts:/api/2.0/mlflow-artifacts/artifacts"):
+    return MlflowArtifactsRepository(artifact_uri)
+
+
+def _mock_server_info_response(uploads=False, downloads=False, status_code=200):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.json.return_value = {
+        "store_type": "SqlStore",
+        "workspaces_enabled": False,
+        "trace_archival_enabled": False,
+        SERVER_INFO_MULTIPART_UPLOADS_ENABLED: uploads,
+        SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED: downloads,
+    }
+    return resp
+
+
+def test_auto_detects_multipart_upload_from_server_info(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo = _make_multipart_repo()
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=_mock_server_info_response(uploads=True),
+    ):
+        assert repo._is_multipart_upload_enabled() is True
+
+
+def test_auto_detects_multipart_download_from_server_info(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD", raising=False)
+    repo = _make_multipart_repo()
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=_mock_server_info_response(downloads=True),
+    ):
+        assert repo._is_multipart_download_enabled() is True
+
+
+def test_env_var_true_overrides_server_no_support(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", "true")
+    repo = _make_multipart_repo()
+    assert repo._is_multipart_upload_enabled() is True
+
+
+def test_env_var_false_overrides_server_support(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", "false")
+    repo = _make_multipart_repo()
+    assert repo._is_multipart_upload_enabled() is False
+
+
+def test_env_var_false_overrides_server_download_support(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD", "false")
+    repo = _make_multipart_repo()
+    assert repo._is_multipart_download_enabled() is False
+
+
+def test_old_server_without_fields_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD", raising=False)
+    repo = _make_multipart_repo()
+
+    resp = mock.Mock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "store_type": "SqlStore",
+        "workspaces_enabled": False,
+    }
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=resp,
+    ):
+        assert repo._is_multipart_upload_enabled() is False
+        assert repo._is_multipart_download_enabled() is False
+
+
+def test_server_info_404_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo = _make_multipart_repo()
+
+    resp = mock.Mock()
+    resp.status_code = 404
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=resp,
+    ):
+        assert repo._is_multipart_upload_enabled() is False
+
+
+def test_server_info_network_error_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo = _make_multipart_repo()
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        side_effect=ConnectionError("connection refused"),
+    ):
+        assert repo._is_multipart_upload_enabled() is False
+
+
+def test_capabilities_cached_per_instance(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo = _make_multipart_repo()
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=_mock_server_info_response(uploads=True, downloads=True),
+    ) as mock_request:
+        assert repo._is_multipart_upload_enabled() is True
+        assert repo._is_multipart_download_enabled() is True
+        mock_request.assert_called_once()
+
+
+def test_separate_instances_fetch_independently(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo1 = _make_multipart_repo()
+    repo2 = _make_multipart_repo()
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=_mock_server_info_response(uploads=True),
+    ) as mock_request:
+        repo1._is_multipart_upload_enabled()
+        repo2._is_multipart_upload_enabled()
+        assert mock_request.call_count == 2
+
+
+def test_capability_probe_uses_artifact_host_and_preserves_path_prefix(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.get_tracking_uri",
+        return_value="http://tracking.example.com/mlflow",
+    ):
+        repo = MlflowArtifactsRepository("mlflow-artifacts://artifacts.example.com:9000/exp")
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        return_value=_mock_server_info_response(uploads=True),
+    ) as mock_request:
+        assert repo._is_multipart_upload_enabled() is True
+
+    host_creds = mock_request.call_args.kwargs["host_creds"]
+    assert host_creds.host == "http://artifacts.example.com:9000/mlflow"
+    assert mock_request.call_args.kwargs["endpoint"] == "/api/3.0/mlflow/server-info"
+
+
+def test_small_upload_skips_server_info_capability_probe(monkeypatch, tmp_path):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo = _make_multipart_repo()
+    small_file = tmp_path / "small.bin"
+    small_file.write_bytes(b"tiny")
+
+    put_resp = mock.Mock()
+    put_resp.status_code = 200
+
+    with (
+        mock.patch(
+            "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        ) as mock_server_info_request,
+        mock.patch(
+            "mlflow.store.artifact.http_artifact_repo.http_request",
+            return_value=put_resp,
+        ),
+    ):
+        repo.log_artifact(str(small_file))
+
+    mock_server_info_request.assert_not_called()
+
+
+def test_capabilities_fetch_is_thread_safe(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD", raising=False)
+    repo = _make_multipart_repo()
+    results = []
+
+    def slow_server_info(*_args, **_kwargs):
+        time.sleep(0.05)
+        return _mock_server_info_response(uploads=True, downloads=True)
+
+    with mock.patch(
+        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        side_effect=slow_server_info,
+    ) as mock_request:
+        threads = [
+            threading.Thread(
+                target=lambda: results.append(repo._is_multipart_upload_enabled()),
+                name=f"multipart-upload-probe-{idx}",
+            )
+            for idx in range(4)
+        ] + [
+            threading.Thread(
+                target=lambda: results.append(repo._is_multipart_download_enabled()),
+                name=f"multipart-download-probe-{idx}",
+            )
+            for idx in range(4)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+    assert mock_request.call_count == 1
+    assert results == [True] * 8


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24327

### What changes are proposed in this pull request?

Advertise presigned artifact upload/download capabilities via the `/api/3.0/mlflow/server-info` endpoint and auto-detect them in the Python client.

**Server-side**: When `--serve-artifacts` is active, the server now reports `presigned_uploads_enabled` and `presigned_downloads_enabled` booleans in the `/server-info` response based on whether the underlying artifact repository implements `MultipartUploadMixin` / `MultipartDownloadMixin`.

**Client-side**: `MlflowArtifactsRepository` now queries `/server-info` to auto-detect presigned transfer support. If the env vars `MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD` / `MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD` are explicitly set, they take precedence; otherwise the client uses the server-advertised capabilities. Results are cached per repository instance.

A template method `_is_multipart_upload_enabled()` is extracted in `HttpArtifactRepository` to allow subclass customization of the upload decision logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests added:
- `tests/server/test_handlers.py` — 4 tests covering `/server-info` presigned fields (default disabled, multipart backend, local backend, repo init error)
- `tests/store/artifact/test_mlflow_artifact_repo.py` — 10 tests in `TestPresignedCapabilityAutoDetection` covering auto-detection, env var overrides, old server compatibility, network errors, and instance caching

Manual testing: Started a local MLflow server with `--serve-artifacts` and verified the `/server-info` endpoint returns `presigned_uploads_enabled` / `presigned_downloads_enabled` fields correctly. Confirmed the Python client auto-detects capabilities without env vars set.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow server now advertises presigned artifact transfer capabilities via `/server-info`. The Python client auto-detects these capabilities, removing the need for users to manually set `MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD` / `MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD` environment variables when the server supports presigned URLs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release