### PR TITLE
Handle uncut `{major}.x` minor in `DatabricksRuntimeVersion.parse`

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -334,6 +334,17 @@ _dbconnect_udf_sandbox_info_cache: DBConnectUDFSandboxInfo | None = None
 _UNCUT_MINOR = 999
 
 
+def _parse_minor_token(minor_token: str) -> int:
+    """
+    Parse a Databricks runtime minor-version token into a comparable int.
+
+    In DBR, an ``x`` (or ``x-<suffix>``) minor denotes the latest *uncut* minor of a major, which
+    is always ahead of any already-released minor. A numeric token parses as-is; any non-numeric
+    token maps to ``_UNCUT_MINOR`` (a ceiling) so ``{major}.x`` sorts above every concrete minor.
+    """
+    return int(minor_token) if minor_token.isdigit() else _UNCUT_MINOR
+
+
 def parse_dbr_runtime_major_minor(dbr_version: str) -> tuple[int, int]:
     """
     Extract the leading ``(major, minor)`` integer components from a raw Databricks
@@ -351,7 +362,7 @@ def parse_dbr_runtime_major_minor(dbr_version: str) -> tuple[int, int]:
     """
     parts = dbr_version.split(".")
     major = int(parts[0])
-    minor = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else _UNCUT_MINOR
+    minor = _parse_minor_token(parts[1]) if len(parts) > 1 else _UNCUT_MINOR
     return major, minor
 
 
@@ -1404,11 +1415,14 @@ class DatabricksRuntimeVersion(NamedTuple):
             if dbr_version_splits[0] == "client":
                 is_client_image = True
                 major = int(dbr_version_splits[1])
-                minor = int(dbr_version_splits[2]) if len(dbr_version_splits) > 2 else 0
+                has_minor = len(dbr_version_splits) > 2
+                minor = _parse_minor_token(dbr_version_splits[2]) if has_minor else 0
             else:
                 is_client_image = False
                 major = int(dbr_version_splits[0])
-                minor = int(dbr_version_splits[1])
+                # A missing minor (e.g. bare "13") is still an error; a present but non-numeric
+                # minor (e.g. "18.x-photon-scala2") is the latest uncut minor of that major.
+                minor = _parse_minor_token(dbr_version_splits[1])
             return cls(is_client_image, major, minor, is_gpu_image)
         except Exception:
             raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -365,6 +365,12 @@ def parse_dbr_runtime_major_minor(dbr_version: str) -> tuple[int, int]:
     In DBR, ``{major}.x`` denotes the latest *uncut* minor of that major, which is always ahead
     of any already-released minor. So a non-numeric minor (e.g. ``'x'``) maps to ``_UNCUT_MINOR``
     (a ceiling), ensuring ``{major}.x`` compares greater than any concrete ``{major}.{minor}``.
+
+    Note: the SQL ``dbr_version`` string always carries a minor (or ``.x``), so a bare major
+    (``'18'``) is not expected here and is tolerated as uncut. This differs from
+    ``DatabricksRuntimeVersion.parse``, whose env-var input treats a bare major as malformed and
+    raises — the two entry points parse different-shaped inputs, so the contracts intentionally
+    differ.
     """
     parts = dbr_version.split(".")
     major = int(parts[0])
@@ -1430,8 +1436,10 @@ class DatabricksRuntimeVersion(NamedTuple):
                 # minor (e.g. "18.x-photon-scala2") is the latest uncut minor of that major.
                 minor = _parse_minor_token(dbr_version_splits[1])
             return cls(is_client_image, major, minor, is_gpu_image)
-        except Exception:
-            raise MlflowException(f"Failed to parse databricks runtime version '{dbr_version}'.")
+        except Exception as e:
+            raise MlflowException(
+                f"Failed to parse databricks runtime version '{dbr_version}'."
+            ) from e
 
 
 def get_databricks_runtime_major_minor_version():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import platform
+import re
 import subprocess
 import time
 from dataclasses import dataclass
@@ -333,6 +334,9 @@ _dbconnect_udf_sandbox_info_cache: DBConnectUDFSandboxInfo | None = None
 # minor above any real cut minor while keeping the parsed version a plain `tuple[int, int]`.
 _UNCUT_MINOR = 999
 
+# ASCII-only decimal digits; `str.isdigit()`/`isdecimal()` also accept non-ASCII digits.
+_ASCII_DIGITS = re.compile(r"[0-9]+")
+
 
 def _parse_minor_token(minor_token: str) -> int:
     """
@@ -343,8 +347,11 @@ def _parse_minor_token(minor_token: str) -> int:
     of any already-released minor, so it maps to ``_UNCUT_MINOR`` (a ceiling) — ensuring
     ``{major}.x`` sorts above every concrete minor. Any other token (e.g. ``'yyy'``) is malformed
     and raises ``ValueError`` so callers surface it rather than silently treating it as uncut.
+
+    Matching uses an explicit ASCII-digit regex rather than ``str.isdigit()``, which also accepts
+    non-ASCII digits (e.g. superscripts, other scripts) that DBR version strings never contain.
     """
-    if minor_token.isdigit():
+    if _ASCII_DIGITS.fullmatch(minor_token):
         return int(minor_token)
     if minor_token == "x" or minor_token.startswith("x-"):
         return _UNCUT_MINOR

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -338,11 +338,17 @@ def _parse_minor_token(minor_token: str) -> int:
     """
     Parse a Databricks runtime minor-version token into a comparable int.
 
-    In DBR, an ``x`` (or ``x-<suffix>``) minor denotes the latest *uncut* minor of a major, which
-    is always ahead of any already-released minor. A numeric token parses as-is; any non-numeric
-    token maps to ``_UNCUT_MINOR`` (a ceiling) so ``{major}.x`` sorts above every concrete minor.
+    A numeric token (``'4'``) parses as-is. In DBR, an ``x`` (or ``x-<suffix>`` such as
+    ``x-photon-scala2``) minor denotes the latest *uncut* minor of a major, which is always ahead
+    of any already-released minor, so it maps to ``_UNCUT_MINOR`` (a ceiling) — ensuring
+    ``{major}.x`` sorts above every concrete minor. Any other token (e.g. ``'yyy'``) is malformed
+    and raises ``ValueError`` so callers surface it rather than silently treating it as uncut.
     """
-    return int(minor_token) if minor_token.isdigit() else _UNCUT_MINOR
+    if minor_token.isdigit():
+        return int(minor_token)
+    if minor_token == "x" or minor_token.startswith("x-"):
+        return _UNCUT_MINOR
+    raise ValueError(f"Unrecognized Databricks runtime minor version token: {minor_token!r}")
 
 
 def parse_dbr_runtime_major_minor(dbr_version: str) -> tuple[int, int]:

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -858,9 +858,19 @@ def test_parse_dbr_runtime_major_minor(dbr_version, expected):
     assert databricks_utils.parse_dbr_runtime_major_minor(dbr_version) == expected
 
 
-@pytest.mark.parametrize("dbr_version", ["17.yyy", "18.foo-bar"])
+@pytest.mark.parametrize(
+    "dbr_version",
+    [
+        "17.yyy",
+        "18.foo-bar",
+        # Non-ASCII digits (superscript '²', Thai '๓') satisfy str.isdigit() but are not valid
+        # DBR minors and must raise rather than be treated as numeric.
+        "15.²",
+        "15.๓",
+    ],
+)
 def test_parse_dbr_runtime_major_minor_malformed(dbr_version):
-    # A malformed minor (not numeric and not the uncut 'x' marker) must raise, not silently
+    # A malformed minor (not ASCII-numeric and not the uncut 'x' marker) must raise, not silently
     # degrade to the uncut sentinel.
     with pytest.raises(ValueError, match="Unrecognized Databricks runtime minor version token"):
         databricks_utils.parse_dbr_runtime_major_minor(dbr_version)

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -976,6 +976,11 @@ def test_print_databricks_deployment_job_url():
         ("client.10.0-gpu", True, 10, 0, True),
         ("14.3-gpu", False, 14, 3, True),
         ("15.1-gpu", False, 15, 1, True),
+        # Newer uncut images have a non-numeric minor -> latest uncut minor of that major.
+        ("18.x-photon-scala2", False, 18, databricks_utils._UNCUT_MINOR, False),
+        ("18.x-aarch64-photon-scala2", False, 18, databricks_utils._UNCUT_MINOR, False),
+        ("client.5.x", True, 5, databricks_utils._UNCUT_MINOR, False),
+        ("18.x-gpu", False, 18, databricks_utils._UNCUT_MINOR, True),
     ],
 )
 def test_databricks_runtime_version_parse(

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -760,9 +760,17 @@ def test_get_databricks_runtime_major_minor_version(
     assert dbr_version.minor == minor
 
 
-def test_get_dbr_major_minor_version_throws_on_invalid_version_key(monkeypatch):
-    # minor version is not allowed to be a string
+def test_get_dbr_major_minor_version_uncut_minor(monkeypatch):
+    # '{major}.x' is the latest uncut minor of that major, not an error.
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "12.x")
+    dbr_version = get_databricks_runtime_major_minor_version()
+    assert dbr_version.major == 12
+    assert dbr_version.minor == databricks_utils._UNCUT_MINOR
+
+
+def test_get_dbr_major_minor_version_throws_on_invalid_version_key(monkeypatch):
+    # A malformed minor (not numeric, not the uncut 'x' marker) is still an error.
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "12.yyy")
     with pytest.raises(MlflowException, match="Failed to parse databricks runtime version"):
         get_databricks_runtime_major_minor_version()
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -850,6 +850,14 @@ def test_parse_dbr_runtime_major_minor(dbr_version, expected):
     assert databricks_utils.parse_dbr_runtime_major_minor(dbr_version) == expected
 
 
+@pytest.mark.parametrize("dbr_version", ["17.yyy", "18.foo-bar"])
+def test_parse_dbr_runtime_major_minor_malformed(dbr_version):
+    # A malformed minor (not numeric and not the uncut 'x' marker) must raise, not silently
+    # degrade to the uncut sentinel.
+    with pytest.raises(ValueError, match="Unrecognized Databricks runtime minor version token"):
+        databricks_utils.parse_dbr_runtime_major_minor(dbr_version)
+
+
 def test_parse_dbr_runtime_uncut_minor_sorts_above_concrete_minor():
     # '{major}.x' is the latest uncut minor and must compare greater than any released minor,
     # including a hypothetical future gate threshold within the same major.
@@ -1089,6 +1097,10 @@ def test_databricks_runtime_version_parse_from_env_version(monkeypatch):
         "client",
         "client.invalid",
         "13",
+        # A malformed minor (not numeric, not the uncut 'x' marker) must still raise.
+        "17.yyy",
+        "18.foo-bar",
+        "client.5.yyy",
     ],
 )
 def test_databricks_runtime_version_parse_invalid(invalid_version):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24336

### What changes are proposed in this pull request?

Follow-up to #24336. That PR fixed `parse_dbr_runtime_major_minor` (which parses the
`current_version().dbr_version` SQL string) and the `spark_udf` runtime gate, but a
**second, independent** parser — `DatabricksRuntimeVersion.parse` — had the same latent
bug and now crashes on newer uncut runtime images:

```
MlflowException: Failed to parse databricks runtime version '18.x-photon-scala2'.
  File mlflow/utils/databricks_utils.py, in DatabricksRuntimeVersion.parse()
    major = int(dbr_version_splits[0])
->  minor = int(dbr_version_splits[1])
```

`DatabricksRuntimeVersion.parse` is fed from a different source (the
`DATABRICKS_RUNTIME_VERSION` env var / version file, via `get_databricks_runtime_version()`),
so #24336 didn't cover it. It did `int(dbr_version_splits[1])`, which throws when the minor
component is the non-numeric `x-photon-scala2`.

This PR:

- Extracts a shared `_parse_minor_token` helper (numeric token -> parsed as-is; any
  non-numeric token -> `_UNCUT_MINOR`, the ceiling sentinel introduced in #24336) and uses
  it in **both** `parse_dbr_runtime_major_minor` and `DatabricksRuntimeVersion.parse`, so the
  two parsers share one rule and can't drift again.
- Preserves the strict contract: a **missing** minor on a non-client image (bare `"13"`), and
  non-numeric **majors** (`"invalid"`, `"client"`, `"client.invalid"`), still raise — only a
  **present but non-numeric minor** maps to the uncut-minor sentinel.

`.x` denotes the latest *uncut* minor of a major, which is always ahead of any released minor,
so the ceiling sentinel is the semantically correct value. All `DatabricksRuntimeVersion`
consumers only compare `major` or use `>=` tuple checks (e.g. `>= (13, 2)`), so a high minor
sentinel is safe.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- Extended `test_databricks_runtime_version_parse` with uncut-image cases:
  `18.x-photon-scala2`, `18.x-aarch64-photon-scala2`, `client.5.x`, `18.x-gpu` — each parses to
  `minor == _UNCUT_MINOR` (and `-gpu` is still detected).
- `test_databricks_runtime_version_parse_invalid` (unchanged) confirms `"13"`, `"client"`,
  `"invalid"`, `"client.invalid"` still raise — a regression guard for the preserved contract.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `DatabricksRuntimeVersion.parse` crashing with `Failed to parse databricks runtime version`
on newer Databricks runtime images whose version string has a non-numeric minor component
(e.g. `18.x-photon-scala2`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
