### PR TITLE
Fix scorer aggregations being dropped for sub-metric assessments

### DIFF
--- a/mlflow/genai/scorers/aggregation.py
+++ b/mlflow/genai/scorers/aggregation.py
@@ -65,10 +65,12 @@ def compute_aggregated_metrics(
         # or a sub-metric emitted by a scorer ("retrieval_relevance/precision"). Taking
         # only the suffix resolves the first two but misses the third, which then fell
         # back to ["mean"] and silently dropped the scorer's configured aggregations.
+        # The suffix is tried before the prefix so that a namespace colliding with a
+        # scorer name keeps resolving the way it always has.
         candidates = [name]
         if "/" in name:
             prefix, suffix = name.split("/", 1)
-            candidates += [prefix, suffix]
+            candidates += [suffix, prefix]
 
         # Compute aggregations for the scorer, defaulting to just ["mean"]
         aggregations_to_compute = next(

--- a/mlflow/genai/scorers/aggregation.py
+++ b/mlflow/genai/scorers/aggregation.py
@@ -60,11 +60,21 @@ def compute_aggregated_metrics(
         if not values:
             continue
 
-        # Get the function name from the returned assessment name.
-        scorer_function_name = name.split("/", 1)[-1]
+        # Resolve which scorer produced this assessment. Names come in three shapes:
+        # the scorer name itself ("scorer1"), a namespaced name ("namespace/scorer1"),
+        # or a sub-metric emitted by a scorer ("retrieval_relevance/precision"). Taking
+        # only the suffix resolves the first two but misses the third, which then fell
+        # back to ["mean"] and silently dropped the scorer's configured aggregations.
+        candidates = [name]
+        if "/" in name:
+            prefix, suffix = name.split("/", 1)
+            candidates += [prefix, suffix]
 
         # Compute aggregations for the scorer, defaulting to just ["mean"]
-        aggregations_to_compute = scorer_aggregations.get(scorer_function_name, ["mean"])
+        aggregations_to_compute = next(
+            (scorer_aggregations[c] for c in candidates if c in scorer_aggregations),
+            ["mean"],
+        )
         aggregation_results = _compute_aggregations(values, aggregations_to_compute)
 
         # Each aggregation should be logged as a separate metric

--- a/tests/genai/scorers/test_aggregation.py
+++ b/tests/genai/scorers/test_aggregation.py
@@ -99,6 +99,24 @@ def test_compute_aggregated_metrics_with_namespace():
     assert result["foo/scorer1/max"] == pytest.approx(2.0)
 
 
+def test_compute_aggregated_metrics_namespace_shadowing_scorer_name():
+    # "foo/scorer1" is ambiguous once sub-metrics are resolvable: it could be scorer1
+    # under namespace foo, or a "foo" sub-metric of scorer1. The namespace reading is
+    # the established one, so the suffix must win even when the namespace itself is a
+    # registered scorer name.
+    namespace = Scorer(name="foo", aggregations=["mean"])
+    scorer = Scorer(name="scorer1", aggregations=["min", "max"])
+    eval_results = [
+        EvalResult(eval_item=_EVAL_ITEM, assessments=[Feedback(name="foo/scorer1", value=1.0)]),
+        EvalResult(eval_item=_EVAL_ITEM, assessments=[Feedback(name="foo/scorer1", value=2.0)]),
+    ]
+
+    result = compute_aggregated_metrics(eval_results, [namespace, scorer])
+    assert result["foo/scorer1/min"] == pytest.approx(1.0)
+    assert result["foo/scorer1/max"] == pytest.approx(2.0)
+    assert "foo/scorer1/mean" not in result
+
+
 def test_compute_aggregated_metrics_with_scorer_sub_metric():
     # Scorers may emit a sub-metric named "<scorer>/<sub>" - e.g. RetrievalRelevance
     # produces "retrieval_relevance/precision". The scorer's configured aggregations

--- a/tests/genai/scorers/test_aggregation.py
+++ b/tests/genai/scorers/test_aggregation.py
@@ -99,6 +99,25 @@ def test_compute_aggregated_metrics_with_namespace():
     assert result["foo/scorer1/max"] == pytest.approx(2.0)
 
 
+def test_compute_aggregated_metrics_with_scorer_sub_metric():
+    # Scorers may emit a sub-metric named "<scorer>/<sub>" - e.g. RetrievalRelevance
+    # produces "retrieval_relevance/precision". The scorer's configured aggregations
+    # must still be honored for it, not silently reduced to ["mean"].
+    scorer = Scorer(name="retrieval_relevance", aggregations=["min", "max", "mean"])
+    eval_results = [
+        EvalResult(
+            eval_item=_EVAL_ITEM,
+            assessments=[Feedback(name="retrieval_relevance/precision", value=value)],
+        )
+        for value in (0.0, 0.5, 1.0)
+    ]
+
+    result = compute_aggregated_metrics(eval_results, [scorer])
+    assert result["retrieval_relevance/precision/min"] == pytest.approx(0.0)
+    assert result["retrieval_relevance/precision/max"] == pytest.approx(1.0)
+    assert result["retrieval_relevance/precision/mean"] == pytest.approx(0.5)
+
+
 @pytest.mark.parametrize(
     ("value", "expected_float"),
     [


### PR DESCRIPTION
### Related Issues/PRs

None — there is no existing issue for this. The bug was found while reading `mlflow/genai/scorers/aggregation.py`; happy to open one first if that's preferred.

### What changes are proposed in this pull request?

`compute_aggregated_metrics` resolves which scorer produced an assessment by taking the suffix after the first `/`:

```python
scorer_function_name = name.split("/", 1)[-1]
aggregations_to_compute = scorer_aggregations.get(scorer_function_name, ["mean"])
```

That handles a plain name (`"scorer1"`) and a namespaced one (`"namespace/scorer1"` → `"scorer1"`), but not a **sub-metric emitted by a scorer**. `RetrievalRelevance` logs its span-level feedback as `self.name + "/precision"` (`builtin_scorers.py`), so the name is `"retrieval_relevance/precision"` and the suffix is `"precision"` — not a scorer name. The lookup misses and silently falls back to `["mean"]`, discarding the user's configured `aggregations`.

**Repro** — `RetrievalRelevance(aggregations=["min", "max", "mean"])`:

| | logged |
|---|---|
| expected | `.../precision/min`, `.../precision/max`, `.../precision/mean` |
| actual | `.../precision/mean` only — min/max dropped, no error or warning |

The per-chunk feedbacks from the same scorer are named plainly, so they resolve fine and *do* honor `min`/`max` — meaning one `aggregations=` argument behaves two different ways within the same scorer.

**Fix:** resolve the scorer by trying the full name, then the suffix, then the prefix — covering all three name shapes.

`"a/b"` is inherently ambiguous once sub-metrics are resolvable (namespace + scorer, or scorer + sub-metric), so the order decides which reading wins on a collision. The suffix is tried first because it is the conservative choice: it keeps every namespaced name resolving exactly as it does today, and can only mis-resolve a case that doesn't work at all right now (a scorer named identically to a sub-metric, e.g. `precision`). Trying the prefix first would fix sub-metrics unconditionally but could regress a working `"namespace/scorer1"` whenever the namespace happens to match a scorer name. Thanks to @copilot for catching this.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Two regression tests, each verified to fail without its corresponding change:

- `test_compute_aggregated_metrics_with_scorer_sub_metric` — a `"<scorer>/<sub>"`-shaped assessment honors the scorer's configured aggregations. Fails on unmodified `master` with `KeyError: 'retrieval_relevance/precision/min'`.
- `test_compute_aggregated_metrics_namespace_shadowing_scorer_name` — registers a scorer named `foo` alongside `scorer1` and asserts `foo/scorer1` still resolves to `scorer1`. This pins the candidate ordering: it fails if the prefix is tried before the suffix.

`pytest tests/genai/scorers/test_aggregation.py` → 16 passed (pure Python + numpy, no network/DB). `ruff check` and `ruff format --check` clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Scorer `aggregations` are now honored for sub-metric assessments (e.g. `RetrievalRelevance`'s `retrieval_relevance/precision`), which previously logged only `mean` regardless of the configured aggregations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
