### PR TITLE
Enable artifacts-only mode with workspaces

### DIFF
--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -350,6 +350,23 @@ See the following example of a client REST call in Python attempting to list exp
 mlflow server --artifacts-only ...
 ```
 
+When workspaces are enabled, the artifact-only server must use the same logical workspace provider
+as the tracking server so it can validate `X-MLFLOW-WORKSPACE` before accessing storage. Configure
+the provider explicitly with `--workspace-store-uri`:
+
+```bash
+mlflow server \
+  --artifacts-only \
+  --enable-workspaces \
+  --workspace-store-uri postgresql://user:pass@host/mlflow \
+  --artifacts-destination s3://mlflow-artifacts
+```
+
+In this mode, MLflow initializes the workspace provider for request validation but does not
+initialize the tracking or model registry stores. Tracking and workspace-management APIs remain
+disabled. If the workspace header is omitted, the provider's default workspace is used; unknown
+workspaces and requests without a resolvable default are rejected.
+
 ```python
 import requests
 

--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -24,6 +24,29 @@ mlflow server \
 
 Disable by restarting without `--enable-workspaces` after moving all resources into the `default` workspace.
 
+### Artifacts-only servers
+
+An artifact-serving-only deployment can validate and isolate artifact requests by workspace without
+enabling tracking APIs. The artifact server must explicitly use the same logical workspace provider
+as the tracking server:
+
+```bash
+mlflow server \
+  --artifacts-only \
+  --enable-workspaces \
+  --workspace-store-uri postgresql://user:pass@localhost/mlflow \
+  --artifacts-destination s3://mlflow-artifacts
+```
+
+`MLFLOW_WORKSPACE_STORE_URI` can be used instead of `--workspace-store-uri`. MLflow requires one of
+these explicit settings in this mode because an artifact-only server has no tracking backend from
+which to infer the workspace provider. The server initializes only the workspace provider; tracking,
+model registry, workspace-management, and other non-artifact APIs remain disabled.
+
+Artifact requests continue to use `X-MLFLOW-WORKSPACE`. The provider validates an explicit workspace
+or resolves its default when the header is absent. Unknown workspaces and requests without a
+resolvable default are rejected before accessing artifact storage.
+
 ### Admin Utility: migrate to default workspace
 
 To move all workspace-scoped resources into `default` to disable workspaces, use:
@@ -93,8 +116,11 @@ Clients send `X-MLFLOW-WORKSPACE` on REST calls; UI AJAX routes remain the same 
 
 ## Startup Validation (when `--enable-workspaces`)
 
-- Tracking and registry stores must report `supports_workspaces() == True`
+- Tracking and registry stores must report `supports_workspaces() == True` unless the server is
+  running in `--artifacts-only` mode, where those stores are not initialized.
 - Workspace provider resolved (defaults to SQL-backed provider if none given)
+- With `--artifacts-only`, the workspace provider must be configured explicitly through
+  `--workspace-store-uri` or `MLFLOW_WORKSPACE_STORE_URI`.
 - Reserved `default` workspace exists (created by migration)
 - With `--serve-artifacts`, proxied artifact paths for non-default workspaces must include `workspaces/<workspace>/...`; legacy unprefixed paths remain valid for `default`.
 

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -526,7 +526,7 @@ def _validate_static_prefix(ctx, param, value):
         "Workspace provider backend URI used for workspace CRUD APIs and request routing. "
         "When unspecified, defaults to the backend store URI. This only needs to be specified "
         "when using a workspace store plugin leveraging externally managed workspaces (e.g. "
-        + "Kubernetes namespaces)."
+        + "Kubernetes namespaces), or when combining --enable-workspaces with --artifacts-only."
     ),
 )
 @click.option(
@@ -592,7 +592,7 @@ def server(
     Full guide: https://mlflow.org/docs/latest/self-hosting/architecture/tracking-server
     """
     from mlflow.server import _run_server
-    from mlflow.server.handlers import initialize_backend_stores
+    from mlflow.server.handlers import initialize_backend_stores, initialize_workspace_store
 
     # Get env_file from parent context
     env_file = ctx.parent.params.get("env_file") if ctx.parent else None
@@ -673,6 +673,7 @@ def server(
         artifacts_only,
         backend_store_uri,
         enable_workspaces,
+        workspace_store_uri=workspace_store_uri,
         trace_archival_config_path=str(trace_archival_config) if trace_archival_config else None,
     )
     if trace_archival_config is not None:
@@ -695,7 +696,13 @@ def server(
     if trace_archival_config is not None:
         os.environ[MLFLOW_TRACE_ARCHIVAL_CONFIG.name] = str(trace_archival_config)
 
-    if not artifacts_only:
+    if artifacts_only and enable_workspaces:
+        try:
+            initialize_workspace_store(workspace_store_uri)
+        except Exception:
+            _logger.exception("Error initializing workspace store")
+            sys.exit(1)
+    elif not artifacts_only:
         try:
             initialize_backend_stores(
                 backend_store_uri,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -760,6 +760,10 @@ def initialize_backend_stores(
     _verify_tracking_store_trace_archival_support(tracking_store)
 
 
+def initialize_workspace_store(workspace_store_uri: str) -> None:
+    _get_workspace_store(workspace_uri=workspace_store_uri)
+
+
 def _store_supports_workspaces(
     store: AbstractTrackingStore | AbstractModelRegistryStore | AbstractJobStore,
 ) -> bool:
@@ -1347,6 +1351,7 @@ def _ensure_artifact_root_available(workspace_artifact_root: str | None) -> None
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 @_disable_if_workspaces_disabled
 def _list_workspaces_handler():
     _get_request_message(ListWorkspaces())
@@ -1357,6 +1362,7 @@ def _list_workspaces_handler():
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 @_disable_if_workspaces_disabled
 def _create_workspace_handler():
     request_message, request_json = _get_workspace_request_message(
@@ -1416,6 +1422,7 @@ def _create_workspace_handler():
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 @_disable_if_workspaces_disabled
 def _get_workspace_handler(workspace_name: str):
     if workspace_name != DEFAULT_WORKSPACE_NAME:
@@ -1427,6 +1434,7 @@ def _get_workspace_handler(workspace_name: str):
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 @_disable_if_workspaces_disabled
 def _update_workspace_handler(workspace_name: str):
     if workspace_name != DEFAULT_WORKSPACE_NAME:
@@ -1492,6 +1500,7 @@ def _update_workspace_handler(workspace_name: str):
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 @_disable_if_workspaces_disabled
 def _delete_workspace_handler(workspace_name: str):
     if workspace_name == DEFAULT_WORKSPACE_NAME:
@@ -1516,6 +1525,7 @@ def _delete_workspace_handler(workspace_name: str):
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 def get_artifact_handler():
     run_id = request.args.get("run_id") or request.args.get("run_uuid")
     path = request.args["path"]
@@ -2405,6 +2415,7 @@ def create_promptlab_run_handler():
 
 
 @catch_mlflow_exception
+@_disable_if_artifacts_only
 def upload_artifact_handler():
     args = request.args
     run_uuid = args.get("run_uuid")
@@ -3851,6 +3862,7 @@ def _get_presigned_download_url(artifact_path):
     a presigned URL for downloading an artifact directly from cloud storage.
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
 
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
     _validate_support_multipart_download(artifact_repo)

--- a/mlflow/utils/server_cli_utils.py
+++ b/mlflow/utils/server_cli_utils.py
@@ -67,13 +67,14 @@ def artifacts_only_config_validation(
     artifacts_only: bool,
     backend_store_uri: str,
     enable_workspaces: bool = False,
+    workspace_store_uri: str | None = None,
     trace_archival_config_path: str | None = None,
 ) -> None:
-    if artifacts_only and enable_workspaces:
-        # Workspace mode relies on a workspace provider to resolve the default workspace and seed
-        # request context. Artifact-only servers never load that stack, so they cannot determine
-        # the active workspace safely. This decision can be revisited in the future.
-        raise click.UsageError("--enable-workspaces cannot be combined with --artifacts-only.")
+    if artifacts_only and enable_workspaces and not workspace_store_uri:
+        raise click.UsageError(
+            "--workspace-store-uri is required when combining --enable-workspaces with "
+            "--artifacts-only so artifact requests can be validated against a workspace provider."
+        )
     if artifacts_only and not _is_default_backend_store_uri(backend_store_uri):
         msg = (
             "You are starting a tracking server in `--artifacts-only` mode and have provided a "

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -141,6 +141,7 @@ from mlflow.protos.service_pb2 import (
 from mlflow.protos.webhooks_pb2 import ListWebhooks
 from mlflow.server import (
     ARTIFACTS_DESTINATION_ENV_VAR,
+    ARTIFACTS_ONLY_ENV_VAR,
     BACKEND_STORE_URI_ENV_VAR,
     SERVE_ARTIFACTS_ENV_VAR,
     app,
@@ -164,6 +165,7 @@ from mlflow.server.handlers import (
     _create_prompt_optimization_job,
     _create_registered_model,
     _create_review_queue,
+    _create_workspace_handler,
     _delete_artifact_mlflow_artifacts,
     _delete_dataset_handler,
     _delete_dataset_tag_handler,
@@ -175,6 +177,7 @@ from mlflow.server.handlers import (
     _delete_scorer,
     _delete_trace_tag,
     _delete_trace_tag_v3,
+    _delete_workspace_handler,
     _deprecated_search_traces_v2,
     _download_artifact,
     _get_ajax_path,
@@ -195,12 +198,14 @@ from mlflow.server.handlers import (
     _get_scorer,
     _get_trace,
     _get_trace_artifact_repo,
+    _get_workspace_handler,
     _get_workspace_scoped_repo_path_if_enabled,
     _link_prompts_to_trace,
     _list_artifacts_for_proxied_run_artifact_root,
     _list_scorer_versions,
     _list_scorers,
     _list_webhooks,
+    _list_workspaces_handler,
     _log_batch,
     _query_trace_metrics,
     _register_scorer,
@@ -227,6 +232,7 @@ from mlflow.server.handlers import (
     _update_model_version,
     _update_registered_model,
     _update_review_queue,
+    _update_workspace_handler,
     _upload_artifact,
     _upsert_dataset_records_handler,
     _validate_source_run,
@@ -237,6 +243,7 @@ from mlflow.server.handlers import (
     get_model_version_artifact_handler,
     get_trace_artifact_handler,
     get_ui_telemetry_handler,
+    initialize_workspace_store,
     post_ui_telemetry_handler,
     upload_artifact_handler,
 )
@@ -1218,23 +1225,27 @@ def test_delete_artifact_mlflow_artifacts_throws_for_malicious_path(enable_serve
     assert json_response["message"] == "Invalid path"
 
 
-def test_get_presigned_download_url_success(enable_serve_artifacts):
+def test_get_presigned_download_url_success(enable_serve_artifacts, monkeypatch):
     from mlflow.store.artifact.artifact_repo import MultipartDownloadMixin
 
     class MockMultipartDownloadRepo(MultipartDownloadMixin):
         def get_download_presigned_url(self, artifact_path, expiration=300):
+            self.artifact_path = artifact_path
             return PresignedDownloadUrlResponse(
                 url="https://storage.example.com/presigned?token=abc",
                 headers={"x-custom-header": "value"},
                 file_size=1024,
             )
 
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    artifact_repo = MockMultipartDownloadRepo()
     artifact_path = "run_id/artifacts/model.pkl"
     with (
+        WorkspaceContext("team-a"),
         app.test_request_context(method="GET"),
         mock.patch(
             "mlflow.server.handlers._get_artifact_repo_mlflow_artifacts",
-            return_value=MockMultipartDownloadRepo(),
+            return_value=artifact_repo,
         ),
     ):
         response = _get_presigned_download_url(artifact_path)
@@ -1244,6 +1255,7 @@ def test_get_presigned_download_url_success(enable_serve_artifacts):
     assert data["url"] == "https://storage.example.com/presigned?token=abc"
     assert data["headers"] == {"x-custom-header": "value"}
     assert data["file_size"] == 1024
+    assert artifact_repo.artifact_path == "workspaces/team-a/run_id/artifacts/model.pkl"
 
 
 @pytest.mark.parametrize(
@@ -4987,6 +4999,46 @@ def test_get_workspace_scoped_repo_path_if_enabled_allows_legacy_default_artifac
         assert (
             _get_workspace_scoped_repo_path_if_enabled("1/legacy/artifact") == "1/legacy/artifact"
         )
+
+
+def test_initialize_workspace_store_does_not_initialize_backend_stores():
+    workspace_uri = "sqlite:///workspace.db"
+    with (
+        mock.patch("mlflow.server.handlers._get_workspace_store") as get_workspace_store,
+        mock.patch("mlflow.server.handlers._get_tracking_store") as get_tracking_store,
+        mock.patch("mlflow.server.handlers._get_model_registry_store") as get_registry_store,
+    ):
+        initialize_workspace_store(workspace_uri)
+
+    get_workspace_store.assert_called_once_with(workspace_uri=workspace_uri)
+    get_tracking_store.assert_not_called()
+    get_registry_store.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("handler", "args"),
+    [
+        (_list_workspaces_handler, ()),
+        (_create_workspace_handler, ()),
+        (_get_workspace_handler, ("team-a",)),
+        (_update_workspace_handler, ("team-a",)),
+        (_delete_workspace_handler, ("team-a",)),
+        (get_artifact_handler, ()),
+        (upload_artifact_handler, ()),
+    ],
+)
+def test_tracking_backed_handlers_disabled_in_artifacts_only_mode(monkeypatch, handler, args):
+    monkeypatch.setenv(ARTIFACTS_ONLY_ENV_VAR, "true")
+    with (
+        mock.patch("mlflow.server.handlers._get_workspace_store") as get_workspace_store,
+        mock.patch("mlflow.server.handlers._get_tracking_store") as get_tracking_store,
+        app.test_request_context(),
+    ):
+        response = handler(*args)
+
+    assert response.status_code == 503
+    get_workspace_store.assert_not_called()
+    get_tracking_store.assert_not_called()
 
 
 def test_get_workspace_scoped_repo_path_if_enabled_still_scopes_non_default(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ from click.testing import CliRunner
 import mlflow
 from mlflow.cli import cli, doctor, gc, server
 from mlflow.data import numpy_dataset
-from mlflow.entities import Metric, ViewType
+from mlflow.entities import Metric, ViewType, Workspace
 from mlflow.entities.logged_model import LoggedModelParameter, LoggedModelTag
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
@@ -37,6 +37,7 @@ from mlflow.store.tracking.dbmodels.models import (
 )
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.store.workspace.sqlalchemy_store import SqlAlchemyStore as WorkspaceSqlAlchemyStore
 from mlflow.utils.os import is_windows
 from mlflow.utils.rest_utils import augmented_raise_for_status
 from mlflow.utils.time import get_current_time_millis
@@ -270,9 +271,45 @@ def test_server_mlflow_artifacts_options():
                 run_server_mock.assert_called_once()
 
 
-def test_server_artifacts_only_conflicts_with_enable_workspaces():
+def test_server_artifacts_only_with_workspaces_initializes_only_workspace_store(
+    tmp_path, monkeypatch
+):
+    workspace_uri = f"sqlite:///{tmp_path / 'workspace.db'}"
+    monkeypatch.delenv(MLFLOW_ENABLE_WORKSPACES.name, raising=False)
+    monkeypatch.delenv(MLFLOW_WORKSPACE_STORE_URI.name, raising=False)
+
+    with (
+        mock.patch("mlflow.server._run_server") as run_server_mock,
+        mock.patch("mlflow.server.handlers.initialize_backend_stores") as init_backend,
+        mock.patch("mlflow.server.handlers.initialize_workspace_store") as init_workspace,
+    ):
+        result = CliRunner().invoke(
+            server,
+            [
+                "--artifacts-only",
+                "--enable-workspaces",
+                "--workspace-store-uri",
+                workspace_uri,
+            ],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )
+
+    assert result.exit_code == 0
+    init_workspace.assert_called_once_with(workspace_uri)
+    init_backend.assert_not_called()
+    run_server_mock.assert_called_once()
+    assert MLFLOW_ENABLE_WORKSPACES.get() is True
+    assert MLFLOW_WORKSPACE_STORE_URI.get() == workspace_uri
+
+
+def test_server_artifacts_only_with_workspaces_requires_workspace_store_uri(monkeypatch):
+    monkeypatch.delenv(MLFLOW_ENABLE_WORKSPACES.name, raising=False)
+    monkeypatch.delenv(MLFLOW_WORKSPACE_STORE_URI.name, raising=False)
+
     with pytest.raises(
-        click.UsageError, match="--enable-workspaces cannot be combined with --artifacts-only"
+        click.UsageError,
+        match="--workspace-store-uri is required when combining --enable-workspaces",
     ):
         CliRunner().invoke(
             server,
@@ -280,6 +317,62 @@ def test_server_artifacts_only_conflicts_with_enable_workspaces():
             catch_exceptions=False,
             standalone_mode=False,
         )
+
+
+def test_server_artifacts_only_with_workspaces_uses_environment_configuration(
+    tmp_path, monkeypatch
+):
+    workspace_uri = f"sqlite:///{tmp_path / 'workspace.db'}"
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setenv(MLFLOW_WORKSPACE_STORE_URI.name, workspace_uri)
+
+    with (
+        mock.patch("mlflow.server._run_server") as run_server_mock,
+        mock.patch("mlflow.server.handlers.initialize_backend_stores") as init_backend,
+        mock.patch("mlflow.server.handlers.initialize_workspace_store") as init_workspace,
+    ):
+        result = CliRunner().invoke(
+            server,
+            ["--artifacts-only"],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )
+
+    assert result.exit_code == 0
+    init_workspace.assert_called_once_with(workspace_uri)
+    init_backend.assert_not_called()
+    run_server_mock.assert_called_once()
+
+
+def test_server_artifacts_only_with_workspaces_fails_when_workspace_store_init_fails(
+    tmp_path, monkeypatch
+):
+    workspace_uri = f"sqlite:///{tmp_path / 'workspace.db'}"
+    monkeypatch.delenv(MLFLOW_ENABLE_WORKSPACES.name, raising=False)
+    monkeypatch.delenv(MLFLOW_WORKSPACE_STORE_URI.name, raising=False)
+
+    with (
+        mock.patch("mlflow.server._run_server") as run_server_mock,
+        mock.patch("mlflow.server.handlers.initialize_backend_stores") as init_backend,
+        mock.patch(
+            "mlflow.server.handlers.initialize_workspace_store",
+            side_effect=MlflowException("Invalid workspace provider"),
+        ) as init_workspace,
+    ):
+        result = CliRunner().invoke(
+            server,
+            [
+                "--artifacts-only",
+                "--enable-workspaces",
+                "--workspace-store-uri",
+                workspace_uri,
+            ],
+        )
+
+    assert result.exit_code == 1
+    init_workspace.assert_called_once_with(workspace_uri)
+    init_backend.assert_not_called()
+    run_server_mock.assert_not_called()
 
 
 def _write_trace_archival_config(
@@ -1150,6 +1243,83 @@ def test_mlflow_artifact_list_in_artifacts_only_mode(tmp_path: Path):
             augmented_raise_for_status(resp)
             assert resp.status_code == 200
             assert resp.text == "{}"
+        finally:
+            kill_process_tree(process.pid)
+
+
+def test_mlflow_artifacts_only_with_workspaces(tmp_path: Path):
+    port = get_safe_port()
+    workspace_uri = f"sqlite:///{tmp_path / 'workspaces.db'}"
+    WorkspaceSqlAlchemyStore(workspace_uri).create_workspace(Workspace(name="team-a"))
+    artifact_root = tmp_path / "artifacts"
+    env = {**os.environ}
+    for name in [
+        MLFLOW_ENABLE_WORKSPACES.name,
+        MLFLOW_TRACE_ARCHIVAL_CONFIG.name,
+        MLFLOW_WORKSPACE_STORE_URI.name,
+    ]:
+        env.pop(name, None)
+
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "server",
+            "--port",
+            str(port),
+            "--artifacts-only",
+            "--enable-workspaces",
+            "--workspace-store-uri",
+            workspace_uri,
+            "--artifacts-destination",
+            artifact_root.as_uri(),
+        ],
+        cwd=tmp_path,
+        env=env,
+    ) as process:
+        try:
+            _await_server_up_or_die(port)
+            artifact_url = (
+                f"http://localhost:{port}/api/2.0/mlflow-artifacts/artifacts/run/model.txt"
+            )
+            workspace_header = {"X-MLFLOW-WORKSPACE": "team-a"}
+
+            upload_response = requests.put(
+                artifact_url,
+                headers=workspace_header,
+                data=b"workspace artifact",
+            )
+            augmented_raise_for_status(upload_response)
+
+            download_response = requests.get(artifact_url, headers=workspace_header)
+            augmented_raise_for_status(download_response)
+            assert download_response.content == b"workspace artifact"
+            assert (artifact_root / "workspaces" / "team-a" / "run" / "model.txt").exists()
+
+            default_artifact_url = (
+                f"http://localhost:{port}/api/2.0/mlflow-artifacts/artifacts/default.txt"
+            )
+            default_upload_response = requests.put(
+                default_artifact_url,
+                data=b"default workspace artifact",
+            )
+            augmented_raise_for_status(default_upload_response)
+            assert (artifact_root / "default.txt").read_bytes() == b"default workspace artifact"
+
+            unknown_workspace_response = requests.get(
+                artifact_url,
+                headers={"X-MLFLOW-WORKSPACE": "missing"},
+            )
+            assert unknown_workspace_response.status_code == 404
+
+            tracking_response = requests.get(
+                f"http://localhost:{port}/api/2.0/mlflow/experiments/search",
+                headers=workspace_header,
+            )
+            assert tracking_response.status_code == 503
+            assert "artifacts-only" in tracking_response.text
+            assert not (tmp_path / "mlflow.db").exists()
         finally:
             kill_process_tree(process.pid)
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes https://github.com/mlflow/mlflow/issues/24451

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Allow `--artifacts-only` to be combined with `--enable-workspaces`.

The artifact-only server requires an explicit `--workspace-store-uri` and initializes only the workspace provider needed to validate artifact requests. Tracking and model registry stores remain uninitialized, and non-artifact APIs remain disabled.

This PR also:

- preserves workspace-scoped artifact paths, including presigned downloads
- rejects unknown workspaces and supports provider-default workspace resolution
- documents the required split-server configuration

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow artifact-only servers can now run with workspaces enabled by configuring a shared workspace provider.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
