### PR TITLE
Stop eagerly prefetching full neighboring traces in tracing UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -128,15 +128,6 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
     }, [evaluations, nextEvaluationIdx, onChangeEvaluationId]);
 
     const evaluation = useMemo(() => evaluations?.find(findEval), [evaluations, findEval]);
-    const nextEvaluation = useMemo(
-      () => (nextEvaluationIdx && evaluations ? evaluations?.[nextEvaluationIdx] : undefined),
-      [evaluations, nextEvaluationIdx],
-    );
-    const previousEvaluation = useMemo(
-      () => (previousEvaluationIdx && evaluations ? evaluations?.[previousEvaluationIdx] : undefined),
-      [evaluations, previousEvaluationIdx],
-    );
-
     const tracesTableConfig = useGenAITracesTableConfig();
 
     // --- Auto-polling until trace is complete if the backend supports returning partial spans ---
@@ -165,18 +156,6 @@ export const GenAiEvaluationTracesReviewModal = React.memo(
       getTrace,
       shouldFetchTraceBySearchParamId ? selectedEvaluationId : undefined,
     );
-
-    // Prefetching the next and previous traces to optimize performance
-    // prettier-ignore
-    useGetTrace({
-      getTrace,
-      traceInfo: nextEvaluation?.currentRunValue?.traceInfo,
-    });
-    // prettier-ignore
-    useGetTrace({
-      getTrace,
-      traceInfo: previousEvaluation?.currentRunValue?.traceInfo,
-    });
 
     // is true if only one of the two runs has a trace
     const isSingleTraceView = Boolean(evaluation?.currentRunValue) !== Boolean(evaluation?.otherRunValue);


### PR DESCRIPTION
### Related Issues/PRs

Closes #24408

### What changes are proposed in this pull request?

When a user opens a trace from the tracing table, the app previously prefetched **full trace data (info + spans)** for both the next and previous neighboring traces. For traces with thousands of spans, this caused large unnecessary downloads even if the user never navigated to those traces.

This PR removes the eager neighboring trace prefetch. Trace info for all visible traces is already available in the `evaluations` prop from the search results, so next/previous navigation headers still render immediately. Spans now load on demand only when the user actually navigates to a trace.

**Before:** Opening a trace fires 3 full trace fetches simultaneously (current + next + previous neighbor), each downloading the entire span tree.

**After:** Opening a trace fetches only the current trace. Clicking next/previous fetches that trace on demand.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing: opened traces from the traces table with the Network tab open. Confirmed that only the current trace's requests fire (no neighboring trace IDs appear). Next/previous navigation still works — requests fire on demand when the user clicks the arrows.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Stop eagerly prefetching full neighboring traces (including spans) in the tracing UI. Traces with large span trees no longer cause unnecessary downloads when browsing the traces table.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release