### PR TITLE
Flush stale periodic Huey locks on startup

### DIFF
--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -551,6 +551,7 @@ def _start_periodic_tasks_consumer_proc():
         "-m",
         "huey.bin.huey_consumer",
         "mlflow.server.jobs._periodic_tasks_consumer.huey_instance",
+        "--flush-locks",
         "-w",
         str(PERIODIC_TASKS_WORKER_COUNT),
     ]

--- a/tests/server/jobs/test_utils.py
+++ b/tests/server/jobs/test_utils.py
@@ -1,9 +1,16 @@
 import os
+import sys
+from unittest import mock
 
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.server.jobs.utils import _load_function, _validate_function_parameters
+from mlflow.server.jobs.utils import (
+    PERIODIC_TASKS_WORKER_COUNT,
+    _load_function,
+    _start_periodic_tasks_consumer_proc,
+    _validate_function_parameters,
+)
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="MLflow job execution is not supported on Windows"
@@ -89,6 +96,25 @@ def test_load_function_module_not_found():
 def test_load_function_function_not_found():
     with pytest.raises(MlflowException, match="Function not found in module"):
         _load_function("os.non_exist_function")
+
+
+def test_start_periodic_tasks_consumer_proc_flushes_locks(monkeypatch):
+    monkeypatch.delenv("MLFLOW_LOGGING_LEVEL", raising=False)
+    with mock.patch("mlflow.server.jobs.utils._exec_cmd") as mock_exec_cmd:
+        _start_periodic_tasks_consumer_proc()
+
+    mock_exec_cmd.assert_called_once()
+    cmd = mock_exec_cmd.call_args.args[0]
+    assert cmd == [
+        sys.executable,
+        "-m",
+        "huey.bin.huey_consumer",
+        "mlflow.server.jobs._periodic_tasks_consumer.huey_instance",
+        "--flush-locks",
+        "-w",
+        str(PERIODIC_TASKS_WORKER_COUNT),
+        "-q",
+    ]
 
 
 def test_compute_exclusive_lock_key():


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/discussions/24472

### What changes are proposed in this pull request?

This PR makes the dedicated periodic Huey consumer start with `--flush-locks` so stale scheduler locks from abrupt termination do not permanently block periodic work.

It also adds a focused unit test covering the periodic consumer command construction to prevent regressions.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Tested with:
- `uv run --frozen ruff check mlflow/server/jobs/utils.py tests/server/jobs/test_utils.py`
- `uv run --frozen ruff format --check mlflow/server/jobs/utils.py tests/server/jobs/test_utils.py`
- `uv run --with httpx2 pytest tests/server/jobs/test_utils.py`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The dedicated periodic Huey consumer now clears stale scheduler locks on startup so trace archival and other periodic tasks can recover after abrupt termination instead of remaining stuck.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release