### PR TITLE
fix(tracing): avoid recursion in span aggregation

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -235,8 +235,10 @@ def _aggregate_from_spans(
         else:
             roots.append(span)
 
-    def dfs(span: LiveSpan, ancestor_has_data: bool) -> None:
-        nonlocal has_data
+    stack: list[tuple[LiveSpan, bool]] = [(root, False) for root in reversed(roots)]
+
+    while stack:
+        span, ancestor_has_data = stack.pop()
 
         data = span.get_attribute(attribute_key)
         span_has_data = data is not None
@@ -250,11 +252,9 @@ def _aggregate_from_spans(
             has_data = True
 
         next_ancestor_has_data = ancestor_has_data or span_has_data
-        for child in children_map.get(span.span_id, []):
-            dfs(child, next_ancestor_has_data)
 
-    for root in roots:
-        dfs(root, False)
+        children = children_map.get(span.span_id, [])
+        stack.extend((child, next_ancestor_has_data) for child in reversed(children))
 
     if not has_data:
         return None

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -101,6 +101,46 @@ def test_aggregate_usage_from_spans():
     }
 
 
+def test_aggregate_usage_from_spans_deep_tree():
+    depth = 1100
+
+    spans = []
+    parent_id = None
+
+    for i in range(depth):
+        span_id = i + 1
+
+    spans.append(
+        LiveSpan(
+            create_mock_otel_span(
+                "trace_id",
+                span_id=span_id,
+                parent_id=parent_id,
+                name=f"span_{i}",
+            ),
+            trace_id="tr-123",
+        )
+    )
+    parent_id = span_id
+
+    spans[-1].set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 10,
+            TokenUsageKey.OUTPUT_TOKENS: 5,
+            TokenUsageKey.TOTAL_TOKENS: 15,
+        },
+    )
+
+    usage = aggregate_usage_from_spans(spans)
+
+    assert usage == {
+        TokenUsageKey.INPUT_TOKENS: 10,
+        TokenUsageKey.OUTPUT_TOKENS: 5,
+        TokenUsageKey.TOTAL_TOKENS: 15,
+    }
+
+
 def test_aggregate_usage_from_spans_skips_descendant_usage():
     spans = [
         LiveSpan(create_mock_otel_span("trace_id", span_id=1, name="root"), trace_id="tr-123"),


### PR DESCRIPTION
### Related Issues/PRs

Closes #19284

### What changes are proposed in this pull request?

This PR replaces the recursive span aggregation traversal with an iterative implementation to avoid recursion-related limitations when processing deeply nested span hierarchies. The change preserves the existing aggregation behavior while improving robustness for deeply nested traces.

Additionally, the existing tests were updated to validate the iterative implementation and ensure the aggregation results remain unchanged.

### How is this PR tested?

* [x] Existing unit/integration tests
* [x] New unit/integration tests
* [ ] Manual tests

**Test command:**

```bash
pytest tests/tracing/
```

### Does this PR require documentation update?

* [x] No.

### Does this PR require updating the MLflow Skills repository?

* [x] No.

### Release Notes

#### Is this a user-facing change?

* [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

* [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

* [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

* [ ] This PR is critical and needs to be in the next patch release
* [x] This PR can wait for the next minor release

