### PR TITLE
fix(ui): scale artifact images to parent frame in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunArtifactView.tsx
@@ -75,10 +75,11 @@ export const CompareRunArtifactView = ({
               key={runUuid}
               style={{
                 flex: `1 1 ${colWidth}px`,
-                minWidth: `${colWidth}px`,
+                minWidth: 0,
+                maxWidth: '100%',
                 borderBottom: `1px solid ${theme.colors.grey300}`,
                 padding: !artifactPath ? theme.spacing.md : 0,
-                overflow: 'auto',
+                overflow: 'hidden',
               }}
             >
               <ShowArtifactPage

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,7 +86,7 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',


### PR DESCRIPTION
Fixes #20703

In the comparison view, artifact images were not scaling to fit their column frame. Each run column had a fixed minWidth but no maxWidth, causing images wider than the column to overflow horizontally and show a scrollbar instead of fitting within the parent container.

Two changes:
1. CompareRunArtifactView.tsx: changed minWidth from the fixed colWidth to 0, added maxWidth: 100%, and changed overflow from auto to hidden so each column clips to its allocated frame.
2. ShowArtifactImageView.tsx: changed imageOuterContainer overflow from scroll (which always shows scrollbars) to auto (only shows when content truly overflows).

Changes:
- mlflow/server/js/src/experiment-tracking/components/CompareRunArtifactView.tsx
- mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx