### PR TITLE
Add an "Add to evaluation dataset" action to the prompt playground

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -999,6 +999,9 @@ module.exports = {
   "mlflow.eval-datasets.key-value-tag-modal-save": "",
   "mlflow.eval-datasets.last-updated-cell-tooltip": "",
   "mlflow.eval-datasets.learn-more-link": "",
+  "mlflow.eval-datasets.picker.header-checkbox": "",
+  "mlflow.eval-datasets.picker.multiturn-error": "",
+  "mlflow.eval-datasets.picker.row-checkbox": "",
   "mlflow.eval-datasets.records-toolbar.column-checkbox": "",
   "mlflow.eval-datasets.records-toolbar.columns-toggle": "",
   "mlflow.eval-datasets.records-toolbar.row-size-radio": "",
@@ -1433,9 +1436,6 @@ module.exports = {
 
   // -- mlflow.export-traces-to-dataset-modal --
   "mlflow.export-traces-to-dataset-modal": "",
-  "mlflow.export-traces-to-dataset-modal.header-checkbox": "",
-  "mlflow.export-traces-to-dataset-modal.multiturn-error": "",
-  "mlflow.export-traces-to-dataset-modal.row-checkbox": "",
 
   // -- mlflow.gateway --
   "mlflow.gateway.api-key-details.drawer": "",
@@ -1938,6 +1938,12 @@ module.exports = {
   "mlflow.overview.usage.traces.view_traces_link": "",
 
   // -- mlflow.playground --
+  "mlflow.playground.add_to_dataset": "",
+  "mlflow.playground.add_to_dataset.added": "",
+  "mlflow.playground.add_to_dataset.added.close": "",
+  "mlflow.playground.add_to_dataset.error": "",
+  "mlflow.playground.add_to_dataset.expected_response": "",
+  "mlflow.playground.add_to_dataset.no_input": "",
   "mlflow.playground.clear": "",
   "mlflow.playground.json_code_block.copy": "",
   "mlflow.playground.json_code_block.toggle": "",

--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -734,6 +734,9 @@ module.exports = {
   "mlflow.eval-datasets.key-value-tag-modal-save": "",
   "mlflow.eval-datasets.last-updated-cell-tooltip": "",
   "mlflow.eval-datasets.learn-more-link": "",
+  "mlflow.eval-datasets.picker.header-checkbox": "",
+  "mlflow.eval-datasets.picker.multiturn-error": "",
+  "mlflow.eval-datasets.picker.row-checkbox": "",
   "mlflow.eval-datasets.records-toolbar.column-checkbox": "",
   "mlflow.eval-datasets.records-toolbar.columns-toggle": "",
   "mlflow.eval-datasets.records-toolbar.row-size-radio": "",
@@ -1188,9 +1191,6 @@ module.exports = {
 
   // -- mlflow.export-traces-to-dataset-modal --
   "mlflow.export-traces-to-dataset-modal": "",
-  "mlflow.export-traces-to-dataset-modal.header-checkbox": "",
-  "mlflow.export-traces-to-dataset-modal.multiturn-error": "",
-  "mlflow.export-traces-to-dataset-modal.row-checkbox": "",
 
   // -- mlflow.gateway --
   "mlflow.gateway.api-key-details.drawer": "",
@@ -1825,6 +1825,12 @@ module.exports = {
   "mlflow.overview.usage.traces.view_traces_link": "",
 
   // -- mlflow.playground --
+  "mlflow.playground.add_to_dataset": "",
+  "mlflow.playground.add_to_dataset.added": "",
+  "mlflow.playground.add_to_dataset.added.close": "",
+  "mlflow.playground.add_to_dataset.error": "",
+  "mlflow.playground.add_to_dataset.expected_response": "",
+  "mlflow.playground.add_to_dataset.no_input": "",
   "mlflow.playground.clear": "",
   "mlflow.playground.json_code_block.copy": "",
   "mlflow.playground.json_code_block.toggle": "",

--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -1830,6 +1830,7 @@ module.exports = {
   "mlflow.playground.add_to_dataset.added.close": "",
   "mlflow.playground.add_to_dataset.error": "",
   "mlflow.playground.add_to_dataset.expected_response": "",
+  "mlflow.playground.add_to_dataset.include_expected_response": "",
   "mlflow.playground.add_to_dataset.no_input": "",
   "mlflow.playground.clear": "",
   "mlflow.playground.json_code_block.copy": "",

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/EvaluationDatasetPicker.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/EvaluationDatasetPicker.tsx
@@ -1,0 +1,225 @@
+import {
+  Alert,
+  Empty,
+  Input,
+  SearchIcon,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableRowSelectCell,
+  TableSkeletonRows,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import type { ColumnDef } from '@tanstack/react-table';
+import { flexRender, getCoreRowModel } from '@tanstack/react-table';
+import { useReactTable_unverifiedWithReact18 as useReactTable } from '@databricks/web-shared/react-table';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useCheckMultiturnDatasets } from '../hooks/useCheckMultiturnDatasets';
+import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
+import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatasets';
+import type { EvaluationDataset } from '../types';
+import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
+
+const columns: ColumnDef<EvaluationDataset, string>[] = [
+  {
+    id: 'name',
+    accessorKey: 'name',
+    header: 'Name',
+  },
+];
+
+export interface EvaluationDatasetPickerState {
+  selectedDatasets: EvaluationDataset[];
+  hasMultiturnDataset: boolean;
+  isCheckingMultiturn: boolean;
+}
+
+export const EMPTY_EVALUATION_DATASET_PICKER_STATE: EvaluationDatasetPickerState = {
+  selectedDatasets: [],
+  hasMultiturnDataset: false,
+  isCheckingMultiturn: false,
+};
+
+interface Props {
+  experimentId: string;
+  /**
+   * Receives the live selection plus the multi-turn guard state; parents gate their
+   * confirm action on it. Pass a referentially stable callback (e.g. a state setter).
+   */
+  onStateChange: (state: EvaluationDatasetPickerState) => void;
+  /** Extra loading signal from the parent (e.g. trace fetching) that should keep showing skeleton rows. */
+  isLoadingExternal?: boolean;
+  /** Fixed height for the scrollable dataset table; omit to let the surrounding container size it. */
+  tableHeight?: number;
+  /** When false, holds the datasets request (e.g. while the host modal is closed). Defaults to true. */
+  enabled?: boolean;
+}
+
+/**
+ * Shared dataset-selection block for the "add X to evaluation datasets" modals (trace
+ * export, playground prompt capture): server-side name search, infinite-scroll checkbox
+ * table, inline dataset creation, and the guard that blocks multi-turn datasets.
+ */
+export const EvaluationDatasetPicker = ({
+  experimentId,
+  onStateChange,
+  isLoadingExternal = false,
+  tableHeight,
+  enabled = true,
+}: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [searchFilter, setSearchFilter] = useState('');
+  const [internalSearchFilter, setInternalSearchFilter] = useState(searchFilter);
+
+  const {
+    data: datasets,
+    isLoading: isLoadingDatasets,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+  } = useSearchEvaluationDatasets({ experimentId, nameFilter: searchFilter, enabled });
+
+  const fetchMoreOnBottomReached = useInfiniteScrollFetch({
+    isFetching,
+    hasNextPage: hasNextPage ?? false,
+    fetchNextPage,
+  });
+
+  const table = useReactTable(
+    'mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/EvaluationDatasetPicker.tsx',
+    {
+      columns,
+      getRowId: (row) => row.dataset_id,
+      data: datasets ?? [],
+      getCoreRowModel: getCoreRowModel(),
+      enableColumnResizing: false,
+    },
+  );
+
+  const rowSelection = table.getState().rowSelection;
+  const selectedDatasets = useMemo(
+    () => (datasets ?? []).filter((dataset) => rowSelection[dataset.dataset_id]),
+    [datasets, rowSelection],
+  );
+  const { data: hasMultiturnDataset = false, isLoading: isCheckingMultiturn } = useCheckMultiturnDatasets({
+    datasetIds: selectedDatasets.map((dataset) => dataset.dataset_id),
+  });
+
+  useEffect(() => {
+    onStateChange({ selectedDatasets, hasMultiturnDataset, isCheckingMultiturn });
+  }, [onStateChange, selectedDatasets, hasMultiturnDataset, isCheckingMultiturn]);
+
+  const isInitialLoading = isLoadingDatasets || isLoadingExternal;
+
+  const tableElement = (
+    <Table
+      scrollable
+      onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget as HTMLDivElement)}
+      someRowsSelected={table.getIsSomeRowsSelected() || table.getIsAllRowsSelected()}
+      empty={
+        !isLoadingDatasets &&
+        !isFetching &&
+        datasets.length === 0 && (
+          <Empty
+            description={
+              <FormattedMessage
+                defaultMessage="No evaluation datasets found"
+                description="Empty state for the evaluation datasets page"
+              />
+            }
+          />
+        )
+      }
+    >
+      <TableRow isHeader>
+        <TableRowSelectCell
+          componentId="mlflow.eval-datasets.picker.header-checkbox"
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+        />
+        {table.getLeafHeaders().map((header) => (
+          <TableHeader
+            key={header.id}
+            componentId="mlflow.eval-datasets.column-header"
+            header={header}
+            column={header.column}
+            css={{ width: header.column.columnDef.size, maxWidth: header.column.columnDef.maxSize }}
+          >
+            {flexRender(header.column.columnDef.header, header.getContext())}
+          </TableHeader>
+        ))}
+      </TableRow>
+      {!isInitialLoading &&
+        table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id}>
+            <div>
+              <TableRowSelectCell
+                componentId="mlflow.eval-datasets.picker.row-checkbox"
+                checked={row.getIsSelected()}
+                onChange={row.getToggleSelectedHandler()}
+              />
+            </div>
+            {row.getVisibleCells().map((cell) => (
+              <TableCell
+                key={cell.id}
+                css={{ width: cell.column.columnDef.size, maxWidth: cell.column.columnDef.maxSize }}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      {(isInitialLoading || isFetching) && <TableSkeletonRows table={table} />}
+    </Table>
+  );
+
+  return (
+    <>
+      {hasMultiturnDataset && (
+        <Alert
+          componentId="mlflow.eval-datasets.picker.multiturn-error"
+          type="error"
+          css={{ marginBottom: theme.spacing.sm }}
+          closable={false}
+          message={
+            <FormattedMessage
+              defaultMessage="Adding to multi-turn datasets is not yet supported."
+              description="Error message when a multi-turn evaluation dataset is selected in the dataset picker"
+            />
+          }
+        />
+      )}
+      <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center', marginBottom: theme.spacing.sm }}>
+        <Input
+          allowClear
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Search by dataset name',
+            description: 'Placeholder for the dataset search input in the evaluation dataset picker',
+          })}
+          value={internalSearchFilter}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            setInternalSearchFilter(e.target.value);
+            if (!e.target.value) {
+              setSearchFilter(e.target.value);
+            }
+          }}
+          onClear={() => {
+            setInternalSearchFilter('');
+            setSearchFilter('');
+          }}
+          onPressEnter={() => setSearchFilter(internalSearchFilter)}
+          componentId="mlflow.eval-datasets.search-input"
+          css={{ flex: 1 }}
+          prefix={<SearchIcon />}
+        />
+        <CreateEvaluationDatasetButton experimentId={experimentId} />
+      </div>
+      {tableHeight != null ? <div css={{ height: tableHeight, overflow: 'hidden' }}>{tableElement}</div> : tableElement}
+    </>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.test.tsx
@@ -102,7 +102,7 @@ describe('ExportTracesToDatasetModal', () => {
     );
 
     await user.click(screen.getAllByRole('checkbox')[0]);
-    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('button', { name: 'Add to dataset' }));
 
     await waitFor(() => {
       expect(refetch).toHaveBeenCalledWith({ throwOnError: true });
@@ -149,7 +149,7 @@ describe('ExportTracesToDatasetModal', () => {
     );
 
     await user.click(screen.getAllByRole('checkbox')[0]);
-    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('button', { name: 'Add to dataset' }));
 
     await waitFor(() => {
       expect(refetch).toHaveBeenCalledWith({ throwOnError: true });
@@ -161,7 +161,7 @@ describe('ExportTracesToDatasetModal', () => {
     errorSpy.mockRestore();
   });
 
-  test('waits for in-flight upserts before showing an error and re-enabling Export', async () => {
+  test('waits for in-flight upserts before showing an error and re-enabling the confirm button', async () => {
     const user = userEvent.setup();
     const errorSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
     let resolveSlowUpsert: (value: { insertedCount: number; updatedCount: number }) => void = () => {};
@@ -203,8 +203,9 @@ describe('ExportTracesToDatasetModal', () => {
       />,
     );
 
+    // Header select-all: both datasets are selected, so the confirm button is pluralized.
     await user.click(screen.getAllByRole('checkbox')[0]);
-    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('button', { name: 'Add to 2 datasets' }));
 
     await waitFor(() => {
       expect(upsertAsync).toHaveBeenCalledTimes(2);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx
@@ -1,41 +1,14 @@
-import {
-  Alert,
-  Empty,
-  Input,
-  Modal,
-  SearchIcon,
-  Table,
-  TableCell,
-  TableHeader,
-  TableRow,
-  TableRowSelectCell,
-  TableSkeletonRows,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
-import type { ColumnDef } from '@tanstack/react-table';
-import { flexRender, getCoreRowModel } from '@tanstack/react-table';
-import { useReactTable_unverifiedWithReact18 as useReactTable } from '@databricks/web-shared/react-table';
+import { Modal, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
-import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
-import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatasets';
-import type { EvaluationDataset } from '../types';
 import { useCallback, useState } from 'react';
 import { getModelTraceId } from '@databricks/web-shared/model-trace-explorer';
 import type { ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import { compact } from 'lodash';
 import { extractDatasetInfoFromTraces } from '../utils/datasetUtils';
 import { useUpsertDatasetRecordsMutation } from '../hooks/useUpsertDatasetRecordsMutation';
-import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
 import { useFetchTraces } from '../hooks/useFetchTraces';
-import { useCheckMultiturnDatasets } from '../hooks/useCheckMultiturnDatasets';
-
-const columns: ColumnDef<EvaluationDataset, string>[] = [
-  {
-    id: 'name',
-    accessorKey: 'name',
-    header: 'Name',
-  },
-];
+import { EMPTY_EVALUATION_DATASET_PICKER_STATE, EvaluationDatasetPicker } from './EvaluationDatasetPicker';
+import type { EvaluationDatasetPickerState } from './EvaluationDatasetPicker';
 
 export const ExportTracesToDatasetModal = ({
   experimentId,
@@ -49,8 +22,6 @@ export const ExportTracesToDatasetModal = ({
   selectedTraceInfos: ModelTrace['info'][];
 }) => {
   const { theme } = useDesignSystemTheme();
-  const [searchFilter, setSearchFilter] = useState('');
-  const [internalSearchFilter, setInternalSearchFilter] = useState(searchFilter);
 
   const traceIds = selectedTraceInfos.map((traceInfo) =>
     // hacky wrap just to get the id, as this util function expects
@@ -60,38 +31,8 @@ export const ExportTracesToDatasetModal = ({
   const { data: traces, isLoading: isLoadingTraces } = useFetchTraces({ traceIds });
   const datasetRowsToExport = extractDatasetInfoFromTraces(compact(traces));
 
-  const {
-    data: datasets,
-    isLoading: isLoadingDatasets,
-    isFetching,
-    fetchNextPage,
-    hasNextPage,
-  } = useSearchEvaluationDatasets({ experimentId, nameFilter: searchFilter });
-
-  const isInitialLoading = isLoadingDatasets || isLoadingTraces;
-
-  const fetchMoreOnBottomReached = useInfiniteScrollFetch({
-    isFetching,
-    hasNextPage: hasNextPage ?? false,
-    fetchNextPage,
-  });
-
-  const table = useReactTable(
-    'mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx',
-    {
-      columns,
-      getRowId: (row) => row.dataset_id,
-      data: datasets ?? [],
-      getCoreRowModel: getCoreRowModel(),
-      enableColumnResizing: false,
-    },
-  );
-
-  const selectedDatasets = table.getSelectedRowModel().rows.map((row) => row.original);
-  const selectedDatasetIds = selectedDatasets.map((dataset) => dataset.dataset_id);
-  const { data: hasMultiturnDataset = false, isLoading: isCheckingMultiturn } = useCheckMultiturnDatasets({
-    datasetIds: selectedDatasetIds,
-  });
+  const [pickerState, setPickerState] = useState<EvaluationDatasetPickerState>(EMPTY_EVALUATION_DATASET_PICKER_STATE);
+  const { selectedDatasets, hasMultiturnDataset, isCheckingMultiturn } = pickerState;
 
   const { upsertDatasetRecordsMutation, isLoading: isUpsertingDatasetRecords } = useUpsertDatasetRecordsMutation({
     onSuccess: () => {
@@ -115,7 +56,13 @@ export const ExportTracesToDatasetModal = ({
       componentId="mlflow.export-traces-to-dataset-modal"
       visible={visible}
       onCancel={() => setVisible(false)}
-      okText={<FormattedMessage defaultMessage="Export" description="Export traces to dataset modal action button" />}
+      okText={
+        <FormattedMessage
+          defaultMessage="{count, plural, =0 {Add to dataset} one {Add to dataset} other {Add to # datasets}}"
+          description="Confirm-button label on the add-to-evaluation-datasets modal, reflecting how many datasets are selected"
+          values={{ count: selectedDatasets.length }}
+        />
+      }
       okButtonProps={{
         disabled: isLoadingTraces || selectedDatasets.length === 0 || hasMultiturnDataset || isCheckingMultiturn,
         loading: isUpsertingDatasetRecords,
@@ -123,109 +70,18 @@ export const ExportTracesToDatasetModal = ({
       onOk={handleExport}
       title={
         <FormattedMessage
-          defaultMessage="Export traces to datasets"
-          description="Export traces to dataset modal title"
+          defaultMessage="Add to evaluation datasets"
+          description="Title of the add-to-evaluation-datasets modal"
         />
       }
       zIndex={theme.options.zIndexBase + 10}
     >
       <div css={{ height: '500px', overflow: 'hidden' }}>
-        {hasMultiturnDataset && (
-          <Alert
-            componentId="mlflow.export-traces-to-dataset-modal.multiturn-error"
-            type="error"
-            css={{ marginBottom: theme.spacing.sm }}
-            message={
-              <FormattedMessage
-                defaultMessage="Exporting to multi-turn datasets is not yet supported."
-                description="Error message when trying to export traces to a multiturn dataset"
-              />
-            }
-            closable={false}
-          />
-        )}
-        <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center', marginBottom: theme.spacing.sm }}>
-          <Input
-            allowClear
-            placeholder="Search by dataset name"
-            value={internalSearchFilter}
-            onChange={(e) => {
-              setInternalSearchFilter(e.target.value);
-              if (!e.target.value) {
-                setSearchFilter(e.target.value);
-              }
-            }}
-            onClear={() => {
-              setInternalSearchFilter('');
-              setSearchFilter('');
-            }}
-            onPressEnter={() => setSearchFilter(internalSearchFilter)}
-            componentId="mlflow.eval-datasets.search-input"
-            css={{ flex: 1 }}
-            prefix={<SearchIcon />}
-          />
-          <CreateEvaluationDatasetButton experimentId={experimentId} />
-        </div>
-        <Table
-          scrollable
-          onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget as HTMLDivElement)}
-          someRowsSelected={table.getIsSomeRowsSelected() || table.getIsAllRowsSelected()}
-          empty={
-            !isLoadingDatasets &&
-            !isFetching &&
-            datasets.length === 0 && (
-              <Empty
-                description={
-                  <FormattedMessage
-                    defaultMessage="No evaluation datasets found"
-                    description="Empty state for the evaluation datasets page"
-                  />
-                }
-              />
-            )
-          }
-        >
-          <TableRow isHeader>
-            <TableRowSelectCell
-              componentId="mlflow.export-traces-to-dataset-modal.header-checkbox"
-              checked={table.getIsAllRowsSelected()}
-              indeterminate={table.getIsSomeRowsSelected()}
-              onChange={table.getToggleAllRowsSelectedHandler()}
-            />
-            {table.getLeafHeaders().map((header) => (
-              <TableHeader
-                key={header.id}
-                componentId="mlflow.eval-datasets.column-header"
-                header={header}
-                column={header.column}
-                css={{ width: header.column.columnDef.size, maxWidth: header.column.columnDef.maxSize }}
-              >
-                {flexRender(header.column.columnDef.header, header.getContext())}
-              </TableHeader>
-            ))}
-          </TableRow>
-          {!isInitialLoading &&
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                <div>
-                  <TableRowSelectCell
-                    componentId="mlflow.export-traces-to-dataset-modal.row-checkbox"
-                    checked={row.getIsSelected()}
-                    onChange={row.getToggleSelectedHandler()}
-                  />
-                </div>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell
-                    key={cell.id}
-                    css={{ width: cell.column.columnDef.size, maxWidth: cell.column.columnDef.maxSize }}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          {(isInitialLoading || isFetching) && <TableSkeletonRows table={table} />}
-        </Table>
+        <EvaluationDatasetPicker
+          experimentId={experimentId}
+          onStateChange={setPickerState}
+          isLoadingExternal={isLoadingTraces}
+        />
       </div>
     </Modal>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx
@@ -1,42 +1,15 @@
-import {
-  Alert,
-  Empty,
-  Input,
-  Modal,
-  SearchIcon,
-  Table,
-  TableCell,
-  TableHeader,
-  TableRow,
-  TableRowSelectCell,
-  TableSkeletonRows,
-  useDesignSystemTheme,
-} from '@databricks/design-system';
-import type { ColumnDef } from '@tanstack/react-table';
-import { flexRender, getCoreRowModel } from '@tanstack/react-table';
-import { useReactTable_unverifiedWithReact18 as useReactTable } from '@databricks/web-shared/react-table';
+import { Modal, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
-import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatasets';
-import type { EvaluationDataset } from '../types';
 import { useCallback, useState } from 'react';
 import { getModelTraceId } from '@databricks/web-shared/model-trace-explorer';
 import type { ModelTrace } from '@databricks/web-shared/model-trace-explorer';
 import { compact } from 'lodash';
 import { extractDatasetInfoFromTraces } from '../utils/datasetUtils';
 import { useUpsertDatasetRecordsMutation } from '../hooks/useUpsertDatasetRecordsMutation';
-import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
 import { useFetchTraces } from '../hooks/useFetchTraces';
-import { useCheckMultiturnDatasets } from '../hooks/useCheckMultiturnDatasets';
 import Utils from '@mlflow/mlflow/src/common/utils/Utils';
-
-const columns: ColumnDef<EvaluationDataset, string>[] = [
-  {
-    id: 'name',
-    accessorKey: 'name',
-    header: 'Name',
-  },
-];
+import { EMPTY_EVALUATION_DATASET_PICKER_STATE, EvaluationDatasetPicker } from './EvaluationDatasetPicker';
+import type { EvaluationDatasetPickerState } from './EvaluationDatasetPicker';
 
 export const ExportTracesToDatasetModal = ({
   experimentId,
@@ -51,8 +24,6 @@ export const ExportTracesToDatasetModal = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
-  const [searchFilter, setSearchFilter] = useState('');
-  const [internalSearchFilter, setInternalSearchFilter] = useState(searchFilter);
 
   const traceIds = selectedTraceInfos.map((traceInfo) =>
     // hacky wrap just to get the id, as this util function expects
@@ -64,38 +35,8 @@ export const ExportTracesToDatasetModal = ({
   });
   const [isExporting, setIsExporting] = useState(false);
 
-  const {
-    data: datasets,
-    isLoading: isLoadingDatasets,
-    isFetching,
-    fetchNextPage,
-    hasNextPage,
-  } = useSearchEvaluationDatasets({ experimentId, nameFilter: searchFilter });
-
-  const isInitialLoading = isLoadingDatasets || isLoadingTraces;
-
-  const fetchMoreOnBottomReached = useInfiniteScrollFetch({
-    isFetching,
-    hasNextPage: hasNextPage ?? false,
-    fetchNextPage,
-  });
-
-  const table = useReactTable(
-    'mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx',
-    {
-      columns,
-      getRowId: (row) => row.dataset_id,
-      data: datasets ?? [],
-      getCoreRowModel: getCoreRowModel(),
-      enableColumnResizing: false,
-    },
-  );
-
-  const selectedDatasets = table.getSelectedRowModel().rows.map((row) => row.original);
-  const selectedDatasetIds = selectedDatasets.map((dataset) => dataset.dataset_id);
-  const { data: hasMultiturnDataset = false, isLoading: isCheckingMultiturn } = useCheckMultiturnDatasets({
-    datasetIds: selectedDatasetIds,
-  });
+  const [pickerState, setPickerState] = useState<EvaluationDatasetPickerState>(EMPTY_EVALUATION_DATASET_PICKER_STATE);
+  const { selectedDatasets, hasMultiturnDataset, isCheckingMultiturn } = pickerState;
 
   const {
     upsertDatasetRecordsMutationAsync,
@@ -124,14 +65,14 @@ export const ExportTracesToDatasetModal = ({
       );
       invalidateAfterUpsert(succeededDatasetIds);
       if (results.some((result) => result.status === 'rejected')) {
-        throw new Error('Failed to export traces to datasets.');
+        throw new Error('Failed to add traces to datasets.');
       }
       setVisible(false);
     } catch {
       Utils.displayGlobalErrorNotification(
         intl.formatMessage({
-          defaultMessage: 'Failed to export traces to datasets.',
-          description: 'Error toast when exporting traces to evaluation datasets fails',
+          defaultMessage: 'Failed to add traces to datasets.',
+          description: 'Error toast when adding traces to evaluation datasets fails',
         }),
       );
     } finally {
@@ -144,7 +85,13 @@ export const ExportTracesToDatasetModal = ({
       componentId="mlflow.export-traces-to-dataset-modal"
       visible={visible}
       onCancel={() => setVisible(false)}
-      okText={<FormattedMessage defaultMessage="Export" description="Export traces to dataset modal action button" />}
+      okText={
+        <FormattedMessage
+          defaultMessage="{count, plural, =0 {Add to dataset} one {Add to dataset} other {Add to # datasets}}"
+          description="Confirm-button label on the add-to-evaluation-datasets modal, reflecting how many datasets are selected"
+          values={{ count: selectedDatasets.length }}
+        />
+      }
       okButtonProps={{
         disabled:
           isLoadingTraces || isExporting || selectedDatasets.length === 0 || hasMultiturnDataset || isCheckingMultiturn,
@@ -153,109 +100,18 @@ export const ExportTracesToDatasetModal = ({
       onOk={handleExport}
       title={
         <FormattedMessage
-          defaultMessage="Export traces to datasets"
-          description="Export traces to dataset modal title"
+          defaultMessage="Add to evaluation datasets"
+          description="Title of the add-to-evaluation-datasets modal"
         />
       }
       zIndex={theme.options.zIndexBase + 10}
     >
       <div css={{ height: '500px', overflow: 'hidden' }}>
-        {hasMultiturnDataset && (
-          <Alert
-            componentId="mlflow.export-traces-to-dataset-modal.multiturn-error"
-            type="error"
-            css={{ marginBottom: theme.spacing.sm }}
-            message={
-              <FormattedMessage
-                defaultMessage="Exporting to multi-turn datasets is not yet supported."
-                description="Error message when trying to export traces to a multiturn dataset"
-              />
-            }
-            closable={false}
-          />
-        )}
-        <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center', marginBottom: theme.spacing.sm }}>
-          <Input
-            allowClear
-            placeholder="Search by dataset name"
-            value={internalSearchFilter}
-            onChange={(e) => {
-              setInternalSearchFilter(e.target.value);
-              if (!e.target.value) {
-                setSearchFilter(e.target.value);
-              }
-            }}
-            onClear={() => {
-              setInternalSearchFilter('');
-              setSearchFilter('');
-            }}
-            onPressEnter={() => setSearchFilter(internalSearchFilter)}
-            componentId="mlflow.eval-datasets.search-input"
-            css={{ flex: 1 }}
-            prefix={<SearchIcon />}
-          />
-          <CreateEvaluationDatasetButton experimentId={experimentId} />
-        </div>
-        <Table
-          scrollable
-          onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget as HTMLDivElement)}
-          someRowsSelected={table.getIsSomeRowsSelected() || table.getIsAllRowsSelected()}
-          empty={
-            !isLoadingDatasets &&
-            !isFetching &&
-            datasets.length === 0 && (
-              <Empty
-                description={
-                  <FormattedMessage
-                    defaultMessage="No evaluation datasets found"
-                    description="Empty state for the evaluation datasets page"
-                  />
-                }
-              />
-            )
-          }
-        >
-          <TableRow isHeader>
-            <TableRowSelectCell
-              componentId="mlflow.export-traces-to-dataset-modal.header-checkbox"
-              checked={table.getIsAllRowsSelected()}
-              indeterminate={table.getIsSomeRowsSelected()}
-              onChange={table.getToggleAllRowsSelectedHandler()}
-            />
-            {table.getLeafHeaders().map((header) => (
-              <TableHeader
-                key={header.id}
-                componentId="mlflow.eval-datasets.column-header"
-                header={header}
-                column={header.column}
-                css={{ width: header.column.columnDef.size, maxWidth: header.column.columnDef.maxSize }}
-              >
-                {flexRender(header.column.columnDef.header, header.getContext())}
-              </TableHeader>
-            ))}
-          </TableRow>
-          {!isInitialLoading &&
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                <div>
-                  <TableRowSelectCell
-                    componentId="mlflow.export-traces-to-dataset-modal.row-checkbox"
-                    checked={row.getIsSelected()}
-                    onChange={row.getToggleSelectedHandler()}
-                  />
-                </div>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell
-                    key={cell.id}
-                    css={{ width: cell.column.columnDef.size, maxWidth: cell.column.columnDef.maxSize }}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          {(isInitialLoading || isFetching) && <TableSkeletonRows table={table} />}
-        </Table>
+        <EvaluationDatasetPicker
+          experimentId={experimentId}
+          onStateChange={setPickerState}
+          isLoadingExternal={isLoadingTraces}
+        />
       </div>
     </Modal>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -12,7 +12,9 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import ErrorUtils from '../../../common/utils/ErrorUtils';
+import { useParams } from '../../../common/utils/RoutingUtils';
 import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
+import { AddToDatasetModal } from './components/AddToDatasetModal';
 import { PlaygroundTopBar } from './components/PlaygroundTopBar';
 import { PromptInputPanel } from './components/PromptInputPanel';
 import { PromptRegistryPicker } from './components/PromptRegistryPicker';
@@ -35,6 +37,7 @@ const EMPTY_USER_MESSAGE: ConversationMessage = { role: 'user', content: '' };
 const PlaygroundPage = () => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
+  const { experimentId } = useParams<{ experimentId: string }>();
   const [endpointName, setEndpointName] = useState<string>('');
   const [messages, setMessages] = useState<ConversationMessage[]>([{ ...EMPTY_USER_MESSAGE }]);
   const [params, setParams] = useState<PlaygroundParams>({});
@@ -47,6 +50,7 @@ const PlaygroundPage = () => {
   const [responseFormatSchemaText, setResponseFormatSchemaText] = useState<string>('');
   const [showRegistryPicker, setShowRegistryPicker] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
+  const [showAddToDatasetModal, setShowAddToDatasetModal] = useState(false);
   // The registry prompt currently loaded into the playground, if any. Lets the
   // save modal default to appending a new version of that prompt and preserve
   // its type.
@@ -59,6 +63,7 @@ const PlaygroundPage = () => {
     withSettings: boolean;
   } | null>(null);
   const [savedToast, setSavedToast] = useState<{ name: string; version: string } | null>(null);
+  const [addedToDatasetToast, setAddedToDatasetToast] = useState<{ datasetNames: string[] } | null>(null);
 
   const { mutate, error, isLoading, reset } = useChatCompletionMutation();
 
@@ -73,6 +78,12 @@ const PlaygroundPage = () => {
     const t = window.setTimeout(() => setSavedToast(null), 4000);
     return () => window.clearTimeout(t);
   }, [savedToast]);
+
+  useEffect(() => {
+    if (!addedToDatasetToast) return;
+    const t = window.setTimeout(() => setAddedToDatasetToast(null), 4000);
+    return () => window.clearTimeout(t);
+  }, [addedToDatasetToast]);
 
   const handleRegistryLoad = (payload: PromptLoadPayload) => {
     setMessages(payload.messages.length > 0 ? payload.messages : [{ ...EMPTY_USER_MESSAGE }]);
@@ -95,6 +106,11 @@ const PlaygroundPage = () => {
     // Chain subsequent saves onto the freshly created version.
     setLoadedPrompt({ name, version, promptType });
     setSavedToast({ name, version });
+  };
+
+  const handleAddedToDataset = ({ datasetNames }: { datasetNames: string[] }) => {
+    setShowAddToDatasetModal(false);
+    setAddedToDatasetToast({ datasetNames });
   };
 
   const handleAddTool = () => {
@@ -301,6 +317,8 @@ const PlaygroundPage = () => {
         onOpenRegistry={() => setShowRegistryPicker(true)}
         onOpenSave={() => setShowSaveModal(true)}
         saveDisabled={conversationIsEmpty}
+        onOpenAddToDataset={() => setShowAddToDatasetModal(true)}
+        addToDatasetDisabled={conversationIsEmpty}
       />
       <Spacer size="sm" shrinks={false} />
       <div css={{ borderTop: `1px solid ${theme.colors.border}`, flexShrink: 0 }} role="separator" aria-hidden="true" />
@@ -446,6 +464,14 @@ const PlaygroundPage = () => {
         loadedPromptType={loadedPrompt?.promptType}
         onSaved={handleSaved}
       />
+      <AddToDatasetModal
+        visible={showAddToDatasetModal}
+        onCancel={() => setShowAddToDatasetModal(false)}
+        experimentId={experimentId ?? ''}
+        messages={messages}
+        variables={variables}
+        onAdded={handleAddedToDataset}
+      />
       {loadedToast && (
         <Notification.Provider>
           <Notification.Root severity="success" componentId="mlflow.playground.prompt_registry_picker.loaded">
@@ -480,6 +506,21 @@ const PlaygroundPage = () => {
               />
             </Notification.Title>
             <Notification.Close componentId="mlflow.playground.save_prompt_version.saved.close" />
+          </Notification.Root>
+          <Notification.Viewport />
+        </Notification.Provider>
+      )}
+      {addedToDatasetToast && (
+        <Notification.Provider>
+          <Notification.Root severity="success" componentId="mlflow.playground.add_to_dataset.added">
+            <Notification.Title>
+              <FormattedMessage
+                defaultMessage="Added to {count, plural, one {{name}} other {# datasets}}"
+                description="Success toast shown on the playground after adding the current prompt to one or more evaluation datasets"
+                values={{ count: addedToDatasetToast.datasetNames.length, name: addedToDatasetToast.datasetNames[0] }}
+              />
+            </Notification.Title>
+            <Notification.Close componentId="mlflow.playground.add_to_dataset.added.close" />
           </Notification.Root>
           <Notification.Viewport />
         </Notification.Provider>

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -12,8 +12,10 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import ErrorUtils from '../../../common/utils/ErrorUtils';
+import { useParams } from '../../../common/utils/RoutingUtils';
 import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
 import { AssistantAwareActionBar } from '../../../common/components/AssistantAwareActionBar';
+import { AddToDatasetModal } from './components/AddToDatasetModal';
 import { PlaygroundTopBar } from './components/PlaygroundTopBar';
 import { PromptInputPanel } from './components/PromptInputPanel';
 import { PromptRegistryPicker } from './components/PromptRegistryPicker';
@@ -36,6 +38,7 @@ const EMPTY_USER_MESSAGE: ConversationMessage = { role: 'user', content: '' };
 const PlaygroundPage = () => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
+  const { experimentId } = useParams<{ experimentId: string }>();
   const [endpointName, setEndpointName] = useState<string>('');
   const [messages, setMessages] = useState<ConversationMessage[]>([{ ...EMPTY_USER_MESSAGE }]);
   const [params, setParams] = useState<PlaygroundParams>({});
@@ -48,6 +51,7 @@ const PlaygroundPage = () => {
   const [responseFormatSchemaText, setResponseFormatSchemaText] = useState<string>('');
   const [showRegistryPicker, setShowRegistryPicker] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
+  const [showAddToDatasetModal, setShowAddToDatasetModal] = useState(false);
   // The registry prompt currently loaded into the playground, if any. Lets the
   // save modal default to appending a new version of that prompt and preserve
   // its type.
@@ -60,6 +64,7 @@ const PlaygroundPage = () => {
     withSettings: boolean;
   } | null>(null);
   const [savedToast, setSavedToast] = useState<{ name: string; version: string } | null>(null);
+  const [addedToDatasetToast, setAddedToDatasetToast] = useState<{ datasetNames: string[] } | null>(null);
 
   const { mutate, error, isLoading, reset } = useChatCompletionMutation();
 
@@ -74,6 +79,12 @@ const PlaygroundPage = () => {
     const t = window.setTimeout(() => setSavedToast(null), 4000);
     return () => window.clearTimeout(t);
   }, [savedToast]);
+
+  useEffect(() => {
+    if (!addedToDatasetToast) return;
+    const t = window.setTimeout(() => setAddedToDatasetToast(null), 4000);
+    return () => window.clearTimeout(t);
+  }, [addedToDatasetToast]);
 
   const handleRegistryLoad = (payload: PromptLoadPayload) => {
     setMessages(payload.messages.length > 0 ? payload.messages : [{ ...EMPTY_USER_MESSAGE }]);
@@ -96,6 +107,11 @@ const PlaygroundPage = () => {
     // Chain subsequent saves onto the freshly created version.
     setLoadedPrompt({ name, version, promptType });
     setSavedToast({ name, version });
+  };
+
+  const handleAddedToDataset = ({ datasetNames }: { datasetNames: string[] }) => {
+    setShowAddToDatasetModal(false);
+    setAddedToDatasetToast({ datasetNames });
   };
 
   const handleAddTool = () => {
@@ -302,6 +318,8 @@ const PlaygroundPage = () => {
         onOpenRegistry={() => setShowRegistryPicker(true)}
         onOpenSave={() => setShowSaveModal(true)}
         saveDisabled={conversationIsEmpty}
+        onOpenAddToDataset={() => setShowAddToDatasetModal(true)}
+        addToDatasetDisabled={conversationIsEmpty}
       />
       <Spacer size="sm" shrinks={false} />
       <div css={{ borderTop: `1px solid ${theme.colors.border}`, flexShrink: 0 }} role="separator" aria-hidden="true" />
@@ -447,6 +465,14 @@ const PlaygroundPage = () => {
         loadedPromptType={loadedPrompt?.promptType}
         onSaved={handleSaved}
       />
+      <AddToDatasetModal
+        visible={showAddToDatasetModal}
+        onCancel={() => setShowAddToDatasetModal(false)}
+        experimentId={experimentId ?? ''}
+        messages={messages}
+        variables={variables}
+        onAdded={handleAddedToDataset}
+      />
       {loadedToast && (
         <Notification.Provider>
           <Notification.Root severity="success" componentId="mlflow.playground.prompt_registry_picker.loaded">
@@ -481,6 +507,21 @@ const PlaygroundPage = () => {
               />
             </Notification.Title>
             <Notification.Close componentId="mlflow.playground.save_prompt_version.saved.close" />
+          </Notification.Root>
+          <Notification.Viewport />
+        </Notification.Provider>
+      )}
+      {addedToDatasetToast && (
+        <Notification.Provider>
+          <Notification.Root severity="success" componentId="mlflow.playground.add_to_dataset.added">
+            <Notification.Title>
+              <FormattedMessage
+                defaultMessage="Added to {count, plural, one {{name}} other {# datasets}}"
+                description="Success toast shown on the playground after adding the current prompt to one or more evaluation datasets"
+                values={{ count: addedToDatasetToast.datasetNames.length, name: addedToDatasetToast.datasetNames[0] }}
+              />
+            </Notification.Title>
+            <Notification.Close componentId="mlflow.playground.add_to_dataset.added.close" />
           </Notification.Root>
           <Notification.Viewport />
         </Notification.Provider>

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetButton.tsx
@@ -1,0 +1,18 @@
+import { Button, TableIcon } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+
+interface Props {
+  onOpen: () => void;
+  disabled?: boolean;
+}
+
+export const AddToDatasetButton = ({ onOpen, disabled }: Props) => {
+  return (
+    <Button componentId="mlflow.playground.add_to_dataset" icon={<TableIcon />} onClick={onOpen} disabled={disabled}>
+      <FormattedMessage
+        defaultMessage="Add to evaluation datasets"
+        description="Label for the playground top-bar button that opens the add-to-evaluation-datasets modal"
+      />
+    </Button>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetButton.tsx
@@ -1,4 +1,4 @@
-import { Button, TableIcon } from '@databricks/design-system';
+import { Button, DatabaseIcon } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 
 interface Props {
@@ -8,9 +8,9 @@ interface Props {
 
 export const AddToDatasetButton = ({ onOpen, disabled }: Props) => {
   return (
-    <Button componentId="mlflow.playground.add_to_dataset" icon={<TableIcon />} onClick={onOpen} disabled={disabled}>
+    <Button componentId="mlflow.playground.add_to_dataset" icon={<DatabaseIcon />} onClick={onOpen} disabled={disabled}>
       <FormattedMessage
-        defaultMessage="Add to evaluation datasets"
+        defaultMessage="Add to datasets"
         description="Label for the playground top-bar button that opens the add-to-evaluation-datasets modal"
       />
     </Button>

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.test.tsx
@@ -1,0 +1,181 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { PointerEventsCheckLevel } from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEventGlobal from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { useCheckMultiturnDatasets } from '../../experiment-evaluation-datasets/hooks/useCheckMultiturnDatasets';
+import { useSearchEvaluationDatasets } from '../../experiment-evaluation-datasets/hooks/useSearchEvaluationDatasets';
+import { useUpsertDatasetRecordsMutation } from '../../experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation';
+import type { ConversationMessage } from '../types';
+import { AddToDatasetModal } from './AddToDatasetModal';
+
+jest.mock('../../experiment-evaluation-datasets/hooks/useSearchEvaluationDatasets', () => ({
+  useSearchEvaluationDatasets: jest.fn(),
+}));
+jest.mock('../../experiment-evaluation-datasets/hooks/useCheckMultiturnDatasets', () => ({
+  useCheckMultiturnDatasets: jest.fn(),
+}));
+jest.mock('../../experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation', () => ({
+  useUpsertDatasetRecordsMutation: jest.fn(),
+}));
+// The create-dataset button opens its own modal + mutation; stub it to keep this test focused.
+jest.mock('../../experiment-evaluation-datasets/components/CreateEvaluationDatasetButton', () => ({
+  CreateEvaluationDatasetButton: () => <button type="button">Create dataset</button>,
+}));
+
+// Modal overlays mask elements behind pointer-events checks; disable so userEvent can click through.
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+const mockSearchDatasets = jest.mocked(useSearchEvaluationDatasets);
+const mockCheckMultiturn = jest.mocked(useCheckMultiturnDatasets);
+const mockUpsertMutation = jest.mocked(useUpsertDatasetRecordsMutation);
+
+const upsertDatasetRecordsMutation = jest.fn();
+
+const CONVERSATION: ConversationMessage[] = [
+  { role: 'user', content: 'What is MLflow?' },
+  { role: 'assistant', content: 'MLflow is an ML platform.' },
+  { role: 'user', content: '' },
+];
+
+const setDatasets = (datasets: Array<{ dataset_id: string; name: string }>) => {
+  mockSearchDatasets.mockReturnValue({
+    data: datasets,
+    isLoading: false,
+    isFetching: false,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    refetch: jest.fn(),
+    error: null,
+  } as any);
+};
+
+const renderModal = ({
+  messages = CONVERSATION,
+  variables = {},
+}: { messages?: ConversationMessage[]; variables?: Record<string, string> } = {}) => {
+  const onCancel = jest.fn();
+  const onAdded = jest.fn();
+  render(
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <AddToDatasetModal
+          visible
+          onCancel={onCancel}
+          experimentId="exp-1"
+          messages={messages}
+          variables={variables}
+          onAdded={onAdded}
+        />
+      </DesignSystemProvider>
+    </IntlProvider>,
+  );
+  return { onCancel, onAdded };
+};
+
+const selectFirstDatasetRow = async () => {
+  // First checkbox is the header select-all; the row checkboxes follow.
+  const checkboxes = await screen.findAllByRole('checkbox');
+  await userEvent.click(checkboxes[checkboxes.length - 1]);
+};
+
+describe('AddToDatasetModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckMultiturn.mockReturnValue({ data: false, isLoading: false });
+    mockUpsertMutation.mockImplementation(({ onSuccess }: any) => ({
+      upsertDatasetRecordsMutation: upsertDatasetRecordsMutation.mockImplementation(() => onSuccess?.()),
+      isLoading: false,
+    })) as any;
+    setDatasets([{ dataset_id: 'd1', name: 'My Dataset' }]);
+  });
+
+  it('renders the search input, dataset table and create button, with Add disabled until a dataset is selected', async () => {
+    renderModal();
+
+    expect(await screen.findByText('Add to evaluation datasets')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search by dataset name/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create dataset/i })).toBeInTheDocument();
+    expect(screen.getByText('My Dataset')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
+  });
+
+  it('defaults the expected response to the latest assistant reply', async () => {
+    renderModal();
+
+    const expectedResponse = await screen.findByLabelText(/expected response/i);
+    expect(expectedResponse).toHaveValue('MLflow is an ML platform.');
+  });
+
+  it('upserts the record into the selected dataset and reports success', async () => {
+    const { onAdded } = renderModal();
+
+    await selectFirstDatasetRow();
+
+    const addButton = screen.getByRole('button', { name: /add to dataset/i });
+    await waitFor(() => expect(addButton).toBeEnabled());
+    await userEvent.click(addButton);
+
+    expect(upsertDatasetRecordsMutation).toHaveBeenCalledWith({
+      datasetId: 'd1',
+      records: JSON.stringify([
+        {
+          inputs: { messages: [{ role: 'user', content: 'What is MLflow?' }] },
+          expectations: { expected_response: 'MLflow is an ML platform.' },
+        },
+      ]),
+    });
+    await waitFor(() => expect(onAdded).toHaveBeenCalledWith({ datasetNames: ['My Dataset'] }));
+  });
+
+  it('shows the empty state when the experiment has no datasets', async () => {
+    setDatasets([]);
+    renderModal();
+
+    expect(await screen.findByText(/no evaluation datasets found/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
+  });
+
+  it('warns and blocks adding when there is no input message', async () => {
+    renderModal({ messages: [{ role: 'user', content: '' }] });
+
+    expect(await screen.findByText(/add at least one non-empty message/i)).toBeInTheDocument();
+    await selectFirstDatasetRow();
+    expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
+    expect(upsertDatasetRecordsMutation).not.toHaveBeenCalled();
+  });
+
+  it('does not report success for an in-flight upsert after the modal was cancelled', async () => {
+    let resolveUpsert: (() => void) | undefined;
+    mockUpsertMutation.mockImplementation(({ onSuccess }: any) => ({
+      upsertDatasetRecordsMutation: jest.fn(() => {
+        resolveUpsert = onSuccess;
+      }),
+      isLoading: false,
+    })) as any;
+    const { onCancel, onAdded } = renderModal();
+
+    await selectFirstDatasetRow();
+    const addButton = screen.getByRole('button', { name: /add to dataset/i });
+    await waitFor(() => expect(addButton).toBeEnabled());
+    await userEvent.click(addButton);
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+
+    resolveUpsert?.();
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+
+  it('blocks adding to multi-turn datasets with an error alert', async () => {
+    mockCheckMultiturn.mockReturnValue({ data: true, isLoading: false });
+    renderModal();
+
+    await selectFirstDatasetRow();
+
+    expect(await screen.findByText(/multi-turn datasets is not yet supported/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
+    expect(upsertDatasetRecordsMutation).not.toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.test.tsx
@@ -1,6 +1,6 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { PointerEventsCheckLevel } from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEventGlobal from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
@@ -31,7 +31,15 @@ const mockSearchDatasets = jest.mocked(useSearchEvaluationDatasets);
 const mockCheckMultiturn = jest.mocked(useCheckMultiturnDatasets);
 const mockUpsertMutation = jest.mocked(useUpsertDatasetRecordsMutation);
 
-const upsertDatasetRecordsMutation = jest.fn();
+const upsertDatasetRecordsMutationAsync = jest.fn<(payload: { datasetId: string; records: string }) => Promise<any>>();
+const invalidateAfterUpsert = jest.fn();
+
+const mockUpsert = (mutationAsync: typeof upsertDatasetRecordsMutationAsync) =>
+  mockUpsertMutation.mockReturnValue({
+    upsertDatasetRecordsMutationAsync: mutationAsync,
+    invalidateAfterUpsert,
+    isLoading: false,
+  } as any);
 
 const CONVERSATION: ConversationMessage[] = [
   { role: 'user', content: 'What is MLflow?' },
@@ -75,19 +83,17 @@ const renderModal = ({
 };
 
 const selectFirstDatasetRow = async () => {
-  // First checkbox is the header select-all; the row checkboxes follow.
-  const checkboxes = await screen.findAllByRole('checkbox');
-  await userEvent.click(checkboxes[checkboxes.length - 1]);
+  // Scoped to the dataset row so it can't pick up the header select-all or the
+  // expected-response opt-in checkbox elsewhere in the modal.
+  const row = await screen.findByRole('row', { name: /my dataset/i });
+  await userEvent.click(within(row).getByRole('checkbox'));
 };
 
 describe('AddToDatasetModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCheckMultiturn.mockReturnValue({ data: false, isLoading: false });
-    mockUpsertMutation.mockImplementation(({ onSuccess }: any) => ({
-      upsertDatasetRecordsMutation: upsertDatasetRecordsMutation.mockImplementation(() => onSuccess?.()),
-      isLoading: false,
-    })) as any;
+    mockUpsert(upsertDatasetRecordsMutationAsync.mockResolvedValue({ insertedCount: 1, updatedCount: 0 }));
     setDatasets([{ dataset_id: 'd1', name: 'My Dataset' }]);
   });
 
@@ -101,11 +107,13 @@ describe('AddToDatasetModal', () => {
     expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
   });
 
-  it('defaults the expected response to the latest assistant reply', async () => {
+  it('opts in and defaults the expected response to the latest assistant reply', async () => {
     renderModal();
 
-    const expectedResponse = await screen.findByLabelText(/expected response/i);
-    expect(expectedResponse).toHaveValue('MLflow is an ML platform.');
+    expect(await screen.findByRole('checkbox', { name: /add expected response/i })).toBeChecked();
+    expect(screen.getByPlaceholderText(/the reference answer to score responses against/i)).toHaveValue(
+      'MLflow is an ML platform.',
+    );
   });
 
   it('upserts the record into the selected dataset and reports success', async () => {
@@ -117,7 +125,7 @@ describe('AddToDatasetModal', () => {
     await waitFor(() => expect(addButton).toBeEnabled());
     await userEvent.click(addButton);
 
-    expect(upsertDatasetRecordsMutation).toHaveBeenCalledWith({
+    expect(upsertDatasetRecordsMutationAsync).toHaveBeenCalledWith({
       datasetId: 'd1',
       records: JSON.stringify([
         {
@@ -127,6 +135,44 @@ describe('AddToDatasetModal', () => {
       ]),
     });
     await waitFor(() => expect(onAdded).toHaveBeenCalledWith({ datasetNames: ['My Dataset'] }));
+    expect(invalidateAfterUpsert).toHaveBeenCalledWith(['d1']);
+  });
+
+  it('omits expectations when the expected-response opt-in is unchecked', async () => {
+    renderModal();
+
+    await userEvent.click(await screen.findByRole('checkbox', { name: /add expected response/i }));
+    expect(screen.queryByLabelText(/the reference answer to score responses against/i)).not.toBeInTheDocument();
+
+    await selectFirstDatasetRow();
+    const addButton = screen.getByRole('button', { name: /add to dataset/i });
+    await waitFor(() => expect(addButton).toBeEnabled());
+    await userEvent.click(addButton);
+
+    expect(upsertDatasetRecordsMutationAsync).toHaveBeenCalledWith({
+      datasetId: 'd1',
+      records: JSON.stringify([{ inputs: { messages: [{ role: 'user', content: 'What is MLflow?' }] } }]),
+    });
+  });
+
+  it('leaves the expected-response opt-in unchecked when the prompt has not been run', async () => {
+    renderModal({ messages: [{ role: 'user', content: 'What is MLflow?' }] });
+
+    expect(await screen.findByRole('checkbox', { name: /add expected response/i })).not.toBeChecked();
+    expect(screen.queryByPlaceholderText(/the reference answer to score responses against/i)).not.toBeInTheDocument();
+  });
+
+  it('surfaces an error and skips the success path when the upsert fails', async () => {
+    mockUpsert(upsertDatasetRecordsMutationAsync.mockRejectedValue(new Error('Dataset is read-only')));
+    const { onAdded } = renderModal();
+
+    await selectFirstDatasetRow();
+    const addButton = screen.getByRole('button', { name: /add to dataset/i });
+    await waitFor(() => expect(addButton).toBeEnabled());
+    await userEvent.click(addButton);
+
+    expect(await screen.findByText('Dataset is read-only')).toBeInTheDocument();
+    expect(onAdded).not.toHaveBeenCalled();
   });
 
   it('shows the empty state when the experiment has no datasets', async () => {
@@ -143,17 +189,19 @@ describe('AddToDatasetModal', () => {
     expect(await screen.findByText(/add at least one non-empty message/i)).toBeInTheDocument();
     await selectFirstDatasetRow();
     expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
-    expect(upsertDatasetRecordsMutation).not.toHaveBeenCalled();
+    expect(upsertDatasetRecordsMutationAsync).not.toHaveBeenCalled();
   });
 
   it('does not report success for an in-flight upsert after the modal was cancelled', async () => {
-    let resolveUpsert: (() => void) | undefined;
-    mockUpsertMutation.mockImplementation(({ onSuccess }: any) => ({
-      upsertDatasetRecordsMutation: jest.fn(() => {
-        resolveUpsert = onSuccess;
-      }),
-      isLoading: false,
-    })) as any;
+    let resolveUpsert: ((value: unknown) => void) | undefined;
+    mockUpsert(
+      upsertDatasetRecordsMutationAsync.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveUpsert = resolve;
+          }),
+      ),
+    );
     const { onCancel, onAdded } = renderModal();
 
     await selectFirstDatasetRow();
@@ -164,7 +212,9 @@ describe('AddToDatasetModal', () => {
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalled();
 
-    resolveUpsert?.();
+    // The record still lands, but the abandoned interaction must not fire the success path.
+    resolveUpsert?.({ insertedCount: 1, updatedCount: 0 });
+    await waitFor(() => expect(invalidateAfterUpsert).toHaveBeenCalledWith(['d1']));
     expect(onAdded).not.toHaveBeenCalled();
   });
 
@@ -176,6 +226,6 @@ describe('AddToDatasetModal', () => {
 
     expect(await screen.findByText(/multi-turn datasets is not yet supported/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add to dataset/i })).toBeDisabled();
-    expect(upsertDatasetRecordsMutation).not.toHaveBeenCalled();
+    expect(upsertDatasetRecordsMutationAsync).not.toHaveBeenCalled();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.tsx
@@ -1,0 +1,262 @@
+import { Alert, FormUI, Input, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import {
+  EMPTY_EVALUATION_DATASET_PICKER_STATE,
+  EvaluationDatasetPicker,
+} from '../../experiment-evaluation-datasets/components/EvaluationDatasetPicker';
+import type { EvaluationDatasetPickerState } from '../../experiment-evaluation-datasets/components/EvaluationDatasetPicker';
+import { useUpsertDatasetRecordsMutation } from '../../experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation';
+import { buildPlaygroundDatasetRecord, getDatasetInputMessages, getLatestAssistantContent } from '../datasetRecord';
+import type { ConversationMessage } from '../types';
+
+const { TextArea } = Input;
+
+const PREVIEW_CONTENT_CAP = 120;
+const PICKER_TABLE_HEIGHT = 240;
+
+const truncate = (s: string, cap: number) => (s.length > cap ? `${s.slice(0, cap)}…` : s);
+
+// React Query types query/mutation errors as `unknown`; narrow to a displayable message.
+const getErrorMessage = (error: unknown): string | undefined => (error instanceof Error ? error.message : undefined);
+
+interface Props {
+  visible: boolean;
+  onCancel: () => void;
+  experimentId: string;
+  messages: ConversationMessage[];
+  variables: Record<string, string>;
+  onAdded: (result: { datasetNames: string[] }) => void;
+}
+
+export const AddToDatasetModal = ({ visible, onCancel, experimentId, messages, variables, onAdded }: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [pickerState, setPickerState] = useState<EvaluationDatasetPickerState>(EMPTY_EVALUATION_DATASET_PICKER_STATE);
+  // Remounting the picker resets its selection and search; bumped on every modal open.
+  const [pickerResetKey, setPickerResetKey] = useState(0);
+  const [expectedResponse, setExpectedResponse] = useState('');
+  const [submitError, setSubmitError] = useState<string | undefined>(undefined);
+
+  const { selectedDatasets, hasMultiturnDataset, isCheckingMultiturn } = pickerState;
+
+  const inputMessages = useMemo(() => getDatasetInputMessages(messages, variables), [messages, variables]);
+
+  // One confirm fans out into one upsert per selected dataset; notify the parent only after
+  // the last one succeeds, and drop the batch on the first error so a partial failure
+  // surfaces instead of a success toast.
+  const pendingBatchRef = useRef<{ remaining: number; datasetNames: string[] } | null>(null);
+  const { upsertDatasetRecordsMutation, isLoading: isAdding } = useUpsertDatasetRecordsMutation({
+    onSuccess: () => {
+      const batch = pendingBatchRef.current;
+      if (!batch) return;
+      batch.remaining -= 1;
+      if (batch.remaining === 0) {
+        pendingBatchRef.current = null;
+        onAdded({ datasetNames: batch.datasetNames });
+      }
+    },
+    onError: (error) => {
+      pendingBatchRef.current = null;
+      setSubmitError(
+        getErrorMessage(error) ??
+          intl.formatMessage({
+            defaultMessage: 'Failed to add the record to the dataset',
+            description: 'Fallback error shown when adding a playground prompt to an evaluation dataset fails',
+          }),
+      );
+    },
+  });
+
+  // Latest snapshot of the conversation for the open-time reset below, kept out of the
+  // effect deps so editing messages while the modal is open doesn't overwrite the user's
+  // edits to the expected response.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
+  // Reset the form each time the modal is opened: clear the previous selection and search
+  // (by remounting the picker), default the expected response to the latest assistant
+  // reply, and drop any prior error or leftover in-flight batch.
+  useEffect(() => {
+    if (!visible) return;
+    pendingBatchRef.current = null;
+    setPickerResetKey((key) => key + 1);
+    setPickerState(EMPTY_EVALUATION_DATASET_PICKER_STATE);
+    setExpectedResponse(getLatestAssistantContent(messagesRef.current));
+    setSubmitError(undefined);
+  }, [visible]);
+
+  const hasInput = inputMessages.length > 0;
+  const canAdd = selectedDatasets.length > 0 && hasInput && !hasMultiturnDataset && !isCheckingMultiturn && !isAdding;
+
+  const handleAdd = () => {
+    if (!canAdd) return;
+    setSubmitError(undefined);
+    const records = JSON.stringify([buildPlaygroundDatasetRecord({ inputMessages, expectedResponse })]);
+    pendingBatchRef.current = {
+      remaining: selectedDatasets.length,
+      datasetNames: selectedDatasets.map((dataset) => dataset.name),
+    };
+    selectedDatasets.forEach((dataset) => upsertDatasetRecordsMutation({ datasetId: dataset.dataset_id, records }));
+  };
+
+  // Drop any in-flight batch on dismiss so a late upsert success can't fire the
+  // onAdded success path after the user has cancelled.
+  const handleCancel = () => {
+    pendingBatchRef.current = null;
+    onCancel();
+  };
+
+  return (
+    <Modal
+      componentId="mlflow.playground.add_to_dataset"
+      visible={visible}
+      onCancel={handleCancel}
+      title={
+        <FormattedMessage
+          defaultMessage="Add to evaluation datasets"
+          description="Title of the add-to-evaluation-datasets modal"
+        />
+      }
+      okText={
+        <FormattedMessage
+          defaultMessage="{count, plural, =0 {Add to dataset} one {Add to dataset} other {Add to # datasets}}"
+          description="Confirm-button label on the add-to-evaluation-datasets modal, reflecting how many datasets are selected"
+          values={{ count: selectedDatasets.length }}
+        />
+      }
+      okButtonProps={{ disabled: !canAdd, loading: isAdding }}
+      onOk={handleAdd}
+      cancelText={
+        <FormattedMessage
+          defaultMessage="Cancel"
+          description="Cancel-button label on the playground add-to-evaluation-dataset modal"
+        />
+      }
+      size="wide"
+      zIndex={theme.options.zIndexBase + 10}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        <Typography.Paragraph withoutMargins>
+          <FormattedMessage
+            defaultMessage="Save the current prompt as a record in an evaluation dataset. The messages become the record's inputs, and the response is stored as the expected answer so you can score it with judges later."
+            description="Intro paragraph at the top of the playground add-to-evaluation-dataset modal"
+          />
+        </Typography.Paragraph>
+
+        {submitError && (
+          <Alert
+            componentId="mlflow.playground.add_to_dataset.error"
+            type="error"
+            closable={false}
+            message={submitError}
+          />
+        )}
+
+        {!hasInput && (
+          <Alert
+            componentId="mlflow.playground.add_to_dataset.no_input"
+            type="warning"
+            closable={false}
+            message={
+              <FormattedMessage
+                defaultMessage="Add at least one non-empty message before adding this prompt to a dataset."
+                description="Warning shown in the playground add-to-dataset modal when there is no input message to store"
+              />
+            }
+          />
+        )}
+
+        <div>
+          <EvaluationDatasetPicker
+            key={pickerResetKey}
+            experimentId={experimentId}
+            onStateChange={setPickerState}
+            tableHeight={PICKER_TABLE_HEIGHT}
+            enabled={visible}
+          />
+        </div>
+
+        <div>
+          <FormUI.Label htmlFor="mlflow.playground.add_to_dataset.expected_response">
+            <FormattedMessage
+              defaultMessage="Expected response (optional)"
+              description="Label for the expected-response editor on the playground add-to-dataset modal"
+            />
+          </FormUI.Label>
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="Stored as expectations.expected_response — the reference answer that judges such as Correctness compare against."
+              description="Hint under the expected-response editor on the playground add-to-dataset modal"
+            />
+          </FormUI.Hint>
+          <TextArea
+            componentId="mlflow.playground.add_to_dataset.expected_response"
+            id="mlflow.playground.add_to_dataset.expected_response"
+            value={expectedResponse}
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setExpectedResponse(event.target.value)}
+            autoSize={{ minRows: 3, maxRows: 12 }}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'The reference answer to score responses against',
+              description: 'Placeholder for the expected-response editor on the playground add-to-dataset modal',
+            })}
+          />
+        </div>
+
+        {hasInput && (
+          <>
+            <div css={{ borderTop: `1px solid ${theme.colors.border}` }} role="separator" aria-hidden="true" />
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.spacing.sm,
+                border: `1px solid ${theme.colors.border}`,
+                borderRadius: theme.general.borderRadiusBase,
+                padding: theme.spacing.md,
+              }}
+            >
+              <Typography.Text
+                size="sm"
+                color="secondary"
+                bold
+                css={{ textTransform: 'uppercase', letterSpacing: 0.5 }}
+              >
+                <FormattedMessage
+                  defaultMessage="Inputs"
+                  description="Header of the input-messages preview in the playground add-to-dataset modal"
+                />
+              </Typography.Text>
+              <div
+                css={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: theme.spacing.xs,
+                  maxHeight: 240,
+                  overflowY: 'auto',
+                  paddingRight: theme.spacing.xs,
+                }}
+              >
+                {inputMessages.map((message, index) => (
+                  <div
+                    key={`${message.role}-${index}`}
+                    css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'baseline' }}
+                  >
+                    <Typography.Text bold css={{ minWidth: 72 }}>
+                      {message.role}
+                    </Typography.Text>
+                    <Typography.Text color="secondary">
+                      {truncate(message.content ?? '', PREVIEW_CONTENT_CAP)}
+                    </Typography.Text>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/AddToDatasetModal.tsx
@@ -1,4 +1,4 @@
-import { Alert, FormUI, Input, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Alert, Checkbox, FormUI, Input, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -38,37 +38,23 @@ export const AddToDatasetModal = ({ visible, onCancel, experimentId, messages, v
   // Remounting the picker resets its selection and search; bumped on every modal open.
   const [pickerResetKey, setPickerResetKey] = useState(0);
   const [expectedResponse, setExpectedResponse] = useState('');
+  // Storing a reference answer is opt-in; unchecked, the record is created with inputs only.
+  const [includeExpectedResponse, setIncludeExpectedResponse] = useState(false);
   const [submitError, setSubmitError] = useState<string | undefined>(undefined);
 
   const { selectedDatasets, hasMultiturnDataset, isCheckingMultiturn } = pickerState;
 
   const inputMessages = useMemo(() => getDatasetInputMessages(messages, variables), [messages, variables]);
 
-  // One confirm fans out into one upsert per selected dataset; notify the parent only after
-  // the last one succeeds, and drop the batch on the first error so a partial failure
-  // surfaces instead of a success toast.
-  const pendingBatchRef = useRef<{ remaining: number; datasetNames: string[] } | null>(null);
-  const { upsertDatasetRecordsMutation, isLoading: isAdding } = useUpsertDatasetRecordsMutation({
-    onSuccess: () => {
-      const batch = pendingBatchRef.current;
-      if (!batch) return;
-      batch.remaining -= 1;
-      if (batch.remaining === 0) {
-        pendingBatchRef.current = null;
-        onAdded({ datasetNames: batch.datasetNames });
-      }
-    },
-    onError: (error) => {
-      pendingBatchRef.current = null;
-      setSubmitError(
-        getErrorMessage(error) ??
-          intl.formatMessage({
-            defaultMessage: 'Failed to add the record to the dataset',
-            description: 'Fallback error shown when adding a playground prompt to an evaluation dataset fails',
-          }),
-      );
-    },
-  });
+  const {
+    upsertDatasetRecordsMutationAsync,
+    invalidateAfterUpsert,
+    isLoading: isAdding,
+  } = useUpsertDatasetRecordsMutation();
+
+  // Bumped on cancel so a still-in-flight batch can tell it has been dismissed and skip
+  // the success path (toast / closing) the user no longer asked for.
+  const submissionGenerationRef = useRef(0);
 
   // Latest snapshot of the conversation for the open-time reset below, kept out of the
   // effect deps so editing messages while the modal is open doesn't overwrite the user's
@@ -78,34 +64,65 @@ export const AddToDatasetModal = ({ visible, onCancel, experimentId, messages, v
 
   // Reset the form each time the modal is opened: clear the previous selection and search
   // (by remounting the picker), default the expected response to the latest assistant
-  // reply, and drop any prior error or leftover in-flight batch.
+  // reply, and drop any prior error or leftover in-flight batch. The opt-in starts checked
+  // only when there is a reply to pre-fill, so the prompt-only case stays inputs-only.
   useEffect(() => {
     if (!visible) return;
-    pendingBatchRef.current = null;
+    submissionGenerationRef.current += 1;
     setPickerResetKey((key) => key + 1);
     setPickerState(EMPTY_EVALUATION_DATASET_PICKER_STATE);
-    setExpectedResponse(getLatestAssistantContent(messagesRef.current));
+    const latestAssistantContent = getLatestAssistantContent(messagesRef.current);
+    setExpectedResponse(latestAssistantContent);
+    setIncludeExpectedResponse(latestAssistantContent.trim().length > 0);
     setSubmitError(undefined);
   }, [visible]);
 
   const hasInput = inputMessages.length > 0;
   const canAdd = selectedDatasets.length > 0 && hasInput && !hasMultiturnDataset && !isCheckingMultiturn && !isAdding;
 
-  const handleAdd = () => {
+  // One confirm fans out into one upsert per selected dataset. Record counts and the open
+  // records table are invalidated for the datasets that succeeded, and a partial failure
+  // surfaces as an error instead of a success toast.
+  const handleAdd = async () => {
     if (!canAdd) return;
     setSubmitError(undefined);
-    const records = JSON.stringify([buildPlaygroundDatasetRecord({ inputMessages, expectedResponse })]);
-    pendingBatchRef.current = {
-      remaining: selectedDatasets.length,
-      datasetNames: selectedDatasets.map((dataset) => dataset.name),
-    };
-    selectedDatasets.forEach((dataset) => upsertDatasetRecordsMutation({ datasetId: dataset.dataset_id, records }));
+    const generation = submissionGenerationRef.current;
+    const datasets = selectedDatasets;
+    const records = JSON.stringify([
+      buildPlaygroundDatasetRecord({
+        inputMessages,
+        expectedResponse: includeExpectedResponse ? expectedResponse : '',
+      }),
+    ]);
+
+    const results = await Promise.allSettled(
+      datasets.map((dataset) => upsertDatasetRecordsMutationAsync({ datasetId: dataset.dataset_id, records })),
+    );
+    const succeeded = datasets.filter((_, index) => results[index].status === 'fulfilled');
+    invalidateAfterUpsert(succeeded.map((dataset) => dataset.dataset_id));
+
+    // The user dismissed the modal while the batch was in flight; the records still landed,
+    // but the success toast / close would be for an interaction they already abandoned.
+    if (generation !== submissionGenerationRef.current) return;
+
+    const firstRejection = results.find((result) => result.status === 'rejected');
+    if (firstRejection) {
+      setSubmitError(
+        getErrorMessage((firstRejection as PromiseRejectedResult).reason) ??
+          intl.formatMessage({
+            defaultMessage: 'Failed to add the record to the dataset',
+            description: 'Fallback error shown when adding a playground prompt to an evaluation dataset fails',
+          }),
+      );
+      return;
+    }
+    onAdded({ datasetNames: succeeded.map((dataset) => dataset.name) });
   };
 
-  // Drop any in-flight batch on dismiss so a late upsert success can't fire the
+  // Invalidate any in-flight batch on dismiss so a late upsert success can't fire the
   // onAdded success path after the user has cancelled.
   const handleCancel = () => {
-    pendingBatchRef.current = null;
+    submissionGenerationRef.current += 1;
     onCancel();
   };
 
@@ -141,7 +158,7 @@ export const AddToDatasetModal = ({ visible, onCancel, experimentId, messages, v
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
         <Typography.Paragraph withoutMargins>
           <FormattedMessage
-            defaultMessage="Save the current prompt as a record in an evaluation dataset. The messages become the record's inputs, and the response is stored as the expected answer so you can score it with judges later."
+            defaultMessage="Save the current prompt as a record in an evaluation dataset. The messages become the record's inputs, and you can optionally store an expected response so you can score it with judges later."
             description="Intro paragraph at the top of the playground add-to-evaluation-dataset modal"
           />
         </Typography.Paragraph>
@@ -176,32 +193,6 @@ export const AddToDatasetModal = ({ visible, onCancel, experimentId, messages, v
             onStateChange={setPickerState}
             tableHeight={PICKER_TABLE_HEIGHT}
             enabled={visible}
-          />
-        </div>
-
-        <div>
-          <FormUI.Label htmlFor="mlflow.playground.add_to_dataset.expected_response">
-            <FormattedMessage
-              defaultMessage="Expected response (optional)"
-              description="Label for the expected-response editor on the playground add-to-dataset modal"
-            />
-          </FormUI.Label>
-          <FormUI.Hint>
-            <FormattedMessage
-              defaultMessage="Stored as expectations.expected_response — the reference answer that judges such as Correctness compare against."
-              description="Hint under the expected-response editor on the playground add-to-dataset modal"
-            />
-          </FormUI.Hint>
-          <TextArea
-            componentId="mlflow.playground.add_to_dataset.expected_response"
-            id="mlflow.playground.add_to_dataset.expected_response"
-            value={expectedResponse}
-            onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setExpectedResponse(event.target.value)}
-            autoSize={{ minRows: 3, maxRows: 12 }}
-            placeholder={intl.formatMessage({
-              defaultMessage: 'The reference answer to score responses against',
-              description: 'Placeholder for the expected-response editor on the playground add-to-dataset modal',
-            })}
           />
         </div>
 
@@ -256,6 +247,39 @@ export const AddToDatasetModal = ({ visible, onCancel, experimentId, messages, v
             </div>
           </>
         )}
+
+        <div>
+          <Checkbox
+            componentId="mlflow.playground.add_to_dataset.include_expected_response"
+            isChecked={includeExpectedResponse}
+            onChange={setIncludeExpectedResponse}
+          >
+            <FormattedMessage
+              defaultMessage="Add expected response"
+              description="Label of the checkbox that opts into storing an expected response on the playground add-to-dataset modal"
+            />
+          </Checkbox>
+          <FormUI.Hint>
+            <FormattedMessage
+              defaultMessage="Stored as expectations.expected_response — the reference answer that judges such as Correctness compare against."
+              description="Hint under the expected-response editor on the playground add-to-dataset modal"
+            />
+          </FormUI.Hint>
+          {includeExpectedResponse && (
+            <TextArea
+              componentId="mlflow.playground.add_to_dataset.expected_response"
+              id="mlflow.playground.add_to_dataset.expected_response"
+              value={expectedResponse}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setExpectedResponse(event.target.value)}
+              autoSize={{ minRows: 3, maxRows: 12 }}
+              css={{ marginTop: theme.spacing.sm }}
+              placeholder={intl.formatMessage({
+                defaultMessage: 'The reference answer to score responses against',
+                description: 'Placeholder for the expected-response editor on the playground add-to-dataset modal',
+              })}
+            />
+          )}
+        </div>
       </div>
     </Modal>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
@@ -28,6 +28,7 @@ const renderTopBar = () => {
   const onEndpointSelect = jest.fn();
   const onOpenRegistry = jest.fn();
   const onOpenSave = jest.fn();
+  const onOpenAddToDataset = jest.fn();
   const noop = jest.fn();
   render(
     <IntlProvider locale="en">
@@ -53,21 +54,23 @@ const renderTopBar = () => {
           onVariablesChange={noop}
           onOpenRegistry={onOpenRegistry}
           onOpenSave={onOpenSave}
+          onOpenAddToDataset={onOpenAddToDataset}
         />
       </DesignSystemProvider>
     </IntlProvider>,
   );
-  return { onEndpointSelect, onOpenRegistry, onOpenSave };
+  return { onEndpointSelect, onOpenRegistry, onOpenSave, onOpenAddToDataset };
 };
 
 describe('PlaygroundTopBar', () => {
-  it('renders the endpoint selector and the four top-bar buttons', () => {
+  it('renders the endpoint selector and the five top-bar buttons', () => {
     renderTopBar();
     expect(screen.getByTestId('endpoint-selector-test-input')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /open model parameters/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /open variable values/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /load prompt/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save prompt/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to evaluation dataset/i })).toBeInTheDocument();
   });
 
   it('wires onOpenRegistry to the Load button', async () => {
@@ -80,5 +83,11 @@ describe('PlaygroundTopBar', () => {
     const { onOpenSave } = renderTopBar();
     await userEvent.click(screen.getByRole('button', { name: /save prompt/i }));
     expect(onOpenSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('wires onOpenAddToDataset to the Add to dataset button', async () => {
+    const { onOpenAddToDataset } = renderTopBar();
+    await userEvent.click(screen.getByRole('button', { name: /add to evaluation dataset/i }));
+    expect(onOpenAddToDataset).toHaveBeenCalledTimes(1);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.test.tsx
@@ -70,7 +70,7 @@ describe('PlaygroundTopBar', () => {
     expect(screen.getByRole('button', { name: /open variable values/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /load prompt/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /save prompt/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /add to evaluation dataset/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to datasets/i })).toBeInTheDocument();
   });
 
   it('wires onOpenRegistry to the Load button', async () => {
@@ -87,7 +87,7 @@ describe('PlaygroundTopBar', () => {
 
   it('wires onOpenAddToDataset to the Add to dataset button', async () => {
     const { onOpenAddToDataset } = renderTopBar();
-    await userEvent.click(screen.getByRole('button', { name: /add to evaluation dataset/i }));
+    await userEvent.click(screen.getByRole('button', { name: /add to datasets/i }));
     expect(onOpenAddToDataset).toHaveBeenCalledTimes(1);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/components/PlaygroundTopBar.tsx
@@ -1,6 +1,7 @@
 import { useDesignSystemTheme } from '@databricks/design-system';
 import { EndpointSelector } from '../../../components/EndpointSelector';
 import type { ChatMessage, PlaygroundParams, PlaygroundTool, ResponseFormatType, ToolChoice } from '../types';
+import { AddToDatasetButton } from './AddToDatasetButton';
 import { ParametersButton } from './ParametersButton';
 import { RegistryButton } from './RegistryButton';
 import { SaveToRegistryButton } from './SaveToRegistryButton';
@@ -28,6 +29,8 @@ interface Props {
   onOpenRegistry: () => void;
   onOpenSave: () => void;
   saveDisabled?: boolean;
+  onOpenAddToDataset: () => void;
+  addToDatasetDisabled?: boolean;
 }
 
 export const PlaygroundTopBar = ({
@@ -52,6 +55,8 @@ export const PlaygroundTopBar = ({
   onOpenRegistry,
   onOpenSave,
   saveDisabled,
+  onOpenAddToDataset,
+  addToDatasetDisabled,
 }: Props) => {
   const { theme } = useDesignSystemTheme();
 
@@ -89,6 +94,7 @@ export const PlaygroundTopBar = ({
       <VariablesButton messages={messages} value={variables} onChange={onVariablesChange} />
       <RegistryButton onOpen={onOpenRegistry} />
       <SaveToRegistryButton onOpen={onOpenSave} disabled={saveDisabled} />
+      <AddToDatasetButton onOpen={onOpenAddToDataset} disabled={addToDatasetDisabled} />
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/datasetRecord.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/datasetRecord.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildPlaygroundDatasetRecord, getDatasetInputMessages, getLatestAssistantContent } from './datasetRecord';
+import type { ConversationMessage } from './types';
+
+describe('getLatestAssistantContent', () => {
+  it('returns the content of the most recent assistant reply', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'First' },
+      { role: 'user', content: 'Again' },
+      { role: 'assistant', content: 'Second' },
+      { role: 'user', content: '' },
+    ];
+    expect(getLatestAssistantContent(messages)).toBe('Second');
+  });
+
+  it('returns an empty string when there is no assistant reply yet', () => {
+    expect(getLatestAssistantContent([{ role: 'user', content: 'Hi' }])).toBe('');
+  });
+
+  it('returns an empty string once the user has typed a new turn after the last assistant reply', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello' },
+      { role: 'user', content: 'A brand new question' },
+    ];
+    expect(getLatestAssistantContent(messages)).toBe('');
+  });
+
+  it('treats a null assistant content (e.g. a tool-call-only reply) as an empty string', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: null },
+    ];
+    expect(getLatestAssistantContent(messages)).toBe('');
+  });
+});
+
+describe('getDatasetInputMessages', () => {
+  it('resolves variables and drops the assistant reply and the trailing empty composer', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'system', content: 'You are {{ persona }}.' },
+      { role: 'user', content: 'Summarize {{ topic }}' },
+      { role: 'assistant', content: 'Here is the summary', usage: { total_tokens: 10 } },
+      { role: 'user', content: '' },
+    ];
+    expect(getDatasetInputMessages(messages, { persona: 'concise', topic: 'MLflow' })).toEqual([
+      { role: 'system', content: 'You are concise.' },
+      { role: 'user', content: 'Summarize MLflow' },
+    ]);
+  });
+
+  it('keeps prior turns (including earlier assistant replies) as multi-turn input context', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello' },
+      { role: 'user', content: 'Tell me more' },
+      { role: 'assistant', content: 'Sure, here it is' },
+      { role: 'user', content: '' },
+    ];
+    expect(getDatasetInputMessages(messages, {})).toEqual([
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello' },
+      { role: 'user', content: 'Tell me more' },
+    ]);
+  });
+
+  it('keeps the whole conversation, reply included, once a new non-empty turn follows the last assistant reply', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello', usage: { total_tokens: 5 } },
+      { role: 'user', content: 'A brand new question' },
+    ];
+    expect(getDatasetInputMessages(messages, {})).toEqual([
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello' },
+      { role: 'user', content: 'A brand new question' },
+    ]);
+  });
+
+  it('returns every non-empty turn when the prompt has not been run yet', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'system', content: 'Be helpful' },
+      { role: 'user', content: 'Hello' },
+    ];
+    expect(getDatasetInputMessages(messages, {})).toEqual([
+      { role: 'system', content: 'Be helpful' },
+      { role: 'user', content: 'Hello' },
+    ]);
+  });
+
+  it('filters out empty-content turns', () => {
+    const messages: ConversationMessage[] = [
+      { role: 'system', content: '   ' },
+      { role: 'user', content: 'Only this' },
+    ];
+    expect(getDatasetInputMessages(messages, {})).toEqual([{ role: 'user', content: 'Only this' }]);
+  });
+});
+
+describe('buildPlaygroundDatasetRecord', () => {
+  it('stores inputs as { messages } and a non-empty expected response under expectations', () => {
+    const record = buildPlaygroundDatasetRecord({
+      inputMessages: [{ role: 'user', content: 'Question' }],
+      expectedResponse: 'Answer',
+    });
+    expect(record).toEqual({
+      inputs: { messages: [{ role: 'user', content: 'Question' }] },
+      expectations: { expected_response: 'Answer' },
+    });
+  });
+
+  it('trims the expected response before storing it', () => {
+    const record = buildPlaygroundDatasetRecord({
+      inputMessages: [{ role: 'user', content: 'Question' }],
+      expectedResponse: '  Answer  ',
+    });
+    expect(record.expectations).toEqual({ expected_response: 'Answer' });
+  });
+
+  it('omits expectations entirely when the expected response is blank', () => {
+    const record = buildPlaygroundDatasetRecord({
+      inputMessages: [{ role: 'user', content: 'Question' }],
+      expectedResponse: '   ',
+    });
+    expect(record).toEqual({ inputs: { messages: [{ role: 'user', content: 'Question' }] } });
+    expect(record).not.toHaveProperty('expectations');
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/datasetRecord.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/datasetRecord.ts
@@ -1,0 +1,82 @@
+import type { DatasetRecord } from '../experiment-evaluation-datasets-v2/hooks/useDatasetsQueries';
+import type { ChatMessage, ConversationMessage } from './types';
+import { substituteVariables } from './utils';
+
+const findLastAssistantIndex = (messages: ConversationMessage[]): number => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'assistant') {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const hasContentAfterIndex = (messages: ConversationMessage[], index: number): boolean =>
+  messages.slice(index + 1).some((message) => (message.content ?? '').trim().length > 0);
+
+/**
+ * The latest assistant reply is split off as the record's expected response only while
+ * it is still the end of the conversation (nothing but the empty next-turn composer
+ * after it). Once the user types a new turn, the reply stops being "the answer to the
+ * current prompt": it becomes conversation context inside the inputs instead, and no
+ * expected response is pre-filled.
+ */
+const isLatestAssistantTheExpectation = (messages: ConversationMessage[], lastAssistantIndex: number): boolean =>
+  lastAssistantIndex >= 0 && !hasContentAfterIndex(messages, lastAssistantIndex);
+
+/**
+ * Content of the assistant reply that answers the current prompt, or `''` when there is
+ * none — either the prompt has not been run yet, or the user has already typed a new
+ * turn after the last reply (so that reply no longer matches the prompt being saved).
+ * Used to pre-fill the editable "expected response" field.
+ */
+export const getLatestAssistantContent = (messages: ConversationMessage[]): string => {
+  const lastAssistantIndex = findLastAssistantIndex(messages);
+  if (!isLatestAssistantTheExpectation(messages, lastAssistantIndex)) {
+    return '';
+  }
+  return messages[lastAssistantIndex].content ?? '';
+};
+
+/**
+ * The turns that make up the model input for a dataset record, with `{{ variables }}`
+ * resolved to their values. When the conversation ends at the latest assistant reply,
+ * that reply is excluded — it is captured separately as the expected response. When the
+ * user has typed a new turn after the reply, the whole conversation (reply included, as
+ * multi-turn context) is the input. Empty-content turns are filtered out, and each turn
+ * is reduced to `{ role, content }` (display-only fields such as `usage` are stripped).
+ */
+export const getDatasetInputMessages = (
+  messages: ConversationMessage[],
+  variables: Record<string, string>,
+): ChatMessage[] => {
+  const lastAssistantIndex = findLastAssistantIndex(messages);
+  const inputTurns = isLatestAssistantTheExpectation(messages, lastAssistantIndex)
+    ? messages.slice(0, lastAssistantIndex)
+    : messages;
+  return substituteVariables(inputTurns, variables)
+    .filter((message) => (message.content ?? '').trim().length > 0)
+    .map(({ role, content }) => ({ role, content }));
+};
+
+/**
+ * Builds the evaluation-dataset record from playground state. Inputs are stored under
+ * the single-turn `{ messages: [...] }` schema the datasets UI and built-in judges
+ * expect; a non-empty expected response is stored under `expectations.expected_response`
+ * — the key `Correctness` and other reference-based judges read. The expectations field
+ * is omitted entirely when no reference answer is provided, so the record stays valid for
+ * reference-free scorers.
+ */
+export const buildPlaygroundDatasetRecord = ({
+  inputMessages,
+  expectedResponse,
+}: {
+  inputMessages: ChatMessage[];
+  expectedResponse: string;
+}): Partial<DatasetRecord> => {
+  const trimmed = expectedResponse.trim();
+  return {
+    inputs: { messages: inputMessages },
+    ...(trimmed ? { expectations: { expected_response: trimmed } } : {}),
+  };
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -87,6 +87,10 @@
     "defaultMessage": "Last updated",
     "description": "Header for the dataset last-updated column"
   },
+  "+QgbkW": {
+    "defaultMessage": "Expected response (optional)",
+    "description": "Label for the expected-response editor on the playground add-to-dataset modal"
+  },
   "+T+iqa": {
     "defaultMessage": "Select baseline run",
     "description": "Placeholder text for the baseline run selector dropdown"
@@ -130,6 +134,10 @@
   "+dbgRR": {
     "defaultMessage": "{numUniqueValues} values",
     "description": "Text for number of unique values for categorical assessment"
+  },
+  "+ee/pP": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Button text for adding a trace to a dataset"
   },
   "+erxn2": {
     "defaultMessage": "Optimize prompts",
@@ -238,6 +246,10 @@
   "/Aup8Q": {
     "defaultMessage": "Request time",
     "description": "Column label for request time"
+  },
+  "/B2QGb": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Label for the playground top-bar button that opens the add-to-evaluation-datasets modal"
   },
   "/C16tY": {
     "defaultMessage": "Tool Usage Over Time",
@@ -630,6 +642,10 @@
   "0wxgDJ": {
     "defaultMessage": "Add tags",
     "description": "Add new prompt version tags button"
+  },
+  "0yLpN3": {
+    "defaultMessage": "Add at least one non-empty message before adding this prompt to a dataset.",
+    "description": "Warning shown in the playground add-to-dataset modal when there is no input message to store"
   },
   "0yvVF0": {
     "defaultMessage": "Refresh traces",
@@ -1394,6 +1410,10 @@
   "4g2H7S": {
     "defaultMessage": "Prompt content is required",
     "description": "A validation state for the chat prompt content in the prompt creation modal"
+  },
+  "4iMYW6": {
+    "defaultMessage": "{count, plural, =0 {Add to dataset} one {Add to dataset} other {Add to # datasets}}",
+    "description": "Confirm-button label on the add-to-evaluation-datasets modal, reflecting how many datasets are selected"
   },
   "4iVjvu": {
     "defaultMessage": "Create a user to get started.",
@@ -2511,6 +2531,10 @@
     "defaultMessage": "Docs",
     "description": "Sidebar link for docs page"
   },
+  "A3A88W": {
+    "defaultMessage": "The reference answer to score responses against",
+    "description": "Placeholder for the expected-response editor on the playground add-to-dataset modal"
+  },
   "A3bM/D": {
     "defaultMessage": "Assistant",
     "description": "Tooltip for assistant button"
@@ -3615,10 +3639,6 @@
     "defaultMessage": "Key:",
     "description": "Label for tag key in modal"
   },
-  "FhnIR9": {
-    "defaultMessage": "Exporting to multi-turn datasets is not yet supported.",
-    "description": "Error message when trying to export traces to a multiturn dataset"
-  },
   "FiKsFK": {
     "defaultMessage": "Last modified",
     "description": "Header for the last modified column in the registered prompts table"
@@ -4563,6 +4583,10 @@
     "defaultMessage": "Current Spend",
     "description": "Budget current spend column header"
   },
+  "KyKszW": {
+    "defaultMessage": "Added to {count, plural, one {{name}} other {# datasets}}",
+    "description": "Success toast shown on the playground after adding the current prompt to one or more evaluation datasets"
+  },
   "Kya8N3": {
     "defaultMessage": "Pass",
     "description": "Passing evaluation status in the evaluations table."
@@ -4806,6 +4830,10 @@
   "MBNIRk": {
     "defaultMessage": "Attributes",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > attributes heading"
+  },
+  "MFHrh9": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Button text for adding a trace to an evaluation dataset"
   },
   "MGcWqh": {
     "defaultMessage": "Schema",
@@ -5099,10 +5127,6 @@
     "defaultMessage": "Override saved view",
     "description": "Experiment page > shared view banner > button that overwrites the user's own saved view with the shared view"
   },
-  "NekUba": {
-    "defaultMessage": "Add to dataset",
-    "description": "Button text for adding a trace to an evaluation dataset"
-  },
   "NhEmyj": {
     "defaultMessage": "Training runs",
     "description": "Label for the training runs tab in the MLflow experiment navbar"
@@ -5262,6 +5286,10 @@
   "OHDirZ": {
     "defaultMessage": "Use the trash icon to remove the tools from the request.",
     "description": "Closing line of the Tools info popover explaining how the trash icon removes tools"
+  },
+  "OHnjaH": {
+    "defaultMessage": "Save the current prompt as a record in an evaluation dataset. The messages become the record's inputs, and the response is stored as the expected answer so you can score it with judges later.",
+    "description": "Intro paragraph at the top of the playground add-to-evaluation-dataset modal"
   },
   "OIJAhv": {
     "defaultMessage": "Function name is required",
@@ -5714,10 +5742,6 @@
   "Qb78hE": {
     "defaultMessage": "Messages",
     "description": "Subsection header listing messages of the selected prompt version on the playground prompt-registry picker modal"
-  },
-  "QcEYpD": {
-    "defaultMessage": "Add to evaluation dataset",
-    "description": "Add traces to evaluation dataset action"
   },
   "QevoXx": {
     "defaultMessage": "Error details",
@@ -7375,6 +7399,10 @@
     "defaultMessage": "No matching users",
     "description": "Add to review queue: no users match the search"
   },
+  "YZB/ur": {
+    "defaultMessage": "Adding to multi-turn datasets is not yet supported.",
+    "description": "Error message when a multi-turn evaluation dataset is selected in the dataset picker"
+  },
   "YZDyOo": {
     "defaultMessage": "Path:",
     "description": "Label to display the full path of where the artifact of the experiment runs is located"
@@ -7494,10 +7522,6 @@
   "ZAqdq9": {
     "defaultMessage": "Edit API key",
     "description": "Gateway > API key details drawer > Edit API key button aria label"
-  },
-  "ZBRK9J": {
-    "defaultMessage": "Export traces to datasets",
-    "description": "Export traces to dataset modal title"
   },
   "ZBZBrn": {
     "defaultMessage": "Input /1M",
@@ -7690,10 +7714,6 @@
   "a0NgR8": {
     "defaultMessage": "Type",
     "description": "Header for \"type\" column in the UC table schema"
-  },
-  "a1liZ7": {
-    "defaultMessage": "Export",
-    "description": "Export traces to dataset modal action button"
   },
   "a3G5A7": {
     "defaultMessage": "Provider",
@@ -7938,6 +7958,10 @@
   "bCdY2j": {
     "defaultMessage": "Add \"{label}\"",
     "description": "Evaluation review > assessments > add new custom value element"
+  },
+  "bFkH7V": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel-button label on the playground add-to-evaluation-dataset modal"
   },
   "bGHzui": {
     "defaultMessage": "Custom judge",
@@ -10015,6 +10039,14 @@
     "defaultMessage": "Discard",
     "description": "Experiment page > artifact compare view > prompt lab artifact synchronization > submit button label"
   },
+  "kNUE3r": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Add traces to evaluation dataset action"
+  },
+  "kPXtWR": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Title of the add-to-evaluation-datasets modal"
+  },
   "kQ9rmr": {
     "defaultMessage": "Operator",
     "description": "Usage overview > filter row > operator column label"
@@ -10811,10 +10843,6 @@
     "defaultMessage": "Manage questions",
     "description": "Review queue sidebar: manage-questions button"
   },
-  "oLHs0C": {
-    "defaultMessage": "Add to dataset",
-    "description": "Button text for adding a trace to a dataset"
-  },
   "oM11pD": {
     "defaultMessage": "Error",
     "description": "The label for an error assessment above a bar-chart in the summary stats."
@@ -11279,6 +11307,10 @@
     "defaultMessage": "Copied to clipboard",
     "description": "Success message after copying trace link"
   },
+  "qgLMU0": {
+    "defaultMessage": "Search by dataset name",
+    "description": "Placeholder for the dataset search input in the evaluation dataset picker"
+  },
   "qhOwHa": {
     "defaultMessage": "Endpoints",
     "description": "Sidebar link for gateway endpoints"
@@ -11550,6 +11582,10 @@
   "rt9clc": {
     "defaultMessage": "Return a 400 error with the guardrail name and reason. The original request or response is not passed through.",
     "description": "Block action description"
+  },
+  "rv0xwU": {
+    "defaultMessage": "Stored as expectations.expected_response — the reference answer that judges such as Correctness compare against.",
+    "description": "Hint under the expected-response editor on the playground add-to-dataset modal"
   },
   "rvRhzv": {
     "defaultMessage": "Masked Key:",
@@ -12231,6 +12267,10 @@
     "defaultMessage": "This column contains all models logged or evaluated by the run. Click into an individual run to see more detailed information about all models associated with it.",
     "description": "A descriptive tooltip for the \"Models\" column header in the runs table on the MLflow experiment detail page"
   },
+  "vY4UFz": {
+    "defaultMessage": "Inputs",
+    "description": "Header of the input-messages preview in the playground add-to-dataset modal"
+  },
   "vaJYHp": {
     "defaultMessage": "At least one form field has incorrect value. Please correct and try again.",
     "description": "Generic error message for an invalid form input"
@@ -12742,6 +12782,10 @@
   "xyQFjH": {
     "defaultMessage": "Prompt Caching",
     "description": "Filter option for prompt caching support"
+  },
+  "xzUBOm": {
+    "defaultMessage": "Failed to add the record to the dataset",
+    "description": "Fallback error shown when adding a playground prompt to an evaluation dataset fails"
   },
   "y2oQyU": {
     "defaultMessage": "Model name",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -147,6 +147,10 @@
     "defaultMessage": "{numUniqueValues} values",
     "description": "Text for number of unique values for categorical assessment"
   },
+  "+ee/pP": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Button text for adding a trace to a dataset"
+  },
   "+erxn2": {
     "defaultMessage": "Optimize prompts",
     "description": "Home page news card title two"
@@ -706,6 +710,10 @@
   "0wxgDJ": {
     "defaultMessage": "Add tags",
     "description": "Add new prompt version tags button"
+  },
+  "0yLpN3": {
+    "defaultMessage": "Add at least one non-empty message before adding this prompt to a dataset.",
+    "description": "Warning shown in the playground add-to-dataset modal when there is no input message to store"
   },
   "0yvVF0": {
     "defaultMessage": "Refresh traces",
@@ -1607,6 +1615,10 @@
     "defaultMessage": "default",
     "description": "Tooltip for default fallback icon"
   },
+  "4iMYW6": {
+    "defaultMessage": "{count, plural, =0 {Add to dataset} one {Add to dataset} other {Add to # datasets}}",
+    "description": "Confirm-button label on the add-to-evaluation-datasets modal, reflecting how many datasets are selected"
+  },
   "4iVjvu": {
     "defaultMessage": "Create a user to get started.",
     "description": "Empty state description for users table"
@@ -1855,6 +1867,10 @@
     "defaultMessage": "Delete",
     "description": "Delete button text"
   },
+  "5spJ/4": {
+    "defaultMessage": "Save the current prompt as a record in an evaluation dataset. The messages become the record's inputs, and you can optionally store an expected response so you can score it with judges later.",
+    "description": "Intro paragraph at the top of the playground add-to-evaluation-dataset modal"
+  },
   "5sy3VL": {
     "defaultMessage": "e.g. 40",
     "description": "Placeholder for the top-k input on the playground parameters panel"
@@ -1942,10 +1958,6 @@
   "6HjFD0": {
     "defaultMessage": "Key name",
     "description": "API key name column header"
-  },
-  "6Hpgz8": {
-    "defaultMessage": "Failed to export traces to datasets.",
-    "description": "Error toast when exporting traces to evaluation datasets fails"
   },
   "6I8pKa": {
     "defaultMessage": "Auth Type:",
@@ -2966,6 +2978,10 @@
   "A1ljDC": {
     "defaultMessage": "Docs",
     "description": "Sidebar link for docs page"
+  },
+  "A3A88W": {
+    "defaultMessage": "The reference answer to score responses against",
+    "description": "Placeholder for the expected-response editor on the playground add-to-dataset modal"
   },
   "A3bM/D": {
     "defaultMessage": "Assistant",
@@ -4299,10 +4315,6 @@
     "defaultMessage": "Key:",
     "description": "Label for tag key in modal"
   },
-  "FhnIR9": {
-    "defaultMessage": "Exporting to multi-turn datasets is not yet supported.",
-    "description": "Error message when trying to export traces to a multiturn dataset"
-  },
   "FiKsFK": {
     "defaultMessage": "Last modified",
     "description": "Header for the last modified column in the registered prompts table"
@@ -4322,6 +4334,10 @@
   "Fk7Mme": {
     "defaultMessage": "{count, plural, one {# user queue} other {# user queues}}",
     "description": "Manage review questions: count of user queues affected by deleting the question"
+  },
+  "Fm3kcN": {
+    "defaultMessage": "Failed to add traces to datasets.",
+    "description": "Error toast when adding traces to evaluation datasets fails"
   },
   "FmKAee": {
     "defaultMessage": "Observability",
@@ -5539,6 +5555,10 @@
     "defaultMessage": "Current Spend",
     "description": "Budget current spend column header"
   },
+  "KyKszW": {
+    "defaultMessage": "Added to {count, plural, one {{name}} other {# datasets}}",
+    "description": "Success toast shown on the playground after adding the current prompt to one or more evaluation datasets"
+  },
   "Kya8N3": {
     "defaultMessage": "Pass",
     "description": "Passing evaluation status in the evaluations table."
@@ -5826,6 +5846,10 @@
   "MEbk2j": {
     "defaultMessage": "Source",
     "description": "Trace filter field: source name"
+  },
+  "MFHrh9": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Button text for adding a trace to an evaluation dataset"
   },
   "MGTSWI": {
     "defaultMessage": "Remove filter",
@@ -6231,10 +6255,6 @@
     "defaultMessage": "One last step to run issue detection",
     "description": "Headline of the API key step in the issue detection modal"
   },
-  "NekUba": {
-    "defaultMessage": "Add to dataset",
-    "description": "Button text for adding a trace to an evaluation dataset"
-  },
   "NhEmyj": {
     "defaultMessage": "Training runs",
     "description": "Label for the training runs tab in the MLflow experiment navbar"
@@ -6470,6 +6490,10 @@
   "OWfx/j": {
     "defaultMessage": "Regression",
     "description": "Label for experiments focused on regression modeling"
+  },
+  "OX5CBk": {
+    "defaultMessage": "Add to datasets",
+    "description": "Label for the playground top-bar button that opens the add-to-evaluation-datasets modal"
   },
   "OXcY79": {
     "defaultMessage": "Profile",
@@ -6978,10 +7002,6 @@
   "Qb78hE": {
     "defaultMessage": "Messages",
     "description": "Subsection header listing messages of the selected prompt version on the playground prompt-registry picker modal"
-  },
-  "QcEYpD": {
-    "defaultMessage": "Add to evaluation dataset",
-    "description": "Add traces to evaluation dataset action"
   },
   "QevoXx": {
     "defaultMessage": "Error details",
@@ -8711,6 +8731,10 @@
     "defaultMessage": "Reset period",
     "description": "Budget reset period column header"
   },
+  "XLIJ6w": {
+    "defaultMessage": "Add expected response",
+    "description": "Label of the checkbox that opts into storing an expected response on the playground add-to-dataset modal"
+  },
   "XLSmZx": {
     "defaultMessage": "Create prompt version",
     "description": "A header for the create prompt version modal in the prompt management UI"
@@ -8991,6 +9015,10 @@
     "defaultMessage": "No matching users",
     "description": "Add to review queue: no users match the search"
   },
+  "YZB/ur": {
+    "defaultMessage": "Adding to multi-turn datasets is not yet supported.",
+    "description": "Error message when a multi-turn evaluation dataset is selected in the dataset picker"
+  },
   "YZDyOo": {
     "defaultMessage": "Path:",
     "description": "Label to display the full path of where the artifact of the experiment runs is located"
@@ -9126,10 +9154,6 @@
   "ZAqdq9": {
     "defaultMessage": "Edit API key",
     "description": "Gateway > API key details drawer > Edit API key button aria label"
-  },
-  "ZBRK9J": {
-    "defaultMessage": "Export traces to datasets",
-    "description": "Export traces to dataset modal title"
   },
   "ZBZBrn": {
     "defaultMessage": "Input /1M",
@@ -9338,10 +9362,6 @@
   "a0NgR8": {
     "defaultMessage": "Type",
     "description": "Header for \"type\" column in the UC table schema"
-  },
-  "a1liZ7": {
-    "defaultMessage": "Export",
-    "description": "Export traces to dataset modal action button"
   },
   "a3G5A7": {
     "defaultMessage": "Provider",
@@ -9638,6 +9658,10 @@
   "bDtS96": {
     "defaultMessage": "Created:",
     "description": "Endpoint expanded created label"
+  },
+  "bFkH7V": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel-button label on the playground add-to-evaluation-dataset modal"
   },
   "bGHzui": {
     "defaultMessage": "Custom judge",
@@ -12179,6 +12203,14 @@
     "defaultMessage": "Discard",
     "description": "Experiment page > artifact compare view > prompt lab artifact synchronization > submit button label"
   },
+  "kNUE3r": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Add traces to evaluation dataset action"
+  },
+  "kPXtWR": {
+    "defaultMessage": "Add to evaluation datasets",
+    "description": "Title of the add-to-evaluation-datasets modal"
+  },
   "kQ9rmr": {
     "defaultMessage": "Operator",
     "description": "Usage overview > filter row > operator column label"
@@ -13123,10 +13155,6 @@
     "defaultMessage": "Manage questions",
     "description": "Review queue sidebar: manage-questions button"
   },
-  "oLHs0C": {
-    "defaultMessage": "Add to dataset",
-    "description": "Button text for adding a trace to a dataset"
-  },
   "oM+XmM": {
     "defaultMessage": "Column options for {column}",
     "description": "Accessible label for the per-column options menu button in the traces table header"
@@ -13675,6 +13703,10 @@
     "defaultMessage": "Edit access endpoint",
     "description": "Aria label for edit access endpoint button"
   },
+  "qgLMU0": {
+    "defaultMessage": "Search by dataset name",
+    "description": "Placeholder for the dataset search input in the evaluation dataset picker"
+  },
   "qhOwHa": {
     "defaultMessage": "Endpoints",
     "description": "Sidebar link for gateway endpoints"
@@ -13974,6 +14006,10 @@
   "rt9clc": {
     "defaultMessage": "Return a 400 error with the guardrail name and reason. The original request or response is not passed through.",
     "description": "Block action description"
+  },
+  "rv0xwU": {
+    "defaultMessage": "Stored as expectations.expected_response — the reference answer that judges such as Correctness compare against.",
+    "description": "Hint under the expected-response editor on the playground add-to-dataset modal"
   },
   "rvRhzv": {
     "defaultMessage": "Masked Key:",
@@ -14779,6 +14815,10 @@
     "defaultMessage": "Processing",
     "description": "Processing indicator while Assistant is streaming a response"
   },
+  "vY4UFz": {
+    "defaultMessage": "Inputs",
+    "description": "Header of the input-messages preview in the playground add-to-dataset modal"
+  },
   "vaJYHp": {
     "defaultMessage": "At least one form field has incorrect value. Please correct and try again.",
     "description": "Generic error message for an invalid form input"
@@ -15418,6 +15458,10 @@
   "xyQFjH": {
     "defaultMessage": "Prompt Caching",
     "description": "Filter option for prompt caching support"
+  },
+  "xzUBOm": {
+    "defaultMessage": "Failed to add the record to the dataset",
+    "description": "Fallback error shown when adding a playground prompt to an evaluation dataset fails"
   },
   "y2oQyU": {
     "defaultMessage": "Model name",

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.test.tsx
@@ -69,7 +69,7 @@ describe('GenAITracesTableActions — Run judges', () => {
     createTestTraceInfoV3('trace-2', 'req-2', 'World', [], EXPERIMENT_ID),
   ];
 
-  it('shows "Run judges" alongside "Add to evaluation dataset" when both actions are provided', async () => {
+  it('shows "Run judges" alongside "Add to evaluation datasets" when both actions are provided', async () => {
     renderActions(
       {
         exportToEvals: true,
@@ -81,7 +81,7 @@ describe('GenAITracesTableActions — Run judges', () => {
     await openActionsDropdown();
 
     expect(screen.getByRole('menuitem', { name: 'Run judges' })).toBeInTheDocument();
-    expect(screen.getByRole('menuitem', { name: 'Add to evaluation dataset' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Add to evaluation datasets' })).toBeInTheDocument();
   });
 
   it('shows "Run judges" even when exportToEvals is false', async () => {
@@ -96,7 +96,7 @@ describe('GenAITracesTableActions — Run judges', () => {
     await openActionsDropdown();
 
     expect(screen.getByRole('menuitem', { name: 'Run judges' })).toBeInTheDocument();
-    expect(screen.queryByRole('menuitem', { name: 'Add to evaluation dataset' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Add to evaluation datasets' })).not.toBeInTheDocument();
   });
 
   it('does not show "Run judges" when runJudgesAction is not provided', async () => {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/GenAITracesTableActions.tsx
@@ -318,7 +318,7 @@ const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
                           onClick={handleExportToDatasets}
                         >
                           {intl.formatMessage({
-                            defaultMessage: 'Add to evaluation dataset',
+                            defaultMessage: 'Add to evaluation datasets',
                             description: 'Add traces to evaluation dataset action',
                           })}
                         </DropdownMenu.Item>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDrawer.tsx
@@ -208,7 +208,7 @@ export const ModelTraceExplorerDrawer = ({
                 icon={<PlusIcon />}
               >
                 <FormattedMessage
-                  defaultMessage="Add to dataset"
+                  defaultMessage="Add to evaluation datasets"
                   description="Button text for adding a trace to a dataset"
                 />
               </Button>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AddToDatasetButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AddToDatasetButton.tsx
@@ -18,7 +18,7 @@ export const AddToDatasetButton = () => {
       size="small"
     >
       <FormattedMessage
-        defaultMessage="Add to dataset"
+        defaultMessage="Add to evaluation datasets"
         description="Button text for adding a trace to an evaluation dataset"
       />
     </Button>


### PR DESCRIPTION
### Related Issues/PRs

Relates to the prompt playground ↔ evaluation integration effort (adding a prompt to a dataset; running judges on a playground prompt is a follow-up).

### What changes are proposed in this pull request?

Adds an **Add to dataset** button to the prompt playground top bar. It opens a modal that saves the current prompt as a record in one or more evaluation datasets:

- The conversation turns (with `{{ variables }}` resolved) are stored as `inputs.messages` — the single-turn schema the datasets UI and built-in judges expect.
- The latest assistant reply pre-fills an editable **Expected response** field, stored as `expectations.expected_response` — the key reference-based judges such as `Correctness` read — so the record is immediately scorable. Left blank, the record is created with inputs only.

The dataset picker mirrors the existing `ExportTracesToDatasetModal` and reuses its building blocks rather than introducing new ones: `useSearchEvaluationDatasets` (server-side name filter + infinite scroll), the checkbox dataset table (multi-select), the inline `CreateEvaluationDatasetButton`, the `useCheckMultiturnDatasets` guard (blocks adding a `messages` record into a multi-turn dataset), and `useUpsertDatasetRecordsMutation` for the write. No new backend surface.

New pure helpers in `datasetRecord.ts` own the conversation → record mapping (latest-assistant extraction, variable substitution, empty-turn filtering, expectations omission).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New suites: `datasetRecord.test.ts` (record-mapping logic) and `AddToDatasetModal.test.tsx` (selection, prefill, upsert payload, empty/no-input/multi-turn states); `PlaygroundTopBar.test.tsx` extended for the new button. Existing `PlaygroundPage.test.tsx` (31 tests) passes unchanged. `type-check`, `lint`, `prettier:check`, and `i18n:check` are clean.

Manually verified end-to-end on the dev server: added a prompt from the playground and confirmed the stored record via `GET /ajax-api/3.0/mlflow/datasets/{id}/records`:

```json
{
  "inputs": { "messages": [{ "role": "user", "content": "what in mlflow" }] },
  "expectations": { "expected_response": "test" }
}
```

<img width="1530" height="711" alt="img1" src="https://github.com/user-attachments/assets/b21d74fd-f0c9-4968-bc77-41d3549f38fa" />
<img width="968" height="836" alt="img2" src="https://github.com/user-attachments/assets/786af193-07e3-42d6-b960-153ce75460a5" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The prompt playground can now save the current prompt — with an optional expected response — as a record in an evaluation dataset, so prompts iterated on in the playground can flow directly into judge-based evaluation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release