### PR TITLE
Fix pytorch `pt2` export for batch-size-1 `input_example` (use `Dim.AUTO`)

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -537,20 +537,32 @@ def save_model(
             )
 
         tensor_spec_list = signature.inputs.inputs
+        input_example_tensors = [
+            torch.from_numpy(v) if isinstance(v, np.ndarray) else v for v in input_example
+        ]
 
+        # `torch.export` specializes size-0 and size-1 dimensions to constants. Marking such a
+        # dimension as a hard dynamic `Dim` raises a ConstraintViolation ("You marked ... as
+        # dynamic but your code specialized it to be a constant (1)"), which breaks logging a
+        # model whose `input_example` has a batch size of 1. `Dim.AUTO` (available in torch>=2.6)
+        # lets the exporter decide dynamic-vs-static per dimension and tolerates specialization,
+        # so a size-1 dimension is exported as static instead of failing. On older torch we fall
+        # back to only marking dimensions whose example size is > 1 as dynamic.
         dynamic_shapes = []
-
-        for tensor_spec in tensor_spec_list:
-            try:
-                dynamic_dim = tensor_spec.shape.index(-1)
-                dynamic_shape = {dynamic_dim: ExportDim("dynamic_dim")}
-            except ValueError:
-                dynamic_shape = None
-            dynamic_shapes.append(dynamic_shape)
+        for tensor_spec, example_tensor in zip(tensor_spec_list, input_example_tensors):
+            dynamic_shape = {}
+            for dim_idx, dim_size in enumerate(tensor_spec.shape):
+                if dim_size != -1:
+                    continue
+                if hasattr(ExportDim, "AUTO"):
+                    dynamic_shape[dim_idx] = ExportDim.AUTO
+                elif example_tensor.shape[dim_idx] > 1:
+                    dynamic_shape[dim_idx] = ExportDim(f"dim_{dim_idx}")
+            dynamic_shapes.append(dynamic_shape or None)
 
         exported_prog = torch.export.export(
             pytorch_model,
-            tuple(torch.from_numpy(v) if isinstance(v, np.ndarray) else v for v in input_example),
+            tuple(input_example_tensors),
             dynamic_shapes=dynamic_shapes,
         )
         model_path = os.path.join(model_data_path, _EXPORTED_TORCH_MODEL_FILE_NAME)

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -556,8 +556,8 @@ def save_model(
         dynamic_shapes = []
         # `strict=True` so a signature/`input_example` arity mismatch fails loudly instead of
         # silently truncating and misaligning `dynamic_shapes` with the exported inputs.
-        for input_idx, (tensor_spec, example_tensor) in enumerate(
-            zip(tensor_spec_list, input_example_tensors, strict=True)
+        for tensor_spec, example_tensor in zip(
+            tensor_spec_list, input_example_tensors, strict=True
         ):
             dynamic_shape = {}
             for dim_idx, dim_size in enumerate(tensor_spec.shape):
@@ -566,10 +566,13 @@ def save_model(
                 if hasattr(ExportDim, "AUTO"):
                     dynamic_shape[dim_idx] = ExportDim.AUTO
                 elif example_tensor.shape[dim_idx] > 1:
-                    # Names must be unique per (input, dim): `torch.export` treats identically
-                    # named `Dim`s as the same symbolic dimension and forces them equal, which
-                    # would wrongly couple independent inputs.
-                    dynamic_shape[dim_idx] = ExportDim(f"input_{input_idx}_dim_{dim_idx}")
+                    # Name is keyed on the dimension index and SHARED across inputs on purpose:
+                    # batched multi-inputs share the same batch dimension, so `torch.export`
+                    # requires the same-index dynamic dims to use one `Dim`. Per-input-unique
+                    # names make it treat them as independent and then raise "Constraints
+                    # violated" when it discovers they must be equal. `Dim.AUTO` infers this
+                    # coupling automatically on torch>=2.6.
+                    dynamic_shape[dim_idx] = ExportDim(f"dim_{dim_idx}")
             dynamic_shapes.append(dynamic_shape or None)
 
         exported_prog = torch.export.export(

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -548,8 +548,17 @@ def save_model(
         # lets the exporter decide dynamic-vs-static per dimension and tolerates specialization,
         # so a size-1 dimension is exported as static instead of failing. On older torch we fall
         # back to only marking dimensions whose example size is > 1 as dynamic.
+        #
+        # Note: a size-1 dimension is exported as STATIC on every supported torch version
+        # (`Dim.AUTO` specializes it on torch>=2.6; the fallback skips it on torch 2.4-2.5), so a
+        # dynamic batch dimension requires an `input_example` with a batch size > 1. This is
+        # expected behavior, not a limitation of this code.
         dynamic_shapes = []
-        for tensor_spec, example_tensor in zip(tensor_spec_list, input_example_tensors):
+        # `strict=True` so a signature/`input_example` arity mismatch fails loudly instead of
+        # silently truncating and misaligning `dynamic_shapes` with the exported inputs.
+        for input_idx, (tensor_spec, example_tensor) in enumerate(
+            zip(tensor_spec_list, input_example_tensors, strict=True)
+        ):
             dynamic_shape = {}
             for dim_idx, dim_size in enumerate(tensor_spec.shape):
                 if dim_size != -1:
@@ -557,7 +566,10 @@ def save_model(
                 if hasattr(ExportDim, "AUTO"):
                     dynamic_shape[dim_idx] = ExportDim.AUTO
                 elif example_tensor.shape[dim_idx] > 1:
-                    dynamic_shape[dim_idx] = ExportDim(f"dim_{dim_idx}")
+                    # Names must be unique per (input, dim): `torch.export` treats identically
+                    # named `Dim`s as the same symbolic dimension and forces them equal, which
+                    # would wrongly couple independent inputs.
+                    dynamic_shape[dim_idx] = ExportDim(f"input_{input_idx}_dim_{dim_idx}")
             dynamic_shapes.append(dynamic_shape or None)
 
         exported_prog = torch.export.export(

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1497,3 +1497,18 @@ def test_exported_model_with_small_batch_size_input_example(tmp_path, batch_size
     loaded_pyfunc = mlflow.pyfunc.load_model(model_path)
     predictions = loaded_pyfunc.predict(input_example)
     assert predictions.shape == (batch_size, 1)
+
+    if batch_size == 1:
+        # A batch-size-1 example is exported STATIC by design (torch.export specializes size-1
+        # dims), so we assert only that the round-trip succeeds, not batch-dim dynamism.
+        return
+
+    # A batch>1 example yields a dynamic batch dim, so the exported model must accept a
+    # different batch size. This proves the dim is genuinely dynamic rather than a fully-static
+    # export that only happens to match the saved batch size.
+    other_batch = 2 * batch_size
+    other_input = torch.randn(other_batch, 4).numpy()
+    with torch.no_grad():
+        other_actual = loaded_model(torch.from_numpy(other_input))
+    assert tuple(other_actual.shape) == (other_batch, 1)
+    assert loaded_pyfunc.predict(other_input).shape == (other_batch, 1)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1467,3 +1467,33 @@ def test_save_and_load_exported_model_with_multi_inputs(model_path):
         model_loaded(*input_example),
         decimal=4,
     )
+
+
+@pytest.mark.skipif(
+    Version(torch.__version__) < Version("2.4"), reason="This test requires torch>=2.4"
+)
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_exported_model_with_small_batch_size_input_example(tmp_path, batch_size):
+    # Regression test for https://github.com/mlflow/mlflow/pull/24494: a batch-size-1
+    # `input_example` used to fail the default "pt2" export with a `torch.export`
+    # ConstraintViolation, because the batch dim (marked dynamic from the inferred signature)
+    # gets specialized to the constant 1. batch_size=2 locks in the dynamic-dim case.
+    model = get_sequential_model()
+    model.eval()
+    input_example = torch.randn(batch_size, 4).numpy()
+
+    model_path = tmp_path / "model"
+    # Default serialization ("pt2") must succeed for any batch size, including 1.
+    mlflow.pytorch.save_model(model, model_path, input_example=input_example)
+    assert (model_path / "data" / "model.pt2").exists()
+
+    loaded_model = mlflow.pytorch.load_model(model_path)
+    input_tensor = torch.from_numpy(input_example)
+    with torch.no_grad():
+        expected = model(input_tensor)
+        actual = loaded_model(input_tensor)
+    np.testing.assert_array_almost_equal(actual, expected, decimal=4)
+
+    loaded_pyfunc = mlflow.pyfunc.load_model(model_path)
+    predictions = loaded_pyfunc.predict(input_example)
+    assert predictions.shape == (batch_size, 1)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23988 (which changed the default `serialization_format` to `"pt2"` in 3.14.0 and introduced this regression).

### What changes are proposed in this pull request?

**Root cause.** MLflow 3.14.0 changed the default `serialization_format` for `mlflow.pytorch.log_model` / `save_model` to `"pt2"` (#23988). The pt2 path traces the model with `torch.export.export()` and builds `dynamic_shapes` by marking every dimension that `infer_signature` reports as `-1` (the batch dim) with a hard dynamic `torch.export.Dim`. `torch.export` specializes size-0 and size-1 dimensions to constants, so when the `input_example` has a batch size of 1 the batch dim is specialized to `1`, which conflicts with the hard dynamic `Dim` and raises:

```
UserError: Constraints violated (dynamic_dim)! You marked dynamic_dim as dynamic
but your code specialized it to be a constant (1). ... occurred when calling torch.export.export.
```

This broke a very common pattern (logging a model with a single-example input) that worked in 3.13.

**Fix.** Build `dynamic_shapes` with `torch.export.Dim.AUTO` (available in torch>=2.6), which lets the exporter decide dynamic-vs-static per dimension and tolerates 0/1 specialization: a size-1 dimension is exported as static instead of raising. For batch sizes > 1 the dimension stays dynamic, so the existing dynamic-batch behavior is preserved. On torch < 2.6 (2.4/2.5, still supported by the pt2 path) we fall back to only marking dimensions whose example size is > 1 as dynamic. The "pt2 requires `input_example`" error is intentional and unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Manual (torch 2.8.0): reproduced the `ConstraintViolation` with a batch-size-1 `input_example`, then confirmed the fix. A batch-1 example and a batch-2 example both log successfully, the exported model reloads and predicts, and a `resnet18` batch-1 example (the reported case) now logs and scores. Verified that batch>1 examples still export a dynamic batch dimension (export from a batch-3 example runs on batch-6 inputs).

Existing tests: ran the pt2/export tests in `tests/pytorch/test_pytorch_model_export.py` (`test_save_and_load_exported_model`, `test_exported_model_infer_dynamic_dim`, `test_load_exported_model_check_device_mismatch`, `test_save_and_load_exported_model_with_multi_inputs`) - all pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a regression in MLflow 3.14.0 where `mlflow.pytorch.log_model` / `save_model` with the default `pt2` serialization format failed with a `torch.export` ConstraintViolation when the `input_example` had a batch size of 1.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
