### PR TITLE
[BUG] Fix link_prompts_to_trace silently succeeding for nonexistent traces

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -801,13 +801,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         In single-tenant mode, validates that the trace exists. Workspace-aware
         subclasses override this to also enforce workspace scoping.
         """
-        exists_row = (
-            session
-            .query(SqlTraceInfo.request_id)
-            .filter(SqlTraceInfo.request_id == trace_id)
-            .first()
-        )
-        if exists_row is None:
+        if session.get(SqlTraceInfo, trace_id) is None:
             raise MlflowException(
                 f"Trace with ID '{trace_id}' not found.",
                 RESOURCE_DOES_NOT_EXIST,

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -796,12 +796,22 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
 
     def _validate_trace_accessible(self, session, trace_id: str) -> None:
         """
-        Hook for subclasses to validate trace access. No-op by default.
+        Hook for subclasses to validate trace access.
 
-        In single-tenant mode, validation is not needed - the database will
-        raise appropriate errors if the trace doesn't exist.
+        In single-tenant mode, validates that the trace exists. Workspace-aware
+        subclasses override this to also enforce workspace scoping.
         """
-        return
+        exists_row = (
+            session
+            .query(SqlTraceInfo.request_id)
+            .filter(SqlTraceInfo.request_id == trace_id)
+            .first()
+        )
+        if exists_row is None:
+            raise MlflowException(
+                f"Trace with ID '{trace_id}' not found.",
+                RESOURCE_DOES_NOT_EXIST,
+            )
 
     def _validate_dataset_accessible(self, session, dataset_id: str) -> None:
         """

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -3038,7 +3038,7 @@ def test_link_prompts_to_trace_nonexistent_trace(store: SqlAlchemyStore):
 
     with pytest.raises(MlflowException, match=r"Trace with ID .* not found") as excinfo:
         store.link_prompts_to_trace(trace_id, [prompt_version])
-    assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+    assert excinfo.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
 
     from mlflow.store.tracking.dbmodels.models import SqlEntityAssociation
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -3028,6 +3028,30 @@ def test_search_traces_with_prompts_filter_invalid_format(
         store.search_traces([exp_id], filter_string=filter_string)
 
 
+def test_link_prompts_to_trace_nonexistent_trace(store: SqlAlchemyStore):
+    trace_id = "tr-does-not-exist"
+    prompt_version = PromptVersion(
+        name="my-prompt",
+        version=1,
+        template="Hello {{name}}",
+    )
+
+    with pytest.raises(MlflowException, match=r"Trace with ID .* not found") as excinfo:
+        store.link_prompts_to_trace(trace_id, [prompt_version])
+    assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+    from mlflow.store.tracking.dbmodels.models import SqlEntityAssociation
+
+    with store.ManagedSessionMaker() as session:
+        count = (
+            session
+            .query(SqlEntityAssociation)
+            .filter(SqlEntityAssociation.source_id == trace_id)
+            .count()
+        )
+        assert count == 0
+
+
 def test_search_traces_with_prompts_filter_no_matches(store: SqlAlchemyStore):
     exp_id = store.create_experiment("test_prompts_no_match")
 


### PR DESCRIPTION
Validate trace existence in `SqlAlchemyStore._validate_trace_accessible` so single-tenant mode raises `RESOURCE_DOES_NOT_EXIST` instead of creating orphaned prompt associations.

Fixes #24067

### Related Issues/PRs

Closes #24067

### What changes are proposed in this pull request?

`SqlAlchemyStore.link_prompts_to_trace` already calls `_validate_trace_accessible`, but in single-tenant mode that hook was a no-op. Because `SqlEntityAssociation` has no foreign key to traces, linking prompts to a nonexistent `trace_id` silently created orphaned associations.

This PR updates `SqlAlchemyStore._validate_trace_accessible` to explicitly check for the trace in `SqlTraceInfo` and raise `RESOURCE_DOES_NOT_EXIST` when it is missing. Workspace-aware stores continue to use their existing workspace-scoped override.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_link_prompts_to_trace_nonexistent_trace` in `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py` to verify:
- `link_prompts_to_trace` raises `MlflowException` with `RESOURCE_DOES_NOT_EXIST` for a nonexistent trace
- No orphaned `SqlEntityAssociation` rows are created

Also verified related prompt-linking and workspace-scoped tests still pass.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`link_prompts_to_trace` now raises an error when the target trace does not exist, instead of silently creating orphaned prompt associations in single-tenant mode.

- [ ] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release