### PR TITLE
Fix scorer aggregations being dropped for sub-metric assessments

### DIFF
--- a/mlflow/genai/scorers/aggregation.py
+++ b/mlflow/genai/scorers/aggregation.py
@@ -60,11 +60,21 @@ def compute_aggregated_metrics(
         if not values:
             continue
 
-        # Get the function name from the returned assessment name.
-        scorer_function_name = name.split("/", 1)[-1]
+        # Resolve which scorer produced this assessment. Names come in three shapes:
+        # the scorer name itself ("scorer1"), a namespaced name ("namespace/scorer1"),
+        # or a sub-metric emitted by a scorer ("retrieval_relevance/precision"). Taking
+        # only the suffix resolves the first two but misses the third, which then fell
+        # back to ["mean"] and silently dropped the scorer's configured aggregations.
+        candidates = [name]
+        if "/" in name:
+            prefix, suffix = name.split("/", 1)
+            candidates += [prefix, suffix]
 
         # Compute aggregations for the scorer, defaulting to just ["mean"]
-        aggregations_to_compute = scorer_aggregations.get(scorer_function_name, ["mean"])
+        aggregations_to_compute = next(
+            (scorer_aggregations[c] for c in candidates if c in scorer_aggregations),
+            ["mean"],
+        )
         aggregation_results = _compute_aggregations(values, aggregations_to_compute)
 
         # Each aggregation should be logged as a separate metric

--- a/tests/genai/scorers/test_aggregation.py
+++ b/tests/genai/scorers/test_aggregation.py
@@ -99,6 +99,25 @@ def test_compute_aggregated_metrics_with_namespace():
     assert result["foo/scorer1/max"] == pytest.approx(2.0)
 
 
+def test_compute_aggregated_metrics_with_scorer_sub_metric():
+    # Scorers may emit a sub-metric named "<scorer>/<sub>" - e.g. RetrievalRelevance
+    # produces "retrieval_relevance/precision". The scorer's configured aggregations
+    # must still be honored for it, not silently reduced to ["mean"].
+    scorer = Scorer(name="retrieval_relevance", aggregations=["min", "max", "mean"])
+    eval_results = [
+        EvalResult(
+            eval_item=_EVAL_ITEM,
+            assessments=[Feedback(name="retrieval_relevance/precision", value=value)],
+        )
+        for value in (0.0, 0.5, 1.0)
+    ]
+
+    result = compute_aggregated_metrics(eval_results, [scorer])
+    assert result["retrieval_relevance/precision/min"] == pytest.approx(0.0)
+    assert result["retrieval_relevance/precision/max"] == pytest.approx(1.0)
+    assert result["retrieval_relevance/precision/mean"] == pytest.approx(0.5)
+
+
 @pytest.mark.parametrize(
     ("value", "expected_float"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number <!-- no existing issue; bug found while reading `mlflow/genai/scorers/aggregation.py` -->

### What changes are proposed in this pull request?

`compute_aggregated_metrics` resolves which scorer produced an assessment by taking the suffix after the first `/`:

```python
scorer_function_name = name.split("/", 1)[-1]
aggregations_to_compute = scorer_aggregations.get(scorer_function_name, ["mean"])
```

That handles a plain name (`"scorer1"`) and a namespaced one (`"namespace/scorer1"` → `"scorer1"`), but not a **sub-metric emitted by a scorer**. `RetrievalRelevance` logs its span-level feedback as `self.name + "/precision"` (`builtin_scorers.py`), so the name is `"retrieval_relevance/precision"` and the suffix is `"precision"` — not a scorer name. The lookup misses and silently falls back to `["mean"]`, discarding the user's configured `aggregations`.

**Repro** — `RetrievalRelevance(aggregations=["min", "max", "mean"])`:

| | logged |
|---|---|
| expected | `.../precision/min`, `.../precision/max`, `.../precision/mean` |
| actual | `.../precision/mean` only — min/max dropped, no error or warning |

The per-chunk feedbacks from the same scorer are named plainly, so they resolve fine and *do* honor `min`/`max` — meaning one `aggregations=` argument behaves two different ways within the same scorer.

**Fix:** resolve the scorer by trying the full name, then the prefix, then the suffix — covering all three name shapes. Existing namespaced behavior is unchanged (`"foo/scorer1"` still resolves via the suffix, as asserted by the existing `test_compute_aggregated_metrics_with_namespace`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_compute_aggregated_metrics_with_scorer_sub_metric`, asserting a `"<scorer>/<sub>"`-shaped assessment honors the scorer's configured aggregations. On unmodified source it fails with `KeyError: 'retrieval_relevance/precision/min'`; it passes with the fix.

`pytest tests/genai/scorers/test_aggregation.py` → 15 passed (pure Python + numpy, no network/DB).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Scorer `aggregations` are now honored for sub-metric assessments (e.g. `RetrievalRelevance`'s `retrieval_relevance/precision`), which previously logged only `mean` regardless of the configured aggregations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
