### PR TITLE
De-flake job endpoint tests by gating on consumer readiness

### DIFF
--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -101,6 +101,26 @@ class Client:
         return response.json()["jobs"]
 
 
+def wait_for_job_consumer_ready(client: Client, timeout: float = 60) -> None:
+    job_id = client.submit_job(
+        job_name="simple_job_fun",
+        params={"x": 0, "y": 0},
+    )["job_id"]
+    deadline = time.time() + timeout
+    last_status = None
+    while time.time() < deadline:
+        last_status = client.get_job(job_id)["status"]
+        if last_status == "SUCCEEDED":
+            return
+        if last_status in ["FAILED", "TIMEOUT", "CANCELED"]:
+            raise RuntimeError(f"Readiness probe job finished with status {last_status}")
+        time.sleep(0.5)
+    raise TimeoutError(
+        f"Job consumer did not complete the readiness probe within {timeout:g} seconds, "
+        f"last status: {last_status}"
+    )
+
+
 @pytest.fixture(scope="module")
 def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
     from tests.helper_functions import get_safe_port
@@ -138,9 +158,8 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
         start_new_session=True,  # new session & process group
     ) as server_proc:
         try:
-            time.sleep(10)  # wait the job runner up
             # wait server up.
-            deadline = time.time() + 15
+            deadline = time.time() + 60
             while time.time() < deadline:
                 time.sleep(1)
                 try:
@@ -150,8 +169,10 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
                 if resp.status_code == 200:
                     break
             else:
-                raise TimeoutError("Server did not report healthy within 15 seconds")
-            yield Client(f"http://127.0.0.1:{port}")
+                raise TimeoutError("Server did not report healthy within 60 seconds")
+            client = Client(f"http://127.0.0.1:{port}")
+            wait_for_job_consumer_ready(client)
+            yield client
         finally:
             # NOTE that we need to kill subprocesses
             # (uvicorn server / huey task runner)
@@ -208,6 +229,7 @@ def test_job_cancel(client: Client):
         "retry_count": 0,
         "status_details": None,
     }
+    wait_for_job_consumer_ready(client)
 
 
 def test_job_endpoint_invalid_job_name(client: Client):


### PR DESCRIPTION
### Related Issues/PRs

N/A. These are pre-existing flaky job endpoint timeouts and are independent of #24489.

### What changes are proposed in this pull request?

This is a test-only change in `tests/server/jobs/test_endpoint.py`.

- Replace the fixed `time.sleep(10)` startup assumption with a real consumer readiness probe that submits `simple_job_fun` and polls `get_job` until the throwaway job succeeds before yielding the fixture client.
- Keep server startup as polling and widen the `/health` polling budget to avoid losing the old 10 second buffer when the fixed sleep is removed.
- After `test_job_cancel` verifies the canceled job state, run the same probe so the module-scoped single worker is ready before later tests submit jobs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

```bash
for i in $(seq 1 10); do uv run pytest tests/server/jobs/test_endpoint.py::test_job_cancel tests/server/jobs/test_endpoint.py::test_job_endpoint_search -q -p no:randomly || break; done
uv run ruff check tests/server/jobs/test_endpoint.py
uv run ruff format --check tests/server/jobs/test_endpoint.py
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release