### PR TITLE
Fix MCP registry review follow-ups (#24380)

### DIFF
--- a/mlflow/entities/mcp_access_binding.py
+++ b/mlflow/entities/mcp_access_binding.py
@@ -4,12 +4,14 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mlflow.entities.mcp_server import MCPRemoteTransportType
+from mlflow.utils.annotations import experimental
 from mlflow.utils.workspace_utils import resolve_entity_workspace_name
 
 if TYPE_CHECKING:
     from mlflow.entities.mcp_server_version import MCPServerVersion
 
 
+@experimental(version="3.15.0")
 @dataclass
 class MCPAccessBinding:
     binding_id: int

--- a/mlflow/entities/mcp_server.py
+++ b/mlflow/entities/mcp_server.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from mlflow.exceptions import MlflowException
+from mlflow.utils.annotations import experimental
 from mlflow.utils.workspace_utils import resolve_entity_workspace_name
 
 if TYPE_CHECKING:
@@ -79,6 +80,7 @@ def validate_mcp_server_name(name: str) -> None:
         )
 
 
+@experimental(version="3.15.0")
 @dataclass(frozen=True)
 class MCPTool:
     name: str
@@ -126,12 +128,14 @@ class MCPTool:
         )
 
 
+@experimental(version="3.15.0")
 @dataclass(frozen=True)
 class MCPServerTag:
     key: str
     value: str
 
 
+@experimental(version="3.15.0")
 @dataclass
 class MCPServer:
     name: str

--- a/mlflow/entities/mcp_server_alias.py
+++ b/mlflow/entities/mcp_server_alias.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from mlflow.utils.annotations import experimental
 
+
+@experimental(version="3.15.0")
 @dataclass(frozen=True)
 class MCPServerAlias:
     name: str

--- a/mlflow/entities/mcp_server_version.py
+++ b/mlflow/entities/mcp_server_version.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from mlflow.entities.mcp_server import MCPStatus, MCPTool
+from mlflow.utils.annotations import experimental
 from mlflow.utils.workspace_utils import resolve_entity_workspace_name
 
 
+@experimental(version="3.15.0")
 @dataclass
 class MCPServerVersion:
     name: str

--- a/mlflow/genai/mcp_servers.py
+++ b/mlflow/genai/mcp_servers.py
@@ -53,11 +53,15 @@ def _validate_binding_remotes(
                 "Invalid server_json.remotes entry. Expected each remote to be an object."
             )
         url = remote.get("url")
-        if not url:
+        if url is None:
             continue
-        transport_str = remote.get("type", "streamable-http")
+        if not isinstance(url, str) or not url.strip():
+            raise MlflowException.invalid_parameter_value(
+                "Invalid server_json.remotes entry. Expected remote.url to be a non-empty string."
+            )
+        transport_str = "streamable-http" if remote.get("type") is None else remote.get("type")
         transport = _parse_enum(transport_str, MCPRemoteTransportType, "transport_type")
-        validated_remotes.append((url, transport))
+        validated_remotes.append((url.strip(), transport))
 
     return validated_remotes
 
@@ -67,7 +71,7 @@ def register_mcp_server(
     server_json: dict[str, Any],
     display_name: str | None = None,
     source: str | None = None,
-    status: Literal["draft", "active", "deprecated", "deleted"] = "draft",
+    status: Literal["draft", "active"] = "draft",
     tools: list[MCPTool] | None = None,
     create_access_bindings_from_remotes: bool = False,
 ) -> MCPServerVersion:
@@ -82,10 +86,12 @@ def register_mcp_server(
             and ``version`` at the top level.
         display_name: Human-readable label for the version.
         source: Provenance URI (e.g., a git repository URL).
-        status: Initial status (default ``"draft"``).
+        status: Initial status. Only ``"draft"`` and ``"active"`` are supported
+            during registration.
         tools: Declared tool definitions for this version.
         create_access_bindings_from_remotes: When ``True``, create one direct-access
-            binding per ``remotes[]`` entry in ``server_json``.
+            binding per ``remotes[]`` entry in ``server_json``. This requires
+            ``status="active"``.
 
     Returns:
         The created :py:class:`MCPServerVersion <mlflow.entities.MCPServerVersion>`.
@@ -107,14 +113,18 @@ def register_mcp_server(
     """
     client = MlflowClient()
     parsed_status = _parse_enum(status, MCPStatus, "status")
+    if parsed_status not in (MCPStatus.DRAFT, MCPStatus.ACTIVE):
+        raise MlflowException.invalid_parameter_value(
+            "Initial MCP server registration status must be 'draft' or 'active'."
+        )
 
-    should_create_bindings = create_access_bindings_from_remotes and parsed_status in (
-        MCPStatus.ACTIVE,
-        MCPStatus.DEPRECATED,
-    )
+    if create_access_bindings_from_remotes and parsed_status != MCPStatus.ACTIVE:
+        raise MlflowException.invalid_parameter_value(
+            "create_access_bindings_from_remotes=True requires status='active'."
+        )
 
     validated_remotes: list[tuple[str, MCPRemoteTransportType]] = []
-    if should_create_bindings:
+    if create_access_bindings_from_remotes:
         validated_remotes = _validate_binding_remotes(server_json)
 
     version = client.create_mcp_server_version(
@@ -197,7 +207,7 @@ def register_mcp_server_from_url(
     url: str,
     display_name: str | None = None,
     source: str | None = None,
-    status: Literal["draft", "active", "deprecated", "deleted"] = "draft",
+    status: Literal["draft", "active"] = "draft",
     tools: list[MCPTool] | None = None,
     create_access_bindings_from_remotes: bool = False,
 ) -> MCPServerVersion:
@@ -209,10 +219,12 @@ def register_mcp_server_from_url(
             pointing to a ``server.json`` document.
         display_name: Human-readable label for the version.
         source: Provenance URI; defaults to ``url`` when not provided.
-        status: Initial status (default ``"draft"``).
+        status: Initial status. Only ``"draft"`` and ``"active"`` are supported
+            during registration.
         tools: Declared tool definitions for this version.
         create_access_bindings_from_remotes: When ``True``, create one direct-access
-            binding per ``remotes[]`` entry in ``server_json``.
+            binding per ``remotes[]`` entry in ``server_json``. This requires
+            ``status="active"``.
 
     Returns:
         The created :py:class:`MCPServerVersion <mlflow.entities.MCPServerVersion>`.
@@ -270,6 +282,9 @@ def search_mcp_servers(
     Args:
         filter_string: SQL-like filter expression (e.g., ``"status = 'active'"``,
             ``"tags.team = 'platform'"``, ``"has_access_bindings = 'true'"``).
+            See
+            ``https://mlflow.org/docs/latest/ml/search/search-runs/#search-query-syntax-deep-dive``
+            for the filter syntax guide.
         max_results: Maximum number of results to return.
         order_by: List of columns to order by.
         page_token: Token for retrieving the next page of results.
@@ -330,6 +345,8 @@ def update_mcp_server(
 def delete_mcp_server(name: str) -> None:
     """
     Delete an MCP server and all its child entities.
+
+    Deletion is rejected while any version of the server is still ``ACTIVE``.
 
     Args:
         name: Server name.
@@ -392,7 +409,9 @@ def search_mcp_server_versions(
 
     Args:
         name: Server name.
-        filter_string: SQL-like filter (e.g., ``"status = 'active'"``).
+        filter_string: SQL-like filter (e.g., ``"status = 'active'"``). See
+            ``https://mlflow.org/docs/latest/ml/search/search-runs/#search-query-syntax-deep-dive``
+            for the filter syntax guide.
         max_results: Maximum number of results.
         order_by: List of columns to order by.
         page_token: Token for the next page.
@@ -519,7 +538,9 @@ def search_mcp_access_bindings(
         server_name: If provided, limit results to this server.
         server_version: If provided, limit results to bindings targeting this version.
         server_alias: If provided, limit results to bindings targeting this alias.
-        filter_string: SQL-like filter.
+        filter_string: SQL-like filter. See
+            ``https://mlflow.org/docs/latest/ml/search/search-runs/#search-query-syntax-deep-dive``
+            for the filter syntax guide.
         max_results: Maximum number of results.
         order_by: List of columns to order by.
         page_token: Token for the next page.

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -4773,6 +4773,42 @@ def _find_fastapi_response_filter(
     )
 
 
+def _apply_fastapi_response_filter(
+    response_filter: Callable[[str, bytes, StarletteRequest], bytes],
+    username: str,
+    body: bytes,
+    request: StarletteRequest,
+    response,
+    path: str,
+):
+    headers = {k: v for k, v in response.headers.items() if k.lower() != "content-length"}
+    try:
+        filtered_content = response_filter(username, body, request)
+    except MlflowException as e:
+        _logger.exception("response filter failed for %s %s", request.method, path)
+        return JSONResponse(
+            status_code=e.get_http_status_code(),
+            content=json.loads(e.serialize_as_json()),
+        )
+    except Exception:
+        _logger.exception("response filter failed for %s %s", request.method, path)
+        error = MlflowException(
+            "Failed to filter response for protected collection route",
+            error_code=INTERNAL_ERROR,
+        )
+        return JSONResponse(
+            status_code=error.get_http_status_code(),
+            content=json.loads(error.serialize_as_json()),
+        )
+
+    return FilteredResponse(
+        content=filtered_content,
+        status_code=response.status_code,
+        headers=headers,
+        media_type=response.media_type,
+    )
+
+
 def add_fastapi_permission_middleware(app: FastAPI) -> None:
     """
     Add permission middleware to FastAPI app for routes not handled by Flask.
@@ -4887,12 +4923,13 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
             body = bytearray()
             async for chunk in response.body_iterator:
                 body.extend(chunk)
-            headers = {k: v for k, v in response.headers.items() if k.lower() != "content-length"}
-            return FilteredResponse(
-                content=response_filter(user.username, bytes(body), request),
-                status_code=response.status_code,
-                headers=headers,
-                media_type=response.media_type,
+            return _apply_fastapi_response_filter(
+                response_filter=response_filter,
+                username=user.username,
+                body=bytes(body),
+                request=request,
+                response=response,
+                path=path,
             )
 
         return response

--- a/mlflow/server/mcp_server_api.py
+++ b/mlflow/server/mcp_server_api.py
@@ -25,13 +25,15 @@ from mlflow.entities.mcp_server import (
 )
 from mlflow.entities.mcp_server_version import MCPServerVersion
 from mlflow.exceptions import MlflowException
-from mlflow.utils.validation import _validate_mcp_icon_url
+from mlflow.utils.validation import _validate_mcp_icon_mime_type, _validate_mcp_icon_url
 
 if TYPE_CHECKING:
     from mlflow.store.tracking.mcp_server_registry.abstract_mixin import MCPIcon
 
 _MCP_SERVER_AJAX_API_PREFIX = "/ajax-api/3.0/mlflow/mcp-servers"
 _MCP_SERVER_API_PREFIX = "/api/3.0/mlflow/mcp-servers"
+_MAX_MCP_ICONS_PER_LIST = 100
+_MAX_MCP_TOOLS_PER_LIST = 1000
 
 
 def get_mcp_server_api_route_prefixes() -> tuple[str, ...]:
@@ -81,15 +83,8 @@ class MCPIconRequestPayload(_BaseMCPIconPayload):
     @field_validator("mimeType")
     @classmethod
     def _validate_mime_type(cls, value: str | None) -> str | None:
-        if value is None:
-            return value
-        normalized = value.strip().lower()
-        if not normalized.startswith("image/") or normalized == "image/":
-            raise MlflowException.invalid_parameter_value(
-                f"Invalid icon mimeType {value!r}. Allowed values must use the 'image/*' "
-                "media type."
-            )
-        return normalized
+        _validate_mcp_icon_mime_type(value)
+        return None if value is None else value.strip().lower()
 
 
 class MCPIconResponsePayload(_BaseMCPIconPayload):
@@ -112,7 +107,9 @@ class ServerJSONPayload(BaseModel):
     version: str
     title: str | None = None
     description: str | None = None
-    icons: list[MCPIconRequestPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = Field(
+        default=None, max_length=_MAX_MCP_ICONS_PER_LIST
+    )
     packages: list[ServerJSONPackagePayload] | None = None
     remotes: list[ServerJSONRemotePayload] | None = None
     repository: ServerJSONRepositoryPayload | None = None
@@ -143,8 +140,8 @@ class ServerJSONPackagePayload(BaseModel):
 class ServerJSONRemotePayload(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-    type: str
-    url: str
+    type: str | None = None
+    url: str | None = None
 
 
 class MCPToolRequestPayload(BaseModel):
@@ -154,7 +151,9 @@ class MCPToolRequestPayload(BaseModel):
     inputSchema: dict[str, Any] | None = None
     outputSchema: dict[str, Any] | None = None
     annotations: dict[str, Any] | None = None
-    icons: list[MCPIconRequestPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = Field(
+        default=None, max_length=_MAX_MCP_ICONS_PER_LIST
+    )
     execution: dict[str, Any] | None = None
 
 
@@ -172,13 +171,17 @@ class MCPToolResponsePayload(BaseModel):
 class CreateMCPServerRequest(BaseModel):
     name: str
     description: str | None = None
-    icons: list[MCPIconRequestPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = Field(
+        default=None, max_length=_MAX_MCP_ICONS_PER_LIST
+    )
 
 
 class UpdateMCPServerRequest(BaseModel):
     display_name: str | None = None
     description: str | None = None
-    icons: list[MCPIconRequestPayload] | None = None
+    icons: list[MCPIconRequestPayload] | None = Field(
+        default=None, max_length=_MAX_MCP_ICONS_PER_LIST
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -196,13 +199,17 @@ class CreateMCPServerVersionRequest(BaseModel):
     display_name: str | None = None
     status: str = "draft"
     source: str | None = None
-    tools: list[MCPToolRequestPayload] | None = None
+    tools: list[MCPToolRequestPayload] | None = Field(
+        default=None, max_length=_MAX_MCP_TOOLS_PER_LIST
+    )
 
 
 class UpdateMCPServerVersionRequest(BaseModel):
     display_name: str | None = None
     status: str | None = None
-    tools: list[MCPToolRequestPayload] | None = None
+    tools: list[MCPToolRequestPayload] | None = Field(
+        default=None, max_length=_MAX_MCP_TOOLS_PER_LIST
+    )
 
 
 class CreateMCPAccessBindingRequest(BaseModel):

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -43,10 +43,25 @@ from mlflow.utils.search_utils import (
 )
 from mlflow.utils.semver_utils import encode_prerelease_sort_key, parse_semver
 from mlflow.utils.time import get_current_time_millis
+from mlflow.utils.validation import _validate_mcp_icon_payloads
 
 SEARCH_MCP_SERVER_MAX_RESULTS_THRESHOLD = 1000
 
 _VALID_FILTER_COMPARATORS = {"=", "!=", ">", ">=", "<", "<=", "LIKE", "ILIKE", "IN"}
+
+
+def _validate_server_json_icon_fields(server_json: dict[str, Any]) -> None:
+    # Keep validation aligned with schema-defined icon locations only. Extra free-form
+    # metadata (for example under ``_meta``) must continue to round-trip untouched.
+    _validate_mcp_icon_payloads(server_json.get("icons"), "server_json.icons")
+
+
+def _validate_tool_icons(tools: list[MCPTool] | None, field_name: str = "tools") -> None:
+    if tools is None:
+        return
+
+    for idx, tool in enumerate(tools):
+        _validate_mcp_icon_payloads(tool.icons, f"{field_name}[{idx}].icons")
 
 
 class SqlAlchemyMCPServerRegistryMixin:
@@ -69,6 +84,7 @@ class SqlAlchemyMCPServerRegistryMixin:
         created_by: str | None = None,
     ) -> MCPServer:
         validate_mcp_server_name(name)
+        _validate_mcp_icon_payloads(icons, "icons")
         now = get_current_time_millis()
         with self.ManagedSessionMaker(read_only=False) as session:
             try:
@@ -181,6 +197,8 @@ class SqlAlchemyMCPServerRegistryMixin:
         icons: list[MCPIcon] | None = NOT_SET,
         last_updated_by: str | None = None,
     ) -> MCPServer:
+        if icons is not NOT_SET:
+            _validate_mcp_icon_payloads(icons, "icons")
         with self.ManagedSessionMaker(read_only=False) as session:
             server = self._get_entity_or_raise(session, SqlMCPServer, {"name": name}, "MCPServer")
             if description is not NOT_SET:
@@ -200,6 +218,21 @@ class SqlAlchemyMCPServerRegistryMixin:
     def delete_mcp_server(self, name: str) -> None:
         with self.ManagedSessionMaker(read_only=False) as session:
             server = self._get_entity_or_raise(session, SqlMCPServer, {"name": name}, "MCPServer")
+            active_version = (
+                self
+                ._get_query(session, SqlMCPServerVersion)
+                .filter(
+                    SqlMCPServerVersion.name == name,
+                    SqlMCPServerVersion.status == MCPStatus.ACTIVE.value,
+                )
+                .first()
+            )
+            if active_version is not None:
+                raise MlflowException(
+                    f"Cannot delete MCP server '{name}' while it still has an active version "
+                    f"('{active_version.version}'). Delete or deactivate the active version first.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
             session.delete(server)
 
     # --- MCPServerVersion operations ---
@@ -221,10 +254,12 @@ class SqlAlchemyMCPServerRegistryMixin:
                 error_code=INVALID_PARAMETER_VALUE,
             )
         validate_mcp_server_name(name)
+        _validate_server_json_icon_fields(server_json)
         parsed_version = parse_semver(version, param_name="server_json.version")
 
         now = get_current_time_millis()
         status = status or MCPStatus.DRAFT
+        _validate_tool_icons(tools)
         tools_json = None if tools is None else [t.to_dict() for t in tools]
 
         with self.ManagedSessionMaker(read_only=False) as session:
@@ -410,6 +445,8 @@ class SqlAlchemyMCPServerRegistryMixin:
         tools: list[MCPTool] | None = NOT_SET,
         last_updated_by: str | None = None,
     ) -> MCPServerVersion:
+        if tools is not NOT_SET:
+            _validate_tool_icons(tools)
         with self.ManagedSessionMaker(read_only=False) as session:
             sv = self._get_live_mcp_server_version_or_raise(session, name, version)
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -995,6 +995,46 @@ def _validate_mcp_icon_url(url: str) -> None:
         )
 
 
+def _validate_mcp_icon_mime_type(mime_type: str | None) -> None:
+    if mime_type is None:
+        return
+
+    if not isinstance(mime_type, str):
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid icon mimeType {mime_type!r}. Allowed values must use the 'image/*' media "
+            "type."
+        )
+
+    normalized = mime_type.strip().lower()
+    if not normalized.startswith("image/") or normalized == "image/":
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid icon mimeType {mime_type!r}. Allowed values must use the 'image/*' "
+            "media type."
+        )
+
+
+def _validate_mcp_icon_payloads(icons: Any, field_name: str = "icons") -> None:
+    if icons is None:
+        return
+
+    if not isinstance(icons, list):
+        raise MlflowException.invalid_parameter_value(f"Invalid {field_name}. Expected a list.")
+
+    for idx, icon in enumerate(icons):
+        icon_field_name = f"{field_name}[{idx}]"
+        if not isinstance(icon, dict):
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid {icon_field_name}. Expected an object."
+            )
+        if "src" not in icon:
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid {icon_field_name}. Missing required key 'src'."
+            )
+
+        _validate_mcp_icon_url(icon["src"])
+        _validate_mcp_icon_mime_type(icon.get("mimeType"))
+
+
 def _validate_webhook_url(url: str) -> None:
     if not isinstance(url, str):
         raise MlflowException.invalid_parameter_value(

--- a/tests/entities/test_mcp_server_entities.py
+++ b/tests/entities/test_mcp_server_entities.py
@@ -5,9 +5,11 @@ from mlflow.entities.mcp_server import (
     VALID_STATUS_TRANSITIONS,
     MCPRemoteTransportType,
     MCPServer,
+    MCPServerTag,
     MCPStatus,
     MCPTool,
 )
+from mlflow.entities.mcp_server_alias import MCPServerAlias
 from mlflow.entities.mcp_server_version import MCPServerVersion
 from mlflow.exceptions import MlflowException
 
@@ -96,3 +98,12 @@ def test_mcp_access_binding_workspace_resolution():
         endpoint_url="https://example.com/mcp",
     )
     assert binding.workspace == "default"
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [MCPAccessBinding, MCPServer, MCPServerAlias, MCPServerTag, MCPServerVersion, MCPTool],
+)
+def test_mcp_entities_are_marked_experimental(cls):
+    assert cls.__doc__ is not None
+    assert "Experimental: This class may change" in cls.__doc__

--- a/tests/genai/test_mcp_servers.py
+++ b/tests/genai/test_mcp_servers.py
@@ -33,6 +33,21 @@ def patch_store(store):
         yield
 
 
+@pytest.fixture(autouse=True)
+def mock_icon_url_dns_resolution():
+    def _resolve(host, port, *a, **kw):
+        if host == "localhost":
+            ip = "127.0.0.1"
+        elif host == "example.com" or host.endswith(".example.com"):
+            ip = "8.8.8.8"
+        else:
+            ip = host
+        return [(None, None, None, None, (ip, 0))]
+
+    with mock.patch("mlflow.utils.validation.socket.getaddrinfo", side_effect=_resolve):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -119,7 +134,7 @@ def test_register_mcp_server_no_bindings_when_flag_false():
 
 
 @pytest.mark.parametrize("status", ["draft", None])
-def test_register_mcp_server_skips_auto_bindings_for_draft(status):
+def test_register_mcp_server_rejects_auto_bindings_for_inactive_initial_status(status):
     kwargs = {
         "server_json": _server_json(
             f"io.github.test/draft-no-bind-{status}",
@@ -130,26 +145,37 @@ def test_register_mcp_server_skips_auto_bindings_for_draft(status):
     }
     if status is not None:
         kwargs["status"] = status
-    version = genai.register_mcp_server(**kwargs)
+    with pytest.raises(
+        MlflowException, match="create_access_bindings_from_remotes=True requires status='active'"
+    ):
+        genai.register_mcp_server(**kwargs)
 
-    bindings = genai.search_mcp_access_bindings(server_name=version.name)
-    assert len(bindings) == 0
-    assert version.status == MCPStatus.DRAFT
+    with pytest.raises(MlflowException, match="not found"):
+        genai.get_mcp_server(name=kwargs["server_json"]["name"])
 
 
-@pytest.mark.parametrize("status", ["active", "deprecated"])
-def test_register_mcp_server_creates_bindings_for_published_statuses(status):
+def test_register_mcp_server_creates_bindings_for_active_status():
     sj = _server_json(
-        f"io.github.test/published-bind-{status}",
+        "io.github.test/published-bind-active",
         "1.0.0",
         remotes=[{"type": "streamable-http", "url": "https://mcp.example.com/pub"}],
     )
     version = genai.register_mcp_server(
-        server_json=sj, status=status, create_access_bindings_from_remotes=True
+        server_json=sj, status="active", create_access_bindings_from_remotes=True
     )
 
     bindings = genai.search_mcp_access_bindings(server_name=version.name)
     assert len(bindings) == 1
+
+
+@pytest.mark.parametrize("status", ["deprecated", "deleted"])
+def test_register_mcp_server_rejects_non_initial_statuses(status):
+    sj = _server_json(f"io.github.test/reject-status-{status}", "1.0.0")
+
+    with pytest.raises(
+        MlflowException, match="Initial MCP server registration status must be 'draft' or 'active'"
+    ):
+        genai.register_mcp_server(server_json=sj, status=status)
 
 
 def test_register_mcp_server_skips_remotes_without_url():
@@ -173,6 +199,46 @@ def test_register_mcp_server_accepts_null_remotes():
 
     bindings = genai.search_mcp_access_bindings(server_name=version.name)
     assert len(bindings) == 0
+
+
+@pytest.mark.parametrize("url", [123, True])
+def test_register_mcp_server_rejects_remote_with_non_string_url(url):
+    sj = _server_json(
+        "io.github.test/bad-remote-url-type",
+        "1.0.0",
+        remotes=[{"type": "streamable-http", "url": url}],
+    )
+    with pytest.raises(MlflowException, match="remote.url"):
+        genai.register_mcp_server(
+            server_json=sj, status="active", create_access_bindings_from_remotes=True
+        )
+
+
+def test_register_mcp_server_rejects_remote_with_blank_url():
+    sj = _server_json(
+        "io.github.test/bad-remote-url-blank",
+        "1.0.0",
+        remotes=[{"type": "streamable-http", "url": "   "}],
+    )
+    with pytest.raises(MlflowException, match="remote.url"):
+        genai.register_mcp_server(
+            server_json=sj, status="active", create_access_bindings_from_remotes=True
+        )
+
+
+def test_register_mcp_server_defaults_null_remote_type_to_streamable_http():
+    sj = _server_json(
+        "io.github.test/null-remote-type",
+        "1.0.0",
+        remotes=[{"type": None, "url": "https://mcp.example.com/default-type"}],
+    )
+    version = genai.register_mcp_server(
+        server_json=sj, status="active", create_access_bindings_from_remotes=True
+    )
+
+    bindings = genai.search_mcp_access_bindings(server_name=version.name)
+    assert len(bindings) == 1
+    assert bindings[0].transport_type == MCPRemoteTransportType.STREAMABLE_HTTP
 
 
 def test_register_mcp_server_rejects_non_list_remotes():
@@ -380,6 +446,16 @@ def test_delete_mcp_server():
     genai.delete_mcp_server(name="io.github.test/del-server")
     with pytest.raises(MlflowException, match="MCP server .* not found"):
         genai.get_mcp_server(name="io.github.test/del-server")
+
+
+def test_delete_mcp_server_rejects_active_version():
+    name = "io.github.test/del-active-server"
+    genai.register_mcp_server(server_json=_server_json(name, "1.0.0"), status="active")
+
+    with pytest.raises(MlflowException, match="active version"):
+        genai.delete_mcp_server(name=name)
+
+    assert genai.get_mcp_server(name=name).name == name
 
 
 # ---------------------------------------------------------------------------
@@ -651,6 +727,15 @@ def test_mlflow_client_create_and_get_server():
     assert fetched.description == "via client"
 
 
+def test_mlflow_client_create_server_rejects_risky_icons():
+    client = MlflowClient()
+    with pytest.raises(MlflowException, match="Icon URL"):
+        client.create_mcp_server(
+            name="io.github.test/client-icon-server",
+            icons=[{"src": "https://127.0.0.1/icon.png"}],
+        )
+
+
 def test_mlflow_client_version_lifecycle():
     client = MlflowClient()
     sj = _server_json("io.github.test/lifecycle-ver", "1.0.0")
@@ -673,6 +758,30 @@ def test_mlflow_client_version_lifecycle():
 
     with pytest.raises(MlflowException, match="not found"):
         client.get_mcp_server_version(name="io.github.test/lifecycle-ver", version="1.0.0")
+
+
+def test_mlflow_client_create_version_rejects_risky_server_json_icons():
+    client = MlflowClient()
+    with pytest.raises(MlflowException, match="Icon URL"):
+        client.create_mcp_server_version(
+            server_json=_server_json(
+                "io.github.test/client-server-json-icons",
+                "1.0.0",
+                icons=[{"src": "https://127.0.0.1/icon.png"}],
+            )
+        )
+
+
+def test_mlflow_client_update_version_rejects_risky_tool_icons():
+    client = MlflowClient()
+    client.create_mcp_server_version(_server_json("io.github.test/client-tool-icons", "1.0.0"))
+
+    with pytest.raises(MlflowException, match="Icon URL"):
+        client.update_mcp_server_version(
+            name="io.github.test/client-tool-icons",
+            version="1.0.0",
+            tools=[MCPTool(name="search", icons=[{"src": "https://127.0.0.1/icon.png"}])],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import re
 import subprocess
 import sys
@@ -4632,6 +4633,35 @@ def test_read_predicate_honors_grant_default_workspace_access(
 )
 def test_response_filter_matches_trailing_slash(path):
     assert _find_fastapi_response_filter(path, "GET") is not None
+
+
+@pytest.mark.parametrize("prefix", [_MCP_AJAX_PREFIX, _MCP_REST_PREFIX])
+@pytest.mark.parametrize("path_suffix", ["/com.test/server", "/bindings/123"])
+def test_response_filter_requires_exact_collection_route_match(prefix, path_suffix):
+    assert _find_fastapi_response_filter(f"{prefix}{path_suffix}", "GET") is None
+
+
+def test_apply_fastapi_response_filter_fails_closed():
+    request = SimpleNamespace(method="GET")
+    response = SimpleNamespace(
+        status_code=200,
+        headers={"content-length": "2", "x-test": "1"},
+        media_type="application/json",
+    )
+
+    filtered = auth_module._apply_fastapi_response_filter(
+        response_filter=lambda *_: (_ for _ in ()).throw(ValueError("boom")),
+        username="alice",
+        body=b'{"mcp_servers":[]}',
+        request=request,
+        response=response,
+        path=_MCP_REST_PREFIX,
+    )
+
+    assert filtered.status_code == 500
+    payload = json.loads(filtered.body)
+    assert payload["error_code"] == "INTERNAL_ERROR"
+    assert "Failed to filter response" in payload["message"]
 
 
 @pytest.mark.parametrize("prefix", [_MCP_AJAX_PREFIX, _MCP_REST_PREFIX])

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -85,6 +85,13 @@ def test_create_server_with_icons(client):
     assert r.json()["icons"] == icons
 
 
+def test_create_server_rejects_too_many_icons(client):
+    icons = [{"src": f"https://example.com/icon-{i}.png"} for i in range(101)]
+    r = client.post(PREFIX, json={"name": "com.example/too-many-icons", "icons": icons})
+    assert r.status_code == 400
+    assert "at most 100 items" in r.text
+
+
 def test_create_server_with_icons_preserves_extra_fields(client):
     icons = [
         {
@@ -361,6 +368,19 @@ def test_delete_server(client):
     assert client.get(f"{PREFIX}/{_encode_path_param('com.example/del')}").status_code == 404
 
 
+def test_delete_server_rejects_active_version(client):
+    name = "com.example/del-active"
+    sj = _server_json(name, "1.0.0")
+    client.post(
+        f"{PREFIX}/{_encode_path_param(name)}/versions",
+        json={"server_json": sj, "status": "active"},
+    )
+
+    r = client.delete(f"{PREFIX}/{_encode_path_param(name)}")
+    assert r.status_code == 400
+    assert "active version" in r.text
+
+
 def test_server_crud_with_slashed_name(client):
     name = "io.github.org/my-server"
     client.post(PREFIX, json={"name": name})
@@ -535,6 +555,17 @@ def test_create_version_with_tools(client):
     assert data["tools"][0]["name"] == "web_search"
 
 
+def test_create_version_rejects_too_many_tools(client):
+    sj = _server_json("com.example/too-many-tools", "1.0.0")
+    tools = [{"name": f"tool-{i}"} for i in range(1001)]
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/too-many-tools')}/versions",
+        json={"server_json": sj, "tools": tools, "status": "active"},
+    )
+    assert r.status_code == 400
+    assert "at most 1000 items" in r.text
+
+
 def test_create_version_with_tool_icons_preserves_extra_fields(client):
     sj = _server_json("com.example/tool-icons-server", "1.0.0")
     tools = [
@@ -581,6 +612,49 @@ def test_create_version_rejects_risky_server_json_icon_urls(client):
     )
     assert r.status_code == 400
     assert "Icon URL" in r.text
+
+
+def test_create_version_accepts_remote_with_null_type(client):
+    sj = _server_json(
+        "com.example/null-remote-type",
+        "1.0.0",
+        remotes=[{"type": None, "url": "https://example.com/mcp"}],
+    )
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/null-remote-type')}/versions",
+        json={"server_json": sj, "status": "active"},
+    )
+    assert r.status_code == 200
+    assert r.json()["server_json"]["remotes"][0]["type"] is None
+
+
+def test_create_version_accepts_remote_without_url(client):
+    sj = _server_json(
+        "com.example/missing-remote-url",
+        "1.0.0",
+        remotes=[{"type": "streamable-http"}],
+    )
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/missing-remote-url')}/versions",
+        json={"server_json": sj, "status": "active"},
+    )
+    assert r.status_code == 200
+    assert r.json()["server_json"]["remotes"][0]["type"] == "streamable-http"
+    assert "url" not in r.json()["server_json"]["remotes"][0]
+
+
+def test_create_version_preserves_meta_icons_metadata(client):
+    sj = _server_json(
+        "com.example/meta-icons",
+        "1.0.0",
+        _meta={"icons": {"not": "an-icon-list"}, "other": "preserved"},
+    )
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/meta-icons')}/versions",
+        json={"server_json": sj, "status": "active"},
+    )
+    assert r.status_code == 200
+    assert r.json()["server_json"]["_meta"] == sj["_meta"]
 
 
 def test_create_version_preserves_empty_tools_list(client):

--- a/tests/store/tracking/mcp_server_registry/test_rest_mixin.py
+++ b/tests/store/tracking/mcp_server_registry/test_rest_mixin.py
@@ -265,6 +265,31 @@ def test_create_version_with_tools(rest_client):
     assert ver.tools[0].name == "search"
 
 
+def test_create_version_accepts_remote_with_null_type(rest_client):
+    ver = rest_client.create_mcp_server_version(
+        _server_json(
+            "io.github.test/null-remote-type",
+            "1.0.0",
+            remotes=[{"type": None, "url": "https://example.com/mcp"}],
+        ),
+        status=MCPStatus.ACTIVE,
+    )
+    assert ver.server_json["remotes"][0]["type"] is None
+
+
+def test_create_version_accepts_remote_without_url(rest_client):
+    ver = rest_client.create_mcp_server_version(
+        _server_json(
+            "io.github.test/missing-remote-url",
+            "1.0.0",
+            remotes=[{"type": "streamable-http"}],
+        ),
+        status=MCPStatus.ACTIVE,
+    )
+    assert ver.server_json["remotes"][0]["type"] == "streamable-http"
+    assert "url" not in ver.server_json["remotes"][0]
+
+
 def test_create_version_preserves_empty_tools_list(rest_client):
     sj = _server_json("io.github.test/empty-tools-srv", "1.0.0")
     ver = rest_client.create_mcp_server_version(sj, status=MCPStatus.ACTIVE, tools=[])
@@ -573,6 +598,16 @@ def test_server_json_explicit_nulls_preserved(rest_client):
     assert "custom_field" in ver.server_json
     assert ver.server_json["custom_field"] is None
     assert "repository" not in ver.server_json
+
+
+def test_server_json_meta_icons_metadata_preserved(rest_client):
+    sj = _server_json(
+        "io.github.test/meta-icons",
+        "1.0.0",
+        _meta={"icons": {"not": "an-icon-list"}, "other": "preserved"},
+    )
+    ver = rest_client.create_mcp_server_version(sj, status=MCPStatus.ACTIVE)
+    assert ver.server_json["_meta"] == sj["_meta"]
 
 
 def test_tools_round_trip(rest_client):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -6,11 +6,26 @@ from mlflow.exceptions import MlflowException
 pytestmark = pytest.mark.notrackingurimock
 
 
-def _server_json(name="io.github.test/servererver", version="1.0.0", description=None):
+def _server_json(name="io.github.test/servererver", version="1.0.0", description=None, **extra):
     server_json = {"name": name, "version": version, "title": f"Test {name}"}
     if description is not None:
         server_json["description"] = description
+    server_json.update(extra)
     return server_json
+
+
+@pytest.fixture(autouse=True)
+def mock_icon_url_dns_resolution(monkeypatch):
+    def _resolve(host, port, *a, **kw):
+        if host == "localhost":
+            ip = "127.0.0.1"
+        elif host == "example.com" or host.endswith(".example.com"):
+            ip = "8.8.8.8"
+        else:
+            ip = host
+        return [(None, None, None, None, (ip, 0))]
+
+    monkeypatch.setattr("mlflow.utils.validation.socket.getaddrinfo", _resolve)
 
 
 def _setup_server(store, name, versions=("1.0.0",), aliases=None):
@@ -93,6 +108,14 @@ def test_create_mcp_server_with_icons(store):
     icons = [{"src": "https://example.com/icon.png", "sizes": "32x32"}]
     server = store.create_mcp_server("io.github.test/servererver", icons=icons)
     assert server.icons == icons
+
+
+def test_create_mcp_server_rejects_risky_icons(store):
+    with pytest.raises(MlflowException, match="Icon URL"):
+        store.create_mcp_server(
+            "io.github.test/risky-icons",
+            icons=[{"src": "https://127.0.0.1/icon.png"}],
+        )
 
 
 def test_update_mcp_server_sets_last_updated_by(store):
@@ -188,6 +211,15 @@ def test_update_mcp_server_description(store):
     store.create_mcp_server("io.github.test/servererver", description="old")
     updated = store.update_mcp_server("io.github.test/servererver", description="new")
     assert updated.description == "new"
+
+
+def test_update_mcp_server_rejects_risky_icons(store):
+    store.create_mcp_server("io.github.test/update-icons")
+    with pytest.raises(MlflowException, match="Icon URL"):
+        store.update_mcp_server(
+            "io.github.test/update-icons",
+            icons=[{"src": "https://127.0.0.1/icon.png"}],
+        )
 
 
 def test_update_mcp_server_display_name(store):
@@ -375,6 +407,15 @@ def test_delete_mcp_server_cascades_to_bindings(store):
     assert len(result) == 0
 
 
+def test_delete_mcp_server_with_active_version_raises(store):
+    store.create_mcp_server_version(
+        _server_json("io.github.test/delete-active-server", "1.0.0"),
+        status=MCPStatus.ACTIVE,
+    )
+    with pytest.raises(MlflowException, match="active version"):
+        store.delete_mcp_server("io.github.test/delete-active-server")
+
+
 # --- MCPServerVersion CRUD ---
 
 
@@ -392,6 +433,28 @@ def test_create_mcp_server_version(store):
     assert sv.server_json == _server_json()
     assert sv.created_by == "alice"
     assert sv.last_updated_by == "alice"
+
+
+def test_create_mcp_server_version_rejects_risky_server_json_icons(store):
+    with pytest.raises(MlflowException, match="Icon URL"):
+        store.create_mcp_server_version(
+            _server_json(
+                "io.github.test/server-json-icons",
+                "1.0.0",
+                icons=[{"src": "https://127.0.0.1/icon.png"}],
+            )
+        )
+
+
+def test_create_mcp_server_version_preserves_meta_icons_metadata(store):
+    sv = store.create_mcp_server_version(
+        _server_json(
+            "io.github.test/meta-icons",
+            "1.0.0",
+            _meta={"icons": {"not": "an-icon-list"}, "other": "preserved"},
+        )
+    )
+    assert sv.server_json["_meta"] == {"icons": {"not": "an-icon-list"}, "other": "preserved"}
 
 
 def test_create_mcp_server_version_auto_creates_parent(store):
@@ -492,6 +555,14 @@ def test_create_mcp_server_version_with_tools(store):
     assert sv.tools is not None
     assert len(sv.tools) == 1
     assert sv.tools[0].name == "web_search"
+
+
+def test_create_mcp_server_version_rejects_risky_tool_icons(store):
+    with pytest.raises(MlflowException, match="Icon URL"):
+        store.create_mcp_server_version(
+            _server_json(),
+            tools=[MCPTool(name="search", icons=[{"src": "https://127.0.0.1/icon.png"}])],
+        )
 
 
 def test_create_mcp_server_version_with_empty_tools_preserves_empty_list(store):
@@ -813,6 +884,16 @@ def test_update_mcp_server_version_tools(store):
     updated = store.update_mcp_server_version("io.github.test/servererver", "1.0.0", tools=tools)
     assert len(updated.tools) == 1
     assert updated.tools[0].name == "calculator"
+
+
+def test_update_mcp_server_version_rejects_risky_tool_icons(store):
+    store.create_mcp_server_version(_server_json())
+    with pytest.raises(MlflowException, match="Icon URL"):
+        store.update_mcp_server_version(
+            "io.github.test/servererver",
+            "1.0.0",
+            tools=[MCPTool(name="search", icons=[{"src": "https://127.0.0.1/icon.png"}])],
+        )
 
 
 def test_update_mcp_server_version_tools_empty_list_preserved(store):

--- a/tests/utils/test_semver_utils.py
+++ b/tests/utils/test_semver_utils.py
@@ -345,6 +345,7 @@ def test_compare_semver_matches_reference_comparator_for_generated_corpus():
             for parts in product(identifier_pool, repeat=length)
         )
 
-    for left in versions:
-        for right in versions:
-            assert compare_semver(left, right) == _compare_semver_precedence(left, right)
+    reference_sorted = sorted(versions, key=cmp_to_key(_compare_semver_precedence))
+    compare_semver_sorted = sorted(versions, key=cmp_to_key(compare_semver))
+
+    assert compare_semver_sorted == reference_sorted


### PR DESCRIPTION
Improve MCP registry registration and write paths so review-driven validation, lifecycle, and auth filtering fixes land before merge.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
