### PR TITLE
Empty the TypeScript min-version floor-violation allowlist

### DIFF
--- a/libs/typescript/scripts/known-floor-violations.txt
+++ b/libs/typescript/scripts/known-floor-violations.txt
@@ -1,10 +1,10 @@
-# Integrations known to import an @mlflow/* symbol that is newer than the
-# version their package.json declares as the floor. These are pre-existing
-# violations of the same class as mlflow#24167 (opencode dropped session
-# metadata against the published @mlflow/core). The min-version gate
-# (check-min-mlflow-deps.sh) reports them but does NOT fail on them, so the
-# gate can be turned on now and block *new* regressions immediately while
-# these are fixed incrementally.
+# Integrations that import an @mlflow/* symbol newer than the version their
+# package.json declares as the floor -- the same class as mlflow#24167 (opencode
+# dropped session metadata against the published @mlflow/core). The min-version
+# gate (check-min-mlflow-deps.sh) reports allowlisted entries but does NOT fail
+# on them, so pre-existing violations can be fixed incrementally while the gate
+# blocks *new* regressions immediately. This list is currently empty -- every
+# integration type-checks against its declared floor.
 #
 # To fix an entry, first check whether the missing symbol was ever published
 # ('npm view @mlflow/core versions', then 'npm pack @mlflow/core@latest' and grep
@@ -16,6 +16,3 @@
 # prints a notice asking you to remove it from this file.
 #
 # One integration directory name per line (matches integrations/<name>).
-claude-code
-codex
-qwen-code

--- a/libs/typescript/scripts/known-floor-violations.txt
+++ b/libs/typescript/scripts/known-floor-violations.txt
@@ -1,10 +1,12 @@
 # Integrations that import an @mlflow/* symbol newer than the version their
 # package.json declares as the floor -- the same class as mlflow#24167 (opencode
 # dropped session metadata against the published @mlflow/core). The min-version
-# gate (check-min-mlflow-deps.sh) reports allowlisted entries but does NOT fail
-# on them, so pre-existing violations can be fixed incrementally while the gate
-# blocks *new* regressions immediately. This list is currently empty -- every
-# integration type-checks against its declared floor.
+# gate (check-min-mlflow-deps.sh) does not fail on an allowlisted entry while it
+# still violates its floor, so pre-existing violations can be fixed incrementally
+# while the gate blocks *new* regressions immediately. The one exception: once an
+# allowlisted entry starts type-checking against its floor again, the gate fails
+# to force its removal (so the list can't silently rot). This list is currently
+# empty -- every integration type-checks against its declared floor.
 #
 # To fix an entry, first check whether the missing symbol was ever published
 # ('npm view @mlflow/core versions', then 'npm pack @mlflow/core@latest' and grep
@@ -12,7 +14,6 @@
 # raise the @mlflow/* floor in package.json to that version. If it exists in no
 # published version, raising the floor cannot help -- inline the value in the
 # integration instead (see integrations/openclaw/src/service.ts). Then delete
-# the entry from here. When an allowlisted integration starts passing, the gate
-# prints a notice asking you to remove it from this file.
+# the entry from here -- the gate fails until you do, naming the entry to remove.
 #
 # One integration directory name per line (matches integrations/<name>).


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24167, follow-up to #24268

### What changes are proposed in this pull request?

Empties the min-version floor-violation allowlist (`libs/typescript/scripts/known-floor-violations.txt`).

The gate added in #24268 grandfathered `claude-code`, `codex`, and `qwen-code` because they imported `@mlflow/core` symbols newer than their declared floor. All three now declare a floor of `^0.3.0`, and published `0.3.0` exports every symbol they import (`InMemoryTraceManager`, `TraceMetadataKey.TRACE_SESSION`/`.TRACE_USER`, `TokenUsageKey.CACHE_*_INPUT_TOKENS`, `createAuthProvider`, `MlflowClient.getExperimentByName`, etc.), so they now type-check against their floor. They were therefore stale allowlist entries and the gate was failing on them ("allowlisted but now pass -- delete them"). Removing them makes the gate pass against a fully honest set of floors, and any future regression fails immediately with nothing shielding it.

However, https://github.com/mlflow/mlflow/pull/24299 bumped it before the PR got merged, so there's a disconnect and its failing now, I empty the allowlist to restore CI. 

### How is this PR tested?

- [x] Existing unit/integration tests

Ran `bash scripts/check-min-mlflow-deps.sh` locally: before this change it exits 1 (three stale allowlist entries); after emptying the allowlist it exits 0 with "Minimum-version check passed".

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
