### PR TITLE
Fix `llama_index` streaming trace finalization and `model_dict` key handling

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -245,7 +245,9 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                 # before this ancestor span exits. If so, its resolution was already recorded
                 # and we close it here instead of pending it (which would leave it open and
                 # the trace stuck in IN_PROGRESS).
-                if not self._stream_resolver.resolve_pending_parent(span, token=token):
+                if not self._stream_resolver.resolve_pending_parent(
+                    span, token=token, open_span_ids=self._open_mlflow_span_ids()
+                ):
                     # If the result is a generator, we keep the span in progress for streaming
                     # and end it when the generator is exhausted.
                     is_pended = self._stream_resolver.register_stream_span(span, result)
@@ -288,8 +290,17 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
 
     def resolve_pending_stream_span(self, span: LiveSpan, event: Any):
         """End the pending streaming span(s)"""
-        self._stream_resolver.resolve(span, event)
+        self._stream_resolver.resolve(span, event, open_span_ids=self._open_mlflow_span_ids())
         self._pending_spans.pop(event.span_id, None)
+
+    def _open_mlflow_span_ids(self) -> set[str]:
+        """MLflow span IDs of the currently open (still executing) LlamaIndex spans."""
+        with self.lock:
+            return {
+                llama_span._mlflow_span.span_id
+                for llama_span in self.open_spans.values()
+                if llama_span is not None and llama_span._mlflow_span is not None
+            }
 
     def prepare_to_drop_span(self, id_: str, err: Exception | None, **kwargs) -> _LlamaSpan:
         """Logic for handling errors during the model execution."""
@@ -627,7 +638,33 @@ class StreamResolver:
         self._span_id_to_span_and_gen[span.span_id] = (span, stream)
         return True
 
-    def resolve_pending_parent(self, span: LiveSpan, token: Any | None = None) -> bool:
+    def _record_pending_resolution(
+        self,
+        parent_id: str | None,
+        resolution: tuple[SpanStatusCode, str | None],
+        open_span_ids: set[str] | None,
+    ) -> None:
+        """
+        Record a resolution for an ancestor span that has not registered as a pending
+        stream yet, so it is closed immediately when it exits (see resolve_pending_parent).
+
+        Only record when the parent genuinely still needs resolving, i.e. it is still open
+        (executing) and awaiting resolution. A parent that is absent (root, parent_id is
+        None) or already closed does not need resolving through this mechanism, and
+        recording for it would leave a stale entry that could later close an unrelated span.
+        """
+        if parent_id is None:
+            return
+        if open_span_ids is not None and parent_id not in open_span_ids:
+            return
+        self._pending_parent_resolutions[parent_id] = resolution
+
+    def resolve_pending_parent(
+        self,
+        span: LiveSpan,
+        token: Any | None = None,
+        open_span_ids: set[str] | None = None,
+    ) -> bool:
         """
         Close a span whose descendant stream was already resolved out-of-order.
 
@@ -641,6 +678,8 @@ class StreamResolver:
         Args:
             span: The span that is about to be pended as a stream.
             token: The OTel context token for the span, detached when the span is closed.
+            open_span_ids: MLflow span IDs of the currently open spans, used to decide
+                whether the next ancestor still needs a recorded resolution.
 
         Returns:
             True if a recorded resolution was found and the span was closed, False otherwise.
@@ -654,11 +693,12 @@ class StreamResolver:
         # here (passing the token so it is detached) and do not register/pend it again.
         _end_span(span=span, status=status, outputs=output_text, token=token)
 
-        if span.parent_id is not None:
-            self._pending_parent_resolutions[span.parent_id] = resolution
+        self._record_pending_resolution(span.parent_id, resolution, open_span_ids)
         return True
 
-    def resolve(self, span: LiveSpan, event: _StreamEndEvent):
+    def resolve(
+        self, span: LiveSpan, event: _StreamEndEvent, open_span_ids: set[str] | None = None
+    ):
         """
         Finish the streaming span and recursively resolve the parent spans that
         returns the same (or derived) stream.
@@ -702,5 +742,7 @@ class StreamResolver:
         # resolution for the first ancestor that has not registered yet so it can be
         # closed immediately when it exits (see resolve_pending_parent). Without this, such
         # ancestors would stay open and the trace would be stuck in the IN_PROGRESS state.
-        if span.parent_id is not None:
-            self._pending_parent_resolutions[span.parent_id] = (status, output_text)
+        # On the fully-resolved path (all ancestors already closed by the loop above), the
+        # loop stops at the root or a non-streaming ancestor that no longer needs resolving,
+        # so _record_pending_resolution skips it.
+        self._record_pending_resolution(span.parent_id, (status, output_text), open_span_ids)

--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -241,17 +241,22 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
                     detach_span_from_context(token)
                 return None  # Keep the span in open_spans
             elif self._stream_resolver.is_streaming_result(result):
-                # If the result is a generator, we keep the span in progress for streaming
-                # and end it when the generator is exhausted.
-                is_pended = self._stream_resolver.register_stream_span(span, result)
-                if is_pended:
-                    self._pending_spans[id_] = llama_span
-                    # We still need to detach the span from the context, otherwise it will
-                    # be considered as "active"
-                    detach_span_from_context(token)
-                else:
-                    # If the span is not pended successfully, end it immediately
-                    _end_span(span=span, outputs=result, token=token)
+                # In llama-index-core >= 0.14.17 a descendant LLM stream may be resolved
+                # before this ancestor span exits. If so, its resolution was already recorded
+                # and we close it here instead of pending it (which would leave it open and
+                # the trace stuck in IN_PROGRESS).
+                if not self._stream_resolver.resolve_pending_parent(span, token=token):
+                    # If the result is a generator, we keep the span in progress for streaming
+                    # and end it when the generator is exhausted.
+                    is_pended = self._stream_resolver.register_stream_span(span, result)
+                    if is_pended:
+                        self._pending_spans[id_] = llama_span
+                        # We still need to detach the span from the context, otherwise it will
+                        # be considered as "active"
+                        detach_span_from_context(token)
+                    else:
+                        # If the span is not pended successfully, end it immediately
+                        _end_span(span=span, outputs=result, token=token)
             else:
                 _end_span(span=span, outputs=result, token=token)
 
@@ -568,6 +573,12 @@ class StreamResolver:
 
     def __init__(self):
         self._span_id_to_span_and_gen: dict[str, tuple[LiveSpan, Generator]] = {}
+        # Maps a span_id -> (status, output_text) for ancestor spans whose descendant
+        # stream was resolved before the ancestor exited and registered as a pending
+        # stream. In llama-index-core >= 0.14.17, the LLM stream end event can fire and
+        # resolve the stream before the enclosing query-engine spans exit. Such ancestors
+        # are closed immediately when they register instead of being left open forever.
+        self._pending_parent_resolutions: dict[str, tuple[SpanStatusCode, str | None]] = {}
 
     def is_streaming_result(self, result: Any) -> bool:
         return (
@@ -616,6 +627,37 @@ class StreamResolver:
         self._span_id_to_span_and_gen[span.span_id] = (span, stream)
         return True
 
+    def resolve_pending_parent(self, span: LiveSpan, token: Any | None = None) -> bool:
+        """
+        Close a span whose descendant stream was already resolved out-of-order.
+
+        In llama-index-core >= 0.14.17 the LLM stream end event can fire before the
+        enclosing query-engine spans exit. When that happens, `resolve()` records the
+        resolution for the not-yet-registered ancestor. This method is called when such
+        an ancestor finally exits: it closes the span immediately (detaching its OTel
+        token) instead of pending it, and propagates the resolution to the next ancestor
+        so the whole chain is finalized as each span exits.
+
+        Args:
+            span: The span that is about to be pended as a stream.
+            token: The OTel context token for the span, detached when the span is closed.
+
+        Returns:
+            True if a recorded resolution was found and the span was closed, False otherwise.
+        """
+        resolution = self._pending_parent_resolutions.pop(span.span_id, None)
+        if resolution is None:
+            return False
+
+        status, output_text = resolution
+        # The span was never pended, so it still holds an active OTel token. End it once
+        # here (passing the token so it is detached) and do not register/pend it again.
+        _end_span(span=span, status=status, outputs=output_text, token=token)
+
+        if span.parent_id is not None:
+            self._pending_parent_resolutions[span.parent_id] = resolution
+        return True
+
     def resolve(self, span: LiveSpan, event: _StreamEndEvent):
         """
         Finish the streaming span and recursively resolve the parent spans that
@@ -654,3 +696,11 @@ class StreamResolver:
                 # as token stream can be modified by callers. However, it is technically
                 # challenging to track the modified stream across multiple spans.
                 _end_span(span=span, status=status, outputs=output_text)
+
+        # In llama-index-core >= 0.14.17 the LLM stream end event can fire before the
+        # enclosing query-engine spans exit and register as pending streams. Record the
+        # resolution for the first ancestor that has not registered yet so it can be
+        # closed immediately when it exits (see resolve_pending_parent). Without this, such
+        # ancestors would stay open and the trace would be stuck in the IN_PROGRESS state.
+        if span.parent_id is not None:
+            self._pending_parent_resolutions[span.parent_id] = (status, output_text)

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -101,7 +101,11 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
     assert attr["invocation_params"]["model_name"] == model_name
     # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
     # in the start event instead of the model config (keyed by "model").
-    assert (attr["model_dict"].get("model") or attr["model_dict"].get("model_name")) == model_name
+    assert (
+        v
+        if (v := attr["model_dict"].get("model")) is not None
+        else attr["model_dict"].get("model_name")
+    ) == model_name
     assert spans[0].model_name == model_name
 
     assert traces[0].info.token_usage == {
@@ -165,7 +169,11 @@ def test_trace_llm_complete_stream():
     assert attr["invocation_params"]["model_name"] == model_name
     # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
     # in the start event instead of the model config (keyed by "model").
-    assert (attr["model_dict"].get("model") or attr["model_dict"].get("model_name")) == model_name
+    assert (
+        v
+        if (v := attr["model_dict"].get("model")) is not None
+        else attr["model_dict"].get("model_name")
+    ) == model_name
     assert spans[0].model_name == model_name
     assert traces[0].info.token_usage == {
         TokenUsageKey.INPUT_TOKENS: 9,
@@ -251,7 +259,9 @@ def test_trace_llm_chat(is_async, mock_litellm_cost):
     # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
     # in the start event instead of the model config (keyed by "model").
     assert (
-        attr["model_dict"].get("model") or attr["model_dict"].get("model_name")
+        v
+        if (v := attr["model_dict"].get("model")) is not None
+        else attr["model_dict"].get("model_name")
     ) == llm.metadata.model_name
     assert spans[0].model_name == llm.metadata.model_name
     if not IS_TRACING_SDK_ONLY:
@@ -404,7 +414,9 @@ def test_trace_llm_chat_stream():
     # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
     # in the start event instead of the model config (keyed by "model").
     assert (
-        attr["model_dict"].get("model") or attr["model_dict"].get("model_name")
+        v
+        if (v := attr["model_dict"].get("model")) is not None
+        else attr["model_dict"].get("model_name")
     ) == llm.metadata.model_name
     assert spans[0].model_name == llm.metadata.model_name
     assert traces[0].info.token_usage == {

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -99,7 +99,9 @@ def test_trace_llm_complete(is_async, mock_litellm_cost):
 
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
-    assert attr["model_dict"]["model"] == model_name
+    # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
+    # in the start event instead of the model config (keyed by "model").
+    assert (attr["model_dict"].get("model") or attr["model_dict"].get("model_name")) == model_name
     assert spans[0].model_name == model_name
 
     assert traces[0].info.token_usage == {
@@ -161,7 +163,9 @@ def test_trace_llm_complete_stream():
     }
     assert attr["prompt"] == "Hello"
     assert attr["invocation_params"]["model_name"] == model_name
-    assert attr["model_dict"]["model"] == model_name
+    # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
+    # in the start event instead of the model config (keyed by "model").
+    assert (attr["model_dict"].get("model") or attr["model_dict"].get("model_name")) == model_name
     assert spans[0].model_name == model_name
     assert traces[0].info.token_usage == {
         TokenUsageKey.INPUT_TOKENS: 9,
@@ -244,7 +248,11 @@ def test_trace_llm_chat(is_async, mock_litellm_cost):
         TokenUsageKey.TOTAL_TOKENS: 21,
     }
     assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
-    assert attr["model_dict"]["model"] == llm.metadata.model_name
+    # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
+    # in the start event instead of the model config (keyed by "model").
+    assert (
+        attr["model_dict"].get("model") or attr["model_dict"].get("model_name")
+    ) == llm.metadata.model_name
     assert spans[0].model_name == llm.metadata.model_name
     if not IS_TRACING_SDK_ONLY:
         assert spans[0].llm_cost == {
@@ -393,7 +401,11 @@ def test_trace_llm_chat_stream():
         TokenUsageKey.TOTAL_TOKENS: 21,
     }
     assert attr["invocation_params"]["model_name"] == llm.metadata.model_name
-    assert attr["model_dict"]["model"] == llm.metadata.model_name
+    # llama-index-core >= 0.14.17 records the LLMMetadata dict (keyed by "model_name")
+    # in the start event instead of the model config (keyed by "model").
+    assert (
+        attr["model_dict"].get("model") or attr["model_dict"].get("model_name")
+    ) == llm.metadata.model_name
     assert spans[0].model_name == llm.metadata.model_name
     assert traces[0].info.token_usage == {
         TokenUsageKey.INPUT_TOKENS: 9,


### PR DESCRIPTION
### Related Issues/PRs

Relates to the `llama_index` / `autologging` cross-version test failures on the `0.14.16` job (the `llama-index` meta-package resolves `llama-index-core==0.14.23`).

### What changes are proposed in this pull request?

This PR fixes 8 failing `llama_index` autologging cross-version tests. The CI job is labeled `0.14.16` (the `llama-index` meta-package version), but that meta-package now resolves `llama-index-core==0.14.23`, which introduced two independent breaking changes.

**Root cause A (source bug): streaming query-engine traces are stuck `IN_PROGRESS`.**

In `llama-index-core >= 0.14.17` the execution order around streaming inverted: the LLM stream's end event fires and MLflow resolves the stream *before* the enclosing query-engine spans (`CompactAndRefine.get_response` / `synthesize`, `RetrieverQueryEngine._query` / `query`) exit and register themselves as pending streams.

`StreamResolver.resolve()` only closed ancestor spans that were already present in `_span_id_to_span_and_gen`. Ancestors that registered *after* the stream resolved were never closed, so they stayed open, the trace was stuck `IN_PROGRESS`, and the read-back trace metadata never received `mlflow.modelId`.

The fix makes `StreamResolver` order-independent:

- When the recursive parent-walk in `resolve()` stops at an ancestor that has not registered yet, it records `parent_span_id -> (status, output_text)` in a new `_pending_parent_resolutions` dict.
- In `prepare_to_exit_span()`, before pending a streaming span, the new `resolve_pending_parent()` checks whether a resolution was already recorded for that span. If so, it closes the span immediately (ending it once with the recorded output and detaching the OTel token, without double-ending or re-registering) and propagates the resolution to the next ancestor. As each ancestor exits, the whole chain is finalized.

Direct `llm.stream_*` resolution already worked, so the change is scoped to ancestor propagation, with care taken around token detach ordering and avoiding a double `end()`.

User impact: query-engine streaming traces were left stuck in the `IN_PROGRESS` state on `llama-index-core >= 0.14.17`.

**Root cause B (test-only): `model_dict` key renamed.**

`llama-index-core` changed the LLM start-event payload from `to_dict()` to `to_payload()`. The recorded `model_dict` is now the `LLMMetadata` dict, whose key is `model_name` (there is no `model` key). The MLflow source is already tolerant (`_extract_and_set_model_name` uses `.get("model")`, and `mlflow.llm.model` is still set via the instance-metadata fallback, so `span.model_name` is correct). Only the test assertions were brittle. They now accept either key so older matrix versions keep passing:

```python
assert (attr["model_dict"].get("model") or attr["model_dict"].get("model_name")) == model_name
```

### How is this PR tested?

- [x] Existing unit/integration tests

Reproduced the exact CI dependency set locally (`llama-index==0.14.16` resolving `llama-index-core==0.14.23`, `llama-index-llms-openai==0.6.26`, `openai` 2.x) and confirmed all 8 tests failed before the change, then passed after:

- `tests/llama_index/test_llama_index_tracer.py::test_trace_query_engine[False-True]` (was `IN_PROGRESS != OK`)
- `tests/llama_index/test_llama_index_autolog.py::test_autolog_link_traces_to_loaded_model_index_query[True]` (was `KeyError: 'mlflow.modelId'`)
- `test_trace_llm_complete[True/False]`, `test_trace_llm_complete_stream`, `test_trace_llm_chat[True/False]`, `test_trace_llm_chat_stream` (were `KeyError: 'model'`)

The full `test_llama_index_tracer.py` and `test_llama_index_autolog.py` suites (the two files the autologging CVT job runs) pass with no regressions (44 passed, 5 skipped).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed LlamaIndex query-engine streaming traces being stuck in the `IN_PROGRESS` state on `llama-index-core >= 0.14.17`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
