### PR TITLE
Add telemetry events for MCP server registry operations

### DIFF
--- a/mlflow/genai/mcp_servers.py
+++ b/mlflow/genai/mcp_servers.py
@@ -12,6 +12,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.mcp_server_registry.abstract_mixin import NOT_SET, MCPIcon
+from mlflow.telemetry.events import McpRegistryRegisterServerFromUrlEvent
+from mlflow.telemetry.track import record_usage_event
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.annotations import experimental
 from mlflow.utils.file_utils import local_file_uri_to_path
@@ -200,6 +202,7 @@ def _read_server_json_remote(url: str) -> dict[str, Any]:
         ) from e
 
 
+@record_usage_event(McpRegistryRegisterServerFromUrlEvent)
 @experimental(version="3.15.0")
 def register_mcp_server_from_url(
     url: str,

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -36,6 +36,11 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlMCPServerVersionTag,
 )
 from mlflow.store.tracking.mcp_server_registry.abstract_mixin import NOT_SET, MCPIcon
+from mlflow.telemetry.events import (
+    McpRegistryCreateAccessEndpointEvent,
+    McpRegistryCreateServerVersionEvent,
+)
+from mlflow.telemetry.track import record_usage_event
 from mlflow.utils.search_utils import (
     SearchMCPAccessEndpointUtils,
     SearchMCPServerUtils,
@@ -240,6 +245,7 @@ class SqlAlchemyMCPServerRegistryMixin:
 
     # --- MCPServerVersion operations ---
 
+    @record_usage_event(McpRegistryCreateServerVersionEvent)
     def create_mcp_server_version(
         self,
         server_json: dict[str, Any],
@@ -576,6 +582,7 @@ class SqlAlchemyMCPServerRegistryMixin:
             )
         return target_sv
 
+    @record_usage_event(McpRegistryCreateAccessEndpointEvent)
     def create_mcp_access_endpoint(
         self,
         server_name: str,

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from mlflow.entities import Feedback
 from mlflow.entities.issue import IssueSeverity, IssueStatus
+from mlflow.entities.mcp_server import MCPStatus
 from mlflow.environment_variables import MLFLOW_ENABLE_OTEL_GENAI_SEMCONV
 from mlflow.telemetry.constant import (
     GENAI_MODULES,
@@ -431,6 +432,64 @@ class LogBatchEvent(Event):
 
 class McpRunEvent(Event):
     name: str = "mcp_run"
+
+
+# MCP Server Registry Events
+class McpRegistryCreateServerVersionEvent(Event):
+    name: str = "mcp_registry_create_server_version"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        server_json = arguments.get("server_json") or {}
+        tools = arguments.get("tools")
+        status = arguments.get("status") or MCPStatus.DRAFT
+        return {
+            "status": status.value if hasattr(status, "value") else status,
+            "has_source": arguments.get("source") is not None,
+            "num_tools": len(tools) if tools is not None else None,
+            "has_remotes": bool(server_json.get("remotes")),
+        }
+
+
+class McpRegistryRegisterServerFromUrlEvent(Event):
+    """URL-based registration also triggers McpRegistryCreateServerVersionEvent
+    from the inner store call; analytics consumers should expect both events
+    per successful register_mcp_server_from_url invocation.
+    """
+
+    name: str = "mcp_registry_register_server_from_url"
+
+    _KNOWN_SCHEMES = {"http", "https", "file", "ftp", "ftps", "s3", "gs", "abfss"}
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        url = arguments.get("url") or ""
+        scheme = urlparse(url).scheme.lower()
+        if scheme in cls._KNOWN_SCHEMES:
+            url_scheme = scheme
+        elif not scheme or len(scheme) == 1:
+            url_scheme = "file"
+        else:
+            url_scheme = "other"
+        return {
+            "url_scheme": url_scheme,
+        }
+
+
+class McpRegistryCreateAccessEndpointEvent(Event):
+    name: str = "mcp_registry_create_access_endpoint"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        transport_type = arguments.get("transport_type")
+        return {
+            "transport_type": transport_type.value
+            if hasattr(transport_type, "value")
+            else str(transport_type)
+            if transport_type
+            else None,
+            "uses_alias": arguments.get("server_alias") is not None,
+        }
 
 
 class TrackingServerStartEvent(Event):

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -436,6 +436,10 @@ class McpRunEvent(Event):
 
 # MCP Server Registry Events
 class McpRegistryCreateServerVersionEvent(Event):
+    """Tracked on the store (server-side), so this fires for creations via UI,
+    REST API, and SDK — including the inner create from register_mcp_server_from_url.
+    """
+
     name: str = "mcp_registry_create_server_version"
 
     @classmethod
@@ -452,7 +456,9 @@ class McpRegistryCreateServerVersionEvent(Event):
 
 
 class McpRegistryRegisterServerFromUrlEvent(Event):
-    """URL-based registration also triggers McpRegistryCreateServerVersionEvent
+    """SDK-only: fires from register_mcp_server_from_url, not UI/REST creations.
+
+    Successful URL registration also triggers McpRegistryCreateServerVersionEvent
     from the inner store call; analytics consumers should expect both events
     per successful register_mcp_server_from_url invocation.
     """

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -12,6 +12,7 @@ from mlflow.entities.gateway_budget_policy import (
     BudgetUnit,
 )
 from mlflow.entities.issue import Issue, IssueSeverity, IssueStatus
+from mlflow.entities.mcp_server import MCPRemoteTransportType, MCPStatus
 from mlflow.genai.discovery.entities import DiscoverIssuesResult
 from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 from mlflow.telemetry.events import (
@@ -41,6 +42,9 @@ from mlflow.telemetry.events import (
     GenAIEvaluateEvent,
     LogAssessmentEvent,
     MakeJudgeEvent,
+    McpRegistryCreateAccessEndpointEvent,
+    McpRegistryCreateServerVersionEvent,
+    McpRegistryRegisterServerFromUrlEvent,
     MergeRecordsEvent,
     OptimizePromptsJobEvent,
     PromptOptimizationEvent,
@@ -873,3 +877,148 @@ def test_genai_evaluate_event_parse_eval_data_type(arguments, expected_eval_data
 )
 def test_trace_attachments_event_parse(arguments, expected):
     assert TraceAttachmentsEvent.parse(arguments) == expected
+
+
+# --- MCP Server Registry Event Tests ---
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_params"),
+    [
+        (
+            {
+                "server_json": {
+                    "name": "test",
+                    "version": "1.0.0",
+                    "remotes": [{"url": "http://x"}],
+                },
+                "source": "https://github.com/test",
+                "status": MCPStatus.ACTIVE,
+                "tools": [Mock(), Mock()],
+            },
+            {
+                "status": "active",
+                "has_source": True,
+                "num_tools": 2,
+                "has_remotes": True,
+            },
+        ),
+        (
+            {
+                "server_json": {"name": "test", "version": "1.0.0"},
+                "source": None,
+                "status": MCPStatus.DRAFT,
+                "tools": None,
+            },
+            {
+                "status": "draft",
+                "has_source": False,
+                "num_tools": None,
+                "has_remotes": False,
+            },
+        ),
+        (
+            {
+                "server_json": {"name": "test", "version": "1.0.0"},
+                "status": "draft",
+            },
+            {
+                "status": "draft",
+                "has_source": False,
+                "num_tools": None,
+                "has_remotes": False,
+            },
+        ),
+        (
+            {},
+            {
+                "status": "draft",
+                "has_source": False,
+                "num_tools": None,
+                "has_remotes": False,
+            },
+        ),
+    ],
+)
+def test_mcp_registry_create_server_version_parse_params(arguments, expected_params):
+    assert McpRegistryCreateServerVersionEvent.name == "mcp_registry_create_server_version"
+    assert McpRegistryCreateServerVersionEvent.parse(arguments) == expected_params
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_params"),
+    [
+        (
+            {"url": "https://example.com/server.json"},
+            {"url_scheme": "https"},
+        ),
+        (
+            {"url": "http://example.com/server.json"},
+            {"url_scheme": "http"},
+        ),
+        (
+            {"url": "file:///tmp/server.json"},
+            {"url_scheme": "file"},
+        ),
+        (
+            {"url": "/tmp/server.json"},
+            {"url_scheme": "file"},
+        ),
+        (
+            {"url": ""},
+            {"url_scheme": "file"},
+        ),
+        (
+            {},
+            {"url_scheme": "file"},
+        ),
+        (
+            {"url": "C:\\Users\\test\\server.json"},
+            {"url_scheme": "file"},
+        ),
+        (
+            {"url": "ssh://git@github.com/org/repo.git"},
+            {"url_scheme": "other"},
+        ),
+        (
+            {"url": "git://github.com/org/repo.git"},
+            {"url_scheme": "other"},
+        ),
+    ],
+)
+def test_mcp_registry_register_server_from_url_parse_params(arguments, expected_params):
+    assert McpRegistryRegisterServerFromUrlEvent.name == "mcp_registry_register_server_from_url"
+    assert McpRegistryRegisterServerFromUrlEvent.parse(arguments) == expected_params
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_params"),
+    [
+        (
+            {
+                "transport_type": MCPRemoteTransportType.STREAMABLE_HTTP,
+                "server_alias": "production",
+            },
+            {"transport_type": "streamable-http", "uses_alias": True},
+        ),
+        (
+            {
+                "transport_type": MCPRemoteTransportType.SSE,
+                "server_version": "1.0.0",
+                "server_alias": None,
+            },
+            {"transport_type": "sse", "uses_alias": False},
+        ),
+        (
+            {"transport_type": None, "server_alias": None},
+            {"transport_type": None, "uses_alias": False},
+        ),
+        (
+            {},
+            {"transport_type": None, "uses_alias": False},
+        ),
+    ],
+)
+def test_mcp_registry_create_access_endpoint_parse_params(arguments, expected_params):
+    assert McpRegistryCreateAccessEndpointEvent.name == "mcp_registry_create_access_endpoint"
+    assert McpRegistryCreateAccessEndpointEvent.parse(arguments) == expected_params

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -105,6 +105,9 @@ from mlflow.telemetry.events import (
     LogMetricEvent,
     LogParamEvent,
     MakeJudgeEvent,
+    McpRegistryCreateAccessEndpointEvent,
+    McpRegistryCreateServerVersionEvent,
+    McpRegistryRegisterServerFromUrlEvent,
     McpRunEvent,
     MergeRecordsEvent,
     PromptOptimizationEvent,
@@ -2523,3 +2526,129 @@ def test_update_issue_telemetry(mock_requests, mock_telemetry_client: TelemetryC
             "source_run_id": None,
         },
     )
+
+
+def test_mcp_registry_create_server_version_telemetry(
+    mock_requests, mock_telemetry_client: TelemetryClient, tmp_path
+):
+    from mlflow.entities.mcp_server import MCPStatus, MCPTool
+
+    db_path = tmp_path / "mlflow.db"
+    store = SqlAlchemyStore(f"sqlite:///{db_path}", tmp_path.as_posix())
+
+    store.create_mcp_server_version(
+        server_json={
+            "name": "io.test/my-server",
+            "version": "1.0.0",
+            "remotes": [{"url": "https://mcp.example.com"}],
+        },
+        source="https://github.com/test/repo",
+        status=MCPStatus.DRAFT,
+        tools=[MCPTool(name="search", description="Search the web")],
+    )
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        McpRegistryCreateServerVersionEvent.name,
+        {
+            "status": "draft",
+            "has_source": True,
+            "num_tools": 1,
+            "has_remotes": True,
+        },
+    )
+
+    store.create_mcp_server_version(
+        server_json={"name": "io.test/simple-server", "version": "0.1.0"},
+    )
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        McpRegistryCreateServerVersionEvent.name,
+        {
+            "status": "draft",
+            "has_source": False,
+            "num_tools": None,
+            "has_remotes": False,
+        },
+    )
+
+
+def test_mcp_registry_create_access_endpoint_telemetry(
+    mock_requests, mock_telemetry_client: TelemetryClient, tmp_path
+):
+    from mlflow.entities.mcp_server import MCPRemoteTransportType, MCPStatus
+
+    db_path = tmp_path / "mlflow.db"
+    store = SqlAlchemyStore(f"sqlite:///{db_path}", tmp_path.as_posix())
+
+    store.create_mcp_server_version(
+        server_json={"name": "io.test/my-server", "version": "1.0.0"},
+        status=MCPStatus.ACTIVE,
+    )
+    mock_telemetry_client.flush()
+    mock_requests.clear()
+
+    store.create_mcp_access_endpoint(
+        server_name="io.test/my-server",
+        url="https://mcp.example.com",
+        transport_type=MCPRemoteTransportType.STREAMABLE_HTTP,
+        server_version="1.0.0",
+    )
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        McpRegistryCreateAccessEndpointEvent.name,
+        {"transport_type": "streamable-http", "uses_alias": False},
+    )
+
+    store.set_mcp_server_alias(name="io.test/my-server", alias="production", version="1.0.0")
+    store.create_mcp_access_endpoint(
+        server_name="io.test/my-server",
+        url="https://mcp-prod.example.com",
+        transport_type=MCPRemoteTransportType.SSE,
+        server_alias="production",
+    )
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        McpRegistryCreateAccessEndpointEvent.name,
+        {"transport_type": "sse", "uses_alias": True},
+    )
+
+
+def test_mcp_registry_register_server_from_url_telemetry(
+    mock_requests, mock_telemetry_client: TelemetryClient, tmp_path
+):
+    import mlflow.genai
+
+    server_json = {"name": "io.test/url-server", "version": "1.0.0"}
+    json_path = tmp_path / "server.json"
+    json_path.write_text(json.dumps(server_json))
+
+    mlflow.genai.register_mcp_server_from_url(url=str(json_path))
+
+    mock_telemetry_client.flush()
+
+    from_url_events = [
+        record
+        for record in mock_requests
+        if record["data"]["event_name"] == McpRegistryRegisterServerFromUrlEvent.name
+    ]
+    assert len(from_url_events) == 1
+    params = json.loads(from_url_events[0]["data"]["params"])
+    assert params == {"url_scheme": "file"}
+
+    create_version_events = [
+        record
+        for record in mock_requests
+        if record["data"]["event_name"] == McpRegistryCreateServerVersionEvent.name
+    ]
+    assert len(create_version_events) == 1
+    params = json.loads(create_version_events[0]["data"]["params"])
+    assert params == {
+        "status": "draft",
+        "has_source": True,
+        "num_tools": None,
+        "has_remotes": False,
+    }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24476

### What changes are proposed in this pull request?

Adds usage telemetry for three MCP server registry operations:

- `create_mcp_server_version` — tracks status (defaults to `"draft"` matching the store default), source presence, tool count, and whether remotes are configured
- `register_mcp_server_from_url` — tracks the URL scheme, normalized to a known set (`http`, `https`, `file`, `ftp`, `ftps`, `s3`, `gs`, `abfss`); unknown or single-letter schemes (e.g. Windows drive letters) map to `"file"`
- `create_mcp_access_endpoint` — tracks transport type and whether an alias is used

Each event uses the existing `@record_usage_event` decorator and `Event.parse()` pattern, emitting only safe aggregate signals (no PII, no URLs, no server names).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Unit tests in `tests/telemetry/test_events.py` validate `parse()` output for each event class across edge cases (missing keys, enum vs string values, empty inputs, Windows paths).

Integration tests in `tests/telemetry/test_tracked_events.py` exercise the full decorator → flush → validate path against a real `SqlAlchemyStore` and mock telemetry client.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release