### PR TITLE
Fix `RecursionError` corrupting deeply nested traces

### DIFF
--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -330,12 +330,20 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
         })
 
         spans = trace.span_dict.values()
-        # Aggregate token usage information from all spans
-        if usage := aggregate_usage_from_spans(spans):
-            trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
+        # Aggregate token usage and cost as best-effort: this metadata is optional, and a
+        # failure here must never abort root-span export / trace finalization (#24344).
+        try:
+            if usage := aggregate_usage_from_spans(spans):
+                trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
 
-        if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
-            trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
+            if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
+                trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
+        except Exception:
+            _logger.warning(
+                "Failed to aggregate token usage/cost for the trace; continuing "
+                "finalization without it.",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
 
     def _truncate_metadata(self, value: str | None) -> str:
         """Get truncated value of the attribute if it exceeds the maximum length."""

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -338,10 +338,11 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
 
             if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
                 trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
-        except Exception:
+        except Exception as e:
             _logger.warning(
-                "Failed to aggregate token usage/cost for the trace; continuing "
-                "finalization without it.",
+                f"Failed to aggregate token usage/cost for trace {trace.info.trace_id}: {e}. "
+                "Continuing finalization without it. For full traceback, set logging level "
+                "to debug.",
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
 

--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -148,10 +148,11 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
 
                 if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
                     trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
-            except Exception:
+            except Exception as e:
                 _logger.warning(
-                    "Failed to aggregate token usage/cost for the trace; continuing "
-                    "finalization without it.",
+                    f"Failed to aggregate token usage/cost for trace {trace_id}: {e}. "
+                    "Continuing finalization without it. For full traceback, set logging "
+                    "level to debug.",
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
 

--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -140,12 +140,20 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
 
             spans = list(trace.span_dict.values())
 
-            # Aggregate token usage information from all spans
-            if usage := aggregate_usage_from_spans(spans):
-                trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
+            # Aggregate token usage and cost as best-effort: this metadata is optional, and
+            # a failure here must never abort root-span export / trace finalization (#24344).
+            try:
+                if usage := aggregate_usage_from_spans(spans):
+                    trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
 
-            if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
-                trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
+                if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
+                    trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
+            except Exception:
+                _logger.warning(
+                    "Failed to aggregate token usage/cost for the trace; continuing "
+                    "finalization without it.",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
 
         super().on_end(span)
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -235,8 +235,14 @@ def _aggregate_from_spans(
         else:
             roots.append(span)
 
-    def dfs(span: LiveSpan, ancestor_has_data: bool) -> None:
-        nonlocal has_data
+    # Iterative DFS with an explicit stack. A recursive walk overflows Python's call
+    # stack for deeply nested traces (~1000+ levels), which used to abort root-span
+    # finalization and permanently corrupt the trace (#24344). Children are pushed in
+    # reverse so that stack.pop() (LIFO) visits them in their original order, matching
+    # the previous recursive traversal exactly.
+    stack: list[tuple[LiveSpan, bool]] = [(root, False) for root in reversed(roots)]
+    while stack:
+        span, ancestor_has_data = stack.pop()
 
         data = span.get_attribute(attribute_key)
         span_has_data = data is not None
@@ -250,11 +256,8 @@ def _aggregate_from_spans(
             has_data = True
 
         next_ancestor_has_data = ancestor_has_data or span_has_data
-        for child in children_map.get(span.span_id, []):
-            dfs(child, next_ancestor_has_data)
-
-    for root in roots:
-        dfs(root, False)
+        children = children_map.get(span.span_id, [])
+        stack.extend((child, next_ancestor_has_data) for child in reversed(children))
 
     if not has_data:
         return None

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -235,12 +235,14 @@ def _aggregate_from_spans(
         else:
             roots.append(span)
 
-    # Iterative DFS with an explicit stack. A recursive walk overflows Python's call
-    # stack for deeply nested traces (~1000+ levels), which used to abort root-span
-    # finalization and permanently corrupt the trace (#24344). Children are pushed in
-    # reverse so that stack.pop() (LIFO) visits them in their original order, matching
-    # the previous recursive traversal exactly.
-    stack: list[tuple[LiveSpan, bool]] = [(root, False) for root in reversed(roots)]
+    # Iterative DFS with an explicit stack, instead of recursion, to avoid overflowing
+    # Python's call stack for deeply nested traces (~1000+ levels). A recursive walk here
+    # used to abort root-span finalization and permanently corrupt the trace.
+    #
+    # Visit order is irrelevant: totals is a sum and has_data an OR (both commutative), and
+    # each span's ancestor_has_data is fixed by its ancestor chain, not by sibling visit
+    # order. So a plain stack (no reversed()) yields identical results.
+    stack: list[tuple[LiveSpan, bool]] = [(root, False) for root in roots]
     while stack:
         span, ancestor_has_data = stack.pop()
 
@@ -256,8 +258,9 @@ def _aggregate_from_spans(
             has_data = True
 
         next_ancestor_has_data = ancestor_has_data or span_has_data
-        children = children_map.get(span.span_id, [])
-        stack.extend((child, next_ancestor_has_data) for child in reversed(children))
+        stack.extend(
+            (child, next_ancestor_has_data) for child in children_map.get(span.span_id, [])
+        )
 
     if not has_data:
         return None

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -35,6 +35,7 @@ from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import (
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
+    TokenUsageKey,
     TraceMetadataKey,
     TraceTagKey,
 )
@@ -268,6 +269,38 @@ def test_trace(wrap_sync_func, with_active_run, async_logging_enabled):
         "mlflow.spanInputs": {"t": 8},
         "mlflow.spanOutputs": 64,
     }
+
+
+def test_deep_trace_is_not_corrupted_by_aggregation(async_logging_enabled):
+    # Regression test for #24344: a trace nested deeper than the recursion limit used to
+    # raise RecursionError while aggregating token usage during root-span finalization,
+    # aborting export and leaving the trace permanently stuck IN_PROGRESS with corrupted
+    # span data. The trace must finalize to a terminal state and be loadable.
+    depth = 1100  # > sys.getrecursionlimit() default of 1000
+
+    spans = [start_span_no_context("root", span_type=SpanType.AGENT)]
+    for i in range(depth):
+        spans.append(start_span_no_context(f"level_{i}", parent_span=spans[-1]))
+
+    spans[-1].set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 10,
+            TokenUsageKey.OUTPUT_TOKENS: 5,
+            TokenUsageKey.TOTAL_TOKENS: 15,
+        },
+    )
+
+    for s in reversed(spans):
+        s.end()
+
+    if async_logging_enabled:
+        mlflow.flush_trace_async_logging(terminate=True)
+
+    trace_id = spans[0].trace_id
+    trace = mlflow.get_trace(trace_id)
+    assert trace is not None
+    assert trace.info.state == TraceState.OK
 
 
 @pytest.mark.parametrize("wrap_sync_func", [True, False])

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -275,21 +275,29 @@ def test_deep_trace_is_not_corrupted_by_aggregation(async_logging_enabled):
     # Regression test for #24344: a trace nested deeper than the recursion limit used to
     # raise RecursionError while aggregating token usage during root-span finalization,
     # aborting export and leaving the trace permanently stuck IN_PROGRESS with corrupted
-    # span data. The trace must finalize to a terminal state and be loadable.
+    # span data. The trace must (a) finalize to a terminal state and be loadable, and
+    # (b) still aggregate token usage correctly across multiple LLM spans.
     depth = 1100  # > sys.getrecursionlimit() default of 1000
 
+    # A deep backbone (no usage) that exceeds the recursion limit...
     spans = [start_span_no_context("root", span_type=SpanType.AGENT)]
     for i in range(depth):
         spans.append(start_span_no_context(f"level_{i}", parent_span=spans[-1]))
 
-    spans[-1].set_attribute(
-        SpanAttributeKey.CHAT_USAGE,
-        {
-            TokenUsageKey.INPUT_TOKENS: 10,
-            TokenUsageKey.OUTPUT_TOKENS: 5,
-            TokenUsageKey.TOTAL_TOKENS: 15,
-        },
-    )
+    # ...ending in a fan of sibling LLM leaves that each carry usage. None is an ancestor
+    # of another, so aggregation must SUM all of them (3 * {10, 5, 15}).
+    backbone_leaf = spans[-1]
+    for j in range(3):
+        leaf = start_span_no_context(f"llm_{j}", span_type=SpanType.LLM, parent_span=backbone_leaf)
+        leaf.set_attribute(
+            SpanAttributeKey.CHAT_USAGE,
+            {
+                TokenUsageKey.INPUT_TOKENS: 10,
+                TokenUsageKey.OUTPUT_TOKENS: 5,
+                TokenUsageKey.TOTAL_TOKENS: 15,
+            },
+        )
+        leaf.end()
 
     for s in reversed(spans):
         s.end()
@@ -301,6 +309,11 @@ def test_deep_trace_is_not_corrupted_by_aggregation(async_logging_enabled):
     trace = mlflow.get_trace(trace_id)
     assert trace is not None
     assert trace.info.state == TraceState.OK
+    assert trace.info.token_usage == {
+        TokenUsageKey.INPUT_TOKENS: 30,
+        TokenUsageKey.OUTPUT_TOKENS: 15,
+        TokenUsageKey.TOTAL_TOKENS: 45,
+    }
 
 
 @pytest.mark.parametrize("wrap_sync_func", [True, False])

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -153,6 +153,85 @@ def test_aggregate_usage_from_spans_skips_descendant_usage():
     }
 
 
+def test_aggregate_usage_from_spans_deep_tree():
+    # A linearly nested trace deeper than the default recursion limit (1000) must not
+    # raise RecursionError during aggregation. Regression test for the deep-trace
+    # corruption bug (#24344). Spans are constructed INSIDE the loop.
+    depth = 1100
+    spans = []
+    parent_id = None
+    for i in range(depth):
+        span_id = i + 1
+        spans.append(
+            LiveSpan(
+                create_mock_otel_span(
+                    "trace_id", span_id=span_id, name=f"span_{i}", parent_id=parent_id
+                ),
+                trace_id="tr-123",
+            )
+        )
+        parent_id = span_id
+
+    spans[-1].set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 10,
+            TokenUsageKey.OUTPUT_TOKENS: 5,
+            TokenUsageKey.TOTAL_TOKENS: 15,
+        },
+    )
+
+    assert aggregate_usage_from_spans(spans) == {
+        TokenUsageKey.INPUT_TOKENS: 10,
+        TokenUsageKey.OUTPUT_TOKENS: 5,
+        TokenUsageKey.TOTAL_TOKENS: 15,
+    }
+
+
+def test_aggregate_usage_from_spans_deep_tree_skips_descendant_usage():
+    # The anti-double-counting invariant must survive the deep-tree traversal: usage on
+    # an ancestor should suppress the same attribute on all its descendants, even past
+    # the recursion limit. Guards the iterative conversion against ancestor-flag bugs.
+    depth = 1100
+    spans = []
+    parent_id = None
+    for i in range(depth):
+        span_id = i + 1
+        spans.append(
+            LiveSpan(
+                create_mock_otel_span(
+                    "trace_id", span_id=span_id, name=f"span_{i}", parent_id=parent_id
+                ),
+                trace_id="tr-123",
+            )
+        )
+        parent_id = span_id
+
+    # Usage on the root (counted) and on the leaf (must be skipped as a descendant).
+    spans[0].set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 10,
+            TokenUsageKey.OUTPUT_TOKENS: 20,
+            TokenUsageKey.TOTAL_TOKENS: 30,
+        },
+    )
+    spans[-1].set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 999,
+            TokenUsageKey.OUTPUT_TOKENS: 999,
+            TokenUsageKey.TOTAL_TOKENS: 999,
+        },
+    )
+
+    assert aggregate_usage_from_spans(spans) == {
+        TokenUsageKey.INPUT_TOKENS: 10,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 30,
+    }
+
+
 def test_aggregate_usage_from_spans_with_cached_tokens():
     spans = [
         LiveSpan(create_mock_otel_span("trace_id", span_id=i, name=f"span_{i}"), trace_id="tr-123")

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -153,67 +153,73 @@ def test_aggregate_usage_from_spans_skips_descendant_usage():
     }
 
 
-def test_aggregate_usage_from_spans_deep_tree():
-    # A linearly nested trace deeper than the default recursion limit (1000) must not
-    # raise RecursionError during aggregation. Regression test for the deep-trace
-    # corruption bug (#24344). Spans are constructed INSIDE the loop.
-    depth = 1100
-    spans = []
-    parent_id = None
-    for i in range(depth):
-        span_id = i + 1
+def _deep_chain(spans, start_id, length, parent_id, name):
+    # Append a chain of `length` spans (no usage) under `parent_id`, returning the id of
+    # the deepest span. Used to push traversal past the recursion limit.
+    for i in range(length):
+        span_id = start_id + i
         spans.append(
             LiveSpan(
                 create_mock_otel_span(
-                    "trace_id", span_id=span_id, name=f"span_{i}", parent_id=parent_id
+                    "trace_id", span_id=span_id, name=f"{name}_{i}", parent_id=parent_id
                 ),
                 trace_id="tr-123",
             )
         )
         parent_id = span_id
+    return parent_id
 
-    spans[-1].set_attribute(
-        SpanAttributeKey.CHAT_USAGE,
-        {
-            TokenUsageKey.INPUT_TOKENS: 10,
-            TokenUsageKey.OUTPUT_TOKENS: 5,
-            TokenUsageKey.TOTAL_TOKENS: 15,
-        },
-    )
 
+def test_aggregate_usage_from_spans_deep_tree_aggregates_leaves():
+    # A deep backbone (no usage) that exceeds the recursion limit, ending in a fan of
+    # sibling leaves that each carry usage. None of the leaves is an ancestor of another,
+    # so aggregation must SUM all of them — the fix must survive the depth AND still
+    # aggregate. Regression test for #24344.
+    spans = [LiveSpan(create_mock_otel_span("trace_id", span_id=1, name="root"), trace_id="tr-123")]
+    deepest = _deep_chain(spans, start_id=2, length=1100, parent_id=1, name="backbone")
+
+    num_leaves = 5
+    for j in range(num_leaves):
+        leaf = LiveSpan(
+            create_mock_otel_span(
+                "trace_id", span_id=10_000 + j, name=f"leaf_{j}", parent_id=deepest
+            ),
+            trace_id="tr-123",
+        )
+        leaf.set_attribute(
+            SpanAttributeKey.CHAT_USAGE,
+            {
+                TokenUsageKey.INPUT_TOKENS: 2,
+                TokenUsageKey.OUTPUT_TOKENS: 3,
+                TokenUsageKey.TOTAL_TOKENS: 5,
+            },
+        )
+        spans.append(leaf)
+
+    # All 5 sibling leaves are summed: 5 * {2, 3, 5}.
     assert aggregate_usage_from_spans(spans) == {
         TokenUsageKey.INPUT_TOKENS: 10,
-        TokenUsageKey.OUTPUT_TOKENS: 5,
-        TokenUsageKey.TOTAL_TOKENS: 15,
+        TokenUsageKey.OUTPUT_TOKENS: 15,
+        TokenUsageKey.TOTAL_TOKENS: 25,
     }
 
 
-def test_aggregate_usage_from_spans_deep_tree_skips_descendant_usage():
-    # The anti-double-counting invariant must survive the deep-tree traversal: usage on
-    # an ancestor should suppress the same attribute on all its descendants, even past
-    # the recursion limit. Guards the iterative conversion against ancestor-flag bugs.
-    depth = 1100
-    spans = []
-    parent_id = None
-    for i in range(depth):
-        span_id = i + 1
-        spans.append(
-            LiveSpan(
-                create_mock_otel_span(
-                    "trace_id", span_id=span_id, name=f"span_{i}", parent_id=parent_id
-                ),
-                trace_id="tr-123",
-            )
-        )
-        parent_id = span_id
+def test_aggregate_usage_from_spans_deep_tree_sums_and_skips_descendants():
+    # A deep tree where usage lives on two independent branches (both counted and summed)
+    # and also on a descendant of a data-bearing span (skipped). Verifies that both real
+    # summation AND the anti-double-counting invariant survive past the recursion limit.
+    spans = [LiveSpan(create_mock_otel_span("trace_id", span_id=1, name="root"), trace_id="tr-123")]
 
-    # Usage on the root (counted) and on the leaf (must be skipped as a descendant).
-    spans[0].set_attribute(
+    # Branch 1: a deep chain off the root. Its top node carries usage (counted); its
+    # deepest node also carries usage (a descendant of the top -> must be skipped).
+    _deep_chain(spans, start_id=100, length=1100, parent_id=1, name="b1")
+    branch1_top = spans[1]  # first span appended by the chain, child of root
+    branch1_top.set_attribute(
         SpanAttributeKey.CHAT_USAGE,
         {
-            TokenUsageKey.INPUT_TOKENS: 10,
-            TokenUsageKey.OUTPUT_TOKENS: 20,
-            TokenUsageKey.TOTAL_TOKENS: 30,
+            TokenUsageKey.INPUT_TOKENS: 100,
+            TokenUsageKey.OUTPUT_TOKENS: 200,
+            TokenUsageKey.TOTAL_TOKENS: 300,
         },
     )
     spans[-1].set_attribute(
@@ -225,10 +231,26 @@ def test_aggregate_usage_from_spans_deep_tree_skips_descendant_usage():
         },
     )
 
+    # Branch 2: an independent node off the root (not a descendant of branch 1) -> counted.
+    branch2 = LiveSpan(
+        create_mock_otel_span("trace_id", span_id=5000, name="b2", parent_id=1),
+        trace_id="tr-123",
+    )
+    branch2.set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 1,
+            TokenUsageKey.OUTPUT_TOKENS: 2,
+            TokenUsageKey.TOTAL_TOKENS: 3,
+        },
+    )
+    spans.append(branch2)
+
+    # branch1_top (100/200/300) + branch2 (1/2/3); the deep descendant of branch1 is skipped.
     assert aggregate_usage_from_spans(spans) == {
-        TokenUsageKey.INPUT_TOKENS: 10,
-        TokenUsageKey.OUTPUT_TOKENS: 20,
-        TokenUsageKey.TOTAL_TOKENS: 30,
+        TokenUsageKey.INPUT_TOKENS: 101,
+        TokenUsageKey.OUTPUT_TOKENS: 202,
+        TokenUsageKey.TOTAL_TOKENS: 303,
     }
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24344 

### What changes are proposed in this pull request?

`aggregate_usage_from_spans` / `aggregate_cost_from_spans` walk the span tree with a **recursive** DFS. When a trace's nesting depth approaches Python's recursion limit (~1000), the walk raises `RecursionError` while ending the **root** span — inside `_update_trace_info`, which runs **before** the root span is exported. The result is a permanently corrupted trace:

- `mlflow.get_trace(trace_id)` returns `None` (`span data is corrupted`)
- the trace is stuck in `IN_PROGRESS` forever and shows up in `search_traces` as eternally-running
- previews and token usage are never written

Two changes:

1. **Core fix** — convert the recursive `dfs()` in `_aggregate_from_spans` (`mlflow/tracing/utils/__init__.py`) to an iterative explicit-stack walk. Children are pushed reversed so LIFO `pop()` preserves the exact original visit order and the anti-double-counting `ancestor_has_data` invariant. This single function is the only recursive span traversal on the finalization path, and both aggregation call sites funnel through it. No behavior change for normal traces.
2. **Hardening** — wrap the aggregation calls at both processor call sites (`base_mlflow.py`, `inference_table.py`) in a best-effort `try/except`. Losing optional usage/cost metadata for one trace is strictly better than corrupting the trace; an aggregation failure must never again abort root-span export / trace finalization.

Out of scope (verified unaffected): `SqlAlchemyStore.log_spans` already aggregates with a flat loop, not recursion.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests (each fails before the fix, passes after):
- `test_aggregate_usage_from_spans_deep_tree` — a depth-1100 tree aggregates without `RecursionError`.
- `test_aggregate_usage_from_spans_deep_tree_skips_descendant_usage` — the anti-double-counting invariant survives the deep traversal.
- `test_deep_trace_is_not_corrupted_by_aggregation` (end-to-end through the processor) — a deep trace ends, flushes, and `get_trace` returns a non-`None` trace in a terminal (`OK`) state rather than corrupted / `IN_PROGRESS`.

Existing `test_aggregate_usage_from_spans*` and the broader `tests/tracing/test_fluent.py` trace suite (128 tests) remain green.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Deeply nested traces (~1000+ span nesting) no longer raise `RecursionError` during finalization; token-usage/cost aggregation now degrades gracefully instead of corrupting the trace.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release