### PR TITLE
Add mlflow-falsify to the community Model Evaluation plugins

### DIFF
--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -695,6 +695,28 @@ export ARTIFACTORY_ARTIFACTS_DELETE_SKIP=true
 ```
 
   </TabItem>
+  <TabItem value="run-context-governance" label="Run Context & Governance">
+
+#### **falsify Plugin**
+
+Tag every run with a tamper-evident [PRML](https://spec.falsify.dev/v0.1) pre-registration manifest, binding the run to the metric, threshold, and dataset that were committed before the experiment ran:
+
+```bash
+pip install mlflow-falsify
+```
+
+```python
+import mlflow
+
+# With a .prml.yaml (or prml.yaml) in the working directory or any
+# ancestor, every run is automatically tagged with the pre-registered
+# claim: prml.manifest_hash, prml.metric, prml.comparator,
+# prml.threshold, prml.dataset_id, ...
+with mlflow.start_run():
+    mlflow.log_metric("accuracy", 0.95)
+```
+
+  </TabItem>
 </Tabs>
 
 ## Testing Your Plugin

--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -706,13 +706,17 @@ pip install mlflow-falsify
 ```
 
 ```python
-import mlflow
+import mlflow, mlflow_falsify
 
 # With a .prml.yaml (or prml.yaml) in the working directory or any
 # ancestor, every run is automatically tagged with the pre-registered
 # claim: prml.manifest_hash, prml.metric, prml.comparator,
 # prml.threshold, prml.dataset_id, ...
-with mlflow.start_run():
+#
+# locked_run() additionally verifies the locked predicate at run end,
+# tagging prml.verdict = PASS | FAIL | UNVERIFIED | TAMPERED (TAMPERED
+# means the manifest changed mid-run).
+with mlflow_falsify.locked_run():
     mlflow.log_metric("accuracy", 0.95)
 ```
 

--- a/docs/docs/classic-ml/plugins/index.mdx
+++ b/docs/docs/classic-ml/plugins/index.mdx
@@ -697,9 +697,9 @@ export ARTIFACTORY_ARTIFACTS_DELETE_SKIP=true
   </TabItem>
   <TabItem value="run-context-governance" label="Run Context & Governance">
 
-#### **falsify Plugin**
+#### **Falsify Plugin**
 
-Tag every run with a tamper-evident [PRML](https://spec.falsify.dev/v0.1) pre-registration manifest, binding the run to the metric, threshold, and dataset that were committed before the experiment ran:
+Tag every run with a tamper-evident [PRML](https://spec.falsify.dev/v0.1) pre-registration manifest, binding the run to the metric, threshold, and dataset that were committed before the experiment ran. The same locking pattern ships as an adapter on the [UK AI Safety Institute's Inspect extensions page](https://inspect.aisi.org.uk/extensions.html):
 
 ```bash
 pip install mlflow-falsify


### PR DESCRIPTION
### Related Issues/PRs

Relates to: #24329 (auto-closed by the template bot before the description was completed, cannot be reopened) and #23569 (earlier attempt at the same change, now closed as a duplicate of this PR).

### What changes are proposed in this pull request?

Adds `mlflow-falsify` to the **Model Evaluation** tab of the Popular Community Plugins section, alongside Giskard and Trubrics. It uses MLflow's `RunContextProvider` plugin interface — a plugin type this page documents under "Developing Custom Plugins", but for which no community plugin is currently listed on this page.

**What the plugin does:** when a `.prml.yaml` / `prml.yaml` manifest is present in the working directory or any ancestor, every MLflow run is automatically tagged with the pre-registered evaluation claim it is bound to (`prml.manifest_hash`, `prml.metric`, `prml.comparator`, `prml.threshold`, `prml.dataset_id`, ...). PRML is a small open spec (CC BY 4.0) for tamper-evident pre-registration of ML eval claims: the metric/threshold/dataset are committed to a SHA-256 before the run, so moving the bar afterwards is detectable.

- PyPI: https://pypi.org/project/mlflow-falsify/ (MIT)
- Source: https://github.com/studio-11-co/mlflow-falsify
- Maintained: weekly canary CI runs the test suite against the latest released `mlflow` (plus regular CI on Python 3.10–3.12), so breakage from MLflow API changes is caught within days.

Docs-only change, one file, 20 added lines, no structural change to the page (an earlier revision of this PR proposed a new tab; it is now folded into the existing Model Evaluation tab).

### How is this PR tested?

- [x] Manual tests

Docs-only change; verified the MDX block matches the surrounding `<TabItem>` structure and code-block formatting of the existing community plugin entries. The plugin's own behavior (tag names, manifest discovery) is covered by its test suite and a weekly canary CI against latest `mlflow`.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


