### PR TITLE
Fix UI unresponsiveness in experiment chart view with many charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGrid.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGrid.test.tsx
@@ -35,9 +35,11 @@ jest.mock('../../../../common/utils/FeatureUtils', () => ({
   shouldEnableHidingChartsWithNoData: jest.fn(() => true),
 }));
 
-// Mock useIsInViewport hook to simulate that the chart element is in the viewport
+const mockUseIsInViewport = jest.fn(() => ({ isInViewport: true, setElementRef: jest.fn() }));
+
+// Mock useIsInViewport hook to simulate that the chart element is in the viewport by default
 jest.mock('../hooks/useIsInViewport', () => ({
-  useIsInViewport: () => ({ isInViewport: true, setElementRef: jest.fn() }),
+  useIsInViewport: () => mockUseIsInViewport(),
 }));
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
@@ -529,6 +531,108 @@ describe('RunsChartsDraggableCardsGrid', () => {
     await waitFor(() => {
       expect(screen.queryAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(0);
       expect(screen.getByText('No charts in this section')).toBeInTheDocument();
+    });
+  });
+
+  test('virtualizes large grids by rendering placeholders for groups outside the viewport', async () => {
+    // Create enough cards to trigger virtualization (threshold is 30).
+    const cards = Array.from({ length: 60 }, (_, i) => ({
+      type: RunsChartType.BAR,
+      metricKey: `metric_${i + 1}`,
+      uuid: `card_${i + 1}`,
+    })) as RunsChartsBarCardConfig[];
+
+    // Simulate groups outside the viewport.
+    mockUseIsInViewport.mockReturnValue({ isInViewport: false, setElementRef: jest.fn() });
+
+    const TestComponent = () => {
+      const [uiState, setUIState] = useState<ExperimentRunsChartsUIConfiguration>({
+        ...createExperimentPageUIState(),
+        compareRunCharts: cards,
+      });
+
+      return (
+        <RunsChartsUIConfigurationContextProvider updateChartsUIState={setUIState}>
+          <RunsChartsDraggableCardsGridContextProvider visibleChartCards={cards}>
+            <RunsChartsDraggableCardsGridSection
+              cardsConfig={uiState.compareRunCharts ?? []}
+              chartRunData={[]}
+              sectionId="virtualization-test"
+              setFullScreenChart={noop}
+              groupBy={null}
+              onRemoveChart={noop}
+              onStartEditChart={noop}
+              sectionConfig={{
+                display: true,
+                isReordered: false,
+                name: 'section_1',
+                uuid: 'section_1',
+                cardHeight: 360,
+                columns: 3,
+              }}
+            />
+          </RunsChartsDraggableCardsGridContextProvider>
+        </RunsChartsUIConfigurationContextProvider>
+      );
+    };
+
+    renderTestComponent(<TestComponent />);
+
+    await waitFor(() => {
+      // No chart cards should be mounted; only group placeholders should exist.
+      expect(screen.queryAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(0);
+      expect(screen.getAllByTestId('virtualized-chart-group-placeholder')).toHaveLength(2);
+    });
+
+    // Reset the mock so subsequent tests render cards normally.
+    mockUseIsInViewport.mockReturnValue({ isInViewport: true, setElementRef: jest.fn() });
+  });
+
+  test('renders all cards in a virtualized grid when groups are in the viewport', async () => {
+    // Create enough cards to trigger virtualization (threshold is 30).
+    const cards = Array.from({ length: 60 }, (_, i) => ({
+      type: RunsChartType.BAR,
+      metricKey: `metric_${i + 1}`,
+      uuid: `card_${i + 1}`,
+    })) as RunsChartsBarCardConfig[];
+
+    mockUseIsInViewport.mockReturnValue({ isInViewport: true, setElementRef: jest.fn() });
+
+    const TestComponent = () => {
+      const [uiState, setUIState] = useState<ExperimentRunsChartsUIConfiguration>({
+        ...createExperimentPageUIState(),
+        compareRunCharts: cards,
+      });
+
+      return (
+        <RunsChartsUIConfigurationContextProvider updateChartsUIState={setUIState}>
+          <RunsChartsDraggableCardsGridContextProvider visibleChartCards={cards}>
+            <RunsChartsDraggableCardsGridSection
+              cardsConfig={uiState.compareRunCharts ?? []}
+              chartRunData={[]}
+              sectionId="virtualization-test"
+              setFullScreenChart={noop}
+              groupBy={null}
+              onRemoveChart={noop}
+              onStartEditChart={noop}
+              sectionConfig={{
+                display: true,
+                isReordered: false,
+                name: 'section_1',
+                uuid: 'section_1',
+                cardHeight: 360,
+                columns: 3,
+              }}
+            />
+          </RunsChartsDraggableCardsGridContextProvider>
+        </RunsChartsUIConfigurationContextProvider>
+      );
+    };
+
+    renderTestComponent(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('experiment-view-compare-runs-card-drag-handle')).toHaveLength(60);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridSection.tsx
@@ -1,4 +1,5 @@
 import { Empty, useDesignSystemTheme } from '@databricks/design-system';
+import { chunk } from 'lodash';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useUpdateRunsChartsUIConfiguration } from '../hooks/useRunsChartsUIConfiguration';
 import type { RunsChartsCardConfig } from '../runs-charts.types';
@@ -14,11 +15,19 @@ import {
   useRunsChartsDraggableGridStateContext,
 } from './RunsChartsDraggableCardsGridContext';
 import { RunsChartsDraggablePreview } from './RunsChartsDraggablePreview';
+import { RunsChartsVirtualizedGroup } from './RunsChartsVirtualizedGroup';
 import { DRAGGABLE_CARD_TRANSITION_NAME, type RunsChartCardSetFullscreenFn } from './cards/ChartCard.common';
 import type { RunsGroupByConfig } from '../../experiment-page/utils/experimentPage.group-row-utils';
 import type { RunsChartsGlobalLineChartConfig } from '../../experiment-page/models/ExperimentPageUIState';
 
 const rowHeightSuggestions = [300, 330, 360, 400, 500];
+
+// Number of chart cards per virtualization group. Larger groups reduce the
+// number of IntersectionObserver targets but increase the work per visible group.
+const CHART_CARDS_PER_VIRTUAL_GROUP = 30;
+
+// Disable virtualization for small grids where the overhead is not worth it.
+const VIRTUALIZATION_DISABLE_THRESHOLD = CHART_CARDS_PER_VIRTUAL_GROUP;
 
 const getColumnSuggestions = (containerWidth: number, gapSize = 8) =>
   [1, 2, 3, 4, 5].map((n) => ({
@@ -167,6 +176,13 @@ export const RunsChartsDraggableCardsGridSection = memo(
         return !isEmptyChartCard(cardConfig);
       });
     }, [cardsConfig, chartRunData, hideEmptyCharts]);
+
+    const cardGroups = useMemo(() => {
+      if (cardsToRender.length <= VIRTUALIZATION_DISABLE_THRESHOLD) {
+        return null;
+      }
+      return chunk(cardsToRender, CHART_CARDS_PER_VIRTUAL_GROUP);
+    }, [cardsToRender]);
 
     // Calculate the transforms for each card based on the dragged card and its position.
     const cardTransforms = useMemo(() => {
@@ -358,33 +374,58 @@ export const RunsChartsDraggableCardsGridSection = memo(
             />
           </div>
         )}
-        {cardsToRender.map((cardConfig, index, array) => {
-          return (
-            <RunsChartsDraggableCard
-              key={cardConfig.uuid}
-              uuid={cardConfig.uuid ?? ''}
-              translateBy={cardTransforms[cardConfig.uuid ?? '']}
-              onResizeStart={onResizeStart}
-              onResizeStop={onResizeStop}
-              onResize={onResize}
-              cardConfig={cardConfig}
-              chartRunData={chartRunData}
-              onReorderWith={onSwapCards}
-              index={index}
-              height={cardHeight}
-              canMoveDown={Boolean(array[index + 1])}
-              canMoveUp={Boolean(array[index - 1])}
-              canMoveToTop={index > 0}
-              canMoveToBottom={index < array.length - 1}
-              previousChartUuid={array[index - 1]?.uuid}
-              nextChartUuid={array[index + 1]?.uuid}
-              hideEmptyCharts={hideEmptyCharts}
-              firstChartUuid={array[0]?.uuid}
-              lastChartUuid={array[array.length - 1]?.uuid}
-              {...cardProps}
-            />
-          );
-        })}
+        {cardGroups
+          ? cardGroups.map((groupCards, groupIndex) => (
+              <RunsChartsVirtualizedGroup
+                key={`virtual-group-${sectionId}-${groupIndex}`}
+                cards={groupCards}
+                allCards={cardsToRender}
+                groupStartIndex={groupIndex * CHART_CARDS_PER_VIRTUAL_GROUP}
+                columns={columns}
+                cardHeight={cardHeight}
+                gap={theme.spacing.sm}
+                chartRunData={chartRunData}
+                onRemoveChart={cardProps.onRemoveChart}
+                onStartEditChart={cardProps.onStartEditChart}
+                setFullScreenChart={cardProps.setFullScreenChart}
+                groupBy={cardProps.groupBy}
+                autoRefreshEnabled={cardProps.autoRefreshEnabled}
+                hideEmptyCharts={hideEmptyCharts}
+                globalLineChartConfig={cardProps.globalLineChartConfig}
+                onResizeStart={onResizeStart}
+                onResizeStop={onResizeStop}
+                onResize={onResize}
+                onReorderWith={onSwapCards}
+                getTranslateBy={(uuid) => cardTransforms[uuid ?? '']}
+              />
+            ))
+          : cardsToRender.map((cardConfig, index, array) => {
+              return (
+                <RunsChartsDraggableCard
+                  key={cardConfig.uuid}
+                  uuid={cardConfig.uuid ?? ''}
+                  translateBy={cardTransforms[cardConfig.uuid ?? '']}
+                  onResizeStart={onResizeStart}
+                  onResizeStop={onResizeStop}
+                  onResize={onResize}
+                  cardConfig={cardConfig}
+                  chartRunData={chartRunData}
+                  onReorderWith={onSwapCards}
+                  index={index}
+                  height={cardHeight}
+                  canMoveDown={Boolean(array[index + 1])}
+                  canMoveUp={Boolean(array[index - 1])}
+                  canMoveToTop={index > 0}
+                  canMoveToBottom={index < array.length - 1}
+                  previousChartUuid={array[index - 1]?.uuid}
+                  nextChartUuid={array[index + 1]?.uuid}
+                  hideEmptyCharts={hideEmptyCharts}
+                  firstChartUuid={array[0]?.uuid}
+                  lastChartUuid={array[array.length - 1]?.uuid}
+                  {...cardProps}
+                />
+              );
+            })}
         {dragPreview && <RunsChartsDraggablePreview {...dragPreview} />}
         {resizePreview && <RunsChartsDraggablePreview {...resizePreview} />}
       </div>

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsVirtualizedGroup.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsVirtualizedGroup.tsx
@@ -1,0 +1,133 @@
+import { memo } from 'react';
+import { useIsInViewport } from '../hooks/useIsInViewport';
+import type { RunsChartsCardConfig } from '../runs-charts.types';
+import type { RunsChartsRunData } from './RunsCharts.common';
+import { RunsChartsDraggableCard } from './RunsChartsDraggableCard';
+import type { RunsChartCardSetFullscreenFn } from './cards/ChartCard.common';
+import type { RunsGroupByConfig } from '../../experiment-page/utils/experimentPage.group-row-utils';
+import type { RunsChartsGlobalLineChartConfig } from '../../experiment-page/models/ExperimentPageUIState';
+
+const VIRTUAL_GROUP_OVERSCAN_MARGIN = '400px';
+
+export interface RunsChartsVirtualizedGroupProps {
+  cards: RunsChartsCardConfig[];
+  allCards: RunsChartsCardConfig[];
+  groupStartIndex: number;
+  columns: number;
+  cardHeight: number;
+  gap: number;
+  chartRunData: RunsChartsRunData[];
+  onRemoveChart: (chart: RunsChartsCardConfig) => void;
+  onStartEditChart: (chart: RunsChartsCardConfig) => void;
+  setFullScreenChart: RunsChartCardSetFullscreenFn;
+  groupBy: RunsGroupByConfig | null;
+  autoRefreshEnabled?: boolean;
+  hideEmptyCharts?: boolean;
+  globalLineChartConfig?: RunsChartsGlobalLineChartConfig;
+  onResizeStart: (rect: DOMRect) => void;
+  onResizeStop: () => void;
+  onResize: (width: number, height: number) => void;
+  onReorderWith: (draggedKey: string, targetDropKey: string) => void;
+  getTranslateBy: (uuid?: string) => { x: number; y: number; overflowing: boolean } | undefined;
+}
+
+/**
+ * Renders a group of chart cards with viewport-based virtualization.
+ *
+ * When the group is outside the viewport (with overscan), only a single
+ * placeholder div is rendered to preserve the grid layout and scroll height.
+ * When inside the viewport, the actual draggable chart cards are mounted.
+ */
+export const RunsChartsVirtualizedGroup = memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    cards,
+    allCards,
+    groupStartIndex,
+    columns,
+    cardHeight,
+    gap,
+    chartRunData,
+    onRemoveChart,
+    onStartEditChart,
+    setFullScreenChart,
+    groupBy,
+    autoRefreshEnabled,
+    hideEmptyCharts,
+    globalLineChartConfig,
+    onResizeStart,
+    onResizeStop,
+    onResize,
+    onReorderWith,
+    getTranslateBy,
+  }: RunsChartsVirtualizedGroupProps) => {
+    const { setElementRef, isInViewport } = useIsInViewport<HTMLDivElement>({
+      enabled: true,
+      rootMargin: VIRTUAL_GROUP_OVERSCAN_MARGIN,
+    });
+
+    const groupRowCount = Math.ceil(cards.length / columns);
+    const groupHeight = groupRowCount * cardHeight + (groupRowCount - 1) * gap;
+
+    // Render a placeholder that preserves the group's layout space.
+    if (!isInViewport) {
+      return (
+        <div
+          ref={setElementRef}
+          data-testid="virtualized-chart-group-placeholder"
+          css={{ gridColumn: '1 / -1' }}
+          style={{ height: groupHeight }}
+        />
+      );
+    }
+
+    return (
+      <>
+        {/**
+         * A zero-height sentinel that stays mounted while the group is visible so
+         * the IntersectionObserver can keep tracking it. It spans the full grid width
+         * and creates a negligible extra grid gap.
+         */}
+        <div
+          ref={setElementRef}
+          data-testid="virtualized-chart-group-sentinel"
+          css={{ gridColumn: '1 / -1' }}
+          style={{ height: 0 }}
+        />
+        {cards.map((cardConfig, localIndex) => {
+          const index = groupStartIndex + localIndex;
+          return (
+            <RunsChartsDraggableCard
+              key={cardConfig.uuid}
+              uuid={cardConfig.uuid ?? ''}
+              onResizeStart={onResizeStart}
+              onResizeStop={onResizeStop}
+              onResize={onResize}
+              cardConfig={cardConfig}
+              chartRunData={chartRunData}
+              onReorderWith={onReorderWith}
+              translateBy={getTranslateBy(cardConfig.uuid)}
+              index={index}
+              height={cardHeight}
+              canMoveDown={Boolean(allCards[index + 1])}
+              canMoveUp={Boolean(allCards[index - 1])}
+              canMoveToTop={index > 0}
+              canMoveToBottom={index < allCards.length - 1}
+              previousChartUuid={allCards[index - 1]?.uuid}
+              nextChartUuid={allCards[index + 1]?.uuid}
+              hideEmptyCharts={hideEmptyCharts}
+              firstChartUuid={allCards[0]?.uuid}
+              lastChartUuid={allCards[allCards.length - 1]?.uuid}
+              onRemoveChart={onRemoveChart}
+              onStartEditChart={onStartEditChart}
+              setFullScreenChart={setFullScreenChart}
+              groupBy={groupBy}
+              autoRefreshEnabled={autoRefreshEnabled}
+              globalLineChartConfig={globalLineChartConfig}
+            />
+          );
+        })}
+      </>
+    );
+  },
+);

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/sections/RunsChartsSectionAccordion.tsx
@@ -316,6 +316,23 @@ export const RunsChartsSectionAccordion = ({
     return { sectionsToRender: compareRunSectionsFiltered, chartsToRender: compareRunChartsFiltered };
   }, [search, compareRunCharts, compareRunSections]);
 
+  /**
+   * Pre-compute and memoize the charts belonging to each section. Without this,
+   * the inner filter creates a new array on every render, causing downstream
+   * components (and their expensive empty-chart checks) to recompute unnecessarily.
+   */
+  const sectionChartsMap = useMemo(() => {
+    const map = new Map<string, RunsChartsCardConfig[]>();
+    (sectionsToRender || []).forEach((sectionConfig) => {
+      const sectionCharts = (chartsToRender || []).filter((config: RunsChartsCardConfig) => {
+        const section = (config as RunsChartsBarCardConfig).metricSectionId;
+        return !config.deleted && section === sectionConfig.uuid;
+      });
+      map.set(sectionConfig.uuid, sectionCharts);
+    });
+    return map;
+  }, [sectionsToRender, chartsToRender]);
+
   const isSearching = search !== '';
 
   if (!compareRunSections || !compareRunCharts) {
@@ -366,10 +383,7 @@ export const RunsChartsSectionAccordion = ({
     <div>
       <MetricChartsAccordion activeKey={activeKey} onActiveKeyChange={onActivePanelChange}>
         {(sectionsToRender || []).map((sectionConfig: ChartSectionConfig, index: number) => {
-          const sectionCharts = (chartsToRender || []).filter((config: RunsChartsCardConfig) => {
-            const section = (config as RunsChartsBarCardConfig).metricSectionId;
-            return !config.deleted && section === sectionConfig.uuid;
-          });
+          const sectionCharts = sectionChartsMap.get(sectionConfig.uuid) ?? [];
 
           return (
             <Accordion.Panel

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useIsInViewport.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/hooks/useIsInViewport.tsx
@@ -1,28 +1,36 @@
 import { useEffect, useRef, useState } from 'react';
 
-// Define a module-global observer and a WeakMap on elements to hold callbacks
-let sharedObserver: IntersectionObserver | null = null;
+// Define module-global observers keyed by rootMargin and a WeakMap on elements to hold callbacks
+const sharedObservers: Record<string, IntersectionObserver> = {};
 const entryCallbackMap = new WeakMap();
 
-const ensureSharedObserverExists = () => {
-  if (!sharedObserver) {
-    sharedObserver = new IntersectionObserver((entries) => {
-      for (const entry of entries) {
-        const entryCallback = entryCallbackMap.get(entry.target);
-        entryCallback?.(entry.isIntersecting);
-      }
-    });
+const getObserverKey = (rootMargin?: string) => rootMargin ?? 'default';
+
+const ensureSharedObserverExists = (rootMargin?: string) => {
+  const observerKey = getObserverKey(rootMargin);
+  if (!sharedObservers[observerKey]) {
+    sharedObservers[observerKey] = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const entryCallback = entryCallbackMap.get(entry.target);
+          entryCallback?.(entry.isIntersecting);
+        }
+      },
+      { rootMargin },
+    );
   }
 };
 
-function observeElement(element: Element, callback: (isIntersecting: boolean) => void) {
-  ensureSharedObserverExists();
+function observeElement(element: Element, callback: (isIntersecting: boolean) => void, rootMargin?: string) {
+  ensureSharedObserverExists(rootMargin);
+  const observerKey = getObserverKey(rootMargin);
+  const observer = sharedObservers[observerKey];
   entryCallbackMap.set(element, callback);
-  sharedObserver?.observe(element);
+  observer?.observe(element);
 
   return () => {
     if (element) {
-      sharedObserver?.unobserve(element);
+      observer?.unobserve(element);
       entryCallbackMap.delete(element);
     }
   };
@@ -32,7 +40,10 @@ function observeElement(element: Element, callback: (isIntersecting: boolean) =>
  * Checks if the element is currently visible within the viewport using IntersectionObserver.
  * If "enabled" is set to false, the returned value will always be true.
  */
-export const useIsInViewport = <T extends Element>({ enabled = true }: { enabled?: boolean } = {}) => {
+export const useIsInViewport = <T extends Element>({
+  enabled = true,
+  rootMargin,
+}: { enabled?: boolean; rootMargin?: string } = {}) => {
   const [element, setElementRef] = useState<T | null>(null);
   const [isInViewport, setIsInViewport] = useState(!enabled);
 
@@ -48,8 +59,8 @@ export const useIsInViewport = <T extends Element>({ enabled = true }: { enabled
       return;
     }
 
-    return observeElement(element, setIsInViewport);
-  }, [enabled, element]);
+    return observeElement(element, setIsInViewport, rootMargin);
+  }, [enabled, element, rootMargin]);
 
   // When the flag is disabled, deferred result is the same as the regular one
   return { isInViewport, setElementRef };


### PR DESCRIPTION
### Related Issues/PRs

Closes #24012

### What changes are proposed in this pull request?

This PR fixes the experiment/run Chart view becoming unresponsive or crashing when an experiment has a large number of distinct metric keys (and therefore a large number of auto-generated chart cards).

Two changes:

1. **Virtualize the draggable chart grid.** `RunsChartsDraggableCardsGridSection` now splits the card list into groups of 30 and only mounts actual `RunsChartsDraggableCard` components for groups that are inside (or near) the viewport. Off-screen groups render a single placeholder div that preserves the grid layout and scroll height. Virtualization is disabled for small grids (≤30 cards) to avoid unnecessary overhead.
2. **Memoize per-section chart filtering.** `RunsChartsSectionAccordion` previously created a new `sectionCharts` array on every render, which caused downstream empty-chart checks to recompute unnecessarily. The filtering is now memoized in a `Map`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added two tests in `RunsChartsDraggableCardsGrid.test.tsx`:
- Large grids render placeholders for groups outside the viewport.
- Large grids render all cards when groups are in the viewport.

All related tests pass:
- `src/experiment-tracking/components/runs-charts`: 112 passed
- `src/experiment-tracking/components/runs-compare`: 19 passed
- `src/experiment-tracking/components/run-page`: 7 passed

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved responsiveness of the experiment/run Chart view when displaying thousands of charts.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release