### PR TITLE
Wrap malformed judge structured output in MlflowException

### DIFF
--- a/mlflow/genai/judges/utils/invocation_utils.py
+++ b/mlflow/genai/judges/utils/invocation_utils.py
@@ -265,8 +265,13 @@ def get_chat_completions_with_structured_output(
     cleaned_response = _strip_markdown_code_blocks(output.response)
     try:
         response_dict = json.loads(cleaned_response, strict=False)
+        return output_schema(**response_dict)
     except json.JSONDecodeError as e:
         raise MlflowException(
             f"Failed to parse response from judge model. Response: {output.response}",
         ) from e
-    return output_schema(**response_dict)
+    except (pydantic.ValidationError, TypeError) as e:
+        raise MlflowException(
+            f"Response from judge model does not match the expected schema: {e}\n\n"
+            f"Response: {output.response}",
+        ) from e

--- a/tests/genai/judges/utils/test_invocation_utils.py
+++ b/tests/genai/judges/utils/test_invocation_utils.py
@@ -439,3 +439,54 @@ def test_structured_output_schema_injection(
 
     assert isinstance(result, TestSchema)
     assert result.outputs == "test result"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "[1, 2, 3]",  # valid JSON, but a list (not a mapping) -> TypeError on **response_dict
+        '"just a string"',  # valid JSON scalar -> TypeError on **response_dict
+        '{"inputs": "only one field"}',  # valid object, missing required field -> ValidationError
+    ],
+)
+def test_get_chat_completions_with_structured_output_malformed_json_raises_mlflow_exception(
+    response,
+):
+    # Regression: the litellm fallback built output_schema(**response_dict) outside the
+    # try and only caught json.JSONDecodeError, so a valid-but-non-object JSON response
+    # (list/scalar) raised a raw TypeError and a schema mismatch raised a raw
+    # pydantic.ValidationError. Both should be wrapped in MlflowException.
+    class FieldExtraction(BaseModel):
+        inputs: str = Field(description="The user's original request")
+        outputs: str = Field(description="The system's final response")
+
+    mock_output = InvokeOutput(
+        response=response,
+        request_id="req-1",
+        num_prompt_tokens=10,
+        num_completion_tokens=5,
+    )
+
+    with (
+        mock.patch(
+            "mlflow.genai.judges.adapters.gateway_adapter.GatewayAdapter.is_applicable",
+            return_value=False,
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
+            return_value=True,
+        ),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._invoke_litellm_and_handle_tools",
+            return_value=mock_output,
+        ),
+        pytest.raises(MlflowException, match=r"does not match the expected schema"),
+    ):
+        get_chat_completions_with_structured_output(
+            model_uri="openai:/gpt-4",
+            messages=[
+                ChatMessage(role="system", content="Extract fields"),
+                ChatMessage(role="user", content="Find inputs and outputs"),
+            ],
+            output_schema=FieldExtraction,
+        )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24302

### What changes are proposed in this pull request?

`get_chat_completions_with_structured_output` (the LiteLLM fallback path in `mlflow/genai/judges/utils/invocation_utils.py`) built `output_schema(**response_dict)` **outside** the `try` that parsed the judge response, and only caught `json.JSONDecodeError`. As a result:

- A valid-but-non-object JSON response (a list or scalar, e.g. `[1, 2, 3]` or `"maybe"`) raised a raw `TypeError` from `**` unpacking.
- A response that is a valid object but missing required schema fields raised a raw `pydantic.ValidationError`.

Both now build the schema object inside the `try` and are converted to `MlflowException` (including the raw response), matching the sibling `parse_structured_output` (Databricks path), which already handles both cases.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `tests/genai/judges/utils/test_invocation_utils.py::test_get_chat_completions_with_structured_output_malformed_json_raises_mlflow_exception`, parametrized over a JSON list, a JSON scalar, and a valid object missing a required field. Each raises a raw `TypeError`/`ValidationError` without the fix and an `MlflowException` with it.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The genai judge structured-output parser now raises a clear `MlflowException` (including the raw response) instead of a raw `TypeError`/`ValidationError` when a judge model returns malformed JSON.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
