### PR TITLE
[fix] Sync sidebar workflow toggle to the opened experiment's kind

### DIFF
--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
@@ -1,17 +1,26 @@
 /* eslint-disable jest/no-standalone-expect */
 import { describe, jest, test, expect, beforeEach } from '@jest/globals';
-import { act, screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from '../utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '../utils/reactQueryHooks';
 import { renderWithDesignSystem } from '../utils/TestUtils.react18';
-import { WorkflowType, WorkflowTypeProvider, useWorkflowType } from './WorkflowTypeContext';
+import {
+  WorkflowType,
+  WorkflowTypeProvider,
+  useWorkflowType,
+  WORKFLOW_TYPE_STORAGE_KEY,
+  WORKFLOW_TYPE_STORAGE_VERSION,
+} from './WorkflowTypeContext';
 import { useGetExperimentQuery } from '../../experiment-tracking/hooks/useExperimentQuery';
 import { EXPERIMENT_KIND_TAG_KEY } from '../../experiment-tracking/utils/ExperimentKindUtils';
+import { setLocalStorageItem } from '../../shared/web-shared/hooks';
 
-const WORKFLOW_TYPE_STORAGE_KEY_V1 = 'mlflow.workflowType_v1';
+// Seed through the same helper (and key construction) the provider's
+// ``useLocalStorage`` uses, so the seed can't silently drift from the real key
+// if the storage key/version constants change.
 const seedWorkflowType = (value: WorkflowType) =>
-  window.localStorage.setItem(WORKFLOW_TYPE_STORAGE_KEY_V1, JSON.stringify(value));
+  setLocalStorageItem(WORKFLOW_TYPE_STORAGE_KEY, WORKFLOW_TYPE_STORAGE_VERSION, false, value);
 
 const mockNavigate = jest.fn();
 
@@ -84,7 +93,9 @@ describe('WorkflowTypeProvider experiment-kind sync', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset the persisted workflow type between tests.
+    // Guarantee a clean slate: clear anything a provider wrote during a prior
+    // test body before seeding this test's starting value.
+    window.localStorage.clear();
     seedWorkflowType(WorkflowType.GENAI);
     mockUseGetExperimentQuery.mockReturnValue({ data: undefined, loading: false } as any);
   });
@@ -173,6 +184,13 @@ describe('WorkflowTypeProvider experiment-kind sync', () => {
       await userEvent.click(screen.getByText('pick-ml'));
     });
     expect(screen.getByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+
+    // Let any subsequent effect cycle run and confirm the auto-sync does NOT
+    // re-fire and revert the manual choice back to the experiment's genai kind.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    await waitFor(() => expect(screen.getByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING));
   });
 
   test('manual toggle still navigates to the experiment page (existing behavior preserved)', async () => {

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
@@ -1,0 +1,187 @@
+/* eslint-disable jest/no-standalone-expect */
+import { describe, jest, test, expect, beforeEach } from '@jest/globals';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { QueryClient, QueryClientProvider } from '../utils/reactQueryHooks';
+import { renderWithDesignSystem } from '../utils/TestUtils.react18';
+import { WorkflowType, WorkflowTypeProvider, useWorkflowType } from './WorkflowTypeContext';
+import { useGetExperimentQuery } from '../../experiment-tracking/hooks/useExperimentQuery';
+import { EXPERIMENT_KIND_TAG_KEY } from '../../experiment-tracking/utils/ExperimentKindUtils';
+
+const WORKFLOW_TYPE_STORAGE_KEY_V1 = 'mlflow.workflowType_v1';
+const seedWorkflowType = (value: WorkflowType) =>
+  window.localStorage.setItem(WORKFLOW_TYPE_STORAGE_KEY_V1, JSON.stringify(value));
+
+const mockNavigate = jest.fn();
+
+jest.mock('../../experiment-tracking/hooks/useExperimentQuery', () => ({
+  useGetExperimentQuery: jest.fn(() => ({ data: undefined, loading: false })),
+}));
+
+jest.mock('@mlflow/mlflow/src/common/utils/RoutingUtils', () => ({
+  ...jest.requireActual<typeof import('@mlflow/mlflow/src/common/utils/RoutingUtils')>(
+    '@mlflow/mlflow/src/common/utils/RoutingUtils',
+  ),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockUseGetExperimentQuery = jest.mocked(useGetExperimentQuery);
+
+const experimentWithKind = (kind: string | undefined, experimentId = '42') => ({
+  data: {
+    experimentId,
+    tags: kind === undefined ? [] : [{ key: EXPERIMENT_KIND_TAG_KEY, value: kind }],
+  },
+  loading: false,
+});
+
+const WorkflowTypeProbe = () => {
+  const { workflowType, setWorkflowType } = useWorkflowType();
+  return (
+    <div>
+      <span data-testid="workflow-type">{workflowType}</span>
+      <button type="button" onClick={() => setWorkflowType(WorkflowType.MACHINE_LEARNING)}>
+        pick-ml
+      </button>
+      <button type="button" onClick={() => setWorkflowType(WorkflowType.GENAI)}>
+        pick-genai
+      </button>
+    </div>
+  );
+};
+
+describe('WorkflowTypeProvider experiment-kind sync', () => {
+  const renderAt = (path: string) => {
+    const queryClient = new QueryClient();
+    return renderWithDesignSystem(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route
+              path="/experiments/:experimentId/*"
+              element={
+                <WorkflowTypeProvider>
+                  <WorkflowTypeProbe />
+                </WorkflowTypeProvider>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <WorkflowTypeProvider>
+                  <WorkflowTypeProbe />
+                </WorkflowTypeProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the persisted workflow type between tests.
+    seedWorkflowType(WorkflowType.GENAI);
+    mockUseGetExperimentQuery.mockReturnValue({ data: undefined, loading: false } as any);
+  });
+
+  test('syncs to MACHINE_LEARNING when opening a custom_model_development experiment', async () => {
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('custom_model_development') as any);
+    renderAt('/experiments/42/runs');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+  });
+
+  test('syncs to MACHINE_LEARNING for inferred + other ML kinds', async () => {
+    for (const kind of [
+      'custom_model_development_inferred',
+      'finetuning',
+      'regression',
+      'classification',
+      'forecasting',
+      'automl',
+    ]) {
+      mockUseGetExperimentQuery.mockReturnValue(experimentWithKind(kind) as any);
+      const { unmount } = renderAt('/experiments/42/runs');
+      expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+      unmount();
+    }
+  });
+
+  test('syncs to GENAI when opening a genai_development experiment', async () => {
+    // Start persisted in ML so we can observe the flip back to GENAI.
+    seedWorkflowType(WorkflowType.MACHINE_LEARNING);
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('genai_development', '7') as any);
+    renderAt('/experiments/7/traces');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.GENAI);
+  });
+
+  test('leaves the current workflow type untouched when the experiment kind tag is absent', async () => {
+    seedWorkflowType(WorkflowType.MACHINE_LEARNING);
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind(undefined, '9') as any);
+    renderAt('/experiments/9/runs');
+    // No definite mapping -> keep whatever was there (persisted ML here), do not force GENAI.
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+  });
+
+  test('leaves the current workflow type untouched for no_inferred_type / empty kinds', async () => {
+    seedWorkflowType(WorkflowType.MACHINE_LEARNING);
+    for (const kind of ['no_inferred_type', '']) {
+      mockUseGetExperimentQuery.mockReturnValue(experimentWithKind(kind, '9') as any);
+      const { unmount } = renderAt('/experiments/9/runs');
+      expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+      unmount();
+    }
+  });
+
+  test('does not sync to a stale experiment kind when the query still holds the previous experiment', async () => {
+    // Apollo keeps returning the previously-observed experiment until the new
+    // one resolves. If the route is already on the genai experiment (7) but the
+    // query data still reflects the classic-ML experiment (id 42), the sync must
+    // NOT flip the toggle to MACHINE_LEARNING based on the stale record.
+    seedWorkflowType(WorkflowType.GENAI);
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('custom_model_development', '42') as any);
+    renderAt('/experiments/7/traces');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.GENAI);
+  });
+
+  test('does not sync (or navigate) when not inside an experiment', async () => {
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('custom_model_development') as any);
+    renderAt('/experiments');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.GENAI);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('auto-sync does not trigger a navigation redirect', async () => {
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('custom_model_development') as any);
+    renderAt('/experiments/42/runs');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+    // The auto-sync must NOT bounce the user off their deep link.
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  test('manual override sticks within the same experiment (kind tag does not clobber it)', async () => {
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('genai_development', '7') as any);
+    renderAt('/experiments/7/traces');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.GENAI);
+
+    // User manually flips to Model training while staying on the same experiment.
+    await act(async () => {
+      await userEvent.click(screen.getByText('pick-ml'));
+    });
+    expect(screen.getByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
+  });
+
+  test('manual toggle still navigates to the experiment page (existing behavior preserved)', async () => {
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('genai_development', '7') as any);
+    renderAt('/experiments/7/traces');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.GENAI);
+
+    await act(async () => {
+      await userEvent.click(screen.getByText('pick-ml'));
+    });
+    // The user-driven toggle should redirect to the experiment default tab.
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.test.tsx
@@ -2,7 +2,7 @@
 import { describe, jest, test, expect, beforeEach } from '@jest/globals';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { MemoryRouter, Route, Routes } from '../utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '../utils/reactQueryHooks';
 import { renderWithDesignSystem } from '../utils/TestUtils.react18';
 import { WorkflowType, WorkflowTypeProvider, useWorkflowType } from './WorkflowTypeContext';
@@ -19,10 +19,10 @@ jest.mock('../../experiment-tracking/hooks/useExperimentQuery', () => ({
   useGetExperimentQuery: jest.fn(() => ({ data: undefined, loading: false })),
 }));
 
-jest.mock('@mlflow/mlflow/src/common/utils/RoutingUtils', () => ({
-  ...jest.requireActual<typeof import('@mlflow/mlflow/src/common/utils/RoutingUtils')>(
-    '@mlflow/mlflow/src/common/utils/RoutingUtils',
-  ),
+// Mock the same module specifier the provider imports (``../utils/RoutingUtils``)
+// so the ``useNavigate`` override is guaranteed to apply to the code under test.
+jest.mock('../utils/RoutingUtils', () => ({
+  ...jest.requireActual<typeof import('../utils/RoutingUtils')>('../utils/RoutingUtils'),
   useNavigate: () => mockNavigate,
 }));
 
@@ -52,9 +52,9 @@ const WorkflowTypeProbe = () => {
 };
 
 describe('WorkflowTypeProvider experiment-kind sync', () => {
-  const renderAt = (path: string) => {
+  const routerTree = (path: string) => {
     const queryClient = new QueryClient();
-    return renderWithDesignSystem(
+    return (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[path]}>
           <Routes>
@@ -76,9 +76,11 @@ describe('WorkflowTypeProvider experiment-kind sync', () => {
             />
           </Routes>
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
   };
+
+  const renderAt = (path: string) => renderWithDesignSystem(routerTree(path));
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -183,5 +185,18 @@ describe('WorkflowTypeProvider experiment-kind sync', () => {
     });
     // The user-driven toggle should redirect to the experiment default tab.
     expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  test('reconciles when the experiment kind tag is populated later on the same experiment', async () => {
+    seedWorkflowType(WorkflowType.GENAI);
+    // First render: experiment loaded but kind tag not yet populated (ambiguous).
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind(undefined, '42') as any);
+    const { rerender } = renderAt('/experiments/42/runs');
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.GENAI);
+
+    // Kind inference lands the tag afterwards while staying on the same experiment.
+    mockUseGetExperimentQuery.mockReturnValue(experimentWithKind('custom_model_development', '42') as any);
+    rerender(routerTree('/experiments/42/runs'));
+    expect(await screen.findByTestId('workflow-type')).toHaveTextContent(WorkflowType.MACHINE_LEARNING);
   });
 });

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
@@ -1,7 +1,12 @@
-import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { useNavigate, useParams } from '../utils/RoutingUtils';
 import Routes from '../../experiment-tracking/routes';
+import { useGetExperimentQuery } from '../../experiment-tracking/hooks/useExperimentQuery';
+import {
+  getExperimentKindFromTagsList,
+  getWorkflowTypeForExperimentKind,
+} from '../../experiment-tracking/utils/ExperimentKindUtils';
 
 export enum WorkflowType {
   GENAI = 'genai',
@@ -45,6 +50,41 @@ export const WorkflowTypeProvider = ({ children }: { children: React.ReactNode }
     },
     [experimentId, navigate, setWorkflowType, workflowType],
   );
+
+  // Sync the workflow type to the experiment the user actually opened, so that
+  // following a shared link into an experiment shows the correct sidebar/toggle
+  // instead of whatever was last persisted (defaulting to GENAI). We key the
+  // sync on the experiment id: it runs once per experiment, letting a manual
+  // toggle override stick while the user stays on that experiment, and only
+  // re-reconciling when they navigate to a different one. This uses the plain
+  // ``setWorkflowType`` (not the navigating ``handleWorkflowTypeChange``) so the
+  // reconciliation never bounces the user off their deep link.
+  const { data: experiment } = useGetExperimentQuery({ experimentId });
+  const lastSyncedExperimentIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!experimentId) {
+      // Reset when leaving experiment scope so re-entering the same experiment
+      // reconciles again.
+      lastSyncedExperimentIdRef.current = undefined;
+      return;
+    }
+    if (lastSyncedExperimentIdRef.current === experimentId) {
+      return;
+    }
+    // Wait until the query has loaded the experiment that matches the current
+    // route. Apollo keeps returning the previously-observed experiment until the
+    // new one resolves, so guarding on the id prevents syncing to a stale kind
+    // (which would also pin the ref and never self-correct).
+    if (!experiment || experiment.experimentId !== experimentId) {
+      return;
+    }
+    const experimentKind = getExperimentKindFromTagsList(experiment.tags);
+    const targetWorkflowType = getWorkflowTypeForExperimentKind(experimentKind);
+    lastSyncedExperimentIdRef.current = experimentId;
+    if (targetWorkflowType && targetWorkflowType !== workflowType) {
+      setWorkflowType(targetWorkflowType);
+    }
+  }, [experimentId, experiment, workflowType, setWorkflowType]);
 
   const contextValue = useMemo(
     () => ({

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from '../utils/RoutingUtils';
 import Routes from '../../experiment-tracking/routes';
 import { useGetExperimentQuery } from '../../experiment-tracking/hooks/useExperimentQuery';
 import {
-  getExperimentKindFromTagsList,
+  getExperimentKindFromTags,
   getWorkflowTypeForExperimentKind,
 } from '../../experiment-tracking/utils/ExperimentKindUtils';
 
@@ -13,8 +13,8 @@ export enum WorkflowType {
   MACHINE_LEARNING = 'machine_learning',
 }
 
-const WORKFLOW_TYPE_STORAGE_KEY = 'mlflow.workflowType';
-const WORKFLOW_TYPE_STORAGE_VERSION = 1;
+export const WORKFLOW_TYPE_STORAGE_KEY = 'mlflow.workflowType';
+export const WORKFLOW_TYPE_STORAGE_VERSION = 1;
 const DEFAULT_WORKFLOW_TYPE = WorkflowType.GENAI;
 
 interface WorkflowTypeContextType {
@@ -91,7 +91,7 @@ export const WorkflowTypeProvider = ({ children }: { children: React.ReactNode }
     if (!experiment || experiment.experimentId !== experimentId) {
       return;
     }
-    const experimentKind = getExperimentKindFromTagsList(experiment.tags);
+    const experimentKind = getExperimentKindFromTags(experiment.tags);
     const targetWorkflowType = getWorkflowTypeForExperimentKind(experimentKind);
     // Only lock (and sync) once we have a definite mapping. An absent/ambiguous
     // kind leaves the current selection untouched and stays eligible to

--- a/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/WorkflowTypeContext.tsx
@@ -36,12 +36,20 @@ export const WorkflowTypeProvider = ({ children }: { children: React.ReactNode }
   });
 
   const { experimentId } = useParams();
+
+  // Records the experiment the user manually toggled within, so auto-sync does
+  // not clobber a deliberate choice (even if the experiment's kind tag lands or
+  // changes later while they stay on that experiment).
+  const manualOverrideExperimentIdRef = useRef<string | undefined>(undefined);
   const handleWorkflowTypeChange = useCallback(
     (newWorkflowType: WorkflowType) => {
       if (newWorkflowType === workflowType) {
         return;
       }
 
+      if (experimentId) {
+        manualOverrideExperimentIdRef.current = experimentId;
+      }
       setWorkflowType(newWorkflowType);
       if (experimentId) {
         // if an experiment is active, redirect to experiment default tab on change
@@ -53,19 +61,25 @@ export const WorkflowTypeProvider = ({ children }: { children: React.ReactNode }
 
   // Sync the workflow type to the experiment the user actually opened, so that
   // following a shared link into an experiment shows the correct sidebar/toggle
-  // instead of whatever was last persisted (defaulting to GENAI). We key the
-  // sync on the experiment id: it runs once per experiment, letting a manual
-  // toggle override stick while the user stays on that experiment, and only
-  // re-reconciling when they navigate to a different one. This uses the plain
-  // ``setWorkflowType`` (not the navigating ``handleWorkflowTypeChange``) so the
-  // reconciliation never bounces the user off their deep link.
+  // instead of whatever was last persisted (defaulting to GENAI). This uses the
+  // plain ``setWorkflowType`` (not the navigating ``handleWorkflowTypeChange``)
+  // so the reconciliation never bounces the user off their deep link.
   const { data: experiment } = useGetExperimentQuery({ experimentId });
+  // Tracks the experiment we have already reconciled to a definite kind. We only
+  // lock this once a definite mapping is applied, so an experiment whose kind tag
+  // is populated later (e.g. by kind inference) still reconciles rather than
+  // being permanently skipped.
   const lastSyncedExperimentIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!experimentId) {
-      // Reset when leaving experiment scope so re-entering the same experiment
+      // Reset when leaving experiment scope so re-entering an experiment
       // reconciles again.
       lastSyncedExperimentIdRef.current = undefined;
+      manualOverrideExperimentIdRef.current = undefined;
+      return;
+    }
+    // A manual toggle within this experiment wins; do not auto-reconcile over it.
+    if (manualOverrideExperimentIdRef.current === experimentId) {
       return;
     }
     if (lastSyncedExperimentIdRef.current === experimentId) {
@@ -73,15 +87,20 @@ export const WorkflowTypeProvider = ({ children }: { children: React.ReactNode }
     }
     // Wait until the query has loaded the experiment that matches the current
     // route. Apollo keeps returning the previously-observed experiment until the
-    // new one resolves, so guarding on the id prevents syncing to a stale kind
-    // (which would also pin the ref and never self-correct).
+    // new one resolves, so guarding on the id prevents syncing to a stale kind.
     if (!experiment || experiment.experimentId !== experimentId) {
       return;
     }
     const experimentKind = getExperimentKindFromTagsList(experiment.tags);
     const targetWorkflowType = getWorkflowTypeForExperimentKind(experimentKind);
+    // Only lock (and sync) once we have a definite mapping. An absent/ambiguous
+    // kind leaves the current selection untouched and stays eligible to
+    // reconcile if the tag is populated later while on the same experiment.
+    if (!targetWorkflowType) {
+      return;
+    }
     lastSyncedExperimentIdRef.current = experimentId;
-    if (targetWorkflowType && targetWorkflowType !== workflowType) {
+    if (targetWorkflowType !== workflowType) {
       setWorkflowType(targetWorkflowType);
     }
   }, [experimentId, experiment, workflowType, setWorkflowType]);

--- a/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from '@jest/globals';
+import { ExperimentKind } from '../constants';
+import { WorkflowType } from '../../common/contexts/WorkflowTypeContext';
+import {
+  getWorkflowTypeForExperimentKind,
+  getExperimentKindFromTagsList,
+  EXPERIMENT_KIND_TAG_KEY,
+} from './ExperimentKindUtils';
+
+describe('getWorkflowTypeForExperimentKind', () => {
+  test('maps GenAI kinds to GENAI', () => {
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.GENAI_DEVELOPMENT)).toBe(WorkflowType.GENAI);
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.GENAI_DEVELOPMENT_INFERRED)).toBe(WorkflowType.GENAI);
+  });
+
+  test('maps classic-ML kinds to MACHINE_LEARNING', () => {
+    for (const kind of [
+      ExperimentKind.CUSTOM_MODEL_DEVELOPMENT,
+      ExperimentKind.CUSTOM_MODEL_DEVELOPMENT_INFERRED,
+      ExperimentKind.FINETUNING,
+      ExperimentKind.REGRESSION,
+      ExperimentKind.CLASSIFICATION,
+      ExperimentKind.FORECASTING,
+      ExperimentKind.AUTOML,
+    ]) {
+      expect(getWorkflowTypeForExperimentKind(kind)).toBe(WorkflowType.MACHINE_LEARNING);
+    }
+  });
+
+  test('returns undefined for ambiguous / absent kinds so callers keep the default', () => {
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.NO_INFERRED_TYPE)).toBeUndefined();
+    expect(getWorkflowTypeForExperimentKind(ExperimentKind.EMPTY)).toBeUndefined();
+    expect(getWorkflowTypeForExperimentKind(undefined)).toBeUndefined();
+  });
+});
+
+describe('getExperimentKindFromTagsList', () => {
+  test('reads the experiment kind tag', () => {
+    expect(getExperimentKindFromTagsList([{ key: EXPERIMENT_KIND_TAG_KEY, value: 'custom_model_development' }])).toBe(
+      ExperimentKind.CUSTOM_MODEL_DEVELOPMENT,
+    );
+  });
+
+  test('returns undefined when the tag is missing', () => {
+    expect(getExperimentKindFromTagsList([{ key: 'other', value: 'x' }])).toBeUndefined();
+    expect(getExperimentKindFromTagsList([])).toBeUndefined();
+    expect(getExperimentKindFromTagsList(undefined)).toBeUndefined();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.test.ts
@@ -3,7 +3,7 @@ import { ExperimentKind } from '../constants';
 import { WorkflowType } from '../../common/contexts/WorkflowTypeContext';
 import {
   getWorkflowTypeForExperimentKind,
-  getExperimentKindFromTagsList,
+  getExperimentKindFromTags,
   EXPERIMENT_KIND_TAG_KEY,
 } from './ExperimentKindUtils';
 
@@ -34,16 +34,16 @@ describe('getWorkflowTypeForExperimentKind', () => {
   });
 });
 
-describe('getExperimentKindFromTagsList', () => {
+describe('getExperimentKindFromTags', () => {
   test('reads the experiment kind tag', () => {
-    expect(getExperimentKindFromTagsList([{ key: EXPERIMENT_KIND_TAG_KEY, value: 'custom_model_development' }])).toBe(
+    expect(getExperimentKindFromTags([{ key: EXPERIMENT_KIND_TAG_KEY, value: 'custom_model_development' }])).toBe(
       ExperimentKind.CUSTOM_MODEL_DEVELOPMENT,
     );
   });
 
   test('returns undefined when the tag is missing', () => {
-    expect(getExperimentKindFromTagsList([{ key: 'other', value: 'x' }])).toBeUndefined();
-    expect(getExperimentKindFromTagsList([])).toBeUndefined();
-    expect(getExperimentKindFromTagsList(undefined)).toBeUndefined();
+    expect(getExperimentKindFromTags([{ key: 'other', value: 'x' }])).toBeUndefined();
+    expect(getExperimentKindFromTags([])).toBeUndefined();
+    expect(getExperimentKindFromTags(undefined)).toBeUndefined();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.ts
@@ -167,3 +167,41 @@ export const getExperimentKindForWorkflowType = (workflowType: WorkflowType): Ex
   }
   return ExperimentKind.CUSTOM_MODEL_DEVELOPMENT;
 };
+
+/**
+ * Maps an ExperimentKind to the WorkflowType that should be reflected in the
+ * sidebar when the user opens that experiment. Returns ``undefined`` for kinds
+ * with no definite mapping (missing tag, ``NO_INFERRED_TYPE``, ``EMPTY``) so
+ * the caller can leave the current selection (and the GENAI default) untouched
+ * rather than forcing a switch.
+ */
+export const getWorkflowTypeForExperimentKind = (
+  experimentKind: ExperimentKind | undefined,
+): WorkflowType | undefined => {
+  switch (experimentKind) {
+    case ExperimentKind.GENAI_DEVELOPMENT:
+    case ExperimentKind.GENAI_DEVELOPMENT_INFERRED:
+      return WorkflowType.GENAI;
+    case ExperimentKind.CUSTOM_MODEL_DEVELOPMENT:
+    case ExperimentKind.CUSTOM_MODEL_DEVELOPMENT_INFERRED:
+    case ExperimentKind.FINETUNING:
+    case ExperimentKind.REGRESSION:
+    case ExperimentKind.CLASSIFICATION:
+    case ExperimentKind.FORECASTING:
+    case ExperimentKind.AUTOML:
+      return WorkflowType.MACHINE_LEARNING;
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Reads the ``mlflow.experimentKind`` tag from an experiment's tags. Exported so
+ * consumers (e.g. the workflow-type sync) can reconcile UI state with the
+ * experiment the user actually opened.
+ */
+export const getExperimentKindFromTagsList = (
+  experimentTags?:
+    | ({ __typename: 'MlflowExperimentTag'; key: string | null; value: string | null }[] | null)
+    | KeyValueEntity[],
+): ExperimentKind | undefined => getExperimentKindFromTags(experimentTags);

--- a/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/ExperimentKindUtils.ts
@@ -8,7 +8,7 @@ import { shouldEnableWorkflowBasedNavigation } from '../../common/utils/FeatureU
 
 export const EXPERIMENT_KIND_TAG_KEY = 'mlflow.experimentKind';
 
-const getExperimentKindFromTags = (
+export const getExperimentKindFromTags = (
   experimentTags?:
     | ({ __typename: 'MlflowExperimentTag'; key: string | null; value: string | null }[] | null)
     | KeyValueEntity[],
@@ -194,14 +194,3 @@ export const getWorkflowTypeForExperimentKind = (
       return undefined;
   }
 };
-
-/**
- * Reads the ``mlflow.experimentKind`` tag from an experiment's tags. Exported so
- * consumers (e.g. the workflow-type sync) can reconcile UI state with the
- * experiment the user actually opened.
- */
-export const getExperimentKindFromTagsList = (
-  experimentTags?:
-    | ({ __typename: 'MlflowExperimentTag'; key: string | null; value: string | null }[] | null)
-    | KeyValueEntity[],
-): ExperimentKind | undefined => getExperimentKindFromTags(experimentTags);


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The sidebar **GenAI / Model training** toggle (`workflowType`) was backed only by `localStorage` (default `GENAI`) and never reconciled with the experiment the user actually opened. Following a shared link into an experiment (e.g. `/experiments/2/runs?viewStateShareKey=...`) in a fresh tab showed GenAI chrome even for a `custom_model_development` (classic ML) experiment, so the toggle and sidebar disagreed with the page.

`WorkflowTypeProvider` now reads the opened experiment's `mlflow.experimentKind` tag and syncs `workflowType` to the mapped type, keyed on experiment id so it reconciles once per experiment:

- genai kinds → GenAI; `custom_model_development(_inferred)`, finetuning, regression, classification, forecasting, automl → Model training
- A manual toggle override still sticks while the user stays on that experiment
- Uses the non-navigating setter, so the sync never bounces the user off their deep link
- Ambiguous/absent kinds (`no_inferred_type`, empty, missing) leave the current selection untouched, preserving the `GENAI` default and the demo-card flows
- An experiment-id identity guard prevents syncing to a stale Apollo record while navigating between experiments

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests: `WorkflowTypeContext.test.tsx` (sync per kind, manual-override persistence, no-navigation, stale-record guard) and `ExperimentKindUtils.test.ts` (kind→workflow mapping). Manually verified in a local dev server with Playwright across a classic-ML and a GenAI experiment — screenshots below.

<!-- Screenshots: verify-ml-runs-seeded (localStorage seeded GENAI, opened classic-ML runs page → toggle correctly shows Model training), verify-genai (localStorage seeded ML, opened GenAI experiment → toggle correctly shows GenAI). -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The GenAI / Model training sidebar toggle now reflects the kind of the experiment you open (e.g. following a shared link), instead of staying on the last-used or default value.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
