### PR TITLE
[fix] Fix runs-table column reordering before pinned anchors

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -58,10 +58,8 @@ import { columnStateToPrefs, getReorderCorrection, prefsToColumnState } from './
 const ROW_BUFFER = 101; // How many rows to keep rendered, even ones not visible
 const LARGE_COLUMN_COUNT_THRESHOLD = 1000; // Threshold to determine if we should optimize column rendering
 
-// Leading pinned-left columns that must stay leftmost: Run Name, then Created (`runDateAndNestInfo`
-// is the Created column's field/colId). A user can drag another column in front of these but the
-// layout can't persist it there, so getReorderCorrection snaps it back. Order matters — it's the
-// order they're restored to.
+// Pinned-left anchors that must stay leftmost, in restore order: Run Name, then Created
+// (`runDateAndNestInfo` is the Created column's colId).
 const LEADING_ANCHOR_COLUMN_IDS = [
   makeCanonicalSortKey(COLUMN_TYPES.ATTRIBUTES, ATTRIBUTE_COLUMN_LABELS.RUN_NAME),
   'runDateAndNestInfo',
@@ -302,18 +300,19 @@ export const ExperimentViewRunsTable = React.memo(
           return;
         }
         if (event.source === 'uiColumnMoved' || event.source === 'uiColumnDragged') {
-          // The leading Run Name + Created columns are pinned-left anchors. ag-grid lets a user drop
-          // another column in front of them, but that layout can't be persisted (see
-          // getReorderCorrection), so snap it back before capturing. The corrective applyColumnState
-          // re-fires this handler with source 'api', which the guard above ignores — no recursion,
-          // and the rejected order is never persisted.
+          // Wait for allColumns to populate (one tick after grid-ready) before reasoning about
+          // order — otherwise a very fast first drag would skip the anchor correction and capture
+          // an unvalidated layout.
+          if (allColumnsRef.current.length === 0) {
+            return;
+          }
+          // Snap a column dropped in front of the pinned anchors back (see getReorderCorrection).
+          // The corrective applyColumnState re-fires with source 'api', which is ignored above, so
+          // there's no recursion and the rejected order is never persisted.
           const currentOrder = event.columnApi.getColumnState().map((column) => column.colId);
           const corrected = getReorderCorrection(currentOrder, LEADING_ANCHOR_COLUMN_IDS, allColumnsRef.current);
           if (corrected) {
-            event.columnApi.applyColumnState({
-              state: corrected.map((colId) => ({ colId })),
-              applyOrder: true,
-            });
+            event.columnApi.applyColumnState({ state: corrected.map((colId) => ({ colId })), applyOrder: true });
             return;
           }
           captureColumnState(event.columnApi);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -53,10 +53,19 @@ import { useToggleRowVisibilityCallback } from '../../hooks/useToggleRowVisibili
 import { ExperimentViewRunsTableHeaderContextProvider } from './ExperimentViewRunsTableHeaderContext';
 import { useRunsHighlightTableRow } from '../../../runs-charts/hooks/useRunsHighlightTableRow';
 import { debounce, isEmpty, isEqual } from 'lodash';
-import { columnStateToPrefs, prefsToColumnState } from './agGridColumnPrefsAdapter';
+import { columnStateToPrefs, getReorderCorrection, prefsToColumnState } from './agGridColumnPrefsAdapter';
 
 const ROW_BUFFER = 101; // How many rows to keep rendered, even ones not visible
 const LARGE_COLUMN_COUNT_THRESHOLD = 1000; // Threshold to determine if we should optimize column rendering
+
+// Leading pinned-left columns that must stay leftmost: Run Name, then Created (`runDateAndNestInfo`
+// is the Created column's field/colId). A user can drag another column in front of these but the
+// layout can't persist it there, so getReorderCorrection snaps it back. Order matters — it's the
+// order they're restored to.
+const LEADING_ANCHOR_COLUMN_IDS = [
+  makeCanonicalSortKey(COLUMN_TYPES.ATTRIBUTES, ATTRIBUTE_COLUMN_LABELS.RUN_NAME),
+  'runDateAndNestInfo',
+];
 
 export interface ExperimentViewRunsTableProps {
   /**
@@ -293,6 +302,20 @@ export const ExperimentViewRunsTable = React.memo(
           return;
         }
         if (event.source === 'uiColumnMoved' || event.source === 'uiColumnDragged') {
+          // The leading Run Name + Created columns are pinned-left anchors. ag-grid lets a user drop
+          // another column in front of them, but that layout can't be persisted (see
+          // getReorderCorrection), so snap it back before capturing. The corrective applyColumnState
+          // re-fires this handler with source 'api', which the guard above ignores — no recursion,
+          // and the rejected order is never persisted.
+          const currentOrder = event.columnApi.getColumnState().map((column) => column.colId);
+          const corrected = getReorderCorrection(currentOrder, LEADING_ANCHOR_COLUMN_IDS, allColumnsRef.current);
+          if (corrected) {
+            event.columnApi.applyColumnState({
+              state: corrected.map((colId) => ({ colId })),
+              applyOrder: true,
+            });
+            return;
+          }
           captureColumnState(event.columnApi);
         }
       },

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from '@jest/globals';
 import type { ColumnState } from '@ag-grid-community/core';
 
-import { columnStateToPrefs, prefsToColumnState } from './agGridColumnPrefsAdapter';
+import { columnStateToPrefs, getReorderCorrection, prefsToColumnState } from './agGridColumnPrefsAdapter';
 
 const ALL = ['a', 'b', 'c', 'd'] as const;
+
+// Realistic runs-table shape: "cb" stands in for the structural checkbox column (ag-grid gives it
+// an auto colId, not present in the data-column set); RUN_NAME + CREATED are the pinned anchors.
+const RUN_NAME = 'attributes.`Run Name`';
+const CREATED = 'runDateAndNestInfo';
+const ANCHORS = [RUN_NAME, CREATED];
+const DATA = [RUN_NAME, CREATED, 'datasets', 'duration', 'attributes.`Source`'];
 
 describe('agGridColumnPrefsAdapter', () => {
   describe('prefsToColumnState', () => {
@@ -38,5 +45,54 @@ describe('agGridColumnPrefsAdapter', () => {
     const restored = columnStateToPrefs(prefsToColumnState(['b', 'a', 'c', 'd'], { b: 150 }) as ColumnState[], ALL);
     expect(restored.columnOrder).toEqual(['b', 'a', 'c', 'd']);
     expect(restored.columnWidths).toEqual({ b: 150 });
+  });
+
+  describe('getReorderCorrection', () => {
+    test('returns null for the default valid order (anchors lead the data columns)', () => {
+      const order = ['1', RUN_NAME, CREATED, 'datasets', 'duration', 'attributes.`Source`'];
+      expect(getReorderCorrection(order, ANCHORS, DATA)).toBeNull();
+    });
+
+    test('returns null when only non-anchor data columns are reordered', () => {
+      const order = ['1', RUN_NAME, CREATED, 'duration', 'attributes.`Source`', 'datasets'];
+      expect(getReorderCorrection(order, ANCHORS, DATA)).toBeNull();
+    });
+
+    test('snaps a data column dropped before Run Name back behind the anchors', () => {
+      // User dragged Source in front of Run Name.
+      const order = ['1', 'attributes.`Source`', RUN_NAME, CREATED, 'datasets', 'duration'];
+      expect(getReorderCorrection(order, ANCHORS, DATA)).toEqual([
+        '1',
+        RUN_NAME,
+        CREATED,
+        'attributes.`Source`',
+        'datasets',
+        'duration',
+      ]);
+    });
+
+    test('corrects a column dropped between the two anchors', () => {
+      const order = ['1', RUN_NAME, 'duration', CREATED, 'datasets', 'attributes.`Source`'];
+      expect(getReorderCorrection(order, ANCHORS, DATA)).toEqual([
+        '1',
+        RUN_NAME,
+        CREATED,
+        'duration',
+        'datasets',
+        'attributes.`Source`',
+      ]);
+    });
+
+    test('keeps the structural checkbox column in its leading slot', () => {
+      const order = ['1', 'datasets', RUN_NAME, CREATED, 'duration', 'attributes.`Source`'];
+      const corrected = getReorderCorrection(order, ANCHORS, DATA);
+      expect(corrected?.[0]).toBe('1');
+      expect(corrected).toEqual(['1', RUN_NAME, CREATED, 'datasets', 'duration', 'attributes.`Source`']);
+    });
+
+    test('returns null when no anchors are present (compact/compare layouts)', () => {
+      const order = ['1', 'datasets', 'duration', 'attributes.`Source`'];
+      expect(getReorderCorrection(order, ANCHORS, DATA)).toBeNull();
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.test.ts
@@ -94,5 +94,12 @@ describe('agGridColumnPrefsAdapter', () => {
       const order = ['1', 'datasets', 'duration', 'attributes.`Source`'];
       expect(getReorderCorrection(order, ANCHORS, DATA)).toBeNull();
     });
+
+    test('returns null when anchors are configured but absent from the data columns', () => {
+      // dataColIds not yet populated (empty) — nothing is treated as a data column, so there is
+      // no order to protect and the correction is intentionally skipped.
+      const order = ['1', 'attributes.`Source`', RUN_NAME, CREATED];
+      expect(getReorderCorrection(order, ANCHORS, [])).toBeNull();
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.ts
@@ -17,24 +17,11 @@ export const prefsToColumnState = (columnOrder: string[], columnWidths: Record<s
   }));
 
 /**
- * The leading attribute columns (Run Name, Created) are pinned-left and can't be dragged
- * themselves, but ag-grid still lets a user drop ANOTHER data column in front of them. That layout
- * can't be persisted — the adapter round-trips order + width but not `pinned`, so the pinned
- * anchors re-sort left on reload and the move silently reverts. Rather than persist a layout we
- * can't restore, we detect the violation after a move and snap the order back.
- *
- * Inputs:
- * - `currentOrder`: colIds ag-grid reports after a move, in display order. This includes the
- *   structural checkbox column, whose colId ag-grid auto-generates (e.g. "1") — it is NOT a data
- *   column and must be left wherever ag-grid put it (it is lockPosition-anchored to index 0).
- * - `anchorColIds`: the data columns that must stay ahead of all other DATA columns.
- * - `dataColIds`: every real (user-facing) data colId — i.e. `allColumns`, which already excludes
- *   the checkbox. Only these are reordered; anything else in `currentOrder` is structural and left
- *   in place.
- *
- * Returns `null` if the data-column order is already valid, otherwise the corrected full colId
- * order to re-apply (structural columns kept in their current slots, anchors moved ahead of the
- * other data columns, remaining data columns keeping their relative order).
+ * Keeps the pinned anchor columns (Run Name, Created) ahead of all other data columns after a
+ * drag. ag-grid lets a user drop a column in front of them, but the adapter doesn't persist
+ * `pinned`, so that layout reverts on reload. Returns the corrected colId order to re-apply, or
+ * `null` if already valid. `dataColIds` (= `allColumns`) excludes the structural checkbox, whose
+ * auto-generated colId is left in its current slot.
  */
 export const getReorderCorrection = (
   currentOrder: (string | null | undefined)[],
@@ -47,8 +34,6 @@ export const getReorderCorrection = (
   const isAnchor = (colId: string | null | undefined): colId is string =>
     typeof colId === 'string' && anchorSet.has(colId);
 
-  // Position of each anchor among the DATA columns only (ignoring structural columns like the
-  // checkbox). If no anchors are present there is nothing to protect (compact/compare layouts).
   const dataOrder = currentOrder.filter(isData);
   const anchorsPresent = anchorColIds.filter((id) => dataSet.has(id) && dataOrder.includes(id));
   if (anchorsPresent.length === 0) {
@@ -56,20 +41,13 @@ export const getReorderCorrection = (
   }
   const lastAnchorIdxInData = Math.max(...anchorsPresent.map((id) => dataOrder.indexOf(id)));
 
-  // Violation: a non-anchor data column sits before the last anchor among the data columns.
-  const violated = dataOrder.slice(0, lastAnchorIdxInData).some((colId) => !isAnchor(colId));
-  if (!violated) {
+  // A non-anchor data column sitting before the last anchor is the violation to correct.
+  if (!dataOrder.slice(0, lastAnchorIdxInData).some((colId) => !isAnchor(colId))) {
     return null;
   }
 
-  // Desired data-column order: anchors first (configured order), then the rest in current order.
-  const rest = dataOrder.filter((colId) => !isAnchor(colId));
-  const desiredData = [...anchorsPresent, ...rest];
-
-  // Re-thread the desired data order back through `currentOrder`, leaving every structural
-  // (non-data) column exactly where it is. Walk the original slots; data slots get filled from
-  // desiredData in sequence, structural slots (e.g. the checkbox) pass through untouched. Slots
-  // with no colId are dropped — applyColumnState leaves any unlisted column in place.
+  const desiredData = [...anchorsPresent, ...dataOrder.filter((colId) => !isAnchor(colId))];
+  // Re-thread the desired data order through the original slots; non-data slots (checkbox) stay put.
   let d = 0;
   return currentOrder.reduce<string[]>((acc, colId) => {
     if (isData(colId)) {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.ts
@@ -47,7 +47,9 @@ export const getReorderCorrection = (
   }
 
   const desiredData = [...anchorsPresent, ...dataOrder.filter((colId) => !isAnchor(colId))];
-  // Re-thread the desired data order through the original slots; non-data slots (checkbox) stay put.
+  // Re-thread the desired data order through the original slots. Non-data columns (e.g. the
+  // checkbox) are re-emitted in their existing position by colId — they are not dropped and not
+  // relied on to stay in place implicitly. Only null/undefined colIds are omitted.
   let d = 0;
   return currentOrder.reduce<string[]>((acc, colId) => {
     if (isData(colId)) {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/agGridColumnPrefsAdapter.ts
@@ -17,6 +17,71 @@ export const prefsToColumnState = (columnOrder: string[], columnWidths: Record<s
   }));
 
 /**
+ * The leading attribute columns (Run Name, Created) are pinned-left and can't be dragged
+ * themselves, but ag-grid still lets a user drop ANOTHER data column in front of them. That layout
+ * can't be persisted — the adapter round-trips order + width but not `pinned`, so the pinned
+ * anchors re-sort left on reload and the move silently reverts. Rather than persist a layout we
+ * can't restore, we detect the violation after a move and snap the order back.
+ *
+ * Inputs:
+ * - `currentOrder`: colIds ag-grid reports after a move, in display order. This includes the
+ *   structural checkbox column, whose colId ag-grid auto-generates (e.g. "1") — it is NOT a data
+ *   column and must be left wherever ag-grid put it (it is lockPosition-anchored to index 0).
+ * - `anchorColIds`: the data columns that must stay ahead of all other DATA columns.
+ * - `dataColIds`: every real (user-facing) data colId — i.e. `allColumns`, which already excludes
+ *   the checkbox. Only these are reordered; anything else in `currentOrder` is structural and left
+ *   in place.
+ *
+ * Returns `null` if the data-column order is already valid, otherwise the corrected full colId
+ * order to re-apply (structural columns kept in their current slots, anchors moved ahead of the
+ * other data columns, remaining data columns keeping their relative order).
+ */
+export const getReorderCorrection = (
+  currentOrder: (string | null | undefined)[],
+  anchorColIds: string[],
+  dataColIds: readonly string[],
+): string[] | null => {
+  const dataSet = new Set(dataColIds);
+  const anchorSet = new Set(anchorColIds);
+  const isData = (colId: string | null | undefined): colId is string => typeof colId === 'string' && dataSet.has(colId);
+  const isAnchor = (colId: string | null | undefined): colId is string =>
+    typeof colId === 'string' && anchorSet.has(colId);
+
+  // Position of each anchor among the DATA columns only (ignoring structural columns like the
+  // checkbox). If no anchors are present there is nothing to protect (compact/compare layouts).
+  const dataOrder = currentOrder.filter(isData);
+  const anchorsPresent = anchorColIds.filter((id) => dataSet.has(id) && dataOrder.includes(id));
+  if (anchorsPresent.length === 0) {
+    return null;
+  }
+  const lastAnchorIdxInData = Math.max(...anchorsPresent.map((id) => dataOrder.indexOf(id)));
+
+  // Violation: a non-anchor data column sits before the last anchor among the data columns.
+  const violated = dataOrder.slice(0, lastAnchorIdxInData).some((colId) => !isAnchor(colId));
+  if (!violated) {
+    return null;
+  }
+
+  // Desired data-column order: anchors first (configured order), then the rest in current order.
+  const rest = dataOrder.filter((colId) => !isAnchor(colId));
+  const desiredData = [...anchorsPresent, ...rest];
+
+  // Re-thread the desired data order back through `currentOrder`, leaving every structural
+  // (non-data) column exactly where it is. Walk the original slots; data slots get filled from
+  // desiredData in sequence, structural slots (e.g. the checkbox) pass through untouched. Slots
+  // with no colId are dropped — applyColumnState leaves any unlisted column in place.
+  let d = 0;
+  return currentOrder.reduce<string[]>((acc, colId) => {
+    if (isData(colId)) {
+      acc.push(desiredData[d++]);
+    } else if (typeof colId === 'string') {
+      acc.push(colId);
+    }
+    return acc;
+  }, []);
+};
+
+/**
  * ag-grid -> model. Read `columnApi.getColumnState()` on move/resize.
  * `allColumns` bounds the result to known colIds; widths are sanitized to
  * finite, positive numbers so corrupt values never get persisted.

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -362,8 +362,6 @@ export const useRunsColumnDefinitions = ({
       headerName: ATTRIBUTE_COLUMN_LABELS.DURATION,
       field: 'duration',
       initialWidth: 80,
-      // Always-visible anchor column: allow resize but lock its position.
-      suppressMovable: true,
     });
 
     // Experiment name column


### PR DESCRIPTION
### Related Issues/PRs

NA, bugfix for https://github.com/mlflow/mlflow/pull/24152

### What changes are proposed in this pull request?

Two related runs-table column fixes.

**1. Columns could be dropped in front of the pinned Run Name / Created anchors, but the move never persisted.**

The runs table pins **Run Name** and **Created** to the left and marks them `suppressMovable`. But `suppressMovable` only stops *those* columns from being dragged — it does not stop the user from dragging *another* column in front of them. That layout can't be persisted: the column-prefs adapter round-trips column order + width but **not** `pinned`, so on reload the pinned anchors re-sort back to the left and the user's move silently reverts. From the user's side: "I can move a column before Run Name, but it never stays there after refresh."

Fix: a new pure helper `getReorderCorrection` runs after each user drag. If a data column landed before the anchors, it re-applies the corrected order so the drop **visibly snaps back**, rather than persisting a layout we can't restore. Key details:
- It reasons only about known data colIds (`allColumns`), so the **structural checkbox column** — whose colId ag-grid auto-generates (`"1"`) and which isn't a data column — is left in its leading slot untouched.
- The corrective `applyColumnState` re-fires `onColumnMoved` with `source: 'api'`, which the existing gesture allowlist ignores → no recursion, and the rejected order is never captured/persisted.

**2. The Duration column was needlessly locked.**

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New unit tests** cover `getReorderCorrection`: valid default order (no-op), non-anchor reorder (no-op), a column dropped before Run Name (snapped back), a column dropped between the two anchors (corrected), the checkbox staying in its leading slot, and the no-anchors compact/compare case (no-op).

https://github.com/user-attachments/assets/965b49e9-224b-40d7-a289-bf38dd1dcecd




### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes the experiment runs table so columns can no longer be dropped in front of the pinned Run Name/Created columns (where the position couldn't be saved), and makes the Duration column reorderable like other columns.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
