### PR TITLE
fix: prevent duplicate table creation error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Running `mlflow db upgrade` from 3.7.0 to 3.8.x fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. The error occurs in `_initialize_tables` which calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, causing SQLAlchemy to attempt to create tables that may already exist.

## Fix
Explicitly pass `checkfirst=True` to `InitialBase.metadata.create_all()` to ensure existing tables are not re-created. This aligns with SQLAlchemy's default behavior but makes it explicit to avoid edge cases where the default might be overridden.

Closes #19943