### PR TITLE
Fix shap pip-requirements test for skops default serialization

### DIFF
--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -294,7 +294,7 @@ def test_merge_environment_with_duplicates():
 
 def test_log_model_with_pip_requirements(shap_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
-    sklearn_default_reqs = mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)
+    sklearn_default_reqs = mlflow.sklearn.get_default_pip_requirements(include_skops=True)
     # Path to a requirements file
     req_file = tmp_path.joinpath("requirements.txt")
     req_file.write_text("a")
@@ -333,7 +333,7 @@ def test_log_model_with_pip_requirements(shap_model, tmp_path):
 def test_log_model_with_extra_pip_requirements(shap_model, tmp_path):
     expected_mlflow_version = _mlflow_major_version_string()
     shap_default_reqs = mlflow.shap.get_default_pip_requirements()
-    sklearn_default_reqs = mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)
+    sklearn_default_reqs = mlflow.sklearn.get_default_pip_requirements(include_skops=True)
 
     # Path to a requirements file
     req_file = tmp_path.joinpath("requirements.txt")

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
@@ -373,6 +374,24 @@ def test_log_model_with_extra_pip_requirements(shap_model, tmp_path):
             ],
             ["a"],
         )
+
+
+def test_log_model_serializes_underlying_model_with_skops(shap_model):
+    # Guard that the underlying sklearn model is serialized with skops (not cloudpickle) by
+    # default. The serialization artifact is the only discriminating signal: both skops and
+    # cloudpickle appear in the auto-inferred pip requirements regardless of format, so the
+    # requirements can't guard this default.
+    with mlflow.start_run():
+        model_info = mlflow.shap.log_explainer(shap_model, "model")
+
+    underlying_model_path = Path(
+        _download_artifact_from_uri(model_info.model_uri), "underlying_model"
+    )
+    sklearn_conf = _get_flavor_configuration(
+        model_path=underlying_model_path, flavor_name=mlflow.sklearn.FLAVOR_NAME
+    )
+    assert sklearn_conf["serialization_format"] == mlflow.sklearn.SERIALIZATION_FORMAT_SKOPS
+    assert (underlying_model_path / "model.skops").exists()
 
 
 def create_identity_function():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23987

### What changes are proposed in this pull request?

Test-only fix for the `shap / models` cross-version test failure on `tests/shap/test_log.py::test_log_model_with_pip_requirements` (all shap versions 0.46.0-0.51.0).

Root cause: PR #23987 flipped the `mlflow.sklearn` default `serialization_format` from cloudpickle to skops. `mlflow.shap.save_explainer` serializes the underlying sklearn model via `mlflow.sklearn.save_model(...)` without passing a format, so it now serializes with skops. The skops-serialized model's default pip requirements are `[scikit-learn==X, skops==Y]` (no cloudpickle). The test still built its expectation with `mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)`, so the subset assertion in `_assert_pip_requirements` failed because `cloudpickle` was no longer present.

The fix updates the expectation to `mlflow.sklearn.get_default_pip_requirements(include_skops=True)` in both `test_log_model_with_pip_requirements` and `test_log_model_with_extra_pip_requirements`, matching what the underlying model now contributes. No source change is needed; the skops default is intentional.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Reproduced the failure locally in an isolated venv (shap 0.51.0, skops 0.14.0, scikit-learn 1.9.0) before the change, then confirmed both `test_log_model_with_pip_requirements` and `test_log_model_with_extra_pip_requirements` pass after it. Verified the underlying model now contributes `['scikit-learn==1.9.0', 'skops==0.14.0']` rather than cloudpickle.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release