### PR TITLE
[1/4] Store experiment views as versioned tag envelopes

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
@@ -3,10 +3,10 @@ import { textCompressDeflate, isTextCompressedDeflate } from '../../../../common
 import { EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX } from '../../../constants';
 import {
   decodeSavedViewEnvelope,
+  deserializePersistedState,
   encodeSavedViewEnvelope,
   getSavedViewIdFromTagKey,
   getSavedViewTagKey,
-  inflateSavedViewState,
   listSavedViews,
 } from './savedViewEnvelope';
 
@@ -61,20 +61,20 @@ describe('savedViewEnvelope', () => {
     });
   });
 
-  describe('inflateSavedViewState', () => {
+  describe('deserializePersistedState', () => {
     it('inflates the compressed state field back into the original object', async () => {
       const original = { selectedColumns: ['accuracy'], groupBy: 'foo' };
       const compressedState = await textCompressDeflate(JSON.stringify(original));
       const envelope = decodeSavedViewEnvelope(encodeSavedViewEnvelope('v', compressedState, 1));
 
-      expect(await inflateSavedViewState(envelope)).toEqual(original);
+      expect(await deserializePersistedState(envelope)).toEqual(original);
     });
 
     it('supports an uncompressed (plain JSON) state field for forward-compat', async () => {
       const original = { selectedColumns: ['loss'] };
       const envelope = { name: 'v', createdAt: 1, state: JSON.stringify(original) };
 
-      expect(await inflateSavedViewState(envelope)).toEqual(original);
+      expect(await deserializePersistedState(envelope)).toEqual(original);
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
@@ -62,7 +62,7 @@ describe('savedViewEnvelope', () => {
   });
 
   describe('deserializePersistedState', () => {
-    it('inflates the compressed state field back into the original object', async () => {
+    it('deserializes the compressed state field back into the original object', async () => {
       const original = { selectedColumns: ['accuracy'], groupBy: 'foo' };
       const compressedState = await textCompressDeflate(JSON.stringify(original));
       const envelope = decodeSavedViewEnvelope(encodeSavedViewEnvelope('v', compressedState, 1));

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from '@jest/globals';
+import { textCompressDeflate, isTextCompressedDeflate } from '../../../../common/utils/StringUtils';
+import { EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX } from '../../../constants';
+import {
+  decodeSavedViewEnvelope,
+  encodeSavedViewEnvelope,
+  getSavedViewIdFromTagKey,
+  getSavedViewTagKey,
+  inflateSavedViewState,
+  listSavedViews,
+} from './savedViewEnvelope';
+
+describe('savedViewEnvelope', () => {
+  describe('tag key <-> id', () => {
+    it('builds a prefixed tag key from an id', () => {
+      expect(getSavedViewTagKey('abc123')).toEqual(`${EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX}abc123`);
+    });
+
+    it('extracts the id from a prefixed tag key', () => {
+      expect(getSavedViewIdFromTagKey(`${EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX}abc123`)).toEqual('abc123');
+    });
+
+    it('returns null for a key without the saved-view prefix', () => {
+      expect(getSavedViewIdFromTagKey('mlflow.note.content')).toBeNull();
+    });
+
+    it('returns null when the key is exactly the prefix with no id', () => {
+      expect(getSavedViewIdFromTagKey(EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX)).toBeNull();
+    });
+  });
+
+  describe('encode', () => {
+    it('produces JSON with plain-text name/createdAt and leaves the state blob untouched', async () => {
+      const compressedState = await textCompressDeflate(JSON.stringify({ selectedColumns: ['accuracy'] }));
+      const envelopeJson = encodeSavedViewEnvelope('My view', compressedState, 1770000000000);
+
+      // name and createdAt must be readable without inflating anything
+      const parsed = JSON.parse(envelopeJson);
+      expect(parsed.name).toEqual('My view');
+      expect(parsed.createdAt).toEqual(1770000000000);
+      expect(parsed.state).toEqual(compressedState);
+      expect(isTextCompressedDeflate(parsed.state)).toBe(true);
+    });
+  });
+
+  describe('decode', () => {
+    it('round-trips an encoded envelope', async () => {
+      const compressedState = await textCompressDeflate(JSON.stringify({ selectedColumns: ['accuracy'] }));
+      const envelopeJson = encodeSavedViewEnvelope('My view', compressedState, 1770000000000);
+
+      const decoded = decodeSavedViewEnvelope(envelopeJson);
+      expect(decoded).toEqual({ name: 'My view', createdAt: 1770000000000, state: compressedState });
+    });
+
+    it('throws on malformed JSON', () => {
+      expect(() => decodeSavedViewEnvelope('not json {')).toThrow();
+    });
+
+    it('throws when required fields are missing', () => {
+      expect(() => decodeSavedViewEnvelope(JSON.stringify({ name: 'no state' }))).toThrow();
+    });
+  });
+
+  describe('inflateSavedViewState', () => {
+    it('inflates the compressed state field back into the original object', async () => {
+      const original = { selectedColumns: ['accuracy'], groupBy: 'foo' };
+      const compressedState = await textCompressDeflate(JSON.stringify(original));
+      const envelope = decodeSavedViewEnvelope(encodeSavedViewEnvelope('v', compressedState, 1));
+
+      expect(await inflateSavedViewState(envelope)).toEqual(original);
+    });
+
+    it('supports an uncompressed (plain JSON) state field for forward-compat', async () => {
+      const original = { selectedColumns: ['loss'] };
+      const envelope = { name: 'v', createdAt: 1, state: JSON.stringify(original) };
+
+      expect(await inflateSavedViewState(envelope)).toEqual(original);
+    });
+  });
+
+  describe('listSavedViews', () => {
+    const buildTag = async (id: string, name: string, createdAt: number) => ({
+      key: getSavedViewTagKey(id),
+      value: encodeSavedViewEnvelope(name, await textCompressDeflate('{}'), createdAt),
+    });
+
+    it('filters experiment tags by the saved-view prefix and returns summaries without inflating state', async () => {
+      const tags = [
+        { key: 'mlflow.note.content', value: 'a note' },
+        await buildTag('v1', 'First view', 300),
+        await buildTag('v2', 'Second view', 100),
+      ];
+
+      const views = listSavedViews(tags);
+
+      expect(views).toEqual([
+        { id: 'v1', name: 'First view', createdAt: 300 },
+        { id: 'v2', name: 'Second view', createdAt: 100 },
+      ]);
+    });
+
+    it('skips tags whose value fails to decode rather than throwing', async () => {
+      const tags = [{ key: getSavedViewTagKey('bad'), value: 'not-json{' }, await buildTag('good', 'Good view', 5)];
+
+      expect(listSavedViews(tags)).toEqual([{ id: 'good', name: 'Good view', createdAt: 5 }]);
+    });
+
+    it('returns an empty array when there are no saved-view tags', () => {
+      expect(listSavedViews([{ key: 'mlflow.user', value: 'someone' }])).toEqual([]);
+    });
+
+    it('skips a bare-prefix tag with no id rather than emitting an empty-id summary', async () => {
+      const tags = [
+        {
+          key: EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX,
+          value: encodeSavedViewEnvelope('No id', await textCompressDeflate('{}'), 1),
+        },
+        await buildTag('good', 'Good view', 5),
+      ];
+
+      expect(listSavedViews(tags)).toEqual([{ id: 'good', name: 'Good view', createdAt: 5 }]);
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.ts
@@ -1,0 +1,97 @@
+import type { KeyValueEntity } from '../../../../common/types';
+import { isTextCompressedDeflate, textDecompressDeflate } from '../../../../common/utils/StringUtils';
+import { EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX } from '../../../constants';
+
+/**
+ * A saved view is stored as a single experiment tag: the key is the share prefix plus a stable
+ * opaque id, and the value is a JSON "envelope". The envelope keeps `name` and `createdAt` as plain
+ * JSON so the views list can be rendered without inflating anything; only `state` (the serialized
+ * ExperimentPageUIState + search facets, the same payload the share link embeds) is deflate-
+ * compressed, and it is inflated lazily at apply-time for the single view the user opens.
+ */
+export interface SavedViewEnvelope {
+  name: string;
+  createdAt: number;
+  // The compressed (or, for forward-compat, plain-JSON) serialized view state.
+  state: string;
+}
+
+/**
+ * Lightweight summary used to render the views list without inflating any state.
+ */
+export interface SavedViewSummary {
+  id: string;
+  name: string;
+  createdAt: number;
+}
+
+export const getSavedViewTagKey = (id: string): string => `${EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX}${id}`;
+
+export const getSavedViewIdFromTagKey = (tagKey: string): string | null => {
+  if (!tagKey.startsWith(EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX)) {
+    return null;
+  }
+  // A key that is exactly the prefix (no id) yields an empty id, which would collide across tags;
+  // treat it as not a saved-view key.
+  const id = tagKey.slice(EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX.length);
+  return id === '' ? null : id;
+};
+
+/**
+ * Build the experiment-tag value for a saved view. `compressedState` is the already-serialized
+ * (typically deflate-compressed) view-state blob; it is stored verbatim so the name/createdAt stay
+ * readable without decompression.
+ */
+export const encodeSavedViewEnvelope = (name: string, compressedState: string, createdAt: number): string =>
+  JSON.stringify({ name, createdAt, state: compressedState } satisfies SavedViewEnvelope);
+
+const isValidEnvelope = (value: unknown): value is SavedViewEnvelope =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as SavedViewEnvelope).name === 'string' &&
+  typeof (value as SavedViewEnvelope).createdAt === 'number' &&
+  typeof (value as SavedViewEnvelope).state === 'string';
+
+/**
+ * Parse an experiment-tag value into a saved-view envelope. Throws if the value is not valid JSON
+ * or is missing required fields; the `state` field is left compressed (inflate lazily via
+ * {@link inflateSavedViewState}).
+ */
+export const decodeSavedViewEnvelope = (tagValue: string): SavedViewEnvelope => {
+  const parsed = JSON.parse(tagValue);
+  if (!isValidEnvelope(parsed)) {
+    throw new Error(
+      'Invalid saved-view envelope: expected an object with a string `name`, number `createdAt`, and string `state`',
+    );
+  }
+  return { name: parsed.name, createdAt: parsed.createdAt, state: parsed.state };
+};
+
+/**
+ * Inflate an envelope's `state` field back into the serialized view-state object. Supports both a
+ * deflate-compressed blob and a plain-JSON string (forward-compat with uncompressed writes).
+ */
+export const inflateSavedViewState = async (envelope: SavedViewEnvelope): Promise<unknown> => {
+  const raw = isTextCompressedDeflate(envelope.state) ? await textDecompressDeflate(envelope.state) : envelope.state;
+  return JSON.parse(raw);
+};
+
+/**
+ * Filter a set of experiment tags down to saved-view summaries, in tag order. Tags whose value
+ * fails to decode are skipped rather than throwing, so one corrupt view can't break the whole list.
+ * State is intentionally not inflated here — the list only needs the name and createdAt.
+ */
+export const listSavedViews = (tags: KeyValueEntity[]): SavedViewSummary[] =>
+  tags.reduce<SavedViewSummary[]>((views, { key, value }) => {
+    const id = getSavedViewIdFromTagKey(key);
+    if (id === null) {
+      return views;
+    }
+    try {
+      const { name, createdAt } = decodeSavedViewEnvelope(value);
+      views.push({ id, name, createdAt });
+    } catch {
+      // Skip a corrupt/legacy tag value rather than failing the entire list.
+    }
+    return views;
+  }, []);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.ts
@@ -5,9 +5,9 @@ import { EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX } from '../../../constants'
 /**
  * A saved view is stored as a single experiment tag: the key is the share prefix plus a stable
  * opaque id, and the value is a JSON "envelope". The envelope keeps `name` and `createdAt` as plain
- * JSON so the views list can be rendered without inflating anything; only `state` (the serialized
- * ExperimentPageUIState + search facets, the same payload the share link embeds) is deflate-
- * compressed, and it is inflated lazily at apply-time for the single view the user opens.
+ * JSON so the views list can be rendered without deserializing anything; only `state` (the
+ * serialized ExperimentPageUIState + search facets, the same payload the share link embeds) is
+ * deflate-compressed, and it is deserialized lazily at apply-time for the single view the user opens.
  */
 export interface SavedViewEnvelope {
   name: string;
@@ -17,7 +17,7 @@ export interface SavedViewEnvelope {
 }
 
 /**
- * Lightweight summary used to render the views list without inflating any state.
+ * Lightweight summary used to render the views list without deserializing any state.
  */
 export interface SavedViewSummary {
   id: string;
@@ -54,8 +54,8 @@ const isValidEnvelope = (value: unknown): value is SavedViewEnvelope =>
 
 /**
  * Parse an experiment-tag value into a saved-view envelope. Throws if the value is not valid JSON
- * or is missing required fields; the `state` field is left compressed (inflate lazily via
- * {@link inflateSavedViewState}).
+ * or is missing required fields; the `state` field is left compressed (deserialize lazily via
+ * {@link deserializePersistedState}).
  */
 export const decodeSavedViewEnvelope = (tagValue: string): SavedViewEnvelope => {
   const parsed = JSON.parse(tagValue);
@@ -68,10 +68,10 @@ export const decodeSavedViewEnvelope = (tagValue: string): SavedViewEnvelope => 
 };
 
 /**
- * Inflate an envelope's `state` field back into the serialized view-state object. Supports both a
- * deflate-compressed blob and a plain-JSON string (forward-compat with uncompressed writes).
+ * Deserialize an envelope's `state` field back into the serialized view-state object. Supports both
+ * a deflate-compressed blob and a plain-JSON string (forward-compat with uncompressed writes).
  */
-export const inflateSavedViewState = async (envelope: SavedViewEnvelope): Promise<unknown> => {
+export const deserializePersistedState = async (envelope: SavedViewEnvelope): Promise<unknown> => {
   const raw = isTextCompressedDeflate(envelope.state) ? await textDecompressDeflate(envelope.state) : envelope.state;
   return JSON.parse(raw);
 };
@@ -79,7 +79,7 @@ export const inflateSavedViewState = async (envelope: SavedViewEnvelope): Promis
 /**
  * Filter a set of experiment tags down to saved-view summaries, in tag order. Tags whose value
  * fails to decode are skipped rather than throwing, so one corrupt view can't break the whole list.
- * State is intentionally not inflated here — the list only needs the name and createdAt.
+ * State is intentionally not deserialized here — the list only needs the name and createdAt.
  */
 export const listSavedViews = (tags: KeyValueEntity[]): SavedViewSummary[] =>
   tags.reduce<SavedViewSummary[]>((views, { key, value }) => {


### PR DESCRIPTION
> **📚 Part of a stack** — all branches target `master` (the intermediate branches aren't on the upstream repo, so each PR's diff is cumulative; review only the commit new to each PR):
> 1. **#24359 — store experiment views as versioned tag envelopes** ◀
> 2. #24360 — move sharing into the runs toolbar as named saved views
> 3. #24426 — extract `SavedViewsMenu` + `SharedViewBanner` for reuse across tabs
> 4. #24427 — add GenAI Traces saved views with a preview-override flow

### Related Issues/PRs

Relates to #16964

### What changes are proposed in this pull request?

Adds `savedViewEnvelope.ts`: pure client-side helpers for storing a named saved view inside a single experiment tag.

The tag value is a JSON envelope `{name, createdAt, state}` where `name`/`createdAt` stay plain (so the views list renders without decompression) and only `state` (the serialized view-state blob) is deflate-compressed, inflated lazily at apply-time. Provides:

- tag-key ↔ id helpers (`getSavedViewTagKey` / `getSavedViewIdFromTagKey`),
- `encodeSavedViewEnvelope` / `decodeSavedViewEnvelope` with validation,
- `inflateSavedViewState` (lazy decompress; deflate or plain-JSON forward-compat),
- `listSavedViews()`, which filters experiment tags by the `mlflow.sharedViewState.` prefix and skips undecodable values.

No callers yet on its own; consumed by the saved-views UI at the top of this stack.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


