### PR TITLE
Harden batch-processor thread-leak tests against ambient tracer-provider state

### DIFF
--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -32,6 +32,7 @@ from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 from mlflow.tracing.processor.otel import OtelSpanProcessor
 from mlflow.tracing.processor.uc_table import DatabricksUCTableSpanProcessor
 from mlflow.tracing.provider import (
+    _get_span_processor,
     _get_tracer,
     _initialize_tracer_provider,
     _IsolatedRandomIdGenerator,
@@ -383,7 +384,21 @@ def test_disable_enable_tracing_not_mutate_otel_provider(monkeypatch):
 
 
 def _count_batch_processor_threads() -> int:
-    return sum("OtelBatchSpanRecordProcessor" in t.name for t in threading.enumerate())
+    # Match the "OtelBatchSpan" prefix rather than the full worker-thread name:
+    # OTel SDK versions name this daemon thread differently ("OtelBatchSpanProcessor"
+    # on older releases, "OtelBatchSpanRecordProcessor" on current ones), and the
+    # protobuf cross-version CI job exercises both.
+    return sum("OtelBatchSpan" in t.name for t in threading.enumerate())
+
+
+def _assert_batch_path_active() -> None:
+    # Guard against a vacuous pass: the async BatchSpanProcessor path must actually
+    # be active before we measure the baseline thread count. Assert on the active
+    # processor's batch delegate directly so the guard does not depend on OTel's
+    # worker-thread name (which varies across SDK versions).
+    processor = _get_span_processor()
+    assert processor is not None
+    assert processor._batch_delegate is not None
 
 
 @pytest.fixture
@@ -400,10 +415,15 @@ def test_disable_enable_does_not_leak_batch_processor_threads(batch_span_process
     def f():
         return 0
 
+    # Rebuild the tracer provider from a clean slate so the first traced call
+    # constructs the async BatchSpanProcessor under this test's env, regardless of
+    # what an earlier test in a sharded run left on the global provider.
+    mlflow.tracing.reset()
+
     # Prime a real BatchSpanProcessor (and its daemon thread).
     f()
+    _assert_batch_path_active()
     baseline = _count_batch_processor_threads()
-    # Guard against a vacuous pass: the batch path must actually be active.
     assert baseline >= 1
 
     # Each enable() used to build a fresh provider + BatchSpanProcessor without
@@ -424,7 +444,13 @@ def test_trace_disabled_does_not_leak_batch_processor_threads(batch_span_process
     def wrapped():
         return 0
 
+    # Rebuild the tracer provider from a clean slate so the first traced call
+    # constructs the async BatchSpanProcessor under this test's env, regardless of
+    # what an earlier test in a sharded run left on the global provider.
+    mlflow.tracing.reset()
+
     f()
+    _assert_batch_path_active()
     baseline = _count_batch_processor_threads()
     assert baseline >= 1
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24209

### What changes are proposed in this pull request?

Test-only change. The protobuf cross-version workflow
(`.github/workflows/protobuf-cross-test.yml`, matrix `protobuf_major_version` 3/4/5)
intermittently fails two tracing tests with `assert 0 >= 1`:

- `test_disable_enable_does_not_leak_batch_processor_threads`
- `test_trace_disabled_does_not_leak_batch_processor_threads`

These are **pre-existing flaky failures on master** (added by #24267), surfaced by
the proto-only workflow. They are independent of #24489, which only triggered the
workflow. The baseline batch-processor thread count could be `0` because:

1. An earlier test in a sharded run leaves the global tracer provider initialized
   without the async batch delegate, and these two tests did not force a rebuild
   before measuring the baseline.
2. Some `opentelemetry-sdk` versions name the batch worker thread
   `OtelBatchSpanProcessor` (no `Record`), so the old full-name substring match
   (`OtelBatchSpanRecordProcessor`) missed it and returned `0`.

This PR hardens the two tests (only `tests/tracing/test_provider.py` is touched):

- Force a clean tracing rebuild via `mlflow.tracing.reset()` at the start of both
  tests, so the first traced call builds the async `BatchSpanProcessor` under the
  test's own env regardless of ambient global state.
- Match the `OtelBatchSpan` thread-name prefix (covers both legacy and current OTel
  worker-thread names), and additionally assert the active processor's
  `_batch_delegate` is present, a guard that does not depend on OTel thread naming.
- **Preserve the existing `<= baseline` leak assertion**, which is the #24209
  regression guard. No sleeps or retry/flaky markers were added.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

`uv run pytest tests/tracing/test_provider.py` passes (50 passed), including under
`protobuf==4.*`, under randomized ordering (`pytest-randomly` seeds 1 / 42 / 2026),
in isolation, and with a non-batch test ordered before the target test.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.
