### PR TITLE
[chart] Add optional External Secrets Operator support

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -6,6 +6,7 @@ A production-ready Helm chart for deploying [MLflow](https://mlflow.org) on Kube
 
 - **MLflow server** with configurable CLI options
 - **TLS support** via an existing Kubernetes Secret
+- **External Secrets Operator integration** to create the backend store credential Secret from AWS Secrets Manager, GCP Secret Manager, Vault, or any other supported provider
 - **Persistent storage** with a PersistentVolumeClaim for SQLite or file-based artifact stores
 - **Ingress** for external access
 - **Prometheus metrics** and optional ServiceMonitor for the Prometheus Operator

--- a/charts/templates/externalsecret.yaml
+++ b/charts/templates/externalsecret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "mlflow.fullname" . }}-externalsecret
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ include "mlflow.fullname" . }}
+    kind: SecretStore
+  target:
+    name: {{ .Values.externalSecrets.secretName | default (include "mlflow.fullname" .) }}
+    creationPolicy: Owner
+    {{- with .Values.externalSecrets.template }}
+    template:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/templates/secretstore.yaml
+++ b/charts/templates/secretstore.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: SecretStore
+metadata:
+  name: {{ include "mlflow.fullname" . }}
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+spec:
+  provider:
+    {{- toYaml .Values.externalSecrets.provider | nindent 4 }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -169,6 +169,61 @@ tls:
   # Name of the TLS Secret containing tls.crt and tls.key.
   secretName: mlflow-tls
 
+# Create the backend store credential Secret via the External Secrets
+# Operator (https://external-secrets.io/) instead of managing it outside
+# the chart. When enabled, creates a SecretStore and ExternalSecret; disabled
+# by default so existing users are unaffected.
+#
+# Example (AWS Secrets Manager, building a postgres URI from separate
+# username/password fields in the remote secret):
+#   externalSecrets:
+#     enabled: true
+#     provider:
+#       aws:
+#         service: SecretsManager
+#         region: eu-west-1
+#         auth:
+#           jwt:
+#             serviceAccountRef:
+#               name: mlflow
+#     secretName: mlflow-backend-store
+#     template:
+#       engineVersion: v2
+#       data:
+#         db-uri: "postgresql://{{ .username }}:{{ .password }}@my-db-host:5432/mlflow"
+#     data:
+#       - secretKey: username
+#         remoteRef:
+#           key: my-remote-secret-name
+#           property: username
+#       - secretKey: password
+#         remoteRef:
+#           key: my-remote-secret-name
+#           property: password
+#   mlflow:
+#     backendStoreUriFrom:
+#       secretKeyRef:
+#         name: mlflow-backend-store
+#         key: db-uri
+externalSecrets:
+  enabled: false
+  # apiVersion for both the SecretStore and ExternalSecret resources.
+  apiVersion: external-secrets.io/v1
+  # Passed through as SecretStore.spec.provider — any provider ESO supports
+  # (aws, gcpsm, azurekv, vault, etc.). Required when enabled.
+  provider: {}
+  refreshInterval: 1h
+  # Name of the Secret the ExternalSecret creates. Defaults to the chart's
+  # fullname when empty.
+  secretName: ""
+  # Passed through as ExternalSecret.spec.target.template. Optional — use
+  # when the Secret's keys need to be derived from the remote data (e.g.
+  # assembling a connection URI from separate fields), rather than mapped
+  # one-to-one.
+  template: {}
+  # Passed through as ExternalSecret.spec.data. Required when enabled.
+  data: []
+
 # NetworkPolicy restricting ingress and egress traffic for the MLflow pod.
 # Egress rules allow DNS, HTTPS, Kubernetes API, common databases, and S3.
 networkPolicy:


### PR DESCRIPTION
### Related Issues/PRs

Closes #24502

### What changes are proposed in this pull request?

Adds optional `SecretStore`/`ExternalSecret` templates to the Helm chart, so it can create the backend store credential Secret itself instead of requiring users to manage it outside the chart with hand-rolled manifests.

Gated behind `externalSecrets.enabled` (default `false`) — existing users/deployments are unaffected.

Provider-agnostic: `externalSecrets.provider` is passed straight through to `SecretStore.spec.provider`, so it works with any provider [External Secrets Operator](https://external-secrets.io/) supports (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, Vault, etc.), not just one. Same for `externalSecrets.data`/`externalSecrets.template`, passed through to `ExternalSecret.spec.data`/`spec.target.template` — this lets the Secret's keys be assembled from multiple remote fields (e.g. building a `postgresql://user:pass@host/db` URI from separate username/password fields), which is the common case for wiring this up to `mlflow.backendStoreUriFrom`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`helm lint`/`helm template` (both the exact commands the `Helm Chart` CI workflow runs, and with the feature enabled via a realistic AWS Secrets Manager example) pass clean:

```
$ helm lint charts/ --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db"
==> Linting charts/
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template mlflow charts/ --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db"
# renders unchanged — new templates emit nothing when disabled
```

With `externalSecrets.enabled: true` and a provider config, the `SecretStore`/`ExternalSecret` render correctly against the real ESO CRD schema (verified `spec.provider.<name>` nesting, `data`/`target.template` passthrough).

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

Added a full worked example directly in `values.yaml` and updated the chart README's features list.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds optional support for the Helm chart to create its own backend-store credential Secret via the External Secrets Operator, instead of requiring it to be managed outside the chart.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release