### PR TITLE
Consolidate trace child-row merges into one sorted-order helper 

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -896,6 +896,8 @@ class Linter(ast.NodeVisitor):
     def visit_For(self, node: ast.For) -> None:
         if self.prev_stmt and rules.AssignBeforeAppend.check(node, self.prev_stmt):
             self._check(Range.from_node(node), rules.AssignBeforeAppend())
+        if rules.ForbiddenTraceChildMerge.check(node):
+            self._check(Range.from_node(node), rules.ForbiddenTraceChildMerge())
         self.generic_visit(node)
 
     def visit_type_annotation(self, node: ast.expr) -> None:

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -899,6 +899,8 @@ class Linter(ast.NodeVisitor):
     def visit_For(self, node: ast.For) -> None:
         if self.prev_stmt and rules.AssignBeforeAppend.check(node, self.prev_stmt):
             self._check(Range.from_node(node), rules.AssignBeforeAppend())
+        if rules.ForbiddenTraceChildMerge.check(node):
+            self._check(Range.from_node(node), rules.ForbiddenTraceChildMerge())
         self.generic_visit(node)
 
     def visit_type_annotation(self, node: ast.expr) -> None:

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -903,6 +903,11 @@ class Linter(ast.NodeVisitor):
             self._check(Range.from_node(node), rules.ForbiddenTraceChildMerge())
         self.generic_visit(node)
 
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        if rules.ForbiddenTraceChildMerge.check(node):
+            self._check(Range.from_node(node), rules.ForbiddenTraceChildMerge())
+        self.generic_visit(node)
+
     def visit_type_annotation(self, node: ast.expr) -> None:
         visitor = TypeAnnotationVisitor(self)
         visitor.visit(node)

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -12,6 +12,7 @@ from clint.rules.forbidden_make_judge_in_builtin_scorers import (
 )
 from clint.rules.forbidden_set_active_model_usage import ForbiddenSetActiveModelUsage
 from clint.rules.forbidden_top_level_import import ForbiddenTopLevelImport
+from clint.rules.forbidden_trace_child_merge import ForbiddenTraceChildMerge
 from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
 from clint.rules.get_artifact_uri import GetArtifactUri
 from clint.rules.implicit_optional import ImplicitOptional
@@ -72,6 +73,7 @@ __all__ = [
     "ForbiddenDeprecationWarning",
     "ForbiddenMakeJudgeInBuiltinScorers",
     "ForbiddenSetActiveModelUsage",
+    "ForbiddenTraceChildMerge",
     "ForbiddenTopLevelImport",
     "GetArtifactUri",
     "ForbiddenTraceUIInNotebook",

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -12,6 +12,7 @@ from clint.rules.forbidden_make_judge_in_builtin_scorers import (
 )
 from clint.rules.forbidden_set_active_model_usage import ForbiddenSetActiveModelUsage
 from clint.rules.forbidden_top_level_import import ForbiddenTopLevelImport
+from clint.rules.forbidden_trace_child_merge import ForbiddenTraceChildMerge
 from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
 from clint.rules.get_artifact_uri import GetArtifactUri
 from clint.rules.implicit_optional import ImplicitOptional
@@ -73,6 +74,7 @@ __all__ = [
     "ForbiddenDeprecationWarning",
     "ForbiddenMakeJudgeInBuiltinScorers",
     "ForbiddenSetActiveModelUsage",
+    "ForbiddenTraceChildMerge",
     "ForbiddenTopLevelImport",
     "GetArtifactUri",
     "ForbiddenTraceUIInNotebook",

--- a/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
+++ b/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
@@ -1,0 +1,72 @@
+import ast
+from collections.abc import Iterator
+
+from clint.rules.base import Rule
+
+_TRACE_CHILD_MODELS = frozenset({"SqlTraceTag", "SqlTraceMetadata", "SqlTraceMetrics"})
+
+
+class ForbiddenTraceChildMerge(Rule):
+    def _message(self) -> str:
+        return (
+            "Do not merge SqlTraceTag / SqlTraceMetadata / SqlTraceMetrics rows in a loop "
+            "directly. Use `_merge_trace_child_rows_in_lock_order` so the rows are merged "
+            "in sorted key order and concurrent writers cannot deadlock on the PK index "
+            "(see #24338)."
+        )
+
+    @staticmethod
+    def check(node: ast.For) -> bool:
+        """Flag a `for` loop that merges a trace child model with a per-iteration key.
+
+        ``session.merge(SqlTrace{Tag,Metadata,Metrics}(request_id=..., key=<name>, ...))``
+        inside a loop is the exact pattern that regresses the #24338 deadlock fix: the loop
+        can acquire the PK-index locks in caller-dependent order. Route it through
+        ``_merge_trace_child_rows_in_lock_order`` instead.
+
+        Matched only when ``key`` is a bare loop-bound name — the shape every trace-child
+        merge site actually uses (``for k, v in d.items(): ... key=k``). This is a
+        defense-in-depth backstop, not the primary guarantee (that is the helper plus the
+        sorted-order tests), so it deliberately stays narrow to avoid false positives:
+        a constant key (``key=TraceTagKey.SPANS_LOCATION``) is a single fixed row that
+        cannot self-invert, and the shared helper merges a variable ``model_class`` rather
+        than a literal trace-child constructor. A hand-written loop that varied the key via
+        an attribute/subscript (``key=item.key``) would slip past — an accepted gap, since
+        no such site exists and broadening it would flag safe fixed-attribute merges.
+
+        Only this loop's own body is inspected; a nested loop is judged by its own
+        ``visit_For`` so an offending inner loop is reported once, at the inner loop.
+        """
+        return any(
+            ForbiddenTraceChildMerge._is_trace_child_merge(call)
+            for call in ForbiddenTraceChildMerge._calls_excluding_nested_loops(node)
+        )
+
+    @staticmethod
+    def _calls_excluding_nested_loops(node: ast.For) -> Iterator[ast.Call]:
+        # Walk the loop body but prune nested loop subtrees at any depth, so a merge that
+        # belongs to an inner loop is attributed only to that inner loop (which gets its
+        # own visit_For), never doubly reported on an enclosing loop.
+        for child in ast.iter_child_nodes(node):
+            stack = [child]
+            while stack:
+                cur = stack.pop()
+                if isinstance(cur, (ast.For, ast.AsyncFor)):
+                    continue
+                if isinstance(cur, ast.Call):
+                    yield cur
+                stack.extend(ast.iter_child_nodes(cur))
+
+    @staticmethod
+    def _is_trace_child_merge(stmt: ast.AST) -> bool:
+        match stmt:
+            case ast.Call(
+                func=ast.Attribute(attr="merge"),
+                args=[ast.Call(func=ast.Name(id=model), keywords=keywords), *_],
+            ) if model in _TRACE_CHILD_MODELS:
+                # Match only a bare loop-bound name key (the shape real sites use). A
+                # constant key is a single fixed row and is safe; see check() for the
+                # accepted attribute/subscript-key gap.
+                return any(kw.arg == "key" and isinstance(kw.value, ast.Name) for kw in keywords)
+            case _:
+                return False

--- a/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
+++ b/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
@@ -16,8 +16,8 @@ class ForbiddenTraceChildMerge(Rule):
         )
 
     @staticmethod
-    def check(node: ast.For) -> bool:
-        """Flag a `for` loop that merges a trace child model with a per-iteration key.
+    def check(node: ast.For | ast.AsyncFor) -> bool:
+        """Flag a loop that merges a trace child model with a per-iteration key.
 
         ``session.merge(SqlTrace{Tag,Metadata,Metrics}(request_id=..., key=<name>, ...))``
         inside a loop is the exact pattern that regresses the #24338 deadlock fix: the loop
@@ -35,7 +35,7 @@ class ForbiddenTraceChildMerge(Rule):
         no such site exists and broadening it would flag safe fixed-attribute merges.
 
         Only this loop's own body is inspected; a nested loop is judged by its own
-        ``visit_For`` so an offending inner loop is reported once, at the inner loop.
+        linter visitor so an offending inner loop is reported once, at the inner loop.
         """
         return any(
             ForbiddenTraceChildMerge._is_trace_child_merge(call)
@@ -43,10 +43,10 @@ class ForbiddenTraceChildMerge(Rule):
         )
 
     @staticmethod
-    def _calls_excluding_nested_loops(node: ast.For) -> Iterator[ast.Call]:
+    def _calls_excluding_nested_loops(node: ast.For | ast.AsyncFor) -> Iterator[ast.Call]:
         # Walk the loop body but prune nested loop subtrees at any depth, so a merge that
         # belongs to an inner loop is attributed only to that inner loop (which gets its
-        # own visit_For), never doubly reported on an enclosing loop.
+        # own linter visitor), never doubly reported on an enclosing loop.
         for child in ast.iter_child_nodes(node):
             stack = [child]
             while stack:

--- a/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
+++ b/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
@@ -37,8 +37,13 @@ class ForbiddenTraceChildMerge(Rule):
         Only this loop's own body is inspected; a nested loop is judged by its own
         linter visitor so an offending inner loop is reported once, at the inner loop.
         """
+        loop_bound_names = {
+            child.id
+            for child in ast.walk(node.target)
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+        }
         return any(
-            ForbiddenTraceChildMerge._is_trace_child_merge(call)
+            ForbiddenTraceChildMerge._is_trace_child_merge(call, loop_bound_names)
             for call in ForbiddenTraceChildMerge._calls_excluding_nested_loops(node)
         )
 
@@ -60,7 +65,7 @@ class ForbiddenTraceChildMerge(Rule):
                 stack.extend(ast.iter_child_nodes(cur))
 
     @staticmethod
-    def _is_trace_child_merge(stmt: ast.AST) -> bool:
+    def _is_trace_child_merge(stmt: ast.AST, loop_bound_names: set[str]) -> bool:
         match stmt:
             case ast.Call(
                 func=ast.Attribute(attr="merge"),
@@ -69,6 +74,11 @@ class ForbiddenTraceChildMerge(Rule):
                 # Match only a bare loop-bound name key (the shape real sites use). A
                 # constant key is a single fixed row and is safe; see check() for the
                 # accepted attribute/subscript-key gap.
-                return any(kw.arg == "key" and isinstance(kw.value, ast.Name) for kw in keywords)
+                return any(
+                    kw.arg == "key"
+                    and isinstance(kw.value, ast.Name)
+                    and kw.value.id in loop_bound_names
+                    for kw in keywords
+                )
             case _:
                 return False

--- a/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
+++ b/dev/clint/src/clint/rules/forbidden_trace_child_merge.py
@@ -55,6 +55,8 @@ class ForbiddenTraceChildMerge(Rule):
                     continue
                 if isinstance(cur, ast.Call):
                     yield cur
+                    # Keep walking: a relevant merge may be nested in this call's arguments;
+                    # the harmless outer call is yielded first and rejected by the matcher.
                 stack.extend(ast.iter_child_nodes(cur))
 
     @staticmethod

--- a/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Position, Range, lint_file
+from clint.rules import ForbiddenTraceChildMerge
+
+
+def test_flags_looped_trace_metadata_merge(index: SymbolIndex) -> None:
+    code = """
+for k, v in metadata.items():
+    session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 1
+    assert all(isinstance(r.rule, ForbiddenTraceChildMerge) for r in results)
+    assert results[0].range == Range(Position(1, 0))
+
+
+def test_flags_looped_trace_tag_merge(index: SymbolIndex) -> None:
+    code = """
+for tag_key, tag_value in tags.items():
+    session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 1
+
+
+def test_flags_looped_trace_metrics_merge(index: SymbolIndex) -> None:
+    code = """
+for k, v in metrics.items():
+    session.merge(SqlTraceMetrics(request_id=trace_id, key=k, value=v))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 1
+
+
+def test_no_flag_single_row_merge(index: SymbolIndex) -> None:
+    # set_trace_tag / archival single fixed-key merges are not in a loop and cannot
+    # self-invert their own PK-lock order, so they are safe and must not be flagged.
+    code = """
+session.merge(SqlTraceTag(request_id=trace_id, key=key, value=value))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 0
+
+
+def test_no_flag_fixed_key_merge_in_outer_loop(index: SymbolIndex) -> None:
+    # A single fixed-key merge (constant/attribute key) inside an outer loop over trace
+    # ids writes one row per trace and cannot self-invert the PK-lock order, so it is safe.
+    code = """
+for trace_id in all_trace_ids:
+    session.merge(
+        SqlTraceTag(request_id=trace_id, key=TraceTagKey.SPANS_LOCATION, value=loc)
+    )
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 0
+
+
+def test_no_flag_helper_variable_merge(index: SymbolIndex) -> None:
+    # The shared helper merges a variable model class, not a literal trace-child
+    # constructor, so it is not matched even though it merges inside a loop.
+    code = """
+for key, value in sorted(values.items()):
+    session.merge(model_class(request_id=request_id, key=key, value=value))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 0
+
+
+def test_no_flag_looped_non_trace_merge(index: SymbolIndex) -> None:
+    # Looping a merge of an unrelated model is out of scope for this rule.
+    code = """
+for tag in tags:
+    session.merge(SqlTag(key=tag.key, value=tag.value))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 0

--- a/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
@@ -28,6 +28,16 @@ for tag_key, tag_value in tags.items():
     assert len(results) == 1
 
 
+def test_flags_simple_loop_bound_key_name(index: SymbolIndex) -> None:
+    code = """
+for key in tag_keys:
+    session.merge(SqlTraceTag(request_id=trace_id, key=key, value=value))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 1
+
+
 def test_flags_looped_trace_metrics_merge(index: SymbolIndex) -> None:
     code = """
 for k, v in metrics.items():
@@ -78,6 +88,17 @@ for trace_id in all_trace_ids:
     session.merge(
         SqlTraceTag(request_id=trace_id, key=TraceTagKey.SPANS_LOCATION, value=loc)
     )
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 0
+
+
+def test_no_flag_fixed_key_alias_in_outer_loop(index: SymbolIndex) -> None:
+    code = """
+fixed_key = TraceTagKey.SPANS_LOCATION
+for trace_id in all_trace_ids:
+    session.merge(SqlTraceTag(request_id=trace_id, key=fixed_key, value=loc))
 """
     config = Config(select={ForbiddenTraceChildMerge.name})
     results = lint_file(Path("test.py"), code, config, index)

--- a/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
@@ -38,6 +38,16 @@ for k, v in metrics.items():
     assert len(results) == 1
 
 
+def test_flags_trace_child_merge_nested_in_outer_call(index: SymbolIndex) -> None:
+    code = """
+for k, v in metadata.items():
+    print(session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v)))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 1
+
+
 def test_flags_async_looped_trace_tag_merge(index: SymbolIndex) -> None:
     code = """
 async for tag_key, tag_value in tags:

--- a/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_child_merge.py
@@ -38,6 +38,17 @@ for k, v in metrics.items():
     assert len(results) == 1
 
 
+def test_flags_async_looped_trace_tag_merge(index: SymbolIndex) -> None:
+    code = """
+async for tag_key, tag_value in tags:
+    session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
+"""
+    config = Config(select={ForbiddenTraceChildMerge.name})
+    results = lint_file(Path("test.py"), code, config, index)
+    assert len(results) == 1
+    assert results[0].range == Range(Position(1, 0))
+
+
 def test_no_flag_single_row_merge(index: SymbolIndex) -> None:
     # set_trace_tag / archival single fixed-key merges are not in a loop and cannot
     # self-invert their own PK-lock order, so they are safe and must not be flagged.

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3525,8 +3525,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 response_preview=trace_info.response_preview,
             )
 
+            # Build user tags in sorted key order (matching the metadata/metrics cascade
+            # below) so trace child cascades acquire PK-index locks deterministically; see
+            # _merge_trace_child_rows_in_lock_order for the full deadlock rationale (#24338).
             tags = [
-                SqlTraceTag(request_id=trace_id, key=k, value=v) for k, v in trace_info.tags.items()
+                SqlTraceTag(request_id=trace_id, key=k, value=v)
+                for k, v in sorted(trace_info.tags.items())
             ] + [self._get_trace_artifact_location_tag(experiment, trace_id)]
             sql_trace_info.tags = tags
 
@@ -3562,10 +3566,9 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             sql_trace_info.assessments = sql_assessments
 
             try:
-                # Happy path: attach metadata/metrics via cascade for a single flush.
-                # Emit rows in sorted key order so concurrent writers acquire the
-                # trace_request_metadata / trace_metrics PK-index locks in a consistent
-                # order across transactions and cannot deadlock.
+                # Happy path: attach metadata/metrics via cascade for a single flush, in
+                # sorted key order for the same lock-ordering reason as the tags above
+                # (see _merge_trace_child_rows_in_lock_order).
                 sql_trace_info.request_metadata = [
                     SqlTraceMetadata(request_id=trace_id, key=k, value=v)
                     for k, v in sorted(request_metadata.items())
@@ -3585,10 +3588,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 session.rollback()
                 session.expunge_all()
                 # Rebuild child rows after expunging the failed parent tree so later
-                # per-row merges cannot drag its stale trace_info state back in.
-                tags = [
-                    SqlTraceTag(request_id=trace_id, key=tag.key, value=tag.value) for tag in tags
-                ]
+                # per-row merges cannot drag its stale trace_info state back in. Collect
+                # tag key/values into a dict so they can be merged in sorted lock order
+                # below (last write wins on any duplicate key; keys are unique here).
+                tag_values = {tag.key: tag.value for tag in tags}
                 sql_assessments = []
                 for a in trace_info.assessments:
                     sql_assessment = SqlAssessments.from_mlflow_entity(a)
@@ -3634,19 +3637,19 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 if trace_info.response_preview is not None:
                     db_sql_trace_info.response_preview = trace_info.response_preview
 
-                for tag in tags:
-                    session.merge(tag)
+                # Upsert tags/metadata/metrics in sorted key order so the complete data
+                # from start_trace() overwrites any partial values from log_spans() while
+                # keeping PK-index lock acquisition consistent across transactions.
+                # Assessments are keyed differently and are not part of that lock class.
+                _merge_trace_child_rows_in_lock_order(session, SqlTraceTag, trace_id, tag_values)
                 for assessment in sql_assessments:
                     session.merge(assessment)
-
-                # Upsert metadata and metrics individually so the complete data
-                # from start_trace() overwrites any partial values from log_spans().
-                # Merge in sorted key order to keep PK-index lock acquisition consistent
-                # across transactions and avoid deadlocks.
-                for k, v in sorted(request_metadata.items()):
-                    session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v))
-                for k, v in sorted(trace_metrics.items()):
-                    session.merge(SqlTraceMetrics(request_id=trace_id, key=k, value=v))
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetadata, trace_id, request_metadata
+                )
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetrics, trace_id, trace_metrics
+                )
                 session.flush()
                 sql_trace_info = self._get_sql_trace_info(
                     session,
@@ -5355,12 +5358,12 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     if not existing_user_id:
                         metadata_writes[TraceMetadataKey.TRACE_USER] = agg.user_id
 
-                # Emit the collected metadata/metrics merges in sorted key order so
-                # PK-index lock acquisition is deterministic across transactions (#24332).
-                for key, value in sorted(metadata_writes.items()):
-                    session.merge(SqlTraceMetadata(request_id=trace_id, key=key, value=value))
-                for key, value in sorted(metric_writes.items()):
-                    session.merge(SqlTraceMetrics(request_id=trace_id, key=key, value=value))
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetadata, trace_id, metadata_writes
+                )
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetrics, trace_id, metric_writes
+                )
 
                 if update_dict:
                     # `trace_id` was selected through workspace-scoped reads earlier in this
@@ -5412,6 +5415,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     None,
                 )
                 if resource is not None:
+                    resource_tag_values: dict[str, str] = {}
                     for key, value in resource.attributes.items():
                         # Skip OTel SDK internal metadata and the reserved mlflow.*
                         # namespace so a client cannot clobber bookkeeping tags
@@ -5424,19 +5428,19 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                         except Exception:
                             _logger.debug("Skipping invalid resource attribute %r", key)
                             continue
-                        session.merge(
-                            SqlTraceTag(
-                                request_id=trace_id,
-                                key=key,
-                                value=str_value,
-                            )
-                        )
+                        resource_tag_values[key] = str_value
+                    # Merge validated resource tags in sorted lock order. Written before the
+                    # user tags below so user-defined tags win on key collision.
+                    _merge_trace_child_rows_in_lock_order(
+                        session, SqlTraceTag, trace_id, resource_tag_values
+                    )
 
                 # Restore user-defined tags carried via mlflow.traceTag.* attributes on the root
                 # span (set by OtelSpanProcessor when the trace was exported over OTLP).
                 # Written after resource attributes so user tags take precedence on collision.
-                for tag_key, tag_value in agg.trace_tags.items():
-                    session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceTag, trace_id, agg.trace_tags
+                )
 
         return spans
 
@@ -7523,11 +7527,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                 status=TraceStatus.IN_PROGRESS,
             )
 
-            trace_info.tags = [SqlTraceTag(key=k, value=v) for k, v in tags.items()]
+            # Build tags/metadata in sorted key order for deterministic PK-index lock
+            # acquisition (see _merge_trace_child_rows_in_lock_order, #24338).
+            trace_info.tags = [SqlTraceTag(key=k, value=v) for k, v in sorted(tags.items())]
             trace_info.tags.append(self._get_trace_artifact_location_tag(experiment, request_id))
-
-            # Emit metadata rows in sorted key order to keep PK-index lock acquisition
-            # consistent with the other trace-metadata writers and avoid deadlocks (#24332).
             trace_info.request_metadata = [
                 SqlTraceMetadata(key=k, value=v) for k, v in sorted(request_metadata.items())
             ]
@@ -7568,13 +7571,10 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             sql_trace_info.execution_time_ms = execution_time_ms
             sql_trace_info.status = status
             session.merge(sql_trace_info)
-            # Merge metadata in sorted key order so concurrent writers acquire the
-            # trace_request_metadata PK-index locks in a consistent order and cannot
-            # deadlock.
-            for k, v in sorted(request_metadata.items()):
-                session.merge(SqlTraceMetadata(request_id=request_id, key=k, value=v))
-            for k, v in tags.items():
-                session.merge(SqlTraceTag(request_id=request_id, key=k, value=v))
+            _merge_trace_child_rows_in_lock_order(
+                session, SqlTraceMetadata, request_id, request_metadata
+            )
+            _merge_trace_child_rows_in_lock_order(session, SqlTraceTag, request_id, tags)
             return TraceInfoV2.from_v3(sql_trace_info.to_mlflow_entity())
 
     def add_dataset_to_experiments(
@@ -9778,6 +9778,32 @@ class _TraceAggregate:
 # re-fetch before retrying. 10 attempts reduces span drops in high-concurrency
 # scenarios without significant backend load increase (log_spans runs async).
 _LOG_SPANS_MAX_TRACE_CREATE_RETRIES = 10
+
+
+def _merge_trace_child_rows_in_lock_order(
+    session: Session,
+    model_class: type,
+    request_id: str,
+    values: dict[str, Any],
+) -> None:
+    """Upsert trace child rows (tags / request_metadata / metrics) in sorted key order.
+
+    ``model_class`` must be one of ``SqlTraceTag``, ``SqlTraceMetadata``, or
+    ``SqlTraceMetrics`` — the three structurally identical trace child tables, each keyed
+    by the composite primary key ``(request_id, key)`` with a single ``value`` column.
+
+    Rows are merged in sorted key order so that concurrent writers (notably a
+    ``start_trace()`` / ``log_spans()`` race, issue #24338) acquire the per-table
+    PK-index locks in a consistent order across transactions and cannot form the circular
+    wait that produces a Postgres deadlock. This function is the single chokepoint for
+    that ordering guarantee: never merge these three models in ad-hoc order elsewhere
+    (the ``forbidden_trace_child_merge`` clint rule enforces this).
+
+    Workspace-agnostic: trace child rows are keyed only by ``request_id``; workspace
+    scoping is enforced by the caller when it locks/reads the parent ``trace_info`` row.
+    """
+    for key, value in sorted(values.items()):
+        session.merge(model_class(request_id=request_id, key=key, value=value))
 
 
 def _bulk_upsert(session: Session, model_class: type, rows: list[dict[str, Any]]) -> None:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3751,8 +3751,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 response_preview=trace_info.response_preview,
             )
 
+            # Build user tags in sorted key order (matching the metadata/metrics cascade
+            # below) so trace child cascades acquire PK-index locks deterministically; see
+            # _merge_trace_child_rows_in_lock_order for the full deadlock rationale (#24338).
             tags = [
-                SqlTraceTag(request_id=trace_id, key=k, value=v) for k, v in trace_info.tags.items()
+                SqlTraceTag(request_id=trace_id, key=k, value=v)
+                for k, v in sorted(trace_info.tags.items())
             ] + [self._get_trace_artifact_location_tag(experiment, trace_id)]
             sql_trace_info.tags = tags
 
@@ -3788,10 +3792,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             sql_trace_info.assessments = sql_assessments
 
             try:
-                # Happy path: attach metadata/metrics via cascade for a single flush.
-                # Emit rows in sorted key order so concurrent writers acquire the
-                # trace_request_metadata / trace_metrics PK-index locks in a consistent
-                # order across transactions and cannot deadlock.
+                # Happy path: attach metadata/metrics via cascade for a single flush, in
+                # sorted key order for the same lock-ordering reason as the tags above
+                # (see _merge_trace_child_rows_in_lock_order).
                 sql_trace_info.request_metadata = [
                     SqlTraceMetadata(request_id=trace_id, key=k, value=v)
                     for k, v in sorted(request_metadata.items())
@@ -3811,10 +3814,10 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session.rollback()
                 session.expunge_all()
                 # Rebuild child rows after expunging the failed parent tree so later
-                # per-row merges cannot drag its stale trace_info state back in.
-                tags = [
-                    SqlTraceTag(request_id=trace_id, key=tag.key, value=tag.value) for tag in tags
-                ]
+                # per-row merges cannot drag its stale trace_info state back in. Collect
+                # tag key/values into a dict so they can be merged in sorted lock order
+                # below (last write wins on any duplicate key; keys are unique here).
+                tag_values = {tag.key: tag.value for tag in tags}
                 sql_assessments = []
                 for a in trace_info.assessments:
                     sql_assessment = SqlAssessments.from_mlflow_entity(a)
@@ -3860,19 +3863,19 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 if trace_info.response_preview is not None:
                     db_sql_trace_info.response_preview = trace_info.response_preview
 
-                for tag in tags:
-                    session.merge(tag)
+                # Upsert tags/metadata/metrics in sorted key order so the complete data
+                # from start_trace() overwrites any partial values from log_spans() while
+                # keeping PK-index lock acquisition consistent across transactions.
+                # Assessments are keyed differently and are not part of that lock class.
+                _merge_trace_child_rows_in_lock_order(session, SqlTraceTag, trace_id, tag_values)
                 for assessment in sql_assessments:
                     session.merge(assessment)
-
-                # Upsert metadata and metrics individually so the complete data
-                # from start_trace() overwrites any partial values from log_spans().
-                # Merge in sorted key order to keep PK-index lock acquisition consistent
-                # across transactions and avoid deadlocks.
-                for k, v in sorted(request_metadata.items()):
-                    session.merge(SqlTraceMetadata(request_id=trace_id, key=k, value=v))
-                for k, v in sorted(trace_metrics.items()):
-                    session.merge(SqlTraceMetrics(request_id=trace_id, key=k, value=v))
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetadata, trace_id, request_metadata
+                )
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetrics, trace_id, trace_metrics
+                )
                 session.flush()
                 sql_trace_info = self._get_sql_trace_info(
                     session,
@@ -5717,12 +5720,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     if not existing_user_id:
                         metadata_writes[TraceMetadataKey.TRACE_USER] = agg.user_id
 
-                # Emit the collected metadata/metrics merges in sorted key order so
-                # PK-index lock acquisition is deterministic across transactions (#24332).
-                for key, value in sorted(metadata_writes.items()):
-                    session.merge(SqlTraceMetadata(request_id=trace_id, key=key, value=value))
-                for key, value in sorted(metric_writes.items()):
-                    session.merge(SqlTraceMetrics(request_id=trace_id, key=key, value=value))
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetadata, trace_id, metadata_writes
+                )
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceMetrics, trace_id, metric_writes
+                )
 
                 if update_dict:
                     # `trace_id` was selected through workspace-scoped reads earlier in this
@@ -5774,6 +5777,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     None,
                 )
                 if resource is not None:
+                    resource_tag_values: dict[str, str] = {}
                     for key, value in resource.attributes.items():
                         # Skip OTel SDK internal metadata and the reserved mlflow.*
                         # namespace so a client cannot clobber bookkeeping tags
@@ -5786,19 +5790,19 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         except Exception:
                             _logger.debug("Skipping invalid resource attribute %r", key)
                             continue
-                        session.merge(
-                            SqlTraceTag(
-                                request_id=trace_id,
-                                key=key,
-                                value=str_value,
-                            )
-                        )
+                        resource_tag_values[key] = str_value
+                    # Merge validated resource tags in sorted lock order. Written before the
+                    # user tags below so user-defined tags win on key collision.
+                    _merge_trace_child_rows_in_lock_order(
+                        session, SqlTraceTag, trace_id, resource_tag_values
+                    )
 
                 # Restore user-defined tags carried via mlflow.traceTag.* attributes on the root
                 # span (set by OtelSpanProcessor when the trace was exported over OTLP).
                 # Written after resource attributes so user tags take precedence on collision.
-                for tag_key, tag_value in agg.trace_tags.items():
-                    session.merge(SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value))
+                _merge_trace_child_rows_in_lock_order(
+                    session, SqlTraceTag, trace_id, agg.trace_tags
+                )
 
         return spans
 
@@ -7872,11 +7876,10 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 status=TraceStatus.IN_PROGRESS,
             )
 
-            trace_info.tags = [SqlTraceTag(key=k, value=v) for k, v in tags.items()]
+            # Build tags/metadata in sorted key order for deterministic PK-index lock
+            # acquisition (see _merge_trace_child_rows_in_lock_order, #24338).
+            trace_info.tags = [SqlTraceTag(key=k, value=v) for k, v in sorted(tags.items())]
             trace_info.tags.append(self._get_trace_artifact_location_tag(experiment, request_id))
-
-            # Emit metadata rows in sorted key order to keep PK-index lock acquisition
-            # consistent with the other trace-metadata writers and avoid deadlocks (#24332).
             trace_info.request_metadata = [
                 SqlTraceMetadata(key=k, value=v) for k, v in sorted(request_metadata.items())
             ]
@@ -7917,13 +7920,10 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             sql_trace_info.execution_time_ms = execution_time_ms
             sql_trace_info.status = status
             session.merge(sql_trace_info)
-            # Merge metadata in sorted key order so concurrent writers acquire the
-            # trace_request_metadata PK-index locks in a consistent order and cannot
-            # deadlock.
-            for k, v in sorted(request_metadata.items()):
-                session.merge(SqlTraceMetadata(request_id=request_id, key=k, value=v))
-            for k, v in tags.items():
-                session.merge(SqlTraceTag(request_id=request_id, key=k, value=v))
+            _merge_trace_child_rows_in_lock_order(
+                session, SqlTraceMetadata, request_id, request_metadata
+            )
+            _merge_trace_child_rows_in_lock_order(session, SqlTraceTag, request_id, tags)
             return TraceInfoV2.from_v3(sql_trace_info.to_mlflow_entity())
 
     def add_dataset_to_experiments(
@@ -10234,6 +10234,32 @@ class _TraceAggregate:
 # re-fetch before retrying. 10 attempts reduces span drops in high-concurrency
 # scenarios without significant backend load increase (log_spans runs async).
 _LOG_SPANS_MAX_TRACE_CREATE_RETRIES = 10
+
+
+def _merge_trace_child_rows_in_lock_order(
+    session: Session,
+    model_class: type,
+    request_id: str,
+    values: dict[str, Any],
+) -> None:
+    """Upsert trace child rows (tags / request_metadata / metrics) in sorted key order.
+
+    ``model_class`` must be one of ``SqlTraceTag``, ``SqlTraceMetadata``, or
+    ``SqlTraceMetrics`` — the three structurally identical trace child tables, each keyed
+    by the composite primary key ``(request_id, key)`` with a single ``value`` column.
+
+    Rows are merged in sorted key order so that concurrent writers (notably a
+    ``start_trace()`` / ``log_spans()`` race, issue #24338) acquire the per-table
+    PK-index locks in a consistent order across transactions and cannot form the circular
+    wait that produces a Postgres deadlock. This function is the single chokepoint for
+    that ordering guarantee: never merge these three models in ad-hoc order elsewhere
+    (the ``forbidden_trace_child_merge`` clint rule enforces this).
+
+    Workspace-agnostic: trace child rows are keyed only by ``request_id``; workspace
+    scoping is enforced by the caller when it locks/reads the parent ``trace_info`` row.
+    """
+    for key, value in sorted(values.items()):
+        session.merge(model_class(request_id=request_id, key=key, value=value))
 
 
 def _bulk_upsert(session: Session, model_class: type, rows: list[dict[str, Any]]) -> None:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3762,8 +3762,8 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             }
             tags = [
                 SqlTraceTag(request_id=trace_id, key=k, value=v)
-                for k, v in sorted(trace_info.tags.items())
-            ] + [artifact_location_tag]
+                for k, v in sorted(tag_values.items())
+            ]
             sql_trace_info.tags = tags
 
             # Build metadata and metrics but don't attach to sql_trace_info yet —

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5494,13 +5494,23 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 if self.db_type == MSSQL:
                     # SQL Server does not guarantee that ORDER BY controls UPDLOCK acquisition.
                     # Single-row queries make the sorted Python order authoritative.
-                    locked_traces = [
-                        self._trace_row_lock_query(session, [trace_id]).one()
-                        for trace_id in sorted(preexisting_trace_ids)
-                    ]
+                    locked_traces = []
+                    for trace_id in sorted(preexisting_trace_ids):
+                        trace = self._trace_row_lock_query(session, [trace_id]).one_or_none()
+                        if trace is not None:
+                            locked_traces.append(trace)
                 else:
                     locked_traces = self._trace_row_lock_query(session, preexisting_trace_ids).all()
-                existing_traces.update({trace.request_id: trace for trace in locked_traces})
+                locked_traces_by_id = {trace.request_id: trace for trace in locked_traces}
+                missing_locked_trace_ids = sorted(
+                    set(preexisting_trace_ids) - locked_traces_by_id.keys()
+                )
+                if missing_locked_trace_ids:
+                    self._raise_log_spans_trace_write_conflict_error(
+                        blocked_trace_ids={},
+                        missing_trace_ids=missing_locked_trace_ids,
+                    )
+                existing_traces.update(locked_traces_by_id)
 
             # Fill in experiment_id on span rows now that we have trace infos
             for row in all_span_rows:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5764,13 +5764,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             # atomically with the new DB-backed payload generation.
             for trace_id in all_trace_ids:
                 agg = trace_aggregates[trace_id]
-                session.merge(
-                    SqlTraceTag(
-                        request_id=trace_id,
-                        key=TraceTagKey.SPANS_LOCATION,
-                        value=SpansLocation.TRACKING_STORE.value,
-                    )
-                )
+                trace_tag_values = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE.value}
 
                 # Persist OTel resource attributes (e.g., service.name) as trace tags so
                 # they are visible in the UI and available for filtering. Resource is attached
@@ -5787,7 +5781,6 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     None,
                 )
                 if resource is not None:
-                    resource_tag_values: dict[str, str] = {}
                     for key, value in resource.attributes.items():
                         # Skip OTel SDK internal metadata and the reserved mlflow.*
                         # namespace so a client cannot clobber bookkeeping tags
@@ -5800,18 +5793,15 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         except Exception:
                             _logger.debug("Skipping invalid resource attribute %r", key)
                             continue
-                        resource_tag_values[key] = str_value
-                    # Merge validated resource tags in sorted lock order. Written before the
-                    # user tags below so user-defined tags win on key collision.
-                    _merge_trace_child_rows_in_lock_order(
-                        session, SqlTraceTag, trace_id, resource_tag_values
-                    )
+                        trace_tag_values[key] = str_value
 
                 # Restore user-defined tags carried via mlflow.traceTag.* attributes on the root
-                # span (set by OtelSpanProcessor when the trace was exported over OTLP).
-                # Written after resource attributes so user tags take precedence on collision.
+                # span (set by OtelSpanProcessor when the trace was exported over OTLP). Applying
+                # them last preserves their precedence over resource attributes (and over the
+                # spans-location tag, matching the prior sequence of merge calls).
+                trace_tag_values.update(agg.trace_tags)
                 _merge_trace_child_rows_in_lock_order(
-                    session, SqlTraceTag, trace_id, agg.trace_tags
+                    session, SqlTraceTag, trace_id, trace_tag_values
                 )
 
         return spans

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5762,7 +5762,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             # succeeds so
             # span writes, including span-only changes that did not update trace_info, commit
             # atomically with the new DB-backed payload generation.
-            for trace_id in all_trace_ids:
+            for trace_id in sorted(all_trace_ids):
                 agg = trace_aggregates[trace_id]
                 trace_tag_values = {TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE.value}
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -7880,8 +7880,14 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
             # Build tags/metadata in sorted key order for deterministic PK-index lock
             # acquisition (see _merge_trace_child_rows_in_lock_order, #24338).
-            trace_info.tags = [SqlTraceTag(key=k, value=v) for k, v in sorted(tags.items())]
-            trace_info.tags.append(self._get_trace_artifact_location_tag(experiment, request_id))
+            artifact_location_tag = self._get_trace_artifact_location_tag(experiment, request_id)
+            combined_tags = {
+                **tags,
+                artifact_location_tag.key: artifact_location_tag.value,
+            }
+            trace_info.tags = [
+                SqlTraceTag(key=k, value=v) for k, v in sorted(combined_tags.items())
+            ]
             trace_info.request_metadata = [
                 SqlTraceMetadata(key=k, value=v) for k, v in sorted(request_metadata.items())
             ]

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3755,10 +3755,15 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             # Build user tags in sorted key order (matching the metadata/metrics cascade
             # below) so trace child cascades acquire PK-index locks deterministically; see
             # _merge_trace_child_rows_in_lock_order for the full deadlock rationale (#24338).
+            artifact_location_tag = self._get_trace_artifact_location_tag(experiment, trace_id)
+            tag_values = {
+                **trace_info.tags,
+                artifact_location_tag.key: artifact_location_tag.value,
+            }
             tags = [
                 SqlTraceTag(request_id=trace_id, key=k, value=v)
                 for k, v in sorted(trace_info.tags.items())
-            ] + [self._get_trace_artifact_location_tag(experiment, trace_id)]
+            ] + [artifact_location_tag]
             sql_trace_info.tags = tags
 
             # Build metadata and metrics but don't attach to sql_trace_info yet —
@@ -3814,11 +3819,8 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 # that were already attached to the trace.
                 session.rollback()
                 session.expunge_all()
-                # Rebuild child rows after expunging the failed parent tree so later
-                # per-row merges cannot drag its stale trace_info state back in. Collect
-                # tag key/values into a dict so they can be merged in sorted lock order
-                # below (last write wins on any duplicate key; keys are unique here).
-                tag_values = {tag.key: tag.value for tag in tags}
+                # Rebuild assessments after expunging the failed parent tree so later
+                # merges cannot drag its stale trace_info state back in.
                 sql_assessments = []
                 for a in trace_info.assessments:
                     sql_assessment = SqlAssessments.from_mlflow_entity(a)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1067,6 +1067,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         query = (
             session
             .query(SqlTraceInfo)
+            .populate_existing()
             .filter(SqlTraceInfo.request_id.in_(trace_ids))
             .order_by(SqlTraceInfo.request_id)
         )
@@ -5488,7 +5489,16 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             if preexisting_trace_ids := [
                 trace_id for trace_id in all_trace_ids if trace_id not in created_trace_ids
             ]:
-                self._trace_row_lock_query(session, preexisting_trace_ids).all()
+                if self.db_type == MSSQL:
+                    # SQL Server does not guarantee that ORDER BY controls UPDLOCK acquisition.
+                    # Single-row queries make the sorted Python order authoritative.
+                    locked_traces = [
+                        self._trace_row_lock_query(session, [trace_id]).one()
+                        for trace_id in sorted(preexisting_trace_ids)
+                    ]
+                else:
+                    locked_traces = self._trace_row_lock_query(session, preexisting_trace_ids).all()
+                existing_traces.update({trace.request_id: trace for trace in locked_traces})
 
             # Fill in experiment_id on span rows now that we have trace infos
             for row in all_span_rows:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -7922,7 +7922,17 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             The updated TraceInfo object.
         """
         with self.ManagedSessionMaker(read_only=False) as session:
-            sql_trace_info = self._get_sql_trace_info(session, request_id)
+            sql_trace_info = (
+                self
+                ._trace_query(session, for_update_or_delete=True)
+                .filter(SqlTraceInfo.request_id == request_id)
+                .one_or_none()
+            )
+            if sql_trace_info is None:
+                raise MlflowException(
+                    f"Trace with ID '{request_id}' not found.",
+                    RESOURCE_DOES_NOT_EXIST,
+                )
             trace_start_time_ms = sql_trace_info.timestamp_ms
             execution_time_ms = timestamp_ms - trace_start_time_ms
             sql_trace_info.execution_time_ms = execution_time_ms

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -9866,19 +9866,26 @@ def test_log_spans_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
         assert keys == sorted(keys), f"keys for {rid} not sorted: {keys}"
 
 
-def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_order(
+def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_key_order(
     store: SqlAlchemyStore,
 ):
     """The IntegrityError conflict path is where the reported start_trace()/log_spans()
     race actually occurs (issue #24332): log_spans() creates the trace first, then
-    start_trace() hits IntegrityError and upserts metadata/metrics via per-row
-    session.merge(). This test forces that branch and asserts BOTH merge loops emit keys
-    in sorted order — the happy-path tests never execute these lines, so a regression
+    start_trace() hits IntegrityError and upserts metadata/metrics/tags via per-row
+    session.merge(). This test forces that branch and asserts all three merge loops emit
+    keys in sorted order — the happy-path tests never execute these lines, so a regression
     that dropped the sort there would otherwise pass CI silently.
+
+    Tags share the same trace_tags_pk lock-ordering class as metadata/metrics: a
+    concurrent log_spans() also merges the trace's user tags, so unsorted tag merges here
+    can deadlock two writers on the tag PK-index the same way (#24338 follow-up). All three
+    row families now route through ``_merge_trace_child_rows_sorted``.
 
     We spy on Session.merge (the ORM operation the conflict branch actually uses) rather
     than the SQL cursor, because the merges here emit UPDATE statements (the keys were
     already inserted by log_spans) whose positional params carry no parseable column list.
+    The spy filters by row type and request_id, so the interleaved tag/assessment merges
+    the conflict branch also performs do not pollute the metadata/metric key lists.
     """
     experiment_id = store.create_experiment("sorted-order-conflict-path")
     trace_id = f"tr-{uuid.uuid4().hex}"
@@ -9898,9 +9905,10 @@ def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_ord
     }
     store.log_spans(experiment_id, [create_mlflow_span(otel_span, trace_id, "LLM")])
 
-    # 2. Record the key order of every metadata/metric row merged during start_trace().
+    # 2. Record the key order of every metadata/metric/tag row merged during start_trace().
     merged_metadata_keys: list[str] = []
     merged_metric_keys: list[str] = []
+    merged_tag_keys: list[str] = []
     real_merge = sqlalchemy.orm.Session.merge
 
     def _spy_merge(self, instance, *args, **kwargs):
@@ -9908,6 +9916,8 @@ def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_ord
             merged_metadata_keys.append(instance.key)
         elif isinstance(instance, SqlTraceMetrics) and instance.request_id == trace_id:
             merged_metric_keys.append(instance.key)
+        elif isinstance(instance, SqlTraceTag) and instance.request_id == trace_id:
+            merged_tag_keys.append(instance.key)
         return real_merge(self, instance, *args, **kwargs)
 
     # Metadata whose natural dict order is NOT sorted; token usage yields several
@@ -9922,25 +9932,155 @@ def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_ord
         }),
         "mlflow.traceInputs": "in",
     }
+    # Tags in deliberately unsorted insertion order so a dropped sort is observable.
+    trace_tags = {"zeta": "1", "alpha": "2", "mid": "3"}
     trace_info = TraceInfo(
         trace_id=trace_id,
         trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
         request_time=0,
         execution_duration=1,
         state=TraceState.OK,
-        tags={},
+        tags=trace_tags,
         trace_metadata=trace_metadata,
     )
 
     with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
         store.start_trace(trace_info)
 
-    # Both loops must actually have merged multiple keys, else the ordering assertions
+    # Each loop must actually have merged multiple keys, else the ordering assertions
     # are vacuous (e.g. if start_trace took the happy path instead of the conflict path).
     assert len(merged_metadata_keys) >= 2, merged_metadata_keys
     assert len(merged_metric_keys) >= 2, merged_metric_keys
+    assert len(merged_tag_keys) >= 2, merged_tag_keys
     assert merged_metadata_keys == sorted(merged_metadata_keys)
     assert merged_metric_keys == sorted(merged_metric_keys)
+    assert merged_tag_keys == sorted(merged_tag_keys)
+
+
+def test_log_spans_merges_user_trace_tags_in_sorted_key_order(store: SqlAlchemyStore):
+    """log_spans() merges user-defined trace tags (mlflow.traceTag.* span attributes) via
+    per-row session.merge(). A concurrent start_trace() merges the same tag keys, so
+    unsorted tag merges here can deadlock on trace_tags_pk (#24338 follow-up). Assert the
+    user tags are merged in sorted key order.
+
+    We isolate user tags by filtering to non-``mlflow.`` keys, so the SPANS_LOCATION tag,
+    the artifact-location tag, and any resource-namespace tags do not enter the assertion.
+    """
+    experiment_id = store.create_experiment("sorted-order-log-spans-tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    otel_span = create_test_otel_span(
+        trace_id=trace_id, name="root", trace_id_num=222, span_id_num=222
+    )
+    # User trace tags in deliberately unsorted insertion order.
+    otel_span._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        f"{SpanAttributeKey.TRACE_TAG_PREFIX}zeta": json.dumps("1"),
+        f"{SpanAttributeKey.TRACE_TAG_PREFIX}alpha": json.dumps("2"),
+        f"{SpanAttributeKey.TRACE_TAG_PREFIX}mid": json.dumps("3"),
+    }
+
+    merged_user_tag_keys: list[str] = []
+    real_merge = sqlalchemy.orm.Session.merge
+
+    def _spy_merge(self, instance, *args, **kwargs):
+        if (
+            isinstance(instance, SqlTraceTag)
+            and instance.request_id == trace_id
+            and not instance.key.startswith("mlflow.")
+        ):
+            merged_user_tag_keys.append(instance.key)
+        return real_merge(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
+        store.log_spans(experiment_id, [create_mlflow_span(otel_span, trace_id, "LLM")])
+
+    assert len(merged_user_tag_keys) >= 2, merged_user_tag_keys
+    assert merged_user_tag_keys == sorted(merged_user_tag_keys)
+
+
+def test_log_spans_merges_resource_attribute_tags_in_sorted_key_order(store: SqlAlchemyStore):
+    """Resource-attribute tags are also merged per-key via session.merge(), so they share
+    the trace_tags_pk lock-ordering class. Assert they are merged in sorted key order and
+    still write before user tags (precedence is covered separately).
+    """
+    experiment_id = store.create_experiment("sorted-order-resource-tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    resource = _OTelResource({"zeta": "z", "alpha": "a", "mid": "m"})
+    span = create_mlflow_span(
+        OTelReadableSpan(
+            name="root",
+            context=trace_api.SpanContext(
+                trace_id=333,
+                span_id=333,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            parent=None,
+            attributes={"mlflow.traceRequestId": json.dumps(trace_id)},
+            start_time=1000000000,
+            end_time=2000000000,
+            resource=resource,
+        ),
+        trace_id,
+    )
+
+    merged_resource_tag_keys: list[str] = []
+    real_merge = sqlalchemy.orm.Session.merge
+
+    def _spy_merge(self, instance, *args, **kwargs):
+        if (
+            isinstance(instance, SqlTraceTag)
+            and instance.request_id == trace_id
+            and instance.key in {"zeta", "alpha", "mid"}
+        ):
+            merged_resource_tag_keys.append(instance.key)
+        return real_merge(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
+        store.log_spans(experiment_id, [span])
+
+    assert len(merged_resource_tag_keys) >= 2, merged_resource_tag_keys
+    assert merged_resource_tag_keys == sorted(merged_resource_tag_keys)
+
+
+def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlchemyStore):
+    """The happy INSERT path attaches tags via a relationship-collection cascade, not
+    per-row merge, so the conflict-path spy test cannot cover it. Capture the constructed
+    ``sql_trace_info`` at ``session.add`` and assert the user tag rows were built in sorted
+    key order (excluding the trailing artifact-location tag appended after them).
+
+    Mirrors #24338's sorted metadata cascade so all trace child cascades are deterministic.
+    """
+    experiment_id = store.create_experiment("sorted-order-happy-path-tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=0,
+        execution_duration=1,
+        state=TraceState.OK,
+        tags={"zeta": "1", "alpha": "2", "mid": "3"},
+        trace_metadata={},
+    )
+
+    captured_tag_keys: list[str] = []
+    real_add = sqlalchemy.orm.Session.add
+
+    def _spy_add(self, instance, *args, **kwargs):
+        if isinstance(instance, SqlTraceInfo) and instance.request_id == trace_id:
+            # Exclude the artifact-location tag appended after the user tags.
+            captured_tag_keys.extend(
+                t.key for t in instance.tags if t.key != MLFLOW_ARTIFACT_LOCATION
+            )
+        return real_add(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "add", _spy_add):
+        store.start_trace(trace_info)
+
+    assert len(captured_tag_keys) >= 2, captured_tag_keys
+    assert captured_tag_keys == sorted(captured_tag_keys)
 
 
 @pytest.mark.parametrize(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10588,19 +10588,26 @@ def test_log_spans_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
         assert keys == sorted(keys), f"keys for {rid} not sorted: {keys}"
 
 
-def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_order(
+def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_key_order(
     store: SqlAlchemyStore,
 ):
     """The IntegrityError conflict path is where the reported start_trace()/log_spans()
     race actually occurs (issue #24332): log_spans() creates the trace first, then
-    start_trace() hits IntegrityError and upserts metadata/metrics via per-row
-    session.merge(). This test forces that branch and asserts BOTH merge loops emit keys
-    in sorted order — the happy-path tests never execute these lines, so a regression
+    start_trace() hits IntegrityError and upserts metadata/metrics/tags via per-row
+    session.merge(). This test forces that branch and asserts all three merge loops emit
+    keys in sorted order — the happy-path tests never execute these lines, so a regression
     that dropped the sort there would otherwise pass CI silently.
+
+    Tags share the same trace_tags_pk lock-ordering class as metadata/metrics: a
+    concurrent log_spans() also merges the trace's user tags, so unsorted tag merges here
+    can deadlock two writers on the tag PK-index the same way (#24338 follow-up). All three
+    row families now route through ``_merge_trace_child_rows_sorted``.
 
     We spy on Session.merge (the ORM operation the conflict branch actually uses) rather
     than the SQL cursor, because the merges here emit UPDATE statements (the keys were
     already inserted by log_spans) whose positional params carry no parseable column list.
+    The spy filters by row type and request_id, so the interleaved tag/assessment merges
+    the conflict branch also performs do not pollute the metadata/metric key lists.
     """
     experiment_id = store.create_experiment("sorted-order-conflict-path")
     trace_id = f"tr-{uuid.uuid4().hex}"
@@ -10620,9 +10627,10 @@ def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_ord
     }
     store.log_spans(experiment_id, [create_mlflow_span(otel_span, trace_id, "LLM")])
 
-    # 2. Record the key order of every metadata/metric row merged during start_trace().
+    # 2. Record the key order of every metadata/metric/tag row merged during start_trace().
     merged_metadata_keys: list[str] = []
     merged_metric_keys: list[str] = []
+    merged_tag_keys: list[str] = []
     real_merge = sqlalchemy.orm.Session.merge
 
     def _spy_merge(self, instance, *args, **kwargs):
@@ -10630,6 +10638,8 @@ def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_ord
             merged_metadata_keys.append(instance.key)
         elif isinstance(instance, SqlTraceMetrics) and instance.request_id == trace_id:
             merged_metric_keys.append(instance.key)
+        elif isinstance(instance, SqlTraceTag) and instance.request_id == trace_id:
+            merged_tag_keys.append(instance.key)
         return real_merge(self, instance, *args, **kwargs)
 
     # Metadata whose natural dict order is NOT sorted; token usage yields several
@@ -10644,25 +10654,155 @@ def test_start_trace_conflict_path_merges_metadata_and_metrics_in_sorted_key_ord
         }),
         "mlflow.traceInputs": "in",
     }
+    # Tags in deliberately unsorted insertion order so a dropped sort is observable.
+    trace_tags = {"zeta": "1", "alpha": "2", "mid": "3"}
     trace_info = TraceInfo(
         trace_id=trace_id,
         trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
         request_time=0,
         execution_duration=1,
         state=TraceState.OK,
-        tags={},
+        tags=trace_tags,
         trace_metadata=trace_metadata,
     )
 
     with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
         store.start_trace(trace_info)
 
-    # Both loops must actually have merged multiple keys, else the ordering assertions
+    # Each loop must actually have merged multiple keys, else the ordering assertions
     # are vacuous (e.g. if start_trace took the happy path instead of the conflict path).
     assert len(merged_metadata_keys) >= 2, merged_metadata_keys
     assert len(merged_metric_keys) >= 2, merged_metric_keys
+    assert len(merged_tag_keys) >= 2, merged_tag_keys
     assert merged_metadata_keys == sorted(merged_metadata_keys)
     assert merged_metric_keys == sorted(merged_metric_keys)
+    assert merged_tag_keys == sorted(merged_tag_keys)
+
+
+def test_log_spans_merges_user_trace_tags_in_sorted_key_order(store: SqlAlchemyStore):
+    """log_spans() merges user-defined trace tags (mlflow.traceTag.* span attributes) via
+    per-row session.merge(). A concurrent start_trace() merges the same tag keys, so
+    unsorted tag merges here can deadlock on trace_tags_pk (#24338 follow-up). Assert the
+    user tags are merged in sorted key order.
+
+    We isolate user tags by filtering to non-``mlflow.`` keys, so the SPANS_LOCATION tag,
+    the artifact-location tag, and any resource-namespace tags do not enter the assertion.
+    """
+    experiment_id = store.create_experiment("sorted-order-log-spans-tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    otel_span = create_test_otel_span(
+        trace_id=trace_id, name="root", trace_id_num=222, span_id_num=222
+    )
+    # User trace tags in deliberately unsorted insertion order.
+    otel_span._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        f"{SpanAttributeKey.TRACE_TAG_PREFIX}zeta": json.dumps("1"),
+        f"{SpanAttributeKey.TRACE_TAG_PREFIX}alpha": json.dumps("2"),
+        f"{SpanAttributeKey.TRACE_TAG_PREFIX}mid": json.dumps("3"),
+    }
+
+    merged_user_tag_keys: list[str] = []
+    real_merge = sqlalchemy.orm.Session.merge
+
+    def _spy_merge(self, instance, *args, **kwargs):
+        if (
+            isinstance(instance, SqlTraceTag)
+            and instance.request_id == trace_id
+            and not instance.key.startswith("mlflow.")
+        ):
+            merged_user_tag_keys.append(instance.key)
+        return real_merge(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
+        store.log_spans(experiment_id, [create_mlflow_span(otel_span, trace_id, "LLM")])
+
+    assert len(merged_user_tag_keys) >= 2, merged_user_tag_keys
+    assert merged_user_tag_keys == sorted(merged_user_tag_keys)
+
+
+def test_log_spans_merges_resource_attribute_tags_in_sorted_key_order(store: SqlAlchemyStore):
+    """Resource-attribute tags are also merged per-key via session.merge(), so they share
+    the trace_tags_pk lock-ordering class. Assert they are merged in sorted key order and
+    still write before user tags (precedence is covered separately).
+    """
+    experiment_id = store.create_experiment("sorted-order-resource-tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    resource = _OTelResource({"zeta": "z", "alpha": "a", "mid": "m"})
+    span = create_mlflow_span(
+        OTelReadableSpan(
+            name="root",
+            context=trace_api.SpanContext(
+                trace_id=333,
+                span_id=333,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            parent=None,
+            attributes={"mlflow.traceRequestId": json.dumps(trace_id)},
+            start_time=1000000000,
+            end_time=2000000000,
+            resource=resource,
+        ),
+        trace_id,
+    )
+
+    merged_resource_tag_keys: list[str] = []
+    real_merge = sqlalchemy.orm.Session.merge
+
+    def _spy_merge(self, instance, *args, **kwargs):
+        if (
+            isinstance(instance, SqlTraceTag)
+            and instance.request_id == trace_id
+            and instance.key in {"zeta", "alpha", "mid"}
+        ):
+            merged_resource_tag_keys.append(instance.key)
+        return real_merge(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
+        store.log_spans(experiment_id, [span])
+
+    assert len(merged_resource_tag_keys) >= 2, merged_resource_tag_keys
+    assert merged_resource_tag_keys == sorted(merged_resource_tag_keys)
+
+
+def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlchemyStore):
+    """The happy INSERT path attaches tags via a relationship-collection cascade, not
+    per-row merge, so the conflict-path spy test cannot cover it. Capture the constructed
+    ``sql_trace_info`` at ``session.add`` and assert the user tag rows were built in sorted
+    key order (excluding the trailing artifact-location tag appended after them).
+
+    Mirrors #24338's sorted metadata cascade so all trace child cascades are deterministic.
+    """
+    experiment_id = store.create_experiment("sorted-order-happy-path-tags")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
+        request_time=0,
+        execution_duration=1,
+        state=TraceState.OK,
+        tags={"zeta": "1", "alpha": "2", "mid": "3"},
+        trace_metadata={},
+    )
+
+    captured_tag_keys: list[str] = []
+    real_add = sqlalchemy.orm.Session.add
+
+    def _spy_add(self, instance, *args, **kwargs):
+        if isinstance(instance, SqlTraceInfo) and instance.request_id == trace_id:
+            # Exclude the artifact-location tag appended after the user tags.
+            captured_tag_keys.extend(
+                t.key for t in instance.tags if t.key != MLFLOW_ARTIFACT_LOCATION
+            )
+        return real_add(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "add", _spy_add):
+        store.start_trace(trace_info)
+
+    assert len(captured_tag_keys) >= 2, captured_tag_keys
+    assert captured_tag_keys == sorted(captured_tag_keys)
 
 
 @pytest.mark.parametrize(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5038,6 +5038,59 @@ def test_log_spans_locks_preexisting_trace_rows_only(store: SqlAlchemyStore) -> 
     assert store.get_trace_info(trace_id).token_usage["total_tokens"] == 300
 
 
+def test_log_spans_lock_refreshes_phase_one_trace_info(store: SqlAlchemyStore) -> None:
+    original_experiment_id = store.create_experiment("stale-parent-original")
+    refreshed_experiment_id = store.create_experiment("stale-parent-refreshed")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    _create_trace(store, trace_id, original_experiment_id)
+    original_lock = store._trace_row_lock_query
+
+    def update_before_lock(session, trace_ids):
+        # Phase 1 has cached the old parent. Simulate a concurrent commit before the locking
+        # reread; populate_existing() must replace that identity-map state.
+        with store.engine.begin() as connection:
+            connection.execute(
+                sqlalchemy
+                .update(SqlTraceInfo)
+                .where(SqlTraceInfo.request_id == trace_id)
+                .values(experiment_id=refreshed_experiment_id)
+            )
+        return original_lock(session, trace_ids)
+
+    span = create_test_span(trace_id, name="span", span_id=111, span_type="LLM")
+    with mock.patch.object(store, "_trace_row_lock_query", side_effect=update_before_lock):
+        store.log_spans(original_experiment_id, [span])
+
+    with store.ManagedSessionMaker() as session:
+        sql_span = session.query(SqlSpan).filter(SqlSpan.trace_id == trace_id).one()
+        assert sql_span.experiment_id == int(refreshed_experiment_id)
+
+
+def test_log_spans_locks_mssql_trace_rows_individually_in_sorted_order(
+    store: SqlAlchemyStore,
+) -> None:
+    experiment_id = store.create_experiment("mssql-parent-lock-order")
+    trace_ids = [f"tr-b-{uuid.uuid4().hex}", f"tr-a-{uuid.uuid4().hex}"]
+    for trace_id in trace_ids:
+        _create_trace(store, trace_id, experiment_id)
+    spans = [
+        create_test_span(trace_id, name="span", span_id=i, span_type="LLM")
+        for i, trace_id in enumerate(trace_ids, start=1)
+    ]
+
+    with (
+        mock.patch.object(store, "db_type", MSSQL),
+        mock.patch.object(
+            store, "_trace_row_lock_query", wraps=store._trace_row_lock_query
+        ) as mock_lock,
+    ):
+        store.log_spans(experiment_id, spans)
+
+    assert [call.args[1] for call in mock_lock.call_args_list] == [
+        [trace_id] for trace_id in sorted(trace_ids)
+    ]
+
+
 @pytest.mark.parametrize(
     ("db_type", "locking"),
     [

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5155,6 +5155,32 @@ def test_log_spans_locks_mssql_trace_rows_individually_in_sorted_order(
     ]
 
 
+def test_log_spans_reports_trace_deleted_before_mssql_parent_lock(
+    store: SqlAlchemyStore,
+) -> None:
+    experiment_id = store.create_experiment("mssql-parent-deleted-before-lock")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    _create_trace(store, trace_id, experiment_id)
+    span = create_test_span(trace_id, name="span", span_id=1, span_type="LLM")
+    missing_lock_query = mock.MagicMock()
+    missing_lock_query.one_or_none.return_value = None
+
+    with (
+        mock.patch.object(store, "db_type", MSSQL),
+        mock.patch.object(store, "_trace_row_lock_query", return_value=missing_lock_query),
+        pytest.raises(
+            MlflowException,
+            match=f"Cannot log spans to traces that no longer exist: '{trace_id}'",
+        ) as exc_info,
+    ):
+        store.log_spans(experiment_id, [span])
+
+    assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+    missing_lock_query.one_or_none.assert_called_once_with()
+    with store.ManagedSessionMaker() as session:
+        assert session.query(SqlSpan).filter(SqlSpan.trace_id == trace_id).count() == 0
+
+
 @pytest.mark.parametrize(
     ("db_type", "locking"),
     [

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -172,6 +172,70 @@ def test_legacy_start_and_end_trace_v2(store: SqlAlchemyStore):
     assert trace_info.to_v3() == store.get_trace_info(request_id)
 
 
+def test_end_trace_v2_locks_parent_before_merging_children(
+    store: SqlAlchemyStore, workspaces_enabled: bool
+):
+    experiment_id = store.create_experiment("test_end_trace_v2_lock_order")
+    request_id = store.deprecated_start_trace_v2(
+        experiment_id=experiment_id,
+        timestamp_ms=1234,
+        request_metadata={},
+        tags={},
+    ).request_id
+    events = []
+    original_trace_query = store._trace_query
+    original_merge = sqlalchemy_store_module._merge_trace_child_rows_in_lock_order
+
+    def tracked_trace_query(session, for_update_or_delete=False, workspace=None):
+        events.append(("trace_query", for_update_or_delete))
+        return original_trace_query(
+            session,
+            for_update_or_delete=for_update_or_delete,
+            workspace=workspace,
+        )
+
+    def tracked_merge(session, model_class, request_id, values):
+        events.append(model_class)
+        return original_merge(session, model_class, request_id, values)
+
+    with (
+        mock.patch.object(store, "_trace_query", side_effect=tracked_trace_query),
+        mock.patch.object(
+            sqlalchemy_store_module,
+            "_merge_trace_child_rows_in_lock_order",
+            side_effect=tracked_merge,
+        ),
+    ):
+        store.deprecated_end_trace_v2(
+            request_id=request_id,
+            timestamp_ms=2345,
+            status=TraceStatus.OK,
+            request_metadata={"metadata": "value"},
+            tags={"tag": "value"},
+        )
+
+        assert events == [("trace_query", True), SqlTraceMetadata, SqlTraceTag]
+
+        if workspaces_enabled:
+            store._get_workspace_provider_instance().create_workspace(Workspace(name="team-b"))
+            events.clear()
+            with WorkspaceContext("team-b"):
+                with pytest.raises(
+                    MlflowException,
+                    match=f"Trace with ID '{request_id}' not found.",
+                ) as exc_info:
+                    store.deprecated_end_trace_v2(
+                        request_id=request_id,
+                        timestamp_ms=3456,
+                        status=TraceStatus.OK,
+                        request_metadata={"other": "metadata"},
+                        tags={"other": "tag"},
+                    )
+
+            assert exc_info.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+            assert events == [("trace_query", True)]
+
+
 def test_start_trace(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_experiment")
     trace_info = TraceInfo(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10734,7 +10734,7 @@ def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_ke
     assert len(merged_tag_keys) >= 2, merged_tag_keys
     assert merged_metadata_keys == sorted(merged_metadata_keys)
     assert merged_metric_keys == sorted(merged_metric_keys)
-    assert merged_tag_keys == sorted(merged_tag_keys)
+    assert merged_tag_keys == sorted(trace_tags)
     assert result.tags[MLFLOW_ARTIFACT_LOCATION].endswith(f"/{trace_id}/artifacts")
 
 
@@ -10874,8 +10874,8 @@ def test_log_spans_merges_trace_tags_in_sorted_order_across_traces(store: SqlAlc
 def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlchemyStore):
     """The happy INSERT path attaches tags via a relationship-collection cascade, not
     per-row merge, so the conflict-path spy test cannot cover it. Capture the constructed
-    ``sql_trace_info`` at ``session.add`` and assert the user tag rows were built in sorted
-    key order (excluding the trailing artifact-location tag appended after them).
+    ``sql_trace_info`` at ``session.add`` and assert all tag rows were built from the merged
+    tag values in global sorted key order.
 
     Mirrors #24338's sorted metadata cascade so all trace child cascades are deterministic.
     """
@@ -10887,26 +10887,35 @@ def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlche
         request_time=0,
         execution_duration=1,
         state=TraceState.OK,
-        tags={"zeta": "1", "alpha": "2", "mid": "3"},
+        tags={
+            "zeta": "1",
+            MLFLOW_ARTIFACT_LOCATION: "user-supplied-location",
+            "alpha": "2",
+            "mid": "3",
+        },
         trace_metadata={},
     )
 
-    captured_tag_keys: list[str] = []
+    captured_tags: list[tuple[str, str]] = []
     real_add = sqlalchemy.orm.Session.add
 
     def _spy_add(self, instance, *args, **kwargs):
         if isinstance(instance, SqlTraceInfo) and instance.request_id == trace_id:
-            # Exclude the artifact-location tag appended after the user tags.
-            captured_tag_keys.extend(
-                t.key for t in instance.tags if t.key != MLFLOW_ARTIFACT_LOCATION
-            )
+            captured_tags.extend((tag.key, tag.value) for tag in instance.tags)
         return real_add(self, instance, *args, **kwargs)
 
     with mock.patch.object(sqlalchemy.orm.Session, "add", _spy_add):
         store.start_trace(trace_info)
 
-    assert len(captured_tag_keys) >= 2, captured_tag_keys
-    assert captured_tag_keys == sorted(captured_tag_keys)
+    artifact_location = dict(captured_tags)[MLFLOW_ARTIFACT_LOCATION]
+    assert artifact_location != "user-supplied-location"
+    assert artifact_location.endswith(f"/{trace_id}/artifacts")
+    assert captured_tags == sorted(
+        {
+            **trace_info.tags,
+            MLFLOW_ARTIFACT_LOCATION: artifact_location,
+        }.items()
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10812,13 +10812,13 @@ def test_log_spans_merges_all_trace_tags_in_global_sorted_key_order(store: SqlAl
     with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
         store.log_spans(experiment_id, [span])
 
-    assert merged_tag_keys == sorted({
+    assert merged_tag_keys == sorted([
         TraceTagKey.SPANS_LOCATION,
         "alpha",
         "omega",
         "shared",
         "zeta",
-    })
+    ])
     assert store.get_trace_info(trace_id).tags["shared"] == "user"
 
 
@@ -10855,14 +10855,14 @@ def test_log_spans_merges_trace_tags_in_sorted_order_across_traces(store: SqlAlc
             [make_span(trace_id_b, 444), make_span(trace_id_a, 555)],
         )
 
-    assert merged_tag_pairs == sorted({
+    assert merged_tag_pairs == sorted([
         (trace_id_a, TraceTagKey.SPANS_LOCATION),
         (trace_id_a, "alpha"),
         (trace_id_a, "zeta"),
         (trace_id_b, TraceTagKey.SPANS_LOCATION),
         (trace_id_b, "alpha"),
         (trace_id_b, "zeta"),
-    })
+    ])
 
 
 def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlchemyStore):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10654,7 +10654,7 @@ def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_ke
     Tags share the same trace_tags_pk lock-ordering class as metadata/metrics: a
     concurrent log_spans() also merges the trace's user tags, so unsorted tag merges here
     can deadlock two writers on the tag PK-index the same way (#24338 follow-up). All three
-    row families now route through ``_merge_trace_child_rows_sorted``.
+    row families now route through ``_merge_trace_child_rows_in_lock_order``.
 
     We spy on Session.merge (the ORM operation the conflict branch actually uses) rather
     than the SQL cursor, because the merges here emit UPDATE statements (the keys were
@@ -10774,15 +10774,11 @@ def test_log_spans_merges_user_trace_tags_in_sorted_key_order(store: SqlAlchemyS
     assert merged_user_tag_keys == sorted(merged_user_tag_keys)
 
 
-def test_log_spans_merges_resource_attribute_tags_in_sorted_key_order(store: SqlAlchemyStore):
-    """Resource-attribute tags are also merged per-key via session.merge(), so they share
-    the trace_tags_pk lock-ordering class. Assert they are merged in sorted key order and
-    still write before user tags (precedence is covered separately).
-    """
+def test_log_spans_merges_all_trace_tags_in_global_sorted_key_order(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("sorted-order-resource-tags")
     trace_id = f"tr-{uuid.uuid4().hex}"
 
-    resource = _OTelResource({"zeta": "z", "alpha": "a", "mid": "m"})
+    resource = _OTelResource({"zeta": "z", "shared": "resource", "alpha": "a"})
     span = create_mlflow_span(
         OTelReadableSpan(
             name="root",
@@ -10793,7 +10789,11 @@ def test_log_spans_merges_resource_attribute_tags_in_sorted_key_order(store: Sql
                 trace_flags=trace_api.TraceFlags(1),
             ),
             parent=None,
-            attributes={"mlflow.traceRequestId": json.dumps(trace_id)},
+            attributes={
+                "mlflow.traceRequestId": json.dumps(trace_id),
+                f"{SpanAttributeKey.TRACE_TAG_PREFIX}shared": json.dumps("user"),
+                f"{SpanAttributeKey.TRACE_TAG_PREFIX}omega": json.dumps("o"),
+            },
             start_time=1000000000,
             end_time=2000000000,
             resource=resource,
@@ -10801,23 +10801,25 @@ def test_log_spans_merges_resource_attribute_tags_in_sorted_key_order(store: Sql
         trace_id,
     )
 
-    merged_resource_tag_keys: list[str] = []
+    merged_tag_keys: list[str] = []
     real_merge = sqlalchemy.orm.Session.merge
 
     def _spy_merge(self, instance, *args, **kwargs):
-        if (
-            isinstance(instance, SqlTraceTag)
-            and instance.request_id == trace_id
-            and instance.key in {"zeta", "alpha", "mid"}
-        ):
-            merged_resource_tag_keys.append(instance.key)
+        if isinstance(instance, SqlTraceTag) and instance.request_id == trace_id:
+            merged_tag_keys.append(instance.key)
         return real_merge(self, instance, *args, **kwargs)
 
     with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
         store.log_spans(experiment_id, [span])
 
-    assert len(merged_resource_tag_keys) >= 2, merged_resource_tag_keys
-    assert merged_resource_tag_keys == sorted(merged_resource_tag_keys)
+    assert merged_tag_keys == sorted({
+        TraceTagKey.SPANS_LOCATION,
+        "alpha",
+        "omega",
+        "shared",
+        "zeta",
+    })
+    assert store.get_trace_info(trace_id).tags["shared"] == "user"
 
 
 def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlchemyStore):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10822,6 +10822,49 @@ def test_log_spans_merges_all_trace_tags_in_global_sorted_key_order(store: SqlAl
     assert store.get_trace_info(trace_id).tags["shared"] == "user"
 
 
+def test_log_spans_merges_trace_tags_in_sorted_order_across_traces(store: SqlAlchemyStore):
+    experiment_id = store.create_experiment("sorted-order-tags-across-traces")
+    trace_id_a = f"tr-a-{uuid.uuid4().hex}"
+    trace_id_b = f"tr-b-{uuid.uuid4().hex}"
+
+    def make_span(trace_id: str, span_id: int):
+        otel_span = create_test_otel_span(
+            trace_id=trace_id,
+            name="root",
+            trace_id_num=span_id,
+            span_id_num=span_id,
+        )
+        otel_span._attributes = {
+            "mlflow.traceRequestId": json.dumps(trace_id),
+            f"{SpanAttributeKey.TRACE_TAG_PREFIX}zeta": json.dumps("z"),
+            f"{SpanAttributeKey.TRACE_TAG_PREFIX}alpha": json.dumps("a"),
+        }
+        return create_mlflow_span(otel_span, trace_id, "LLM")
+
+    merged_tag_pairs: list[tuple[str, str]] = []
+    real_merge = sqlalchemy.orm.Session.merge
+
+    def _spy_merge(self, instance, *args, **kwargs):
+        if isinstance(instance, SqlTraceTag):
+            merged_tag_pairs.append((instance.request_id, instance.key))
+        return real_merge(self, instance, *args, **kwargs)
+
+    with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
+        store.log_spans(
+            experiment_id,
+            [make_span(trace_id_b, 444), make_span(trace_id_a, 555)],
+        )
+
+    assert merged_tag_pairs == sorted({
+        (trace_id_a, TraceTagKey.SPANS_LOCATION),
+        (trace_id_a, "alpha"),
+        (trace_id_a, "zeta"),
+        (trace_id_b, TraceTagKey.SPANS_LOCATION),
+        (trace_id_b, "alpha"),
+        (trace_id_b, "zeta"),
+    })
+
+
 def test_start_trace_happy_path_assigns_tags_in_sorted_key_order(store: SqlAlchemyStore):
     """The happy INSERT path attaches tags via a relationship-collection cascade, not
     per-row merge, so the conflict-path spy test cannot cover it. Capture the constructed

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10708,7 +10708,12 @@ def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_ke
         "mlflow.traceInputs": "in",
     }
     # Tags in deliberately unsorted insertion order so a dropped sort is observable.
-    trace_tags = {"zeta": "1", "alpha": "2", "mid": "3"}
+    trace_tags = {
+        "zeta": "1",
+        MLFLOW_ARTIFACT_LOCATION: "user-supplied-location",
+        "alpha": "2",
+        "mid": "3",
+    }
     trace_info = TraceInfo(
         trace_id=trace_id,
         trace_location=trace_location.TraceLocation.from_experiment_id(experiment_id),
@@ -10720,7 +10725,7 @@ def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_ke
     )
 
     with mock.patch.object(sqlalchemy.orm.Session, "merge", _spy_merge):
-        store.start_trace(trace_info)
+        result = store.start_trace(trace_info)
 
     # Each loop must actually have merged multiple keys, else the ordering assertions
     # are vacuous (e.g. if start_trace took the happy path instead of the conflict path).
@@ -10730,6 +10735,7 @@ def test_start_trace_conflict_path_merges_metadata_metrics_and_tags_in_sorted_ke
     assert merged_metadata_keys == sorted(merged_metadata_keys)
     assert merged_metric_keys == sorted(merged_metric_keys)
     assert merged_tag_keys == sorted(merged_tag_keys)
+    assert result.tags[MLFLOW_ARTIFACT_LOCATION].endswith(f"/{trace_id}/artifacts")
 
 
 def test_log_spans_merges_user_trace_tags_in_sorted_key_order(store: SqlAlchemyStore):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -10554,27 +10554,52 @@ def test_start_trace_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore)
     assert metadata_keys == sorted(metadata_keys)
 
 
-def test_deprecated_start_trace_v2_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):
-    """The legacy V2 start-trace path must also write metadata in sorted key order, so it
-    keeps a consistent PK-index lock order with the other writers (issue #24332).
+def test_deprecated_start_trace_v2_writes_child_rows_in_sorted_key_order(
+    store: SqlAlchemyStore,
+):
+    """The legacy V2 start-trace path must also write metadata and tags in sorted key order,
+    so it keeps a consistent PK-index lock order with the other writers (issue #24332).
     """
     experiment_id = store.create_experiment("sorted-order-v2")
     # Metadata whose natural dict order is NOT sorted.
     request_metadata = {"rq_z": "z", "rq_a": "a", "rq_m": "m"}
+    tags = {
+        "zeta": "1",
+        MLFLOW_ARTIFACT_LOCATION: "user-supplied-location",
+        "alpha": "2",
+    }
+    captured_tags: list[tuple[str, str]] = []
+    real_add = sqlalchemy.orm.Session.add
+
+    def _spy_add(self, instance, *args, **kwargs):
+        if isinstance(instance, SqlTraceInfo):
+            captured_tags.extend((tag.key, tag.value) for tag in instance.tags)
+        return real_add(self, instance, *args, **kwargs)
+
     captured, remove = _capture_trace_metadata_write_keys(store)
     try:
-        store.deprecated_start_trace_v2(
-            experiment_id=experiment_id,
-            timestamp_ms=1234,
-            request_metadata=request_metadata,
-            tags={},
-        )
+        with mock.patch.object(sqlalchemy.orm.Session, "add", _spy_add):
+            trace_info = store.deprecated_start_trace_v2(
+                experiment_id=experiment_id,
+                timestamp_ms=1234,
+                request_metadata=request_metadata,
+                tags=tags,
+            )
     finally:
         remove()
 
     metadata_keys = [k for k in captured if k in request_metadata]
     assert metadata_keys, "expected trace_request_metadata writes to be captured"
     assert metadata_keys == sorted(metadata_keys)
+    artifact_location = dict(captured_tags)[MLFLOW_ARTIFACT_LOCATION]
+    assert artifact_location != "user-supplied-location"
+    assert artifact_location.endswith(f"/{trace_info.request_id}/artifacts")
+    assert captured_tags == sorted(
+        {
+            **tags,
+            MLFLOW_ARTIFACT_LOCATION: artifact_location,
+        }.items()
+    )
 
 
 def test_log_spans_writes_metadata_in_sorted_key_order(store: SqlAlchemyStore):


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #24338, which fixed #24332.

### What changes are proposed in this pull request?

#24338 prevented a Postgres deadlock between concurrent `start_trace()` and `log_spans()` calls by writing trace metadata and metrics in deterministic `(request_id, key)` order. This follow-up closes the remaining lock-order gaps:

- Adds `_merge_trace_child_rows_in_lock_order()` as the single sorted-upsert path for `SqlTraceTag`, `SqlTraceMetadata`, and `SqlTraceMetrics` rows.
- Routes the `start_trace()` conflict path, `log_spans()`, and `deprecated_end_trace_v2()` through the helper. Tag values from the spans-location tag, OTel resource attributes, and user tags are combined before one globally sorted write, while preserving user-tag precedence.
- Sorts trace-tag cascade inserts in the `start_trace()` happy path and `deprecated_start_trace_v2()`.
- Strengthens parent-row locking before child writes: conflict paths lock and reread the persistent trace, `log_spans()` refreshes locked ORM state and acquires SQL Server locks one trace at a time in sorted order, and `deprecated_end_trace_v2()` takes a workspace-scoped parent lock before merging metadata and tags.
- Adds a `clint` rule that rejects direct loop-based merges of trace tag, metadata, or metric rows and points new call sites to the helper.

Together, these changes keep concurrent SQL trace writers on the same parent-before-child and `(request_id, key)` lock order. There are no schema or API changes; row ordering is not observable because tags, metadata, and metrics are returned as mappings.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Regression tests cover sorted child-row writes for `start_trace()`, `log_spans()`, and the deprecated V2 paths; global ordering across tag sources and trace IDs; tag precedence and artifact-location behavior; parent-lock acquisition and ORM refresh; deterministic SQL Server locking; and workspace isolation. The new `clint` rule is tested for both `for` and `async for` loops, nested loops, and allowed fixed-key/helper cases.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prevents remaining trace-tag and parent/child lock-order races from deadlocking concurrent SQL trace writes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
