### PR TITLE
Fix basic-auth before-request validators invoking view functions

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2631,6 +2631,13 @@ BEFORE_REQUEST_VALIDATORS = {
     for http_path, handler, methods in get_endpoints(get_before_request_handler)
     for method in methods
     if "/scorers/online-config" not in http_path
+    # ``get_endpoints`` hardcodes the view function as the handler for explicitly
+    # defined endpoints (e.g. ``/mlflow/issues/invoke``), ignoring the selector we
+    # pass. Keep only genuine auth validators so a view function like
+    # ``_invoke_issue_detection_handler`` isn't mistakenly invoked as a before-request
+    # validator (which would run the endpoint's side effects — creating runs and
+    # submitting jobs — a second time, before the real handler runs).
+    and handler in BEFORE_REQUEST_HANDLERS.values()
 }
 
 # Auth-related routes

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -200,6 +200,37 @@ def test_proxy_artifact_mpu_validator_returns_update_for_post():
     assert validator is auth_module.validate_can_update_experiment_artifact_proxy
 
 
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/ajax-api/3.0/mlflow/issues/invoke", "POST"),
+        ("/ajax-api/3.0/mlflow/genai/evaluate/invoke", "POST"),
+        ("/ajax-api/3.0/mlflow/demo/generate", "POST"),
+        ("/ajax-api/3.0/mlflow/demo/delete", "POST"),
+        ("/ajax-api/3.0/mlflow/jobs/<job_id>", "GET"),
+        ("/ajax-api/3.0/mlflow/jobs/cancel/<job_id>", "PATCH"),
+        ("/graphql", "GET"),
+        ("/api/3.0/mlflow/server-info", "GET"),
+    ],
+)
+def test_before_request_validators_excludes_view_function_endpoints(path, method):
+    # ``get_endpoints`` hardcodes the view function for explicitly defined endpoints,
+    # so without filtering these leak into BEFORE_REQUEST_VALIDATORS and get called as
+    # validators — re-running the endpoint's side effects. Guard against that.
+    assert (path, method) not in auth_module.BEFORE_REQUEST_VALIDATORS
+
+
+def test_before_request_validators_only_contains_real_validators():
+    proto_validators = set(auth_module.BEFORE_REQUEST_HANDLERS.values())
+    leaked = {
+        (path, method): handler
+        for (path, method), handler in auth_module.BEFORE_REQUEST_VALIDATORS.items()
+        if getattr(handler, "__module__", "") == "mlflow.server.handlers"
+        and handler not in proto_validators
+    }
+    assert leaked == {}
+
+
 def test_proxy_artifact_authorization_required(client, monkeypatch):
     username1, password1 = create_user(client.tracking_uri)
     username2, password2 = create_user(client.tracking_uri)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24120

### What changes are proposed in this pull request?

`BEFORE_REQUEST_VALIDATORS` is built from `get_endpoints(get_before_request_handler)`. For explicitly defined endpoints (e.g. `/mlflow/issues/invoke`, `/mlflow/genai/evaluate/invoke`, `/mlflow/demo/*`, `/mlflow/jobs/*`), `get_endpoints` hardcodes the view function as the handler and ignores the selector, so those view functions leak into `BEFORE_REQUEST_VALIDATORS`.

Because `_before_request` calls the resolved validator with no arguments (`if not validator(): ...`) and these view functions also take no arguments, basic-auth ends up **executing the endpoint's view function during the auth phase**, then Flask runs the real view again. For `/issues/invoke` this creates a run and submits an issue-detection job **twice** per request. This only affects non-admin users, since admins short-circuit before the validators run.

This mirrors the leak on the after-request side (#24322): the same view functions are also wrongly registered as after-request handlers, where they're called with the response object and raise `TypeError`. Fixing that path alone would turn the double-submit from a loud 500 into a silent success, so the before-request registration needs the same guard.

The fix restricts the generated validators to genuine auth validators by keeping only handlers present in `BEFORE_REQUEST_HANDLERS.values()`. Dropped entries fall through to the existing "no validator = allow authenticated request" behavior in `_find_validator`, so public reads (GraphQL, server-info, gateway config) are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added `test_before_request_validators_excludes_view_function_endpoints` (parametrized over the leaked endpoints) and `test_before_request_validators_only_contains_real_validators`. The full `tests/server/auth/test_auth.py` suite passes (114 tests).

Manual: started `mlflow server --app-name basic-auth`, created a non-admin user, and sent `POST /ajax-api/3.0/mlflow/issues/invoke`. Before the fix the request created 2 runs; after the fix it creates 1.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where, with the `basic-auth` app enabled, non-admin requests to endpoints such as `/mlflow/issues/invoke` executed the endpoint's side effects twice (e.g. creating duplicate runs and jobs).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release