### PR TITLE
Fix admin permission grants failing with `FEATURE_DISABLED` when workspaces are disabled

### DIFF
--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import userEventGlobal from '@testing-library/user-event';
 import React from 'react';
-import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { fireEvent, renderWithDesignSystem, screen, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 
 import { CreateUserModal } from './CreateUserModal';
 
@@ -9,7 +9,18 @@ let userEvent: ReturnType<typeof userEventGlobal.setup>;
 beforeEach(() => {
   userEvent = userEventGlobal.setup();
   mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false });
+  // ``null`` is what ``useActiveWorkspace`` actually returns on a
+  // single-tenant server — the fix must not coerce it back to a workspace.
+  mockUseActiveWorkspace.mockReturnValue(null);
 });
+
+// ``fireEvent.change``-based credential fill: per-keystroke ``userEvent.type``
+// pushed the grant-flow tests past jest's default 5s per-test timeout on
+// loaded CI runners, and ``jest.setTimeout`` is banned by lint.
+const fillCredentials = () => {
+  fireEvent.change(screen.getByPlaceholderText('Enter username'), { target: { value: 'newbie' } });
+  fireEvent.change(screen.getByPlaceholderText('Enter password'), { target: { value: 'hunter2' } });
+};
 
 // Typed as ``(...args: any[]) => any`` so ``mockResolvedValue`` accepts the
 // realistic response shapes the component awaits. ``jest.fn()``'s default
@@ -17,6 +28,7 @@ beforeEach(() => {
 const mockCreateUserMutateAsync = jest.fn<(...args: any[]) => any>();
 const mockGrantPermissionMutateAsync = jest.fn<(...args: any[]) => any>();
 const mockUseWorkspacesEnabled = jest.fn<() => { workspacesEnabled: boolean }>();
+const mockUseActiveWorkspace = jest.fn<() => string | null>();
 
 jest.mock('../hooks', () => ({
   AdminQueryKeys: {
@@ -33,15 +45,15 @@ jest.mock('../hooks', () => ({
   // the stub has to exist; only the shape matters.
   useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
   useRolesQuery: () => ({ data: { roles: [] }, isLoading: false, error: null }),
-  useWorkspaceOptions: () => ['default'],
+  useWorkspaceOptions: () => ['default', 'team-a'],
 }));
 
 jest.mock('../../workspaces/utils/WorkspaceUtils', () => ({
-  useActiveWorkspace: () => 'default',
+  useActiveWorkspace: () => mockUseActiveWorkspace(),
 }));
 
 jest.mock('../../workspaces/hooks/useWorkspaces', () => ({
-  useWorkspaces: () => ({ workspaces: [{ name: 'default' }], isLoading: false }),
+  useWorkspaces: () => ({ workspaces: [{ name: 'default' }, { name: 'team-a' }], isLoading: false }),
 }));
 
 jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
@@ -91,8 +103,7 @@ describe('CreateUserModal — collapsible optional sections', () => {
     const onClose = jest.fn();
     renderWithDesignSystem(<CreateUserModal open onClose={onClose} />);
 
-    await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
-    await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
+    fillCredentials();
     // Sanity-check we're still in the default-collapsed state before submit
     // — otherwise the test isn't really exercising what we claim.
     expect(screen.getByRole('button', { name: /Role assignment/ })).toHaveAttribute('aria-expanded', 'false');
@@ -124,8 +135,7 @@ describe('CreateUserModal — discard-confirm gate on unsaved direct-grant draft
     await userEvent.click(screen.getByRole('button', { name: /Direct permissions/ }));
     await userEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
 
-    await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
-    await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
+    fillCredentials();
 
     // Submit button stays enabled — the gate is the dialog, not a lock.
     const submit = screen.getByRole('button', { name: /^Create user and grant access$|^Create user$/ });
@@ -154,8 +164,7 @@ describe('CreateUserModal — discard-confirm gate on unsaved direct-grant draft
     await userEvent.click(screen.getByRole('button', { name: /Direct permissions/ }));
     await userEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
 
-    await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
-    await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
+    fillCredentials();
 
     await userEvent.click(screen.getByRole('button', { name: /^Create user and grant access$|^Create user$/ }));
     expect(await screen.findByText('Discard unsaved direct permission?')).toBeInTheDocument();
@@ -175,13 +184,15 @@ describe('CreateUserModal — workspace targeting on direct grants', () => {
     mockGrantPermissionMutateAsync.mockReset();
   });
 
-  const stageGrantAndSubmit = async () => {
-    await userEvent.click(screen.getByRole('button', { name: /Direct permissions/ }));
-    await userEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
-    await userEvent.click(screen.getByRole('button', { name: /^Add$/ }));
-    await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
-    await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
-    await userEvent.click(screen.getByRole('button', { name: /^Create user and grant access$/ }));
+  // ``fireEvent`` instead of ``userEvent``: this is the heaviest flow in the
+  // file (mounts the collapsed direct-permissions form), and the pointer
+  // pipeline made it exceed the default 5s timeout on loaded CI runners.
+  const stageGrantAndSubmit = () => {
+    fireEvent.click(screen.getByRole('button', { name: /Direct permissions/ }));
+    fireEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    fillCredentials();
+    fireEvent.click(screen.getByRole('button', { name: /^Create user and grant access$/ }));
   };
 
   it('omits the workspace when workspaces are disabled', async () => {
@@ -193,8 +204,11 @@ describe('CreateUserModal — workspace targeting on direct grants', () => {
     const onClose = jest.fn();
     renderWithDesignSystem(<CreateUserModal open onClose={onClose} />);
 
-    await stageGrantAndSubmit();
+    stageGrantAndSubmit();
 
+    // The submit handler is async (create → grant → close); ``onClose`` is
+    // its last step, so waiting on it settles the whole chain.
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
     expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
     expect(mockGrantPermissionMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -205,18 +219,21 @@ describe('CreateUserModal — workspace targeting on direct grants', () => {
       }),
     );
     expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBeUndefined();
-    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('targets the selected workspace when workspaces are enabled', async () => {
     mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: true });
+    // A non-default active workspace: the pre-fix coercion also produced
+    // ``'default'``, so asserting ``'default'`` here would pass on the
+    // broken code too.
+    mockUseActiveWorkspace.mockReturnValue('team-a');
     mockCreateUserMutateAsync.mockResolvedValue({ user: { username: 'newbie' } });
     mockGrantPermissionMutateAsync.mockResolvedValue({});
     renderWithDesignSystem(<CreateUserModal open onClose={jest.fn()} />);
 
-    await stageGrantAndSubmit();
+    stageGrantAndSubmit();
 
-    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
-    expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBe('default');
+    await waitFor(() => expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1));
+    expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBe('team-a');
   });
 });

--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -8,6 +8,7 @@ import { CreateUserModal } from './CreateUserModal';
 let userEvent: ReturnType<typeof userEventGlobal.setup>;
 beforeEach(() => {
   userEvent = userEventGlobal.setup();
+  mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false });
 });
 
 // Typed as ``(...args: any[]) => any`` so ``mockResolvedValue`` accepts the
@@ -15,6 +16,7 @@ beforeEach(() => {
 // signature is ``() => never``, which would reject the payload.
 const mockCreateUserMutateAsync = jest.fn<(...args: any[]) => any>();
 const mockGrantPermissionMutateAsync = jest.fn<(...args: any[]) => any>();
+const mockUseWorkspacesEnabled = jest.fn<() => { workspacesEnabled: boolean }>();
 
 jest.mock('../hooks', () => ({
   AdminQueryKeys: {
@@ -43,7 +45,7 @@ jest.mock('../../workspaces/hooks/useWorkspaces', () => ({
 }));
 
 jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
-  useWorkspacesEnabled: () => ({ workspacesEnabled: false }),
+  useWorkspacesEnabled: () => mockUseWorkspacesEnabled(),
 }));
 
 jest.mock('@mlflow/mlflow/src/common/utils/reactQueryHooks', () => ({
@@ -164,5 +166,57 @@ describe('CreateUserModal — discard-confirm gate on unsaved direct-grant draft
     await userEvent.click(screen.getByRole('button', { name: /^Back$/ }));
     expect(mockCreateUserMutateAsync).not.toHaveBeenCalled();
     expect(mockGrantPermissionMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('CreateUserModal — workspace targeting on direct grants', () => {
+  beforeEach(() => {
+    mockCreateUserMutateAsync.mockReset();
+    mockGrantPermissionMutateAsync.mockReset();
+  });
+
+  const stageGrantAndSubmit = async () => {
+    await userEvent.click(screen.getByRole('button', { name: /Direct permissions/ }));
+    await userEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
+    await userEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    await userEvent.type(screen.getByPlaceholderText('Enter username'), 'newbie');
+    await userEvent.type(screen.getByPlaceholderText('Enter password'), 'hunter2');
+    await userEvent.click(screen.getByRole('button', { name: /^Create user and grant access$/ }));
+  };
+
+  it('omits the workspace when workspaces are disabled', async () => {
+    // Regression: single-tenant servers reject ANY ``X-MLFLOW-WORKSPACE``
+    // header (even ``default``) with FEATURE_DISABLED, so the modal must not
+    // coerce "no active workspace" into ``default`` on the grant request.
+    mockCreateUserMutateAsync.mockResolvedValue({ user: { username: 'newbie' } });
+    mockGrantPermissionMutateAsync.mockResolvedValue({});
+    const onClose = jest.fn();
+    renderWithDesignSystem(<CreateUserModal open onClose={onClose} />);
+
+    await stageGrantAndSubmit();
+
+    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource_type: 'experiment',
+        resource_id: '*',
+        username: 'newbie',
+        permission: 'READ',
+      }),
+    );
+    expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBeUndefined();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('targets the selected workspace when workspaces are enabled', async () => {
+    mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: true });
+    mockCreateUserMutateAsync.mockResolvedValue({ user: { username: 'newbie' } });
+    mockGrantPermissionMutateAsync.mockResolvedValue({});
+    renderWithDesignSystem(<CreateUserModal open onClose={jest.fn()} />);
+
+    await stageGrantAndSubmit();
+
+    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBe('default');
   });
 });

--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -5,6 +5,11 @@ import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/
 
 import { CreateUserModal } from './CreateUserModal';
 
+// Increase timeout: the grant-flow tests mount the collapsed direct-permissions
+// form and type credentials through userEvent, which exceeds the default 5s
+// on slower CI runners.
+jest.setTimeout(30000);
+
 let userEvent: ReturnType<typeof userEventGlobal.setup>;
 beforeEach(() => {
   userEvent = userEventGlobal.setup();

--- a/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.test.tsx
@@ -5,11 +5,6 @@ import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/
 
 import { CreateUserModal } from './CreateUserModal';
 
-// Increase timeout: the grant-flow tests mount the collapsed direct-permissions
-// form and type credentials through userEvent, which exceeds the default 5s
-// on slower CI runners.
-jest.setTimeout(30000);
-
 let userEvent: ReturnType<typeof userEventGlobal.setup>;
 beforeEach(() => {
   userEvent = userEventGlobal.setup();

--- a/mlflow/server/js/src/admin/components/CreateUserModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateUserModal.tsx
@@ -66,6 +66,10 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
   const [roleValue, setRoleValue] = useState<RoleAssignmentValue>(ROLE_ASSIGNMENT_DEFAULT);
   const [directPermissions, setDirectPermissions] = useState<StagedDirectPermission[]>([]);
   const [grantWorkspace, setGrantWorkspace] = useState<string>(initialGrantWorkspace);
+  // In single-tenant mode there is no workspace dimension — pass ``undefined``
+  // so the ``X-MLFLOW-WORKSPACE`` header is omitted (the server rejects any
+  // workspace header, including ``default``, when workspaces are disabled).
+  const grantWorkspaceForRequest = workspacesEnabled ? grantWorkspace : undefined;
   // Reported by ``DirectPermissionsSection`` whenever the in-progress draft
   // is dirty (any field touched away from default). The modal uses this to
   // pop a confirm-discard dialog on submit so the admin can't silently
@@ -168,7 +172,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
             resource_id: p.resourceId,
             username: trimmedUsername,
             permission: p.permission,
-            workspace: grantWorkspace,
+            workspace: grantWorkspaceForRequest,
           });
         } catch (e: any) {
           failures.push(
@@ -195,7 +199,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
     wantsDirect,
     roleValue.roleIds,
     directPermissions,
-    grantWorkspace,
+    grantWorkspaceForRequest,
     createdUsername,
     createUser,
     queryClient,
@@ -318,7 +322,7 @@ export const CreateUserModal = ({ open, onClose }: CreateUserModalProps) => {
           key={String(open)}
           value={directPermissions}
           onChange={setDirectPermissions}
-          workspace={grantWorkspace}
+          workspace={grantWorkspaceForRequest}
           disabled={submitting}
           onUnsavedDraftChange={setHasUnsavedDirectDraft}
         />

--- a/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
@@ -5,11 +5,6 @@ import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/
 
 import { EditAccessModal } from './EditAccessModal';
 
-// Increase timeout: the grant-flow tests drive multi-step userEvent
-// interactions through the full modal, which exceeds the default 5s
-// on slower CI runners.
-jest.setTimeout(30000);
-
 // Per-test override for ``useUserRolesQuery`` so each case can pick its own
 // success / error shape. ``mockReset`` in ``beforeEach`` keeps cross-test
 // state from leaking.

--- a/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import userEventGlobal from '@testing-library/user-event';
 import React from 'react';
 import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 
@@ -8,6 +9,9 @@ import { EditAccessModal } from './EditAccessModal';
 // success / error shape. ``mockReset`` in ``beforeEach`` keeps cross-test
 // state from leaking.
 const mockUseUserRolesQuery = jest.fn();
+// Typed as ``(...args: any[]) => any`` so ``mockResolvedValue`` accepts the
+// realistic response shapes the component awaits.
+const mockGrantPermissionMutateAsync = jest.fn<(...args: any[]) => any>();
 
 jest.mock('../hooks', () => ({
   AdminQueryKeys: {
@@ -17,7 +21,8 @@ jest.mock('../hooks', () => ({
     resourceOptions: (resourceType: string) => ['admin_resource_options', resourceType],
   },
   useCurrentUserIsAdmin: () => false,
-  useGrantUserPermission: () => ({ mutateAsync: jest.fn() }),
+  useGrantUserPermission: () => ({ mutateAsync: mockGrantPermissionMutateAsync }),
+  useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
   useRevokeUserPermission: () => ({ mutateAsync: jest.fn() }),
   useRolesQuery: () => ({ data: { roles: [] }, isLoading: false, error: null }),
   useUserRolesQuery: (username: string) => mockUseUserRolesQuery(username),
@@ -73,5 +78,40 @@ describe('EditAccessModal — rolesError handling', () => {
     });
     renderWithDesignSystem(<EditAccessModal open onClose={jest.fn()} username="alice" />);
     expect(screen.getByRole('button', { name: /Review changes/ })).toBeDisabled();
+  });
+});
+
+describe('EditAccessModal — workspace targeting on direct grants', () => {
+  beforeEach(() => {
+    mockUseUserRolesQuery.mockReset();
+    mockGrantPermissionMutateAsync.mockReset();
+  });
+
+  it('omits the workspace on grant when workspaces are disabled', async () => {
+    // Regression: single-tenant servers reject ANY ``X-MLFLOW-WORKSPACE``
+    // header (even ``default``) with FEATURE_DISABLED, so the modal must not
+    // coerce "no active workspace" into ``default`` on the grant request.
+    const userEvent = userEventGlobal.setup();
+    mockUseUserRolesQuery.mockReturnValue({ data: { roles: [] }, isLoading: false, error: null });
+    mockGrantPermissionMutateAsync.mockResolvedValue({});
+    const onClose = jest.fn();
+    renderWithDesignSystem(<EditAccessModal open onClose={onClose} username="alice" />);
+
+    await userEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
+    await userEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    await userEvent.click(screen.getByRole('button', { name: /^Review changes$/ }));
+    await userEvent.click(screen.getByRole('button', { name: /^Apply changes$/ }));
+
+    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource_type: 'experiment',
+        resource_id: '*',
+        username: 'alice',
+        permission: 'READ',
+      }),
+    );
+    expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBeUndefined();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
@@ -5,6 +5,11 @@ import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/
 
 import { EditAccessModal } from './EditAccessModal';
 
+// Increase timeout: the grant-flow tests drive multi-step userEvent
+// interactions through the full modal, which exceeds the default 5s
+// on slower CI runners.
+jest.setTimeout(30000);
+
 // Per-test override for ``useUserRolesQuery`` so each case can pick its own
 // success / error shape. ``mockReset`` in ``beforeEach`` keeps cross-test
 // state from leaking.

--- a/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import userEventGlobal from '@testing-library/user-event';
 import React from 'react';
-import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { fireEvent, renderWithDesignSystem, screen, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 
 import { EditAccessModal } from './EditAccessModal';
 
@@ -12,6 +11,9 @@ const mockUseUserRolesQuery = jest.fn();
 // Typed as ``(...args: any[]) => any`` so ``mockResolvedValue`` accepts the
 // realistic response shapes the component awaits.
 const mockGrantPermissionMutateAsync = jest.fn<(...args: any[]) => any>();
+const mockRevokePermissionMutateAsync = jest.fn<(...args: any[]) => any>();
+const mockUseWorkspacesEnabled = jest.fn<() => { workspacesEnabled: boolean }>();
+const mockUseActiveWorkspace = jest.fn<() => string | null>();
 
 jest.mock('../hooks', () => ({
   AdminQueryKeys: {
@@ -23,7 +25,7 @@ jest.mock('../hooks', () => ({
   useCurrentUserIsAdmin: () => false,
   useGrantUserPermission: () => ({ mutateAsync: mockGrantPermissionMutateAsync }),
   useResourceOptionsQuery: () => ({ options: [], isLoading: false, error: null }),
-  useRevokeUserPermission: () => ({ mutateAsync: jest.fn() }),
+  useRevokeUserPermission: () => ({ mutateAsync: mockRevokePermissionMutateAsync }),
   useRolesQuery: () => ({ data: { roles: [] }, isLoading: false, error: null }),
   useUserRolesQuery: (username: string) => mockUseUserRolesQuery(username),
   useUsersQuery: () => ({
@@ -35,7 +37,7 @@ jest.mock('../hooks', () => ({
 }));
 
 jest.mock('../../workspaces/utils/WorkspaceUtils', () => ({
-  useActiveWorkspace: () => null,
+  useActiveWorkspace: () => mockUseActiveWorkspace(),
 }));
 
 jest.mock('../../workspaces/hooks/useWorkspaces', () => ({
@@ -43,12 +45,30 @@ jest.mock('../../workspaces/hooks/useWorkspaces', () => ({
 }));
 
 jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
-  useWorkspacesEnabled: () => ({ workspacesEnabled: false }),
+  useWorkspacesEnabled: () => mockUseWorkspacesEnabled(),
 }));
 
 jest.mock('@mlflow/mlflow/src/common/utils/reactQueryHooks', () => ({
   useQueryClient: () => ({ invalidateQueries: jest.fn() }),
 }));
+
+beforeEach(() => {
+  mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false });
+  // ``null`` is what ``useActiveWorkspace`` actually returns on a
+  // single-tenant server.
+  mockUseActiveWorkspace.mockReturnValue(null);
+});
+
+// Direct grants surface through the synthetic ``__user_<id>__`` role
+// (``SYNTHETIC_USER_ROLE_NAME_RE``); the modal flattens its ``permissions``
+// into the editable pre-filled list. ``EDIT`` (not ``READ``) so a staged
+// grant from the form's defaults can't collide with this row's diff key.
+const syntheticUserRole = (workspace: string) => ({
+  id: 99,
+  name: '__user_1__',
+  workspace,
+  permissions: [{ resource_type: 'experiment', resource_pattern: '*', permission: 'EDIT' }],
+});
 
 describe('EditAccessModal — rolesError handling', () => {
   beforeEach(() => {
@@ -81,27 +101,33 @@ describe('EditAccessModal — rolesError handling', () => {
   });
 });
 
-describe('EditAccessModal — workspace targeting on direct grants', () => {
+describe('EditAccessModal — workspace targeting on direct grants and revokes', () => {
   beforeEach(() => {
     mockUseUserRolesQuery.mockReset();
     mockGrantPermissionMutateAsync.mockReset();
+    mockRevokePermissionMutateAsync.mockReset();
   });
 
   it('omits the workspace on grant when workspaces are disabled', async () => {
     // Regression: single-tenant servers reject ANY ``X-MLFLOW-WORKSPACE``
     // header (even ``default``) with FEATURE_DISABLED, so the modal must not
     // coerce "no active workspace" into ``default`` on the grant request.
-    const userEvent = userEventGlobal.setup();
     mockUseUserRolesQuery.mockReturnValue({ data: { roles: [] }, isLoading: false, error: null });
     mockGrantPermissionMutateAsync.mockResolvedValue({});
     const onClose = jest.fn();
     renderWithDesignSystem(<EditAccessModal open onClose={onClose} username="alice" />);
 
-    await userEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
-    await userEvent.click(screen.getByRole('button', { name: /^Add$/ }));
-    await userEvent.click(screen.getByRole('button', { name: /^Review changes$/ }));
-    await userEvent.click(screen.getByRole('button', { name: /^Apply changes$/ }));
+    // ``fireEvent`` instead of ``userEvent`` throughout this describe: the
+    // multi-step flows exceeded jest's default 5s timeout on loaded CI
+    // runners with the pointer pipeline, and ``jest.setTimeout`` is banned.
+    fireEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Review changes$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Apply changes$/ }));
 
+    // ``onClose`` is the async submit chain's last step — waiting on it
+    // settles the whole chain.
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
     expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
     expect(mockGrantPermissionMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -112,6 +138,64 @@ describe('EditAccessModal — workspace targeting on direct grants', () => {
       }),
     );
     expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBeUndefined();
-    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the workspace on revoke when workspaces are disabled', async () => {
+    // The revoke call got the same single-tenant fix as grant: removing a
+    // pre-filled row must not send an ``X-MLFLOW-WORKSPACE`` header.
+    mockUseUserRolesQuery.mockReturnValue({
+      data: { roles: [syntheticUserRole('default')] },
+      isLoading: false,
+      error: null,
+    });
+    mockRevokePermissionMutateAsync.mockResolvedValue({});
+    const onClose = jest.fn();
+    renderWithDesignSystem(<EditAccessModal open onClose={onClose} username="alice" />);
+
+    // The pre-fill effect seeds the row asynchronously — removing it stages
+    // the revoke.
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove experiment *' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Review changes$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Apply changes$/ }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(mockRevokePermissionMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockRevokePermissionMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ resource_type: 'experiment', resource_id: '*', username: 'alice' }),
+    );
+    expect(mockRevokePermissionMutateAsync.mock.calls[0][0].workspace).toBeUndefined();
+    expect(mockGrantPermissionMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('targets the active workspace on grant and revoke when workspaces are enabled', async () => {
+    mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: true });
+    // A non-default active workspace: the pre-fix coercion also produced
+    // ``'default'``, so asserting ``'default'`` would pass on the broken
+    // code too.
+    mockUseActiveWorkspace.mockReturnValue('team-a');
+    mockUseUserRolesQuery.mockReturnValue({
+      data: { roles: [syntheticUserRole('team-a')] },
+      isLoading: false,
+      error: null,
+    });
+    mockGrantPermissionMutateAsync.mockResolvedValue({});
+    mockRevokePermissionMutateAsync.mockResolvedValue({});
+    renderWithDesignSystem(<EditAccessModal open onClose={jest.fn()} username="alice" />);
+
+    // Stage a revoke (remove the pre-filled ``EDIT`` row) first, then a
+    // grant (the form's default ``READ`` — a different diff key, so the
+    // pair can't cancel out) — one submit applies both.
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove experiment *' }));
+    fireEvent.click(screen.getByRole('radio', { name: /^All experiments$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Review changes$/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Apply changes$/ }));
+
+    // Revokes run after grants in the submit chain — waiting on the revoke
+    // settles both.
+    await waitFor(() => expect(mockRevokePermissionMutateAsync).toHaveBeenCalledTimes(1));
+    expect(mockGrantPermissionMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockGrantPermissionMutateAsync.mock.calls[0][0].workspace).toBe('team-a');
+    expect(mockRevokePermissionMutateAsync.mock.calls[0][0].workspace).toBe('team-a');
   });
 });

--- a/mlflow/server/js/src/admin/components/EditAccessModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditAccessModal.tsx
@@ -81,6 +81,10 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
   const { workspaces } = useWorkspaces(showWorkspaceSelector);
   const initialGrantWorkspace = activeWorkspace ?? DEFAULT_WORKSPACE_NAME;
   const [grantWorkspace, setGrantWorkspace] = useState<string>(initialGrantWorkspace);
+  // In single-tenant mode there is no workspace dimension — pass ``undefined``
+  // so the ``X-MLFLOW-WORKSPACE`` header is omitted (the server rejects any
+  // workspace header, including ``default``, when workspaces are disabled).
+  const grantWorkspaceForRequest = workspacesEnabled ? grantWorkspace : undefined;
 
   // --- Current state from backend (used to pre-fill + compute diff) ---
   const { data: rolesData, isLoading: rolesLoading, error: rolesError } = useUserRolesQuery(username);
@@ -297,7 +301,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
           resource_id: p.resourceId,
           username,
           permission: p.permission,
-          workspace: grantWorkspace,
+          workspace: grantWorkspaceForRequest,
         });
       } catch (e: any) {
         failures.push(
@@ -311,7 +315,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
           resource_type: p.resourceType,
           resource_id: p.resourceId,
           username,
-          workspace: grantWorkspace,
+          workspace: grantWorkspaceForRequest,
         });
       } catch (e: any) {
         failures.push(
@@ -328,7 +332,17 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
     filledForWorkspaceRef.current = null;
     setStep('edit');
     setSubmitting(false);
-  }, [diff, isAdmin, username, grantWorkspace, queryClient, grantPermission, revokePermission, onClose, renderRoleId]);
+  }, [
+    diff,
+    isAdmin,
+    username,
+    grantWorkspaceForRequest,
+    queryClient,
+    grantPermission,
+    revokePermission,
+    onClose,
+    renderRoleId,
+  ]);
 
   return (
     <Modal
@@ -481,7 +495,7 @@ export const EditAccessModal = ({ open, onClose, username }: EditAccessModalProp
                   key={String(open)}
                   value={directPermissions}
                   onChange={setDirectPermissions}
-                  workspace={grantWorkspace}
+                  workspace={grantWorkspaceForRequest}
                   disabled={submitting}
                   onUnsavedDraftChange={setHasUnsavedDirectDraft}
                 />


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

In single-tenant mode (`MLFLOW_ENABLE_WORKSPACES` off), the admin "Edit access" and "Create user" modals coerced the null active workspace into the string 'default' and passed it on every grant/revoke request and resource-picker query. That made the browser send an `X-MLFLOW-WORKSPACE` header, which the server rejects with `FEATURE_DISABLED` ("Workspace APIs are not available") before the request reaches the permission handler — so admins could not grant any experiment / gateway-endpoint permissions from the UI.

This PR derives a request-scoped workspace (`grantWorkspaceForRequest`) that is `undefined` when workspaces are disabled, so the header is omitted entirely; the auth store already falls back to the default workspace on its own in single-tenant mode. Workspace-enabled behavior is unchanged — when workspaces are on, the selected grant workspace is passed exactly as before.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New regression tests in `CreateUserModal.test.tsx` and `EditAccessModal.test.tsx` pin that grant/revoke calls carry no workspace when workspaces are disabled (both modals) and still target the selected workspace when they are enabled. Full `src/admin` jest suite passes (11 suites, 71 tests) along with `yarn type-check`.

Error:
<img width="905" height="906" alt="Error" src="https://github.com/user-attachments/assets/a7475549-2cd4-4532-931e-264f9d87898c" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the admin "Create user" and "Edit access" modals failing to grant or revoke permissions with `FEATURE_DISABLED` on servers running without workspaces enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release