### PR TITLE
fix: avoid duplicate table creation during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,7 +86,8 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    if not _all_tables_exist(engine):
+        _upgrade_db(engine)
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating to 3.8.x from 3.7.0, the upgrade fails with `Table 'secrets' already exists`. This happens because `_initialize_tables` creates all tables from `InitialBase`, then unconditionally runs Alembic migrations which try to create the 'secrets' table again.

## Fix
Added a check `if not _all_tables_exist(engine)` before calling `_upgrade_db` in `_initialize_tables`, so that migrations are only applied if there are missing tables. This prevents Alembic from attempting to recreate tables that already exist.

Closes #19943