### PR TITLE
fix(types): map dataclass float fields to double (64-bit)

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1364,7 +1364,7 @@ def _map_field_type(field):
     field_type_mapping = {
         bool: "boolean",
         int: "long",  # int is mapped to long to support 64-bit integers
-        builtins.float: "float",
+        builtins.float: "double",  # float is mapped to double to support 64-bit floats
         str: "string",
         bytes: "binary",
         dt.date: "datetime",

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1804,6 +1804,23 @@ def test_convert_dataclass_to_schema_complex():
     ]
 
 
+def test_convert_dataclass_to_schema_float_maps_to_double():
+    # Python's float is 64-bit, so a dataclass float field must map to "double"
+    # (mirroring int -> long); mapping it to 32-bit "float" makes the inferred
+    # signature reject the very float64 values it describes.
+    @dataclass
+    class Output:
+        label: str = "a"
+        score: float = 0.0
+        scores: list[float] = field(default_factory=lambda: [0.0])
+
+    assert convert_dataclass_to_schema(Output).to_dict() == [
+        {"type": "string", "name": "label", "required": True},
+        {"type": "double", "name": "score", "required": True},
+        {"type": "array", "items": {"type": "double"}, "name": "scores", "required": True},
+    ]
+
+
 def test_convert_dataclass_to_schema_invalid():
     # Invalid dataclass with Union
     @dataclass

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1821,6 +1821,31 @@ def test_convert_dataclass_to_schema_float_maps_to_double():
     ]
 
 
+def test_convert_dataclass_to_schema_nested_float_maps_to_double():
+    # The float -> double mapping must also hold on the nested object/property path
+    # (_convert_field_to_property), which builds the properties of nested dataclass fields.
+    @dataclass
+    class Inner:
+        score: float = 0.0
+        scores: list[float] = field(default_factory=lambda: [0.0])
+
+    @dataclass
+    class Outer:
+        inner: Inner = field(default_factory=Inner)
+
+    assert convert_dataclass_to_schema(Outer).to_dict() == [
+        {
+            "type": "object",
+            "properties": {
+                "score": {"type": "double", "required": True},
+                "scores": {"type": "array", "items": {"type": "double"}, "required": True},
+            },
+            "name": "inner",
+            "required": True,
+        }
+    ]
+
+
 def test_convert_dataclass_to_schema_invalid():
     # Invalid dataclass with Union
     @dataclass


### PR DESCRIPTION
### Related Issues/PRs

Relates to #12968 (the analogous `int` -> `long` fix).

### What changes are proposed in this pull request?

`_map_field_type` in `mlflow/types/schema.py` maps a Python `float` dataclass field to the 32-bit `"float"` datatype:

```python
int: "long",  # int is mapped to long to support 64-bit integers
builtins.float: "float",   # Python float is 64-bit, not 32-bit
```

But Python's `float` is IEEE-754 **64-bit** (`float64` / `DataType.double`). So `convert_dataclass_to_schema` / `infer_signature` produce a signature whose float columns are `float32`, and `_enforce_schema` then rejects the very `float64` values the dataclass describes:

```python
@dataclass
class Output:
    score: float = 0.0

schema = convert_dataclass_to_schema(Output)          # score -> DataType.float (32-bit)
_enforce_schema(pd.DataFrame([{"score": 0.1}]), schema)
# MlflowException: Incompatible input types for column score.
#   Can not safely convert float64 to float32.
```

This is the same defect class fixed for `int` in #12968 (`int` -> `long`, "to support 64-bit integers"), left unfixed for `float`. Everywhere else in mlflow, Python `float` is `double` — `SCALAR_TO_DATATYPE_MAPPING` (`float: DataType.double`), `_infer_schema({"x": 1.5})` -> `double`, and `_enforce_mlflow_datatype` (float -> double upcast). `_map_field_type` feeds both `convert_dataclass_to_schema` and `_convert_field_to_property`, so scalar-, `list[float]`- and nested-dataclass-float fields are all affected.

Fix (one line): `builtins.float: "double"`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_convert_dataclass_to_schema_float_maps_to_double`, asserting a dataclass `float` and `list[float]` map to `"double"`. It fails before the change (maps to `"float"`) and passes after. The existing dataclass-schema tests use only `bool`/`int`/`str`, so nothing asserted the old behavior.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `convert_dataclass_to_schema` / `infer_signature` mapping Python `float` dataclass fields to 32-bit `float` instead of 64-bit `double`, which caused the inferred model signature to reject valid `float64` values during schema enforcement.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
