### PR TITLE
Support Microsoft Entra ID as a backend for mlflow.login()

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -213,6 +213,12 @@ MLFLOW_TRACKING_AWS_SIGV4 = _BooleanEnvironmentVariable("MLFLOW_TRACKING_AWS_SIG
 #: (default: ``None``). When set, it will overwrite the "Authorization" HTTP header.
 MLFLOW_TRACKING_AUTH = _EnvironmentVariable("MLFLOW_TRACKING_AUTH", str, None)
 
+#: Specifies the Microsoft Entra ID token scope used by ``mlflow.login(backend="entra")``
+#: and the ``entra`` request auth provider (``MLFLOW_TRACKING_AUTH=entra``), e.g.
+#: ``api://<client-id>/.default`` for a tracking server registered as an Entra ID
+#: application (default: ``None``).
+MLFLOW_ENTRA_ID_SCOPE = _EnvironmentVariable("MLFLOW_ENTRA_ID_SCOPE", str, None)
+
 #: Specifies the chunk size to use when downloading a file from GCS
 #: (default: ``None``). If None, the chunk size is automatically determined by the
 #: ``google-cloud-storage`` package.

--- a/mlflow/tracking/request_auth/entra_request_auth_provider.py
+++ b/mlflow/tracking/request_auth/entra_request_auth_provider.py
@@ -1,0 +1,124 @@
+"""Request auth provider for Microsoft Entra ID (formerly Azure Active Directory).
+
+This module provides an auth plugin activated via ``MLFLOW_TRACKING_AUTH=entra``.
+It adds an ``Authorization: Bearer <token>`` header to outgoing requests, acquiring
+tokens with :class:`azure.identity.DefaultAzureCredential`. Tokens are cached and
+refreshed in memory by ``azure-identity``, so requests keep working after the
+initial token expires.
+
+The token scope is read from the ``MLFLOW_ENTRA_ID_SCOPE`` environment variable,
+e.g. ``api://<client-id>/.default`` for a tracking server registered as an Entra ID
+application.
+
+Requires the ``azure-identity`` package. Install it with:
+    pip install azure-identity
+"""
+
+import logging
+import threading
+
+from mlflow.environment_variables import MLFLOW_ENTRA_ID_SCOPE
+from mlflow.exceptions import MlflowException
+from mlflow.tracking.request_auth.abstract_request_auth_provider import RequestAuthProvider
+
+_logger = logging.getLogger(__name__)
+
+AUTHORIZATION_HEADER_NAME = "Authorization"
+
+_credential = None
+_credential_lock = threading.Lock()
+
+
+def _check_azure_identity_installed():
+    try:
+        from azure.identity import DefaultAzureCredential  # noqa: F401
+    except ImportError:
+        raise MlflowException(
+            "The 'azure-identity' package is required to use Microsoft Entra ID "
+            "authentication (MLFLOW_TRACKING_AUTH=entra), but it is not installed. "
+            "Install it with: pip install azure-identity"
+        )
+
+
+def _get_entra_scope() -> str:
+    scope = MLFLOW_ENTRA_ID_SCOPE.get()
+    if not scope:
+        raise MlflowException(
+            "No Microsoft Entra ID token scope is configured. Set the "
+            f"{MLFLOW_ENTRA_ID_SCOPE.name} environment variable to the scope of your "
+            "MLflow tracking server's app registration, e.g. 'api://<client-id>/.default'."
+        )
+    return scope
+
+
+def _get_credential():
+    """Return a process-wide ``DefaultAzureCredential``, creating it lazily.
+
+    ``DefaultAzureCredential`` caches access tokens in memory and refreshes them
+    shortly before they expire, so reusing a single instance avoids
+    re-authenticating on every request.
+    """
+    global _credential
+    with _credential_lock:
+        if _credential is None:
+            from azure.identity import DefaultAzureCredential
+
+            _credential = DefaultAzureCredential()
+        return _credential
+
+
+def _get_token() -> str:
+    """Acquire a Microsoft Entra ID access token for the configured scope."""
+    scope = _get_entra_scope()
+    try:
+        access_token = _get_credential().get_token(scope)
+    except MlflowException:
+        raise
+    except Exception as e:
+        raise MlflowException(
+            f"Failed to acquire a Microsoft Entra ID token for scope '{scope}': {e}. "
+            "Ensure that valid Azure credentials are available, e.g. by running "
+            "`az login`, or by setting the AZURE_CLIENT_ID, AZURE_TENANT_ID and "
+            "AZURE_CLIENT_SECRET environment variables."
+        )
+    return access_token.token
+
+
+class EntraAuth:
+    """Custom authentication class for Microsoft Entra ID.
+
+    This class is callable and will be invoked by the requests library
+    to add an ``Authorization`` header to each request.
+    """
+
+    def __call__(self, request):
+        """Add a Microsoft Entra ID bearer token to the request.
+
+        Args:
+            request: The prepared request object from the requests library.
+
+        Returns:
+            The modified request object with the authorization header.
+
+        Raises:
+            MlflowException: If no scope is configured or no token can be acquired.
+        """
+        if AUTHORIZATION_HEADER_NAME not in request.headers:
+            request.headers[AUTHORIZATION_HEADER_NAME] = f"Bearer {_get_token()}"
+        return request
+
+
+class EntraRequestAuthProvider(RequestAuthProvider):
+    """Provides bearer token authentication backed by Microsoft Entra ID.
+
+    This provider adds an ``Authorization`` header with a token acquired via
+    ``azure.identity.DefaultAzureCredential`` for the scope configured through
+    ``MLFLOW_ENTRA_ID_SCOPE``. Use ``MLFLOW_TRACKING_AUTH=entra`` to enable.
+    """
+
+    def get_name(self) -> str:
+        return "entra"
+
+    def get_auth(self):
+        _check_azure_identity_installed()
+        return EntraAuth()

--- a/mlflow/tracking/request_auth/registry.py
+++ b/mlflow/tracking/request_auth/registry.py
@@ -1,5 +1,8 @@
 import warnings
 
+from mlflow.tracking.request_auth.entra_request_auth_provider import (
+    EntraRequestAuthProvider,
+)
 from mlflow.tracking.request_auth.kubernetes_request_auth_provider import (
     KubernetesNamespacedRequestAuthProvider,
     KubernetesRequestAuthProvider,
@@ -33,6 +36,7 @@ class RequestAuthProviderRegistry:
 
 
 _request_auth_provider_registry = RequestAuthProviderRegistry()
+_request_auth_provider_registry.register(EntraRequestAuthProvider)
 _request_auth_provider_registry.register(KubernetesRequestAuthProvider)
 _request_auth_provider_registry.register(KubernetesNamespacedRequestAuthProvider)
 _request_auth_provider_registry.register_entrypoints()

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -5,6 +5,7 @@ import os
 from typing import NamedTuple
 
 from mlflow.environment_variables import (
+    MLFLOW_ENTRA_ID_SCOPE,
     MLFLOW_TRACKING_AUTH,
     MLFLOW_TRACKING_AWS_SIGV4,
     MLFLOW_TRACKING_CLIENT_CERT_PATH,
@@ -12,6 +13,7 @@ from mlflow.environment_variables import (
     MLFLOW_TRACKING_PASSWORD,
     MLFLOW_TRACKING_SERVER_CERT_PATH,
     MLFLOW_TRACKING_TOKEN,
+    MLFLOW_TRACKING_URI,
     MLFLOW_TRACKING_USERNAME,
 )
 from mlflow.exceptions import MlflowException
@@ -76,12 +78,23 @@ def get_default_host_creds(store_uri):
 def login(backend: str = "databricks", interactive: bool = True) -> None:
     """Configure MLflow server authentication and connect MLflow to tracking server.
 
-    This method provides a simple way to connect MLflow to its tracking server. Currently only
-    Databricks tracking server is supported. Users will be prompted to enter the credentials if no
-    existing Databricks profile is found, and the credentials will be saved to `~/.databrickscfg`.
+    This method provides a simple way to connect MLflow to its tracking server. The following
+    backends are supported:
+
+    - "databricks" (default): Connect to a Databricks tracking server. Users will be prompted
+      to enter the credentials if no existing Databricks profile is found, and the credentials
+      will be saved to `~/.databrickscfg`.
+    - "entra": Connect to an MLflow tracking server protected by Microsoft Entra ID (formerly
+      Azure Active Directory). Access tokens are acquired with
+      ``azure.identity.DefaultAzureCredential`` (which supports environment credentials,
+      managed identities, the Azure CLI login and more) for the scope configured through the
+      ``MLFLOW_ENTRA_ID_SCOPE`` environment variable, and attached to every outgoing request.
+      Requires the ``azure-identity`` package. Users will be prompted for the token scope and
+      the tracking server URI if they are not set via the ``MLFLOW_ENTRA_ID_SCOPE`` and
+      ``MLFLOW_TRACKING_URI`` environment variables.
 
     Args:
-        backend: string, the backend of the tracking server. Currently only "databricks" is
+        backend: string, the backend of the tracking server. "databricks" and "entra" are
             supported.
 
         interactive: bool, controls request for user input on missing credentials. If true, user
@@ -102,9 +115,13 @@ def login(backend: str = "databricks", interactive: bool = True) -> None:
     if backend == "databricks":
         _databricks_login(interactive)
         set_tracking_uri("databricks")
+    elif backend == "entra":
+        host = _entra_login(interactive)
+        set_tracking_uri(host)
     else:
         raise MlflowException(
-            f"Currently only 'databricks' backend is supported, received `backend={backend}`."
+            "Currently only 'databricks' and 'entra' backends are supported, "
+            f"received `backend={backend}`."
         )
 
 
@@ -229,3 +246,68 @@ def _databricks_login(interactive):
     except Exception as e:
         # If user entered invalid auth, we will raise an error and ask users to retry.
         raise MlflowException(f"`mlflow.login()` failed with error: {e}")
+
+
+def _validate_entra_auth():
+    # Check that a Microsoft Entra ID token can be acquired for the configured scope.
+    try:
+        from azure.identity import DefaultAzureCredential  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "The azure-identity package is not installed. To use "
+            '`mlflow.login(backend="entra")`, please install it by '
+            "`pip install azure-identity`."
+        )
+
+    from mlflow.tracking.request_auth.entra_request_auth_provider import _get_token
+
+    try:
+        # Failed token acquisition will throw an error.
+        _get_token()
+        _logger.info("Successfully acquired a Microsoft Entra ID token.")
+    except Exception as e:
+        raise MlflowException(f"Failed to validate Microsoft Entra ID credentials: {e}")
+
+
+def _entra_login(interactive):
+    """Set up Microsoft Entra ID authentication.
+
+    Returns:
+        The tracking server URI to connect to.
+    """
+    if not MLFLOW_ENTRA_ID_SCOPE.get():
+        if not interactive:
+            raise MlflowException(
+                f"{MLFLOW_ENTRA_ID_SCOPE.name} must be set while running in non-interactive mode."
+            )
+        while True:
+            scope = input("Entra ID token scope (e.g. api://<client-id>/.default): ").strip()
+            if scope:
+                break
+            _logger.error("Scope must not be empty, please retry.")
+        MLFLOW_ENTRA_ID_SCOPE.set(scope)
+
+    host = MLFLOW_TRACKING_URI.get()
+    if not (host and host.startswith(("http://", "https://"))):
+        if not interactive:
+            raise MlflowException(
+                f"{MLFLOW_TRACKING_URI.name} must be set to an HTTP(S) tracking server URI "
+                "while running in non-interactive mode."
+            )
+        while True:
+            host = input("MLflow tracking server URI (should begin with https://): ").strip()
+            if host.startswith(("http://", "https://")):
+                break
+            _logger.error(f"Invalid URI: {host}, URI must begin with https://, please retry.")
+
+    try:
+        # Failed validation will throw an error.
+        _validate_entra_auth()
+    except Exception as e:
+        raise MlflowException(f"`mlflow.login()` failed with error: {e}")
+
+    # Instruct the tracking client to authenticate requests via the "entra" request auth
+    # provider, which acquires (and transparently refreshes) tokens on each request.
+    MLFLOW_TRACKING_AUTH.set("entra")
+    _logger.info(f"Successfully signed in with Microsoft Entra ID. Host: {host}.")
+    return host

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -295,10 +295,11 @@ def _entra_login(interactive):
                 "while running in non-interactive mode."
             )
         while True:
-            host = input("MLflow tracking server URI (should begin with https://): ").strip()
+            host = input("MLflow tracking server URI (should begin with http(s)://): ").strip()
             if host.startswith(("http://", "https://")):
                 break
-            _logger.error(f"Invalid URI: {host}, URI must begin with https://, please retry.")
+            _logger.error(f"Invalid URI: {host}, URI must begin with http(s)://, please retry.")
+        MLFLOW_TRACKING_URI.set(host)
 
     try:
         # Failed validation will throw an error.

--- a/tests/tracking/request_auth/test_entra_request_auth_provider.py
+++ b/tests/tracking/request_auth/test_entra_request_auth_provider.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("azure.identity")
+
+import mlflow.tracking.request_auth.entra_request_auth_provider as _entra_auth
+from mlflow.environment_variables import MLFLOW_ENTRA_ID_SCOPE
+from mlflow.exceptions import MlflowException
+from mlflow.tracking.request_auth.entra_request_auth_provider import (
+    AUTHORIZATION_HEADER_NAME,
+    EntraAuth,
+    EntraRequestAuthProvider,
+)
+
+_SCOPE = "api://dummy-client-id/.default"
+
+
+@pytest.fixture(autouse=True)
+def _reset_credential():
+    _entra_auth._credential = None
+    yield
+    _entra_auth._credential = None
+
+
+@pytest.fixture
+def scope_env(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENTRA_ID_SCOPE.name, _SCOPE)
+
+
+def _make_request(headers=None):
+    return SimpleNamespace(headers=headers if headers is not None else {})
+
+
+def _mock_credential(token="dummy-token"):
+    credential = mock.Mock()
+    credential.get_token.return_value = SimpleNamespace(token=token)
+    return credential
+
+
+def test_provider_registration():
+    provider = EntraRequestAuthProvider()
+    assert provider.get_name() == "entra"
+    assert isinstance(provider.get_auth(), EntraAuth)
+
+
+def test_provider_raises_without_azure_identity():
+    with (
+        mock.patch.dict("sys.modules", {"azure.identity": None}),
+        pytest.raises(MlflowException, match="azure-identity.*not installed"),
+    ):
+        EntraRequestAuthProvider().get_auth()
+
+
+def test_auth_raises_without_scope(monkeypatch):
+    monkeypatch.delenv(MLFLOW_ENTRA_ID_SCOPE.name, raising=False)
+    with pytest.raises(MlflowException, match=MLFLOW_ENTRA_ID_SCOPE.name):
+        EntraAuth()(_make_request())
+
+
+def test_auth_adds_bearer_token(scope_env):
+    credential = _mock_credential(token="dummy-token")
+    with mock.patch("azure.identity.DefaultAzureCredential", return_value=credential):
+        request = EntraAuth()(_make_request())
+
+    assert request.headers[AUTHORIZATION_HEADER_NAME] == "Bearer dummy-token"
+    credential.get_token.assert_called_once_with(_SCOPE)
+
+
+def test_auth_does_not_overwrite_existing_header(scope_env):
+    credential = _mock_credential()
+    with mock.patch("azure.identity.DefaultAzureCredential", return_value=credential):
+        request = EntraAuth()(_make_request({AUTHORIZATION_HEADER_NAME: "Bearer preset"}))
+
+    assert request.headers[AUTHORIZATION_HEADER_NAME] == "Bearer preset"
+    credential.get_token.assert_not_called()
+
+
+def test_auth_reuses_credential_across_requests(scope_env):
+    credential = _mock_credential()
+    with mock.patch(
+        "azure.identity.DefaultAzureCredential", return_value=credential
+    ) as credential_cls:
+        auth = EntraAuth()
+        auth(_make_request())
+        auth(_make_request())
+
+    credential_cls.assert_called_once()
+    assert credential.get_token.call_count == 2
+
+
+def test_auth_wraps_token_acquisition_failure(scope_env):
+    credential = mock.Mock()
+    credential.get_token.side_effect = Exception("no credentials available")
+    with (
+        mock.patch("azure.identity.DefaultAzureCredential", return_value=credential),
+        pytest.raises(MlflowException, match=f"token for scope '{_SCOPE}'"),
+    ):
+        EntraAuth()(_make_request())

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -180,6 +180,7 @@ def test_mlflow_login_entra(monkeypatch):
     validate_mock.assert_called_once()
     assert MLFLOW_ENTRA_ID_SCOPE.get() == "api://dummy-client-id/.default"
     assert MLFLOW_TRACKING_AUTH.get() == "entra"
+    assert MLFLOW_TRACKING_URI.get() == "https://mlflow.example.com"
     assert get_tracking_uri() == "https://mlflow.example.com"
 
 

--- a/tests/utils/test_credentials.py
+++ b/tests/utils/test_credentials.py
@@ -4,7 +4,13 @@ from unittest.mock import patch
 import pytest
 
 from mlflow import get_tracking_uri
-from mlflow.environment_variables import MLFLOW_TRACKING_PASSWORD, MLFLOW_TRACKING_USERNAME
+from mlflow.environment_variables import (
+    MLFLOW_ENTRA_ID_SCOPE,
+    MLFLOW_TRACKING_AUTH,
+    MLFLOW_TRACKING_PASSWORD,
+    MLFLOW_TRACKING_URI,
+    MLFLOW_TRACKING_USERNAME,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.utils.credentials import login, read_mlflow_creds
 
@@ -148,3 +154,86 @@ def test_mlflow_login_noninteractive():
             match="No valid Databricks credentials found while running in non-interactive mode",
         ):
             login(backend="databricks", interactive=False)
+
+
+def _clear_env_var(monkeypatch, env_var):
+    # `monkeypatch.setenv` records the original state (including absence) so that
+    # values set by the code under test are reverted after the test.
+    monkeypatch.setenv(env_var.name, "placeholder")
+    monkeypatch.delenv(env_var.name)
+
+
+def test_mlflow_login_entra(monkeypatch):
+    for env_var in (MLFLOW_ENTRA_ID_SCOPE, MLFLOW_TRACKING_AUTH, MLFLOW_TRACKING_URI):
+        _clear_env_var(monkeypatch, env_var)
+
+    # Mock `input()` to return the token scope and host in order.
+    with (
+        patch(
+            "builtins.input",
+            side_effect=["api://dummy-client-id/.default", "https://mlflow.example.com"],
+        ),
+        patch("mlflow.utils.credentials._validate_entra_auth") as validate_mock,
+    ):
+        login(backend="entra")
+
+    validate_mock.assert_called_once()
+    assert MLFLOW_ENTRA_ID_SCOPE.get() == "api://dummy-client-id/.default"
+    assert MLFLOW_TRACKING_AUTH.get() == "entra"
+    assert get_tracking_uri() == "https://mlflow.example.com"
+
+
+def test_mlflow_login_entra_from_env(monkeypatch):
+    _clear_env_var(monkeypatch, MLFLOW_TRACKING_AUTH)
+    monkeypatch.setenv(MLFLOW_ENTRA_ID_SCOPE.name, "api://dummy-client-id/.default")
+    monkeypatch.setenv(MLFLOW_TRACKING_URI.name, "https://mlflow.example.com")
+
+    with patch("mlflow.utils.credentials._validate_entra_auth") as validate_mock:
+        login(backend="entra", interactive=False)
+
+    validate_mock.assert_called_once()
+    assert MLFLOW_TRACKING_AUTH.get() == "entra"
+    assert get_tracking_uri() == "https://mlflow.example.com"
+
+
+def test_mlflow_login_entra_noninteractive_missing_scope(monkeypatch):
+    for env_var in (MLFLOW_ENTRA_ID_SCOPE, MLFLOW_TRACKING_AUTH, MLFLOW_TRACKING_URI):
+        _clear_env_var(monkeypatch, env_var)
+
+    with pytest.raises(
+        MlflowException,
+        match=f"{MLFLOW_ENTRA_ID_SCOPE.name} must be set while running in non-interactive mode",
+    ):
+        login(backend="entra", interactive=False)
+
+
+def test_mlflow_login_entra_noninteractive_missing_uri(monkeypatch):
+    for env_var in (MLFLOW_TRACKING_AUTH, MLFLOW_TRACKING_URI):
+        _clear_env_var(monkeypatch, env_var)
+    monkeypatch.setenv(MLFLOW_ENTRA_ID_SCOPE.name, "api://dummy-client-id/.default")
+
+    with pytest.raises(
+        MlflowException,
+        match=f"{MLFLOW_TRACKING_URI.name} must be set to an HTTP\\(S\\) tracking server URI",
+    ):
+        login(backend="entra", interactive=False)
+
+
+def test_mlflow_login_entra_invalid_credentials(monkeypatch):
+    _clear_env_var(monkeypatch, MLFLOW_TRACKING_AUTH)
+    monkeypatch.setenv(MLFLOW_ENTRA_ID_SCOPE.name, "api://dummy-client-id/.default")
+    monkeypatch.setenv(MLFLOW_TRACKING_URI.name, "https://mlflow.example.com")
+
+    with patch(
+        "mlflow.utils.credentials._validate_entra_auth",
+        side_effect=MlflowException("Failed to validate Microsoft Entra ID credentials."),
+    ):
+        with pytest.raises(MlflowException, match="`mlflow.login\\(\\)` failed with error"):
+            login(backend="entra", interactive=False)
+
+    assert MLFLOW_TRACKING_AUTH.get() is None
+
+
+def test_mlflow_login_unsupported_backend():
+    with pytest.raises(MlflowException, match="received `backend=foo`"):
+        login(backend="foo")


### PR DESCRIPTION
### Related Issues/PRs

Closes #16474

### What changes are proposed in this pull request?

Adds Microsoft Entra ID (formerly Azure AD) as a second backend for `mlflow.login()`:

```python
import mlflow
mlflow.login(backend="entra")
```

- New in-tree request auth provider (`MLFLOW_TRACKING_AUTH=entra`, following the existing `kubernetes` provider pattern) that attaches an `Authorization: Bearer <token>` header to every tracking request, acquiring tokens with `azure.identity.DefaultAzureCredential` (env credentials, managed identities, `az login`, etc.). A single credential instance is reused so azure-identity's in-memory token cache handles refresh transparently — tokens keep working past their initial expiry, unlike a one-shot `MLFLOW_TRACKING_TOKEN`.
- New `MLFLOW_ENTRA_ID_SCOPE` environment variable for the token scope/audience (e.g. `api://<client-id>/.default`). No safe default exists since every deployment's app registration differs; `mlflow.login(backend="entra")` prompts for it interactively when unset.
- `mlflow.login(backend="entra")` resolves scope and tracking URI (env vars or prompts), validates a token can be acquired, then sets `MLFLOW_TRACKING_AUTH=entra` and the tracking URI.

No new required dependency: `azure-identity` is already part of the `mlflow[azure]` extra and is imported lazily with an actionable error when missing.

### How is this PR tested?

- [x] Existing unit/integration tests (`tests/tracking/request_auth` 49/49, `tests/utils/test_credentials.py` 14/14)
- [x] New unit/integration tests (7 provider tests: token acquisition/caching/failure modes/missing dependency; 6 `mlflow.login` tests: prompts, env-var config, non-interactive failures, invalid credentials)

### Does this PR require documentation update?

- [x] No. The `mlflow.login` API reference generates from the updated docstring; happy to add a self-hosting/security docs page in a follow-up if preferred.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.login()` now supports Microsoft Entra ID via `mlflow.login(backend="entra")`, attaching automatically refreshed bearer tokens to tracking requests.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
