### PR TITLE
Fix gateway Try-in-Browser traces rendering as raw `kvlist` data in the UI

### DIFF
--- a/mlflow/gateway/tracing_utils.py
+++ b/mlflow/gateway/tracing_utils.py
@@ -6,6 +6,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+import pydantic
+
 import mlflow
 from mlflow.entities import SpanStatus, SpanType
 from mlflow.entities.trace_location import MlflowExperimentLocation
@@ -48,6 +50,15 @@ def _extract_caller(request_headers: dict[str, str] | None) -> str | None:
     return None
 
 
+def _dump_payload(value: Any) -> Any:
+    """Serialize pydantic request payloads without None fields so the trace input
+    shows only the fields the caller actually sent, not every optional parameter.
+    """
+    if isinstance(value, pydantic.BaseModel):
+        return value.model_dump(exclude_none=True)
+    return value
+
+
 def _maybe_unwrap_single_arg_input(args: tuple[Any], kwargs: dict[str, Any]):
     """Unwrap inputs so trace shows the request body directly.
 
@@ -61,10 +72,10 @@ def _maybe_unwrap_single_arg_input(args: tuple[Any], kwargs: dict[str, Any]):
     # This takes precedence to handle cases where functions are called with
     # keyword arguments (e.g., action=..., payload=..., headers=...)
     if "payload" in kwargs:
-        span.set_inputs(kwargs["payload"])
+        span.set_inputs(_dump_payload(kwargs["payload"]))
     # For other endpoints with a single positional argument
     elif len(args) == 1 and not kwargs:
-        span.set_inputs(args[0])
+        span.set_inputs(_dump_payload(args[0]))
 
 
 def _has_traceparent(headers: dict[str, str]) -> bool:

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
@@ -15,6 +15,9 @@ import {
   createTagColumnId,
   convertTraceInfoV3ToRunEvalEntry,
   getSpansLocation,
+  decodeOtelAnyValue,
+  getSpanAttribute,
+  isOtelAnyValue,
 } from './TraceUtils';
 import { KnownEvaluationResultAssessmentName } from '../components/GenAiEvaluationTracesReview.utils';
 import type { RunEvaluationResultAssessment, RunEvaluationTracesDataEntry } from '../types';
@@ -1091,5 +1094,98 @@ describe('getSpansLocation', () => {
     } as any;
 
     expect(getSpansLocation(traceInfo)).toBe('TRACKING_STORE');
+  });
+});
+
+describe('decodeOtelAnyValue', () => {
+  it('decodes primitive values', () => {
+    expect(decodeOtelAnyValue({ string_value: 'hello' })).toBe('hello');
+    expect(decodeOtelAnyValue({ bool_value: false })).toBe(false);
+    expect(decodeOtelAnyValue({ int_value: 42 })).toBe(42);
+    expect(decodeOtelAnyValue({ int_value: '9007199254740000' })).toBe(9007199254740000);
+    expect(decodeOtelAnyValue({ double_value: 3.14 })).toBe(3.14);
+    expect(decodeOtelAnyValue({ bytes_value: 'aGVsbG8=' })).toBe('aGVsbG8=');
+  });
+
+  it('decodes unset values to null', () => {
+    expect(decodeOtelAnyValue(undefined)).toBeNull();
+    expect(decodeOtelAnyValue({})).toBeNull();
+  });
+
+  it('recursively decodes kvlist and array values', () => {
+    expect(
+      decodeOtelAnyValue({
+        kvlist_value: {
+          values: [
+            {
+              key: 'messages',
+              value: {
+                array_value: {
+                  values: [
+                    {
+                      kvlist_value: {
+                        values: [
+                          { key: 'role', value: { string_value: 'user' } },
+                          { key: 'content', value: { string_value: 'How are you?' } },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            // null fields are serialized as kvlist entries without a value
+            { key: 'stop' },
+          ],
+        },
+      }),
+    ).toEqual({
+      messages: [{ role: 'user', content: 'How are you?' }],
+      stop: null,
+    });
+  });
+
+  it('decodes empty kvlist and array values', () => {
+    expect(decodeOtelAnyValue({ kvlist_value: {} })).toEqual({});
+    expect(decodeOtelAnyValue({ array_value: {} })).toEqual([]);
+  });
+});
+
+describe('isOtelAnyValue', () => {
+  it('returns true for OTLP AnyValue shapes', () => {
+    expect(isOtelAnyValue({ string_value: 'hello' })).toBe(true);
+    expect(isOtelAnyValue({ kvlist_value: { values: [] } })).toBe(true);
+    expect(isOtelAnyValue({ array_value: { values: [] } })).toBe(true);
+  });
+
+  it('returns false for other values', () => {
+    expect(isOtelAnyValue('hello')).toBe(false);
+    expect(isOtelAnyValue(42)).toBe(false);
+    expect(isOtelAnyValue(null)).toBe(false);
+    expect(isOtelAnyValue({ custom_field: 'value' })).toBe(false);
+  });
+});
+
+describe('getSpanAttribute', () => {
+  it('returns values from V3 flat object attributes', () => {
+    expect(getSpanAttribute({ 'mlflow.spanInputs': '{"x": 10}' }, 'mlflow.spanInputs')).toBe('{"x": 10}');
+  });
+
+  it('decodes typed values from OTLP array attributes', () => {
+    const attributes = [
+      { key: 'mlflow.spanType', value: { string_value: 'LLM' } },
+      {
+        key: 'mlflow.spanInputs',
+        value: {
+          kvlist_value: {
+            values: [{ key: 'question', value: { string_value: 'How are you?' } }],
+          },
+        },
+      },
+    ] as any;
+
+    expect(getSpanAttribute(attributes, 'mlflow.spanType')).toBe('LLM');
+    expect(getSpanAttribute(attributes, 'mlflow.spanInputs')).toEqual({ question: 'How are you?' });
+    expect(getSpanAttribute(attributes, 'nonexistent')).toBeUndefined();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
@@ -1103,6 +1103,8 @@ describe('decodeOtelAnyValue', () => {
     expect(decodeOtelAnyValue({ bool_value: false })).toBe(false);
     expect(decodeOtelAnyValue({ int_value: 42 })).toBe(42);
     expect(decodeOtelAnyValue({ int_value: '9007199254740000' })).toBe(9007199254740000);
+    // int64 strings beyond the safe integer range are kept as strings to avoid losing precision
+    expect(decodeOtelAnyValue({ int_value: '9007199254740993' })).toBe('9007199254740993');
     expect(decodeOtelAnyValue({ double_value: 3.14 })).toBe(3.14);
     expect(decodeOtelAnyValue({ bytes_value: 'aGVsbG8=' })).toBe('aGVsbG8=');
   });
@@ -1156,12 +1158,15 @@ describe('isOtelAnyValue', () => {
     expect(isOtelAnyValue({ string_value: 'hello' })).toBe(true);
     expect(isOtelAnyValue({ kvlist_value: { values: [] } })).toBe(true);
     expect(isOtelAnyValue({ array_value: { values: [] } })).toBe(true);
+    // an empty object is how OTLP represents null
+    expect(isOtelAnyValue({})).toBe(true);
   });
 
   it('returns false for other values', () => {
     expect(isOtelAnyValue('hello')).toBe(false);
     expect(isOtelAnyValue(42)).toBe(false);
     expect(isOtelAnyValue(null)).toBe(false);
+    expect(isOtelAnyValue([])).toBe(false);
     expect(isOtelAnyValue({ custom_field: 'value' })).toBe(false);
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
@@ -520,7 +520,11 @@ const OTEL_ANY_VALUE_KEYS = [
  * returned by OTLP-based endpoints such as V3 traces/get and V4 batchGet).
  */
 export const isOtelAnyValue = (value: unknown): value is ModelTraceOtelAnyValue =>
-  typeof value === 'object' && value !== null && OTEL_ANY_VALUE_KEYS.some((key) => key in value);
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  // an empty object is how OTLP represents null, so it is a valid AnyValue
+  (Object.keys(value).length === 0 || OTEL_ANY_VALUE_KEYS.some((key) => key in value));
 
 /**
  * Decode an OTLP AnyValue into a plain JS value. Complex values (dicts and
@@ -539,8 +543,13 @@ export const decodeOtelAnyValue = (value: ModelTraceOtelAnyValue | undefined | n
     return value.bool_value;
   }
   if (!isNil(value.int_value)) {
-    // int64 values may be serialized as strings in proto3 JSON
-    return typeof value.int_value === 'string' ? Number(value.int_value) : value.int_value;
+    if (typeof value.int_value !== 'string') {
+      return value.int_value;
+    }
+    // int64 values may be serialized as strings in proto3 JSON; keep the string
+    // when the value cannot be represented exactly as a JS number
+    const parsed = Number(value.int_value);
+    return Number.isSafeInteger(parsed) ? parsed : value.int_value;
   }
   if (!isNil(value.double_value)) {
     return value.double_value;

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
@@ -7,6 +7,7 @@ import type {
   IssueReferenceAssessment,
   ModelTrace,
   ModelTraceLocation,
+  ModelTraceOtelAnyValue,
   ModelTraceSpan,
   ModelTraceInfoV3,
   RetrieverDocument,
@@ -504,15 +505,64 @@ const getRetrievalAssessmentsByName = (
   return filteredResponseAssessmentsByName;
 };
 
+const OTEL_ANY_VALUE_KEYS = [
+  'string_value',
+  'bool_value',
+  'int_value',
+  'double_value',
+  'bytes_value',
+  'array_value',
+  'kvlist_value',
+] as const;
+
+/**
+ * Check whether a value looks like an OTLP AnyValue (typed attribute value
+ * returned by OTLP-based endpoints such as V3 traces/get and V4 batchGet).
+ */
+export const isOtelAnyValue = (value: unknown): value is ModelTraceOtelAnyValue =>
+  typeof value === 'object' && value !== null && OTEL_ANY_VALUE_KEYS.some((key) => key in value);
+
+/**
+ * Decode an OTLP AnyValue into a plain JS value. Complex values (dicts and
+ * lists, e.g. `mlflow.spanInputs` / `mlflow.spanOutputs`) arrive as nested
+ * `kvlist_value` / `array_value` structures and are decoded recursively.
+ * An unset value (e.g. a kvlist entry for a null field) decodes to null.
+ */
+export const decodeOtelAnyValue = (value: ModelTraceOtelAnyValue | undefined | null): any => {
+  if (isNil(value)) {
+    return null;
+  }
+  if (!isNil(value.string_value)) {
+    return value.string_value;
+  }
+  if (!isNil(value.bool_value)) {
+    return value.bool_value;
+  }
+  if (!isNil(value.int_value)) {
+    // int64 values may be serialized as strings in proto3 JSON
+    return typeof value.int_value === 'string' ? Number(value.int_value) : value.int_value;
+  }
+  if (!isNil(value.double_value)) {
+    return value.double_value;
+  }
+  if (!isNil(value.bytes_value)) {
+    return value.bytes_value;
+  }
+  if (value.array_value) {
+    return (value.array_value.values ?? []).map(decodeOtelAnyValue);
+  }
+  if (value.kvlist_value) {
+    return Object.fromEntries((value.kvlist_value.values ?? []).map((kv) => [kv.key, decodeOtelAnyValue(kv.value)]));
+  }
+  return null;
+};
+
 /**
  * Extract an attribute value from span attributes.
  * V3 traces have flat objects: { 'mlflow.spanInputs': '{"x": 10}' }
  * V4 traces have arrays: [{ key: 'mlflow.spanInputs', value: { string_value: '{"x":10}' } }]
  */
-export const getSpanAttribute = (
-  attributes: ModelTraceSpan['attributes'],
-  attributeKey: string,
-): string | undefined => {
+export const getSpanAttribute = (attributes: ModelTraceSpan['attributes'], attributeKey: string): any => {
   if (!attributes) {
     return undefined;
   }
@@ -528,8 +578,8 @@ export const getSpanAttribute = (
     return undefined;
   }
 
-  // V4 values are typed - return whichever type is present
-  return attribute.value.string_value ?? attribute.value.int_value ?? attribute.value.bool_value;
+  // V4 values are typed OTLP AnyValues - decode into a plain JS value
+  return decodeOtelAnyValue(attribute.value);
 };
 
 /**

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -105,6 +105,22 @@ export type ModelTraceSpanV3 = {
   type?: ModelSpanType;
 };
 
+/**
+ * OTLP AnyValue: the typed attribute value shape returned by OTLP-based
+ * endpoints (V3 traces/get and V4 batchGet). Exactly one field is set;
+ * an empty object represents null.
+ */
+export type ModelTraceOtelAnyValue = {
+  string_value?: string;
+  // int64 values may be serialized as strings in proto3 JSON
+  int_value?: number | string;
+  bool_value?: boolean;
+  double_value?: number;
+  bytes_value?: string;
+  array_value?: { values?: ModelTraceOtelAnyValue[] };
+  kvlist_value?: { values?: Array<{ key: string; value?: ModelTraceOtelAnyValue }> };
+};
+
 export type ModelTraceSpanV4 = {
   trace_id: string;
   span_id: string;
@@ -116,11 +132,7 @@ export type ModelTraceSpanV4 = {
   end_time_unix_nano: string;
   attributes: Array<{
     key: string;
-    value: {
-      string_value?: string;
-      int_value?: number;
-      bool_value?: boolean;
-    };
+    value: ModelTraceOtelAnyValue;
   }>;
   status: { code: ModelSpanStatusCode };
   events?: ModelTraceEvent[];

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -1189,6 +1189,8 @@ describe('convertOtelAttributesToMap', () => {
         { key: 'bool_attr', value: { bool_value: true } },
         { key: 'int_attr', value: { int_value: 42 } },
         { key: 'double_attr', value: { double_value: 3.14 } },
+        // an empty AnyValue is how OTLP represents null
+        { key: 'null_attr', value: {} },
       ],
     } as any;
 
@@ -1202,6 +1204,7 @@ describe('convertOtelAttributesToMap', () => {
         bool_attr: true,
         int_attr: 42,
         double_attr: 3.14,
+        null_attr: null,
       },
     });
   });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -1206,6 +1206,64 @@ describe('convertOtelAttributesToMap', () => {
     });
   });
 
+  it('should recursively decode kvlist and array values', () => {
+    // shape returned by OTLP-based endpoints (e.g. V3 traces/get) for
+    // dict-valued attributes like mlflow.spanInputs / mlflow.spanOutputs
+    const modelTraceSpan = {
+      span_id: '1',
+      attributes: [
+        {
+          key: 'mlflow.spanInputs',
+          value: {
+            kvlist_value: {
+              values: [
+                {
+                  key: 'messages',
+                  value: {
+                    array_value: {
+                      values: [
+                        {
+                          kvlist_value: {
+                            values: [
+                              { key: 'role', value: { string_value: 'user' } },
+                              { key: 'content', value: { string_value: 'How are you?' } },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                { key: 'n', value: { int_value: 1 } },
+                // null fields are serialized as kvlist entries without a value
+                { key: 'stop' },
+              ],
+            },
+          },
+        },
+        { key: 'empty_kvlist', value: { kvlist_value: {} } },
+        { key: 'empty_array', value: { array_value: {} } },
+        { key: 'int64_as_string', value: { int_value: '1783916154' } },
+      ],
+    } as any;
+
+    const result = convertOtelAttributesToMap(modelTraceSpan);
+
+    expect(result).toEqual({
+      span_id: '1',
+      attributes: {
+        'mlflow.spanInputs': {
+          messages: [{ role: 'user', content: 'How are you?' }],
+          n: 1,
+          stop: null,
+        },
+        empty_kvlist: {},
+        empty_array: [],
+        int64_as_string: 1783916154,
+      },
+    });
+  });
+
   it('should convert span with key-value array attributes', () => {
     const modelTraceSpan = {
       span_id: '1',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -70,7 +70,7 @@ import { normalizeVercelAIChatInput, normalizeVercelAIChatOutput } from './chat-
 import { isOtelGenAIChatMessage, normalizeOtelGenAIChatMessage } from './chat-utils/otel';
 import { normalizePydanticAIChatInput, normalizePydanticAIChatOutput } from './chat-utils/pydanticai';
 import { getTimelineTreeNodesList, isNodeImportant } from './timeline-tree/TimelineTree.utils';
-import { getSpanAttribute } from '../genai-traces-table/utils/TraceUtils';
+import { decodeOtelAnyValue, getSpanAttribute, isOtelAnyValue } from '../genai-traces-table/utils/TraceUtils';
 import { normalizeMistralChatInput, normalizeMistralChatOutput } from './chat-utils/mistral';
 import {
   normalizeVoltAgentChatInput,
@@ -1345,22 +1345,9 @@ export const getDefaultActiveTab = (
  */
 export const convertOtelAttributesToMap = (modelTraceSpan: ModelTraceSpan): ModelTraceSpan => {
   const getValue = (value: any) => {
-    if (!isObject(value)) {
-      return value;
-    }
-    if ('string_value' in value) {
-      return value.string_value;
-    }
-    if ('bool_value' in value) {
-      return value.bool_value;
-    }
-    if ('int_value' in value) {
-      return value.int_value;
-    }
-    if ('double_value' in value) {
-      return value.double_value;
-    }
-    return value;
+    // OTLP AnyValues (e.g. kvlist_value for dict-valued attributes like
+    // mlflow.spanInputs) need to be decoded recursively into plain JS values
+    return isOtelAnyValue(value) ? decodeOtelAnyValue(value) : value;
   };
 
   const convertAttributes = (attributes: any) => {

--- a/tests/gateway/test_tracing_utils.py
+++ b/tests/gateway/test_tracing_utils.py
@@ -336,6 +336,30 @@ async def test_maybe_traced_gateway_call_with_message_format(endpoint_config):
 
 
 @pytest.mark.asyncio
+async def test_maybe_traced_gateway_call_excludes_none_fields_from_pydantic_payload(
+    endpoint_config,
+):
+    from mlflow.gateway.schemas import chat
+
+    traced_func = maybe_traced_gateway_call(mock_async_func, endpoint_config)
+    payload = chat.RequestPayload(messages=[{"role": "user", "content": "hi"}])
+    await traced_func(payload)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    trace = traces[0]
+
+    span_name_to_span = {span.name: span for span in trace.data.spans}
+    gateway_span = span_name_to_span[f"gateway/{endpoint_config.endpoint_name}"]
+
+    # Unset optional fields (max_tokens, temperature, ...) should not clutter the input
+    assert gateway_span.inputs == {
+        "messages": [{"role": "user", "content": "hi"}],
+        "n": 1,
+    }
+
+
+@pytest.mark.asyncio
 async def test_maybe_traced_gateway_call_with_payload_kwarg(endpoint_config):
     async def mock_passthrough_func(action, payload, headers=None):
         return {"result": "success", "action": action, "payload": payload}


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Traces logged by the gateway's Try-in-Browser flow rendered as raw OTLP `kvlist_value` structures in the trace UI instead of as a readable chat conversation. Two issues compounded:

1. **UI: OTLP `AnyValue` attributes were only partially decoded.** OTLP-based endpoints (V3 `traces/get`, V4 `batchGet`) return span attributes as typed `AnyValue` objects. `getSpanAttribute` and `convertOtelAttributesToMap` only handled scalar variants (`string_value`, `int_value`, `bool_value`), so dict-valued attributes like `mlflow.spanInputs` — which arrive as nested `kvlist_value`/`array_value` structures — leaked through undecoded and rendered as raw kvlist JSON. This PR adds a recursive `decodeOtelAnyValue` decoder (with `isOtelAnyValue` guard and a proper `ModelTraceOtelAnyValue` type) covering all seven `AnyValue` variants, including int64-as-string handling per proto3 JSON.

2. **Gateway: trace inputs were cluttered with unset optional fields.** `maybe_traced_gateway_call` set the raw pydantic payload as span inputs, so every optional request parameter (`max_tokens`, `temperature`, ...) appeared as `null` in the trace. Payloads are now dumped with `model_dump(exclude_none=True)` so the trace input shows only the fields the caller actually sent.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

New tests cover recursive kvlist/array decoding in `TraceUtils.test.ts` and `ModelTraceExplorer.utils.test.tsx`, and `exclude_none` payload serialization in `tests/gateway/test_tracing_utils.py`.

Manually verified against a live gateway endpoint — the same "Tell me about streaming" Try-in-Browser trace rendered with the pre-fix and post-fix frontend:

**Before** — Inputs and Outputs show raw `kvlist_value` → `{"values": [{"key": ..., "value": ...}]}` JSON blobs with no chat rendering:

![before: raw kvlist rendering](https://raw.githubusercontent.com/joelrobin18/mlflow/b1d161100f750a0782f7d156d81e9743b69bc2ce/gateway-trace-before.png)

**After** — Inputs show `n`, `stream: true`, and the User message as a chat bubble; Outputs show the model, the Assistant reply as a chat bubble, and token usage:

![after: decoded chat rendering](https://raw.githubusercontent.com/joelrobin18/mlflow/b1d161100f750a0782f7d156d81e9743b69bc2ce/gateway-trace-after.png)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed gateway Try-in-Browser traces rendering as raw OTLP kvlist data instead of a readable conversation in the trace UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release