### PR TITLE
Add min/max error bars for grouped average bar charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsBarPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsBarPlot.tsx
@@ -21,6 +21,7 @@ import RunsMetricsLegendWrapper from './RunsMetricsLegendWrapper';
 import { createChartImageDownloadHandler } from '../hooks/useChartImageDownloadHandler';
 import { customMetricBehaviorDefs } from '../../experiment-page/utils/customMetricBehaviorUtils';
 import { RunsChartCardLoadingPlaceholder } from './cards/ChartCard.common';
+import { RunGroupingAggregateFunction } from '../../experiment-page/utils/experimentPage.row-types';
 
 // We're not using params in bar plot
 export type BarPlotRunData = Omit<RunsChartsRunData, 'params' | 'tags' | 'images'>;
@@ -79,6 +80,13 @@ export interface RunsMetricsBarPlotProps extends RunsPlotsCommonProps {
    * Display metric key on the X axis
    */
   displayMetricKey?: boolean;
+
+  /**
+   * When enabled, renders horizontal min-max error bars around each bar,
+   * derived from the run group's aggregated min/max metric history. Only
+   * meaningful for grouped runs whose aggregate function is Average.
+   */
+  showMinMaxRange?: boolean;
 }
 
 const PLOT_CONFIG: Partial<Config> = {
@@ -96,6 +104,53 @@ const Y_AXIS_PARAMS = {
 };
 
 const getFixedPointValue = (val: string | number, places = 2) => (typeof val === 'number' ? val.toFixed(places) : val);
+
+/**
+ * Builds a Plotly horizontal ("x") min-max error bar descriptor for a grouped
+ * bar chart trace. For each run (in the same order as `runsData`), it pulls
+ * the run group's aggregated min/max metric history for `metricKey` (as
+ * populated on `RunsChartsRunData.aggregatedMetricsHistory`, keyed by
+ * `RunGroupingAggregateFunction`) and compares the most recent min/max values
+ * against the already-displayed average value for that run.
+ *
+ * array[i]      = maximum - average
+ * arrayminus[i] = average - minimum
+ *
+ * If the average, minimum, or maximum value is missing for a given run, that
+ * run's error bar values safely default to 0 rather than throwing or
+ * producing NaN.
+ */
+const getMinMaxErrorBars = (runsData: BarPlotRunData[], metricKey: string, averageValues: (number | undefined)[]) => {
+  const array: number[] = [];
+  const arrayminus: number[] = [];
+
+  runsData.forEach((run, index) => {
+    const average = normalizeChartValue(averageValues[index]);
+
+    const minHistory = run.aggregatedMetricsHistory?.[metricKey]?.[RunGroupingAggregateFunction.Min];
+    const maxHistory = run.aggregatedMetricsHistory?.[metricKey]?.[RunGroupingAggregateFunction.Max];
+
+    const minimum = normalizeChartValue(minHistory?.[minHistory.length - 1]?.value);
+    const maximum = normalizeChartValue(maxHistory?.[maxHistory.length - 1]?.value);
+
+    if (typeof average !== 'number' || typeof minimum !== 'number' || typeof maximum !== 'number') {
+      array.push(0);
+      arrayminus.push(0);
+      return;
+    }
+
+    array.push(Math.max(0, maximum - average));
+    arrayminus.push(Math.max(0, average - minimum));
+  });
+
+  return {
+    type: 'data',
+    symmetric: false,
+    array,
+    arrayminus,
+    visible: true,
+  };
+};
 
 /**
  * Highlight function for multi-metric grouped bar charts.
@@ -165,6 +220,7 @@ export const RunsMetricsBarPlot = React.memo(
     displayMetricKey = true,
     selectedRunUuid,
     onSetDownloadHandler,
+    showMinMaxRange = false,
   }: RunsMetricsBarPlotProps) => {
     const metricKeys = useMemo(() => selectedMetricKeys ?? [metricKey], [selectedMetricKeys, metricKey]);
     const isMultiMetric = metricKeys.length > 1;
@@ -200,6 +256,7 @@ export const RunsMetricsBarPlot = React.memo(
             width: barWidth,
             orientation: 'h',
             marker: { color: colors },
+            error_x: showMinMaxRange ? getMinMaxErrorBars(runsData, metricKey, values) : undefined,
           }),
         ];
       }
@@ -235,9 +292,10 @@ export const RunsMetricsBarPlot = React.memo(
           width: groupedBarWidth,
           orientation: 'h',
           marker: { color: METRIC_COLORS[metricIdx % METRIC_COLORS.length] },
+          error_x: showMinMaxRange ? getMinMaxErrorBars(runsData, mKey, values) : undefined,
         });
       });
-    }, [runsData, metricKey, metricKeys, isMultiMetric, barWidth, useDefaultHoverBox]);
+    }, [runsData, metricKey, metricKeys, isMultiMetric, barWidth, useDefaultHoverBox, showMinMaxRange]);
 
     const { layoutHeight, layoutWidth, setContainerDiv, containerDiv, isDynamicSizeSupported } = useDynamicPlotSize();
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsBarPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsBarPlot.tsx
@@ -133,7 +133,14 @@ const getMinMaxErrorBars = (runsData: BarPlotRunData[], metricKey: string, avera
     const minimum = normalizeChartValue(minHistory?.[minHistory.length - 1]?.value);
     const maximum = normalizeChartValue(maxHistory?.[maxHistory.length - 1]?.value);
 
-    if (typeof average !== 'number' || typeof minimum !== 'number' || typeof maximum !== 'number') {
+    if (
+      average === undefined ||
+      minimum === undefined ||
+      maximum === undefined ||
+      !Number.isFinite(average) ||
+      !Number.isFinite(minimum) ||
+      !Number.isFinite(maximum)
+    ) {
       array.push(0);
       arrayminus.push(0);
       return;

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsBarChartCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsBarChartCard.tsx
@@ -10,6 +10,8 @@ import { downloadChartDataCsv } from '../../../experiment-page/utils/experimentP
 import { customMetricBehaviorDefs } from '../../../experiment-page/utils/customMetricBehaviorUtils';
 import { RunsChartsNoDataFoundIndicator } from '../RunsChartsNoDataFoundIndicator';
 import { Tag, Typography } from '@databricks/design-system';
+import type { RunsGroupByConfig } from '../../../experiment-page/utils/experimentPage.group-row-utils';
+import { RunGroupingAggregateFunction } from '../../../experiment-page/utils/experimentPage.row-types';
 
 export interface RunsChartsBarChartCardProps
   extends RunsChartCardReorderProps, RunsChartCardFullScreenProps, RunsChartCardVisibilityProps {
@@ -17,6 +19,7 @@ export interface RunsChartsBarChartCardProps
   chartRunData: RunsChartsRunData[];
 
   hideEmptyCharts?: boolean;
+  groupBy?: RunsGroupByConfig | null;
 
   onDelete: () => void;
   onEdit: () => void;
@@ -50,6 +53,7 @@ export const RunsChartsBarChartCard = ({
   fullScreen,
   setFullScreenChart,
   hideEmptyCharts,
+  groupBy,
   isInViewport: isInViewportProp,
   ...reorderProps
 }: RunsChartsBarChartCardProps) => {
@@ -113,6 +117,7 @@ export const RunsChartsBarChartCard = ({
           onUnhover={resetTooltip}
           selectedRunUuid={selectedRunUuid}
           onSetDownloadHandler={setImageDownloadHandler}
+          showMinMaxRange={groupBy?.aggregateFunction === RunGroupingAggregateFunction.Average}
         />
       ) : null}
     </div>


### PR DESCRIPTION
### Related Issues/PRs

Closes #20824

### What changes are proposed in this pull request?

This PR adds min/max error bars to grouped bar charts when the selected aggregation is average.

For each grouped metric, the chart now calculates the minimum and maximum values from the aggregated metric history and passes them to Plotly through `error_x`. The error bars are only shown for grouped average bar charts and are not applied to ungrouped charts or other aggregations.

The change also wires the existing `groupBy` value through `RunsChartsBarChartCard` into `RunsMetricsBarPlot`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual verification performed:

- Confirmed that grouped average bar charts display min/max error ranges.
- Confirmed that ungrouped bar charts do not display error bars.
- Confirmed that grouped charts using non-average aggregations do not display error bars.
- Ran Prettier successfully.
- Ran ESLint successfully.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Grouped average bar charts in the MLflow UI now display min/max error bars, making it easier to understand the range of values within each group.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release