### PR TITLE
Never surface an empty error message from the MLflow Assistant

### DIFF
--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -465,7 +465,7 @@ class ClaudeCodeProvider(AssistantProvider):
 
         except Exception as e:
             _logger.exception("Error running Claude Code CLI")
-            yield Event.from_error(str(e))
+            yield Event.from_exception(e)
         finally:
             if process is not None and process.returncode is None:
                 process.kill()

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -220,7 +220,7 @@ class CodexProvider(AssistantProvider):
 
         except Exception as e:
             _logger.exception("Error running Codex CLI")
-            yield Event.from_error(str(e))
+            yield Event.from_exception(e)
         finally:
             if mlflow_session_id:
                 clear_process_pid(mlflow_session_id)

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -669,4 +669,4 @@ class OpenAICompatibleProvider(AssistantProvider):
 
         except Exception as e:
             _logger.exception("Error communicating with %s", self._display_name)
-            yield Event.from_error(str(e))
+            yield Event.from_exception(e)

--- a/mlflow/assistant/types.py
+++ b/mlflow/assistant/types.py
@@ -78,7 +78,7 @@ class Event(BaseModel):
         return cls(type=EventType.ERROR, data={"error": error})
 
     @classmethod
-    def from_exception(cls, exc: BaseException) -> "Event":
+    def from_exception(cls, exc: Exception) -> "Event":
         # Some exceptions (e.g. NotImplementedError()) stringify to an empty
         # string, which would surface to the client as an undiagnosable
         # `{"error": ""}`. Fall back to the exception's repr so the error is

--- a/mlflow/assistant/types.py
+++ b/mlflow/assistant/types.py
@@ -78,6 +78,14 @@ class Event(BaseModel):
         return cls(type=EventType.ERROR, data={"error": error})
 
     @classmethod
+    def from_exception(cls, exc: BaseException) -> "Event":
+        # Some exceptions (e.g. NotImplementedError()) stringify to an empty
+        # string, which would surface to the client as an undiagnosable
+        # `{"error": ""}`. Fall back to the exception's repr so the error is
+        # always identifiable.
+        return cls.from_error(str(exc) or repr(exc))
+
+    @classmethod
     def from_message(cls, message: Message) -> "Event":
         return cls(type=EventType.MESSAGE, data={"message": message.model_dump()})
 

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -320,6 +320,29 @@ async def test_astream_handles_process_error():
 
 
 @pytest.mark.asyncio
+async def test_astream_surfaces_non_empty_error_for_empty_exception():
+    # On Windows with >1 server worker, the subprocess spawn raises a bare
+    # NotImplementedError() whose str() is "". The error must still be
+    # diagnosable rather than an empty `{"error": ""}`.
+    with (
+        patch(
+            "mlflow.assistant.providers.claude_code.shutil.which",
+            return_value="/usr/bin/claude",
+        ),
+        patch(
+            "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
+            side_effect=NotImplementedError(),
+        ) as mock_exec,
+    ):
+        provider = ClaudeCodeProvider()
+        events = [e async for e in provider.astream("test prompt", "http://localhost:5000")]
+
+    mock_exec.assert_called_once()
+    assert events[-1].type == EventType.ERROR
+    assert events[-1].data["error"] == "NotImplementedError()"
+
+
+@pytest.mark.asyncio
 async def test_astream_passes_session_id_for_resume():
     mock_process = MagicMock()
     mock_process.stdout = AsyncIterator([b'{"type": "result"}\n'])

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -338,8 +338,9 @@ async def test_astream_surfaces_non_empty_error_for_empty_exception():
         events = [e async for e in provider.astream("test prompt", "http://localhost:5000")]
 
     mock_exec.assert_called_once()
-    assert events[-1].type == EventType.ERROR
-    assert events[-1].data["error"] == "NotImplementedError()"
+    error_events = [e for e in events if e.type == EventType.ERROR]
+    assert len(error_events) == 1
+    assert error_events[0].data["error"] == "NotImplementedError()"
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -321,9 +321,8 @@ async def test_astream_handles_process_error():
 
 @pytest.mark.asyncio
 async def test_astream_surfaces_non_empty_error_for_empty_exception():
-    # On Windows with >1 server worker, the subprocess spawn raises a bare
-    # NotImplementedError() whose str() is "". The error must still be
-    # diagnosable rather than an empty `{"error": ""}`.
+    # A bare exception whose str() is "" (e.g. NotImplementedError()) must
+    # still surface a diagnosable error rather than an empty `{"error": ""}`.
     with (
         patch(
             "mlflow.assistant.providers.claude_code.shutil.which",

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -203,6 +203,27 @@ async def test_astream_yields_error_on_nonzero_exit():
 
 
 @pytest.mark.asyncio
+async def test_astream_surfaces_non_empty_error_for_empty_exception():
+    # On Windows with >1 server worker, the subprocess spawn raises a bare
+    # NotImplementedError() whose str() is "". The error must still be
+    # diagnosable rather than an empty `{"error": ""}`.
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            side_effect=NotImplementedError(),
+        ) as mock_exec,
+    ):
+        provider = CodexProvider()
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    mock_exec.assert_called_once()
+    error_events = [e for e in events if e.type == EventType.ERROR]
+    assert len(error_events) == 1
+    assert error_events[0].data["error"] == "NotImplementedError()"
+
+
+@pytest.mark.asyncio
 async def test_astream_yields_interrupted_on_sigkill():
     mock_proc = _mock_process(returncode=-9)
 

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -204,9 +204,8 @@ async def test_astream_yields_error_on_nonzero_exit():
 
 @pytest.mark.asyncio
 async def test_astream_surfaces_non_empty_error_for_empty_exception():
-    # On Windows with >1 server worker, the subprocess spawn raises a bare
-    # NotImplementedError() whose str() is "". The error must still be
-    # diagnosable rather than an empty `{"error": ""}`.
+    # A bare exception whose str() is "" (e.g. NotImplementedError()) must
+    # still surface a diagnosable error rather than an empty `{"error": ""}`.
     with (
         patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
         patch(

--- a/tests/assistant/test_types.py
+++ b/tests/assistant/test_types.py
@@ -1,0 +1,19 @@
+import pytest
+
+from mlflow.assistant.types import Event, EventType
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (NotImplementedError(), "NotImplementedError()"),
+        (ValueError(), "ValueError()"),
+        (RuntimeError("boom"), "boom"),
+        (ValueError("bad value"), "bad value"),
+    ],
+)
+def test_from_exception_never_yields_empty_error(exc, expected):
+    event = Event.from_exception(exc)
+    assert event.type == EventType.ERROR
+    assert event.data["error"] == expected
+    assert event.data["error"] != ""

--- a/tests/assistant/test_types.py
+++ b/tests/assistant/test_types.py
@@ -16,4 +16,3 @@ def test_from_exception_never_yields_empty_error(exc, expected):
     event = Event.from_exception(exc)
     assert event.type == EventType.ERROR
     assert event.data["error"] == expected
-    assert event.data["error"] != ""


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24405

### What changes are proposed in this pull request?

The in-app MLflow Assistant's CLI/HTTP providers wrap their streaming loop in a catch-all handler that emits `Event.from_error(str(e))`. Some exceptions stringify to the **empty string** — most notably a bare `NotImplementedError()`, which is what the Windows `SelectorEventLoop` raises when it can't spawn a subprocess (see #24405). The result is an undiagnosable SSE payload:

```
event: error
data: {"error": ""}
```

This PR makes the assistant error path always identifiable:

- Add `Event.from_exception(exc)` to `mlflow/assistant/types.py`, which falls back to `repr(exc)` when `str(exc)` is empty (so a bare `NotImplementedError()` surfaces as `"NotImplementedError()"` instead of `""`).
- Route the three provider catch-all handlers (`claude_code`, `codex`, `openai_compatible`) through it.

This is a **diagnosability** fix only — it does not change *when* errors occur. The functional Windows fix (making the subprocess actually spawn under a multi-worker server) is a separate PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `tests/assistant/test_types.py`: `Event.from_exception` yields a non-empty error for zero-arg exceptions (`NotImplementedError()`, `ValueError()`) and preserves the message for exceptions that have one.
- `tests/assistant/providers/test_{claude_code,codex}_provider.py`: patch `create_subprocess_exec` to raise a bare `NotImplementedError()` and assert the stream ends with a non-empty `{"error": "NotImplementedError()"}`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
