### PR TITLE
Fix silent loss of per-iteration logging in `GepaPromptOptimizer` when `valset` is passed via `gepa_kwargs`

### DIFF
--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -155,8 +155,10 @@ class GepaPromptOptimizer(BasePromptOptimizer):
                 prompts_dict: Dictionary mapping prompt names to their templates.
                 tracking_enabled: Whether to log traces/metrics/params/artifacts during
                     optimization.
-                full_dataset_size: Size of the full training dataset, used to distinguish
-                    full validation passes from minibatch evaluations.
+                full_dataset_size: Size of the validation dataset (the custom ``valset``
+                    if one is passed via ``gepa_kwargs``, otherwise the training dataset,
+                    mirroring GEPA's own fallback), used to distinguish full validation
+                    passes from minibatch evaluations.
             """
 
             def __init__(self, eval_function, prompts_dict, tracking_enabled, full_dataset_size):
@@ -340,8 +342,16 @@ class GepaPromptOptimizer(BasePromptOptimizer):
 
                 return reflective_datasets
 
+        # GEPA runs full validation passes on `valset` when one is provided via
+        # gepa_kwargs, and falls back to `trainset` otherwise. The adapter must
+        # mirror that fallback, or full validation passes are never detected and
+        # per-iteration tracking is silently lost (see issue #24461).
+        valset = self.gepa_kwargs.get("valset")
         adapter = MlflowGEPAAdapter(
-            eval_fn, target_prompts, enable_tracking, full_dataset_size=len(train_data)
+            eval_fn,
+            target_prompts,
+            enable_tracking,
+            full_dataset_size=len(valset) if valset is not None else len(train_data),
         )
 
         kwargs = self.gepa_kwargs | {

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -706,7 +706,9 @@ def test_gepa_optimizer_logs_prompt_candidates_with_custom_valset(
 
         with mlflow.start_run():
             with (
-                patch("mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_artifact"),
+                patch(
+                    "mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_artifact"
+                ) as mock_log_artifact,
                 patch(
                     "mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_table"
                 ) as mock_log_table,
@@ -741,6 +743,7 @@ def test_gepa_optimizer_logs_prompt_candidates_with_custom_valset(
                 )
                 assert logged_tables == []
                 assert logged_metrics == []
+                assert mock_log_artifact.call_count == 0
 
                 # Full validation pass over the custom valset SHOULD be logged
                 candidate = {"system_prompt": "Optimized prompt", "instruction": "New instruction"}
@@ -753,3 +756,13 @@ def test_gepa_optimizer_logs_prompt_candidates_with_custom_valset(
     assert len(logged_metrics) == 1
     assert logged_metrics[0]["step"] == 0
     assert logged_metrics[0]["metrics"]["eval_score"] == pytest.approx(0.8)
+
+    # Artifacts (scores.json + one .txt per prompt in the candidate) are logged
+    # under the iteration directory for the full custom-valset pass
+    assert mock_log_artifact.call_count == 3
+    logged_names = {Path(call.args[0]).name for call in mock_log_artifact.call_args_list}
+    assert logged_names == {"scores.json", "system_prompt.txt", "instruction.txt"}
+    assert all(
+        call.kwargs["artifact_path"] == "prompt_candidates/iteration_0"
+        for call in mock_log_artifact.call_args_list
+    )

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -659,3 +659,97 @@ def test_extract_eval_scores_per_scorer(val_aggregate_scores, val_aggregate_subs
 
     result = optimizer._extract_eval_scores(mock_result)
     assert result == expected
+
+
+@pytest.mark.parametrize("valset_size", [3, 6])  # smaller and larger than train_data (4)
+def test_gepa_optimizer_logs_prompt_candidates_with_custom_valset(
+    sample_train_data: list[dict[str, Any]],
+    sample_target_prompts: dict[str, str],
+    mock_eval_fn: Any,
+    valset_size: int,
+):
+    valset = [
+        {"inputs": {"question": f"val question {i}?"}, "outputs": f"val answer {i}"}
+        for i in range(valset_size)
+    ]
+    assert len(valset) != len(sample_train_data)
+
+    mock_gepa_module = MagicMock()
+    mock_modules = {
+        "gepa": mock_gepa_module,
+        "gepa.core": MagicMock(),
+        "gepa.core.adapter": MagicMock(),
+    }
+    mock_gepa_module.EvaluationBatch = MagicMock()
+    mock_gepa_module.GEPAAdapter = object
+
+    optimizer = GepaPromptOptimizer(
+        reflection_model="openai:/gpt-4o", gepa_kwargs={"valset": valset}
+    )
+
+    logged_tables = []
+    logged_metrics = []
+
+    with patch.dict(sys.modules, mock_modules):
+        captured_adapter = None
+
+        def mock_optimize_fn(**kwargs):
+            nonlocal captured_adapter
+            captured_adapter = kwargs["adapter"]
+            mock_result = Mock()
+            mock_result.best_candidate = sample_target_prompts
+            mock_result.val_aggregate_scores = [0.8]
+            mock_result.val_aggregate_subscores = None
+            return mock_result
+
+        mock_gepa_module.optimize = mock_optimize_fn
+
+        with mlflow.start_run():
+            with (
+                patch("mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_artifact"),
+                patch(
+                    "mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_table"
+                ) as mock_log_table,
+                patch(
+                    "mlflow.genai.optimize.optimizers.gepa_optimizer.mlflow.log_metrics"
+                ) as mock_log_metrics,
+            ):
+                mock_log_table.side_effect = lambda data, artifact_file: logged_tables.append({
+                    "data": data,
+                    "artifact_file": artifact_file,
+                })
+                mock_log_metrics.side_effect = lambda metrics, step=None: logged_metrics.append({
+                    "metrics": metrics,
+                    "step": step,
+                })
+
+                optimizer.optimize(
+                    eval_fn=mock_eval_fn,
+                    train_data=sample_train_data,
+                    target_prompts=sample_target_prompts,
+                    enable_tracking=True,
+                )
+
+                # Minibatch evaluation should NOT be logged
+                captured_adapter.evaluate(
+                    sample_train_data[:2], {"system_prompt": "Test"}, capture_traces=False
+                )
+                # A trainset-sized batch is no longer a full validation pass
+                # when a custom valset is provided, so it should NOT be logged
+                captured_adapter.evaluate(
+                    sample_train_data, {"system_prompt": "Test"}, capture_traces=False
+                )
+                assert logged_tables == []
+                assert logged_metrics == []
+
+                # Full validation pass over the custom valset SHOULD be logged
+                candidate = {"system_prompt": "Optimized prompt", "instruction": "New instruction"}
+                captured_adapter.evaluate(valset, candidate, capture_traces=False)
+
+    assert len(logged_tables) == 1
+    assert logged_tables[0]["artifact_file"] == "prompt_candidates/iteration_0/eval_results.json"
+    assert len(logged_tables[0]["data"]["inputs"]) == valset_size
+
+    assert len(logged_metrics) == 1
+    assert logged_metrics[0]["step"] == 0
+    assert logged_metrics[0]["metrics"]["eval_score"] == pytest.approx(0.8)


### PR DESCRIPTION
### Related Issues/PRs

Closes #24461

### What changes are proposed in this pull request?

**Root cause:** `MlflowGEPAAdapter.evaluate()` detects a "full validation pass" — the only case
where per-iteration artifacts and metrics are logged — by comparing the batch size against
`full_dataset_size`, which was hardcoded to `len(train_data)`. However, GEPA only validates on the
trainset when no `valset` is provided; when a `valset` is passed through `gepa_kwargs` (a documented
escape hatch, and `valset` is not among the reserved params overridden by MLflow), full validation
batches have `len(valset)` instead (see gepa's `api.py`:
`val_loader = ensure_loader(valset) if valset is not None else train_loader`). Whenever
`len(valset) != len(train_data)`, the size check never matches, `_log_validation_candidate` is never
called, and all `prompt_candidates/iteration_N/*` artifacts and `eval_score` metrics are silently
dropped. Optimization itself succeeds, so users get no warning.

**Fix:** Derive `full_dataset_size` from the effective validation set, mirroring GEPA's own
fallback: `len(valset)` if a `valset` is present in `gepa_kwargs`, otherwise `len(train_data)`. The
adapter docstring is updated accordingly.

**Backwards compatible:** when no `valset` is passed, `full_dataset_size` resolves to
`len(train_data)` exactly as before; the default path is behavior-identical. Not a significant
change per CONTRIBUTING.md: no REST API changes, no new user-facing APIs, no new dependencies.

**Known residual limitation (pre-existing, out of scope):** the size heuristic can still misfire if
the effective valset size coincides with GEPA's reflection minibatch size (default 3). A more robust
detection would require a signal from GEPA other than batch length; happy to file a follow-up issue
if maintainers think it's worth tracking.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New test `test_gepa_optimizer_logs_prompt_candidates_with_custom_valset` (parametrized with valset
both smaller and larger than the trainset) verifies that: (1) full validation passes over a custom
valset log the iteration table, artifacts, and step-wise metrics; (2) minibatch evaluations still
log nothing; (3) a trainset-sized batch is no longer misclassified as a full validation pass when a
custom valset is present. The existing `test_gepa_optimizer_logs_prompt_candidates` covers the
unchanged default (no-valset) path.

Manual test: a fully offline repro (mocked `gepa`, no LLM calls) that simulates GEPA's evaluation
contract against the adapter and counts logging calls.

Before this PR:
`no valset : log_metrics=1 log_table=1 log_artifact=2
with valset: log_metrics=0 log_table=0 log_artifact=0  <-- per-iteration logging LOST`

After this PR:
`no valset : log_metrics=1 log_table=1 log_artifact=2
with valset: log_metrics=1 log_table=1 log_artifact=2`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `GepaPromptOptimizer` silently skipping per-iteration artifact and metric logging
(`prompt_candidates/iteration_N/*`, `eval_score`) when a custom `valset` is passed via
`gepa_kwargs`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release