### PR TITLE
Fix Huey orphan shutdown and periodic lock recovery

### DIFF
--- a/mlflow/server/jobs/_huey_consumer.py
+++ b/mlflow/server/jobs/_huey_consumer.py
@@ -27,9 +27,8 @@ from mlflow.server.jobs.utils import (
 # Configure Python logging to suppress noisy job logs
 configure_logging_for_jobs()
 
-# ensure the subprocess is killed when parent process dies.
-# The huey consumer's parent process is `_job_runner` process,
-# if `_job_runner` process is died, it means the MLflow server exits.
+# Ensure the subprocess exits if its original parent dies and it gets reparented.
+# The Huey consumer's direct parent process is `_job_runner`.
 threading.Thread(
     target=_exit_when_orphaned,
     name="exit_when_orphaned",

--- a/mlflow/server/jobs/_job_subproc_entry.py
+++ b/mlflow/server/jobs/_job_subproc_entry.py
@@ -39,7 +39,7 @@ def _main():
     # ensure telemetry can be captured within jobs
     set_telemetry_client()
 
-    # ensure the subprocess is killed when parent process dies.
+    # Ensure the subprocess exits if its original parent dies and it gets reparented.
     threading.Thread(
         target=_exit_when_orphaned,
         name="exit_when_orphaned",

--- a/mlflow/server/jobs/_periodic_tasks_consumer.py
+++ b/mlflow/server/jobs/_periodic_tasks_consumer.py
@@ -18,9 +18,8 @@ from mlflow.server.jobs.utils import (
 # Configure Python logging to suppress noisy job logs
 configure_logging_for_jobs()
 
-# Ensure the subprocess is killed when parent process dies.
-# The huey consumer's parent process is `_job_runner` process,
-# if `_job_runner` process is died, it means the MLflow server exits.
+# Ensure the subprocess exits if its original parent dies and it gets reparented.
+# The dedicated periodic consumer's direct parent process is `_job_runner`.
 threading.Thread(
     target=_exit_when_orphaned,
     name="exit_when_orphaned",

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -54,6 +54,7 @@ MLFLOW_SERVER_JOB_RESULT_DUMP_PATH_ENV_VAR = "_MLFLOW_SERVER_JOB_RESULT_DUMP_PAT
 MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH_ENV_VAR = (
     "_MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH"
 )
+MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR = "_MLFLOW_ORIGINAL_PARENT_PID"
 
 # Number of worker threads for the periodic tasks consumer
 PERIODIC_TASKS_WORKER_COUNT = 5
@@ -106,8 +107,16 @@ class JobResult:
 
 
 def _exit_when_orphaned(poll_interval: float = 1) -> None:
+    raw_parent_pid = os.environ.get(MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR)
+    try:
+        parent_pid = int(raw_parent_pid) if raw_parent_pid is not None else 0
+    except (TypeError, ValueError):
+        parent_pid = 0
+    if parent_pid <= 0:
+        parent_pid = os.getppid()
     while True:
-        if os.getppid() == 1:
+        current_parent_pid = os.getppid()
+        if current_parent_pid == 1 or current_parent_pid != parent_pid:
             os._exit(1)
         time.sleep(poll_interval)
 
@@ -156,6 +165,7 @@ def _start_huey_consumer_proc(
         synchronous=False,
         extra_env={
             MLFLOW_HUEY_INSTANCE_KEY: huey_instance_key,
+            MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: str(os.getpid()),
         },
     )
 
@@ -244,6 +254,7 @@ def _exec_job_in_subproc(
         MLFLOW_SERVER_JOB_FUNCTION_FULLNAME_ENV_VAR: function_fullname,
         MLFLOW_SERVER_JOB_RESULT_DUMP_PATH_ENV_VAR: result_file,
         MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH_ENV_VAR: transient_error_classes_file,
+        MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: str(os.getpid()),
         **(extra_envs or {}),
     }
 
@@ -553,6 +564,7 @@ def _start_periodic_tasks_consumer_proc():
         "mlflow.server.jobs._periodic_tasks_consumer.huey_instance",
         "-w",
         str(PERIODIC_TASKS_WORKER_COUNT),
+        "-f",
     ]
 
     # Add quiet flag unless DEBUG logging is explicitly requested,
@@ -565,6 +577,7 @@ def _start_periodic_tasks_consumer_proc():
         cmd,
         capture_output=False,
         synchronous=False,
+        extra_env={MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: str(os.getpid())},
     )
 
 

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -23,12 +23,16 @@ from mlflow.server.jobs import (
 )
 from mlflow.server.jobs._job_subproc_entry import _main
 from mlflow.server.jobs.utils import (
+    MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR,
     MLFLOW_SERVER_JOB_FUNCTION_FULLNAME_ENV_VAR,
     MLFLOW_SERVER_JOB_PARAMS_ENV_VAR,
     MLFLOW_SERVER_JOB_RESULT_DUMP_PATH_ENV_VAR,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH_ENV_VAR,
     _enqueue_unfinished_jobs,
     _exec_job,
+    _exec_job_in_subproc,
+    _exit_when_orphaned,
+    _start_huey_consumer_proc,
 )
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
@@ -957,6 +961,102 @@ def test_update_status_details_on_nonexistent_job(tmp_path: Path):
 
     with pytest.raises(MlflowException, match="Job .+ not found"):
         store.update_status_details("nonexistent-job-id", {"stage": "test"})
+
+
+def test_exit_when_orphaned_exits_when_parent_pid_changes():
+    with (
+        mock.patch.dict(
+            "mlflow.server.jobs.utils.os.environ",
+            {MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: "123"},
+            clear=False,
+        ),
+        mock.patch("mlflow.server.jobs.utils.os.getppid", side_effect=[123, 123, 456]),
+        mock.patch("mlflow.server.jobs.utils.time.sleep"),
+        mock.patch("mlflow.server.jobs.utils.os._exit", side_effect=SystemExit(1)) as mock_exit,
+        pytest.raises(SystemExit, match="1"),
+    ):
+        _exit_when_orphaned(poll_interval=0)
+
+    mock_exit.assert_called_once_with(1)
+
+
+def test_exit_when_orphaned_exits_when_already_orphaned():
+    with (
+        mock.patch.dict(
+            "mlflow.server.jobs.utils.os.environ",
+            {MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: "123"},
+            clear=False,
+        ),
+        mock.patch("mlflow.server.jobs.utils.os.getppid", return_value=1),
+        mock.patch("mlflow.server.jobs.utils.os._exit", side_effect=SystemExit(1)) as mock_exit,
+        pytest.raises(SystemExit, match="1"),
+    ):
+        _exit_when_orphaned(poll_interval=0)
+
+    mock_exit.assert_called_once_with(1)
+
+
+def test_exit_when_orphaned_ignores_invalid_parent_pid_env():
+    with (
+        mock.patch.dict(
+            "mlflow.server.jobs.utils.os.environ",
+            {MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: "not-a-pid"},
+            clear=False,
+        ),
+        mock.patch("mlflow.server.jobs.utils.os.getppid", side_effect=[123, 123, 456]),
+        mock.patch("mlflow.server.jobs.utils.time.sleep"),
+        mock.patch("mlflow.server.jobs.utils.os._exit", side_effect=SystemExit(1)) as mock_exit,
+        pytest.raises(SystemExit, match="1"),
+    ):
+        _exit_when_orphaned(poll_interval=0)
+
+    mock_exit.assert_called_once_with(1)
+
+
+def test_start_huey_consumer_proc_passes_original_parent_pid():
+    with (
+        mock.patch("mlflow.server.jobs.utils.os.getpid", return_value=321),
+        mock.patch("mlflow.utils.process._exec_cmd") as mock_exec_cmd,
+    ):
+        _start_huey_consumer_proc("basic_job_fun", 3)
+
+    assert mock_exec_cmd.call_count == 1
+    assert mock_exec_cmd.call_args.kwargs["extra_env"][MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR] == "321"
+
+
+def test_exec_job_in_subproc_passes_original_parent_pid(tmp_path: Path):
+    mock_job_store = mock.Mock()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        json.dumps({"succeeded": True, "result": "3", "is_transient_error": None, "error": None})
+    )
+    mock_popen = mock.MagicMock()
+    mock_popen.__enter__.return_value = mock_popen
+    mock_popen.__exit__.return_value = False
+    mock_popen.poll.return_value = 0
+    mock_popen.returncode = 0
+
+    with (
+        mock.patch("mlflow.server.jobs.utils.os.getpid", return_value=654),
+        mock.patch("mlflow.server.jobs.utils.subprocess.Popen", return_value=mock_popen) as popen,
+    ):
+        job_result = _exec_job_in_subproc(
+            function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+            params={"x": 1, "y": 2},
+            python_env=None,
+            transient_error_classes=None,
+            timeout=None,
+            tmpdir=str(tmp_path),
+            job_store=mock_job_store,
+            job_id="job-1",
+            job_name="basic_job_fun",
+            workspace=None,
+        )
+
+    assert job_result is not None
+    assert job_result.succeeded is True
+    assert job_result.result == "3"
+    assert popen.call_args.kwargs["env"][MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR] == "654"
 
 
 def test_subproc_entry_telemetry(tmp_path, monkeypatch):

--- a/tests/server/jobs/test_trace_archival_jobs.py
+++ b/tests/server/jobs/test_trace_archival_jobs.py
@@ -20,7 +20,11 @@ from mlflow.environment_variables import (
     MLFLOW_WORKSPACE,
 )
 from mlflow.exceptions import MlflowException
-from mlflow.server.jobs.utils import register_periodic_tasks
+from mlflow.server.jobs.utils import (
+    MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR,
+    _start_periodic_tasks_consumer_proc,
+    register_periodic_tasks,
+)
 from mlflow.store.tracking.dbmodels.models import SqlSpan
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.tracking.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyStore
@@ -676,3 +680,16 @@ def test_register_periodic_tasks_includes_trace_archival_when_configured(monkeyp
 
     assert "online_scoring_scheduler" in huey.periodic_task_names
     assert "trace_archival_scheduler" in huey.periodic_task_names
+
+
+def test_periodic_tasks_consumer_enables_flush_locks():
+    with (
+        patch("mlflow.server.jobs.utils.os.getpid", return_value=987),
+        patch("mlflow.server.jobs.utils._exec_cmd") as mock_exec_cmd,
+    ):
+        _start_periodic_tasks_consumer_proc()
+
+    assert mock_exec_cmd.call_count == 1
+    cmd = mock_exec_cmd.call_args.args[0]
+    assert "-f" in cmd
+    assert mock_exec_cmd.call_args.kwargs["extra_env"][MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR] == "987"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes: https://github.com/mlflow/mlflow/discussions/24472

### What changes are proposed in this pull request?

Pass the expected parent PID to child processes so orphan watchers still exit when reparenting happens before startup. Start the periodic consumer with Huey's lock flush flag to clear stale scheduler locks after crashes.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
