### PR TITLE
fix: prevent duplicate table creation error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from 3.7.0 to 3.8.x, the upgrade fails with `Table 'secrets' already exists` because `_initialize_tables` attempts to create all tables without checking if they already exist. This occurs because the 'secrets' table may have been created by a previous migration or the upgrade process itself.

## Fix
Add `checkfirst=True` to the `InitialBase.metadata.create_all(engine)` call. This is the standard parameter in SQLAlchemy's `create_all` to skip creation of tables that already exist, preventing the "already exists" error.

Closes #19943