### PR TITLE
Collect JUnit XML test results as CI artifacts

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,12 +110,21 @@ jobs:
         run: |
           source dev/setup-ssh.sh
           uv run --no-sync pytest --splits=$SPLITS --group=$GROUP \
+            --junitxml=test-results/python-${GROUP}.xml \
             --quiet --requires-ssh --ignore-flavors \
             --ignore=tests/examples \
             --ignore=tests/evaluate \
             --ignore=tests/genai \
             --ignore=tests/docker \
             tests
+      - name: Upload test results
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: test-results-python-${{ matrix.group }}
+          path: test-results/*.xml
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Run databricks-connect related tests
         run: |
@@ -448,6 +457,7 @@ jobs:
           uv run --no-sync pytest tests \
             --splits=$SPLITS \
             --group=$GROUP \
+            --junitxml=test-results/windows-${GROUP}.xml \
             --ignore-flavors \
             --ignore=tests/projects \
             --ignore=tests/examples \
@@ -465,3 +475,11 @@ jobs:
             --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_delta_datasource \
             --ignore=tests/docker \
             --ignore=tests/demo
+      - name: Upload test results
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: test-results-windows-${{ matrix.group }}
+          path: test-results/*.xml
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Today a flaky test forces a re-run of the whole ~40-minute shard, and the only record of what failed is the raw text log, which GitHub expires. There is no structured, queryable history of test outcomes, durations, or which tests pass only on re-run.

This PR emits JUnit XML from the sharded `python` and `windows` jobs via pytest's built-in `--junitxml`, and uploads it as a per-shard artifact:

- `--junitxml=test-results/<os>-${GROUP}.xml` added to the `python` and `windows` pytest invocations.
- An `Upload test results` step (`actions/upload-artifact`, pinned) with `if: "!cancelled()"` so results are captured even when tests fail — the interesting case — and `if-no-files-found: ignore` + `retention-days: 30`.

This is pure observability: no test behavior changes and nothing gates on it. It unblocks follow-ups without committing to them here: flake detection (find tests that fail-then-pass on re-run), an evidence-based quarantine / `@pytest.mark.flaky` list, and pass/fail/duration dashboards. Scoped to the two slowest jobs to start; extends trivially to `models`/`pyfunc`/`evaluate`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Verified locally that `pytest --junitxml=test-results/python-1.xml ...` produces a well-formed JUnit XML file. Workflow policy checks (`check-github-workflows`, `conftest`, `check-actions`) pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release