### PR TITLE
fix: handle existing tables during DB initialization to avoid 'Table already exists' error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,14 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create tables that do not already exist to avoid errors like "Table already exists"
+    existing_tables = set(sqlalchemy.inspect(engine).get_table_names())
+    tables_to_create = [
+        table for table in InitialBase.metadata.sorted_tables
+        if table.name not in existing_tables
+    ]
+    if tables_to_create:
+        InitialBase.metadata.create_all(engine, tables=tables_to_create)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating from 3.7.0 to 3.8.x, if a table (e.g., 'secrets') already exists in the database (from a previous partial upgrade or manual creation), the `_initialize_tables` function calls `InitialBase.metadata.create_all(engine)` which attempts to create all tables unconditionally, causing a MySQL OperationalError: `Table 'secrets' already exists`. This breaks the entire migration process.

## Fix
Modified `_initialize_tables` to only create tables that do not already exist in the database. Instead of calling `create_all()` which tries to create all tables defined in the metadata, we now inspect existing tables and pass only the missing ones to `create_all(tables=...)`. This prevents the 'Table already exists' error while still ensuring all required tables are present before running Alembic upgrades.

Closes #19943