### PR TITLE
Parallelize the `windows` CI job with pytest-xdist (two-pass)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           source dev/setup-ssh.sh
           uv run --no-sync pytest --splits=$SPLITS --group=$GROUP \
+            -n auto --dist loadscope \
             --quiet --requires-ssh --ignore-flavors \
             --ignore=tests/examples \
             --ignore=tests/evaluate \

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -454,23 +454,31 @@ jobs:
           GROUP: ${{ matrix.group }}
         run: |
           export PATH=$PATH:$HADOOP_HOME/bin
-          uv run --no-sync pytest tests \
-            --splits=$SPLITS \
-            --group=$GROUP \
-            --ignore-flavors \
-            --ignore=tests/projects \
-            --ignore=tests/examples \
-            --ignore=tests/evaluate \
-            --ignore=tests/optuna \
-            --ignore=tests/pyspark/optuna \
-            --ignore=tests/genai \
-            --ignore=tests/sagemaker \
-            --ignore=tests/gateway \
-            --ignore=tests/server/auth \
-            --ignore=tests/data/test_spark_dataset.py \
-            --ignore=tests/data/test_spark_dataset_source.py \
-            --ignore=tests/data/test_delta_dataset_source.py \
-            --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_spark_datasource \
-            --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_delta_datasource \
-            --ignore=tests/docker \
+          # Two passes, mirroring the `python` job: the bulk of the suite runs in
+          # parallel across cores with pytest-xdist (`--serial=exclude -n auto`), and
+          # the xdist-hostile tests (shared Flask app / server config, env-building
+          # subprocesses; see `_XDIST_SERIAL_PATHS` in tests/conftest.py) run serially
+          # afterward (`--serial=only`, no `-n`).
+          COMMON_ARGS=(
+            --splits="$SPLITS" --group="$GROUP"
+            --ignore-flavors
+            --ignore=tests/projects
+            --ignore=tests/examples
+            --ignore=tests/evaluate
+            --ignore=tests/optuna
+            --ignore=tests/pyspark/optuna
+            --ignore=tests/genai
+            --ignore=tests/sagemaker
+            --ignore=tests/gateway
+            --ignore=tests/server/auth
+            --ignore=tests/data/test_spark_dataset.py
+            --ignore=tests/data/test_spark_dataset_source.py
+            --ignore=tests/data/test_delta_dataset_source.py
+            --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_spark_datasource
+            --deselect=tests/data/test_pandas_dataset.py::test_from_pandas_delta_datasource
+            --ignore=tests/docker
             --ignore=tests/demo
+            tests
+          )
+          uv run --no-sync pytest --serial=exclude -n auto --dist loadscope "${COMMON_ARGS[@]}"
+          uv run --no-sync pytest --serial=only "${COMMON_ARGS[@]}"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -109,14 +109,22 @@ jobs:
           GROUP: ${{ matrix.group }}
         run: |
           source dev/setup-ssh.sh
-          uv run --no-sync pytest --splits=$SPLITS --group=$GROUP \
-            -n auto --dist loadscope \
-            --quiet --requires-ssh --ignore-flavors \
-            --ignore=tests/examples \
-            --ignore=tests/evaluate \
-            --ignore=tests/genai \
-            --ignore=tests/docker \
+          # Two passes: the bulk of the suite runs in parallel across cores with
+          # pytest-xdist (`--serial=exclude -n auto`), and the xdist-hostile tests
+          # (shared Spark session, process-global Flask app / server config,
+          # env-building subprocesses; see `_XDIST_SERIAL_PATHS` in tests/conftest.py)
+          # run serially afterward (`--serial=only`, no `-n`).
+          COMMON_ARGS=(
+            --splits="$SPLITS" --group="$GROUP"
+            --quiet --requires-ssh --ignore-flavors
+            --ignore=tests/examples
+            --ignore=tests/evaluate
+            --ignore=tests/genai
+            --ignore=tests/docker
             tests
+          )
+          uv run --no-sync pytest --serial=exclude -n auto --dist loadscope "${COMMON_ARGS[@]}"
+          uv run --no-sync pytest --serial=only "${COMMON_ARGS[@]}"
 
       - name: Run databricks-connect related tests
         run: |

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -5,6 +5,7 @@ pytest-asyncio
 pytest-repeat
 pytest-cov
 pytest-timeout
+pytest-xdist
 httpx
 moto>=4.2.0,<5,!=4.2.5
 azure-storage-blob>=12.0.0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -6,6 +6,8 @@ pytest-repeat
 pytest-cov
 pytest-timeout
 pytest-xdist
+# Used by the `serve_wheel` fixture to build the dev wheel once across xdist workers
+filelock
 httpx
 moto>=4.2.0,<5,!=4.2.5
 azure-storage-blob>=12.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,33 +65,42 @@ _logger = logging.getLogger(__name__)
 # serial if its file path starts with any of these. Verified xdist-hostile against a
 # green serial baseline (they pass serially but fail under `-n auto`):
 #   - tests/data/test_spark_dataset.py, test_spark_dataset_source.py,
-#     test_delta_dataset_source.py: all workers share one Spark/Delta JVM session and
-#     clobber the catalog config across processes.
+#     test_delta_dataset_source.py, test_pandas_dataset.py: all workers share one Spark/Delta
+#     JVM session and clobber the catalog config across processes. (The windows job already
+#     deselects the two spark/delta nodes in test_pandas_dataset.py for the same reason.)
 #   - tests/server/test_prometheus_exporter.py + test_handlers.py: both import the
 #     process-global Flask `app`; the conftest orders prometheus first, but under
 #     `--dist loadscope` they land on different workers and the ordering no longer holds
 #     (Flask forbids `before_request` after the first request).
 #   - tests/server/test_workspace_middleware.py: process-global server config leaks across
 #     workers.
-#   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py: spawn real
-#     env-building subprocesses that contend for CPU/disk and time out when parallelized.
+#   - tests/gateway/providers/test_databricks.py: mocks the global `databricks.sdk` module;
+#     import/mock state leaks across workers ("module 'databricks' has no attribute 'sdk'").
+#   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py, test_projects.py:
+#     spawn real env-building subprocesses that contend for CPU/disk, time out, or race on
+#     the shared conda env list when parallelized.
 #   - tests/server/jobs: job-runner tests whose polling is timing-sensitive under contention.
-#   - tests/db/test_schema.py, tests/tracking/_model_registry/test_utils.py: assume a
-#     filesystem `./mlruns` store, but a sibling worker toggling `MLFLOW_ALLOW_FILE_STORE`
-#     (file-store "maintenance mode") leaks across the process and trips these.
+#   - tests/db/test_schema.py, tests/db/test_tracking_operations.py,
+#     tests/tracking/_model_registry/test_utils.py: assume a filesystem `./mlruns` store, but
+#     a sibling worker toggling `MLFLOW_ALLOW_FILE_STORE` (file-store "maintenance mode")
+#     leaks across the process and trips these.
 #   - tests/tracing/export/test_async_export_queue.py: asserts on live worker/thread counts,
 #     which are perturbed by concurrent xdist workers.
 _XDIST_SERIAL_PATHS = (
     "tests/data/test_spark_dataset.py",
     "tests/data/test_spark_dataset_source.py",
     "tests/data/test_delta_dataset_source.py",
+    "tests/data/test_pandas_dataset.py",
     "tests/server/test_prometheus_exporter.py",
     "tests/server/test_handlers.py",
     "tests/server/test_workspace_middleware.py",
+    "tests/gateway/providers/test_databricks.py",
     "tests/projects/test_virtualenv_projects.py",
     "tests/projects/test_projects_cli.py",
+    "tests/projects/test_projects.py",
     "tests/server/jobs/",
     "tests/db/test_schema.py",
+    "tests/db/test_tracking_operations.py",
     "tests/tracking/_model_registry/test_utils.py",
     "tests/tracing/export/test_async_export_queue.py",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,9 @@ _logger = logging.getLogger(__name__)
 # Each entry is a posix-style path prefix relative to the repo root; a test is treated as
 # serial if its file path starts with any of these. Verified xdist-hostile against a
 # green serial baseline (they pass serially but fail under `-n auto`):
-#   - tests/data/test_spark_dataset.py, test_delta_dataset_source.py: all workers share one
-#     Spark/Delta JVM session and clobber the catalog config across processes.
+#   - tests/data/test_spark_dataset.py, test_spark_dataset_source.py,
+#     test_delta_dataset_source.py: all workers share one Spark/Delta JVM session and
+#     clobber the catalog config across processes.
 #   - tests/server/test_prometheus_exporter.py + test_handlers.py: both import the
 #     process-global Flask `app`; the conftest orders prometheus first, but under
 #     `--dist loadscope` they land on different workers and the ordering no longer holds
@@ -75,8 +76,14 @@ _logger = logging.getLogger(__name__)
 #   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py: spawn real
 #     env-building subprocesses that contend for CPU/disk and time out when parallelized.
 #   - tests/server/jobs: job-runner tests whose polling is timing-sensitive under contention.
+#   - tests/db/test_schema.py, tests/tracking/_model_registry/test_utils.py: assume a
+#     filesystem `./mlruns` store, but a sibling worker toggling `MLFLOW_ALLOW_FILE_STORE`
+#     (file-store "maintenance mode") leaks across the process and trips these.
+#   - tests/tracing/export/test_async_export_queue.py: asserts on live worker/thread counts,
+#     which are perturbed by concurrent xdist workers.
 _XDIST_SERIAL_PATHS = (
     "tests/data/test_spark_dataset.py",
+    "tests/data/test_spark_dataset_source.py",
     "tests/data/test_delta_dataset_source.py",
     "tests/server/test_prometheus_exporter.py",
     "tests/server/test_handlers.py",
@@ -84,6 +91,9 @@ _XDIST_SERIAL_PATHS = (
     "tests/projects/test_virtualenv_projects.py",
     "tests/projects/test_projects_cli.py",
     "tests/server/jobs/",
+    "tests/db/test_schema.py",
+    "tests/tracking/_model_registry/test_utils.py",
+    "tests/tracing/export/test_async_export_queue.py",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import posixpath
 import pstats
 import re
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -1310,6 +1311,19 @@ def db_uri(cached_db: Path) -> Iterator[str]:
 
         if not IS_TRACING_SDK_ONLY and cached_db.exists():
             shutil.copy2(cached_db, db_path)
+            # `cached_db` is session-scoped, so the default experiment's
+            # `artifact_location` is baked in as an absolute path under the shared
+            # session dir. Copying only the DB would leave every test (and any
+            # `mlflow run` subprocess it spawns) writing artifacts into that one
+            # shared directory, which cross-contaminates and, once a subprocess
+            # leaves the tree read-only, fails later writes with EACCES. Repoint
+            # the artifact root at this test's own temp dir so each test is isolated.
+            artifact_root = Path(tmp_dir) / "artifacts"
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "UPDATE experiments SET artifact_location = ? WHERE experiment_id = 0",
+                    (artifact_root.joinpath("0").as_uri(),),
+                )
 
         yield f"sqlite:///{db_path}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1075,6 +1075,8 @@ def serve_wheel(request, tmp_path_factory):
     The server provides upload-time metadata so that uv's ``exclude-newer`` can correctly
     resolve the local dev wheel.
     """
+    from filelock import FileLock
+
     from tests.helper_functions import get_safe_port
     from tests.simple_repository_server import SimpleRepositoryServer
 
@@ -1086,10 +1088,6 @@ def serve_wheel(request, tmp_path_factory):
         yield  # pytest expects a generator fixture to yield
         return
 
-    root = tmp_path_factory.mktemp("root")
-    mlflow_dir = root.joinpath("mlflow")
-    mlflow_dir.mkdir()
-    port = get_safe_port()
     try:
         repo_root = subprocess.check_output(
             [
@@ -1104,18 +1102,39 @@ def serve_wheel(request, tmp_path_factory):
         # In this case, assume we're in the root of the repo.
         repo_root = "."
 
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "wheel",
-            "--wheel-dir",
-            mlflow_dir,
-            "--no-deps",
-            repo_root,
-        ],
-    )
+    def build_wheel(wheel_dir):
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "wheel",
+                "--wheel-dir",
+                wheel_dir,
+                "--no-deps",
+                repo_root,
+            ],
+        )
+
+    if os.environ.get("PYTEST_XDIST_WORKER") is None:
+        # Not running under pytest-xdist: build into this session's own tmp dir.
+        mlflow_dir = tmp_path_factory.mktemp("root").joinpath("mlflow")
+        mlflow_dir.mkdir()
+        build_wheel(mlflow_dir)
+    else:
+        # Under pytest-xdist every worker runs its own session and would otherwise
+        # each run `pip wheel` concurrently, racing on the in-tree `build/` directory
+        # and failing the wheel build. Build the wheel exactly once in a directory
+        # shared across workers (the parent of each worker's basetemp), guarded by a
+        # file lock; the remaining workers reuse the already-built wheel.
+        shared_dir = tmp_path_factory.getbasetemp().parent
+        mlflow_dir = shared_dir.joinpath("mlflow-dev-wheel")
+        with FileLock(str(shared_dir.joinpath("mlflow-dev-wheel.lock"))):
+            if not (mlflow_dir.exists() and any(mlflow_dir.glob("*.whl"))):
+                mlflow_dir.mkdir(exist_ok=True)
+                build_wheel(mlflow_dir)
+
+    port = get_safe_port()
     with SimpleRepositoryServer(mlflow_dir, port) as server:
         index_url = (
             f"{url} {server.url}" if (url := os.environ.get("PIP_EXTRA_INDEX_URL")) else server.url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,9 +77,10 @@ _logger = logging.getLogger(__name__)
 #     workers.
 #   - tests/gateway/providers/test_databricks.py: mocks the global `databricks.sdk` module;
 #     import/mock state leaks across workers ("module 'databricks' has no attribute 'sdk'").
-#   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py, test_projects.py:
-#     spawn real env-building subprocesses that contend for CPU/disk, time out, or race on
-#     the shared conda env list when parallelized.
+#   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py, test_projects.py,
+#     test_docker_projects.py: spawn real env-building / docker subprocesses that contend for
+#     CPU/disk, time out, race on the shared conda env list or docker daemon, and (for docker)
+#     write root-owned artifacts that can't be cleaned up under concurrency.
 #   - tests/server/jobs: job-runner tests whose polling is timing-sensitive under contention.
 #   - tests/db/test_schema.py, tests/db/test_tracking_operations.py,
 #     tests/tracking/_model_registry/test_utils.py: assume a filesystem `./mlruns` store, but
@@ -103,6 +104,7 @@ _XDIST_SERIAL_PATHS = (
     "tests/gateway/providers/test_databricks.py",
     "tests/projects/test_virtualenv_projects.py",
     "tests/projects/test_projects_cli.py",
+    "tests/projects/test_docker_projects.py",
     "tests/projects/test_projects.py",
     "tests/server/jobs/",
     "tests/db/test_schema.py",
@@ -1306,7 +1308,12 @@ def cached_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
 @pytest.fixture
 def db_uri(cached_db: Path) -> Iterator[str]:
     """Returns a fresh SQLite URI for each test by copying the cached database."""
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+    # Managed manually (not `TemporaryDirectory`) so cleanup can never raise. Tests that
+    # spawn a root-owned writer into the artifact tree (e.g. docker projects) leave files
+    # the non-root runner cannot remove; `TemporaryDirectory`'s cleanup re-raises on those
+    # and surfaces as a teardown ERROR, whereas `rmtree(ignore_errors=True)` swallows it.
+    tmp_dir = tempfile.mkdtemp()
+    try:
         db_path = Path(tmp_dir) / "mlflow.db"
 
         if not IS_TRACING_SDK_ONLY and cached_db.exists():
@@ -1326,6 +1333,8 @@ def db_uri(cached_db: Path) -> Iterator[str]:
                 )
 
         yield f"sqlite:///{db_path}"
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1075,8 +1075,6 @@ def serve_wheel(request, tmp_path_factory):
     The server provides upload-time metadata so that uv's ``exclude-newer`` can correctly
     resolve the local dev wheel.
     """
-    from filelock import FileLock
-
     from tests.helper_functions import get_safe_port
     from tests.simple_repository_server import SimpleRepositoryServer
 
@@ -1127,6 +1125,10 @@ def serve_wheel(request, tmp_path_factory):
         # and failing the wheel build. Build the wheel exactly once in a directory
         # shared across workers (the parent of each worker's basetemp), guarded by a
         # file lock; the remaining workers reuse the already-built wheel.
+        # `filelock` is imported lazily here (not at module top) because the skinny
+        # test suite doesn't install it and never runs under xdist.
+        from filelock import FileLock
+
         shared_dir = tmp_path_factory.getbasetemp().parent
         mlflow_dir = shared_dir.joinpath("mlflow-dev-wheel")
         with FileLock(str(shared_dir.joinpath("mlflow-dev-wheel.lock"))):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,11 +86,16 @@ _logger = logging.getLogger(__name__)
 #     leaks across the process and trips these.
 #   - tests/tracing/export/test_async_export_queue.py: asserts on live worker/thread counts,
 #     which are perturbed by concurrent xdist workers.
+#   - tests/data/test_huggingface_dataset_and_source.py, tests/metrics/test_metric_definitions.py:
+#     download models/datasets from huggingface.co; 4 workers hitting HF at once trigger rate
+#     limiting / HTTP 504s. Running them serially keeps concurrent HF load down.
 _XDIST_SERIAL_PATHS = (
     "tests/data/test_spark_dataset.py",
     "tests/data/test_spark_dataset_source.py",
     "tests/data/test_delta_dataset_source.py",
     "tests/data/test_pandas_dataset.py",
+    "tests/data/test_huggingface_dataset_and_source.py",
+    "tests/metrics/test_metric_definitions.py",
     "tests/server/test_prometheus_exporter.py",
     "tests/server/test_handlers.py",
     "tests/server/test_workspace_middleware.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,38 @@ if not IS_TRACING_SDK_ONLY:
 _logger = logging.getLogger(__name__)
 
 
+# Test files that are NOT safe to run under pytest-xdist and must run serially (`-n0`).
+# Each entry is a posix-style path prefix relative to the repo root; a test is treated as
+# serial if its file path starts with any of these. Verified xdist-hostile against a
+# green serial baseline (they pass serially but fail under `-n auto`):
+#   - tests/data/test_spark_dataset.py, test_delta_dataset_source.py: all workers share one
+#     Spark/Delta JVM session and clobber the catalog config across processes.
+#   - tests/server/test_prometheus_exporter.py + test_handlers.py: both import the
+#     process-global Flask `app`; the conftest orders prometheus first, but under
+#     `--dist loadscope` they land on different workers and the ordering no longer holds
+#     (Flask forbids `before_request` after the first request).
+#   - tests/server/test_workspace_middleware.py: process-global server config leaks across
+#     workers.
+#   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py: spawn real
+#     env-building subprocesses that contend for CPU/disk and time out when parallelized.
+#   - tests/server/jobs: job-runner tests whose polling is timing-sensitive under contention.
+_XDIST_SERIAL_PATHS = (
+    "tests/data/test_spark_dataset.py",
+    "tests/data/test_delta_dataset_source.py",
+    "tests/server/test_prometheus_exporter.py",
+    "tests/server/test_handlers.py",
+    "tests/server/test_workspace_middleware.py",
+    "tests/projects/test_virtualenv_projects.py",
+    "tests/projects/test_projects_cli.py",
+    "tests/server/jobs/",
+)
+
+
+def _is_serial_item(item) -> bool:
+    rel = os.path.relpath(str(item.path)).replace(os.sep, posixpath.sep)
+    return rel.startswith(_XDIST_SERIAL_PATHS)
+
+
 # Pytest hooks and configuration from root conftest.py
 def pytest_addoption(parser):
     parser.addoption(
@@ -95,6 +127,17 @@ def pytest_addoption(parser):
         action="store_true",
         default=os.environ.get("CI", "false").lower() == "true",
         help="Serve a wheel for the dev version of MLflow. True by default in CI, False otherwise.",
+    )
+    parser.addoption(
+        "--serial",
+        choices=["include", "only", "exclude"],
+        default="include",
+        help=(
+            "Select tests by their xdist-serial designation (see `_XDIST_SERIAL_PATHS`). "
+            "'include' (default) runs everything; 'exclude' drops the xdist-hostile tests so "
+            "the rest can run under `-n auto`; 'only' runs just the hostile tests (for a serial "
+            "`-n0` pass). Used by the two-pass `python` CI job."
+        ),
     )
     parser.addoption(
         "--profile",
@@ -602,6 +645,15 @@ def pytest_collection_modifyitems(session, config, items):
     # `before_request` on the application after the first request. To avoid this issue,
     # execute `tests.server.test_prometheus_exporter` first by reordering the test items.
     items.sort(key=lambda item: item.module.__name__ != "tests.server.test_prometheus_exporter")
+
+    # Partition xdist-hostile tests (see `_XDIST_SERIAL_PATHS`) so the `python` CI job can
+    # run the bulk under `-n auto` (`--serial=exclude`) and the hostile tests in a serial
+    # `-n0` pass (`--serial=only`). Default `include` keeps every test.
+    serial_mode = config.getoption("--serial")
+    if serial_mode == "exclude":
+        items[:] = [item for item in items if not _is_serial_item(item)]
+    elif serial_mode == "only":
+        items[:] = [item for item in items if _is_serial_item(item)]
 
     # Select the tests to run based on the group and splits
     if (splits := config.getoption("--splits")) and (group := config.getoption("--group")):


### PR DESCRIPTION
> **Stacked PR.** This branch is stacked on #24459 (the `python`-job xdist PR) and its diff includes #24459's commits. Review #24459 first; the windows-specific change is the final commit, `Parallelize the windows CI job with pytest-xdist (two-pass)`. Once #24459 merges, this will shrink to just the windows change.

### Related Issues/PRs

Relates to #24459

### What changes are proposed in this pull request?

Same idle-core problem as the `python` job, on the slowest job in the workflow. `windows-latest` runners have **4 vCPUs**, but the `windows` job ran plain single-process `pytest` across 3 shards — using ~1 of the 4 cores. Its critical path was **65 min** (windows shard 1), the longest of any job.

This applies the same two-pass structure introduced for the `python` job in #24459:

```bash
uv run --no-sync pytest --serial=exclude -n auto --dist loadscope "${COMMON_ARGS[@]}"
uv run --no-sync pytest --serial=only "${COMMON_ARGS[@]}"
```

1. **Bulk pass** (`-n auto --dist loadscope`): the well-behaved tests run concurrently across all 4 vCPUs.
2. **Serial pass** (`--serial=only`): the xdist-hostile tests (`_XDIST_SERIAL_PATHS` in `tests/conftest.py`) run serially.

The `windows` job already `--ignore`s several serially-quarantined paths (`tests/projects`, `tests/gateway`, the Spark datasets), so its serial pass is lighter than the `python` job's.

**Dependency.** This relies on the `--serial={include,only,exclude}` option and the xdist-safe `serve_wheel` fixture added in #24459.

### Baseline (before)

| windows shard | test step |
|---|---|
| windows (1) | **59.5 min** |
| windows (2) | 36.4 min |
| windows (3) | 39.3 min |

Note the ~20-min shard imbalance (duration-blind count-based split); xdist within each shard is the first lever, duration-balanced splitting is possible follow-up.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

CI runs the full `windows` shards under the two-pass design and must stay green. Windows may surface its own xdist-hostile tests (Tk/matplotlib globals, file locks, `HADOOP_HOME`); any that appear will be added to `_XDIST_SERIAL_PATHS`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release