### PR TITLE
Clear Assistant chat storage when setup is incomplete

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -350,6 +350,63 @@ describe('AssistantProvider setup completeness', () => {
     expect(result.current.setupComplete).toBe(true);
     expect(mockListEndpoints).not.toHaveBeenCalled();
   });
+
+  test('no provider selected => clears a stale transcript left over from a previous setup', async () => {
+    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify({ messages: [makeMessage({ id: 'stale' })] }));
+    mockGetConfig.mockResolvedValue(config({}));
+
+    const result = await renderAndWaitForConfig();
+
+    expect(result.current.setupComplete).toBe(false);
+    expect(result.current.messages).toHaveLength(0);
+    // The persist effect writes the cleared state back on a render after isLoadingConfig settles.
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem(CHAT_STORAGE_KEY) ?? '{}');
+      expect(stored.messages).toEqual([]);
+    });
+  });
+
+  test('config fetch fails => clears a stale transcript rather than assuming setup is still complete', async () => {
+    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify({ messages: [makeMessage({ id: 'stale' })] }));
+    mockGetConfig.mockRejectedValue(new Error('network error'));
+
+    const result = await renderAndWaitForConfig();
+
+    expect(result.current.setupComplete).toBe(false);
+    expect(result.current.messages).toHaveLength(0);
+    // Same persist-effect indirection as the success path — assert localStorage too, so a
+    // regression where the catch branch stops triggering the effect would fail this test.
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem(CHAT_STORAGE_KEY) ?? '{}');
+      expect(stored.messages).toEqual([]);
+    });
+  });
+
+  test('a later refreshConfig() (e.g. via openPanel) does not drop an active conversation', async () => {
+    // Setup starts complete, so the mount-time check leaves the conversation alone.
+    mockGetConfig.mockResolvedValue(config({ claude_code: providerConfig({ selected: true }) }));
+
+    const result = await renderAndWaitForConfig();
+    expect(result.current.setupComplete).toBe(true);
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    expect(result.current.messages.length).toBeGreaterThan(0);
+
+    // The provider was removed server-side between the initial check and now; openPanel() refetches.
+    mockGetConfig.mockResolvedValue(config({}));
+    act(() => {
+      result.current.openPanel();
+    });
+
+    // openPanel() fires refreshConfig() without awaiting it, so wait for its config fetch to
+    // resolve before asserting — otherwise this reads state from before the refetch lands.
+    await waitFor(() => expect(result.current.setupComplete).toBe(false));
+    // The conversation the user was having must survive — only the initial mount-time check may
+    // clear a stale transcript; later checks must not silently drop an active one.
+    expect(result.current.messages.length).toBeGreaterThan(0);
+  });
 });
 
 describe('AssistantContext — a new message supersedes a pending permission prompt', () => {
@@ -458,6 +515,8 @@ describe('trimForStorage', () => {
 
 describe('AssistantContext — localStorage chat persistence', () => {
   it('restores messages from localStorage on mount', async () => {
+    // A configured provider — setup completeness is orthogonal to storage restore/clear.
+    mockGetConfig.mockResolvedValue(config({ claude_code: providerConfig({ selected: true }) }));
     localStorage.setItem(
       CHAT_STORAGE_KEY,
       JSON.stringify({ messages: [makeMessage({ id: 'restored', content: 'from storage' })] }),
@@ -487,6 +546,7 @@ describe('AssistantContext — localStorage chat persistence', () => {
   });
 
   it('clears persisted messages when reset() is called', async () => {
+    mockGetConfig.mockResolvedValue(config({ claude_code: providerConfig({ selected: true }) }));
     localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify({ messages: [makeMessage({ id: 'restored' })] }));
 
     const { result } = await renderAssistant();

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -210,15 +210,17 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   // Setup actions
-  const refreshConfig = useCallback(async () => {
+  const refreshConfig = useCallback(async (): Promise<boolean> => {
     setIsLoadingConfig(true);
     try {
       const config = await getConfig();
       const isComplete = await resolveSetupComplete(config);
       setSetupComplete(isComplete);
+      return isComplete;
     } catch {
       // On error, assume setup is not complete
       setSetupComplete(false);
+      return false;
     } finally {
       setIsLoadingConfig(false);
     }
@@ -226,11 +228,6 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   const completeSetup = useCallback(() => {
     setSetupComplete(true);
-    refreshConfig();
-  }, [refreshConfig]);
-
-  // Fetch config on mount
-  useEffect(() => {
     refreshConfig();
   }, [refreshConfig]);
 
@@ -329,6 +326,18 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     streamingMessageRef.current = '';
     setPendingPermission(null);
   }, []);
+
+  // On mount, resolve setup once. messages are seeded synchronously from localStorage, so if setup
+  // turns out incomplete, drop that possibly-stale transcript (the persist effect then clears
+  // storage too). Only the mount check does this — later refreshConfig() calls from openPanel()/
+  // completeSetup() must not wipe a conversation the user is actively having.
+  useEffect(() => {
+    refreshConfig().then((isComplete) => {
+      if (!isComplete) {
+        reset();
+      }
+    });
+  }, [refreshConfig, reset]);
 
   // Begin a new in-flight send: stamp a fresh token in closure,
   // return a checker for whether this send is
@@ -734,7 +743,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   regenerateLastMessage: () => {},
   reset: () => {},
   cancelSession: () => {},
-  refreshConfig: () => Promise.resolve(),
+  refreshConfig: () => Promise.resolve(false),
   completeSetup: () => {},
   respondToPermission: () => {},
 };

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -109,8 +109,8 @@ export interface AssistantAgentActions {
   reset: () => void;
   /** Cancel the current streaming session */
   cancelSession: () => void;
-  /** Fetch/refresh config from backend */
-  refreshConfig: () => Promise<void>;
+  /** Fetch/refresh config from backend; resolves to whether setup is complete */
+  refreshConfig: () => Promise<boolean>;
   /** Mark setup as complete (after wizard finishes) */
   completeSetup: () => void;
   /** Answer the pending tool-call permission prompt */


### PR DESCRIPTION
### Related Issues/PRs

NA

### What changes are proposed in this pull request?

The MLflow Assistant persists its chat transcript to `localStorage` (`mlflow.assistant.chat_v1`), independent of whether a provider is currently configured. If a user had a conversation, then the provider config was removed or changed such that `resolveSetupComplete()` now resolves to `false` (or the config fetch fails), the old transcript was still shown/restored on the next load — a stale conversation from a setup that no longer exists.

This PR makes `refreshConfig()` in `AssistantContext.tsx` clear the in-memory `messages` state whenever setup resolves to incomplete or the config fetch errors. The existing persistence effect (which already runs whenever `messages` settles) then writes that cleared state back to `localStorage`, so the stale transcript doesn't linger.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Cleared when it is not setup
<img width="1280" height="720" alt="assistant-cleared-after-no-setup" src="https://github.com/user-attachments/assets/342f3682-30c7-4677-a960-ad36f3bf7863" />



Added two new tests to `AssistantContext.test.tsx`:
- `no provider selected => clears a stale transcript left over from a previous setup`
- `config fetch fails => clears a stale transcript rather than assuming setup is still complete`

Updated two existing localStorage tests (`restores messages from localStorage on mount`, `clears persisted messages when reset() is called`) to configure a selected provider, since they were implicitly relying on setup being complete.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a bug where the MLflow Assistant chat panel could show a stale conversation transcript from a previous provider configuration after the Assistant's setup was removed or became invalid.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - The PR will be mentioned in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release