### PR TITLE
Widen job-runner test timeouts in `tests/server/jobs/test_endpoint.py`

### DIFF
--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -74,7 +74,7 @@ class Client:
         response.raise_for_status()
         return response.json()
 
-    def wait_job(self, job_id: str, timeout: float = 10) -> dict[str, Any]:
+    def wait_job(self, job_id: str, timeout: float = 30) -> dict[str, Any]:
         beg_time = time.time()
         while time.time() - beg_time <= timeout:
             job_json = self.get_job(job_id)
@@ -184,14 +184,14 @@ def test_job_cancel(client: Client):
         job_name="simple_job_fun",
         params={"x": 3, "y": 4, "sleep_secs": 120},
     )["job_id"]
-    deadline = time.time() + 20
+    deadline = time.time() + 60
     while time.time() < deadline:
         status = client.get_job(job_id)["status"]
         if status == "RUNNING":
             break
         time.sleep(0.5)
     else:
-        raise TimeoutError(f"Job did not start running within 20 seconds, last status: {status}")
+        raise TimeoutError(f"Job did not start running within 60 seconds, last status: {status}")
 
     client.cancel_job(job_id)
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`test_job_cancel` and `test_job_endpoint_search` in `tests/server/jobs/test_endpoint.py` spin up a real job-runner server and poll for job status. Their deadlines are too tight under a loaded CI runner and both flaked in the `python (4)` shard of a recent `master` run:

- `test_job_cancel` waited only 20s for a submitted job to reach `RUNNING` → `TimeoutError: Job did not start running within 20 seconds`.
- `test_job_endpoint_search` relied on `wait_job`'s default 10s finalize timeout → `TimeoutError: The job is not finalized within the timeout.`

The finalize case is not purely a contention issue: `test_job_endpoint_search` takes ~15s on an unloaded local machine, already exceeding the old 10s limit.

This PR widens the deadlines so the tests aren't racing the runner:

- `Client.wait_job` default `timeout`: `10s` → `30s`
- `test_job_cancel` start deadline: `20s` → `60s`

This is a small robustness fix that also unblocks experimenting with `pytest-xdist`, whose in-runner CPU contention would make these edge-timeouts flakier.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Ran the two affected tests locally, both pass (`test_job_endpoint_search` took 15.3s, confirming it was over the old 10s finalize timeout):

```
$ pytest tests/server/jobs/test_endpoint.py::test_job_cancel \
         tests/server/jobs/test_endpoint.py::test_job_endpoint_search
2 passed in 34.14s
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release