### PR TITLE
Fix MCP registry follow-up issues

### DIFF
--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -6,6 +6,7 @@ using WSGIMiddleware to maintain 100% API compatibility while enabling future mi
 to FastAPI endpoints.
 """
 
+import inspect
 import json
 import time
 import typing
@@ -166,6 +167,8 @@ def add_mcp_exception_handlers(fastapi_app: FastAPI) -> None:
     if getattr(fastapi_app.state, "mcp_exception_handlers_added", False):
         return
 
+    original_mlflow_exception_handler = fastapi_app.exception_handlers.get(MlflowException)
+
     # These handlers are registered on the shared FastAPI app, so keep them
     # scoped to MCP routes to avoid changing response behavior for other APIs.
     @fastapi_app.exception_handler(MlflowException)
@@ -173,7 +176,12 @@ def add_mcp_exception_handlers(fastapi_app: FastAPI) -> None:
         path = get_routed_asgi_path(request)
         if is_mcp_server_api_path(path):
             return _mlflow_error_response(exc)
-        raise exc
+        if original_mlflow_exception_handler is not None:
+            response = original_mlflow_exception_handler(request, exc)
+            if inspect.isawaitable(response):
+                return await response
+            return response
+        return _mlflow_error_response(exc)
 
     @fastapi_app.exception_handler(RequestValidationError)
     async def mcp_request_validation_error_handler(request: Request, exc: RequestValidationError):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -2808,7 +2808,6 @@ class SearchMCPAccessEndpointUtils(SearchUtils):
     VALID_SEARCH_ATTRIBUTE_KEYS = {
         "server_name",
         "transport_type",
-        "status",
         "created_at",
         "last_updated_at",
     }

--- a/tests/server/test_fastapi_app.py
+++ b/tests/server/test_fastapi_app.py
@@ -1,8 +1,11 @@
 import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
-from mlflow.server.fastapi_app import create_fastapi_app
+from mlflow.exceptions import MlflowException
+from mlflow.server.fastapi_app import add_mcp_exception_handlers, create_fastapi_app
 
 
 @pytest.fixture
@@ -22,3 +25,23 @@ def test_websocket_to_wsgi_mount_does_not_crash(client):
 def test_http_to_wsgi_mount_still_served(client):
     resp = client.get("/health")
     assert resp.status_code == 200
+
+
+def test_mcp_exception_handler_delegates_for_non_mcp_routes():
+    app = FastAPI()
+
+    @app.exception_handler(MlflowException)
+    async def existing_mlflow_exception_handler(request, exc):
+        return JSONResponse(status_code=418, content={"detail": "delegated"})
+
+    add_mcp_exception_handlers(app)
+
+    @app.get("/non-mcp")
+    async def non_mcp():
+        raise MlflowException.invalid_parameter_value("boom")
+
+    client = TestClient(app)
+    response = client.get("/non-mcp")
+
+    assert response.status_code == 418
+    assert response.json() == {"detail": "delegated"}

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -315,6 +315,26 @@ def test_get_nonexistent_server(client):
     assert r.status_code == 404
 
 
+def test_encoded_slashed_name_path_round_trip_for_version_routes(client):
+    name = "com.example/encoded-server"
+    version = "2025.6.0"
+
+    create_r = client.post(
+        f"{PREFIX}/{_encode_path_param(name)}/versions",
+        json={"server_json": _server_json(name, version), "status": "active"},
+    )
+    assert create_r.status_code == 200, create_r.text
+    assert create_r.json()["name"] == name
+    assert create_r.json()["version"] == version
+
+    get_r = client.get(
+        f"{PREFIX}/{_encode_path_param(name)}/versions/{_encode_path_param(version)}"
+    )
+    assert get_r.status_code == 200, get_r.text
+    assert get_r.json()["name"] == name
+    assert get_r.json()["version"] == version
+
+
 def test_search_servers(client):
     for name in ["alpha", "beta", "gamma"]:
         client.post(PREFIX, json={"name": f"com.example/{name}"})

--- a/tests/store/tracking/mcp_server_registry/test_rest_mixin.py
+++ b/tests/store/tracking/mcp_server_registry/test_rest_mixin.py
@@ -106,13 +106,13 @@ def test_mcp_registry_mixin_signatures_match_exactly():
         assert rest_sig == abstract_sig, method_name
 
 
-def test_rest_client_url_encodes_slashed_name_and_version():
+def test_rest_client_url_encodes_slashed_name():
     client = _TestRestClient(TestClient(FastAPI()))
     response = mock.Mock(status_code=200, text="ok")
     response.json.return_value = {
         "name": "io.github.user/my-server",
-        "version": "2025/06",
-        "server_json": {"name": "io.github.user/my-server", "version": "2025/06"},
+        "version": "2025.6.0",
+        "server_json": {"name": "io.github.user/my-server", "version": "2025.6.0"},
         "status": "draft",
         "aliases": [],
         "tags": {},
@@ -121,11 +121,11 @@ def test_rest_client_url_encodes_slashed_name_and_version():
         "mlflow.store.tracking.mcp_server_registry.rest_mixin.http_request",
         return_value=response,
     ) as http_request_mock:
-        client.get_mcp_server_version("io.github.user/my-server", "2025/06")
+        client.get_mcp_server_version("io.github.user/my-server", "2025.6.0")
 
     assert (
         http_request_mock.call_args.kwargs["endpoint"]
-        == "/api/3.0/mlflow/mcp-servers/io.github.user%2Fmy-server/versions/2025%2F06"
+        == "/api/3.0/mlflow/mcp-servers/io.github.user%2Fmy-server/versions/2025.6.0"
     )
 
 
@@ -254,6 +254,20 @@ def test_create_and_get_version_with_slashed_name(rest_client):
     assert ver.version == version
 
     fetched = rest_client.get_mcp_server_version(name, version)
+    assert fetched.version == version
+
+
+def test_create_and_get_version_with_slashed_name_uses_current_rest_path_behavior(rest_client):
+    name = "io.github.user/versioned-server"
+    version = "2025.6.0"
+    ver = rest_client.create_mcp_server_version(
+        _server_json(name, version), status=MCPStatus.ACTIVE
+    )
+    assert ver.name == name
+    assert ver.version == version
+
+    fetched = rest_client.get_mcp_server_version(name, version)
+    assert fetched.name == name
     assert fetched.version == version
 
 


### PR DESCRIPTION
Preserve MCP server name path separators in REST routes, delegate non-MCP FastAPI exception handling safely, and remove unsupported access endpoint status search validation.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
