### PR TITLE
fix(deps): bump minimum version floors for deps with known CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "graphene<4",
   "gunicorn<27; platform_system != 'Windows'",
   "huey<4,>=2.5.4",
@@ -50,12 +50,12 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
   "pandas<3",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pyarrow<25,>=4.0.0",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "scikit-learn<2",
   "scipy<2",
   "skops<1",
@@ -109,7 +109,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.7.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]


### PR DESCRIPTION
Fixes #23061

Several mlflow-skinny core dependencies used very loose minimum version floors, allowing pip to resolve vulnerable versions in environments like Azure ML curated Docker images.

Bumps minimum floors for 5 deps with known CVEs:

| Dependency | Old floor | New floor | CVE / Advisory |
|---|---|---|---|
| gitpython | >=3.1.9 | >=3.1.47 | GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485 |
| python-dotenv | >=0.19.0 | >=1.2.2 | GHSA-mf9w-mj56-hr94 |
| protobuf | >=3.12.0 | >=6.33.5 | Multiple CVEs |
| requests | >=2.17.3 | >=2.33.0 | GHSA-gc5v-m9x4-r6x2 |
| fastmcp | >=2.7.0 | >=3.2.0 | GHSA-rww4-4w9c-7733 |

Changes:
- pyproject.toml