### PR TITLE
Propagate contextvars into trace read thread pool workers

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -70,6 +70,7 @@ from mlflow.tracing.utils.artifact_utils import get_artifact_uri_for_trace
 from mlflow.tracking._tracking_service.utils import _get_store, _resolve_tracking_uri
 from mlflow.utils import is_uuid
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
+from mlflow.utils.thread_utils import map_with_context
 from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri, is_databricks_uri
 
 _logger = logging.getLogger(__name__)
@@ -435,7 +436,7 @@ class TracingClient:
 
         batch_size = _MLFLOW_SEARCH_TRACES_MAX_BATCH_SIZE.get()
         batches = [trace_ids[i : i + batch_size] for i in range(0, len(trace_ids), batch_size)]
-        for minibatch_traces in executor.map(_fetch_minibatch, batches):
+        for minibatch_traces in map_with_context(executor, _fetch_minibatch, batches):
             traces.extend(minibatch_traces)
         return traces
 
@@ -449,7 +450,8 @@ class TracingClient:
             if location == SpansLocation.ARTIFACT_REPO:
                 traces.extend(
                     tr
-                    for tr in executor.map(
+                    for tr in map_with_context(
+                        executor,
                         self._download_spans_from_artifact_repo,
                         location_trace_infos,
                     )

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -53,6 +53,7 @@ from mlflow.tracing.utils import (
 from mlflow.tracing.utils.search import traces_to_df
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import deprecated, deprecated_parameter, experimental
+from mlflow.utils.thread_utils import map_with_context
 from mlflow.utils.validation import _validate_list_param
 
 _logger = logging.getLogger(__name__)
@@ -1285,7 +1286,7 @@ def search_sessions(
         max_workers=max_workers,
         thread_name_prefix="search_sessions",
     ) as executor:
-        session_results = list(executor.map(fetch_session_traces, session_ids))
+        session_results = list(map_with_context(executor, fetch_session_traces, session_ids))
 
     # Filter out empty sessions, wrap in Session objects, and preserve order
     sessions: list[Session] = [Session(s) for s in session_results if s]

--- a/mlflow/utils/thread_utils.py
+++ b/mlflow/utils/thread_utils.py
@@ -1,6 +1,12 @@
+import contextvars
 import os
 import threading
-from typing import Any
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
 
 
 class ThreadLocalVariable:
@@ -61,3 +67,19 @@ class ThreadLocalVariable:
         """
         self.__global_thread_values.clear()
         self.thread_local = threading.local()
+
+
+def map_with_context(
+    executor: ThreadPoolExecutor,
+    fn: Callable[[T], R],
+    iterable: Iterable[T],
+) -> Iterable[R]:
+    """
+    Like ``executor.map``, but each task runs inside a copy of the caller's contextvars.
+
+    A separate context copy is created per item so concurrent workers do not share
+    the same ``Context.run()`` state.
+    """
+    items = list(iterable)
+    contexts = [contextvars.copy_context() for _ in items]
+    return executor.map(lambda item, ctx: ctx.run(fn, item), items, contexts)

--- a/mlflow/utils/thread_utils.py
+++ b/mlflow/utils/thread_utils.py
@@ -80,6 +80,6 @@ def map_with_context(
     A separate context copy is created per item so concurrent workers do not share
     the same ``Context.run()`` state.
     """
-    items = list(iterable)
+    items = iterable if isinstance(iterable, list) else list(iterable)
     contexts = [contextvars.copy_context() for _ in items]
     return executor.map(lambda item, ctx: ctx.run(fn, item), items, contexts)

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -1,3 +1,4 @@
+import contextvars
 import json
 import uuid
 from unittest.mock import Mock, patch
@@ -162,6 +163,37 @@ def test_batch_get_traces_without_location():
     assert traces == ["trace1"]
     mock_store.batch_get_trace_infos.assert_called_once_with(["id1"])
     mock_store.batch_get_traces.assert_called_once_with(["id1"], None)
+
+
+_REQUEST_CTX = contextvars.ContextVar("request_ctx", default=None)
+
+
+def test_batch_get_traces_propagates_contextvars():
+    mock_store = Mock()
+    trace_info = TraceInfo(
+        trace_id="id1",
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=1000,
+        state=TraceState.OK,
+        tags={TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE},
+    )
+    mock_store.batch_get_trace_infos.return_value = [trace_info]
+
+    captured = []
+
+    def batch_get_traces(ids, location=None):
+        captured.append(_REQUEST_CTX.get())
+        return ["trace1"]
+
+    mock_store.batch_get_traces.side_effect = batch_get_traces
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient()
+        _REQUEST_CTX.set("tenant-b")
+        traces = client.batch_get_traces(["id1"])
+
+    assert traces == ["trace1"]
+    assert captured == ["tenant-b"]
 
 
 def test_batch_get_traces_without_location_for_archive_repo():

--- a/tests/utils/test_thread_utils.py
+++ b/tests/utils/test_thread_utils.py
@@ -14,7 +14,7 @@ def test_map_with_context_propagates_caller_context():
     def worker(_):
         return _TEST_CTX.get()
 
-    with ThreadPoolExecutor(max_workers=2) as executor:
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="test_propagates") as executor:
         results = list(map_with_context(executor, worker, range(2)))
 
     assert results == ["caller-value", "caller-value"]
@@ -26,7 +26,7 @@ def test_map_with_context_concurrent_workers():
     def worker(_):
         return _TEST_CTX.get()
 
-    with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="test_concurrent") as executor:
         results = list(map_with_context(executor, worker, range(16)))
 
     assert results == ["caller-value"] * 16
@@ -36,7 +36,7 @@ def test_map_with_context_preserves_order():
     def worker(x):
         return x * 2
 
-    with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="test_order") as executor:
         results = list(map_with_context(executor, worker, range(8)))
 
     assert results == [x * 2 for x in range(8)]
@@ -48,7 +48,7 @@ def test_map_with_context_propagates_exceptions():
             raise ValueError("boom")
         return x
 
-    with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=4, thread_name_prefix="test_exceptions") as executor:
         with pytest.raises(ValueError, match="boom"):
             list(map_with_context(executor, worker, range(6)))
 
@@ -60,7 +60,7 @@ def test_map_with_context_worker_mutations_do_not_leak_to_caller():
         _TEST_CTX.set("mutated-in-worker")
         return _TEST_CTX.get()
 
-    with ThreadPoolExecutor(max_workers=2) as executor:
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="test_no_leak") as executor:
         list(map_with_context(executor, worker, range(2)))
 
     assert _TEST_CTX.get() == "original"

--- a/tests/utils/test_thread_utils.py
+++ b/tests/utils/test_thread_utils.py
@@ -1,0 +1,66 @@
+import contextvars
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from mlflow.utils.thread_utils import map_with_context
+
+_TEST_CTX = contextvars.ContextVar("test_ctx", default=None)
+
+
+def test_map_with_context_propagates_caller_context():
+    _TEST_CTX.set("caller-value")
+
+    def worker(_):
+        return _TEST_CTX.get()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(map_with_context(executor, worker, range(2)))
+
+    assert results == ["caller-value", "caller-value"]
+
+
+def test_map_with_context_concurrent_workers():
+    _TEST_CTX.set("caller-value")
+
+    def worker(_):
+        return _TEST_CTX.get()
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(map_with_context(executor, worker, range(16)))
+
+    assert results == ["caller-value"] * 16
+
+
+def test_map_with_context_preserves_order():
+    def worker(x):
+        return x * 2
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(map_with_context(executor, worker, range(8)))
+
+    assert results == [x * 2 for x in range(8)]
+
+
+def test_map_with_context_propagates_exceptions():
+    def worker(x):
+        if x == 3:
+            raise ValueError("boom")
+        return x
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        with pytest.raises(ValueError, match="boom"):
+            list(map_with_context(executor, worker, range(6)))
+
+
+def test_map_with_context_worker_mutations_do_not_leak_to_caller():
+    _TEST_CTX.set("original")
+
+    def worker(_):
+        _TEST_CTX.set("mutated-in-worker")
+        return _TEST_CTX.get()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(map_with_context(executor, worker, range(2)))
+
+    assert _TEST_CTX.get() == "original"


### PR DESCRIPTION
# Propagate contextvars into trace read thread pool workers

Trace read paths fan out to ThreadPoolExecutor without copying the caller's contextvars, so integrator per-request state is lost in workers. Use per-task copy_context via map_with_context at each executor.map site.

Fixes #24422

### Related Issues/PRs

Closes #24422

### What changes are proposed in this pull request?

MLflow's trace **read** paths fan work out to `ThreadPoolExecutor`s without propagating the submitting thread's `contextvars` into the worker threads. Any per-request state an integrator stores in a `ContextVar` (e.g. a tenant id read by a SQLAlchemy `checkout` hook to route the DB connection) is therefore lost inside those workers, silently.

This PR adds a small `map_with_context` helper in `mlflow/utils/thread_utils.py` and uses it at each `executor.map` site so every task runs inside a copy of the caller's context:

- `mlflow/tracing/client.py` — `_download_spans_from_batch_get_traces` and `_load_traces_by_location` (covers both `search_traces(include_spans=True)` and `batch_get_traces`)
- `mlflow/tracing/fluent.py` — session fan-out in `search_sessions`

Importantly, the helper captures a **separate** `contextvars.copy_context()` **per task** rather than sharing one context across workers. A single shared context cannot be reused: `contextvars.Context.run()` cannot be entered by more than one thread at a time, so a shared copy would raise `RuntimeError: cannot enter context: is already entered` under concurrency (exactly what these pools do).

```python
def map_with_context(executor, fn, iterable):
    items = list(iterable)
    contexts = [contextvars.copy_context() for _ in items]
    return executor.map(lambda item, ctx: ctx.run(fn, item), items, contexts)
```

Stock single-tenant MLflow is unaffected (nothing in the store layer depends on a caller-set `ContextVar`), and `copy_context` is effectively zero overhead, so this is a safe hardening of the read paths.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests cover propagation into workers, safety under concurrency (16 items over 4 workers — the case that catches the shared-context bug), order preservation, exception propagation, and that a worker mutating the `ContextVar` does not leak back to the caller (`tests/utils/test_thread_utils.py`), plus a `TracingClient.batch_get_traces` context-propagation test (`tests/tracing/test_tracing_client.py`). All new tests and the existing `tests/tracing/test_tracing_client.py` suite pass locally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Trace read paths (`mlflow.search_traces(..., include_spans=True)`, `TracingClient.batch_get_traces`, and session search) now propagate the caller's `contextvars` into their thread-pool workers, so per-request context set by integrators is preserved during span/trace fetches.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
