### PR TITLE
Bump NaiLaOpus orchestrator ref to fix trace export

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -141,7 +141,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: d4ac1fd5e110dbbe3f00db09b65b53d06d022d66
+          ref: 5e5f9229e16b97822ea3349b31285370be36b4d1
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24250

### What changes are proposed in this pull request?

Advances the pinned `mlflow/internal` orchestrator ref in `.github/workflows/nailaopus.yml` (line 144) from `d4ac1fd5` to the current `main` HEAD (`5e5f9229`), which includes the `opentelemetry-sdk<1.43.0` pin.

opentelemetry-sdk 1.43.0 marks an ended span's attributes immutable. The trace-export path writes attributes onto the already-ended root span, which now raises, so the root span fails to finalize and the whole trace is silently dropped, i.e. NaiLaOpus stopped emitting traces. Pinning `opentelemetry-sdk<1.43.0` restores export. The intervening `mlflow/internal` diff was reviewed: a small linear bump (orchestrator skill updates plus the otel pin), with no orchestrator logic risk.

### How is this PR tested?

- [x] Manual tests

Reproduced the dropped-trace failure on opentelemetry-sdk 1.43.0 and confirmed the trace exports on 1.42.1.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
