### PR TITLE
Remove v1 review bot (mlflow-app[bot]) from approval gate exemption

### DIFF
--- a/.github/workflows/approval.js
+++ b/.github/workflows/approval.js
@@ -75,7 +75,7 @@ module.exports = async ({ github, context, core }) => {
     repo: context.repo.repo,
     pull_number: context.issue.number,
   });
-  const APPROVED_BOTS = new Set(["mlflow-app[bot]", "nailaopus[bot]"]);
+  const APPROVED_BOTS = new Set(["nailaopus[bot]"]);
   const maintainerApproved = reviews.some(
     ({ state, user }) =>
       state === "APPROVED" &&


### PR DESCRIPTION
### Related Issues/PRs

Relates to the maintainer-approval gate policy change to treat `/review-v2` (`nailaopus[bot]`) as the review-bot merge-gate authority and stop counting the v1 `/review` bot (`mlflow-app[bot]`) approval stamp.

### What changes are proposed in this pull request?

This PR narrows the maintainer-approval allowlist in `.github/workflows/approval.js` by removing `mlflow-app[bot]` from `APPROVED_BOTS` and retaining `nailaopus[bot]`.

This keeps the one-line scope strictly focused on which bot approvals satisfy the core-maintainer merge gate. `.github/workflows/rerun.yml` is intentionally left unchanged, and the existing `if (authorLogin === "mlflow-app[bot]") { return; }` early-return in `approval.js` also remains unchanged because it governs PR authorship rather than approval stamps.

### How is this PR tested?

- [x] Manual tests

Verified the diff is limited to `.github/workflows/approval.js`, and confirmed the resulting allowlist is `const APPROVED_BOTS = new Set(["nailaopus[bot]"]);` while `rerun.yml` and the bot-author early-return remain unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release