### PR TITLE
[BUG] Fix otel parent context propagation

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1829,6 +1829,7 @@ mlflow.tracing.disable
 mlflow.tracing.disable_notebook_display
 mlflow.tracing.enable
 mlflow.tracing.enable_notebook_display
+mlflow.tracing.get_bridged_tracer_provider
 mlflow.tracing.get_tracing_context_headers_for_http_request
 mlflow.tracing.reset
 mlflow.tracing.set_databricks_monitoring_sql_warehouse_id

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -928,6 +928,25 @@ MLFLOW_USE_DEFAULT_TRACER_PROVIDER = _BooleanEnvironmentVariable(
     "MLFLOW_USE_DEFAULT_TRACER_PROVIDER", True
 )
 
+#: When ``True`` (and MLflow is in isolated tracer provider mode, i.e.
+#: ``MLFLOW_USE_DEFAULT_TRACER_PROVIDER=True``), MLflow also propagates its active span into the
+#: process-global OpenTelemetry context. This lets pure-OpenTelemetry libraries (e.g.
+#: strands-agents, LangChain, LlamaIndex) that read the global OTel context via
+#: ``opentelemetry.trace.get_current_span()`` nest their spans under an MLflow span created with
+#: ``@mlflow.trace`` or ``mlflow.start_span()``.
+#:
+#: .. warning::
+#:     Enabling this makes MLflow's active span visible to *all* OpenTelemetry instrumentation
+#:     in the process (e.g. FastAPI, ``requests``), which reduces the isolation that isolated
+#:     tracer provider mode normally provides. Leave this disabled unless you need pure-OTel
+#:     libraries to nest under MLflow spans. It has no effect in unified mode
+#:     (``MLFLOW_USE_DEFAULT_TRACER_PROVIDER=False``), where the global context is used already.
+#:
+#: (default: ``False``)
+MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT = _BooleanEnvironmentVariable(
+    "MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT", False
+)
+
 #: When set to ``True``, MLflow uses a private ``random.Random`` instance for trace/span ID
 #: generation, making it immune to ``random.seed()`` calls in user code.  Enable this when
 #: ``random.seed()`` causes duplicate trace/span ID errors.

--- a/mlflow/tracing/__init__.py
+++ b/mlflow/tracing/__init__.py
@@ -7,7 +7,13 @@ from mlflow.tracing.distributed import (
     set_tracing_context_from_http_request_headers,
 )
 from mlflow.tracing.enablement import set_experiment_trace_location, unset_experiment_trace_location
-from mlflow.tracing.provider import disable, enable, reset, set_destination
+from mlflow.tracing.provider import (
+    disable,
+    enable,
+    get_bridged_tracer_provider,
+    reset,
+    set_destination,
+)
 from mlflow.tracing.utils import set_span_chat_tools
 
 __all__ = [
@@ -17,6 +23,7 @@ __all__ = [
     "enable",
     "disable_notebook_display",
     "enable_notebook_display",
+    "get_bridged_tracer_provider",
     "get_tracing_context_headers_for_http_request",
     "set_experiment_trace_location",
     "set_span_chat_tools",

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -332,7 +332,13 @@ def safe_set_span_in_context(span: "Span"):
         detach_span_from_context(token)
 
 
-def set_span_in_context(span: "Span") -> object:
+# Token(s) required to later detach a span from the context. In isolated tracer provider mode a
+# tuple of (MLflow runtime token, optional global OTel token) is returned; otherwise a single
+# OpenTelemetry context token is returned.
+SpanContextToken = contextvars.Token | tuple[contextvars.Token, contextvars.Token | None]
+
+
+def set_span_in_context(span: "Span") -> SpanContextToken:
     """
     Set the given OpenTelemetry span as the active span in the current context.
 
@@ -365,7 +371,7 @@ def set_span_in_context(span: "Span") -> object:
         return token
 
 
-def detach_span_from_context(token: object):
+def detach_span_from_context(token: SpanContextToken):
     """
     Remove the active span from the current context.
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -350,6 +350,9 @@ def set_span_in_context(span: "Span") -> SpanContextToken:
     """
     context = trace.set_span_in_context(span._span, context=get_current_context())
     if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
+        # Read the opt-in flag before attaching so that a malformed env var value raises here,
+        # rather than after `mlflow_runtime_context.attach` (which would orphan the token).
+        propagate_to_otel_context = MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.get()
         # In isolated tracer provider mode, attach to MLflow's runtime context so the span does
         # not get mixed with the native OpenTelemetry runtime context.
         mlflow_token = mlflow_runtime_context.attach(context)
@@ -358,7 +361,7 @@ def set_span_in_context(span: "Span") -> SpanContextToken:
         # `opentelemetry.trace.get_current_span()` can nest their spans under the MLflow span.
         # This is opt-in because it exposes the MLflow span to all OTel instrumentation in the
         # process (e.g. FastAPI, requests), reducing the isolation this mode normally provides.
-        if MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.get():
+        if propagate_to_otel_context:
             # Build the new context from the current global OTel context so that other entries
             # (e.g. baggage) set by unrelated OTel instrumentation are preserved while the MLflow
             # span is active.
@@ -367,8 +370,7 @@ def set_span_in_context(span: "Span") -> SpanContextToken:
             return (mlflow_token, otel_token)
         return (mlflow_token, None)
     else:
-        token = context_api.attach(context)
-        return token
+        return context_api.attach(context)
 
 
 def detach_span_from_context(token: SpanContextToken):

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -353,7 +353,10 @@ def set_span_in_context(span: "Span") -> object:
         # This is opt-in because it exposes the MLflow span to all OTel instrumentation in the
         # process (e.g. FastAPI, requests), reducing the isolation this mode normally provides.
         if MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.get():
-            otel_context = trace.set_span_in_context(span._span)
+            # Build the new context from the current global OTel context so that other entries
+            # (e.g. baggage) set by unrelated OTel instrumentation are preserved while the MLflow
+            # span is active.
+            otel_context = trace.set_span_in_context(span._span, context=context_api.get_current())
             otel_token = context_api.attach(otel_context)
             return (mlflow_token, otel_token)
         return (mlflow_token, None)
@@ -371,10 +374,14 @@ def detach_span_from_context(token: object):
     """
     if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
         mlflow_token, otel_token = token
-        # Detach the global OTel context first (reverse order of attach) if it was set.
-        if otel_token is not None:
-            context_api.detach(otel_token)
-        mlflow_runtime_context.detach(mlflow_token)
+        try:
+            # Detach the global OTel context first (reverse order of attach) if it was set.
+            if otel_token is not None:
+                context_api.detach(otel_token)
+        finally:
+            # Always detach MLflow's runtime context, even if the global detach above fails,
+            # so the isolated runtime context is not leaked.
+            mlflow_runtime_context.detach(mlflow_token)
     else:
         context_api.detach(token)
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -33,6 +33,7 @@ from mlflow.entities.trace_location import (
 )
 from mlflow.environment_variables import (
     MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT,
+    MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT,
     MLFLOW_TRACE_SAMPLING_RATIO,
     MLFLOW_TRACE_USE_ISOLATED_RANDOM_ID_GENERATOR,
     MLFLOW_USE_BATCH_SPAN_PROCESSOR,
@@ -343,13 +344,19 @@ def set_span_in_context(span: "Span") -> object:
     """
     context = trace.set_span_in_context(span._span, context=get_current_context())
     if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
+        # In isolated tracer provider mode, attach to MLflow's runtime context so the span does
+        # not get mixed with the native OpenTelemetry runtime context.
         mlflow_token = mlflow_runtime_context.attach(context)
-        # Also propagate the span to the global OTel context so that OTel-based
-        # libraries (e.g., strands-agents, LangChain) can see the MLflow span as
-        # a parent and create properly nested child spans.
-        otel_context = trace.set_span_in_context(span._span)
-        otel_token = context_api.attach(otel_context)
-        return (mlflow_token, otel_token)
+        # Optionally also propagate the span into the process-global OTel context so pure-OTel
+        # libraries (e.g. strands-agents, LangChain) that read
+        # `opentelemetry.trace.get_current_span()` can nest their spans under the MLflow span.
+        # This is opt-in because it exposes the MLflow span to all OTel instrumentation in the
+        # process (e.g. FastAPI, requests), reducing the isolation this mode normally provides.
+        if MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.get():
+            otel_context = trace.set_span_in_context(span._span)
+            otel_token = context_api.attach(otel_context)
+            return (mlflow_token, otel_token)
+        return (mlflow_token, None)
     else:
         token = context_api.attach(context)
         return token
@@ -364,7 +371,9 @@ def detach_span_from_context(token: object):
     """
     if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
         mlflow_token, otel_token = token
-        context_api.detach(otel_token)
+        # Detach the global OTel context first (reverse order of attach) if it was set.
+        if otel_token is not None:
+            context_api.detach(otel_token)
         mlflow_runtime_context.detach(mlflow_token)
     else:
         context_api.detach(token)

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -331,7 +331,7 @@ def safe_set_span_in_context(span: "Span"):
         detach_span_from_context(token)
 
 
-def set_span_in_context(span: "Span") -> contextvars.Token:
+def set_span_in_context(span: "Span") -> object:
     """
     Set the given OpenTelemetry span as the active span in the current context.
 
@@ -343,23 +343,29 @@ def set_span_in_context(span: "Span") -> contextvars.Token:
     """
     context = trace.set_span_in_context(span._span, context=get_current_context())
     if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
-        # When using the default tracer provider, attach to MLflow's runtime context so that span
-        # will not get mixed with the native OpenTelemetry runtime context.
-        token = mlflow_runtime_context.attach(context)
+        mlflow_token = mlflow_runtime_context.attach(context)
+        # Also propagate the span to the global OTel context so that OTel-based
+        # libraries (e.g., strands-agents, LangChain) can see the MLflow span as
+        # a parent and create properly nested child spans.
+        otel_context = trace.set_span_in_context(span._span)
+        otel_token = context_api.attach(otel_context)
+        return (mlflow_token, otel_token)
     else:
         token = context_api.attach(context)
-    return token
+        return token
 
 
-def detach_span_from_context(token: contextvars.Token):
+def detach_span_from_context(token: object):
     """
     Remove the active span from the current context.
 
     Args:
-        token: The token returned by `_set_span_to_active` function.
+        token: The token returned by `set_span_in_context` function.
     """
     if MLFLOW_USE_DEFAULT_TRACER_PROVIDER.get():
-        mlflow_runtime_context.detach(token)
+        mlflow_token, otel_token = token
+        context_api.detach(otel_token)
+        mlflow_runtime_context.detach(mlflow_token)
     else:
         context_api.detach(token)
 

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -470,6 +470,37 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
     _initialize_tracer_provider()
 
 
+def get_bridged_tracer_provider() -> TracerProvider:
+    """
+    Return the OpenTelemetry ``TracerProvider`` that MLflow uses to generate traces.
+
+    This is intended for bridging pure-OpenTelemetry instrumentation libraries into MLflow's
+    tracing pipeline. Many OpenTelemetry instrumentors accept a ``tracer_provider=`` argument
+    (e.g. ``SomeInstrumentor().instrument(tracer_provider=...)``); passing the provider returned
+    by this function makes the spans they create flow through MLflow's span processors, so they
+    receive the correct trace ID and are exported to the configured MLflow destination.
+
+    In the default isolated tracer provider mode
+    (``MLFLOW_USE_DEFAULT_TRACER_PROVIDER=True``) this returns MLflow's isolated provider, so
+    the bridged spans do not depend on the process-global OpenTelemetry provider pipeline and
+    the isolation of unrelated OpenTelemetry instrumentation is preserved. In unified mode
+    (``MLFLOW_USE_DEFAULT_TRACER_PROVIDER=False``) this returns the shared global provider.
+
+    .. note::
+        This bridges where spans are *exported*. For the bridged spans to nest under an active
+        ``@mlflow.trace`` / ``mlflow.start_span`` span, the instrumentor must also read MLflow's
+        active span as the parent. Instrumentors that read the process-global OpenTelemetry
+        context can be enabled to do so by setting
+        ``MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT=True``.
+
+    Returns:
+        The ``TracerProvider`` instance used by MLflow, initializing it if necessary.
+    """
+    # Ensure the provider is initialized before handing it out to external instrumentors.
+    _get_tracer(__name__)
+    return provider.get()
+
+
 def _get_tracer(module_name: str) -> trace.Tracer:
     """
     Get a tracer instance for the given module name.

--- a/mlflow/tracing/utils/token.py
+++ b/mlflow/tracing/utils/token.py
@@ -1,7 +1,10 @@
-import contextvars
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from mlflow.entities import LiveSpan
+
+if TYPE_CHECKING:
+    from mlflow.tracing.provider import SpanContextToken
 
 
 @dataclass
@@ -11,8 +14,9 @@ class SpanWithToken:
 
     The token is a special object that is generated when setting a span as active within
     the Open Telemetry span context. This token is required when inactivate the span i.e.
-    detaching the span from the context.
+    detaching the span from the context. In isolated tracer provider mode it is a tuple of
+    (MLflow runtime token, optional global OTel token); otherwise a single OTel context token.
     """
 
     span: LiveSpan
-    token: contextvars.Token | None = None
+    token: "SpanContextToken | None" = None

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -13,7 +13,7 @@ from mlflow.environment_variables import (
     MLFLOW_USE_DEFAULT_TRACER_PROVIDER,
 )
 from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
-from mlflow.tracing.provider import provider, set_destination
+from mlflow.tracing.provider import get_bridged_tracer_provider, provider, set_destination
 from mlflow.utils.os import is_windows
 
 from tests.tracing.helper import get_traces
@@ -416,3 +416,48 @@ def test_nested_mlflow_spans_maintain_otel_context_when_opted_in(monkeypatch):
         assert after_inner.is_recording(), (
             "Outer span's OTel context should be restored after inner span exits"
         )
+
+
+def test_get_bridged_tracer_provider_returns_mlflow_provider_isolated(monkeypatch):
+    """get_bridged_tracer_provider should hand out MLflow's isolated provider by default.
+
+    This lets OTel instrumentors that accept `tracer_provider=` route spans through MLflow's
+    pipeline without depending on the process-global provider (issue #24105).
+    """
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    experiment_id = mlflow.set_experiment("test_experiment").experiment_id
+    set_destination(MlflowExperimentLocation(experiment_id))
+
+    bridged = get_bridged_tracer_provider()
+    assert bridged is provider.get()
+    processors = bridged._active_span_processor._span_processors
+    assert any(isinstance(p, MlflowV3SpanProcessor) for p in processors)
+
+
+def test_get_bridged_tracer_provider_routes_spans_to_mlflow(monkeypatch):
+    """Spans created via the bridged provider's tracer should be captured by MLflow."""
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    experiment_id = mlflow.set_experiment("test_experiment").experiment_id
+    set_destination(MlflowExperimentLocation(experiment_id))
+
+    bridged = get_bridged_tracer_provider()
+    otel_tracer = bridged.get_tracer("external_instrumentor")
+    with otel_tracer.start_as_current_span("external_span") as span:
+        span.set_attribute("key", "value")
+
+    traces = get_traces()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.trace_id.startswith("tr-")
+    assert trace.info.experiment_id == experiment_id
+    assert any(s.name == "external_span" for s in trace.data.spans)
+
+
+def test_get_bridged_tracer_provider_returns_global_provider_unified(monkeypatch):
+    """In unified mode, the bridged provider is the shared global provider."""
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
+    experiment_id = mlflow.set_experiment("test_experiment").experiment_id
+    set_destination(MlflowExperimentLocation(experiment_id))
+
+    bridged = get_bridged_tracer_provider()
+    assert bridged is otel_trace.get_tracer_provider()

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -382,7 +382,6 @@ def test_mlflow_start_span_sets_otel_parent_context_when_opted_in(monkeypatch):
 
 
 def test_mlflow_span_cleans_up_otel_context_after_exit(monkeypatch):
-    """Verify the OTel global context is cleaned up when the MLflow span ends (opt-in)."""
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
     monkeypatch.setenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, "true")
     mlflow.set_experiment("test_experiment")
@@ -398,7 +397,6 @@ def test_mlflow_span_cleans_up_otel_context_after_exit(monkeypatch):
 
 
 def test_nested_mlflow_spans_maintain_otel_context_when_opted_in(monkeypatch):
-    """Verify nested MLflow spans properly manage the OTel context stack (opt-in)."""
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
     monkeypatch.setenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, "true")
     mlflow.set_experiment("test_experiment")
@@ -435,7 +433,6 @@ def test_get_bridged_tracer_provider_returns_mlflow_provider_isolated(monkeypatc
 
 
 def test_get_bridged_tracer_provider_routes_spans_to_mlflow(monkeypatch):
-    """Spans created via the bridged provider's tracer should be captured by MLflow."""
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
     experiment_id = mlflow.set_experiment("test_experiment").experiment_id
     set_destination(MlflowExperimentLocation(experiment_id))
@@ -454,7 +451,6 @@ def test_get_bridged_tracer_provider_routes_spans_to_mlflow(monkeypatch):
 
 
 def test_get_bridged_tracer_provider_returns_global_provider_unified(monkeypatch):
-    """In unified mode, the bridged provider is the shared global provider."""
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
     experiment_id = mlflow.set_experiment("test_experiment").experiment_id
     set_destination(MlflowExperimentLocation(experiment_id))

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -309,3 +309,85 @@ def test_initialize_tracer_provider_without_otel_provider_set(
     processors = provider.get()._active_span_processor._span_processors
     assert len(processors) == 1
     assert isinstance(processors[0], MlflowV3SpanProcessor)
+
+
+def test_mlflow_trace_decorator_sets_otel_parent_context(monkeypatch):
+    """Regression test for https://github.com/mlflow/mlflow/issues/24105
+
+    @mlflow.trace should propagate the span to the global OTel context so
+    that OTel-based libraries (e.g., strands-agents) can see it as a parent
+    and create properly nested child spans.
+    """
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    mlflow.set_experiment("test_experiment")
+
+    captured = {}
+
+    @mlflow.trace(name="parent")
+    def my_function():
+        current = otel_trace.get_current_span()
+        captured["is_recording"] = current.is_recording()
+        captured["span_type"] = type(current).__name__
+        return 42
+
+    my_function()
+
+    assert captured["is_recording"], (
+        "OTel current span should be recording inside @mlflow.trace"
+    )
+    assert captured["span_type"] != "NonRecordingSpan"
+
+
+def test_mlflow_start_span_sets_otel_parent_context(monkeypatch):
+    """Regression test for https://github.com/mlflow/mlflow/issues/24105
+
+    mlflow.start_span() should propagate the span to the global OTel
+    context so that OTel-based libraries can nest their spans under it.
+    """
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    mlflow.set_experiment("test_experiment")
+
+    with mlflow.start_span(name="parent"):
+        current = otel_trace.get_current_span()
+        is_recording = current.is_recording()
+        span_type_name = type(current).__name__
+
+    assert is_recording, (
+        "OTel current span should be recording inside mlflow.start_span()"
+    )
+    assert span_type_name != "NonRecordingSpan"
+
+
+def test_mlflow_span_cleans_up_otel_context_after_exit(monkeypatch):
+    """Verify the OTel global context is cleaned up when the MLflow span ends."""
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    mlflow.set_experiment("test_experiment")
+
+    with mlflow.start_span(name="parent"):
+        inside = otel_trace.get_current_span()
+        assert inside.is_recording()
+
+    outside = otel_trace.get_current_span()
+    assert not outside.is_recording(), (
+        "OTel context should be cleaned up after the MLflow span exits"
+    )
+
+
+def test_nested_mlflow_spans_maintain_otel_context(monkeypatch):
+    """Verify nested MLflow spans properly manage the OTel context stack."""
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    mlflow.set_experiment("test_experiment")
+
+    with mlflow.start_span(name="outer") as outer_span:
+        outer_otel = otel_trace.get_current_span()
+        assert outer_otel.is_recording()
+
+        with mlflow.start_span(name="inner") as inner_span:
+            inner_otel = otel_trace.get_current_span()
+            assert inner_otel.is_recording()
+            assert inner_span.parent_id == outer_span.span_id
+
+        after_inner = otel_trace.get_current_span()
+        assert after_inner.is_recording(), (
+            "Outer span's OTel context should be restored after inner span exits"
+        )

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -329,7 +329,7 @@ def test_mlflow_span_does_not_leak_to_otel_context_by_default(monkeypatch):
         current = otel_trace.get_current_span()
         # Isolated mode keeps the MLflow span out of the global OTel context.
         assert not current.is_recording()
-        assert type(current).__name__ == "NonRecordingSpan"
+        assert isinstance(current, otel_trace.NonRecordingSpan)
 
 
 def test_mlflow_trace_decorator_sets_otel_parent_context_when_opted_in(monkeypatch):
@@ -349,7 +349,7 @@ def test_mlflow_trace_decorator_sets_otel_parent_context_when_opted_in(monkeypat
     def my_function():
         current = otel_trace.get_current_span()
         captured["is_recording"] = current.is_recording()
-        captured["span_type"] = type(current).__name__
+        captured["is_non_recording"] = isinstance(current, otel_trace.NonRecordingSpan)
         return 42
 
     my_function()
@@ -357,7 +357,7 @@ def test_mlflow_trace_decorator_sets_otel_parent_context_when_opted_in(monkeypat
     assert captured["is_recording"], (
         "OTel current span should be recording inside @mlflow.trace"
     )
-    assert captured["span_type"] != "NonRecordingSpan"
+    assert not captured["is_non_recording"]
 
 
 def test_mlflow_start_span_sets_otel_parent_context_when_opted_in(monkeypatch):
@@ -373,12 +373,12 @@ def test_mlflow_start_span_sets_otel_parent_context_when_opted_in(monkeypatch):
     with mlflow.start_span(name="parent"):
         current = otel_trace.get_current_span()
         is_recording = current.is_recording()
-        span_type_name = type(current).__name__
+        is_non_recording = isinstance(current, otel_trace.NonRecordingSpan)
 
     assert is_recording, (
         "OTel current span should be recording inside mlflow.start_span()"
     )
-    assert span_type_name != "NonRecordingSpan"
+    assert not is_non_recording
 
 
 def test_mlflow_span_cleans_up_otel_context_after_exit(monkeypatch):

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -8,7 +8,10 @@ import mlflow
 from mlflow.entities.span import SpanStatusCode, encode_span_id
 from mlflow.entities.trace_location import MlflowExperimentLocation
 from mlflow.entities.trace_state import TraceState
-from mlflow.environment_variables import MLFLOW_USE_DEFAULT_TRACER_PROVIDER
+from mlflow.environment_variables import (
+    MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT,
+    MLFLOW_USE_DEFAULT_TRACER_PROVIDER,
+)
 from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 from mlflow.tracing.provider import provider, set_destination
 from mlflow.utils.os import is_windows
@@ -311,14 +314,33 @@ def test_initialize_tracer_provider_without_otel_provider_set(
     assert isinstance(processors[0], MlflowV3SpanProcessor)
 
 
-def test_mlflow_trace_decorator_sets_otel_parent_context(monkeypatch):
+def test_mlflow_span_does_not_leak_to_otel_context_by_default(monkeypatch):
     """Regression test for https://github.com/mlflow/mlflow/issues/24105
 
-    @mlflow.trace should propagate the span to the global OTel context so
-    that OTel-based libraries (e.g., strands-agents) can see it as a parent
-    and create properly nested child spans.
+    In isolated tracer provider mode (the default), the MLflow span must NOT leak into the
+    process-global OTel context. This preserves the isolation guarantee so unrelated OTel
+    instrumentation (e.g. FastAPI, requests) does not accidentally nest under MLflow spans.
     """
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    monkeypatch.delenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, raising=False)
+    mlflow.set_experiment("test_experiment")
+
+    with mlflow.start_span(name="parent"):
+        current = otel_trace.get_current_span()
+        # Isolated mode keeps the MLflow span out of the global OTel context.
+        assert not current.is_recording()
+        assert type(current).__name__ == "NonRecordingSpan"
+
+
+def test_mlflow_trace_decorator_sets_otel_parent_context_when_opted_in(monkeypatch):
+    """Regression test for https://github.com/mlflow/mlflow/issues/24105
+
+    With MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT enabled, @mlflow.trace should propagate the
+    span to the global OTel context so that pure-OTel libraries (e.g. strands-agents) can see
+    it as a parent and create properly nested child spans.
+    """
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    monkeypatch.setenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, "true")
     mlflow.set_experiment("test_experiment")
 
     captured = {}
@@ -338,13 +360,14 @@ def test_mlflow_trace_decorator_sets_otel_parent_context(monkeypatch):
     assert captured["span_type"] != "NonRecordingSpan"
 
 
-def test_mlflow_start_span_sets_otel_parent_context(monkeypatch):
+def test_mlflow_start_span_sets_otel_parent_context_when_opted_in(monkeypatch):
     """Regression test for https://github.com/mlflow/mlflow/issues/24105
 
-    mlflow.start_span() should propagate the span to the global OTel
-    context so that OTel-based libraries can nest their spans under it.
+    With MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT enabled, mlflow.start_span() should propagate
+    the span to the global OTel context so that pure-OTel libraries can nest under it.
     """
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    monkeypatch.setenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, "true")
     mlflow.set_experiment("test_experiment")
 
     with mlflow.start_span(name="parent"):
@@ -359,8 +382,9 @@ def test_mlflow_start_span_sets_otel_parent_context(monkeypatch):
 
 
 def test_mlflow_span_cleans_up_otel_context_after_exit(monkeypatch):
-    """Verify the OTel global context is cleaned up when the MLflow span ends."""
+    """Verify the OTel global context is cleaned up when the MLflow span ends (opt-in)."""
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    monkeypatch.setenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, "true")
     mlflow.set_experiment("test_experiment")
 
     with mlflow.start_span(name="parent"):
@@ -373,9 +397,10 @@ def test_mlflow_span_cleans_up_otel_context_after_exit(monkeypatch):
     )
 
 
-def test_nested_mlflow_spans_maintain_otel_context(monkeypatch):
-    """Verify nested MLflow spans properly manage the OTel context stack."""
+def test_nested_mlflow_spans_maintain_otel_context_when_opted_in(monkeypatch):
+    """Verify nested MLflow spans properly manage the OTel context stack (opt-in)."""
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "true")
+    monkeypatch.setenv(MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT.name, "true")
     mlflow.set_experiment("test_experiment")
 
     with mlflow.start_span(name="outer") as outer_span:

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -354,9 +354,7 @@ def test_mlflow_trace_decorator_sets_otel_parent_context_when_opted_in(monkeypat
 
     my_function()
 
-    assert captured["is_recording"], (
-        "OTel current span should be recording inside @mlflow.trace"
-    )
+    assert captured["is_recording"], "OTel current span should be recording inside @mlflow.trace"
     assert not captured["is_non_recording"]
 
 
@@ -375,9 +373,7 @@ def test_mlflow_start_span_sets_otel_parent_context_when_opted_in(monkeypatch):
         is_recording = current.is_recording()
         is_non_recording = isinstance(current, otel_trace.NonRecordingSpan)
 
-    assert is_recording, (
-        "OTel current span should be recording inside mlflow.start_span()"
-    )
+    assert is_recording, "OTel current span should be recording inside mlflow.start_span()"
     assert not is_non_recording
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24105

### What changes are proposed in this pull request?

In the default isolated tracer provider mode (`MLFLOW_USE_DEFAULT_TRACER_PROVIDER=True`), a span created by `@mlflow.trace` / `mlflow.start_span()` never lands in the process-global OpenTelemetry context. As a result `otel_trace.get_current_span()` returns a `NonRecordingSpan`, so pure-OpenTelemetry libraries (e.g. strands-agents, LangChain, LlamaIndex) cannot nest their spans under the MLflow span and end up in a separate orphan trace.

This PR resolves the issue while preserving the isolation guarantee of isolated tracer provider mode. It provides two complementary, isolation-safe mechanisms:

1. **Opt-in global-context propagation** — a new environment variable `MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT` (default `False`). When enabled, MLflow additionally propagates its active span into the process-global OTel context so instrumentors that read `opentelemetry.trace.get_current_span()` can nest under it. It is **opt-in** so that, by default, the MLflow span is *not* exposed to unrelated OTel instrumentation (FastAPI, `requests`, etc.), preserving isolation. `detach_span_from_context` is updated to clean up both contexts.

2. **`mlflow.tracing.get_bridged_tracer_provider()`** — a new public helper that returns the `TracerProvider` MLflow uses. Instrumentors that accept a `tracer_provider=` argument can be pointed at it so their spans flow through MLflow's span processors (correct trace ID + MLflow export) without depending on the process-global provider pipeline and without leaking MLflow spans into the global context.

Together these address the two design concerns raised in the issue discussion: (a) avoid breaking isolation, and (b) avoid silently degrading to "unified mode".

Changed files:
- `mlflow/environment_variables.py` — add `MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT` (default `False`).
- `mlflow/tracing/provider.py` — gate global-context propagation behind the env var; add `get_bridged_tracer_provider()`.
- `mlflow/tracing/__init__.py` — export `get_bridged_tracer_provider`.
- `tests/tracing/opentelemetry/test_integration.py` — regression tests.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/tracing/opentelemetry/test_integration.py` cover: isolation preserved by default (span stays a `NonRecordingSpan` in the global context), opt-in propagation for `@mlflow.trace` and `mlflow.start_span()`, global-context cleanup after span exit, nested-span context management, and `get_bridged_tracer_provider()` routing external OTel spans into MLflow (isolated) plus returning the shared provider in unified mode.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references

`get_bridged_tracer_provider` and the new environment variable are documented via docstrings; the API reference is generated from these.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes OTel parent-context propagation so pure-OpenTelemetry libraries can nest under `@mlflow.trace` / `mlflow.start_span` spans. Adds an opt-in `MLFLOW_TRACE_PROPAGATE_TO_OTEL_CONTEXT` environment variable (default off, preserving isolation) and a new `mlflow.tracing.get_bridged_tracer_provider()` helper for bridging OTel instrumentors into MLflow's tracing pipeline.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release