### PR TITLE
Change MCPAccessEndpoint ID from auto-increment integer to UUID string

### DIFF
--- a/mlflow/entities/mcp_access_endpoint.py
+++ b/mlflow/entities/mcp_access_endpoint.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @experimental(version="3.15.0")
 @dataclass
 class MCPAccessEndpoint:
-    id: int
+    id: str
     server_name: str
     url: str
     transport_type: MCPRemoteTransportType = MCPRemoteTransportType.STREAMABLE_HTTP

--- a/mlflow/genai/mcp_servers.py
+++ b/mlflow/genai/mcp_servers.py
@@ -515,7 +515,7 @@ def create_mcp_access_endpoint(
 
 
 @experimental(version="3.15.0")
-def get_mcp_access_endpoint(server_name: str, endpoint_id: int) -> MCPAccessEndpoint:
+def get_mcp_access_endpoint(server_name: str, endpoint_id: str) -> MCPAccessEndpoint:
     return MlflowClient().get_mcp_access_endpoint(server_name=server_name, endpoint_id=endpoint_id)
 
 
@@ -561,7 +561,7 @@ def search_mcp_access_endpoints(
 @experimental(version="3.15.0")
 def update_mcp_access_endpoint(
     server_name: str,
-    endpoint_id: int,
+    endpoint_id: str,
     url: str | None = NOT_SET,
     transport_type: Literal["streamable-http", "sse"] | None = NOT_SET,
     server_version: str | None = NOT_SET,
@@ -595,7 +595,7 @@ def update_mcp_access_endpoint(
 
 
 @experimental(version="3.15.0")
-def delete_mcp_access_endpoint(server_name: str, endpoint_id: int) -> None:
+def delete_mcp_access_endpoint(server_name: str, endpoint_id: str) -> None:
     MlflowClient().delete_mcp_access_endpoint(server_name=server_name, endpoint_id=endpoint_id)
 
 

--- a/mlflow/server/mcp_server_api.py
+++ b/mlflow/server/mcp_server_api.py
@@ -246,7 +246,7 @@ class AliasResponse(BaseModel):
 
 
 class MCPAccessEndpointSummaryResponse(BaseModel):
-    id: int
+    id: str
     server_name: str
     url: str
     transport_type: str = "streamable-http"
@@ -357,7 +357,7 @@ class MCPServerVersionResponse(BaseModel):
 
 
 class MCPAccessEndpointResponse(BaseModel):
-    id: int
+    id: str
     server_name: str
     url: str
     transport_type: str = "streamable-http"
@@ -520,7 +520,7 @@ def _ensure_version_create_parent_access(
 
 
 def _update_mcp_access_endpoint_kwargs(
-    server_name: str, endpoint_id: int, body: UpdateMCPAccessEndpointRequest
+    server_name: str, endpoint_id: str, body: UpdateMCPAccessEndpointRequest
 ) -> dict[str, Any]:
     kwargs: dict[str, Any] = {"server_name": server_name, "endpoint_id": endpoint_id}
     provided_fields = body.model_fields_set
@@ -729,7 +729,7 @@ def create_mcp_access_endpoint(
     "/{name:path}/endpoints/{endpoint_id}",
     response_model=MCPAccessEndpointResponse,
 )
-def get_mcp_access_endpoint(name: str, endpoint_id: int) -> MCPAccessEndpointResponse:
+def get_mcp_access_endpoint(name: str, endpoint_id: str) -> MCPAccessEndpointResponse:
     from mlflow.server.handlers import _get_tracking_store
 
     store = _get_tracking_store()
@@ -742,7 +742,7 @@ def get_mcp_access_endpoint(name: str, endpoint_id: int) -> MCPAccessEndpointRes
     response_model=MCPAccessEndpointResponse,
 )
 def update_mcp_access_endpoint(
-    name: str, endpoint_id: int, body: UpdateMCPAccessEndpointRequest, request: Request
+    name: str, endpoint_id: str, body: UpdateMCPAccessEndpointRequest, request: Request
 ) -> MCPAccessEndpointResponse:
     from mlflow.server.handlers import _get_tracking_store
 
@@ -755,7 +755,7 @@ def update_mcp_access_endpoint(
 
 
 @mcp_server_router.delete("/{name:path}/endpoints/{endpoint_id}")
-def delete_mcp_access_endpoint(name: str, endpoint_id: int) -> dict[str, Any]:
+def delete_mcp_access_endpoint(name: str, endpoint_id: str) -> dict[str, Any]:
     from mlflow.server.handlers import _get_tracking_store
 
     _get_tracking_store().delete_mcp_access_endpoint(name, endpoint_id)

--- a/mlflow/store/db_migrations/versions/a8b9c0d1e2f3_add_mcp_server_registry_tables.py
+++ b/mlflow/store/db_migrations/versions/a8b9c0d1e2f3_add_mcp_server_registry_tables.py
@@ -158,7 +158,7 @@ def upgrade():
 
     op.create_table(
         "mcp_access_endpoints",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.String(length=36), nullable=False),
         sa.Column(
             "workspace",
             sa.String(length=63),

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -4162,7 +4162,7 @@ class SqlMCPServerAlias(Base):
 class SqlMCPAccessEndpoint(Base):
     __tablename__ = "mcp_access_endpoints"
 
-    id = Column(Integer, autoincrement=True)
+    id = Column(String(36))
     workspace = Column(
         String(63),
         nullable=False,

--- a/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
@@ -273,7 +273,7 @@ class MCPServerRegistryMixin:
         """
         raise NotImplementedError(self.__class__.__name__)
 
-    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> MCPAccessEndpoint:
+    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> MCPAccessEndpoint:
         """Retrieve a specific access endpoint.
 
         Args:
@@ -314,7 +314,7 @@ class MCPServerRegistryMixin:
     def update_mcp_access_endpoint(
         self,
         server_name: str,
-        endpoint_id: int,
+        endpoint_id: str,
         server_version: str | None = NOT_SET,
         server_alias: str | None = NOT_SET,
         url: str | None = NOT_SET,
@@ -340,7 +340,7 @@ class MCPServerRegistryMixin:
         """
         raise NotImplementedError(self.__class__.__name__)
 
-    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> None:
+    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> None:
         """Delete an access endpoint.
 
         Args:

--- a/mlflow/store/tracking/mcp_server_registry/rest_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/rest_mixin.py
@@ -17,7 +17,7 @@ from mlflow.utils.rest_utils import http_request, verify_rest_response
 _MCP_API_PREFIX = "/api/3.0/mlflow/mcp-servers"
 
 
-def _encode_path_param(value: str | int) -> str:
+def _encode_path_param(value: str) -> str:
     return quote(str(value), safe="")
 
 
@@ -241,7 +241,7 @@ class RestMCPServerRegistryMixin:
         data = self._mcp_request("POST", f"{_server_path(server_name)}/endpoints", json=body)
         return MCPAccessEndpoint.from_dict(data)
 
-    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> MCPAccessEndpoint:
+    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> MCPAccessEndpoint:
         data = self._mcp_request(
             "GET", f"{_server_path(server_name)}/endpoints/{_encode_path_param(endpoint_id)}"
         )
@@ -289,7 +289,7 @@ class RestMCPServerRegistryMixin:
     def update_mcp_access_endpoint(
         self,
         server_name: str,
-        endpoint_id: int,
+        endpoint_id: str,
         server_version: str | None = NOT_SET,
         server_alias: str | None = NOT_SET,
         url: str | None = NOT_SET,
@@ -312,7 +312,7 @@ class RestMCPServerRegistryMixin:
         )
         return MCPAccessEndpoint.from_dict(data)
 
-    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> None:
+    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> None:
         self._mcp_request(
             "DELETE", f"{_server_path(server_name)}/endpoints/{_encode_path_param(endpoint_id)}"
         )

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import uuid
 from typing import Any
 
 import sqlalchemy as sa
@@ -141,7 +142,7 @@ class SqlAlchemyMCPServerRegistryMixin:
 
     def _get_nested_endpoint_resolved_versions(
         self, session, servers
-    ) -> dict[int, MCPServerVersion | None]:
+    ) -> dict[str, MCPServerVersion | None]:
         endpoint_ids = [ep.id for server in servers for ep in server.access_endpoints]
         if not endpoint_ids:
             return {}
@@ -612,8 +613,10 @@ class SqlAlchemyMCPServerRegistryMixin:
                     )
             if server_alias is not None:
                 self._get_alias_target_version_or_raise(session, server_name, server_alias)
+            endpoint_id = f"ae-{uuid.uuid4().hex}"
             endpoint = self._with_workspace_field(
                 SqlMCPAccessEndpoint(
+                    id=endpoint_id,
                     server_name=server_name,
                     url=url,
                     transport_type=transport_type.value,
@@ -637,7 +640,7 @@ class SqlAlchemyMCPServerRegistryMixin:
     def _endpoint_query_with_version(
         self,
         session,
-        endpoint_ids: list[int] | None = None,
+        endpoint_ids: list[str] | None = None,
         server_name: str | None = None,
         server_version: str | None = None,
         server_alias: str | None = None,
@@ -667,7 +670,7 @@ class SqlAlchemyMCPServerRegistryMixin:
             .options(contains_eager(SqlMCPAccessEndpoint.resolved_version_rel))
         )
 
-    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> MCPAccessEndpoint:
+    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> MCPAccessEndpoint:
         with self.ManagedSessionMaker() as session:
             endpoint = self._endpoint_query_with_version(
                 session, endpoint_ids=[endpoint_id]
@@ -716,7 +719,7 @@ class SqlAlchemyMCPServerRegistryMixin:
     def update_mcp_access_endpoint(
         self,
         server_name: str,
-        endpoint_id: int,
+        endpoint_id: str,
         server_version: str | None = NOT_SET,
         server_alias: str | None = NOT_SET,
         url: str | None = NOT_SET,
@@ -791,7 +794,7 @@ class SqlAlchemyMCPServerRegistryMixin:
                 .to_mlflow_entity()
             )
 
-    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> None:
+    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> None:
         with self.ManagedSessionMaker(read_only=False) as session:
             endpoint = self._get_entity_or_raise(
                 session,
@@ -1020,7 +1023,7 @@ def _validate_status_transition(current: MCPStatus, new: MCPStatus) -> None:
 
 
 def _resolved_endpoint_targets_subquery(
-    endpoint_ids: list[int] | None = None,
+    endpoint_ids: list[str] | None = None,
     server_name: str | None = None,
     server_version: str | None = None,
     server_alias: str | None = None,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -6893,7 +6893,7 @@ class MlflowClient:
             server_alias=server_alias,
         )
 
-    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> MCPAccessEndpoint:
+    def get_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> MCPAccessEndpoint:
         return self._tracking_client.store.get_mcp_access_endpoint(
             server_name=server_name, endpoint_id=endpoint_id
         )
@@ -6921,7 +6921,7 @@ class MlflowClient:
     def update_mcp_access_endpoint(
         self,
         server_name: str,
-        endpoint_id: int,
+        endpoint_id: str,
         url: str | None = NOT_SET,
         transport_type: MCPRemoteTransportType | None = NOT_SET,
         server_version: str | None = NOT_SET,
@@ -6936,7 +6936,7 @@ class MlflowClient:
             server_alias=server_alias,
         )
 
-    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: int) -> None:
+    def delete_mcp_access_endpoint(self, server_name: str, endpoint_id: str) -> None:
         self._tracking_client.store.delete_mcp_access_endpoint(
             server_name=server_name, endpoint_id=endpoint_id
         )

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -96,6 +96,20 @@ CREATE TABLE jobs (
 )
 
 
+CREATE TABLE mcp_servers (
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	display_name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	description VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	icons NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_by VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_by VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_servers_pk PRIMARY KEY (workspace, name)
+)
+
+
 CREATE TABLE registered_models (
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	creation_time BIGINT,
@@ -253,6 +267,65 @@ CREATE TABLE logged_models (
 	status_message VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE mcp_access_endpoints (
+	id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	server_name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	server_version VARCHAR(128) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	server_alias VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	url VARCHAR(2048) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	transport_type VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('streamable-http') NOT NULL,
+	created_by VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_by VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_access_endpoints_pk PRIMARY KEY (id),
+	CONSTRAINT mcp_access_endpoints_server_fkey FOREIGN KEY(workspace, server_name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_aliases (
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	alias VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	version VARCHAR(128) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	CONSTRAINT mcp_server_aliases_pk PRIMARY KEY (workspace, name, alias),
+	CONSTRAINT mcp_server_aliases_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_tags (
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	key VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT mcp_server_tags_pk PRIMARY KEY (workspace, name, key),
+	CONSTRAINT mcp_server_tags_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_versions (
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	version VARCHAR(128) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	version_major INTEGER NOT NULL,
+	version_minor INTEGER NOT NULL,
+	version_patch INTEGER NOT NULL,
+	version_prerelease_sort_key VARCHAR(512) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	server_json NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	display_name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	status VARCHAR(20) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('draft') NOT NULL,
+	tools NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	source VARCHAR(512) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_by VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_by VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_server_versions_pk PRIMARY KEY (workspace, name, version),
+	CONSTRAINT mcp_server_versions_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 
@@ -508,6 +581,17 @@ CREATE TABLE logged_model_tags (
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
 	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE mcp_server_version_tags (
+	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
+	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	version VARCHAR(128) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	key VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT mcp_server_version_tags_pk PRIMARY KEY (workspace, name, version, key),
+	CONSTRAINT mcp_server_version_tags_version_fkey FOREIGN KEY(workspace, name, version) REFERENCES mcp_server_versions (workspace, name, version) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -97,6 +97,20 @@ CREATE TABLE jobs (
 )
 
 
+CREATE TABLE mcp_servers (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	display_name VARCHAR(256),
+	description TEXT,
+	icons JSON,
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	PRIMARY KEY (workspace, name)
+)
+
+
 CREATE TABLE registered_models (
 	name VARCHAR(256) NOT NULL,
 	creation_time BIGINT,
@@ -255,6 +269,65 @@ CREATE TABLE logged_models (
 	PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK ((`lifecycle_stage` in (_utf8mb4'active',_utf8mb4'deleted')))
+)
+
+
+CREATE TABLE mcp_access_endpoints (
+	id VARCHAR(36) NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	server_name VARCHAR(256) NOT NULL,
+	server_version VARCHAR(128),
+	server_alias VARCHAR(256),
+	url VARCHAR(2048) NOT NULL,
+	transport_type VARCHAR(32) DEFAULT 'streamable-http' NOT NULL,
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	PRIMARY KEY (id),
+	CONSTRAINT mcp_access_endpoints_server_fkey FOREIGN KEY(workspace, server_name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_aliases (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	alias VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	PRIMARY KEY (workspace, name, alias),
+	CONSTRAINT mcp_server_aliases_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_tags (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	PRIMARY KEY (workspace, name, key),
+	CONSTRAINT mcp_server_tags_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_versions (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	version_major INTEGER NOT NULL,
+	version_minor INTEGER NOT NULL,
+	version_patch INTEGER NOT NULL,
+	version_prerelease_sort_key VARCHAR(512) NOT NULL,
+	server_json JSON NOT NULL,
+	display_name VARCHAR(256),
+	status VARCHAR(20) DEFAULT 'draft' NOT NULL,
+	tools JSON,
+	source VARCHAR(512),
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	PRIMARY KEY (workspace, name, version),
+	CONSTRAINT mcp_server_versions_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 
@@ -514,6 +587,17 @@ CREATE TABLE logged_model_tags (
 	PRIMARY KEY (model_id, tag_key),
 	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE mcp_server_version_tags (
+	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	PRIMARY KEY (workspace, name, version, key),
+	CONSTRAINT mcp_server_version_tags_version_fkey FOREIGN KEY(workspace, name, version) REFERENCES mcp_server_versions (workspace, name, version) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -97,6 +97,20 @@ CREATE TABLE jobs (
 )
 
 
+CREATE TABLE mcp_servers (
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	display_name VARCHAR(256),
+	description TEXT,
+	icons JSON,
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_servers_pk PRIMARY KEY (workspace, name)
+)
+
+
 CREATE TABLE registered_models (
 	name VARCHAR(256) NOT NULL,
 	creation_time BIGINT,
@@ -257,6 +271,65 @@ CREATE TABLE logged_models (
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage::text = ANY (ARRAY['active'::character varying, 'deleted'::character varying]::text[]))
+)
+
+
+CREATE TABLE mcp_access_endpoints (
+	id VARCHAR(36) NOT NULL,
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	server_name VARCHAR(256) NOT NULL,
+	server_version VARCHAR(128),
+	server_alias VARCHAR(256),
+	url VARCHAR(2048) NOT NULL,
+	transport_type VARCHAR(32) DEFAULT 'streamable-http'::character varying NOT NULL,
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_access_endpoints_pk PRIMARY KEY (id),
+	CONSTRAINT mcp_access_endpoints_server_fkey FOREIGN KEY(workspace, server_name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_aliases (
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	alias VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	CONSTRAINT mcp_server_aliases_pk PRIMARY KEY (workspace, name, alias),
+	CONSTRAINT mcp_server_aliases_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_tags (
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT mcp_server_tags_pk PRIMARY KEY (workspace, name, key),
+	CONSTRAINT mcp_server_tags_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
+)
+
+
+CREATE TABLE mcp_server_versions (
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	version_major INTEGER NOT NULL,
+	version_minor INTEGER NOT NULL,
+	version_patch INTEGER NOT NULL,
+	version_prerelease_sort_key VARCHAR(512) NOT NULL,
+	server_json JSON NOT NULL,
+	display_name VARCHAR(256),
+	status VARCHAR(20) DEFAULT 'draft'::character varying NOT NULL,
+	tools JSON,
+	source VARCHAR(512),
+	created_by VARCHAR(256),
+	last_updated_by VARCHAR(256),
+	created_at BIGINT NOT NULL,
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT mcp_server_versions_pk PRIMARY KEY (workspace, name, version),
+	CONSTRAINT mcp_server_versions_server_fkey FOREIGN KEY(workspace, name) REFERENCES mcp_servers (workspace, name) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 
@@ -516,6 +589,17 @@ CREATE TABLE logged_model_tags (
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
 	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE mcp_server_version_tags (
+	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	version VARCHAR(128) NOT NULL,
+	key VARCHAR(250) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT mcp_server_version_tags_pk PRIMARY KEY (workspace, name, version, key),
+	CONSTRAINT mcp_server_version_tags_version_fkey FOREIGN KEY(workspace, name, version) REFERENCES mcp_server_versions (workspace, name, version) ON DELETE CASCADE ON UPDATE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -275,7 +275,7 @@ CREATE TABLE logged_models (
 
 
 CREATE TABLE mcp_access_endpoints (
-	id INTEGER NOT NULL,
+	id VARCHAR(36) NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	server_name VARCHAR(256) NOT NULL,
 	server_version VARCHAR(128),

--- a/tests/entities/test_mcp_server_entities.py
+++ b/tests/entities/test_mcp_server_entities.py
@@ -88,7 +88,7 @@ def test_mcp_server_from_dict():
         "aliases": [{"alias": "prod", "version": "1.0.0"}],
         "access_endpoints": [
             {
-                "id": 1,
+                "id": "ae-abc123",
                 "server_name": "test/server",
                 "url": "https://example.com/mcp",
             }
@@ -97,7 +97,7 @@ def test_mcp_server_from_dict():
     assert server.status == MCPStatus.ACTIVE
     assert server.tags == {"team": "platform"}
     assert server.aliases == {"prod": "1.0.0"}
-    assert server.access_endpoints[0].id == 1
+    assert server.access_endpoints[0].id == "ae-abc123"
 
 
 def test_mcp_server_version_workspace_resolution():
@@ -123,7 +123,7 @@ def test_mcp_server_version_from_dict():
 
 def test_mcp_access_endpoint_workspace_resolution():
     endpoint = MCPAccessEndpoint(
-        id=1,
+        id="ae-abc123",
         server_name="test/server",
         url="https://example.com/mcp",
     )
@@ -132,7 +132,7 @@ def test_mcp_access_endpoint_workspace_resolution():
 
 def test_mcp_access_endpoint_from_dict():
     endpoint = MCPAccessEndpoint.from_dict({
-        "id": 1,
+        "id": "ae-abc123",
         "server_name": "test/server",
         "url": "https://example.com/mcp",
         "resolved_version": {

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -275,7 +275,7 @@ CREATE TABLE logged_models (
 
 
 CREATE TABLE mcp_access_endpoints (
-	id INTEGER NOT NULL,
+	id VARCHAR(36) NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	server_name VARCHAR(256) NOT NULL,
 	server_version VARCHAR(128),

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py
@@ -445,7 +445,7 @@ def _insert_row(conn, table_name, workspace, overrides=None, seed=1):
             "version": mcp_server_version,
         },
         "mcp_access_endpoints": {
-            "id": seed,
+            "id": f"ae-{seed}",
             "workspace": workspace,
             "server_name": f"mcp_server_{seed}",
             "url": f"http://localhost/{seed}",

--- a/tests/store/tracking/test_rest_store_mcp_registry.py
+++ b/tests/store/tracking/test_rest_store_mcp_registry.py
@@ -102,7 +102,7 @@ def test_create_mcp_access_endpoint_preserves_workspace(rest_store, mock_http_re
     server_workspace = "production"
     mock_http_request.return_value = _make_response(
         json_data={
-            "id": 1,
+            "id": "ae-abc123",
             "server_name": "com.example/test-server",
             "url": "http://example.com",
             "transport_type": "streamable-http",
@@ -123,7 +123,7 @@ def test_get_mcp_access_endpoint_preserves_workspace(rest_store, mock_http_reque
     server_workspace = "production"
     mock_http_request.return_value = _make_response(
         json_data={
-            "id": 1,
+            "id": "ae-abc123",
             "server_name": "com.example/test-server",
             "url": "http://example.com",
             "transport_type": "streamable-http",
@@ -131,7 +131,7 @@ def test_get_mcp_access_endpoint_preserves_workspace(rest_store, mock_http_reque
         }
     )
 
-    endpoint = rest_store.get_mcp_access_endpoint("com.example/test-server", 1)
+    endpoint = rest_store.get_mcp_access_endpoint("com.example/test-server", "ae-abc123")
     assert endpoint.workspace == server_workspace
 
 
@@ -142,7 +142,7 @@ def test_get_mcp_server_preserves_endpoint_metadata(rest_store, mock_http_reques
             "status": "active",
             "access_endpoints": [
                 {
-                    "id": 1,
+                    "id": "ae-abc123",
                     "server_name": "com.example/test-server",
                     "url": "http://example.com",
                     "transport_type": "streamable-http",
@@ -176,7 +176,7 @@ def test_search_mcp_servers_preserves_endpoint_metadata(rest_store, mock_http_re
                     "status": "active",
                     "access_endpoints": [
                         {
-                            "id": 1,
+                            "id": "ae-abc123",
                             "server_name": "com.example/server1",
                             "url": "http://example1.com",
                             "transport_type": "streamable-http",
@@ -233,7 +233,7 @@ def test_invalid_status_enum_raises_mlflow_exception(rest_store, mock_http_reque
 def test_invalid_transport_type_raises_mlflow_exception(rest_store, mock_http_request):
     mock_http_request.return_value = _make_response(
         json_data={
-            "id": 1,
+            "id": "ae-abc123",
             "server_name": "com.example/test-server",
             "url": "http://example.com",
             "transport_type": "invalid-transport",
@@ -241,7 +241,7 @@ def test_invalid_transport_type_raises_mlflow_exception(rest_store, mock_http_re
     )
 
     with pytest.raises(MlflowException, match="Failed to parse.*transport"):
-        rest_store.get_mcp_access_endpoint("com.example/test-server", 1)
+        rest_store.get_mcp_access_endpoint("com.example/test-server", "ae-abc123")
 
 
 def test_non_dict_response_raises_mlflow_exception(rest_store, mock_http_request):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->
Change MCPAccessEndpoint ID from auto-increment integer to UUID string.

The MCPAccessEndpoint rename PR needs to go in first.

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
