### PR TITLE
Fix `GepaPromptOptimizer` dropping per-iteration logging when `valset` is passed via `gepa_kwargs`

### DIFF
--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -340,8 +340,12 @@ class GepaPromptOptimizer(BasePromptOptimizer):
 
                 return reflective_datasets
 
+        # GEPA reuses `trainset` as the full-validation set when `valset` isn't passed,
+        # so the adapter's notion of "full validation pass" must match whichever one
+        # GEPA is actually using, or per-iteration logging silently never triggers.
+        full_dataset_size = len(self.gepa_kwargs.get("valset") or train_data)
         adapter = MlflowGEPAAdapter(
-            eval_fn, target_prompts, enable_tracking, full_dataset_size=len(train_data)
+            eval_fn, target_prompts, enable_tracking, full_dataset_size=full_dataset_size
         )
 
         kwargs = self.gepa_kwargs | {

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -615,6 +615,69 @@ def test_gepa_optimizer_logs_prompt_candidates(
     assert metrics["metrics"]["eval_score.relevance"] == 0.7
 
 
+def test_gepa_optimizer_logs_prompt_candidates_with_valset(
+    sample_train_data: list[dict[str, Any]],
+    sample_target_prompts: dict[str, str],
+    mock_eval_fn: Any,
+):
+    # A valset with a different size than train_data: GEPA treats this as the
+    # full-validation batch instead of trainset when it's passed via gepa_kwargs.
+    valset = sample_train_data[:2]
+
+    mock_gepa_module = MagicMock()
+    mock_modules = {
+        "gepa": mock_gepa_module,
+        "gepa.core": MagicMock(),
+        "gepa.core.adapter": MagicMock(),
+    }
+    mock_gepa_module.EvaluationBatch = MagicMock()
+    mock_gepa_module.GEPAAdapter = object
+
+    optimizer = GepaPromptOptimizer(
+        reflection_model="openai:/gpt-4o", gepa_kwargs={"valset": valset}
+    )
+
+    logged_metrics = []
+
+    with patch.dict(sys.modules, mock_modules):
+        captured_adapter = None
+
+        def mock_optimize_fn(**kwargs):
+            nonlocal captured_adapter
+            captured_adapter = kwargs["adapter"]
+            mock_result = Mock()
+            mock_result.best_candidate = sample_target_prompts
+            mock_result.val_aggregate_scores = [0.8]
+            mock_result.val_aggregate_subscores = None
+            return mock_result
+
+        mock_gepa_module.optimize = mock_optimize_fn
+
+        with mlflow.start_run():
+            with patch(
+                "mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_metrics"
+            ) as mock_log_metrics:
+                mock_log_metrics.side_effect = lambda metrics, step=None: logged_metrics.append({
+                    "metrics": metrics,
+                    "step": step,
+                })
+
+                optimizer.optimize(
+                    eval_fn=mock_eval_fn,
+                    train_data=sample_train_data,
+                    target_prompts=sample_target_prompts,
+                    enable_tracking=True,
+                )
+
+                # A full-valset evaluation (matches len(valset), not len(train_data))
+                # must be recognized as a full validation pass and logged.
+                candidate = {"system_prompt": "Optimized prompt", "instruction": "New instruction"}
+                captured_adapter.evaluate(valset, candidate, capture_traces=False)
+
+    assert len(logged_metrics) == 1
+    assert logged_metrics[0]["metrics"]["eval_score"] == 0.8
+
+
 @pytest.mark.parametrize(
     ("val_aggregate_scores", "val_aggregate_subscores", "expected"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Closes #24461

### What changes are proposed in this pull request?

`GepaPromptOptimizer.optimize()` builds an internal `MlflowGEPAAdapter` that decides whether an evaluation call from GEPA is a full validation pass or a minibatch by comparing the batch size to a stored `full_dataset_size`. That value was always set to `len(train_data)`, regardless of whether a `valset` was supplied through `gepa_kwargs`.

GEPA treats `valset` as the full-validation set whenever it's provided, and only falls back to `trainset` when it's not. So if a caller passes a `valset` with a different size than `train_data`, the adapter's batch-size check never matches, and `is_full_validation` is always `False`. The result is that per-iteration logging (prompt candidate artifacts, eval result tables, metrics) is silently skipped for the entire optimization run, with no warning that anything went wrong.

This PR computes `full_dataset_size` from `gepa_kwargs["valset"]` when it's present, falling back to `train_data` otherwise, so it matches whichever dataset GEPA is actually using for full validation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_gepa_optimizer_logs_prompt_candidates_with_valset`, which constructs an optimizer with a `valset` sized differently than `train_data`, captures the real adapter GEPA would receive, drives it with a valset-sized batch, and asserts that validation metrics get logged. This test fails against the old code and passes with the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a bug where per-iteration logging (prompt candidate artifacts, eval tables, metrics) was silently lost during GEPA prompt optimization when a `valset` was passed via `gepa_kwargs`.

#### What component(s) does this PR affect?

- [x] `area/evaluation`
- [x] `area/prompts`

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix`

#### Is this PR a critical bugfix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release