### PR TITLE
Reset Keras session between autolog tests to fix optimizer-name uniquification

### DIFF
--- a/tests/keras/conftest.py
+++ b/tests/keras/conftest.py
@@ -1,0 +1,10 @@
+import keras
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_keras_session():
+    # Reset Keras global state before each test so optimizer names aren't uniquified
+    # across tests (a second Adam in the same session becomes "adam_1", which breaks
+    # the optimizer_name assertions in test_autolog.py / test_callback.py).
+    keras.backend.clear_session()

--- a/tests/keras/conftest.py
+++ b/tests/keras/conftest.py
@@ -8,3 +8,6 @@ def clear_keras_session():
     # across tests (a second Adam in the same session becomes "adam_1", which breaks
     # the optimizer_name assertions in test_autolog.py / test_callback.py).
     keras.backend.clear_session()
+    yield
+    # Also clear on teardown so a failing test doesn't leave global state behind.
+    keras.backend.clear_session()

--- a/tests/keras/test_autolog.py
+++ b/tests/keras/test_autolog.py
@@ -14,9 +14,6 @@ from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
 
 @pytest.fixture(autouse=True)
 def clear_autologging_config():
-    # Reset Keras global state so optimizer names aren't uniquified across tests
-    # (a second Adam in the same session becomes "adam_1", breaking name assertions).
-    keras.backend.clear_session()
     yield
     AUTOLOGGING_INTEGRATIONS.pop("keras", None)
 

--- a/tests/keras/test_autolog.py
+++ b/tests/keras/test_autolog.py
@@ -14,6 +14,9 @@ from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
 
 @pytest.fixture(autouse=True)
 def clear_autologging_config():
+    # Reset Keras global state so optimizer names aren't uniquified across tests
+    # (a second Adam in the same session becomes "adam_1", breaking name assertions).
+    keras.backend.clear_session()
     yield
     AUTOLOGGING_INTEGRATIONS.pop("keras", None)
 


### PR DESCRIPTION
### Related Issues/PRs

None. Fixes a flaky/failing test unrelated to any open feature work (surfaced as a CI failure blocking unrelated PRs, e.g. #24309).

### What changes are proposed in this pull request?

`tests/keras/test_autolog.py::test_custom_autolog_behavior` asserts `model_info["optimizer_name"] == "adam"`, but Keras uniquifies optimizer names within a single session: the second `Adam` instance created in the test process becomes `adam_1`, the third `adam_2`, and so on. Because the parametrized cases share one process, later parametrizations fail with `assert 'adam_1' == 'adam'`.

This is a test-isolation bug (order-dependent, pre-existing) rather than a product issue. The fix adds `keras.backend.clear_session()` to the existing `autouse` fixture so each test starts with a fresh Keras global state (and thus a fresh optimizer-name registry).

### How is this PR tested?

- [x] Existing unit/integration tests

Ran the full `tests/keras/test_autolog.py` file (8 passed) and the previously-failing `test_custom_autolog_behavior` parametrizations specifically (3 passed). Before the fix, the 2nd/3rd parametrizations fail with `assert 'adam_1'/'adam_2' == 'adam'`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.