### PR TITLE
Fix `genai.evaluate` crash when a cloned trace is unavailable

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -487,17 +487,26 @@ class _ScoreSubmitter:
     def run_multi_turn(self, multi_turn_eval_results: dict[str, EvalResult], progress_bar) -> None:
         if not self._multi_turn_scorers or not self._session_groups:
             return
-        futures = [
-            self._pool.submit(
-                self._timed_multi_turn_score,
-                session_id=session_id,
-                session_items=session_items,
-                multi_turn_scorers=self._multi_turn_scorers,
-                scorer_rate_limiter=self._limiter,
-                max_retries=self._max_retries,
+        futures = []
+        for session_id, session_items in self._session_groups.items():
+            # Session groups are built before prediction; a clone read-back miss can null an
+            # item's trace afterwards. Drop those items here since session scoring dereferences
+            # trace (e.g. get_first_trace_in_session reads trace.info.request_time), and skip
+            # sessions left with no scorable trace.
+            scorable_items = [item for item in session_items if item.trace is not None]
+            if not scorable_items:
+                _logger.warning(f"Skipping multi-turn session {session_id} with no traces.")
+                continue
+            futures.append(
+                self._pool.submit(
+                    self._timed_multi_turn_score,
+                    session_id=session_id,
+                    session_items=scorable_items,
+                    multi_turn_scorers=self._multi_turn_scorers,
+                    scorer_rate_limiter=self._limiter,
+                    max_retries=self._max_retries,
+                )
             )
-            for session_id, session_items in self._session_groups.items()
-        ]
         for future in as_completed(futures):
             eval_result = future.result()
             if eval_result.eval_item.trace is None:

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -477,7 +477,8 @@ class _ScoreSubmitter:
                 assessments=eval_result.assessments,
             )
         except Exception as e:
-            trace_id = eval_result.eval_item.trace.info.trace_id
+            trace = eval_result.eval_item.trace
+            trace_id = trace.info.trace_id if trace else "<unknown>"
             _logger.warning(f"Failed to log multi-turn assessments for trace {trace_id}: {e}")
         with self._time_lock:
             self._times.append(time.monotonic() - start)
@@ -499,6 +500,9 @@ class _ScoreSubmitter:
         ]
         for future in as_completed(futures):
             eval_result = future.result()
+            if eval_result.eval_item.trace is None:
+                _logger.warning("Skipping multi-turn result with no trace.")
+                continue
             trace_id = eval_result.eval_item.trace.info.trace_id
             multi_turn_eval_results[trace_id] = eval_result
             if progress_bar:
@@ -784,7 +788,20 @@ def _run_predict(
         if _should_clone_trace(eval_item.trace, run_id, experiment_id):
             try:
                 trace_id = copy_trace_to_experiment(eval_item.trace.to_dict())
-                eval_item.trace = mlflow.get_trace(trace_id)
+                # copy_trace_to_experiment exports asynchronously and returns before the write
+                # is durable; flush=True drains pending async writes on a store miss so this
+                # read-after-write resolves deterministically (no-op on a hit).
+                cloned_trace = mlflow.get_trace(trace_id, flush=True)
+                if cloned_trace is None:
+                    # get_trace returns None (does not raise) on a residual miss, so the except
+                    # below never fires. Record it and null the trace; scoring degrades via the
+                    # guard in _get_new_expectations rather than crashing.
+                    eval_item.error_message = (
+                        f"Cloned trace could not be read back from the tracking store "
+                        f"(trace_id={trace_id}); dataset expectations/tags for this row "
+                        f"were not persisted."
+                    )
+                eval_item.trace = cloned_trace
             except Exception as e:
                 eval_item.error_message = f"Failed to clone trace to the current experiment: {e}"
         else:
@@ -932,6 +949,8 @@ def _compute_eval_scores(
 
 
 def _get_new_expectations(eval_item: EvalItem) -> list[Expectation]:
+    if eval_item.trace is None:
+        return []
     existing_expectations = {
         a.name for a in eval_item.trace.info.assessments if a.expectation is not None
     }

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -920,12 +920,16 @@ def construct_eval_result_df(
 
     try:
         trace_id_to_info = {t.info.trace_id: t.info for t in traces}
+        # Skip results whose trace could not be materialized (e.g. a clone read-back miss
+        # nulled eval_item.trace); otherwise a single missing trace would collapse the entire
+        # result DataFrame to None via the except below.
         traces = [
             Trace(
                 info=trace_id_to_info[eval_result.eval_item.trace.info.trace_id],
                 data=eval_result.eval_item.trace.data,
             )
             for eval_result in eval_results
+            if eval_result.eval_item.trace is not None
         ]
         df = traces_to_df(traces)
         # Add unpacked assessment columns. The result df should look like:
@@ -1011,7 +1015,11 @@ def batch_link_traces_to_run(
         eval_results: List of evaluation results containing traces
         max_batch_size: Maximum number of traces to link per batch call
     """
-    trace_ids = [eval_result.eval_item.trace.info.trace_id for eval_result in eval_results]
+    trace_ids = [
+        eval_result.eval_item.trace.info.trace_id
+        for eval_result in eval_results
+        if eval_result.eval_item.trace is not None
+    ]
     # Batch the trace IDs to avoid overwhelming the MLflow backend
     for i in range(0, len(trace_ids), max_batch_size):
         batch = trace_ids[i : i + max_batch_size]

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -2091,13 +2091,12 @@ def test_run_predict_clone_read_hit_sets_trace_without_error(mlflow_experiment_t
     assert eval_item.error_message is None
 
 
-def test_run_multi_turn_skips_result_with_none_trace():
-    eval_item = _make_eval_item(trace=None)
-    submitter = _ScoreSubmitter(
-        eval_items=[eval_item],
+def _make_score_submitter(session_groups):
+    return _ScoreSubmitter(
+        eval_items=[item for items in session_groups.values() for item in items],
         single_turn_scorers=[],
         multi_turn_scorers=[mock.Mock()],
-        session_groups={"session-1": [eval_item]},
+        session_groups=session_groups,
         run_id=None,
         max_retries=0,
         rps=None,
@@ -2105,11 +2104,29 @@ def test_run_multi_turn_skips_result_with_none_trace():
         max_rps_multiplier=1.0,
         pool_workers=1,
     )
+
+
+def test_run_multi_turn_skips_session_with_only_none_traces():
+    submitter = _make_score_submitter({"session-1": [_make_eval_item(trace=None)]})
     multi_turn_eval_results: dict[str, EvalResult] = {}
     with mock.patch(
         "mlflow.genai.evaluation.harness.evaluate_session_level_scorers",
-        return_value=EvalResult(eval_item=eval_item),
+    ) as mock_eval_session:
+        submitter.run_multi_turn(multi_turn_eval_results, progress_bar=None)
+    mock_eval_session.assert_not_called()
+    assert multi_turn_eval_results == {}
+
+
+def test_run_multi_turn_filters_none_trace_items_from_session(mlflow_experiment_trace):
+    valid_item = _make_eval_item(trace=mlflow_experiment_trace)
+    none_item = _make_eval_item(trace=None)
+    submitter = _make_score_submitter({"session-1": [none_item, valid_item]})
+    multi_turn_eval_results: dict[str, EvalResult] = {}
+    with mock.patch(
+        "mlflow.genai.evaluation.harness.evaluate_session_level_scorers",
+        return_value=EvalResult(eval_item=valid_item),
     ) as mock_eval_session:
         submitter.run_multi_turn(multi_turn_eval_results, progress_bar=None)
     mock_eval_session.assert_called_once()
-    assert multi_turn_eval_results == {}
+    assert mock_eval_session.call_args.kwargs["session_items"] == [valid_item]
+    assert multi_turn_eval_results == {"tr-123": mock_eval_session.return_value}

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -18,9 +18,13 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset, create_dataset
-from mlflow.genai.evaluation.entities import EvaluationResult
+from mlflow.genai.evaluation.entities import EvalItem, EvalResult, EvaluationResult
 from mlflow.genai.evaluation.harness import (
     AUTO_INITIAL_RPS,
+    NoOpRateLimiter,
+    _get_new_expectations,
+    _run_predict,
+    _ScoreSubmitter,
     _should_clone_trace,
     backpressure_buffer,
 )
@@ -2002,3 +2006,110 @@ def test_should_clone_trace_does_not_call_get_experiment_id_when_provided(mlflow
     ):
         _should_clone_trace(mlflow_experiment_trace, run_id="run-1", experiment_id="exp-123")
         mock_get_exp.assert_not_called()
+
+
+def _make_eval_item(trace=None, expectations=None):
+    return EvalItem(
+        request_id="req-1",
+        inputs={"question": "q"},
+        outputs="a",
+        expectations=expectations or {},
+        trace=trace,
+    )
+
+
+def test_get_new_expectations_returns_empty_when_trace_is_none():
+    eval_item = _make_eval_item(trace=None, expectations={"expected": "value"})
+    assert _get_new_expectations(eval_item) == []
+
+
+def test_get_new_expectations_filters_existing(mlflow_experiment_trace):
+    eval_item = _make_eval_item(trace=mlflow_experiment_trace, expectations={"correctness": "yes"})
+    with mock.patch(
+        "mlflow.genai.evaluation.entities.get_context",
+        return_value=mock.Mock(**{"get_user_name.return_value": "tester"}),
+    ):
+        result = _get_new_expectations(eval_item)
+    assert [e.name for e in result] == ["correctness"]
+
+
+def test_run_predict_clone_read_miss_records_error_and_nulls_trace(mlflow_experiment_trace):
+    eval_item = _make_eval_item(trace=mlflow_experiment_trace)
+    with (
+        mock.patch(
+            "mlflow.genai.evaluation.harness._should_clone_trace",
+            return_value=True,
+        ) as mock_should_clone,
+        mock.patch(
+            "mlflow.genai.evaluation.harness.copy_trace_to_experiment",
+            return_value="tr-cloned",
+        ) as mock_copy,
+        mock.patch("mlflow.get_trace", return_value=None) as mock_get_trace,
+    ):
+        _run_predict(
+            eval_item,
+            predict_fn=None,
+            run_id=None,
+            rate_limiter=NoOpRateLimiter(),
+            experiment_id="exp-999",
+        )
+    mock_should_clone.assert_called_once()
+    mock_copy.assert_called_once()
+    mock_get_trace.assert_called_once_with("tr-cloned", flush=True)
+    assert eval_item.trace is None
+    assert "could not be read back" in eval_item.error_message
+
+
+def test_run_predict_clone_read_hit_sets_trace_without_error(mlflow_experiment_trace):
+    eval_item = _make_eval_item(trace=mlflow_experiment_trace)
+    cloned = Trace(
+        info=create_test_trace_info(trace_id="tr-cloned", experiment_id="exp-999"),
+        data=TraceData(spans=[]),
+    )
+    with (
+        mock.patch(
+            "mlflow.genai.evaluation.harness._should_clone_trace",
+            return_value=True,
+        ) as mock_should_clone,
+        mock.patch(
+            "mlflow.genai.evaluation.harness.copy_trace_to_experiment",
+            return_value="tr-cloned",
+        ) as mock_copy,
+        mock.patch("mlflow.get_trace", return_value=cloned) as mock_get_trace,
+    ):
+        _run_predict(
+            eval_item,
+            predict_fn=None,
+            run_id=None,
+            rate_limiter=NoOpRateLimiter(),
+            experiment_id="exp-999",
+        )
+    mock_should_clone.assert_called_once()
+    mock_copy.assert_called_once()
+    mock_get_trace.assert_called_once_with("tr-cloned", flush=True)
+    assert eval_item.trace is cloned
+    assert eval_item.error_message is None
+
+
+def test_run_multi_turn_skips_result_with_none_trace():
+    eval_item = _make_eval_item(trace=None)
+    submitter = _ScoreSubmitter(
+        eval_items=[eval_item],
+        single_turn_scorers=[],
+        multi_turn_scorers=[mock.Mock()],
+        session_groups={"session-1": [eval_item]},
+        run_id=None,
+        max_retries=0,
+        rps=None,
+        adaptive=False,
+        max_rps_multiplier=1.0,
+        pool_workers=1,
+    )
+    multi_turn_eval_results: dict[str, EvalResult] = {}
+    with mock.patch(
+        "mlflow.genai.evaluation.harness.evaluate_session_level_scorers",
+        return_value=EvalResult(eval_item=eval_item),
+    ) as mock_eval_session:
+        submitter.run_multi_turn(multi_turn_eval_results, progress_bar=None)
+    mock_eval_session.assert_called_once()
+    assert multi_turn_eval_results == {}

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -2091,6 +2091,36 @@ def test_run_predict_clone_read_hit_sets_trace_without_error(mlflow_experiment_t
     assert eval_item.error_message is None
 
 
+def test_evaluate_completes_when_cloned_trace_read_back_misses():
+    # Reproduce #24355: a real cross-experiment clone (searched traces live in a different
+    # experiment than the eval run), where the cloned trace's async read-back misses and
+    # returns None. evaluate() must complete without the AttributeError instead of crashing.
+    exp_id = mlflow.set_experiment("traces exp").experiment_id
+    with mlflow.start_span(name="qa") as span:
+        span.set_inputs({"question": "What is MLflow?"})
+        span.set_outputs("MLflow is a tool for ML")
+    mlflow.set_experiment("diff exp")
+
+    trace_df = mlflow.search_traces(locations=[exp_id])
+
+    real_get_trace = mlflow.get_trace
+    first_call = {"seen": False}
+
+    def fake_get_trace(trace_id, *args, **kwargs):
+        # The first get_trace in the pipeline is the clone read-back in _run_predict; null it
+        # to simulate the read-after-write miss. Later calls pass through unchanged.
+        if not first_call["seen"]:
+            first_call["seen"] = True
+            return None
+        return real_get_trace(trace_id, *args, **kwargs)
+
+    with mock.patch("mlflow.get_trace", side_effect=fake_get_trace) as mock_get_trace:
+        result = mlflow.genai.evaluate(data=trace_df, scorers=[has_trace])
+
+    mock_get_trace.assert_any_call(mock.ANY, flush=True)
+    assert result.metrics is not None
+
+
 def _make_score_submitter(session_groups):
     return _ScoreSubmitter(
         eval_items=[item for items in session_groups.values() for item in items],


### PR DESCRIPTION
### Related Issues/PRs

Closes #24355

### What changes are proposed in this pull request?

`mlflow.genai.evaluate(data=mlflow.search_traces(...), scorers=[...])` crashes with `AttributeError: 'NoneType' object has no attribute 'info'` when the evaluation run's experiment differs from the searched traces' experiment (e.g. when launched via `mlflow run`).

In that case the harness clones each trace into the eval run's experiment and immediately re-reads it via `mlflow.get_trace(trace_id)`. The clone export is asynchronous, so the read can race the write and miss; `get_trace` returns `None` on a miss (it does not raise), silently overwriting `eval_item.trace` with `None`. Scoring then dereferences `eval_item.trace.info` and crashes.

Changes in `mlflow/genai/evaluation/harness.py`:

- Pass `flush=True` on the clone read-back so pending async writes are drained on a store miss (no-op on a hit), resolving the read-after-write deterministically.
- On a residual miss, set `eval_item.error_message` (surfaced per-row in the result) instead of silently nulling the trace.
- Guard the `eval_item.trace` dereferences in `_get_new_expectations` and the multi-turn scoring path against `None`.

Changes in `mlflow/genai/utils/trace_utils.py` handle cases where the trace is None. In such cases, we prefer to just exclude the traces from the post eval aggregation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/genai/evaluate/test_evaluation.py` cover the clone read miss/hit paths (asserting `flush=True` and `error_message`), the `_get_new_expectations` guard, and the multi-turn None-trace skip. They fail against the unpatched harness with the original `AttributeError`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a crash in `mlflow.genai.evaluate` when evaluating traces from `mlflow.search_traces` under a different experiment (e.g. via `mlflow run`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

🤖 Co-authored with Claude Code.
