### PR TITLE
fix: use checkfirst=True when creating initial tables to avoid 'table already exists' error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating to 3.8.x, the upgrade fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`. If the `secrets` table already exists in the database (e.g., from a previous migration), `create_all` raises an error instead of skipping it.

## Fix
Add `checkfirst=True` to `InitialBase.metadata.create_all(engine)` so that existing tables are ignored during table creation. This is safe because the initial schema tables are only created when they are missing.

Closes #19943