### PR TITLE
Fix role modal resource pickers failing with `FEATURE_DISABLED` when workspaces are disabled

### DIFF
--- a/mlflow/server/js/src/admin/components/CreateRoleModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/CreateRoleModal.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { PointerEventsCheckLevel } from '@testing-library/user-event';
+import userEventGlobal from '@testing-library/user-event';
+import React from 'react';
+import { fireEvent, renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+
+import { CreateRoleModal } from './CreateRoleModal';
+
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+const mockCreateRoleMutateAsync = jest.fn<(...args: any[]) => any>();
+// Capturing mock: the workspace argument is what turns into the
+// ``X-MLFLOW-WORKSPACE`` header on the resource-picker list requests.
+const mockUseResourceOptionsQuery = jest.fn<(...args: any[]) => any>();
+const mockUseWorkspacesEnabled = jest.fn<() => { workspacesEnabled: boolean }>();
+
+jest.mock('../hooks', () => ({
+  useCreateRole: () => ({ mutateAsync: mockCreateRoleMutateAsync }),
+  useResourceOptionsQuery: (resourceType: string, workspace?: string) =>
+    mockUseResourceOptionsQuery(resourceType, workspace),
+  useUsersQuery: () => ({ data: { users: [] }, isLoading: false, error: null }),
+}));
+
+jest.mock('../../workspaces/hooks/useWorkspaces', () => ({
+  useWorkspaces: () => ({ workspaces: [{ name: 'default' }, { name: 'team-a' }], isLoading: false }),
+}));
+
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useWorkspacesEnabled: () => mockUseWorkspacesEnabled(),
+}));
+
+beforeEach(() => {
+  mockCreateRoleMutateAsync.mockReset();
+  mockUseResourceOptionsQuery.mockReset();
+  mockUseResourceOptionsQuery.mockReturnValue({ options: [], isLoading: false, error: null });
+  mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false });
+});
+
+describe('CreateRoleModal — workspace targeting on the resource picker', () => {
+  it('omits the workspace when workspaces are disabled', () => {
+    // Regression: single-tenant servers reject ANY ``X-MLFLOW-WORKSPACE``
+    // header (even ``default``) with FEATURE_DISABLED, so the picker query
+    // must not receive the modal's ``default``-initialized workspace state.
+    renderWithDesignSystem(<CreateRoleModal open onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Permissions/ }));
+
+    expect(mockUseResourceOptionsQuery).toHaveBeenCalledWith('experiment', undefined);
+  });
+
+  it('targets the selected workspace when workspaces are enabled', async () => {
+    mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: true });
+    renderWithDesignSystem(<CreateRoleModal open onClose={jest.fn()} />);
+
+    // A non-default workspace: the state initializes to ``'default'``, so
+    // asserting ``'default'`` here would pass on the broken code too.
+    await userEvent.click(document.getElementById('admin-create-role-modal-workspace')!);
+    await userEvent.click(await screen.findByRole('option', { name: 'team-a' }));
+    fireEvent.click(screen.getByRole('button', { name: /Permissions/ }));
+
+    expect(mockUseResourceOptionsQuery).toHaveBeenLastCalledWith('experiment', 'team-a');
+  });
+});

--- a/mlflow/server/js/src/admin/components/CreateRoleModal.tsx
+++ b/mlflow/server/js/src/admin/components/CreateRoleModal.tsx
@@ -49,6 +49,12 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
 
   const [name, setName] = useState('');
   const [workspace, setWorkspace] = useState(DEFAULT_WORKSPACE_NAME);
+  // In single-tenant mode there is no workspace dimension — pass ``undefined``
+  // to the resource picker so the ``X-MLFLOW-WORKSPACE`` header is omitted
+  // (the server rejects any workspace header, including ``default``, when
+  // workspaces are disabled). The create request keeps the explicit
+  // ``workspace`` body field, which the backend requires in both modes.
+  const resourcePickerWorkspace = workspacesEnabled ? workspace : undefined;
   const [description, setDescription] = useState('');
   const [permissions, setPermissions] = useState<StagedRolePermission[]>([]);
   const [usernames, setUsernames] = useState<string[]>([]);
@@ -262,7 +268,7 @@ export const CreateRoleModal = ({ open, onClose }: CreateRoleModalProps) => {
           key={String(open)}
           value={permissions}
           onChange={setPermissions}
-          workspace={workspace}
+          workspace={resourcePickerWorkspace}
           disabled={submitting}
           onUnsavedDraftChange={setHasUnsavedDraft}
         />

--- a/mlflow/server/js/src/admin/components/EditRoleModal.test.tsx
+++ b/mlflow/server/js/src/admin/components/EditRoleModal.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import React from 'react';
+import { renderWithDesignSystem, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+
+import { EditRoleModal } from './EditRoleModal';
+
+// Capturing mock: the workspace argument is what turns into the
+// ``X-MLFLOW-WORKSPACE`` header on the resource-picker list requests.
+const mockUseResourceOptionsQuery = jest.fn<(...args: any[]) => any>();
+const mockUseWorkspacesEnabled = jest.fn<() => { workspacesEnabled: boolean }>();
+
+jest.mock('../hooks', () => ({
+  useUpdateRole: () => ({ mutateAsync: jest.fn() }),
+  useAddPermission: () => ({ mutateAsync: jest.fn() }),
+  useRemovePermission: () => ({ mutateAsync: jest.fn() }),
+  useAssignRole: () => ({ mutateAsync: jest.fn() }),
+  useUnassignRole: () => ({ mutateAsync: jest.fn() }),
+  useRoleDetailQuery: () => ({
+    data: { role: { id: 1, name: 'team-role', description: '', workspace: 'team-a', permissions: [] } },
+    isLoading: false,
+  }),
+  useRoleUsersQuery: () => ({ data: { assignments: [] }, isLoading: false }),
+  useUsersQuery: () => ({ data: { users: [] }, isLoading: false, error: null }),
+  useResourceOptionsQuery: (resourceType: string, workspace?: string) =>
+    mockUseResourceOptionsQuery(resourceType, workspace),
+}));
+
+jest.mock('../../experiment-tracking/hooks/useServerInfo', () => ({
+  useWorkspacesEnabled: () => mockUseWorkspacesEnabled(),
+}));
+
+beforeEach(() => {
+  mockUseResourceOptionsQuery.mockReset();
+  mockUseResourceOptionsQuery.mockReturnValue({ options: [], isLoading: false, error: null });
+  mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: false });
+});
+
+describe('EditRoleModal — workspace targeting on the resource picker', () => {
+  it('omits the workspace when workspaces are disabled', async () => {
+    // Regression: single-tenant servers reject ANY ``X-MLFLOW-WORKSPACE``
+    // header with FEATURE_DISABLED, so the picker query must not receive the
+    // role's stored workspace when the workspace feature is off.
+    renderWithDesignSystem(<EditRoleModal open onClose={jest.fn()} roleId={1} />);
+
+    expect(await screen.findByText('Add a permission')).toBeInTheDocument();
+    expect(mockUseResourceOptionsQuery).toHaveBeenCalledWith('experiment', undefined);
+  });
+
+  it("targets the role's workspace when workspaces are enabled", async () => {
+    mockUseWorkspacesEnabled.mockReturnValue({ workspacesEnabled: true });
+    renderWithDesignSystem(<EditRoleModal open onClose={jest.fn()} roleId={1} />);
+
+    expect(await screen.findByText('Add a permission')).toBeInTheDocument();
+    expect(mockUseResourceOptionsQuery).toHaveBeenCalledWith('experiment', 'team-a');
+  });
+});

--- a/mlflow/server/js/src/admin/components/EditRoleModal.tsx
+++ b/mlflow/server/js/src/admin/components/EditRoleModal.tsx
@@ -23,6 +23,7 @@ import {
   useUpdateRole,
   useUsersQuery,
 } from '../hooks';
+import { useWorkspacesEnabled } from '../../experiment-tracking/hooks/useServerInfo';
 import { formatResourcePattern, parseResourcePattern } from '../types';
 import { RolePermissionsSection, type StagedRolePermission } from './RolePermissionsSection';
 import { RoleUsersSection } from './RoleUsersSection';
@@ -77,6 +78,12 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
   const currentName = roleData?.role?.name ?? '';
   const currentDescription = roleData?.role?.description ?? '';
   const currentWorkspace = roleData?.role?.workspace ?? '';
+  const { workspacesEnabled } = useWorkspacesEnabled();
+  // In single-tenant mode there is no workspace dimension — pass ``undefined``
+  // to the resource picker so the ``X-MLFLOW-WORKSPACE`` header is omitted
+  // (the server rejects any workspace header, including ``default``, when
+  // workspaces are disabled).
+  const resourcePickerWorkspace = workspacesEnabled ? currentWorkspace : undefined;
 
   const currentPermissions = useMemo<StagedRolePermission[]>(() => {
     return (roleData?.role?.permissions ?? []).map((p) => ({
@@ -419,7 +426,7 @@ export const EditRoleModal = ({ open, onClose, roleId }: EditRoleModalProps) => 
                   key={String(open)}
                   value={permissions}
                   onChange={setPermissions}
-                  workspace={currentWorkspace}
+                  workspace={resourcePickerWorkspace}
                   disabled={submitting}
                   onUnsavedDraftChange={setHasUnsavedDraft}
                 />


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24383

### What changes are proposed in this pull request?

Follow-up to #24383, which fixed the admin "Edit access" and "Create user" modals sending an `X-MLFLOW-WORKSPACE` header to servers running without `MLFLOW_ENABLE_WORKSPACES`. The role modals have the same bug: `CreateRoleModal` initializes its workspace state to `default` and `EditRoleModal` uses the role's stored workspace, and both pass that value unconditionally to the `RolePermissionsSection` resource pickers. The pickers then send `X-MLFLOW-WORKSPACE` on their list requests (e.g. experiment search), which single-tenant servers reject with `FEATURE_DISABLED` ("Workspace APIs are not available"), so the pickers fail to load any options.

This PR passes `undefined` as the picker workspace when `workspacesEnabled` is false, so the header is omitted. The create-role request itself keeps the explicit `workspace` body field, which the backend requires in both modes.

### How is this PR tested?

- [x] New unit/integration tests

New regression tests for both modals assert that the resource-picker query receives `undefined` when workspaces are disabled, and the selected (create) or stored (edit) workspace when enabled — using `team-a` rather than `default` so the enabled-mode assertions fail on the broken code too.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed the admin role modals' resource pickers failing with `FEATURE_DISABLED` on servers running without workspaces enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release