### PR TITLE
Add missing core members to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ MLflow is currently maintained by the following core members with significant co
 - [Tomu Hirata](https://github.com/TomeHirata)
 - [Matt Prahl](https://github.com/mprahl)
 - [Gabriel Fu](https://github.com/gabrielfu)
+- [Joel Robin P](https://github.com/joelrobin18)
+- [Pat Sukprasert](https://github.com/PattaraS)
 
 ## Contribution process
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds Joel Robin P and Pat Sukprasert to the Core Members list in `CONTRIBUTING.md`. Both were added to the Core Members section of `README.md` (#18904 and #21094 respectively), but the corresponding list in `CONTRIBUTING.md` was never updated, leaving the two lists out of sync.

### How is this PR tested?

- [x] Manual tests

Documentation-only change; verified the rendered list matches `README.md`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release