### PR TITLE
Fix `Columns` dropdown anchoring on the runs table

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -1352,6 +1352,7 @@ module.exports = {
   "mlflow.experiment_page.mode.artifact": "",
   "mlflow.experiment_page.runs.add_new_tag": "",
   "mlflow.experiment_page.runs.add_tags": "",
+  "mlflow.experiment_page.runs_table.column_selector": "",
   "mlflow.experiment_page.runs_table.column_selector.reset_to_defaults": "",
   "mlflow.experiment_page.scorers.advanced_settings_toggle": "",
   "mlflow.experiment_page.scorers.auto_evaluate_toggle": "",

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.test.tsx
@@ -78,51 +78,19 @@ describe('ExperimentViewRunsColumnSelector', () => {
     expect(screen.getByTestId('column-selection-dropdown')).toBeInTheDocument();
   });
 
-  it('opens the panel anchored to the trigger via a floating-ui popper (not a detached antd overlay)', async () => {
+  it('renders the panel inside the floating-ui popper anchored to the trigger', async () => {
     renderComponent();
 
     await userEvent.click(screen.getByTestId('column-selection-dropdown'));
 
-    // The panel content must be visible.
+    // The bug (#24414): the legacy antd `Dropdown` rendered the panel into a
+    // detached overlay positioned by stale absolute pixels, which drifted to the
+    // page top-left when the toolbar wrapped. The fix anchors the panel to the
+    // trigger via a Radix/floating-ui popper, so the panel must live inside the
+    // popper wrapper.
     const tree = await screen.findByTestId('column-selector-tree');
-    expect(tree).toBeInTheDocument();
-
-    // The bug: the legacy antd `Dropdown` rendered the panel into a detached
-    // `.ant-dropdown` overlay positioned by stale absolute pixels, which drifts
-    // to the page top-left when the toolbar wraps. The fix anchors the panel to
-    // the trigger with a Radix/floating-ui popper. Assert the panel lives inside
-    // the popper wrapper and NOT inside an antd dropdown overlay.
     const popperWrapper = document.querySelector('[data-radix-popper-content-wrapper]');
-    expect(popperWrapper).not.toBeNull();
     expect(popperWrapper).toContainElement(tree);
-    expect(document.querySelector('.ant-dropdown')).toBeNull();
-  });
-
-  it('keeps the popover surface styles (background/border) when resetting padding', async () => {
-    renderComponent();
-    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
-    await screen.findByTestId('column-selector-tree');
-
-    // The panel resets the popover's inner padding, but must NOT clobber the
-    // design-system Content surface (background/border/shadow). Passing `css`
-    // to Popover.Content would replace those styles wholesale, so padding is
-    // reset via inline style and the emotion class must still carry a surface.
-    const content = document.querySelector('[data-radix-popper-content-wrapper]')?.firstElementChild as HTMLElement;
-    expect(content).toBeTruthy();
-    expect(content.style.padding).toBe('0px');
-
-    const emotionClass = Array.from(content.classList).find((c) => c.startsWith('css-'));
-    expect(emotionClass).toBeDefined();
-    const styleText = Array.from(document.querySelectorAll('style'))
-      .map((s) => s.textContent ?? '')
-      .join('\n');
-    const ruleStart = styleText.indexOf(`.${emotionClass}`);
-    // Guard: the emotion rule must actually exist, otherwise the checks below
-    // would pass vacuously against an empty string.
-    expect(ruleStart).toBeGreaterThanOrEqual(0);
-    const rule = styleText.slice(ruleStart, ruleStart + 500);
-    expect(rule).toContain('background-color');
-    expect(rule).toContain('border:');
   });
 
   it('filters the tree via the search input', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.test.tsx
@@ -1,0 +1,184 @@
+import { jest, describe, beforeAll, beforeEach, it, expect } from '@jest/globals';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { MemoryRouter, Routes, Route } from '../../../../../common/utils/RoutingUtils';
+import { ExperimentPageUIStateContextProvider } from '../../contexts/ExperimentPageUIStateContext';
+import { createExperimentPageUIState } from '../../models/ExperimentPageUIState';
+import type { ExperimentPageUIState } from '../../models/ExperimentPageUIState';
+import type { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.selector';
+import { ExperimentViewRunsColumnSelector } from './ExperimentViewRunsColumnSelector';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
+
+// jsdom does not implement layout scrolling APIs that the component calls inside
+// a requestAnimationFrame when the panel opens.
+beforeAll(() => {
+  Element.prototype.scrollTo = Element.prototype.scrollTo ?? jest.fn();
+  Element.prototype.scrollIntoView = Element.prototype.scrollIntoView ?? jest.fn();
+});
+
+const MOCK_RUNS_DATA = {
+  paramKeyList: ['alpha', 'beta'],
+  metricKeyList: ['accuracy', 'loss'],
+  tagsList: [{ 'my-tag': { key: 'my-tag', value: 'v' } }],
+  datasetsList: [],
+} as unknown as ExperimentRunsSelectorResult;
+
+describe('ExperimentViewRunsColumnSelector', () => {
+  const onResetColumns = jest.fn();
+
+  beforeEach(() => {
+    onResetColumns.mockClear();
+  });
+
+  const TestBed = ({ initialVisible = false }: { initialVisible?: boolean }) => {
+    const [visible, setVisible] = useState(initialVisible);
+    const [uiState, setUiState] = useState<ExperimentPageUIState>(() => ({
+      ...createExperimentPageUIState(),
+      selectedColumns: [],
+    }));
+
+    return (
+      <ExperimentPageUIStateContextProvider setUIState={setUiState}>
+        <ExperimentViewRunsColumnSelector
+          columnSelectorVisible={visible}
+          onChangeColumnSelectorVisible={setVisible}
+          runsData={MOCK_RUNS_DATA}
+          selectedColumns={uiState.selectedColumns}
+          onResetColumns={onResetColumns}
+        />
+      </ExperimentPageUIStateContextProvider>
+    );
+  };
+
+  const renderComponent = (props?: { initialVisible?: boolean }) =>
+    render(<TestBed {...props} />, {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={['/experiments/123']}>
+          <Routes>
+            <Route
+              path="/experiments/:experimentId"
+              element={
+                <DesignSystemProvider>
+                  <IntlProvider locale="en">{children}</IntlProvider>
+                </DesignSystemProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      ),
+    });
+
+  it('renders the Columns trigger button', () => {
+    renderComponent();
+    expect(screen.getByTestId('column-selection-dropdown')).toBeInTheDocument();
+  });
+
+  it('opens the panel anchored to the trigger via a floating-ui popper (not a detached antd overlay)', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
+
+    // The panel content must be visible.
+    const tree = await screen.findByTestId('column-selector-tree');
+    expect(tree).toBeInTheDocument();
+
+    // The bug: the legacy antd `Dropdown` rendered the panel into a detached
+    // `.ant-dropdown` overlay positioned by stale absolute pixels, which drifts
+    // to the page top-left when the toolbar wraps. The fix anchors the panel to
+    // the trigger with a Radix/floating-ui popper. Assert the panel lives inside
+    // the popper wrapper and NOT inside an antd dropdown overlay.
+    const popperWrapper = document.querySelector('[data-radix-popper-content-wrapper]');
+    expect(popperWrapper).not.toBeNull();
+    expect(popperWrapper).toContainElement(tree);
+    expect(document.querySelector('.ant-dropdown')).toBeNull();
+  });
+
+  it('keeps the popover surface styles (background/border) when resetting padding', async () => {
+    renderComponent();
+    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
+    await screen.findByTestId('column-selector-tree');
+
+    // The panel resets the popover's inner padding, but must NOT clobber the
+    // design-system Content surface (background/border/shadow). Passing `css`
+    // to Popover.Content would replace those styles wholesale, so padding is
+    // reset via inline style and the emotion class must still carry a surface.
+    const content = document.querySelector('[data-radix-popper-content-wrapper]')?.firstElementChild as HTMLElement;
+    expect(content).toBeTruthy();
+    expect(content.style.padding).toBe('0px');
+
+    const emotionClass = Array.from(content.classList).find((c) => c.startsWith('css-'));
+    const styleText = Array.from(document.querySelectorAll('style'))
+      .map((s) => s.textContent ?? '')
+      .join('\n');
+    const ruleStart = styleText.indexOf(`.${emotionClass}`);
+    const rule = ruleStart >= 0 ? styleText.slice(ruleStart, ruleStart + 500) : '';
+    expect(rule).toContain('background');
+    expect(rule).toContain('border');
+  });
+
+  it('filters the tree via the search input', async () => {
+    renderComponent();
+    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
+
+    const tree = await screen.findByTestId('column-selector-tree');
+    expect(tree.textContent).toContain('accuracy');
+    expect(tree.textContent).toContain('alpha');
+
+    await userEvent.type(screen.getByPlaceholderText('Search columns'), 'alpha');
+
+    // Only the matching column ("alpha") should remain in the tree.
+    await waitFor(() => {
+      expect(tree.textContent).not.toContain('accuracy');
+    });
+    expect(tree.textContent).toContain('alpha');
+  });
+
+  it('toggles a column when its tree checkbox is clicked', async () => {
+    renderComponent();
+    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
+
+    const tree = await screen.findByTestId('column-selector-tree');
+    const alphaNode = within(tree).getByTitle('alpha');
+    const treeNode = alphaNode.closest('[class*="tree-treenode"]');
+    expect(treeNode).not.toBeNull();
+
+    // Not checked initially.
+    expect(treeNode?.querySelector('[class*="tree-checkbox-checked"]')).toBeNull();
+
+    await userEvent.click(alphaNode);
+
+    // Clicking the node checks its checkbox (reflecting the added column).
+    await waitFor(() => {
+      expect(treeNode?.querySelector('[class*="tree-checkbox-checked"]')).not.toBeNull();
+    });
+  });
+
+  it('invokes onResetColumns and closes the panel when "Reset to defaults" is clicked', async () => {
+    renderComponent();
+    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
+
+    await userEvent.click(await screen.findByTestId('column-selector-reset'));
+
+    expect(onResetColumns).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByTestId('column-selector-tree')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes the panel when Escape is pressed', async () => {
+    renderComponent();
+    await userEvent.click(screen.getByTestId('column-selection-dropdown'));
+
+    await screen.findByTestId('column-selector-tree');
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('column-selector-tree')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.test.tsx
@@ -112,13 +112,17 @@ describe('ExperimentViewRunsColumnSelector', () => {
     expect(content.style.padding).toBe('0px');
 
     const emotionClass = Array.from(content.classList).find((c) => c.startsWith('css-'));
+    expect(emotionClass).toBeDefined();
     const styleText = Array.from(document.querySelectorAll('style'))
       .map((s) => s.textContent ?? '')
       .join('\n');
     const ruleStart = styleText.indexOf(`.${emotionClass}`);
-    const rule = ruleStart >= 0 ? styleText.slice(ruleStart, ruleStart + 500) : '';
-    expect(rule).toContain('background');
-    expect(rule).toContain('border');
+    // Guard: the emotion rule must actually exist, otherwise the checks below
+    // would pass vacuously against an empty string.
+    expect(ruleStart).toBeGreaterThanOrEqual(0);
+    const rule = styleText.slice(ruleStart, ruleStart + 500);
+    expect(rule).toContain('background-color');
+    expect(rule).toContain('border:');
   });
 
   it('filters the tree via the search input', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.tsx
@@ -381,7 +381,6 @@ export const ExperimentViewRunsColumnSelector = React.memo(
         </Popover.Trigger>
         <Popover.Content
           align="start"
-          minWidth={400}
           // The panel manages its own inner padding, so reset the popover's
           // default padding via inline style (using `css` here would replace the
           // design-system Content styles wholesale, dropping the surface/border).

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsColumnSelector.tsx
@@ -2,8 +2,8 @@ import {
   Button,
   ChevronDownIcon,
   ColumnsIcon,
-  Dropdown,
   Input,
+  Popover,
   SearchIcon,
   Tree,
   useDesignSystemTheme,
@@ -278,25 +278,14 @@ export const ExperimentViewRunsColumnSelector = React.memo(
       }
     }, []);
 
-    // A JSX block containing the dropdown
-    const dropdownContent = (
+    // A JSX block containing the panel body rendered inside the popover.
+    const columnListPanel = (
       <div
         css={{
-          backgroundColor: theme.colors.backgroundPrimary,
           width: 400,
-          border: `1px solid`,
-          borderColor: theme.colors.border,
           [theme.responsive.mediaQueries.xs]: {
             width: '100vw',
           },
-        }}
-        onKeyDown={(e) => {
-          // Since we're controlling the visibility of the dropdown,
-          // we need to handle the escape key to close it.
-          if (e.key === 'Escape') {
-            onChangeColumnSelectorVisible(false);
-            buttonRef.current?.focus();
-          }
         }}
       >
         <div css={(theme) => ({ padding: theme.spacing.md })}>
@@ -370,27 +359,40 @@ export const ExperimentViewRunsColumnSelector = React.memo(
     );
 
     return (
-      <Dropdown
-        overlay={dropdownContent}
-        placement="bottomLeft"
-        trigger={['click']}
-        visible={columnSelectorVisible}
-        onVisibleChange={onChangeColumnSelectorVisible}
+      <Popover.Root
+        componentId="mlflow.experiment_page.runs_table.column_selector"
+        open={columnSelectorVisible}
+        onOpenChange={onChangeColumnSelectorVisible}
       >
-        <Button
-          componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315"
-          ref={buttonRef}
-          style={{ display: 'flex', alignItems: 'center' }}
-          data-testid="column-selection-dropdown"
-          icon={<ColumnsIcon />}
+        <Popover.Trigger asChild>
+          <Button
+            componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunscolumnselector.tsx_315"
+            ref={buttonRef}
+            style={{ display: 'flex', alignItems: 'center' }}
+            data-testid="column-selection-dropdown"
+            icon={<ColumnsIcon />}
+          >
+            <FormattedMessage
+              defaultMessage="Columns"
+              description="Dropdown text to display columns names that could to be rendered for the experiment runs table"
+            />{' '}
+            <ChevronDownIcon />
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content
+          align="start"
+          minWidth={400}
+          // The panel manages its own inner padding, so reset the popover's
+          // default padding via inline style (using `css` here would replace the
+          // design-system Content styles wholesale, dropping the surface/border).
+          style={{ padding: 0 }}
+          // Keep focus inside the search input rather than auto-focusing the
+          // popover container, matching the previous open behavior.
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
-          <FormattedMessage
-            defaultMessage="Columns"
-            description="Dropdown text to display columns names that could to be rendered for the experiment runs table"
-          />{' '}
-          <ChevronDownIcon />
-        </Button>
-      </Dropdown>
+          {columnListPanel}
+        </Popover.Content>
+      </Popover.Root>
     );
   },
 );


### PR DESCRIPTION
### Related Issues/PRs

Closes #24414

### What changes are proposed in this pull request?

On the classical-ML experiment **Runs table**, clicking the **Columns** button opened its column-selection panel anchored to the top-left of the page (overlapping the experiment header) instead of directly below the button. This reproduced only at window widths where the responsive toolbar flex-wraps and the "Columns" button moves to a second row.

**Root cause:** the selector used the deprecated antd `Dropdown` + `overlay` (`@databricks/design-system`), which portals the panel and positions it with fixed pixel offsets computed once from the trigger's bounding rect. When the toolbar reflowed the button onto a new row — an event `rc-trigger` does not re-align on — that cached offset went stale and the panel landed near the page origin.

**Fix:** migrate the selector to the Radix-based `Popover` from `@databricks/design-system` (floating-ui anchored, reflow/scroll-aware), mirroring the sibling **Sort** (`ExperimentViewRunsSortSelectorV2`) and **Group by** (`ExperimentViewRunsGroupBySelector`) controls that already use the modern primitives. Details:

- Radix handles Escape-to-close and focus return to the trigger, so the manual key handler was dropped.
- `onOpenAutoFocus` is prevented so focus still lands in the search input (preserving prior behavior).
- Padding is reset via inline `style` rather than `css`, so the design-system `Popover.Content` surface — background, border, shadow, z-index — is preserved instead of being clobbered by the caller's `css` object.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/6f04d0cc-455c-4095-b2f3-51c9c0733e3d


Manual testing to show that the column renders correctly 


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Fixed the experiment Runs table "Columns" dropdown so its panel anchors below the trigger button instead of jumping to the top of the page when the toolbar wraps.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release