### PR TITLE
Add Requesty as an OpenAI-compatible AI gateway provider

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/requesty.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/requesty.mdx
@@ -1,0 +1,13 @@
+---
+title: Tracing Requesty
+description: Trace Requesty AI gateway requests with MLflow using OpenAI-compatible auto-tracing for full observability into multi-model LLM routing.
+sidebar_position: 105
+sidebar_label: Requesty
+keywords: [requesty, tracing, mlflow, ai gateway, openai-compatible, llm routing]
+---
+
+import { OpenAICompatibleGatewayDoc } from "@site/src/components/OpenAICompatibleGatewayDoc";
+
+# Tracing Requesty
+
+<OpenAICompatibleGatewayDoc gatewayId="requesty" />

--- a/docs/src/components/OpenAICompatibleGateways/config.ts
+++ b/docs/src/components/OpenAICompatibleGateways/config.ts
@@ -30,6 +30,17 @@ export const OPENAI_COMPATIBLE_GATEWAYS: OpenAICompatibleGateway[] = [
       'Before following the steps below, you need to create an <ins><a href="https://openrouter.ai/">OpenRouter account</a></ins> and generate an API key from the <ins><a href="https://openrouter.ai/keys">Keys page</a></ins>.',
   },
   {
+    id: 'requesty',
+    name: 'Requesty',
+    description:
+      '<a href="https://requesty.ai/">Requesty</a> is a unified API gateway that provides access to 300+ LLMs from providers like OpenAI, Anthropic, Google, DeepSeek, and many others through a single OpenAI-compatible API. This allows developers to easily switch between models without changing their code.',
+    baseUrl: 'https://router.requesty.ai/v1',
+    apiKeyPlaceholder: '<YOUR_REQUESTY_API_KEY>',
+    sampleModel: 'anthropic/claude-sonnet-4-5',
+    prerequisite:
+      'Before following the steps below, you need to create a <ins><a href="https://app.requesty.ai/">Requesty account</a></ins> and generate an API key from the <ins><a href="https://app.requesty.ai/api-keys">API Keys page</a></ins>.',
+  },
+  {
     id: 'vercel-ai-gateway',
     name: 'Vercel AI Gateway',
     description:

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -62,6 +62,7 @@ class Provider(str, Enum):
     DEEPSEEK = "deepseek"
     XAI = "xai"
     OPENROUTER = "openrouter"
+    REQUESTY = "requesty"
     OLLAMA = "ollama"
     VERTEX_AI = "vertex_ai"
     PORTKEY = "portkey"

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -57,6 +57,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.openrouter import OpenRouterProvider
     from mlflow.gateway.providers.palm import PaLMProvider
     from mlflow.gateway.providers.portkey import PortkeyProvider
+    from mlflow.gateway.providers.requesty import RequestyProvider
     from mlflow.gateway.providers.togetherai import TogetherAIProvider
     from mlflow.gateway.providers.vertex_ai import VertexAIProvider
     from mlflow.gateway.providers.xai import XAIProvider
@@ -84,6 +85,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.OPENROUTER, OpenRouterProvider)
     registry.register(Provider.PALM, PaLMProvider)
     registry.register(Provider.PORTKEY, PortkeyProvider)
+    registry.register(Provider.REQUESTY, RequestyProvider)
     registry.register(Provider.TOGETHERAI, TogetherAIProvider)
     registry.register(Provider.VERTEX_AI, VertexAIProvider)
     registry.register(Provider.XAI, XAIProvider)

--- a/mlflow/gateway/providers/requesty.py
+++ b/mlflow/gateway/providers/requesty.py
@@ -1,0 +1,8 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class RequestyProvider(OpenAICompatibleProvider):
+    DISPLAY_NAME = "Requesty"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://router.requesty.ai/v1"

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -484,6 +484,13 @@ def _get_provider_instance(
         config = _OpenAICompatibleConfig(api_key=os.environ.get("OPENROUTER_API_KEY"))
         return OpenRouterProvider(_get_route_config(config))
 
+    elif provider == Provider.REQUESTY:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.requesty import RequestyProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("REQUESTY_API_KEY"))
+        return RequestyProvider(_get_route_config(config))
+
     elif provider == Provider.OLLAMA:
         from mlflow.gateway.providers.ollama import OllamaConfig, OllamaProvider
 

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -337,6 +337,7 @@ def _build_endpoint_config(
         Provider.DEEPSEEK,
         Provider.XAI,
         Provider.OPENROUTER,
+        Provider.REQUESTY,
         Provider.OLLAMA,
         Provider.PORTKEY,
     }:

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -1024,6 +1024,7 @@ _CORE_PROVIDER_ENV_VARS = {
     "deepseek": "DEEPSEEK_API_KEY",
     "xai": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "requesty": "REQUESTY_API_KEY",
     "togetherai": "TOGETHERAI_API_KEY",
     "bedrock": {
         "aws_access_key_id": "AWS_ACCESS_KEY_ID",

--- a/tests/gateway/providers/test_requesty.py
+++ b/tests/gateway/providers/test_requesty.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.requesty import RequestyProvider
+from mlflow.gateway.schemas import chat
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider() -> RequestyProvider:
+    endpoint_config = EndpointConfig(
+        name="requesty-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "requesty",
+            "name": "openai/gpt-4o-mini",
+            "config": {"api_key": "***"},
+        },
+    )
+    return RequestyProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-req-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "openai/gpt-4o-mini",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from Requesty!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "https://router.requesty.ai/v1"
+
+
+def test_headers():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer ***"}
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.DISPLAY_NAME == "Requesty"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-req-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from Requesty!"


### PR DESCRIPTION
## What

Adds Requesty as an OpenAI-compatible AI Gateway provider, mirroring the existing OpenRouter gateway provider. Requesty is an OpenAI-compatible LLM gateway that uses the same `provider/model` naming convention (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`).

## Changes

- `mlflow/gateway/providers/requesty.py` — `RequestyProvider(OpenAICompatibleProvider)`, `DEFAULT_API_BASE = "https://router.requesty.ai/v1"`, a direct mirror of `openrouter.py`.
- `mlflow/gateway/config.py` — `REQUESTY = "requesty"` added to the in-repo `Provider` enum.
- `mlflow/gateway/provider_registry.py` — registered `Provider.REQUESTY -> RequestyProvider`.
- `mlflow/server/gateway_api.py` — `Provider.REQUESTY` added to the OpenAI-compatible config-building set.
- `mlflow/metrics/genai/model_utils.py` — `REQUESTY` create-provider branch (uses `REQUESTY_API_KEY`).
- `mlflow/utils/providers.py` — `REQUESTY_API_KEY` added to the core provider env-var map.
- `docs/docs/genai/tracing/integrations/listing/requesty.mdx` + `docs/src/components/OpenAICompatibleGateways/config.ts` — docs listing entry.

## Testing

- `ruff check` / `ruff format` clean on the edited Python files.
- `pytest tests/gateway/providers/test_requesty.py tests/gateway/providers/test_openrouter.py` — 8 passed (the new Requesty tests mirror the OpenRouter provider tests: default base URL, headers, name, chat).
- Live-tested against the real endpoint: a `POST /v1/chat/completions` to `https://router.requesty.ai/v1` with `openai/gpt-4o-mini` returned successfully, confirming base URL + `Bearer REQUESTY_API_KEY` + `provider/model` naming.

Note: I did not add a Requesty tile to `docs/src/components/TracingIntegrations/index.tsx` because that requires a committed logo asset I don't have — happy to add it if you can point me at the logo convention.

Docs: https://requesty.ai · https://docs.requesty.ai · https://app.requesty.ai/api-keys · https://app.requesty.ai/router/list

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
