### PR TITLE
Support Portkey routing configuration in the AI Gateway

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -825,6 +825,8 @@ mlflow.gateway.config.OpenAIConfig.validate_field_compatibility
 mlflow.gateway.config.OpenAIConfig.validate_openai_api_key
 mlflow.gateway.config.PaLMConfig
 mlflow.gateway.config.PaLMConfig.validate_palm_api_key
+mlflow.gateway.config.PortkeyConfig
+mlflow.gateway.config.PortkeyConfig.validate_provider_api_key
 mlflow.gateway.config.Provider
 mlflow.gateway.config.Provider.values
 mlflow.gateway.config.RouteDestinationConfig

--- a/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
@@ -274,8 +274,8 @@ When creating a Portkey endpoint:
 
 1. Select **Portkey** as the provider
 2. Enter your Portkey API key and a routing target as described above
-   (the base URL defaults to `https://api.portkey.ai/v1`)
-3. Enter the model name as per your Portkey configuration
+3. Enter your Portkey base URL (e.g. `https://api.portkey.ai/v1`)
+4. Enter the model name as per your Portkey configuration
    (e.g. `gpt-4o`, `@openai-prod/gpt-4o`, or a custom alias)
 
 ```python

--- a/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
@@ -260,12 +260,23 @@ response = client.chat.completions.create(
 
 [Portkey](https://portkey.ai) provides a single OpenAI-compatible API.
 
+In addition to your Portkey API key, Portkey needs to know which upstream provider
+to route each request to. Configure one of the following when creating the endpoint:
+
+- **Provider Slug**: a [Model Catalog](https://portkey.ai/docs/product/model-catalog)
+  integration slug prefixed with `@` (e.g. `@openai-prod`), or a bare provider slug
+  (e.g. `openai`) together with a **Provider API Key** for that provider
+- **Config ID or JSON**: a saved Portkey config ID (e.g. `pc-xxxx`) or a raw JSON config
+- Neither, if your model name already embeds the routing target
+  (e.g. `@openai-prod/gpt-4o`) or your Portkey API key has a default config attached
+
 When creating a Portkey endpoint:
 
 1. Select **Portkey** as the provider
-2. Enter your Portkey API key
-3. Enter your Portkey base URL (e.g. `https://api.portkey.ai/v1`)
-4. Enter the model name as per your Portkey configuration (e.g. a virtual key name, `provider/model-name`, or a custom alias)
+2. Enter your Portkey API key and a routing target as described above
+   (the base URL defaults to `https://api.portkey.ai/v1`)
+3. Enter the model name as per your Portkey configuration
+   (e.g. `gpt-4o`, `@openai-prod/gpt-4o`, or a custom alias)
 
 ```python
 from openai import OpenAI

--- a/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
@@ -266,7 +266,7 @@ to route each request to. Configure one of the following when creating the endpo
 - **Provider Slug**: a [Model Catalog](https://portkey.ai/docs/product/model-catalog)
   integration slug prefixed with `@` (e.g. `@openai-prod`), or a bare provider slug
   (e.g. `openai`) together with a **Provider API Key** for that provider
-- **Config ID or JSON**: a saved Portkey config ID (e.g. `pc-xxxx`) or a raw JSON config
+- **Config ID or JSON**: a saved Portkey config ID (e.g. `pc-xxxx`) or a raw JSON config. This is stored as a secret, since a raw JSON config may embed upstream credentials
 - Neither, if your model name already embeds the routing target
   (e.g. `@openai-prod/gpt-4o`) or your Portkey API key has a default config attached
 

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -288,6 +288,36 @@ class _OpenAICompatibleConfig(ConfigModel):
         return _resolve_api_key_from_input(value)
 
 
+class PortkeyConfig(_OpenAICompatibleConfig):
+    """Config for the Portkey AI gateway provider.
+
+    In addition to the Portkey API key, Portkey must be told which upstream provider
+    to route a request to. This is expressed either as a provider slug
+    (``portkey_provider``), a saved Portkey config (``portkey_config``), or a Model
+    Catalog reference embedded in the model name (e.g. ``@openai-prod/gpt-4o``).
+
+    Args:
+        portkey_provider: Value for the ``x-portkey-provider`` header. Either a Model
+            Catalog integration slug prefixed with ``@`` (e.g. ``@openai-prod``), or a
+            bare provider slug (e.g. ``openai``), which requires ``provider_api_key``.
+        portkey_config: Value for the ``x-portkey-config`` header. A saved Portkey
+            config ID (e.g. ``pc-xxxx``) or a raw JSON config string.
+        provider_api_key: Upstream provider API key, forwarded to Portkey via the
+            ``Authorization`` header. Only needed when ``portkey_provider`` is a bare
+            provider slug whose credentials are not stored in Portkey.
+    """
+
+    portkey_provider: str | None = None
+    portkey_config: str | None = None
+    provider_api_key: str | None = None
+
+    @field_validator("provider_api_key", mode="before")
+    def validate_provider_api_key(cls, value):
+        if value is None:
+            return None
+        return _resolve_api_key_from_input(value)
+
+
 class VertexAIConfig(ConfigModel):
     vertex_project: str
     vertex_location: str | None = None

--- a/mlflow/gateway/providers/portkey.py
+++ b/mlflow/gateway/providers/portkey.py
@@ -21,3 +21,23 @@ class PortkeyProvider(OpenAICompatibleProvider):
         if provider_api_key := self._provider_config.provider_api_key:
             headers["Authorization"] = f"Bearer {provider_api_key}"
         return headers
+
+    def _get_headers(
+        self,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        result = super()._get_headers(headers)
+        # On the passthrough routes, the base class lets a subscription tool's
+        # own Authorization header (Claude Code, Codex, Gemini CLI) pass through
+        # to the upstream. For Portkey, Authorization carries the configured
+        # upstream `provider_api_key`, not a Portkey credential, so an explicitly
+        # configured key must win: a client Authorization targets MLflow, not
+        # Portkey's upstream provider. When no key is configured, the base
+        # behavior is preserved.
+        if self._provider_config.provider_api_key:
+            # drop any client-provided Authorization (any casing) so it cannot
+            # shadow the configured upstream key
+            for key in [k for k in result if k.lower() == "authorization"]:
+                del result[key]
+            result["Authorization"] = f"Bearer {self._provider_config.provider_api_key}"
+        return result

--- a/mlflow/gateway/providers/portkey.py
+++ b/mlflow/gateway/providers/portkey.py
@@ -1,11 +1,23 @@
-from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.config import PortkeyConfig
 from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
 
 
 class PortkeyProvider(OpenAICompatibleProvider):
     DISPLAY_NAME = "Portkey"
-    CONFIG_TYPE = _OpenAICompatibleConfig
+    CONFIG_TYPE = PortkeyConfig
+    DEFAULT_API_BASE = "https://api.portkey.ai/v1"
 
     @property
     def headers(self) -> dict[str, str]:
-        return {"x-portkey-api-key": self._api_key}
+        # Portkey requires a routing target in addition to the Portkey API key:
+        # a provider slug (x-portkey-provider), a saved config (x-portkey-config),
+        # or an "@integration/model" reference in the model name. Bare provider
+        # slugs also need the upstream key, passed via the Authorization header.
+        headers = {"x-portkey-api-key": self._api_key}
+        if portkey_provider := self._provider_config.portkey_provider:
+            headers["x-portkey-provider"] = portkey_provider
+        if portkey_config := self._provider_config.portkey_config:
+            headers["x-portkey-config"] = portkey_config
+        if provider_api_key := self._provider_config.provider_api_key:
+            headers["Authorization"] = f"Bearer {provider_api_key}"
+        return headers

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -347,7 +347,9 @@ def _build_endpoint_config(
             api_key=model_config.secret_value.get(_AuthConfigKey.API_KEY),
             api_base=auth_config.get(_AuthConfigKey.API_BASE),
             portkey_provider=auth_config.get("portkey_provider"),
-            portkey_config=auth_config.get("portkey_config"),
+            # portkey_config is a secret because a raw JSON config may embed
+            # upstream credentials, so it is read from secret_value
+            portkey_config=model_config.secret_value.get("portkey_config"),
             provider_api_key=model_config.secret_value.get("provider_api_key"),
         )
     elif normalize_provider_name(model_config.provider) == Provider.DATABRICKS:

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -30,6 +30,7 @@ from mlflow.gateway.config import (
     MistralConfig,
     OpenAIAPIType,
     OpenAIConfig,
+    PortkeyConfig,
     Provider,
     VertexAIConfig,
     _AuthConfigKey,
@@ -338,9 +339,17 @@ def _build_endpoint_config(
         Provider.XAI,
         Provider.OPENROUTER,
         Provider.OLLAMA,
-        Provider.PORTKEY,
     }:
         provider_config = _build_openai_compatible_config(model_config)
+    elif model_config.provider == Provider.PORTKEY:
+        auth_config = model_config.auth_config or {}
+        provider_config = PortkeyConfig(
+            api_key=model_config.secret_value.get(_AuthConfigKey.API_KEY),
+            api_base=auth_config.get(_AuthConfigKey.API_BASE),
+            portkey_provider=auth_config.get("portkey_provider"),
+            portkey_config=auth_config.get("portkey_config"),
+            provider_api_key=model_config.secret_value.get("provider_api_key"),
+        )
     elif normalize_provider_name(model_config.provider) == Provider.DATABRICKS:
         from mlflow.gateway.providers.databricks import DatabricksConfig
 

--- a/mlflow/server/js/src/gateway/utils/providerUtils.test.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.test.ts
@@ -42,6 +42,9 @@ describe('providerUtils', () => {
       expect(formatCredentialFieldName('aws_access_key_id')).toBe('AWS Access Key ID');
       expect(formatCredentialFieldName('aws_secret_access_key')).toBe('AWS Secret Access Key');
       expect(formatCredentialFieldName('vertex_project')).toBe('Project ID');
+      expect(formatCredentialFieldName('portkey_provider')).toBe('Provider Slug');
+      expect(formatCredentialFieldName('portkey_config')).toBe('Config ID or JSON');
+      expect(formatCredentialFieldName('provider_api_key')).toBe('Provider API Key');
     });
 
     it('formats unknown credential fields with title case', () => {
@@ -77,6 +80,24 @@ describe('providerUtils', () => {
       ];
       const sorted = sortFieldsByProvider(fields, 'databricks');
       expect(sorted.map((f) => f.name)).toEqual(['client_id', 'api_base', 'unknown_field']);
+    });
+
+    it('sorts Portkey fields in the defined order', () => {
+      const fields = [
+        { name: 'api_base', value: '' },
+        { name: 'portkey_config', value: '' },
+        { name: 'provider_api_key', value: '' },
+        { name: 'api_key', value: '' },
+        { name: 'portkey_provider', value: '' },
+      ];
+      const sorted = sortFieldsByProvider(fields, 'portkey');
+      expect(sorted.map((f) => f.name)).toEqual([
+        'api_key',
+        'portkey_provider',
+        'provider_api_key',
+        'portkey_config',
+        'api_base',
+      ]);
     });
 
     it('handles empty fields array', () => {

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -91,6 +91,9 @@ export function formatCredentialFieldName(fieldName: string): string {
     vertex_location: 'Location',
     databricks_token: 'Databricks Token',
     databricks_host: 'Databricks Host',
+    portkey_provider: 'Provider Slug',
+    portkey_config: 'Config ID or JSON',
+    provider_api_key: 'Provider API Key',
   } satisfies Record<string, string>;
 
   if (fieldName in formatMap) {
@@ -102,6 +105,7 @@ export function formatCredentialFieldName(fieldName: string): string {
 
 const PROVIDER_FIELD_ORDER = {
   databricks: ['client_id', 'client_secret', 'api_base'],
+  portkey: ['api_key', 'portkey_provider', 'provider_api_key', 'portkey_config', 'api_base'],
 } satisfies Record<string, string[]>;
 
 export function sortFieldsByProvider<T extends { name: string }>(fields: T[], provider: string): T[] {

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -654,6 +654,47 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
             ],
         },
     },
+    "portkey": {
+        "api_key": {
+            "display_name": "API Key",
+            "description": "Use Portkey API Key with an optional routing target",
+            "default": True,
+            "fields": [
+                {
+                    "name": "api_key",
+                    "description": "Portkey API Key",
+                    "secret": True,
+                    "required": True,
+                },
+                {
+                    "name": "portkey_provider",
+                    "description": "Provider to route to: a Model Catalog slug "
+                    "(e.g. @openai-prod) or a bare provider slug (e.g. openai)",
+                    "secret": False,
+                    "required": False,
+                },
+                {
+                    "name": "portkey_config",
+                    "description": "Portkey config ID (e.g. pc-xxxx) or JSON config",
+                    "secret": False,
+                    "required": False,
+                },
+                {
+                    "name": "provider_api_key",
+                    "description": "Upstream provider API key "
+                    "(only for bare provider slugs not stored in Portkey)",
+                    "secret": True,
+                    "required": False,
+                },
+                {
+                    "name": "api_base",
+                    "description": "Portkey API Base URL (defaults to https://api.portkey.ai/v1)",
+                    "secret": False,
+                    "required": False,
+                },
+            ],
+        },
+    },
     "sagemaker": {
         "access_keys": {
             "display_name": "Access Keys",

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -675,8 +675,10 @@ _PROVIDER_AUTH_MODES: dict[str, dict[str, AuthModeDict]] = {
                 },
                 {
                     "name": "portkey_config",
-                    "description": "Portkey config ID (e.g. pc-xxxx) or JSON config",
-                    "secret": False,
+                    "description": "Portkey config ID (e.g. pc-xxxx) or JSON config. "
+                    "Stored as a secret since a raw JSON config may embed "
+                    "upstream credentials",
+                    "secret": True,
                     "required": False,
                 },
                 {

--- a/tests/gateway/providers/test_portkey.py
+++ b/tests/gateway/providers/test_portkey.py
@@ -1,0 +1,122 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig, PortkeyConfig
+from mlflow.gateway.providers.portkey import PortkeyProvider
+from mlflow.gateway.schemas import chat
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider(provider_config=None, model_name="gpt-4o") -> PortkeyProvider:
+    endpoint_config = EndpointConfig(
+        name="portkey-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "portkey",
+            "name": model_name,
+            "config": {"api_key": "pk-test-key", **(provider_config or {})},
+        },
+    )
+    return PortkeyProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-pk-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gpt-4o",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from Portkey!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.DISPLAY_NAME == "Portkey"
+
+
+def test_config_type():
+    provider = _make_provider()
+    assert isinstance(provider.config.model.config, PortkeyConfig)
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "https://api.portkey.ai/v1"
+
+
+def test_api_base_override():
+    provider = _make_provider({"api_base": "https://portkey.internal.example.com/v1"})
+    assert provider._api_base == "https://portkey.internal.example.com/v1"
+
+
+@pytest.mark.parametrize(
+    ("provider_config", "expected_headers"),
+    [
+        # Model Catalog routing via "@provider/model" names needs no extra headers
+        (
+            {},
+            {"x-portkey-api-key": "pk-test-key"},
+        ),
+        # Managed provider from the Portkey Model Catalog
+        (
+            {"portkey_provider": "@openai-prod"},
+            {"x-portkey-api-key": "pk-test-key", "x-portkey-provider": "@openai-prod"},
+        ),
+        # Saved Portkey config ID
+        (
+            {"portkey_config": "pc-test-1234"},
+            {"x-portkey-api-key": "pk-test-key", "x-portkey-config": "pc-test-1234"},
+        ),
+        # Bare provider slug with the upstream key passed through
+        (
+            {"portkey_provider": "openai", "provider_api_key": "sk-upstream"},
+            {
+                "x-portkey-api-key": "pk-test-key",
+                "x-portkey-provider": "openai",
+                "Authorization": "Bearer sk-upstream",
+            },
+        ),
+    ],
+)
+def test_headers(provider_config, expected_headers):
+    provider = _make_provider(provider_config)
+    assert provider.headers == expected_headers
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider({"portkey_provider": "@openai-prod"})
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session:
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-pk-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from Portkey!"
+
+    session_headers = mock_session.call_args.kwargs["headers"]
+    assert session_headers["x-portkey-api-key"] == "pk-test-key"
+    assert session_headers["x-portkey-provider"] == "@openai-prod"
+
+    mock_client.post.assert_called_once()
+    assert mock_client.post.call_args.args[0] == "https://api.portkey.ai/v1/chat/completions"

--- a/tests/gateway/providers/test_portkey.py
+++ b/tests/gateway/providers/test_portkey.py
@@ -120,3 +120,36 @@ async def test_chat():
 
     mock_client.post.assert_called_once()
     assert mock_client.post.call_args.args[0] == "https://api.portkey.ai/v1/chat/completions"
+
+
+def test_configured_upstream_key_wins_over_client_auth():
+    # A subscription tool (e.g. Claude Code) sends its own Authorization header
+    # on a passthrough request. For Portkey, Authorization carries the upstream
+    # `provider_api_key`, so a configured key must win and the client's key,
+    # which targets MLflow rather than the upstream, must not be forwarded.
+    provider = _make_provider({"portkey_provider": "openai", "provider_api_key": "sk-upstream"})
+    client_headers = {
+        "user-agent": "claude-cli/1.2.3",
+        "authorization": "Bearer sk-client-token",
+    }
+    result = provider._get_headers(client_headers)
+    auth = [v for k, v in result.items() if k.lower() == "authorization"]
+    # exactly one Authorization header, and it is the configured upstream key
+    assert auth == ["Bearer sk-upstream"]
+    assert result["x-portkey-api-key"] == "pk-test-key"
+    assert result["x-portkey-provider"] == "openai"
+
+
+def test_client_auth_preserved_when_no_upstream_key():
+    # Without a configured provider_api_key (e.g. Model Catalog @slug routing),
+    # the base behavior is preserved: a subscription tool may pass its own
+    # Authorization through.
+    provider = _make_provider({"portkey_provider": "@openai-prod"})
+    client_headers = {
+        "user-agent": "claude-cli/1.2.3",
+        "authorization": "Bearer sk-client-token",
+    }
+    result = provider._get_headers(client_headers)
+    auth = [v for k, v in result.items() if k.lower() == "authorization"]
+    assert auth == ["Bearer sk-client-token"]
+    assert result["x-portkey-api-key"] == "pk-test-key"

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -351,10 +351,16 @@ def test_create_provider_from_endpoint_name_mistral(store: SqlAlchemyStore):
 
 
 def test_create_provider_from_endpoint_name_portkey(store: SqlAlchemyStore):
-    # Portkey routing fields flow from auth_config/secret_value into PortkeyConfig
+    # Portkey routing fields flow from auth_config/secret_value into PortkeyConfig.
+    # portkey_config is a secret (it may embed credentials), so it lives in
+    # secret_value; portkey_provider is non-sensitive and lives in auth_config.
     secret = store.create_gateway_secret(
         secret_name="portkey-key",
-        secret_value={"api_key": "pk-test-123", "provider_api_key": "sk-upstream-456"},
+        secret_value={
+            "api_key": "pk-test-123",
+            "provider_api_key": "sk-upstream-456",
+            "portkey_config": "pc-test-789",
+        },
         provider="portkey",
         auth_config={"portkey_provider": "openai"},
     )
@@ -384,10 +390,12 @@ def test_create_provider_from_endpoint_name_portkey(store: SqlAlchemyStore):
     assert isinstance(provider_config, PortkeyConfig)
     assert provider_config.api_key == "pk-test-123"
     assert provider_config.portkey_provider == "openai"
+    assert provider_config.portkey_config == "pc-test-789"
     assert provider_config.provider_api_key == "sk-upstream-456"
     assert provider.headers == {
         "x-portkey-api-key": "pk-test-123",
         "x-portkey-provider": "openai",
+        "x-portkey-config": "pc-test-789",
         "Authorization": "Bearer sk-upstream-456",
     }
 

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -29,6 +29,7 @@ from mlflow.gateway.config import (
     MistralConfig,
     OpenAIAPIType,
     OpenAIConfig,
+    PortkeyConfig,
 )
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER, MLFLOW_GATEWAY_OVERHEAD_HEADER
 from mlflow.gateway.guardrails import _SANITIZE_BYPASS_HEADER, JudgeGuardrail
@@ -42,6 +43,7 @@ from mlflow.gateway.providers.gemini import GeminiProvider
 from mlflow.gateway.providers.litellm import LiteLLMProvider
 from mlflow.gateway.providers.mistral import MistralProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
+from mlflow.gateway.providers.portkey import PortkeyProvider
 from mlflow.gateway.providers.utils import provider_call_duration_ms
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.server.fastapi_app import add_gateway_timing_middleware
@@ -346,6 +348,48 @@ def test_create_provider_from_endpoint_name_mistral(store: SqlAlchemyStore):
     assert isinstance(provider, MistralProvider)
     assert isinstance(provider.config.model.config, MistralConfig)
     assert provider.config.model.config.mistral_api_key == "mistral-test-key"
+
+
+def test_create_provider_from_endpoint_name_portkey(store: SqlAlchemyStore):
+    # Portkey routing fields flow from auth_config/secret_value into PortkeyConfig
+    secret = store.create_gateway_secret(
+        secret_name="portkey-key",
+        secret_value={"api_key": "pk-test-123", "provider_api_key": "sk-upstream-456"},
+        provider="portkey",
+        auth_config={"portkey_provider": "openai"},
+    )
+    model_def = store.create_gateway_model_definition(
+        name="portkey-model",
+        secret_id=secret.secret_id,
+        provider="portkey",
+        model_name="gpt-4o",
+    )
+    endpoint = store.create_gateway_endpoint(
+        name="test-portkey-endpoint",
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+    provider, _ = _create_provider_from_endpoint_name(
+        store, endpoint.name, EndpointType.LLM_V1_CHAT
+    )
+
+    assert isinstance(provider, PortkeyProvider)
+    provider_config = provider.config.model.config
+    assert isinstance(provider_config, PortkeyConfig)
+    assert provider_config.api_key == "pk-test-123"
+    assert provider_config.portkey_provider == "openai"
+    assert provider_config.provider_api_key == "sk-upstream-456"
+    assert provider.headers == {
+        "x-portkey-api-key": "pk-test-123",
+        "x-portkey-provider": "openai",
+        "Authorization": "Bearer sk-upstream-456",
+    }
 
 
 def test_create_provider_from_endpoint_name_gemini(store: SqlAlchemyStore):

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -242,8 +242,9 @@ def test_get_provider_config_portkey_has_routing_fields():
 
     assert secret_fields["api_key"]["required"]
     assert not secret_fields["provider_api_key"]["required"]
+    # portkey_config is a secret because a raw JSON config may embed credentials
+    assert not secret_fields["portkey_config"]["required"]
     assert not config_fields["portkey_provider"]["required"]
-    assert not config_fields["portkey_config"]["required"]
     assert not config_fields["api_base"]["required"]
 
 

--- a/tests/utils/test_providers.py
+++ b/tests/utils/test_providers.py
@@ -232,6 +232,21 @@ def test_get_provider_config_bedrock_has_default_chain():
     assert all(not f["required"] for f in default_chain["config_fields"])
 
 
+def test_get_provider_config_portkey_has_routing_fields():
+    config = get_provider_config_response("portkey")
+    assert config["default_mode"] == "api_key"
+
+    api_key_mode = next(m for m in config["auth_modes"] if m["mode"] == "api_key")
+    secret_fields = {f["name"]: f for f in api_key_mode["secret_fields"]}
+    config_fields = {f["name"]: f for f in api_key_mode["config_fields"]}
+
+    assert secret_fields["api_key"]["required"]
+    assert not secret_fields["provider_api_key"]["required"]
+    assert not config_fields["portkey_provider"]["required"]
+    assert not config_fields["portkey_config"]["required"]
+    assert not config_fields["api_base"]["required"]
+
+
 def test_get_provider_config_sagemaker_has_default_chain():
     config = get_provider_config_response("sagemaker")
     modes = {m["mode"] for m in config["auth_modes"]}


### PR DESCRIPTION
﻿### Related Issues/PRs

Closes #24391

### What changes are proposed in this pull request?

The AI Gateway's Portkey provider only sends the `x-portkey-api-key` header. Portkey requires a routing target on every request (an `x-portkey-provider` slug, an `x-portkey-config` ID, or an `@integration/model` reference in the model name), so unless the Portkey API key has a default config attached on Portkey's side, every request fails with `Either x-portkey-config or x-portkey-provider header is required`.

The endpoint creation flow had no way to supply any routing information, and the provider defined no `DEFAULT_API_BASE`, unlike the other OpenAI-compatible providers.

This PR:

- Adds `PortkeyConfig` (extending `_OpenAICompatibleConfig`) with optional `portkey_provider`, `portkey_config`, and `provider_api_key` fields, emitted as the `x-portkey-provider`, `x-portkey-config`, and `Authorization: Bearer <key>` headers respectively. This covers the three routing modes in Portkey's docs: a managed `@slug` from the Model Catalog, a bare provider slug with a passed-through upstream key, and a saved config ID or JSON. Existing setups (key-attached default configs, `@slug/model` model names) keep working since all new fields are optional.
- Sets `DEFAULT_API_BASE = "https://api.portkey.ai/v1"` on `PortkeyProvider`, matching the sibling providers.
- Declares the new fields in the provider auth schema in `mlflow/utils/providers.py`, so the endpoint creation UI renders them without bespoke frontend logic; adds display names and field ordering in `providerUtils.ts`.
- Builds `PortkeyConfig` from `auth_config`/`secret_value` in `_build_endpoint_config`.
- Updates the Portkey section of the AI Gateway model providers docs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests:

- `tests/gateway/providers/test_portkey.py` (new file): default and overridden API base, header emission for all routing modes (parametrized), and a chat round trip asserting the session headers and request URL.
- `tests/utils/test_providers.py::test_get_provider_config_portkey_has_routing_fields`: the auth schema exposes the new optional fields.
- `tests/server/test_gateway_api.py::test_create_provider_from_endpoint_name_portkey`: end-to-end store-to-provider mapping, including secret handling for `provider_api_key`.
- `providerUtils.test.ts`: display names and field ordering for the new fields.

Ran locally (Windows): the three Python test files above plus `tests/gateway/test_provider_registry.py`, `tests/gateway/providers/test_openai_compatible.py`, and `tests/gateway/test_gateway_config_parsing.py` all pass; `ruff check`, `ruff format --check`, `clint`, and prettier on the touched TS files are clean.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The AI Gateway Portkey provider now supports routing configuration (provider slug, config ID, or upstream provider key) and defaults its API base to `https://api.portkey.ai/v1`, fixing the "Either x-portkey-config or x-portkey-provider header is required" error when creating Portkey endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/uiux`: Front-end, user experience, plotting

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


### Manual verification

**End-to-end run through the gateway to Portkey.** A Portkey endpoint was created (encrypted secret + `portkey_provider` routing), resolved through the gateway's own `_create_provider_from_endpoint_name`, and a chat request was sent. The request reaches the real `api.portkey.ai` and returns a Portkey auth error (a dummy key was used), rather than the `Either x-portkey-config or x-portkey-provider header is required` error the bug produced, which confirms the routing header is now sent:

```
resolved provider: PortkeyProvider
api_base: https://api.portkey.ai/v1
resolved routing -> x-portkey-provider: openai
headers: {'x-portkey-api-key': 'pk-dummy-p...2e', 'x-portkey-provider': 'openai', 'Authorization': 'Bearer sk-...am'}
POST https://api.portkey.ai/v1/chat/completions
------------------------------------------------------------
Portkey responded through the gateway (request reached Portkey):
  HTTPException: 401: Portkey Error: Invalid API Key. Error Code: 03
```

**New endpoint-creation form fields.** The Portkey form is rendered from the provider auth schema (`SecretFormFields` maps `get_provider_config_response("portkey")`), so the fields below are exactly what the endpoint-creation UI shows after this change:

```
default_mode: api_key
  [secret] api_key           required=True    Portkey API Key
  [secret] portkey_config    required=False   Portkey config ID (e.g. pc-xxxx) or JSON config. Stored as a secret since a raw JSON config may embed upstream credentials
  [secret] provider_api_key  required=False   Upstream provider API key (only for bare provider slugs not stored in Portkey)
  [config] portkey_provider  required=False   Provider to route to: a Model Catalog slug (e.g. @openai-prod) or a bare provider slug (e.g. openai)
  [config] api_base          required=False   Portkey API Base URL (defaults to https://api.portkey.ai/v1)
```

with display labels from `providerUtils.ts`: Provider Slug, Config ID or JSON, Provider API Key. I can attach a rendered screenshot of the form as well if that is preferred over the schema output above.
