### PR TITLE
fix: scale artifact images to parent container in comparison view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.tsx
@@ -86,12 +86,13 @@ const ShowArtifactImageView = ({
 const classNames = {
   imageOuterContainer: {
     padding: '10px',
-    overflow: 'scroll',
+    overflow: 'auto',
+    maxWidth: '100%',
     // Let's keep images (esp. transparent PNGs) on the white background regardless of the theme
     background: 'white',
     minHeight: '100%',
   },
-  imageWrapper: { display: 'inline-block' },
+  imageWrapper: { display: 'inline-block', maxWidth: '100%' },
   image: {
     maxWidth: '100%',
     height: 'auto',


### PR DESCRIPTION
### Related Issues/PRs

Closes #20703

### What changes are proposed in this pull request?

Adds `maxWidth: '100%'` to `imageOuterContainer` and `imageWrapper` in `ShowArtifactImageView` so artifact images scale to fit their parent container in the comparison run view. Also changes `overflow: 'scroll'` to `overflow: 'auto'` so scrollbars only show when needed.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The `imageWrapper` had `display: 'inline-block'` which made the image's `maxWidth: '100%'` relative to the wrapper's content-width (itself) rather than the parent container. Adding `maxWidth: '100%'` to both the outer container and wrapper constrains the image to the parent frame.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Artifact images in the run comparison view now scale to fit their parent container instead of overflowing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release