### PR TITLE
Resolve workspace context before running FastAPI auth validators

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -333,7 +333,11 @@ from mlflow.server.handlers import (
     _disable_if_workspaces_disabled as _disable_if_workspaces_disabled,
 )
 from mlflow.server.jobs import get_job
-from mlflow.server.workspace_helpers import _get_workspace_store
+from mlflow.server.workspace_helpers import (
+    WORKSPACE_HEADER_NAME,
+    _get_workspace_store,
+    resolve_workspace_for_request_if_enabled,
+)
 from mlflow.store.entities import PagedList
 from mlflow.store.workspace.utils import get_default_workspace_optional
 from mlflow.utils import workspace_context
@@ -4542,6 +4546,24 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
         if user.is_admin:
             return await call_next(request)
 
+        # The workspace-context middleware registered in ``create_fastapi_app`` runs
+        # *inside* this middleware (Starlette runs the most recently added middleware
+        # first), so the request workspace is not resolved yet when validators execute.
+        # Workspace-scoped lookups inside validators (e.g. resolving a gateway endpoint
+        # by name for the USE check) would fail and deny every non-admin request when
+        # workspaces are enabled. Resolve and set the workspace for the validator run,
+        # mirroring ``workspace_context_middleware``.
+        try:
+            workspace = resolve_workspace_for_request_if_enabled(
+                path, request.headers.get(WORKSPACE_HEADER_NAME)
+            )
+        except MlflowException as e:
+            return PlainTextResponse(
+                e.message,
+                status_code=e.get_http_status_code(),
+            )
+        workspace_context.set_server_request_workspace(workspace.name if workspace else None)
+
         # Run the validator
         try:
             if not await validator(user.username, request):
@@ -4554,6 +4576,8 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
                 e.message,
                 status_code=e.get_http_status_code(),
             )
+        finally:
+            workspace_context.clear_server_request_workspace()
 
         return await call_next(request)
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -25,7 +25,7 @@ from typing import Any, Awaitable, Callable
 import sqlalchemy
 from cachetools import TTLCache
 from fastapi import FastAPI
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from flask import (
     Flask,
     Request,
@@ -4558,9 +4558,9 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
                 path, request.headers.get(WORKSPACE_HEADER_NAME)
             )
         except MlflowException as e:
-            return PlainTextResponse(
-                e.message,
+            return JSONResponse(
                 status_code=e.get_http_status_code(),
+                content=json.loads(e.serialize_as_json()),
             )
         workspace_context.set_server_request_workspace(workspace.name if workspace else None)
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -18,9 +18,11 @@ from mlflow.entities import Dataset, DatasetInput, InputTag, LoggedModelOutput
 from mlflow.entities.logged_model_status import LoggedModelStatus
 from mlflow.environment_variables import (
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
+    MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
     MLFLOW_TRACKING_PASSWORD,
     MLFLOW_TRACKING_USERNAME,
+    MLFLOW_WORKSPACE_STORE_URI,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
@@ -36,6 +38,7 @@ from mlflow.server.auth.routes import (
 )
 from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR, _get_ajax_path
 from mlflow.utils.os import is_windows
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 from tests.helper_functions import kill_process_tree, random_str
 from tests.server.auth.auth_test_utils import (
@@ -44,6 +47,7 @@ from tests.server.auth.auth_test_utils import (
     User,
     create_user,
     grant_role_permission,
+    write_isolated_auth_config,
 )
 from tests.tracking.integration_test_utils import (
     _init_server,
@@ -121,6 +125,29 @@ def fastapi_client(request, tmp_path):
         backend_uri=backend_uri,
         root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
         extra_env=extra_env,
+        app="mlflow.server.auth:create_app",
+        server_type="fastapi",
+    ) as url:
+        yield MlflowClient(url)
+
+
+@pytest.fixture
+def fastapi_workspace_client(tmp_path):
+    """FastAPI client fixture with workspaces enabled, for workspace-scoped gateway auth."""
+    auth_config_path = write_isolated_auth_config(tmp_path)
+    path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+    backend_uri = ("sqlite://" if is_windows() else "sqlite:////") + path[len("file://") :]
+
+    with _init_server(
+        backend_uri=backend_uri,
+        root_artifact_uri=tmp_path.joinpath("artifacts").as_uri(),
+        extra_env={
+            MLFLOW_FLASK_SERVER_SECRET_KEY.name: "my-secret-key",
+            "MLFLOW_AUTH_CONFIG_PATH": str(auth_config_path),
+            MLFLOW_ENABLE_WORKSPACES.name: "true",
+            MLFLOW_WORKSPACE_STORE_URI.name: backend_uri,
+            "_MLFLOW_SGI_NAME": "uvicorn",
+        },
         app="mlflow.server.auth:create_app",
         server_type="fastapi",
     ) as url:
@@ -2243,6 +2270,79 @@ def test_gateway_endpoint_use_permission(fastapi_client, monkeypatch):
             json={"secret_id": secret_id},
             auth=(user1, password1),
         ).raise_for_status()
+
+
+def test_gateway_endpoint_use_permission_with_workspaces(fastapi_workspace_client):
+    tracking_uri = fastapi_workspace_client.tracking_uri
+    admin_auth = (ADMIN_USERNAME, ADMIN_PASSWORD)
+    workspace_headers = {"X-MLFLOW-WORKSPACE": DEFAULT_WORKSPACE_NAME}
+    user, password = create_user(tracking_uri)
+
+    response = requests.post(
+        url=tracking_uri + "/api/3.0/mlflow/gateway/secrets/create",
+        json={
+            "secret_name": "test_secret",
+            "secret_value": {"api_key": "test-key"},
+            "provider": "openai",
+        },
+        auth=admin_auth,
+        headers=workspace_headers,
+    )
+    response.raise_for_status()
+    secret_id = response.json()["secret"]["secret_id"]
+
+    response = requests.post(
+        url=tracking_uri + "/api/3.0/mlflow/gateway/model-definitions/create",
+        json={
+            "name": "test_model_def",
+            "secret_id": secret_id,
+            "provider": "openai",
+            "model_name": "gpt-4",
+        },
+        auth=admin_auth,
+        headers=workspace_headers,
+    )
+    response.raise_for_status()
+    model_definition_id = response.json()["model_definition"]["model_definition_id"]
+
+    response = requests.post(
+        url=tracking_uri + "/api/3.0/mlflow/gateway/endpoints/create",
+        json={
+            "name": "test_endpoint",
+            "model_configs": [
+                {
+                    "model_definition_id": model_definition_id,
+                    "linkage_type": "PRIMARY",
+                }
+            ],
+        },
+        auth=admin_auth,
+        headers=workspace_headers,
+    )
+    response.raise_for_status()
+    endpoint_id = response.json()["endpoint"]["endpoint_id"]
+    endpoint_name = response.json()["endpoint"]["name"]
+
+    # Without a grant the invocation is denied.
+    response = requests.post(
+        url=tracking_uri + f"/gateway/{endpoint_name}/mlflow/invocations",
+        json={"messages": [{"role": "user", "content": "test"}]},
+        auth=(user, password),
+        headers=workspace_headers,
+    )
+    assert response.status_code == 403
+
+    grant_role_permission(tracking_uri, user, "gateway_endpoint", endpoint_id, "USE")
+
+    # With USE granted the request must clear authorization. It then fails on the
+    # fake provider credentials, so anything but 403 means authorization passed.
+    response = requests.post(
+        url=tracking_uri + f"/gateway/{endpoint_name}/mlflow/invocations",
+        json={"messages": [{"role": "user", "content": "test"}]},
+        auth=(user, password),
+        headers=workspace_headers,
+    )
+    assert response.status_code != 403
 
 
 def test_gateway_proxy_authenticates_via_mlflow_auth_header(fastapi_client, monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

#24365  

### What changes are proposed in this pull request?

On servers running the basic-auth app with `MLFLOW_ENABLE_WORKSPACES=true`, every
non-admin gateway invocation (e.g. `POST /gateway/{endpoint}/mlflow/invocations`)
returns `403 Permission denied`, even when the user has a `USE` grant on the endpoint.

`fastapi_permission_middleware` is registered after `workspace_context_middleware`,
and Starlette runs the most recently added middleware first, so authorization
validators execute before the request workspace is resolved. The gateway `USE`
validator's workspace-scoped endpoint lookup then fails, which is treated as deny.

This PR resolves the request workspace inside `fastapi_permission_middleware` and
sets it for the duration of the validator run (mirroring
`workspace_context_middleware`), clearing it afterwards. No behavior change when
workspaces are disabled.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New test: `test_gateway_endpoint_use_permission_with_workspaces` boots the FastAPI
auth server with workspaces enabled and asserts an ungranted user is denied (403)
and a user granted `USE` passes authorization. It fails with `assert 403 != 403`
without the fix. All 21 existing gateway auth tests pass.

Manual: on a live auth+workspaces server, a granted user's invocation went from
`403 Permission denied` to reaching the model provider; an ungranted user remains 403.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed gateway endpoint invocations returning `403 Permission denied` for
  authorized non-admin users when workspaces are enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release