### PR TITLE
fix: scale artifact images to parent container in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,12 +86,13 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
+    maxWidth: '100%',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',
   },
-  imageWrapper: { display: 'inline-block' },
+  imageWrapper: { display: 'inline-block', maxWidth: '100%' },
   image: {
     maxWidth: '100%',
     height: 'auto',


### PR DESCRIPTION
Closes #20703

**What this PR does:**
- Adds `maxWidth: '100%'` to `imageOuterContainer` and `imageWrapper` so artifact images scale to fit their parent container in the comparison run view
- Changes `overflow: 'scroll'` to `overflow: 'auto'` so scrollbars only show when needed

**Why:**
In the run comparison view, artifact images (plots, charts) were not constrained by their parent frame, causing the comparison layout to break or require horizontal scrolling to see the full image.