### PR TITLE
fix: scale artifact images to parent container in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,12 +86,13 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
+    maxWidth: '100%',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',
   },
-  imageWrapper: { display: 'inline-block' },
+  imageWrapper: { display: 'inline-block', maxWidth: '100%' },
   image: {
     maxWidth: '100%',
     height: 'auto',


### PR DESCRIPTION
## Related Issues/PRs
Closes #20703

## What changes are proposed in this pull request?
Adds `maxWidth: '100%'` to `imageOuterContainer` and `imageWrapper` in `ShowArtifactImageView` so artifact images scale to fit their parent container in the comparison run view. Also changes `overflow: 'scroll'` to `overflow: 'auto'` so scrollbars only show when needed.

## How is this PR tested?
The `imageWrapper` had `display: 'inline-block'` which made the image's `maxWidth: '100%'` relative to the wrapper's content-width (itself) rather than the parent container. Adding `maxWidth: '100%'` to both the outer container and wrapper constrains the image to the parent frame. Verified by inspecting the CSS cascade.

## Does this PR require documentation update?
No.

## Does this PR require updating the MLflow Skills repository?
No.

## Release Notes
### Is this a user-facing change?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Artifact images in the run comparison view now scale to fit their parent container instead of overflowing.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment, and scoring
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/ui-ux`: Front-end, user experience, JavaScript, plotting

### How should the PR be classified in the release notes? Choose one:
- [ ] `rn/none` - No release note text
- [ ] `rn/breaking-change` - The PR will cause existing MLflow applications to behave differently or not function
- [x] `rn/feature` - New user-facing features, enhancements, and non-breaking changes
- [ ] `rn/bug-fix` - Bug fix
- [ ] `rn/documentation` - Documentation update
- [ ] `rn/deprecation` - Deprecation of an existing feature or interface

### Is this a PR that will need to be backported to a previous release branch?
- [x] No
- [ ] Yes