### PR TITLE
Add `deleteExperimentTagApi` redux action

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/actions.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions.test.ts
@@ -10,6 +10,8 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import promiseMiddleware from 'redux-promise-middleware';
 import {
+  DELETE_EXPERIMENT_TAG_API,
+  deleteExperimentTagApi,
   fetchMissingParents,
   fetchMissingParentsWithSearchRuns,
   getEvaluationTableArtifact,
@@ -228,6 +230,37 @@ describe('createRun', () => {
         }),
       }),
     );
+  });
+});
+
+describe('deleteExperimentTagApi', () => {
+  beforeEach(() => {
+    jest.spyOn(MlflowService, 'deleteExperimentTag').mockImplementation(() => Promise.resolve({} as any));
+  });
+
+  afterEach(() => {
+    (MlflowService.deleteExperimentTag as any).mockRestore();
+  });
+
+  it('should dispatch DELETE_EXPERIMENT_TAG_API and call the service with the experiment id and key', () => {
+    const action = deleteExperimentTagApi('experiment-123', 'mlflow.sharedViewState.abc', 'req-id');
+
+    expect(action.type).toEqual(DELETE_EXPERIMENT_TAG_API);
+    expect(action.payload).toBeInstanceOf(Promise);
+    expect(MlflowService.deleteExperimentTag).toHaveBeenCalledWith({
+      experiment_id: 'experiment-123',
+      key: 'mlflow.sharedViewState.abc',
+    });
+    expect(action.meta).toEqual({
+      id: 'req-id',
+      experimentId: 'experiment-123',
+      key: 'mlflow.sharedViewState.abc',
+    });
+  });
+
+  it('should default the request id when one is not provided', () => {
+    const action = deleteExperimentTagApi('experiment-123', 'mlflow.sharedViewState.abc');
+    expect(action.meta.id).toEqual(expect.any(String));
   });
 });
 

--- a/mlflow/server/js/src/experiment-tracking/actions.ts
+++ b/mlflow/server/js/src/experiment-tracking/actions.ts
@@ -585,6 +585,18 @@ export const setExperimentTagApi = (experimentId: any, tagName: any, tagValue: a
   };
 };
 
+export const DELETE_EXPERIMENT_TAG_API = 'DELETE_EXPERIMENT_TAG_API';
+export const deleteExperimentTagApi = (experimentId: string, tagName: string, id = getUUID()) => {
+  return {
+    type: DELETE_EXPERIMENT_TAG_API,
+    payload: MlflowService.deleteExperimentTag({
+      experiment_id: experimentId,
+      key: tagName,
+    }),
+    meta: { id, experimentId, key: tagName },
+  };
+};
+
 export const CLOSE_ERROR_MODAL = 'CLOSE_ERROR_MODAL';
 export const closeErrorModal = () => {
   return {


### PR DESCRIPTION
> **📚 Part of a stack** (ML-66716 saved views) — review/merge top to bottom, i.e. base first (#24358 → #24359 → #24360):
> 1. **#24358 — `deleteExperimentTagApi` redux action** ◀ this PR
> 2. #24359 — saved-view tag-value envelope codec + list selector
> 3. #24360 — saved-views management UI + share consolidation
>
> All three target `master` (the intermediate branches aren't on the upstream repo, so each PR's diff is cumulative). **The commit new to this PR is `d9fb65cd5`** — earlier entries in the stack, if any, are already reflected here.

### Related Issues/PRs

Relates to #16964

### What changes are proposed in this pull request?

Adds `deleteExperimentTagApi`, the redux thunk twin of the existing `setExperimentTagApi`, for deleting an experiment tag. The underlying `MlflowService.deleteExperimentTag` service method already exists; this wires it into the redux action layer so callers can dispatch a tag deletion.

This is a small foundation for the upcoming saved-views management UI (later in this stack), which deletes a saved view by removing its backing experiment tag. It has no callers yet on its own.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
