### PR TITLE
fix: prevent 'table already exists' error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,8 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if not _all_tables_exist(engine):
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.x to 3.8.x, the database upgrade fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_initialize_tables` unconditionally calls `InitialBase.metadata.create_all(engine)`, which tries to create all tables regardless of whether they already exist.

## Fix
Add a check using the existing `_all_tables_exist` function before calling `create_all`. If all tables already exist, we skip the creation step and proceed directly to the Alembic migration (`_upgrade_db`). This prevents the duplicate table error.

Closes #19943