### PR TITLE
Improve query efficiency for text search of spans

### DIFF
--- a/mlflow/store/db_migrations/versions/c1d2e3f4a5b6_add_span_experiment_start_time_index.py
+++ b/mlflow/store/db_migrations/versions/c1d2e3f4a5b6_add_span_experiment_start_time_index.py
@@ -1,0 +1,53 @@
+"""add span experiment and start time index
+
+Revision ID: c1d2e3f4a5b6
+Revises: a8b9c0d1e2f3
+
+Create Date: 2026-07-10 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1d2e3f4a5b6"
+down_revision = "a8b9c0d1e2f3"
+branch_labels = None
+depends_on = None
+
+# The composite index's leftmost experiment_id column also supports experiment-only filters, so
+# it replaces the existing experiment_id index rather than being added alongside it.
+
+
+def upgrade():
+    if op.get_bind().dialect.name == "sqlite":
+        with op.batch_alter_table("spans", schema=None) as batch_op:
+            batch_op.drop_index("index_spans_experiment_id")
+            batch_op.create_index(
+                "index_spans_experiment_id_start_time",
+                ["experiment_id", "start_time_unix_nano"],
+                unique=False,
+            )
+    else:
+        op.drop_index("index_spans_experiment_id", table_name="spans")
+        op.create_index(
+            "index_spans_experiment_id_start_time",
+            "spans",
+            ["experiment_id", "start_time_unix_nano"],
+            unique=False,
+        )
+
+
+def downgrade():
+    if op.get_bind().dialect.name == "sqlite":
+        with op.batch_alter_table("spans", schema=None) as batch_op:
+            batch_op.drop_index("index_spans_experiment_id_start_time")
+            batch_op.create_index("index_spans_experiment_id", ["experiment_id"], unique=False)
+    else:
+        op.drop_index("index_spans_experiment_id_start_time", table_name="spans")
+        op.create_index(
+            "index_spans_experiment_id",
+            "spans",
+            ["experiment_id"],
+            unique=False,
+        )

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2049,7 +2049,13 @@ class SqlSpan(Base):
 
     __table_args__ = (
         PrimaryKeyConstraint("trace_id", "span_id", name="spans_pk"),
-        Index("index_spans_experiment_id", "experiment_id"),
+        # The leftmost experiment_id column also supports experiment-only filters, so this
+        # composite index replaces a separate index on experiment_id.
+        Index(
+            "index_spans_experiment_id_start_time",
+            "experiment_id",
+            "start_time_unix_nano",
+        ),
         # Two indexes needed to support both filter patterns efficiently:
         Index(
             "index_spans_experiment_id_status_type", "experiment_id", "status", "type"

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -285,6 +285,8 @@ _TRACE_WRITE_MAX_DEADLOCK_RETRIES = 2
 # and https://docs.sqlalchemy.org/en/latest/orm/mapping_api.html#sqlalchemy.orm.mapper.Mapper
 sqlalchemy.orm.configure_mappers()
 
+_SPAN_SEARCH_TIMESTAMP_TOLERANCE_MS = 10_000
+
 
 class DatasetFilter(TypedDict, total=False):
     """
@@ -3692,6 +3694,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         statement: _SqlAlchemyStatement,
         attribute_filters: list[ColumnElement],
         non_attribute_filters: list[Subquery],
+        span_attribute_filters: list[ColumnElement],
         span_filters: list[Subquery],
         run_id_filter: str | None,
     ) -> _SqlAlchemyStatement:
@@ -3699,13 +3702,14 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         Apply trace filter clauses to a SQLAlchemy statement.
 
         This helper consolidates the logic for applying trace filters that is shared
-        between search_traces() and find_completed_sessions().
+        between search_traces(), find_completed_sessions(), and correlation queries.
 
         Args:
             statement: SQLAlchemy statement (Select or Query) to apply filters to
             attribute_filters: List of attribute filter conditions (e.g., WHERE clauses)
             non_attribute_filters: List of subqueries for tag/metadata filters to join
-            span_filters: List of subqueries for span filters to join
+            span_attribute_filters: Filters combined in a correlated SqlSpan EXISTS clause
+            span_filters: List of subqueries for non-SqlSpan filters to join
             run_id_filter: Optional run_id to filter by
 
         Returns:
@@ -3715,7 +3719,17 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         for non_attr_filter in non_attribute_filters:
             statement = statement.join(non_attr_filter)
 
-        # Apply span filters with explicit join condition
+        # Apply direct span filters in a single correlated EXISTS clause so combined
+        # predicates target the same span without duplicating matching trace rows.
+        if span_attribute_filters:
+            statement = statement.filter(
+                exists().where(
+                    SqlSpan.trace_id == SqlTraceInfo.request_id,
+                    *span_attribute_filters,
+                )
+            )
+
+        # Apply subquery-backed span filters with explicit join condition
         for span_filter in span_filters:
             statement = statement.join(
                 span_filter, SqlTraceInfo.request_id == span_filter.c.request_id
@@ -3787,23 +3801,38 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         self._validate_max_results_param(max_results)
 
         with self.ManagedSessionMaker() as session:
-            locations = self._filter_experiment_ids(session, locations)
+            if locations is not None:
+                locations = self._filter_experiment_ids(session, locations)
+                location_filter = SqlTraceInfo.experiment_id.in_([int(e) for e in locations])
+            else:
+                location_filter = None
 
             cases_orderby, parsed_orderby, sorting_joins = _get_orderby_clauses_for_search_traces(
                 order_by or [], session
             )
-            stmt = select(SqlTraceInfo, *cases_orderby).options(
+            stmt = self._trace_query(session).options(
                 sqlalchemy.orm.selectinload(SqlTraceInfo.tags),
                 sqlalchemy.orm.selectinload(SqlTraceInfo.request_metadata),
                 sqlalchemy.orm.selectinload(SqlTraceInfo.assessments),
             )
+            if cases_orderby:
+                stmt = stmt.add_columns(*cases_orderby)
 
-            attribute_filters, non_attribute_filters, span_filters, run_id_filter = (
-                _get_filter_clauses_for_search_traces(filter_string, session, self._get_dialect())
-            )
+            (
+                attribute_filters,
+                non_attribute_filters,
+                span_attribute_filters,
+                span_filters,
+                run_id_filter,
+            ) = _get_filter_clauses_for_search_traces(filter_string, session, self._get_dialect())
 
             stmt = self._apply_trace_filter_clauses(
-                stmt, attribute_filters, non_attribute_filters, span_filters, run_id_filter
+                stmt,
+                attribute_filters,
+                non_attribute_filters,
+                span_attribute_filters,
+                span_filters,
+                run_id_filter,
             )
 
             # using an outer join is necessary here because we want to be able to sort
@@ -3813,23 +3842,15 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 stmt = stmt.outerjoin(j)
 
             offset = SearchTraceUtils.parse_start_offset_from_page_token(page_token)
-            locations = [int(e) for e in locations]
+            if location_filter is not None:
+                stmt = stmt.filter(location_filter)
 
-            stmt = (
-                # NB: We don't need to distinct the results of joins because of the fact that
-                #   the right tables of the joins are unique on the join key, trace_id.
-                #   This is because the subquery that is joined on the right side is conditioned
-                #   by a key and value pair of tags/metadata, and the combination of key and
-                #   trace_id is unique in those tables.
-                #   Be careful when changing the query building logic, as it may break this
-                #   uniqueness property and require deduplication, which can be expensive.
-                stmt
-                .filter(SqlTraceInfo.experiment_id.in_(locations))
-                .order_by(*parsed_orderby)
-                .offset(offset)
-                .limit(max_results)
+            stmt = stmt.order_by(*parsed_orderby).offset(offset).limit(max_results)
+
+            queried_results = stmt.all()
+            queried_traces = (
+                [row[0] for row in queried_results] if cases_orderby else queried_results
             )
-            queried_traces = session.execute(stmt).scalars(SqlTraceInfo).all()
             trace_infos = [t.to_mlflow_entity() for t in queried_traces]
 
             # Compute next search token
@@ -3985,9 +4006,13 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             return candidate_sessions
 
         # Parse the filter string to get filter clauses
-        attribute_filters, non_attribute_filters, span_filters, run_id_filter = (
-            _get_filter_clauses_for_search_traces(filter_string, session, self._get_dialect())
-        )
+        (
+            attribute_filters,
+            non_attribute_filters,
+            span_attribute_filters,
+            span_filters,
+            run_id_filter,
+        ) = _get_filter_clauses_for_search_traces(filter_string, session, self._get_dialect())
 
         # Subquery: first trace timestamp for each session
         first_trace_metadata = aliased(SqlTraceMetadata)
@@ -4027,6 +4052,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             filtered_trace_query,
             attribute_filters,
             non_attribute_filters,
+            span_attribute_filters,
             span_filters,
             run_id_filter,
         )
@@ -4878,18 +4904,22 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         stmt = select(SqlTraceInfo.request_id).where(SqlTraceInfo.experiment_id.in_(experiment_ids))
 
         if filter_string:
-            attribute_filters, non_attribute_filters, span_filters, run_id_filter = (
-                _get_filter_clauses_for_search_traces(filter_string, session, self._get_dialect())
+            (
+                attribute_filters,
+                non_attribute_filters,
+                span_attribute_filters,
+                span_filters,
+                run_id_filter,
+            ) = _get_filter_clauses_for_search_traces(filter_string, session, self._get_dialect())
+
+            stmt = self._apply_trace_filter_clauses(
+                stmt,
+                attribute_filters,
+                non_attribute_filters,
+                span_attribute_filters,
+                span_filters,
+                run_id_filter,
             )
-
-            for non_attr_filter in non_attribute_filters:
-                stmt = stmt.join(non_attr_filter)
-
-            for span_filter in span_filters:
-                stmt = stmt.join(span_filter, SqlTraceInfo.request_id == span_filter.c.request_id)
-
-            for attr_filter in attribute_filters:
-                stmt = stmt.where(attr_filter)
 
         return stmt
 
@@ -9399,14 +9429,16 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
     Returns:
         attribute_filters: Direct filters on SqlTraceInfo attributes
         non_attribute_filters: Subqueries for tags and metadata
-        span_filters: Subqueries for span filters
+        span_attribute_filters: Direct filters on SqlSpan
+        span_filters: Subqueries for non-SqlSpan filters
         run_id_filter: Special run_id value for linked trace handling
     """
     attribute_filters = []
     non_attribute_filters = []
+    span_attribute_filters = []
     span_filters = []
-    span_filter_conditions = []
     run_id_filter = None
+    span_start_time_lower_bound_ms = None
 
     parsed_filters = SearchTraceUtils.parse_search_filter_for_search_traces(filter_string)
     for sql_statement in parsed_filters:
@@ -9436,6 +9468,12 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
             continue
 
         if SearchTraceUtils.is_attribute(key_type, key_name, comparator):
+            if key_name == "timestamp_ms" and comparator in (">", ">="):
+                span_start_time_lower_bound_ms = (
+                    value
+                    if span_start_time_lower_bound_ms is None
+                    else max(span_start_time_lower_bound_ms, value)
+                )
             if key_name in ("end_time_ms", "end_time"):
                 # end_time = timestamp_ms + execution_time_ms
                 attribute = SqlTraceInfo.timestamp_ms + func.coalesce(
@@ -9558,7 +9596,7 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                     val_filter = SearchTraceUtils.get_sql_comparison_func(comparator, dialect)(
                         span_column, value
                     )
-                span_filter_conditions.append(val_filter)
+                span_attribute_filters.append(val_filter)
                 continue
             elif SearchTraceUtils.is_assessment(key_type, key_name, comparator):
                 # Create subquery to find traces with matching assessments
@@ -9627,24 +9665,26 @@ def _get_filter_clauses_for_search_traces(filter_string, session, dialect):
                 session.query(entity).filter(key_filter, val_filter).subquery()
             )
 
-    # Combine all span filter conditions into a single subquery
-    # This ensures all conditions are applied to the SAME span
-    # Example trace:
-    # span 1. name: foo          status: OK
-    # span 2. name: search_web   status: ERROR
-    # This trace shouldn't be returned for filter_string
-    # 'span.name = "search_web" AND span.status = "OK"'
-    if span_filter_conditions:
-        combined_span_subquery = (
-            session
-            .query(SqlSpan.trace_id.label("request_id"))
-            .filter(*span_filter_conditions)
-            .distinct()
-            .subquery()
-        )
-        span_filters.append(combined_span_subquery)
+    if span_attribute_filters:
+        span_scope_filters = [SqlSpan.experiment_id == SqlTraceInfo.experiment_id]
+        if span_start_time_lower_bound_ms is not None:
+            # Allow minor clock skew between trace and span timestamps while still pruning spans
+            # that are well outside the trace search range.
+            span_start_time_lower_bound_ns = (
+                span_start_time_lower_bound_ms - _SPAN_SEARCH_TIMESTAMP_TOLERANCE_MS
+            ) * 1_000_000
+            span_scope_filters.append(
+                SqlSpan.start_time_unix_nano >= span_start_time_lower_bound_ns
+            )
+        span_attribute_filters[:] = [*span_scope_filters, *span_attribute_filters]
 
-    return attribute_filters, non_attribute_filters, span_filters, run_id_filter
+    return (
+        attribute_filters,
+        non_attribute_filters,
+        span_attribute_filters,
+        span_filters,
+        run_id_filter,
+    )
 
 
 def _get_search_datasets_filter_clauses(parsed_filters, dialect):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_scorers.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_scorers.py
@@ -23,6 +23,7 @@ from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
 from mlflow.store.tracking.dbmodels.models import SqlOnlineScoringConfig
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.utils import TraceJSONEncoder
 
 from tests.store.tracking.sqlalchemy_store.conftest import (
@@ -1189,6 +1190,106 @@ def test_calculate_trace_filter_correlation_zero_counts(store):
     assert result.filter2_count == 5
     assert result.joint_count == 0
     assert math.isnan(result.npmi)
+
+
+def test_calculate_trace_filter_correlation_span_filters_deduplicate_traces(store):
+    exp_id = _create_experiments(store, "span_filter_dedup_correlation")
+
+    trace_id_1 = _create_trace_for_correlation(store, exp_id)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id_1,
+                name="tool_match_1",
+                span_id=111,
+                span_type="TOOL",
+                status=trace_api.StatusCode.OK,
+            ),
+            create_test_span(
+                trace_id_1,
+                name="tool_match_2",
+                span_id=112,
+                span_type="TOOL",
+                status=trace_api.StatusCode.OK,
+            ),
+        ],
+    )
+
+    trace_id_2 = _create_trace_for_correlation(store, exp_id)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id_2,
+                name="tool_match_3",
+                span_id=221,
+                span_type="TOOL",
+                status=trace_api.StatusCode.OK,
+            )
+        ],
+    )
+
+    trace_id_3 = _create_trace_for_correlation(store, exp_id)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id_3,
+                name="llm_no_match",
+                span_id=331,
+                span_type="LLM",
+                status=trace_api.StatusCode.ERROR,
+            )
+        ],
+    )
+
+    result = store.calculate_trace_filter_correlation(
+        experiment_ids=[exp_id],
+        filter_string1='span.type = "TOOL"',
+        filter_string2='span.status = "OK"',
+    )
+
+    assert result.total_count == 3
+    assert result.filter1_count == 2
+    assert result.filter2_count == 2
+    assert result.joint_count == 2
+
+
+def test_calculate_trace_filter_correlation_run_id_filter_matches_linked_traces(store):
+    exp_id = _create_experiments(store, "run_id_filter_correlation")
+    run = store.create_run(exp_id, user_id="user", start_time=0, tags=[], run_name="test_run")
+    run_id = run.info.run_id
+
+    timestamp_ms = time.time_ns() // 1_000_000
+    direct_trace_id = f"tr-{uuid.uuid4()}"
+    store.start_trace(
+        TraceInfo(
+            trace_id=direct_trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=100,
+            state=TraceState.OK,
+            tags={},
+            trace_metadata={TraceMetadataKey.SOURCE_RUN: run_id},
+        )
+    )
+
+    linked_trace_id = _create_trace_for_correlation(store, exp_id)
+    store.link_traces_to_run([linked_trace_id], run_id)
+
+    _create_trace_for_correlation(store, exp_id)
+
+    result = store.calculate_trace_filter_correlation(
+        experiment_ids=[exp_id],
+        filter_string1=f'run_id = "{run_id}"',
+        filter_string2='status = "OK"',
+    )
+
+    assert result.total_count == 3
+    assert result.filter1_count == 2
+    assert result.filter2_count == 3
+    assert result.joint_count == 2
 
 
 def test_calculate_trace_filter_correlation_multiple_experiments(store):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -1047,6 +1047,133 @@ def test_search_traces_combined_span_filters_match_same_span(store: SqlAlchemySt
     assert {t.request_id for t in traces} == {trace1_id, trace2_id}
 
 
+def test_search_traces_span_filters_deduplicate_matching_spans(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_span_filter_dedup")
+    trace_id = "trace1"
+    _create_trace(store, trace_id, exp_id)
+
+    span1 = create_test_span_with_content(
+        trace_id,
+        name="first_match",
+        span_id=111,
+        custom_attributes={"prompt": "needle"},
+    )
+    span2 = create_test_span_with_content(
+        trace_id,
+        name="second_match",
+        span_id=222,
+        custom_attributes={"response": "needle again"},
+    )
+
+    store.log_spans(exp_id, [span1, span2])
+
+    traces, _ = store.search_traces([exp_id], filter_string='trace.text ILIKE "%needle%"')
+    assert [t.request_id for t in traces] == [trace_id]
+
+
+def test_search_traces_span_filters_remain_experiment_scoped(store: SqlAlchemyStore):
+    target_exp_id = store.create_experiment("target_exp")
+    other_exp_id = store.create_experiment("other_exp")
+
+    _create_trace(store, "target-trace", target_exp_id, request_time=1000)
+    _create_trace(store, "other-trace", other_exp_id, request_time=1000)
+
+    matching_span = create_test_span_with_content(
+        "other-trace",
+        name="other_match",
+        span_id=111,
+        custom_attributes={"prompt": "needle"},
+    )
+    store.log_spans(other_exp_id, [matching_span])
+
+    traces, _ = store.search_traces([target_exp_id], filter_string='trace.text ILIKE "%needle%"')
+    assert traces == []
+
+
+def test_search_traces_span_filters_respect_trace_time_window(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_span_time_window")
+    early_trace_id = "trace-early"
+    late_trace_id = "trace-late"
+
+    _create_trace(store, early_trace_id, exp_id, request_time=1000)
+    _create_trace(store, late_trace_id, exp_id, request_time=2000)
+
+    early_matching_span = create_test_span_with_content(
+        early_trace_id,
+        name="early_match",
+        span_id=111,
+        custom_attributes={"prompt": "needle"},
+    )
+    late_non_matching_span = create_test_span_with_content(
+        late_trace_id,
+        name="late_non_match",
+        span_id=222,
+        custom_attributes={"prompt": "different"},
+    )
+    store.log_spans(exp_id, [early_matching_span])
+    store.log_spans(exp_id, [late_non_matching_span])
+
+    traces, _ = store.search_traces(
+        [exp_id],
+        filter_string='timestamp >= 1500 AND timestamp < 2500 AND trace.text ILIKE "%needle%"',
+    )
+    assert traces == []
+
+
+def test_search_traces_span_filters_use_correlated_exists(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_span_correlated_exists")
+
+    with store.ManagedSessionMaker() as session:
+        cases_orderby, parsed_orderby, sorting_joins = (
+            sqlalchemy_store_module._get_orderby_clauses_for_search_traces([], session)
+        )
+        stmt = store._trace_query(session)
+        if cases_orderby:
+            stmt = stmt.add_columns(*cases_orderby)
+
+        (
+            attribute_filters,
+            non_attribute_filters,
+            span_attribute_filters,
+            span_filters,
+            run_id_filter,
+        ) = sqlalchemy_store_module._get_filter_clauses_for_search_traces(
+            (
+                "timestamp >= 20000 AND timestamp > 25000 AND timestamp < 30000 "
+                'AND trace.text ILIKE "%needle%"'
+            ),
+            session,
+            store._get_dialect(),
+        )
+        stmt = store._apply_trace_filter_clauses(
+            stmt,
+            attribute_filters,
+            non_attribute_filters,
+            span_attribute_filters,
+            span_filters,
+            run_id_filter,
+        )
+
+        for join_target in sorting_joins:
+            stmt = stmt.outerjoin(join_target)
+
+        stmt = stmt.filter(SqlTraceInfo.experiment_id.in_([int(exp_id)])).order_by(*parsed_orderby)
+        compiled_sql = str(
+            stmt.statement.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        ).lower()
+
+    assert "exists (select *" in compiled_sql
+    assert "spans.trace_id = trace_info.request_id" in compiled_sql
+    assert "spans.experiment_id = trace_info.experiment_id" in compiled_sql
+    assert "spans.start_time_unix_nano >= 15000000000" in compiled_sql
+    assert "spans.start_time_unix_nano <" not in compiled_sql
+    assert "join spans" not in compiled_sql
+    assert "select distinct spans.trace_id as request_id" not in compiled_sql
+
+
 def test_search_traces_span_filters_with_no_results(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_span_no_results")
 
@@ -5716,6 +5843,52 @@ def test_find_completed_sessions_with_filter_string(store: SqlAlchemyStore):
     )
     assert len(completed) == 1
     assert completed[0].session_id == "session-c"
+
+
+def test_find_completed_sessions_with_span_filter_string(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_find_completed_sessions_with_span_filter")
+
+    # Session A should match, and duplicate matching spans on the first trace
+    # should not duplicate the returned session.
+    _create_trace(
+        store,
+        "trace_a1",
+        exp_id,
+        request_time=1000,
+        trace_metadata={TraceMetadataKey.TRACE_SESSION: "session-a"},
+    )
+    _create_trace(
+        store,
+        "trace_a2",
+        exp_id,
+        request_time=2000,
+        trace_metadata={TraceMetadataKey.TRACE_SESSION: "session-a"},
+    )
+    span_a1 = create_test_span_with_content(
+        "trace_a1",
+        name="first_match",
+        span_id=111,
+        custom_attributes={"prompt": "needle"},
+    )
+    span_a2 = create_test_span_with_content(
+        "trace_a1",
+        name="second_match",
+        span_id=112,
+        custom_attributes={"response": "needle again"},
+    )
+    store.log_spans(exp_id, [span_a1, span_a2])
+
+    completed = store.find_completed_sessions(
+        experiment_id=exp_id,
+        min_last_trace_timestamp_ms=0,
+        max_last_trace_timestamp_ms=10000,
+        filter_string='trace.text ILIKE "%needle%"',
+    )
+
+    assert len(completed) == 1
+    assert completed[0].session_id == "session-a"
+    assert completed[0].first_trace_timestamp_ms == 1000
+    assert completed[0].last_trace_timestamp_ms == 2000
 
 
 def _archive_traces(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -1076,6 +1076,28 @@ def test_search_traces_is_workspace_scoped(workspace_tracking_store):
         assert results[0].trace_id == trace_id_b
 
 
+def test_search_traces_without_locations_is_workspace_scoped_for_span_filters(
+    workspace_tracking_store,
+):
+    with WorkspaceContext("team-search-no-locations-a"):
+        exp_a = workspace_tracking_store.create_experiment("exp-search-no-locations-a")
+        _create_trace(workspace_tracking_store, "trace-a", exp_a)
+        span_a = create_test_span(trace_id="trace-a", name="shared_span", span_id=111)
+        workspace_tracking_store.log_spans(exp_a, [span_a])
+
+    with WorkspaceContext("team-search-no-locations-b"):
+        exp_b = workspace_tracking_store.create_experiment("exp-search-no-locations-b")
+        _create_trace(workspace_tracking_store, "trace-b", exp_b)
+        span_b = create_test_span(trace_id="trace-b", name="shared_span", span_id=222)
+        workspace_tracking_store.log_spans(exp_b, [span_b])
+
+        results, _ = workspace_tracking_store.search_traces(
+            filter_string='span.name = "shared_span"'
+        )
+        assert len(results) == 1
+        assert results[0].trace_id == "trace-b"
+
+
 def test_search_traces_with_assessment_numeric_filters_is_workspace_scoped(
     workspace_tracking_store,
 ):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Addresses https://github.com/mlflow/mlflow/issues/24373

### What changes are proposed in this pull request?



Prior to this commit, text search used a subquery targeting spans across all experiments before filtering down to applicable traces. For example, the query had this shape:

    SELECT ti.*
    FROM trace_info AS ti
    JOIN (
        SELECT DISTINCT s.trace_id AS request_id
        FROM spans AS s
        WHERE s.content ILIKE '%agent_run%'
    ) AS matching_traces
        ON ti.request_id = matching_traces.request_id
    WHERE ti.experiment_id IN (1)
    ORDER BY ti.timestamp_ms DESC, ti.request_id
    LIMIT 50;

This change uses a correlated `EXISTS` query and propagates the experiment scope and a tolerant lower timestamp bound to span filtering. The resulting query has this shape, where `:span_start_ns` is ten seconds before `:start_ms`:

    SELECT ti.*
    FROM trace_info AS ti
    WHERE ti.experiment_id IN (1)
      AND ti.timestamp_ms >= :start_ms
      AND EXISTS (
          SELECT 1
          FROM spans AS s
          WHERE s.trace_id = ti.request_id
            AND s.experiment_id = ti.experiment_id
            AND s.start_time_unix_nano >= :span_start_ns
            AND s.content ILIKE '%agent_run%'
      )
    ORDER BY ti.timestamp_ms DESC, ti.request_id
    LIMIT 50;

On PostgreSQL with 10 million traces and 30 million spans in one experiment, searching 30 days for the newest 50 traces matching `ILIKE '%agent_run%'` dropped from 113.1 seconds on average to 11.6 milliseconds (about 9,700x faster). A seven-day search for absent text dropped from 56.2 to 28.1 seconds because the span timestamp predicate avoids evaluating `ILIKE` outside the requested range.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
