### PR TITLE
Handle TypeError in dump_span_attribute_value fallback

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -135,7 +135,7 @@ def dump_span_attribute_value(value: Any) -> str:
         # Fall back to a repr-based dump so the span attribute is still set and tracing
         # doesn't crash the user's workflow.
         _logger.debug(
-            "Failed to serialize span attribute value due to %s . Falling back to repr. ",
+            "Failed to serialize span attribute value due to %s. Falling back to repr. ",
             type(e).__name__,
             exc_info=True,
         )

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -128,13 +128,15 @@ def dump_span_attribute_value(value: Any) -> str:
     #   for the simplicity in deserialization process.
     try:
         return json.dumps(value, cls=TraceJSONEncoder, ensure_ascii=False)
-    except ValueError:
+    except (ValueError, TypeError) as e:
         # `json.dumps` raises `ValueError: Circular reference detected` for self-referencing
-        # objects (e.g. pydantic_ai's `run_context`). Fall back to a repr-based dump so the
-        # span attribute is still set and tracing doesn't crash the user's workflow.
+        # objects (e.g. pydantic_ai's `run_context`) and `TypeError` for unsupported
+        # structures such as dictionaries with non-serializable keys (e.g. `frozenset`).
+        # Fall back to a repr-based dump so the span attribute is still set and tracing
+        # doesn't crash the user's workflow.
         _logger.debug(
-            "Failed to serialize span attribute value due to circular reference. "
-            "Falling back to repr.",
+            "Failed to serialize span attribute value due to %s . Falling back to repr. ",
+            type(e).__name__,
             exc_info=True,
         )
         return json.dumps(repr(value), ensure_ascii=False)

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -755,3 +755,15 @@ def test_dump_span_attribute_value_handles_circular_reference():
     loaded = json.loads(result)
     assert isinstance(loaded, str)
     assert "run_context" in loaded
+
+
+def test_dump_span_attribute_value_handles_type_error():
+    value = {frozenset({"listener"}): "handler"}
+
+    with pytest.raises(TypeError, match="frozenset"):
+        json.dumps(value)
+
+    result = dump_span_attribute_value(value)
+
+    # Must not raise; fall back result is a valid JSON string containing repr(value).
+    assert result == json.dumps(repr(value), ensure_ascii=False)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24348

### What changes are proposed in this pull request?

This PR extends the existing fallback behavior in `dump_span_attribute_value()` to handle `TypeError` in addition to `ValueError`.

Previously, span attribute serialization failures caused by circular references were handled by falling back to `repr(value)`, but other serialization failures such as dictionaries containing `frozenset` keys raised `TypeError` and interrupted tracing/autologging.

This change ensures span attribute serialization gracefully falls back to `repr(value)` for both cases.

A regression test has been added to verify the fallback behavior when `json.dumps()` raises `TypeError`.


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
