### PR TITLE
Fix `pydantic_ai` autologging to instrument the capabilities-era request path

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -959,6 +959,10 @@ pydantic_ai:
         "git+https://github.com/pydantic/pydantic-ai.git#egg=pydantic-ai"
   autologging:
     minimum: "0.2.19"
+    # 1.107.0 is the newest 1.x release. pydantic-ai 2.0 dropped the `Agent(instrument=...)`
+    # kwarg and removed `pydantic_ai.mcp.MCPServer`, so 2.x needs separate autologging work
+    # before the cap can move past it.
+    maximum: "1.107.0"
     requirements:
       ">= 0.0.0": ["mcp"]
     run: pytest tests/pydantic_ai

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -959,10 +959,6 @@ pydantic_ai:
         "git+https://github.com/pydantic/pydantic-ai.git#egg=pydantic-ai"
   autologging:
     minimum: "0.2.19"
-    # TODO: Bump past 1.94.0 once the tracing tests patch the right model request
-    # entrypoint. pydantic-ai >= 1.96 no longer routes through
-    # `InstrumentedModel.request`, so the mock is bypassed and tests hit the real API.
-    maximum: "1.94.0"
     requirements:
       ">= 0.0.0": ["mcp"]
     run: pytest tests/pydantic_ai

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -143,7 +143,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.2.19",
-            "maximum": "1.94.0"
+            "maximum": "1.107.0"
         }
     },
     "smolagents": {

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -104,6 +104,23 @@ def _tool_manager_uses_execute_tool_call() -> bool:
         return False
 
 
+def _has_instrumentation_capability() -> bool:
+    """Return True if pydantic-ai routes model calls through the Instrumentation capability.
+
+    pydantic-ai >= 1.95 replaced the ``InstrumentedModel`` wrapper with a capabilities
+    system: model requests funnel through ``Instrumentation.wrap_model_request`` instead of
+    ``InstrumentedModel.request``/``request_stream``. When this module is importable we
+    instrument that hook and skip the ``InstrumentedModel`` patch, so exactly one path
+    produces the LLM span (never both).
+    """
+    try:
+        import pydantic_ai.capabilities.instrumentation  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 @autologging_integration(FLAVOR_NAME)
 def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False):
     """
@@ -126,13 +143,14 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
     except ImportError:
         pass
 
+    # On pydantic-ai >= 1.95 the Instrumentation capability (patched below) is the model
+    # request funnel; on older versions it's InstrumentedModel. Instrument exactly one of
+    # them so a single LLM span is produced per model call, never two overlapping spans.
+    has_instrumentation_capability = _has_instrumentation_capability()
+
     tool_manager_path = f"{_get_tool_manager_module_path()}.ToolManager"
     class_map = {
         "pydantic_ai.Agent": agent_methods,
-        "pydantic_ai.models.instrumented.InstrumentedModel": [
-            "request",
-            "request_stream",
-        ],
         # In pydantic-ai >= 1.63.0, _agent_graph calls execute_tool_call directly,
         # bypassing handle_call. Patch execute_tool_call when available; fall back to
         # handle_call for older versions where execute_tool_call doesn't exist.
@@ -141,6 +159,11 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
         else ["handle_call"],
         "pydantic_ai.mcp.MCPServer": ["call_tool", "list_tools"],
     }
+    if not has_instrumentation_capability:
+        class_map["pydantic_ai.models.instrumented.InstrumentedModel"] = [
+            "request",
+            "request_stream",
+        ]
 
     try:
         from pydantic_ai import Tool
@@ -182,24 +205,22 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
             except AttributeError as e:
                 _logger.error("Error patching %s.%s: %s", cls_path, method, e)
 
-    # pydantic-ai >= 1.95 no longer routes model calls through InstrumentedModel (patched
-    # via class_map above, which stays for older versions). Instead, both streaming and
-    # non-streaming model requests funnel through the Instrumentation capability's
-    # wrap_model_request. Patch it so LLM spans are captured on modern versions. This is
-    # provider-agnostic: it fires once per model request regardless of the concrete model.
-    try:
-        from pydantic_ai.capabilities.instrumentation import Instrumentation
+    # pydantic-ai >= 1.95 routes both streaming and non-streaming model requests through
+    # the Instrumentation capability's wrap_model_request instead of InstrumentedModel.
+    # Patch it (and only it, since InstrumentedModel is excluded from class_map above) so a
+    # single provider-agnostic LLM span is produced per model request on modern versions.
+    if has_instrumentation_capability:
+        try:
+            from pydantic_ai.capabilities.instrumentation import Instrumentation
 
-        safe_patch(
-            FLAVOR_NAME,
-            Instrumentation,
-            "wrap_model_request",
-            patched_capability_model_request,
-        )
-    except (ImportError, AttributeError):
-        # Older pydantic-ai versions don't have the capabilities system; the
-        # InstrumentedModel patch above covers them.
-        pass
+            safe_patch(
+                FLAVOR_NAME,
+                Instrumentation,
+                "wrap_model_request",
+                patched_capability_model_request,
+            )
+        except (ImportError, AttributeError) as e:
+            _logger.error("Error patching Instrumentation.wrap_model_request: %s", e)
 
     _record_event(
         AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -7,6 +7,7 @@ from mlflow.pydantic_ai.autolog import (
     patched_agent_init,
     patched_async_class_call,
     patched_async_stream_call,
+    patched_capability_model_request,
     patched_class_call,
     patched_sync_stream_call,
 )
@@ -180,6 +181,25 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
                 _patch_method(cls, method)
             except AttributeError as e:
                 _logger.error("Error patching %s.%s: %s", cls_path, method, e)
+
+    # pydantic-ai >= 1.95 no longer routes model calls through InstrumentedModel (patched
+    # via class_map above, which stays for older versions). Instead, both streaming and
+    # non-streaming model requests funnel through the Instrumentation capability's
+    # wrap_model_request. Patch it so LLM spans are captured on modern versions. This is
+    # provider-agnostic: it fires once per model request regardless of the concrete model.
+    try:
+        from pydantic_ai.capabilities.instrumentation import Instrumentation
+
+        safe_patch(
+            FLAVOR_NAME,
+            Instrumentation,
+            "wrap_model_request",
+            patched_capability_model_request,
+        )
+    except (ImportError, AttributeError):
+        # Older pydantic-ai versions don't have the capabilities system; the
+        # InstrumentedModel patch above covers them.
+        pass
 
     _record_event(
         AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -93,22 +93,29 @@ def _set_span_attributes(span: LiveSpan, instance):
     except Exception as e:
         _logger.warning("Failed saving Agent attributes: %s", e)
 
-    # 3) InstrumentedModel attributes
+    # 3) Model attributes. `Model` covers both `InstrumentedModel` (pydantic-ai < 1.95)
+    #    and the concrete provider models (e.g. `OpenAIChatModel`) that the capabilities-era
+    #    request path invokes (pydantic-ai >= 1.95).
     try:
-        from pydantic_ai.models.instrumented import InstrumentedModel
+        from pydantic_ai.models import Model
 
-        if isinstance(instance, InstrumentedModel):
+        if isinstance(instance, Model):
             model_attrs = _get_model_attributes(instance)
             span.set_attributes({k: v for k, v in model_attrs.items() if v is not None})
             if model_name := getattr(instance, "model_name", None):
                 span.set_attribute(SpanAttributeKey.MODEL, model_name)
-                # Pydantic AI model_name uses "provider:model" format
-                # e.g., "openai:gpt-4o", "anthropic:claude-3-5-haiku"
-                match model_name.split(":", 1):
-                    case [provider, _]:
-                        span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
+                # Prefer the model's own provider identifier (`system`, e.g. "openai").
+                # Fall back to the "provider:model" prefix used by some model_name formats
+                # (e.g. "anthropic:claude-3-5-haiku").
+                provider = getattr(instance, "system", None)
+                if not provider:
+                    match model_name.split(":", 1):
+                        case [prefix, _]:
+                            provider = prefix
+                if provider:
+                    span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
     except Exception as e:
-        _logger.warning("Failed saving InstrumentedModel attributes: %s", e)
+        _logger.warning("Failed saving model attributes: %s", e)
 
     # 4) Tool attributes
     try:
@@ -147,6 +154,52 @@ async def patched_async_class_call(original, self, *args, **kwargs):
         if usage_dict := _parse_usage(result):
             span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
         return result
+
+
+async def patched_capability_model_request(original, self, *args, **kwargs):
+    """Create an LLM span for the capabilities-era model request path.
+
+    pydantic-ai >= 1.95 no longer routes model calls through
+    ``InstrumentedModel.request``/``request_stream``. Instead, every model request
+    (streaming and non-streaming) funnels through the ``Instrumentation`` capability's
+    ``wrap_model_request``. Unlike the ``InstrumentedModel`` path, the concrete model is
+    available on the ``request_context`` argument rather than on ``self`` (which is the
+    capability), so we extract it explicitly to type the span and set model attributes.
+    """
+    cfg = AutoLoggingConfig.init(flavor_name=mlflow.pydantic_ai.FLAVOR_NAME)
+    if not cfg.log_traces:
+        return await original(self, *args, **kwargs)
+
+    request_context = kwargs.get("request_context")
+    if request_context is None:
+        # request_context may be passed positionally on some versions.
+        request_context = next(
+            (a for a in args if hasattr(a, "model") and hasattr(a, "messages")), None
+        )
+    model = getattr(request_context, "model", None)
+
+    span_name = f"{type(model).__name__}.request" if model is not None else "Model.request"
+    with mlflow.start_span(name=span_name, span_type=SpanType.LLM) as span:
+        span.set_inputs(_model_request_inputs(request_context))
+        if model is not None:
+            _set_span_attributes(span, model)
+
+        result = await original(self, *args, **kwargs)
+        span.set_outputs(_serialize_output(result))
+        if usage_dict := _parse_usage(result):
+            span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
+        return result
+
+
+def _model_request_inputs(request_context) -> dict[str, Any]:
+    if request_context is None:
+        return {}
+    inputs = {
+        "messages": getattr(request_context, "messages", None),
+        "model_settings": getattr(request_context, "model_settings", None),
+        "model_request_parameters": getattr(request_context, "model_request_parameters", None),
+    }
+    return {k: v for k, v in inputs.items() if v is not None}
 
 
 def patched_class_call(original, self, *args, **kwargs):
@@ -340,11 +393,14 @@ def _get_span_type(instance) -> str:
     try:
         from pydantic_ai import Agent, Tool
         from pydantic_ai.mcp import MCPServer
-        from pydantic_ai.models.instrumented import InstrumentedModel
+        from pydantic_ai.models import Model
     except ImportError:
         return SpanType.UNKNOWN
 
-    if isinstance(instance, InstrumentedModel):
+    # `Model` covers both `InstrumentedModel` (used on pydantic-ai < 1.95) and the
+    # concrete provider models (e.g. `OpenAIChatModel`) invoked on the capabilities-era
+    # request path (pydantic-ai >= 1.95).
+    if isinstance(instance, Model):
         return SpanType.LLM
     if isinstance(instance, Agent):
         return SpanType.AGENT

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -248,7 +248,10 @@ def patched_async_stream_call(original, self, *args, **kwargs):
 
         # Skip span creation ONLY for Agent.run_stream when inside run_stream_sync.
         # Agent.run_stream_sync already creates a root span, so we don't need another
-        # Agent.run_stream span. But we DO want InstrumentedModel spans (LLM calls).
+        # Agent.run_stream span. But we DO still want the nested model-level LLM span,
+        # which is created regardless of this skip: from InstrumentedModel.request_stream
+        # on pydantic-ai < 1.95, or from the Instrumentation.wrap_model_request capability
+        # hook on >= 1.95 (see patched_capability_model_request).
         # The async context manager for Agent.run_stream won't properly exit when
         # called from run_stream_sync (pydantic_ai's implementation uses a generator
         # that pauses), so we skip it to avoid orphaned spans.

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -106,9 +106,10 @@ def _set_span_attributes(span: LiveSpan, instance):
                 span.set_attribute(SpanAttributeKey.MODEL, model_name)
                 # Prefer the model's own provider identifier (`system`, e.g. "openai").
                 # Fall back to the "provider:model" prefix used by some model_name formats
-                # (e.g. "anthropic:claude-3-5-haiku").
+                # (e.g. "anthropic:claude-3-5-haiku"). Only fall back when `system` is
+                # genuinely absent (None), not when it's an explicit empty string.
                 provider = getattr(instance, "system", None)
-                if not provider:
+                if provider is None:
                     match model_name.split(":", 1):
                         case [prefix, _]:
                             provider = prefix
@@ -165,17 +166,31 @@ async def patched_capability_model_request(original, self, *args, **kwargs):
     ``wrap_model_request``. Unlike the ``InstrumentedModel`` path, the concrete model is
     available on the ``request_context`` argument rather than on ``self`` (which is the
     capability), so we extract it explicitly to type the span and set model attributes.
+
+    A plain span (rather than the ``start_span_no_context`` + finalize-on-completion
+    pattern used for ``Agent.run_stream``) is correct for streaming too: pydantic-ai's
+    streaming path awaits ``wrap_model_request`` via a cooperative hand-off (the handler
+    opens the stream, then blocks until the caller finishes consuming it), so this
+    ``await original(...)`` only returns once the stream is fully consumed and yields the
+    final ``ModelResponse`` with usage. The span therefore stays open for the whole stream
+    and captures outputs + token usage. This is verified by the streaming tests in
+    ``tests/pydantic_ai/test_pydanticai_fluent_tracing.py``.
     """
     cfg = AutoLoggingConfig.init(flavor_name=mlflow.pydantic_ai.FLAVOR_NAME)
     if not cfg.log_traces:
         return await original(self, *args, **kwargs)
 
     request_context = kwargs.get("request_context")
-    if request_context is None:
-        # request_context may be passed positionally on some versions.
-        request_context = next(
-            (a for a in args if hasattr(a, "model") and hasattr(a, "messages")), None
-        )
+    if request_context is None and args:
+        # `request_context` is keyword-only in current pydantic-ai; guard against a
+        # positional call on other versions by matching the concrete context type rather
+        # than duck-typing (which could pick up an unrelated argument).
+        try:
+            from pydantic_ai.models import ModelRequestContext
+
+            request_context = next((a for a in args if isinstance(a, ModelRequestContext)), None)
+        except ImportError:
+            request_context = None
     model = getattr(request_context, "model", None)
 
     span_name = f"{type(model).__name__}.request" if model is not None else "Model.request"

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -11,6 +11,7 @@ from pydantic_ai.usage import Usage
 import mlflow
 import mlflow.pydantic_ai  # ensure the integration module is importable
 from mlflow.entities import SpanType
+from mlflow.pydantic_ai import _has_instrumentation_capability
 from mlflow.tracing.constant import SpanAttributeKey
 
 from tests.tracing.helper import get_traces
@@ -21,6 +22,24 @@ _FINAL_ANSWER_WITH_TOOL = "winner"
 PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
 # Usage was deprecated in favor of RequestUsage in 0.7.3
 IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
+HAS_INSTRUMENTATION_CAPABILITY = _has_instrumentation_capability()
+
+
+def _expected_llm_span_name(model_cls, *, stream: bool = False) -> str:
+    """Return the LLM span name for the path that must be exercised on this version.
+
+    On pydantic-ai >= 1.95 the Instrumentation capability hook
+    (``patched_capability_model_request``) handles both streaming and non-streaming
+    requests and names the span after the concrete model, e.g. ``OpenAIChatModel.request``.
+    On < 1.95 the ``InstrumentedModel`` patch names it ``InstrumentedModel.request`` (or
+    ``InstrumentedModel.request_stream`` for streaming). Asserting the exact name confirms
+    the correct code path ran rather than merely "some LLM span exists".
+    """
+    if HAS_INSTRUMENTATION_CAPABILITY:
+        return f"{model_cls.__name__}.request"
+    return "InstrumentedModel.request_stream" if stream else "InstrumentedModel.request"
+
+
 # run_stream_sync was added in pydantic-ai 1.10.0
 HAS_RUN_STREAM_SYNC = hasattr(Agent, "run_stream_sync")
 # Streaming tests require pydantic-ai >= 1.0.0 due to API changes
@@ -209,8 +228,8 @@ def test_agent_run_sync_enable_fluent_disable_autolog(simple_agent):
     assert spans[1].span_type == SpanType.AGENT
 
     span2 = spans[2]
-    # "InstrumentedModel.request" on pydantic-ai < 1.95, "<ConcreteModel>.request" on >= 1.95.
-    assert span2.name.endswith(".request")
+    # Exact name confirms which instrumentation path produced the LLM span.
+    assert span2.name == _expected_llm_span_name(model_cls)
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
@@ -241,7 +260,7 @@ async def test_agent_run_enable_fluent_disable_autolog(simple_agent):
     assert spans[0].span_type == SpanType.AGENT
 
     span1 = spans[1]
-    assert span1.name.endswith(".request")
+    assert span1.name == _expected_llm_span_name(type(simple_agent.model))
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
@@ -312,9 +331,9 @@ async def test_agent_run_stream_creates_trace(simple_agent):
     assert spans[0].name == "Agent.run_stream"
     assert spans[0].span_type == SpanType.AGENT
 
-    # "InstrumentedModel.request_stream" on pydantic-ai < 1.95; on >= 1.95 the streaming
-    # call funnels through the same Instrumentation hook, producing "<ConcreteModel>.request".
-    assert "request" in spans[1].name
+    # Exact name confirms the streaming request went through the expected path: the
+    # Instrumentation hook (>= 1.95) or InstrumentedModel.request_stream (< 1.95).
+    assert spans[1].name == _expected_llm_span_name(type(simple_agent.model), stream=True)
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
 
@@ -358,7 +377,7 @@ def test_agent_run_stream_sync_creates_trace(simple_agent):
     assert "user_prompt" in spans[0].inputs
     assert spans[0].outputs is not None
 
-    assert "request" in spans[1].name
+    assert spans[1].name == _expected_llm_span_name(type(simple_agent.model), stream=True)
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
 

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -6,7 +6,6 @@ import pytest
 from packaging.version import Version
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
-from pydantic_ai.models.instrumented import InstrumentedModel
 from pydantic_ai.usage import Usage
 
 import mlflow
@@ -192,7 +191,8 @@ def test_agent_run_sync_enable_fluent_disable_autolog(simple_agent):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    model_cls = type(simple_agent.model)
+    with patch.object(model_cls, "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = simple_agent.run_sync("France")
@@ -209,11 +209,12 @@ def test_agent_run_sync_enable_fluent_disable_autolog(simple_agent):
     assert spans[1].span_type == SpanType.AGENT
 
     span2 = spans[2]
-    assert span2.name == "InstrumentedModel.request"
+    # "InstrumentedModel.request" on pydantic-ai < 1.95, "<ConcreteModel>.request" on >= 1.95.
+    assert span2.name.endswith(".request")
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch.object(model_cls, "request", new=request):
         mlflow.pydantic_ai.autolog(disable=True)
         simple_agent.run_sync("France")
     assert len(get_traces()) == 1
@@ -226,7 +227,7 @@ async def test_agent_run_enable_fluent_disable_autolog(simple_agent):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch.object(type(simple_agent.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await simple_agent.run("France")
@@ -240,7 +241,7 @@ async def test_agent_run_enable_fluent_disable_autolog(simple_agent):
     assert spans[0].span_type == SpanType.AGENT
 
     span1 = spans[1]
-    assert span1.name == "InstrumentedModel.request"
+    assert span1.name.endswith(".request")
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
@@ -251,7 +252,7 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     async def request(self, *args, **kwargs):
         return next(sequence)
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch.object(type(agent_with_tool.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = agent_with_tool.run_sync("Put my money on square eighteen", deps=18)
@@ -271,7 +272,7 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     async def request(self, *args, **kwargs):
         return next(sequence)
 
-    with patch.object(InstrumentedModel, "request", new=request):
+    with patch.object(type(agent_with_tool.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await agent_with_tool.run("Put my money on square eighteen", deps=18)
@@ -295,7 +296,7 @@ async def test_agent_run_stream_creates_trace(simple_agent):
     async def request_stream(self, *args, **kwargs):
         yield MockStreamedResponse(response, usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch.object(type(simple_agent.model), "request_stream", new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         async with simple_agent.run_stream("France") as result:
@@ -311,7 +312,9 @@ async def test_agent_run_stream_creates_trace(simple_agent):
     assert spans[0].name == "Agent.run_stream"
     assert spans[0].span_type == SpanType.AGENT
 
-    assert spans[1].name == "InstrumentedModel.request_stream"
+    # "InstrumentedModel.request_stream" on pydantic-ai < 1.95; on >= 1.95 the streaming
+    # call funnels through the same Instrumentation hook, producing "<ConcreteModel>.request".
+    assert "request" in spans[1].name
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
 
@@ -333,7 +336,7 @@ def test_agent_run_stream_sync_creates_trace(simple_agent):
     async def request_stream(self, *args, **kwargs):
         yield MockStreamedResponse(response, usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch.object(type(simple_agent.model), "request_stream", new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = simple_agent.run_stream_sync("France")
@@ -355,7 +358,7 @@ def test_agent_run_stream_sync_creates_trace(simple_agent):
     assert "user_prompt" in spans[0].inputs
     assert spans[0].outputs is not None
 
-    assert spans[1].name == "InstrumentedModel.request_stream"
+    assert "request" in spans[1].name
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
 
@@ -382,7 +385,7 @@ async def test_agent_run_stream_with_tool(agent_with_tool):
             resp = sequence[-1]
             yield MockStreamedResponse(resp, resp.usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch.object(type(agent_with_tool.model), "request_stream", new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         async with agent_with_tool.run_stream("Put my money on square eighteen", deps=18) as result:
@@ -412,7 +415,7 @@ def test_agent_run_stream_sync_with_tool(agent_with_tool):
             resp = sequence[-1]
             yield MockStreamedResponse(resp, resp.usage)
 
-    with patch.object(InstrumentedModel, "request_stream", new=request_stream):
+    with patch.object(type(agent_with_tool.model), "request_stream", new=request_stream):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = agent_with_tool.run_stream_sync("Put my money on square eighteen", deps=18)

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -331,8 +331,10 @@ async def test_agent_run_stream_creates_trace(simple_agent):
     assert spans[0].name == "Agent.run_stream"
     assert spans[0].span_type == SpanType.AGENT
 
-    # Exact name confirms the streaming request went through the expected path: the
-    # Instrumentation hook (>= 1.95) or InstrumentedModel.request_stream (< 1.95).
+    # The test patches the concrete model's request_stream, but on >= 1.95 the streamed
+    # call is delegated through Instrumentation.wrap_model_request. Asserting the exact
+    # capability-hook span name proves the stream came through that hook (not a bypass);
+    # on < 1.95 it is InstrumentedModel.request_stream.
     assert spans[1].name == _expected_llm_span_name(type(simple_agent.model), stream=True)
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id
@@ -377,6 +379,9 @@ def test_agent_run_stream_sync_creates_trace(simple_agent):
     assert "user_prompt" in spans[0].inputs
     assert spans[0].outputs is not None
 
+    # The test patches the concrete model's request_stream, but on >= 1.95 the streamed
+    # call is delegated through Instrumentation.wrap_model_request. Asserting the exact
+    # capability-hook span name proves the stream came through that hook (not a bypass).
     assert spans[1].name == _expected_llm_span_name(type(simple_agent.model), stream=True)
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].parent_id == spans[0].span_id

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -439,7 +439,10 @@ def test_autolog_auto_instrument_captures_llm_spans(mock_litellm_cost):
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    # Should have Agent.run_sync > Agent.run > <ConcreteModel>.request (LLM span)
+    # Should have Agent.run_sync > Agent.run > <ConcreteModel>.request (LLM span).
+    # Exactly one LLM span: on versions that ship the capabilities module, only the
+    # Instrumentation hook instruments (InstrumentedModel is excluded), never both.
+    assert sum(1 for s in spans if s.span_type == SpanType.LLM) == 1
     llm_span = next(s for s in spans if s.span_type == SpanType.LLM)
     assert llm_span.name.endswith(".request")
 

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -128,7 +128,12 @@ def test_agent_run_sync_enable_disable_autolog(simple_agent, mock_litellm_cost):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    # Patch the concrete model's request. On pydantic-ai < 1.95 MLflow wraps
+    # InstrumentedModel (which delegates to this concrete model); on >= 1.95 the concrete
+    # model is invoked directly through the Instrumentation capability. Patching the
+    # concrete class works on both, and avoids hitting the real API.
+    model_cls = type(simple_agent.model)
+    with patch.object(model_cls, "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = simple_agent.run_sync("France")
@@ -156,7 +161,9 @@ def test_agent_run_sync_enable_disable_autolog(simple_agent, mock_litellm_cost):
     assert len(outputs_1["_new_messages_serialized"]) > 0
 
     span2 = spans[2]
-    assert span2.name == "InstrumentedModel.request"
+    # Span name is "InstrumentedModel.request" on pydantic-ai < 1.95 and
+    # "<ConcreteModel>.request" (e.g. "OpenAIChatModel.request") on >= 1.95.
+    assert span2.name.endswith(".request")
     assert span2.span_type == SpanType.LLM
     assert span2.log_level == SpanLogLevel.INFO
     assert span2.parent_id == spans[1].span_id
@@ -182,7 +189,7 @@ def test_agent_run_sync_enable_disable_autolog(simple_agent, mock_litellm_cost):
         "total_tokens": 2,
     }
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch.object(model_cls, "request", new=request):
         mlflow.pydantic_ai.autolog(disable=True)
         simple_agent.run_sync("France")
     assert len(get_traces()) == 1
@@ -195,7 +202,7 @@ async def test_agent_run_enable_disable_autolog(simple_agent, mock_litellm_cost)
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch.object(type(simple_agent.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await simple_agent.run("France")
@@ -209,7 +216,7 @@ async def test_agent_run_enable_disable_autolog(simple_agent, mock_litellm_cost)
     assert spans[0].span_type == SpanType.AGENT
 
     span1 = spans[1]
-    assert span1.name == "InstrumentedModel.request"
+    assert span1.name.endswith(".request")
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
@@ -241,7 +248,7 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool, mock_l
             return sequence.pop(0)
         return resp
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch.object(type(agent_with_tool.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = agent_with_tool.run_sync("Put my money on square eighteen", deps=18)
@@ -281,7 +288,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool, mock_
             return sequence.pop(0)
         return resp
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch.object(type(agent_with_tool.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         result = await agent_with_tool.run("Put my money on square eighteen", deps=18)
@@ -313,10 +320,8 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool, mock_
 
 
 def test_agent_run_sync_failure(simple_agent):
-    with patch(
-        "pydantic_ai.models.instrumented.InstrumentedModel.request",
-        side_effect=ValueError("test error"),
-    ):
+    model_cls = type(simple_agent.model)
+    with patch.object(model_cls, "request", side_effect=ValueError("test error")):
         mlflow.pydantic_ai.autolog(log_traces=True)
 
         with pytest.raises(ValueError, match="test error"):
@@ -332,13 +337,10 @@ def test_agent_run_sync_failure(simple_agent):
     assert spans[0].span_type == SpanType.AGENT
     assert spans[1].name == "Agent.run"
     assert spans[1].span_type == SpanType.AGENT
-    assert spans[2].name.startswith("InstrumentedModel.")
+    assert spans[2].name.endswith(".request")
     assert spans[2].span_type == SpanType.LLM
 
-    with patch(
-        "pydantic_ai.models.instrumented.InstrumentedModel.request",
-        side_effect=ValueError("test error"),
-    ):
+    with patch.object(model_cls, "request", side_effect=ValueError("test error")):
         mlflow.pydantic_ai.autolog(disable=True)
 
         with pytest.raises(ValueError, match="test error"):
@@ -422,13 +424,14 @@ def test_autolog_auto_instrument_captures_llm_spans(mock_litellm_cost):
     async def request(self, *args, **kwargs):
         return dummy
 
-    # Mock must be set BEFORE autolog so autolog patches the mock
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
-        mlflow.pydantic_ai.autolog(log_traces=True)
+    # Enable autolog first so patched Agent.__init__ auto-sets instrument=True, then
+    # patch the resolved concrete model so no real API call is made.
+    mlflow.pydantic_ai.autolog(log_traces=True)
 
-        # Create agent WITHOUT explicitly setting instrument=True
-        agent = Agent("openai:gpt-4o", system_prompt="Tell me the capital of {{input}}.")
+    # Create agent WITHOUT explicitly setting instrument=True
+    agent = Agent("openai:gpt-4o", system_prompt="Tell me the capital of {{input}}.")
 
+    with patch.object(type(agent.model), "request", new=request):
         result = agent.run_sync("France")
         assert result.output == _FINAL_ANSWER_WITHOUT_TOOL
 
@@ -436,12 +439,9 @@ def test_autolog_auto_instrument_captures_llm_spans(mock_litellm_cost):
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    # Should have Agent.run_sync > Agent.run > InstrumentedModel.request
-    span_names = [s.name for s in spans]
-    assert "InstrumentedModel.request" in span_names
-
-    llm_span = next(s for s in spans if s.name == "InstrumentedModel.request")
-    assert llm_span.span_type == SpanType.LLM
+    # Should have Agent.run_sync > Agent.run > <ConcreteModel>.request (LLM span)
+    llm_span = next(s for s in spans if s.span_type == SpanType.LLM)
+    assert llm_span.name.endswith(".request")
 
 
 def test_autolog_does_not_capture_client_references(simple_agent):
@@ -450,7 +450,7 @@ def test_autolog_does_not_capture_client_references(simple_agent):
     async def request(self, *args, **kwargs):
         return dummy
 
-    with patch("pydantic_ai.models.instrumented.InstrumentedModel.request", new=request):
+    with patch.object(type(simple_agent.model), "request", new=request):
         mlflow.pydantic_ai.autolog(log_traces=True)
         simple_agent.run_sync("France")
 
@@ -462,7 +462,9 @@ def test_autolog_does_not_capture_client_references(simple_agent):
         attrs = span.attributes or {}
         for key in attrs:
             assert "client" not in key.lower() or key == "openai_client"
-            assert "provider" not in key.lower()
+            # `mlflow.llm.provider` holds the provider *name* (e.g. "openai"), not a
+            # captured provider object, so it is expected and safe.
+            assert "provider" not in key.lower() or key == SpanAttributeKey.MODEL_PROVIDER
             assert "_state" not in key.lower()
             assert "httpx" not in key.lower()
 

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -12,7 +12,11 @@ from pydantic_ai.usage import Usage
 import mlflow
 import mlflow.pydantic_ai  # ensure the integration module is importable
 from mlflow.entities import SpanLogLevel, SpanType
-from mlflow.pydantic_ai import _get_tool_manager_module_path, _tool_manager_uses_execute_tool_call
+from mlflow.pydantic_ai import (
+    _get_tool_manager_module_path,
+    _has_instrumentation_capability,
+    _tool_manager_uses_execute_tool_call,
+)
 from mlflow.pydantic_ai.autolog import (
     _get_agent_attributes,
     _get_mcp_server_attributes,
@@ -27,9 +31,24 @@ from tests.tracing.helper import get_traces
 PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
 # Usage was deprecated in favor of RequestUsage in 0.7.3
 IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
+HAS_INSTRUMENTATION_CAPABILITY = _has_instrumentation_capability()
 
 _FINAL_ANSWER_WITHOUT_TOOL = "Paris"
 _FINAL_ANSWER_WITH_TOOL = "winner"
+
+
+def _expected_llm_span_name(model_cls) -> str:
+    """Return the LLM span name for the path that must be exercised on this version.
+
+    On pydantic-ai >= 1.95 the span is produced by the Instrumentation capability hook
+    (``patched_capability_model_request``), which names it after the concrete model class,
+    e.g. ``OpenAIChatModel.request``. On < 1.95 it comes from the ``InstrumentedModel``
+    patch, which always names it ``InstrumentedModel.request``. Asserting the exact name
+    confirms the correct code path ran rather than merely "some LLM span exists".
+    """
+    if HAS_INSTRUMENTATION_CAPABILITY:
+        return f"{model_cls.__name__}.request"
+    return "InstrumentedModel.request"
 
 
 def _make_dummy_response_without_tool():
@@ -161,9 +180,9 @@ def test_agent_run_sync_enable_disable_autolog(simple_agent, mock_litellm_cost):
     assert len(outputs_1["_new_messages_serialized"]) > 0
 
     span2 = spans[2]
-    # Span name is "InstrumentedModel.request" on pydantic-ai < 1.95 and
-    # "<ConcreteModel>.request" (e.g. "OpenAIChatModel.request") on >= 1.95.
-    assert span2.name.endswith(".request")
+    # Exact name confirms which instrumentation path produced the LLM span: the capability
+    # hook (>= 1.95) names it after the concrete model, InstrumentedModel (< 1.95) does not.
+    assert span2.name == _expected_llm_span_name(model_cls)
     assert span2.span_type == SpanType.LLM
     assert span2.log_level == SpanLogLevel.INFO
     assert span2.parent_id == spans[1].span_id
@@ -216,7 +235,7 @@ async def test_agent_run_enable_disable_autolog(simple_agent, mock_litellm_cost)
     assert spans[0].span_type == SpanType.AGENT
 
     span1 = spans[1]
-    assert span1.name.endswith(".request")
+    assert span1.name == _expected_llm_span_name(type(simple_agent.model))
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
@@ -337,7 +356,7 @@ def test_agent_run_sync_failure(simple_agent):
     assert spans[0].span_type == SpanType.AGENT
     assert spans[1].name == "Agent.run"
     assert spans[1].span_type == SpanType.AGENT
-    assert spans[2].name.endswith(".request")
+    assert spans[2].name == _expected_llm_span_name(model_cls)
     assert spans[2].span_type == SpanType.LLM
 
     with patch.object(model_cls, "request", side_effect=ValueError("test error")):
@@ -444,7 +463,8 @@ def test_autolog_auto_instrument_captures_llm_spans(mock_litellm_cost):
     # Instrumentation hook instruments (InstrumentedModel is excluded), never both.
     assert sum(1 for s in spans if s.span_type == SpanType.LLM) == 1
     llm_span = next(s for s in spans if s.span_type == SpanType.LLM)
-    assert llm_span.name.endswith(".request")
+    # Exact name confirms the correct path (capability hook on >= 1.95) was exercised.
+    assert llm_span.name == _expected_llm_span_name(type(agent.model))
 
 
 def test_autolog_does_not_capture_client_references(simple_agent):

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -348,6 +348,11 @@ def test_agent_run_sync_failure(simple_agent):
 
     traces = get_traces()
     assert len(traces) == 1
+    # On pydantic-ai >= 1.95 the concrete model's exception propagates unchanged through
+    # the Instrumentation.wrap_model_request hook (patched_capability_model_request marks
+    # its span ERROR and re-raises), so the trace's ERROR status is set by the capability
+    # path rather than the error being swallowed. The exact LLM span name asserted below
+    # confirms the error span came from that path.
     assert traces[0].info.status == "ERROR"
     spans = traces[0].data.spans
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to # (cross-version test failure: `pydantic_ai` / `autologging` on 1.97.0 and 1.107.0)

### What changes are proposed in this pull request?

**Regression:** MLflow autologging captures **no LLM spans** for `pydantic_ai >= 1.95`, silently losing model-call tracing (token usage, cost, model/provider attributes) for every user on a modern `pydantic-ai`. The cross-version test suite caught this because the mocked model response was bypassed and a real OpenAI call leaked through (401 with the dummy key).

**Root cause:** `pydantic-ai >= 1.95` removed the `InstrumentedModel` wrapper from the agent run path. Enabling instrumentation no longer wraps the model; it is applied as a "capability". Model requests now funnel through:

`_agent_graph.ModelRequestNode._make_request` -> `root_capability.wrap_model_request` -> `capabilities/instrumentation.py Instrumentation.wrap_model_request` -> a local `model_handler` closure -> the concrete model's `request` / `request_stream`.

MLflow only patched `InstrumentedModel.request` / `request_stream` and gated LLM-span typing/attributes on `isinstance(instance, InstrumentedModel)`. On modern `pydantic-ai` that code is never hit, so no LLM span is produced.

**Fix (provider-agnostic, both old and new versions keep working):**

- `mlflow/pydantic_ai/__init__.py`: patch `pydantic_ai.capabilities.instrumentation.Instrumentation.wrap_model_request`. Since MLflow forces `instrument=True`, this capability is always present and is the single, provider-agnostic funnel that every model request (streaming and non-streaming) passes through. Guarded by `try/except ImportError`, so older versions skip it and keep using the existing `InstrumentedModel` `class_map` patch. No concrete provider model classes are hardcoded.
- `mlflow/pydantic_ai/autolog.py`: add `patched_capability_model_request`, which reads the concrete model from the `request_context` argument (not `self`, which is the capability), creates the `LLM` span, and records model attributes / usage. `_get_span_type` and `_set_span_attributes` now recognize base `pydantic_ai.models.Model` (covering both `InstrumentedModel` on old versions and concrete models on new ones), and the provider is derived from the model's own `system` identifier with a fallback to the legacy `provider:model` prefix.
- `tests/pydantic_ai/test_pydanticai_tracing.py`, `tests/pydantic_ai/test_pydanticai_fluent_tracing.py`: mock the concrete model's `request` / `request_stream` (resolved via `type(agent.model)`, which handles provider-class renames across versions) instead of `InstrumentedModel`, and assert the LLM span by span type rather than a hardcoded name (the span is `InstrumentedModel.request` on `< 1.95` and `<ConcreteModel>.request` on `>= 1.95`). This keeps the tests network-proof on every version in the matrix.
- `mlflow/ml-package-versions.yml`: remove the temporary `maximum: "1.94.0"` cap (and its stale TODO). Capping would have hidden the lost-tracing regression from real users; with the fix the suite now passes on current `pydantic-ai`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Verified locally in an isolated venv against `pydantic-ai` **1.94.0** (old `InstrumentedModel` path), **1.97.0**, and **1.107.0** (new capabilities path):

- `tests/pydantic_ai/test_pydanticai_tracing.py` + `tests/pydantic_ai/test_pydanticai_fluent_tracing.py`: 28 passed on 1.94.0, 28 passed on 1.97.0, 30 passed (full `tests/pydantic_ai`) on 1.107.0.
- Before the fix, the same tests failed on 1.107.0 by attempting a real network call (the CVT 401), confirming the regression and its resolution.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Restores LLM span capture (token usage, cost, model/provider attributes) for `pydantic-ai >= 1.95`, which had silently stopped being traced.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release