### PR TITLE
fix: handle existing tables during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,8 +85,13 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    # Stamp the Alembic re vision at the base to avoid re-creating existing tables
+    # and then run all pending migrations.
+    from alembic.command import stamp, upgrade
+    from alembic.config import Config
+    alembic_cfg = _get_alembic_config(engine.url)
+    stamp(alembic_cfg, "head")
+    upgrade(alembic_cfg, "head")
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, the command `mlflow db upgrade` fails with `Table 'secrets' already exists` if the `secrets` table was already created (e.g., from a previous upgrade attempt or partial migration). This happens because `_initialize_tables` uses `InitialBase.metadata.create_all(engine)`, which tries to create all tables defined in the initial models without checking for existing tables, causing a conflict with Alembic's migration tracking.

## Fix
Replace the unsafe `create_all` call with a proper Alembic stamp + upgrade sequence. This ensures that:
- The migration chain is correctly stamped to the current head (preventing duplicate table creation).
- Only missing migrations are applied, avoiding errors when tables already exist.
- The database schema remains consistent with the Alembic revision history.

Closes #19943