### PR TITLE
Support Microsoft Entra ID authentication for Azure OpenAI providers

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/supported-models.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/custom-judges/supported-models.mdx
@@ -24,7 +24,7 @@ MLflow supports calling model providers directly using the format `provider:/mod
 | Provider       | URI Format                                                      | Environment Variables                                                                                                                                                                   |
 | -------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | OpenAI         | `openai:/gpt-5.4-mini`                                          | `OPENAI_API_KEY`                                                                                                                                                                        |
-| Azure OpenAI   | `azure:/my-deployment`                                          | `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION`                                                                                                                                  |
+| Azure OpenAI   | `azure:/my-deployment`                                          | `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION`. Microsoft Entra ID authentication is also supported (see note below).                                                           |
 | Anthropic      | `anthropic:/claude-sonnet-4-5`                                  | `ANTHROPIC_API_KEY`                                                                                                                                                                     |
 | Amazon Bedrock | `bedrock:/google.gemma-3-4b-it`                                 | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` (optional). Alternatively: `AWS_BEARER_TOKEN_BEDROCK` for API key auth, or `AWS_ROLE_ARN` for IAM role. |
 | Google Gemini  | `gemini:/gemini-3.1-pro-preview`                                | `GEMINI_API_KEY`                                                                                                                                                                        |
@@ -37,6 +37,10 @@ MLflow supports calling model providers directly using the format `provider:/mod
 | Together AI    | `togetherai:/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | `TOGETHERAI_API_KEY`                                                                                                                                                                    |
 | Ollama         | `ollama:/llama3.2`                                              | None (local)                                                                                                                                                                            |
 | Databricks     | `databricks:/databricks-claude-sonnet-4-5`                      | [Databricks SDK authentication](https://docs.databricks.com/aws/en/dev-tools/auth/index.html) (e.g. `DATABRICKS_HOST` + `DATABRICKS_TOKEN`, or other supported methods)                 |
+
+:::note Azure OpenAI with Microsoft Entra ID
+To authenticate to Azure OpenAI with Microsoft Entra ID instead of an API key, set `MLFLOW_AZURE_OPENAI_AUTH_MODE=entra_id` along with `AZURE_API_BASE` and `AZURE_API_VERSION` (no `AZURE_API_KEY` is needed). Tokens are acquired via azure-identity's `DefaultAzureCredential` (`pip install azure-identity`), which supports managed identities, Azure CLI login, and environment-based service principals (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`).
+:::
 
 :::warning
 Judges configured with direct model providers require credentials to be available locally (typically via environment variables) and **cannot be run from the UI**. Use AI Gateway endpoints if you want to run the judges from the UI.

--- a/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
+++ b/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
@@ -19,7 +19,7 @@ Navigate to `http://localhost:5000/#/settings` and click on the **LLM Connection
 2. Enter a unique name for the connection (e.g., `my-openai-key`)
 3. Select your provider from the dropdown (OpenAI, Anthropic, Google Gemini, etc.)
 4. Choose the authentication method if multiple options are available
-   - For example, OpenAI supports both standard API key authentication and Azure-specific authentication
+   - For example, OpenAI supports both standard API key authentication, Azure-specific api authentication and Azure OpenAI Entra ID authentication.
 5. Enter your credentials (displayed as masked inputs for security)
 6. Fill in any provider-specific configuration fields:
    - **Azure**: Endpoint URL

--- a/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
@@ -211,9 +211,14 @@ Azure OpenAI uses the same passthrough as OpenAI with additional configuration:
 When creating an Azure OpenAI endpoint:
 
 1. Select **Azure OpenAI** as the provider
-2. Enter your Azure endpoint URL
-3. Enter your Azure API key
-4. Specify your deployment name
+2. Choose the authentication method: **API Key**, **Service Principal** (Microsoft Entra ID client credentials), or **Default Azure Credential** (the server's own Azure identity)
+3. Enter your Azure endpoint URL
+4. For **API Key**, enter your Azure API key; for **Service Principal**, enter the client ID, tenant ID, and client secret of your Microsoft Entra ID application; for **Default Azure Credential**, no credentials are entered — tokens are resolved from the server's environment (managed identity, workload identity, Azure CLI login, or `AZURE_*` environment variables)
+5. Specify your deployment name
+
+:::note
+The Service Principal and Default Azure Credential options acquire Microsoft Entra ID tokens at request time and require the `azure-identity` package on the MLflow server (`pip install azure-identity`). With Default Azure Credential, the server's identity (for example, an Azure Container Apps managed identity) must have the **Cognitive Services OpenAI User** role on the Azure OpenAI resource; to select a user-assigned managed identity, set the `AZURE_CLIENT_ID` environment variable on the server.
+:::
 
 ```python
 from openai import OpenAI

--- a/examples/gateway/azure_openai/README.md
+++ b/examples/gateway/azure_openai/README.md
@@ -1,12 +1,13 @@
 ## Example endpoint configuration for Azure OpenAI
 
 The following example configuration shows the 3 supported endpoints for Azure OpenAI: chat, completions, and embeddings.
-Additionally, it illustrates the two separate api types that are supported for this service.
+Additionally, it illustrates the separate access paradigms that are supported for this service.
 
 - `azure` api type: uses a generated token that is applied by setting the API token key directly to an environment variable
-- `azuread` api type: uses Azure Active Directory for supplying the active directory key to be used to an environment variable
+- `azuread` api type with `openai_api_key`: uses a pre-fetched Microsoft Entra ID (formerly Azure Active Directory) access token supplied via an environment variable
+- `azuread` api type without `openai_api_key`: acquires Microsoft Entra ID tokens at request time via [azure-identity](https://pypi.org/project/azure-identity/) (`pip install azure-identity`). With no service principal fields, `DefaultAzureCredential` is used (managed identity, Azure CLI login, or the `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_CLIENT_SECRET` environment variables); with `openai_ad_client_id`, `openai_ad_tenant_id`, and `openai_ad_client_secret` set, that service principal is used via `ClientSecretCredential`
 
-Depending on how your users will be interacting with the MLflow AI Gateway, a single access paradigm (either `azure` **or** `azuread` is recommended, not a mix of both).
+Depending on how your users will be interacting with the MLflow AI Gateway, a single access paradigm is recommended, not a mix of several.
 
 See the [Azure OpenAI configuration](config.yaml) YAML file for example configurations showing all supported endpoint types and the different token access types.
 

--- a/examples/gateway/azure_openai/config.yaml
+++ b/examples/gateway/azure_openai/config.yaml
@@ -34,3 +34,28 @@ endpoints:
         openai_deployment_name: "{your_deployment_name}"
         openai_api_base: "https://{your_resource_name}-azureopenai.openai.azure.com/"
         openai_api_version: "2023-05-15"
+
+  - name: chat_entra_id
+    endpoint_type: llm/v1/chat
+    model:
+      provider: openai
+      name: gpt-4o-mini
+      config:
+        openai_api_type: "azuread"
+        openai_deployment_name: "{your_deployment_name}"
+        openai_api_base: "https://{your_resource_name}-azureopenai.openai.azure.com/"
+        openai_api_version: "2023-05-15"
+
+  - name: chat_service_principal
+    endpoint_type: llm/v1/chat
+    model:
+      provider: openai
+      name: gpt-4o-mini
+      config:
+        openai_api_type: "azuread"
+        openai_ad_client_id: "{your_client_id}"
+        openai_ad_tenant_id: "{your_tenant_id}"
+        openai_ad_client_secret: $AZURE_CLIENT_SECRET
+        openai_deployment_name: "{your_deployment_name}"
+        openai_api_base: "https://{your_resource_name}-azureopenai.openai.azure.com/"
+        openai_api_version: "2023-05-15"

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -846,6 +846,18 @@ MLFLOW_GENAI_JUDGE_DEFAULT_MODEL = _EnvironmentVariable(
     "MLFLOW_GENAI_JUDGE_DEFAULT_MODEL", str, None
 )
 
+#: Authentication mode for the direct Azure OpenAI model provider
+#: (``azure:/<deployment>`` judge/scorer model URIs). Allowed values: ``api_key``
+#: (default, requires ``AZURE_API_KEY``) and ``entra_id`` (Microsoft Entra ID via
+#: azure-identity's ``DefaultAzureCredential``, which supports environment-based
+#: service principals through ``AZURE_CLIENT_ID``/``AZURE_TENANT_ID``/
+#: ``AZURE_CLIENT_SECRET``, managed identity, Azure CLI login, etc.).
+#: ``AZURE_API_BASE`` and ``AZURE_API_VERSION`` are required in both modes.
+#: (default: ``api_key``)
+MLFLOW_AZURE_OPENAI_AUTH_MODE = _EnvironmentVariable(
+    "MLFLOW_AZURE_OPENAI_AUTH_MODE", str, "api_key"
+)
+
 
 #: Skip trace validation during GenAI evaluation. By default (False), MLflow will validate if
 #: the given predict function generates a valid trace, and otherwise wraps it with @mlflow.trace

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -143,22 +143,41 @@ class OpenAIAPIType(str, Enum):
 
 
 class OpenAIConfig(ConfigModel):
-    openai_api_key: str
+    openai_api_key: str | None = None
     openai_api_type: OpenAIAPIType = OpenAIAPIType.OPENAI
     openai_api_base: str | None = None
     openai_api_version: str | None = None
     openai_deployment_name: str | None = None
     openai_organization: str | None = None
+    # Microsoft Entra ID service principal fields, only valid with the 'azuread' api type.
+    # When 'openai_api_type' is 'azuread' and no 'openai_api_key' (static token) is given,
+    # tokens are acquired at request time via azure-identity: 'ClientSecretCredential' if
+    # these fields are set, 'DefaultAzureCredential' otherwise.
+    openai_ad_client_id: str | None = None
+    openai_ad_tenant_id: str | None = None
+    openai_ad_client_secret: str | None = None
 
     @field_validator("openai_api_key", mode="before")
     def validate_openai_api_key(cls, value):
-        return _resolve_api_key_from_input(value)
+        return None if value is None else _resolve_api_key_from_input(value)
+
+    @field_validator("openai_ad_client_secret", mode="before")
+    def validate_openai_ad_client_secret(cls, value):
+        return None if value is None else _resolve_api_key_from_input(value)
 
     @classmethod
     def _validate_field_compatibility(cls, info: dict[str, Any]):
         if not isinstance(info, dict):
             return info
         api_type = (info.get("openai_api_type") or OpenAIAPIType.OPENAI).lower()
+        sp_fields = ("openai_ad_client_id", "openai_ad_tenant_id", "openai_ad_client_secret")
+        provided_sp_fields = [field for field in sp_fields if info.get(field) is not None]
+        if api_type != OpenAIAPIType.AZUREAD and provided_sp_fields:
+            raise MlflowException.invalid_parameter_value(
+                f"OpenAI route configuration can only specify values for "
+                f"'openai_ad_client_id', 'openai_ad_tenant_id', and 'openai_ad_client_secret' "
+                f"if 'openai_api_type' is '{OpenAIAPIType.AZUREAD}'. Found type: '{api_type}'"
+            )
         if api_type == OpenAIAPIType.OPENAI:
             if info.get("openai_deployment_name") is not None:
                 raise MlflowException.invalid_parameter_value(
@@ -168,6 +187,11 @@ class OpenAIConfig(ConfigModel):
                 )
             if info.get("openai_api_base") is None:
                 info["openai_api_base"] = "https://api.openai.com/v1"
+            if info.get("openai_api_key") is None:
+                raise MlflowException.invalid_parameter_value(
+                    f"OpenAI route configuration must specify 'openai_api_key' if "
+                    f"'openai_api_type' is '{OpenAIAPIType.OPENAI}'."
+                )
         elif api_type in (OpenAIAPIType.AZURE, OpenAIAPIType.AZUREAD):
             if info.get("openai_organization") is not None:
                 raise MlflowException.invalid_parameter_value(
@@ -183,6 +207,27 @@ class OpenAIConfig(ConfigModel):
                     f"'openai_deployment_name', and 'openai_api_version' if 'openai_api_type' is "
                     f"'{OpenAIAPIType.AZURE}' or '{OpenAIAPIType.AZUREAD}'."
                 )
+            if api_type == OpenAIAPIType.AZURE and info.get("openai_api_key") is None:
+                raise MlflowException.invalid_parameter_value(
+                    f"OpenAI route configuration must specify 'openai_api_key' if "
+                    f"'openai_api_type' is '{OpenAIAPIType.AZURE}'."
+                )
+            if api_type == OpenAIAPIType.AZUREAD:
+                if info.get("openai_api_key") is not None and provided_sp_fields:
+                    raise MlflowException.invalid_parameter_value(
+                        f"OpenAI route configuration with 'openai_api_type: "
+                        f"{OpenAIAPIType.AZUREAD}' must specify either 'openai_api_key' "
+                        f"(a static Microsoft Entra ID token) or the 'openai_ad_client_id', "
+                        f"'openai_ad_tenant_id', and 'openai_ad_client_secret' service "
+                        f"principal fields, not both."
+                    )
+                if provided_sp_fields and len(provided_sp_fields) < len(sp_fields):
+                    missing_fields = sorted(set(sp_fields) - set(provided_sp_fields))
+                    raise MlflowException.invalid_parameter_value(
+                        f"OpenAI route configuration must specify 'openai_ad_client_id', "
+                        f"'openai_ad_tenant_id', and 'openai_ad_client_secret' together. "
+                        f"Missing: {missing_fields}"
+                    )
         else:
             raise MlflowException.invalid_parameter_value(f"Invalid OpenAI API type '{api_type}'")
 

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -211,9 +211,18 @@ class OpenAIProvider(BaseProvider):
                 headers["OpenAI-Organization"] = org
             return headers
         elif api_type == OpenAIAPIType.AZUREAD:
-            return {
-                "authorization": f"Bearer {self.openai_config.openai_api_key}",
-            }
+            if self.openai_config.openai_api_key is not None:
+                return {
+                    "authorization": f"Bearer {self.openai_config.openai_api_key}",
+                }
+            from mlflow.utils.azure_auth import get_azure_openai_token
+
+            token = get_azure_openai_token(
+                client_id=self.openai_config.openai_ad_client_id,
+                tenant_id=self.openai_config.openai_ad_tenant_id,
+                client_secret=self.openai_config.openai_ad_client_secret,
+            )
+            return {"authorization": f"Bearer {token}"}
         elif api_type == OpenAIAPIType.AZURE:
             return {
                 "api-key": self.openai_config.openai_api_key,

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Any
 import requests
 from pydantic import BaseModel
 
-from mlflow.environment_variables import MLFLOW_GENAI_EVAL_LLM_TIMEOUT
+from mlflow.environment_variables import (
+    MLFLOW_AZURE_OPENAI_AUTH_MODE,
+    MLFLOW_GENAI_EVAL_LLM_TIMEOUT,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import EndpointConfig
 from mlflow.gateway.providers.openai import OpenAIConfig, OpenAIProvider
@@ -359,10 +362,36 @@ def _get_provider_instance(
         return OpenAIProvider(_get_route_config(config))
 
     elif provider == Provider.AZURE:
+        auth_mode = MLFLOW_AZURE_OPENAI_AUTH_MODE.get().lower()
+        if auth_mode not in ("api_key", "entra_id"):
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid value {auth_mode!r} for {MLFLOW_AZURE_OPENAI_AUTH_MODE.name}. "
+                "Allowed values: 'api_key', 'entra_id'."
+            )
+        if auth_mode == "entra_id":
+            if missing_env_vars := [
+                env_var
+                for env_var in (AZURE_API_BASE_ENV_VAR, AZURE_API_VERSION_ENV_VAR)
+                if not os.environ.get(env_var)
+            ]:
+                raise MlflowException.invalid_parameter_value(
+                    f"{missing_env_vars} environment variable(s) must be set to use the "
+                    f"azure provider with {MLFLOW_AZURE_OPENAI_AUTH_MODE.name}='entra_id'."
+                )
+            config = OpenAIConfig(
+                openai_api_key=None,
+                openai_api_type="azuread",
+                openai_api_base=os.environ[AZURE_API_BASE_ENV_VAR],
+                openai_api_version=os.environ[AZURE_API_VERSION_ENV_VAR],
+                openai_deployment_name=model,
+            )
+            return OpenAIProvider(_get_route_config(config))
         if not os.environ.get(AZURE_API_KEY_ENV_VAR):
             raise MlflowException.invalid_parameter_value(
                 f"{AZURE_API_KEY_ENV_VAR} environment variable must be set "
-                "to use the azure provider."
+                "to use the azure provider. Alternatively, set "
+                f"{MLFLOW_AZURE_OPENAI_AUTH_MODE.name}='entra_id' to authenticate with "
+                "Microsoft Entra ID instead of an API key."
             )
         config = OpenAIConfig(
             openai_api_key=os.environ[AZURE_API_KEY_ENV_VAR],

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -304,14 +304,31 @@ def _build_endpoint_config(
         provider_config = OpenAIConfig(**openai_config)
     elif model_config.provider == Provider.AZURE:
         auth_config = model_config.auth_config or {}
+        auth_mode = auth_config.get(_AuthConfigKey.AUTH_MODE, "api_key")
         model_config.provider = Provider.OPENAI
-        provider_config = OpenAIConfig(
-            openai_api_type=OpenAIAPIType.AZURE,
-            openai_api_key=model_config.secret_value.get(_AuthConfigKey.API_KEY),
-            openai_api_base=auth_config.get(_AuthConfigKey.API_BASE),
-            openai_deployment_name=model_config.model_name,
-            openai_api_version=auth_config.get("api_version"),
-        )
+        if auth_mode in ("service_principal", "default_credential"):
+            # Entra ID: 'service_principal' carries explicit client credentials, while
+            # 'default_credential' leaves them unset so the provider falls back to
+            # DefaultAzureCredential (managed identity, workload identity, Azure CLI, ...)
+            secret_value = model_config.secret_value or {}
+            provider_config = OpenAIConfig(
+                openai_api_type=OpenAIAPIType.AZUREAD,
+                openai_api_key=None,
+                openai_api_base=auth_config.get(_AuthConfigKey.API_BASE),
+                openai_deployment_name=model_config.model_name,
+                openai_api_version=auth_config.get("api_version") or "2024-02-01",
+                openai_ad_client_id=auth_config.get("client_id"),
+                openai_ad_tenant_id=auth_config.get("tenant_id"),
+                openai_ad_client_secret=secret_value.get("client_secret"),
+            )
+        else:
+            provider_config = OpenAIConfig(
+                openai_api_type=OpenAIAPIType.AZURE,
+                openai_api_key=model_config.secret_value.get(_AuthConfigKey.API_KEY),
+                openai_api_base=auth_config.get(_AuthConfigKey.API_BASE),
+                openai_deployment_name=model_config.model_name,
+                openai_api_version=auth_config.get("api_version"),
+            )
     elif model_config.provider == Provider.ANTHROPIC:
         anthropic_config = {
             "anthropic_api_key": model_config.secret_value.get(_AuthConfigKey.API_KEY),

--- a/mlflow/utils/azure_auth.py
+++ b/mlflow/utils/azure_auth.py
@@ -1,0 +1,89 @@
+"""Microsoft Entra ID (Azure AD) token acquisition for Azure OpenAI.
+
+``azure-identity`` is an optional dependency and is imported lazily so that this
+module can be imported without it installed.
+"""
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mlflow.exceptions import MlflowException
+
+if TYPE_CHECKING:
+    from azure.core.credentials import AccessToken
+
+_AZURE_COGNITIVE_SERVICES_SCOPE = "https://cognitiveservices.azure.com/.default"
+_TOKEN_EXPIRY_BUFFER_SECONDS = 60
+
+
+@dataclass
+class _CachedCredential:
+    credential: Any
+    token: "AccessToken | None" = None
+
+
+# Gateway providers are constructed per request, so credentials and their tokens are
+# cached at module level to avoid re-authenticating on every request.
+_credential_cache: dict[tuple[str | None, str | None, str | None], _CachedCredential] = {}
+_cache_lock = threading.Lock()
+
+
+def _build_credential(client_id: str | None, tenant_id: str | None, client_secret: str | None):
+    try:
+        from azure.identity import ClientSecretCredential, DefaultAzureCredential
+    except ImportError as e:
+        raise MlflowException(
+            "Using Microsoft Entra ID authentication for Azure OpenAI requires the "
+            "`azure-identity` package. Install it with `pip install azure-identity` or "
+            "`pip install mlflow[azure]`."
+        ) from e
+
+    if client_id and tenant_id and client_secret:
+        return ClientSecretCredential(
+            tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
+        )
+    return DefaultAzureCredential()
+
+
+def get_azure_openai_token(
+    client_id: str | None = None,
+    tenant_id: str | None = None,
+    client_secret: str | None = None,
+) -> str:
+    """Return a valid Microsoft Entra ID bearer token for Azure Cognitive Services.
+
+    When ``client_id``, ``tenant_id``, and ``client_secret`` are all provided, a
+    ``ClientSecretCredential`` (service principal) is used; otherwise
+    ``DefaultAzureCredential`` resolves credentials from the environment (environment
+    variables, managed identity, Azure CLI login, etc.). Tokens are refreshed when they
+    are within ``_TOKEN_EXPIRY_BUFFER_SECONDS`` of expiry.
+    """
+    cache_key = (client_id, tenant_id, client_secret)
+    with _cache_lock:
+        entry = _credential_cache.get(cache_key)
+        if entry is None:
+            entry = _CachedCredential(_build_credential(client_id, tenant_id, client_secret))
+            _credential_cache[cache_key] = entry
+
+        if (
+            entry.token is None
+            or entry.token.expires_on < time.time() + _TOKEN_EXPIRY_BUFFER_SECONDS
+        ):
+            from azure.core.exceptions import ClientAuthenticationError
+
+            try:
+                entry.token = entry.credential.get_token(_AZURE_COGNITIVE_SERVICES_SCOPE)
+            except ClientAuthenticationError as e:
+                raise MlflowException(
+                    "Unable to acquire a Microsoft Entra ID token for Azure OpenAI due to "
+                    f"the following error: {e.message}"
+                ) from e
+
+        return entry.token.token
+
+
+def _reset_credential_cache() -> None:
+    with _cache_lock:
+        _credential_cache.clear()

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -519,45 +519,65 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                 },
             ],
         },
-        # TODO: uncomment this once it's supported by OpenAIConfig
-        # "service_principal": {
-        #     "display_name": "Service Principal",
-        #     "description": "Use Azure AD Service Principal (client credentials)",
-        #     "runtime_auth": "azure_service_principal",
-        #     "fields": [
-        #         {
-        #             "name": "client_secret",
-        #             "description": "Azure AD Client Secret",
-        #             "secret": True,
-        #             "required": True,
-        #         },
-        #         {
-        #             "name": "api_base",
-        #             "description": "Azure OpenAI endpoint URL",
-        #             "secret": False,
-        #             "required": True,
-        #         },
-        #         {
-        #             "name": "client_id",
-        #             "description": "Azure AD Application (Client) ID",
-        #             "secret": False,
-        #             "required": True,
-        #         },
-        #         {
-        #             "name": "tenant_id",
-        #             "description": "Azure AD Tenant ID",
-        #             "secret": False,
-        #             "required": True,
-        #         },
-        #         {
-        #             "name": "api_version",
-        #             "description": "API version (e.g., 2024-02-01)",
-        #             "secret": False,
-        #             "required": False,
-        #             "default": "2024-02-01",
-        #         },
-        #     ],
-        # },
+        "service_principal": {
+            "display_name": "Service Principal",
+            "description": "Use Azure AD Service Principal (client credentials)",
+            "runtime_auth": "azure_service_principal",
+            "fields": [
+                {
+                    "name": "client_secret",
+                    "description": "Azure AD Client Secret",
+                    "secret": True,
+                    "required": True,
+                },
+                {
+                    "name": "api_base",
+                    "description": "Azure OpenAI endpoint URL",
+                    "secret": False,
+                    "required": True,
+                },
+                {
+                    "name": "client_id",
+                    "description": "Azure AD Application (Client) ID",
+                    "secret": False,
+                    "required": True,
+                },
+                {
+                    "name": "tenant_id",
+                    "description": "Azure AD Tenant ID",
+                    "secret": False,
+                    "required": True,
+                },
+                {
+                    "name": "api_version",
+                    "description": "API version (e.g., 2024-02-01)",
+                    "secret": False,
+                    "required": False,
+                    "default": "2024-02-01",
+                },
+            ],
+        },
+        "default_credential": {
+            "display_name": "Default Azure Credential",
+            "description": "Use the server's Azure identity (managed identity, workload "
+            "identity, Azure CLI login, or environment credentials)",
+            "runtime_auth": "azure_default_credential",
+            "fields": [
+                {
+                    "name": "api_base",
+                    "description": "Azure OpenAI endpoint URL",
+                    "secret": False,
+                    "required": True,
+                },
+                {
+                    "name": "api_version",
+                    "description": "API version (e.g., 2024-02-01)",
+                    "secret": False,
+                    "required": False,
+                    "default": "2024-02-01",
+                },
+            ],
+        },
     },
     "vertex_ai": {
         "service_account_json": {

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -821,6 +821,97 @@ async def test_azuread_openai():
         )
 
 
+def azure_entra_config(**config_overrides):
+    config = azure_config(api_type="azuread")
+    del config["model"]["config"]["openai_api_key"]
+    config["model"]["config"].update(config_overrides)
+    return config
+
+
+@pytest.mark.asyncio
+async def test_azuread_openai_entra_id_default_credential():
+    resp = chat_response()
+    config = azure_entra_config()
+    mock_client = mock_http_client(MockAsyncResponse(resp))
+
+    with (
+        mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client,
+        mock.patch(
+            "mlflow.utils.azure_auth.get_azure_openai_token", return_value="entra-token"
+        ) as mock_get_token,
+    ):
+        provider = OpenAIProvider(EndpointConfig(**config))
+        payload = {
+            "prompt": "This is a test",
+        }
+        await provider.completions(completions.RequestPayload(**payload))
+        mock_get_token.assert_called_once_with(client_id=None, tenant_id=None, client_secret=None)
+        mock_build_client.assert_called_once()
+        call_headers = mock_build_client.call_args.kwargs["headers"]
+        assert call_headers.get("authorization") == "Bearer entra-token"
+        mock_client.post.assert_called_once_with(
+            (
+                "https://test-azureopenai.openai.azure.com/openai/deployments/test-gpt35"
+                "/completions?api-version=2023-05-15"
+            ),
+            json={
+                "n": 1,
+                "prompt": "This is a test",
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+        )
+
+
+@pytest.mark.asyncio
+async def test_azuread_openai_entra_id_service_principal():
+    resp = chat_response()
+    config = azure_entra_config(
+        openai_ad_client_id="client-id",
+        openai_ad_tenant_id="tenant-id",
+        openai_ad_client_secret="client-secret",
+    )
+    mock_client = mock_http_client(MockAsyncResponse(resp))
+
+    with (
+        mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client,
+        mock.patch(
+            "mlflow.utils.azure_auth.get_azure_openai_token", return_value="entra-token"
+        ) as mock_get_token,
+    ):
+        provider = OpenAIProvider(EndpointConfig(**config))
+        payload = {
+            "prompt": "This is a test",
+        }
+        await provider.completions(completions.RequestPayload(**payload))
+        mock_get_token.assert_called_once_with(
+            client_id="client-id", tenant_id="tenant-id", client_secret="client-secret"
+        )
+        mock_build_client.assert_called_once()
+        call_headers = mock_build_client.call_args.kwargs["headers"]
+        assert call_headers.get("authorization") == "Bearer entra-token"
+
+
+@pytest.mark.asyncio
+async def test_azuread_openai_static_token_does_not_acquire_entra_token():
+    resp = chat_response()
+    config = azure_config(api_type="azuread")
+    mock_client = mock_http_client(MockAsyncResponse(resp))
+
+    with (
+        mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client,
+        mock.patch("mlflow.utils.azure_auth.get_azure_openai_token") as mock_get_token,
+    ):
+        provider = OpenAIProvider(EndpointConfig(**config))
+        payload = {
+            "prompt": "This is a test",
+        }
+        await provider.completions(completions.RequestPayload(**payload))
+        mock_get_token.assert_not_called()
+        mock_build_client.assert_called_once()
+        call_headers = mock_build_client.call_args.kwargs["headers"]
+        assert call_headers.get("authorization") == "Bearer key"
+
+
 @pytest.mark.parametrize(
     ("api_type", "api_base", "deployment_name", "api_version", "organization"),
     [
@@ -900,6 +991,83 @@ def test_invalid_openai_configs_throw_on_construction(
             openai_deployment_name=deployment_name,
             openai_api_version=api_version,
             openai_organization=organization,
+        )
+
+
+@pytest.mark.parametrize(
+    ("api_key", "ad_client_id", "ad_tenant_id", "ad_client_secret"),
+    [
+        # No API key: tokens are acquired at request time via DefaultAzureCredential
+        (None, None, None, None),
+        # Service principal fields: tokens are acquired via ClientSecretCredential
+        (None, "client-id", "tenant-id", "client-secret"),
+        # Static pre-fetched Entra ID token
+        ("static-token", None, None, None),
+    ],
+)
+def test_azuread_configs_support_entra_id_auth(
+    api_key,
+    ad_client_id,
+    ad_tenant_id,
+    ad_client_secret,
+):
+    config = OpenAIConfig(
+        openai_api_key=api_key,
+        openai_api_type="azuread",
+        openai_api_base="https://test.openai.azure.com",
+        openai_deployment_name="mock-dep",
+        openai_api_version="2023-05-15",
+        openai_ad_client_id=ad_client_id,
+        openai_ad_tenant_id=ad_tenant_id,
+        openai_ad_client_secret=ad_client_secret,
+    )
+    assert config.openai_api_key == api_key
+    assert config.openai_ad_client_id == ad_client_id
+    assert config.openai_ad_tenant_id == ad_tenant_id
+    assert config.openai_ad_client_secret == ad_client_secret
+
+
+@pytest.mark.parametrize(
+    ("api_type", "api_key", "ad_client_id", "ad_tenant_id", "ad_client_secret"),
+    [
+        # Missing API key when the api type is not 'azuread'
+        ("openai", None, None, None, None),
+        ("azure", None, None, None, None),
+        # Entra ID service principal fields require the 'azuread' api type
+        ("openai", "key", "client-id", "tenant-id", "client-secret"),
+        ("azure", "key", "client-id", "tenant-id", "client-secret"),
+        # Both a static token and service principal fields
+        ("azuread", "token", "client-id", "tenant-id", "client-secret"),
+        # Partial service principal fields
+        ("azuread", None, "client-id", None, None),
+        ("azuread", None, "client-id", "tenant-id", None),
+        ("azuread", None, None, None, "client-secret"),
+    ],
+)
+def test_invalid_entra_id_openai_configs_throw_on_construction(
+    api_type,
+    api_key,
+    ad_client_id,
+    ad_tenant_id,
+    ad_client_secret,
+):
+    azure_fields = (
+        {
+            "openai_api_base": "https://test.openai.azure.com",
+            "openai_deployment_name": "mock-dep",
+            "openai_api_version": "2023-05-15",
+        }
+        if api_type != "openai"
+        else {}
+    )
+    with pytest.raises(MlflowException, match="OpenAI"):
+        OpenAIConfig(
+            openai_api_key=api_key,
+            openai_api_type=api_type,
+            openai_ad_client_id=ad_client_id,
+            openai_ad_tenant_id=ad_tenant_id,
+            openai_ad_client_secret=ad_client_secret,
+            **azure_fields,
         )
 
 

--- a/tests/gateway/test_gateway_config_parsing.py
+++ b/tests/gateway/test_gateway_config_parsing.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 import yaml
 
@@ -188,6 +186,64 @@ def test_route_configuration_parsing(basic_config_dict, tmp_path, monkeypatch):
     assert claude_conf.anthropic_api_key == "api_key"
 
 
+def test_azuread_entra_id_route_configuration_parsing(tmp_path, monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_RESOLVE_API_KEY_FROM_ENV", "true")
+    monkeypatch.setenv("AZURE_SP_CLIENT_SECRET", "resolved-client-secret")
+    config = {
+        "endpoints": [
+            {
+                "name": "chat-default-credential",
+                "endpoint_type": "llm/v1/chat",
+                "model": {
+                    "name": "gpt-4",
+                    "provider": "openai",
+                    "config": {
+                        "openai_api_type": "azuread",
+                        "openai_api_base": "https://test.openai.azure.com",
+                        "openai_deployment_name": "test-gpt4",
+                        "openai_api_version": "2024-02-01",
+                    },
+                },
+            },
+            {
+                "name": "chat-service-principal",
+                "endpoint_type": "llm/v1/chat",
+                "model": {
+                    "name": "gpt-4",
+                    "provider": "openai",
+                    "config": {
+                        "openai_api_type": "azuread",
+                        "openai_api_base": "https://test.openai.azure.com",
+                        "openai_deployment_name": "test-gpt4",
+                        "openai_api_version": "2024-02-01",
+                        "openai_ad_client_id": "client-id",
+                        "openai_ad_tenant_id": "tenant-id",
+                        "openai_ad_client_secret": "$AZURE_SP_CLIENT_SECRET",
+                    },
+                },
+            },
+        ]
+    }
+    conf_path = tmp_path.joinpath("config.yaml")
+    conf_path.write_text(yaml.safe_dump(config))
+    loaded_config = _load_gateway_config(conf_path)
+
+    default_credential_conf = loaded_config.endpoints[0].model.config
+    assert isinstance(default_credential_conf, OpenAIConfig)
+    assert default_credential_conf.openai_api_type == "azuread"
+    assert default_credential_conf.openai_api_key is None
+    assert default_credential_conf.openai_ad_client_id is None
+    assert default_credential_conf.openai_ad_tenant_id is None
+    assert default_credential_conf.openai_ad_client_secret is None
+
+    sp_conf = loaded_config.endpoints[1].model.config
+    assert isinstance(sp_conf, OpenAIConfig)
+    assert sp_conf.openai_api_key is None
+    assert sp_conf.openai_ad_client_id == "client-id"
+    assert sp_conf.openai_ad_tenant_id == "tenant-id"
+    assert sp_conf.openai_ad_client_secret == "resolved-client-secret"
+
+
 def test_convert_route_config_to_routes_payload(basic_config_dict, tmp_path):
     conf_path = tmp_path.joinpath("config.yaml")
     conf_path.write_text(yaml.safe_dump(basic_config_dict))
@@ -281,7 +337,7 @@ def test_invalid_model_definition(tmp_path):
     conf_path.write_text(yaml.safe_dump(invalid_partial_config))
 
     with pytest.raises(
-        MlflowException, match=re.compile(r"validation error.+openai_api_key", re.DOTALL)
+        MlflowException, match=r"OpenAI route configuration must specify 'openai_api_key'"
     ):
         _load_gateway_config(conf_path)
 

--- a/tests/metrics/genai/test_model_utils.py
+++ b/tests/metrics/genai/test_model_utils.py
@@ -37,6 +37,14 @@ def set_azure_envs(monkeypatch):
     monkeypatch.setenv("AZURE_API_VERSION", "2023-05-15")
 
 
+@pytest.fixture
+def set_azure_entra_envs(monkeypatch):
+    monkeypatch.delenv("AZURE_API_KEY", raising=False)
+    monkeypatch.setenv("MLFLOW_AZURE_OPENAI_AUTH_MODE", "entra_id")
+    monkeypatch.setenv("AZURE_API_BASE", "https://openai-for.openai.azure.com/")
+    monkeypatch.setenv("AZURE_API_VERSION", "2023-05-15")
+
+
 @pytest.fixture(autouse=True)
 def force_reload_openai():
     # Force reloading OpenAI module in the next test case. This is because they store
@@ -208,6 +216,50 @@ def test_score_model_azure_openai(set_azure_envs):
                 "temperature": 0.1,
             },
         )
+
+
+def test_score_model_azure_openai_entra_id(set_azure_entra_envs):
+    with (
+        mock.patch(
+            "mlflow.metrics.genai.model_utils._send_request", return_value=_OAI_RESPONSE
+        ) as mock_post,
+        mock.patch(
+            "mlflow.utils.azure_auth.get_azure_openai_token", return_value="entra-token"
+        ) as mock_get_token,
+    ):
+        resp = score_model_on_payload("azure:/test-openai", "my prompt", {"temperature": 0.1})
+
+        assert resp == "\n\nThis is a test!"
+        mock_get_token.assert_called_once_with(client_id=None, tenant_id=None, client_secret=None)
+        mock_post.assert_called_once_with(
+            endpoint="https://openai-for.openai.azure.com/openai/deployments/test-openai/chat/completions?api-version=2023-05-15",
+            headers={"authorization": "Bearer entra-token"},
+            payload={
+                "messages": [{"role": "user", "content": "my prompt"}],
+                "temperature": 0.1,
+            },
+        )
+
+
+@pytest.mark.parametrize("missing_env_var", ["AZURE_API_BASE", "AZURE_API_VERSION"])
+def test_score_model_azure_openai_entra_id_missing_env_vars(
+    set_azure_entra_envs, monkeypatch, missing_env_var
+):
+    monkeypatch.delenv(missing_env_var)
+    with pytest.raises(MlflowException, match=missing_env_var):
+        score_model_on_payload("azure:/test-openai", "my prompt")
+
+
+def test_score_model_azure_openai_invalid_auth_mode(monkeypatch):
+    monkeypatch.setenv("MLFLOW_AZURE_OPENAI_AUTH_MODE", "managed_identity")
+    with pytest.raises(MlflowException, match="Invalid value 'managed_identity'"):
+        score_model_on_payload("azure:/test-openai", "my prompt")
+
+
+def test_score_model_azure_openai_without_key(monkeypatch):
+    monkeypatch.delenv("AZURE_API_KEY", raising=False)
+    with pytest.raises(MlflowException, match="AZURE_API_KEY environment variable must be set"):
+        score_model_on_payload("azure:/test-openai", "my prompt")
 
 
 def test_score_model_anthropic(monkeypatch):

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -249,6 +249,106 @@ def test_create_provider_from_endpoint_name_azure_openai_with_azuread(store: Sql
     assert provider.config.model.config.openai_api_key == "azuread-api-key-test"
 
 
+@pytest.mark.parametrize(
+    ("api_version", "expected_api_version"),
+    [
+        ("2024-06-01", "2024-06-01"),
+        (None, "2024-02-01"),
+    ],
+)
+def test_create_provider_from_endpoint_name_azure_service_principal(
+    store: SqlAlchemyStore, api_version, expected_api_version
+):
+    auth_config = {
+        "auth_mode": "service_principal",
+        "api_base": "https://my-resource-sp.openai.azure.com",
+        "client_id": "sp-client-id",
+        "tenant_id": "sp-tenant-id",
+    }
+    if api_version is not None:
+        auth_config["api_version"] = api_version
+    secret = store.create_gateway_secret(
+        secret_name=f"azure-sp-secret-{api_version}",
+        secret_value={"client_secret": "sp-client-secret"},
+        provider="azure",
+        auth_config=auth_config,
+    )
+    model_def = store.create_gateway_model_definition(
+        name=f"azure-sp-model-{api_version}",
+        secret_id=secret.secret_id,
+        provider="azure",
+        model_name="gpt-4",
+    )
+    endpoint = store.create_gateway_endpoint(
+        name=f"test-azure-sp-endpoint-{api_version}",
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+    provider, _ = _create_provider_from_endpoint_name(
+        store, endpoint.name, EndpointType.LLM_V1_CHAT
+    )
+
+    assert isinstance(provider, OpenAIProvider)
+    assert isinstance(provider.config.model.config, OpenAIConfig)
+    assert provider.config.model.config.openai_api_type == OpenAIAPIType.AZUREAD
+    assert provider.config.model.config.openai_api_key is None
+    assert provider.config.model.config.openai_api_base == "https://my-resource-sp.openai.azure.com"
+    assert provider.config.model.config.openai_deployment_name == "gpt-4"
+    assert provider.config.model.config.openai_api_version == expected_api_version
+    assert provider.config.model.config.openai_ad_client_id == "sp-client-id"
+    assert provider.config.model.config.openai_ad_tenant_id == "sp-tenant-id"
+    assert provider.config.model.config.openai_ad_client_secret == "sp-client-secret"
+
+
+def test_create_provider_from_endpoint_name_azure_default_credential(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="azure-default-credential",
+        secret_value={},
+        provider="azure",
+        auth_config={
+            "auth_mode": "default_credential",
+            "api_base": "https://my-resource-dc.openai.azure.com",
+        },
+    )
+    model_def = store.create_gateway_model_definition(
+        name="azure-dc-model",
+        secret_id=secret.secret_id,
+        provider="azure",
+        model_name="gpt-4",
+    )
+    endpoint = store.create_gateway_endpoint(
+        name="test-azure-dc-endpoint",
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+    provider, _ = _create_provider_from_endpoint_name(
+        store, endpoint.name, EndpointType.LLM_V1_CHAT
+    )
+
+    assert isinstance(provider, OpenAIProvider)
+    assert isinstance(provider.config.model.config, OpenAIConfig)
+    assert provider.config.model.config.openai_api_type == OpenAIAPIType.AZUREAD
+    assert provider.config.model.config.openai_api_key is None
+    assert provider.config.model.config.openai_api_base == "https://my-resource-dc.openai.azure.com"
+    assert provider.config.model.config.openai_deployment_name == "gpt-4"
+    assert provider.config.model.config.openai_api_version == "2024-02-01"
+    assert provider.config.model.config.openai_ad_client_id is None
+    assert provider.config.model.config.openai_ad_tenant_id is None
+    assert provider.config.model.config.openai_ad_client_secret is None
+
+
 def test_create_provider_from_endpoint_name_anthropic(store: SqlAlchemyStore):
     secret = store.create_gateway_secret(
         secret_name="anthropic-key",

--- a/tests/utils/test_azure_auth.py
+++ b/tests/utils/test_azure_auth.py
@@ -1,0 +1,129 @@
+import sys
+import time
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.utils.azure_auth import _reset_credential_cache, get_azure_openai_token
+
+
+class FakeClientAuthenticationError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+
+def make_token(token="entra-token", expires_in=3600):
+    return SimpleNamespace(token=token, expires_on=time.time() + expires_in)
+
+
+@pytest.fixture(autouse=True)
+def reset_credential_cache():
+    _reset_credential_cache()
+    yield
+    _reset_credential_cache()
+
+
+@pytest.fixture
+def fake_azure_identity():
+    identity = mock.Mock()
+    exceptions = mock.Mock(ClientAuthenticationError=FakeClientAuthenticationError)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "azure.identity": identity,
+            "azure.core.exceptions": exceptions,
+        },
+    ):
+        yield identity
+
+
+def test_default_azure_credential_used_without_service_principal(fake_azure_identity):
+    credential = mock.Mock(get_token=mock.Mock(return_value=make_token()))
+    fake_azure_identity.DefaultAzureCredential.return_value = credential
+
+    assert get_azure_openai_token() == "entra-token"
+
+    fake_azure_identity.DefaultAzureCredential.assert_called_once_with()
+    fake_azure_identity.ClientSecretCredential.assert_not_called()
+    credential.get_token.assert_called_once_with("https://cognitiveservices.azure.com/.default")
+
+
+def test_client_secret_credential_used_with_service_principal(fake_azure_identity):
+    credential = mock.Mock(get_token=mock.Mock(return_value=make_token()))
+    fake_azure_identity.ClientSecretCredential.return_value = credential
+
+    token = get_azure_openai_token(
+        client_id="client-id", tenant_id="tenant-id", client_secret="client-secret"
+    )
+
+    assert token == "entra-token"
+    fake_azure_identity.ClientSecretCredential.assert_called_once_with(
+        tenant_id="tenant-id", client_id="client-id", client_secret="client-secret"
+    )
+    fake_azure_identity.DefaultAzureCredential.assert_not_called()
+    credential.get_token.assert_called_once_with("https://cognitiveservices.azure.com/.default")
+
+
+def test_missing_azure_identity_raises_helpful_error():
+    with (
+        mock.patch.dict(sys.modules, {"azure.identity": None}),
+        pytest.raises(MlflowException, match="pip install azure-identity"),
+    ):
+        get_azure_openai_token()
+
+
+def test_credential_and_token_are_cached(fake_azure_identity):
+    credential = mock.Mock(get_token=mock.Mock(return_value=make_token()))
+    fake_azure_identity.DefaultAzureCredential.return_value = credential
+
+    assert get_azure_openai_token() == "entra-token"
+    assert get_azure_openai_token() == "entra-token"
+
+    fake_azure_identity.DefaultAzureCredential.assert_called_once_with()
+    credential.get_token.assert_called_once()
+
+
+def test_token_is_refreshed_near_expiry(fake_azure_identity):
+    expiring = make_token(token="old-token", expires_in=30)
+    fresh = make_token(token="new-token")
+    credential = mock.Mock(get_token=mock.Mock(side_effect=[expiring, fresh]))
+    fake_azure_identity.DefaultAzureCredential.return_value = credential
+
+    assert get_azure_openai_token() == "old-token"
+    assert get_azure_openai_token() == "new-token"
+
+    fake_azure_identity.DefaultAzureCredential.assert_called_once_with()
+    assert credential.get_token.call_count == 2
+
+
+def test_distinct_service_principals_use_distinct_credentials(fake_azure_identity):
+    fake_azure_identity.ClientSecretCredential.side_effect = [
+        mock.Mock(get_token=mock.Mock(return_value=make_token(token="token-a"))),
+        mock.Mock(get_token=mock.Mock(return_value=make_token(token="token-b"))),
+    ]
+
+    token_a = get_azure_openai_token(
+        client_id="client-a", tenant_id="tenant-id", client_secret="secret"
+    )
+    token_b = get_azure_openai_token(
+        client_id="client-b", tenant_id="tenant-id", client_secret="secret"
+    )
+
+    assert token_a == "token-a"
+    assert token_b == "token-b"
+    assert fake_azure_identity.ClientSecretCredential.call_count == 2
+
+
+def test_client_authentication_error_is_wrapped(fake_azure_identity):
+    credential = mock.Mock(
+        get_token=mock.Mock(side_effect=FakeClientAuthenticationError("bad credentials"))
+    )
+    fake_azure_identity.DefaultAzureCredential.return_value = credential
+
+    with pytest.raises(MlflowException, match="bad credentials"):
+        get_azure_openai_token()
+
+    credential.get_token.assert_called_once()

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -250,6 +250,35 @@ def test_get_provider_config_vertex_ai_has_default_chain():
     assert project_field["required"] is True
 
 
+def test_get_provider_config_azure_has_entra_id_modes():
+    config = get_provider_config_response("azure")
+    modes = {m["mode"] for m in config["auth_modes"]}
+    assert modes == {"api_key", "service_principal", "default_credential"}
+    assert config["default_mode"] == "api_key"
+
+    service_principal = next(m for m in config["auth_modes"] if m["mode"] == "service_principal")
+    assert service_principal["display_name"] == "Service Principal"
+    assert [f["name"] for f in service_principal["secret_fields"]] == ["client_secret"]
+    assert {f["name"] for f in service_principal["config_fields"]} == {
+        "api_base",
+        "client_id",
+        "tenant_id",
+        "api_version",
+    }
+    api_version_field = next(
+        f for f in service_principal["config_fields"] if f["name"] == "api_version"
+    )
+    assert api_version_field["required"] is False
+    assert api_version_field["default"] == "2024-02-01"
+
+    default_credential = next(m for m in config["auth_modes"] if m["mode"] == "default_credential")
+    assert default_credential["display_name"] == "Default Azure Credential"
+    assert default_credential["secret_fields"] == []
+    assert {f["name"] for f in default_credential["config_fields"]} == {"api_base", "api_version"}
+    api_base_field = next(f for f in default_credential["config_fields"] if f["name"] == "api_base")
+    assert api_base_field["required"] is True
+
+
 _MOCK_PROVIDER_DATA = {
     "test_provider": {
         "test-model": {


### PR DESCRIPTION
Adds Entra ID (Azure AD) token acquisition via azure-identity across:

- OpenAIProvider: the `azuread` api type without a static key now acquires tokens at request time (DefaultAzureCredential, or ClientSecretCredential when the new openai_ad_client_id / openai_ad_tenant_id / openai_ad_client_secret config fields are set), with module-level credential/token caching and refresh near expiry
- Direct `azure:/<deployment>` judge/scorer model URIs: opt-in via the new MLFLOW_AZURE_OPENAI_AUTH_MODE=entra_id environment variable
- DB-backed gateway ("LLM Connections" UI): enables the previously drafted "service_principal" auth mode for the azure provider and adds a "default_credential" mode that uses the server's own Azure identity (e.g. a Container Apps managed identity) with no stored secret

The existing `azuread` static-token and `azure` api-key behaviors are unchanged; azure-identity remains an optional dependency (lazy import).

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="3764" height="847" alt="image" src="https://github.com/user-attachments/assets/21cabb71-0dd1-45b4-a17a-ea890a7ef963" />

### Does this PR require documentation update?


- [x] Yes. I've updated:
  - [x] Examples
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?


- [x] No.


### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Azure OpenAI endpoints and `azure:/` judge models now support Microsoft Entra ID authentication (`DefaultAzureCredential` or service principal client credentials) as an alternative to API keys, across the AI Gateway YAML config, the LLM Connections UI, and the `MLFLOW_AZURE_OPENAI_AUTH_MODE=entra_id` environment variable.



#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
