### PR TITLE
fix: use Base.metadata instead of InitialBase.metadata in _initialize_tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from 3.7.0 to 3.8.x, the upgrade fails with "Table 'secrets' already exists" because `_initialize_tables` uses `InitialBase.metadata.create_all()` which does not check for existing tables properly. The `secrets` table was added to `InitialBase` in 3.8.0, but may already exist from a previous Alembic migration.

## Fix
Replace `InitialBase.metadata.create_all(engine)` with `Base.metadata.create_all(engine)` in `_initialize_tables`. `Base.metadata` includes all registered ORM models and SQLAlchemy's `create_all` inherently uses `IF NOT EXISTS` semantics, preventing the duplicate table creation error.

Closes #19943