### PR TITLE
[4/N] Show session token usage and active provider in the Assistant composer

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -826,6 +826,7 @@ module.exports = {
   "mlflow.assistant.chat_panel.settings.tooltip": "",
   "mlflow.assistant.chat_panel.setup": "",
   "mlflow.assistant.chat_panel.suggestion.card": "",
+  "mlflow.assistant.chat_panel.usage_info": "",
   "mlflow.assistant.fab": "",
   "mlflow.assistant.icon_button": "",
   "mlflow.assistant.icon_button.tooltip": "",

--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -816,6 +816,7 @@ module.exports = {
   "mlflow.assistant.chat_panel.context.trace": "",
   "mlflow.assistant.chat_panel.copy": "",
   "mlflow.assistant.chat_panel.copy.tooltip": "",
+  "mlflow.assistant.chat_panel.provider_info.tooltip": "",
   "mlflow.assistant.chat_panel.regenerate": "",
   "mlflow.assistant.chat_panel.regenerate.tooltip": "",
   "mlflow.assistant.chat_panel.remote_close": "",

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -561,10 +561,11 @@ class ClaudeCodeProvider(AssistantProvider):
         rather than recomputing. The shape matches the usage event emitted by
         the gateway provider so the UI handles both identically.
         """
+        cache_read_tokens = usage.get("cache_read_input_tokens") or 0
         prompt_tokens = (
             (usage.get("input_tokens") or 0)
             + (usage.get("cache_creation_input_tokens") or 0)
-            + (usage.get("cache_read_input_tokens") or 0)
+            + cache_read_tokens
         )
         completion_tokens = usage.get("output_tokens") or 0
         return Event.from_stream_event({
@@ -573,6 +574,9 @@ class ClaudeCodeProvider(AssistantProvider):
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
+                # Subset of prompt_tokens re-read from the prompt cache (cheap). Surfaced
+                # so the UI can distinguish fresh input from resent, cached context.
+                "cache_read_tokens": cache_read_tokens,
                 "total_cost_usd": cost_usd,
             },
         })

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -260,6 +260,9 @@ class CodexProvider(AssistantProvider):
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
+                # Subset of prompt_tokens re-read from the prompt cache (cheap). Surfaced
+                # so the UI can distinguish fresh input from resent, cached context.
+                "cache_read_tokens": cache_read or 0,
                 "total_cost_usd": cost[CostKey.TOTAL_COST] if cost else None,
             },
         })

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -90,6 +90,9 @@ def _build_usage_event(usage: dict[str, Any], model: str | None) -> Event:
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": usage.get("total_tokens") or 0,
+            # Subset of prompt_tokens re-read from the prompt cache (cheap). Surfaced
+            # so the UI can distinguish fresh input from resent, cached context.
+            "cache_read_tokens": cache_read or 0,
             "total_cost_usd": cost[CostKey.TOTAL_COST] if cost else None,
         },
     })

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { renderWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { AssistantChatPanel, AssistantMessageBody, groupParts } from './AssistantChatPanel';
-import type { AssistantPart, ChatMessage } from './types';
+import type { AssistantPart, ChatMessage, TokenUsage } from './types';
 import { useLogTelemetryEvent } from '../telemetry/hooks/useLogTelemetryEvent';
 
 jest.mock('../telemetry/hooks/useLogTelemetryEvent', () => ({
@@ -21,6 +21,14 @@ const mockCancelSession = jest.fn();
 const mockClearPendingPrompt = jest.fn();
 let mockSetupComplete = true;
 let mockPendingPrompt: string | null = null;
+const EMPTY_TOKEN_USAGE: TokenUsage = {
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+  cacheReadTokens: 0,
+  costUsd: null,
+};
+let mockTokenUsage: TokenUsage = EMPTY_TOKEN_USAGE;
 
 jest.mock('./AssistantContext', () => ({
   useAssistant: () => ({
@@ -37,7 +45,7 @@ jest.mock('./AssistantContext', () => ({
     selectedProvider: null,
     pendingPrompt: mockPendingPrompt,
     canUseAssistant: true,
-    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: null },
+    tokenUsage: mockTokenUsage,
     openPanel: jest.fn(),
     closePanel: jest.fn(),
     sendMessage: mockSendMessage,
@@ -76,6 +84,7 @@ describe('AssistantChatPanel', () => {
     mockClearPendingPrompt.mockClear();
     mockSetupComplete = true;
     mockPendingPrompt = null;
+    mockTokenUsage = EMPTY_TOKEN_USAGE;
     mockLogTelemetryEvent = jest.fn();
     jest.mocked(useLogTelemetryEvent).mockReturnValue(mockLogTelemetryEvent);
   });
@@ -189,6 +198,24 @@ describe('AssistantChatPanel', () => {
     await user.keyboard('{Enter}');
 
     expect(mockLogTelemetryEvent).not.toHaveBeenCalled();
+  });
+
+  test('token footer shows a compact total and an info trigger when usage is present', () => {
+    mockTokenUsage = { promptTokens: 200, completionTokens: 30, totalTokens: 230, cacheReadTokens: 120, costUsd: 0.02 };
+    renderChatPanel();
+
+    // Compact headline reflects the full processed total; the breakdown (fresh vs cached
+    // input) lives in the hover tooltip, which Radix doesn't reliably open in JSDOM, so
+    // the fresh/cached arithmetic is covered by AssistantContext's accumulation test.
+    expect(screen.getByText('230')).toBeInTheDocument();
+    expect(screen.getByLabelText('More information')).toBeInTheDocument();
+  });
+
+  test('token footer is hidden when no tokens have been used', () => {
+    mockTokenUsage = EMPTY_TOKEN_USAGE;
+    renderChatPanel();
+
+    expect(screen.queryByLabelText('More information')).not.toBeInTheDocument();
   });
 });
 

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -34,6 +34,7 @@ jest.mock('./AssistantContext', () => ({
     setupComplete: mockSetupComplete,
     isLoadingConfig: false,
     isLocalServer: true,
+    selectedProvider: null,
     pendingPrompt: mockPendingPrompt,
     canUseAssistant: true,
     tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: null },

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -549,7 +549,7 @@ const ChatPanelContent = () => {
               borderTop: `1px solid ${theme.colors.borderDecorative}`,
             }}
           >
-            {selectedProvider ? <ProviderIndicator provider={selectedProvider} /> : <div css={{ flex: 1 }} />}
+            {selectedProvider && <ProviderIndicator provider={selectedProvider} />}
             <div css={{ flex: 1 }} />
             {tokenUsage.totalTokens > 0 && (
               <div css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -12,6 +12,7 @@ import {
   DesignSystemEventProviderAnalyticsEventTypes,
   DesignSystemEventProviderComponentTypes,
   GearIcon,
+  InfoTooltip,
   RefreshIcon,
   SparkleDoubleIcon,
   SparkleIcon,
@@ -53,6 +54,18 @@ const DOTS_ANIMATION = {
   '66%': { content: '".."' },
   '100%': { content: '"..."' },
 };
+
+// Abbreviate token counts for the compact usage footer (e.g. 45257 -> "45.3K").
+const formatCompactTokens = (n: number): string =>
+  new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(n);
+
+// Sub-dollar estimates need more precision than cents (e.g. "$0.0045").
+const formatCostUsd = (cost: number): string =>
+  new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: cost < 1 ? 4 : 2,
+  }).format(cost);
 
 export type MessagePartGroup = { kind: 'text'; text: string } | { kind: 'tools'; calls: ToolCallPart[] };
 
@@ -332,6 +345,7 @@ const ChatPanelContent = () => {
     sendMessage,
     regenerateLastMessage,
     cancelSession,
+    tokenUsage,
     pendingPrompt,
     clearPendingPrompt,
     pendingPermission,
@@ -459,37 +473,95 @@ const ChatPanelContent = () => {
             backgroundColor: theme.colors.backgroundPrimary,
           }}
         >
-          <div css={{ display: 'flex', alignItems: 'flex-end' }}>
-            <textarea
-              ref={textareaRef}
-              placeholder="Ask a question..."
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              rows={1}
-              css={{
-                flex: 1,
+          <AssistantContextTags />
+          <textarea
+            ref={textareaRef}
+            placeholder="Ask a question..."
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={1}
+            css={{
+              width: '100%',
+              border: 'none',
+              outline: 'none',
+              backgroundColor: 'transparent',
+              fontSize: theme.typography.fontSizeBase,
+              color: theme.colors.textPrimary,
+              padding: theme.spacing.xs,
+              resize: 'none',
+              overflowX: 'hidden',
+              overflowY: 'auto',
+              fontFamily: 'inherit',
+              lineHeight: 'inherit',
+              maxHeight: 150,
+              '&::placeholder': {
+                color: theme.colors.textPlaceholder,
+              },
+              '&:focus': {
                 border: 'none',
                 outline: 'none',
-                backgroundColor: 'transparent',
-                fontSize: theme.typography.fontSizeBase,
-                color: theme.colors.textPrimary,
-                padding: theme.spacing.xs,
-                resize: 'none',
-                overflowX: 'hidden',
-                overflowY: 'auto',
-                fontFamily: 'inherit',
-                lineHeight: 'inherit',
-                maxHeight: 150,
-                '&::placeholder': {
-                  color: theme.colors.textPlaceholder,
-                },
-                '&:focus': {
-                  border: 'none',
-                  outline: 'none',
-                },
-              }}
-            />
+              },
+            }}
+          />
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              paddingTop: theme.spacing.sm,
+              marginTop: theme.spacing.xs,
+              borderTop: `1px solid ${theme.colors.borderDecorative}`,
+            }}
+          >
+            <div css={{ flex: 1 }} />
+            {tokenUsage.totalTokens > 0 && (
+              <div css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                <Typography.Text size="sm" color="secondary" css={{ fontVariantNumeric: 'tabular-nums' }}>
+                  {formatCompactTokens(tokenUsage.totalTokens)}
+                </Typography.Text>
+                <InfoTooltip
+                  componentId="mlflow.assistant.chat_panel.usage_info"
+                  content={
+                    <div
+                      css={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: theme.spacing.xs,
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
+                      <span>
+                        <FormattedMessage
+                          defaultMessage="Input {input} · Output {output} tokens"
+                          description="Breakdown of session token usage into input (prompt) and output (completion) tokens"
+                          values={{
+                            input: tokenUsage.promptTokens.toLocaleString(),
+                            output: tokenUsage.completionTokens.toLocaleString(),
+                          }}
+                        />
+                      </span>
+                      {tokenUsage.costUsd != null ? (
+                        <span>
+                          <FormattedMessage
+                            defaultMessage="Estimated cost ~{cost} — from public model pricing; actual may vary (provider and cache rates)."
+                            description="Estimated session cost with a disclaimer that it is approximate"
+                            values={{ cost: formatCostUsd(tokenUsage.costUsd) }}
+                          />
+                        </span>
+                      ) : (
+                        <span>
+                          <FormattedMessage
+                            defaultMessage="Cost estimate unavailable for this model."
+                            description="Shown when the assistant's model is not in the pricing catalog so cost cannot be estimated"
+                          />
+                        </span>
+                      )}
+                    </div>
+                  }
+                />
+              </div>
+            )}
             <Button
               componentId="mlflow.assistant.chat_panel.send"
               onClick={isStreaming ? cancelSession : handleSend}
@@ -498,7 +570,6 @@ const ChatPanelContent = () => {
               aria-label="Send message"
             />
           </div>
-          <AssistantContextTags />
         </div>
       </div>
     </div>

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -29,6 +29,8 @@ import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import { useAssistant } from './AssistantContext';
 import { useAssistantPageContext } from './AssistantPageContext';
+import { getAssistantProvider } from './providerRegistry';
+import type { SelectedProvider } from './types';
 import { AssistantContextTags } from './AssistantContextTags';
 import { ToolPermissionPrompt } from './ToolPermissionPrompt';
 import { ToolCallGroup, type ToolCallPart } from './ToolCallCard';
@@ -66,6 +68,38 @@ const formatCostUsd = (cost: number): string =>
     currency: 'USD',
     maximumFractionDigits: cost < 1 ? 4 : 2,
   }).format(cost);
+
+/**
+ * Read-only indicator of the provider/model backing the session. Shows the provider's brand
+ * logo + name, with the model name in a tooltip. Display-only — there is intentionally no
+ * affordance to change the provider from the composer (that lives in Settings).
+ */
+const ProviderIndicator = ({ provider }: { provider: SelectedProvider }) => {
+  const { theme } = useDesignSystemTheme();
+  const meta = getAssistantProvider(provider.id);
+  const label = meta?.name ?? provider.id;
+  return (
+    <Tooltip
+      componentId="mlflow.assistant.chat_panel.provider_info.tooltip"
+      content={
+        <FormattedMessage
+          defaultMessage="Model: {model}"
+          description="Tooltip on the assistant composer showing the active provider's configured model name"
+          values={{ model: provider.model }}
+        />
+      }
+    >
+      <div css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs, minWidth: 0 }}>
+        {meta?.logo && (
+          <img src={meta.logo} alt="" aria-hidden css={{ width: 14, height: 14, flexShrink: 0, borderRadius: 2 }} />
+        )}
+        <Typography.Text size="sm" color="secondary" css={{ whiteSpace: 'nowrap' }}>
+          {label}
+        </Typography.Text>
+      </div>
+    </Tooltip>
+  );
+};
 
 export type MessagePartGroup = { kind: 'text'; text: string } | { kind: 'tools'; calls: ToolCallPart[] };
 
@@ -346,6 +380,7 @@ const ChatPanelContent = () => {
     regenerateLastMessage,
     cancelSession,
     tokenUsage,
+    selectedProvider,
     pendingPrompt,
     clearPendingPrompt,
     pendingPermission,
@@ -514,6 +549,7 @@ const ChatPanelContent = () => {
               borderTop: `1px solid ${theme.colors.borderDecorative}`,
             }}
           >
+            {selectedProvider ? <ProviderIndicator provider={selectedProvider} /> : <div css={{ flex: 1 }} />}
             <div css={{ flex: 1 }} />
             {tokenUsage.totalTokens > 0 && (
               <div css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -572,11 +572,20 @@ const ChatPanelContent = () => {
                           defaultMessage="Input {input} · Output {output} tokens"
                           description="Breakdown of session token usage into input (prompt) and output (completion) tokens"
                           values={{
-                            input: tokenUsage.promptTokens.toLocaleString(),
+                            input: (tokenUsage.promptTokens - tokenUsage.cacheReadTokens).toLocaleString(),
                             output: tokenUsage.completionTokens.toLocaleString(),
                           }}
                         />
                       </span>
+                      {tokenUsage.cacheReadTokens > 0 && (
+                        <span>
+                          <FormattedMessage
+                            defaultMessage="Cached {cached} tokens — reused conversation context, billed at a reduced rate"
+                            description="Portion of input tokens re-read from the provider's prompt cache across turns"
+                            values={{ cached: tokenUsage.cacheReadTokens.toLocaleString() }}
+                          />
+                        </span>
+                      )}
                       {tokenUsage.costUsd != null ? (
                         <span>
                           <FormattedMessage

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -25,7 +25,7 @@ import {
   WrenchSparkleIcon,
   Spinner,
 } from '@databricks/design-system';
-import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { FormattedMessage, useIntl, type IntlShape } from '@databricks/i18n';
 
 import { useAssistant } from './AssistantContext';
 import { useAssistantPageContext } from './AssistantPageContext';
@@ -58,16 +58,17 @@ const DOTS_ANIMATION = {
 };
 
 // Abbreviate token counts for the compact usage footer (e.g. 45257 -> "45.3K").
-const formatCompactTokens = (n: number): string =>
-  new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(n);
+// Formats through react-intl's locale so numbers match the surrounding FormattedMessage text.
+const formatCompactTokens = (intl: IntlShape, n: number): string =>
+  intl.formatNumber(n, { notation: 'compact', maximumFractionDigits: 1 });
 
 // Sub-dollar estimates need more precision than cents (e.g. "$0.0045").
-const formatCostUsd = (cost: number): string =>
-  new Intl.NumberFormat(undefined, {
+const formatCostUsd = (intl: IntlShape, cost: number): string =>
+  intl.formatNumber(cost, {
     style: 'currency',
     currency: 'USD',
     maximumFractionDigits: cost < 1 ? 4 : 2,
-  }).format(cost);
+  });
 
 /**
  * Read-only indicator of the provider/model backing the session. Shows the provider's brand
@@ -93,7 +94,11 @@ const ProviderIndicator = ({ provider }: { provider: SelectedProvider }) => {
         {meta?.logo && (
           <img src={meta.logo} alt="" aria-hidden css={{ width: 14, height: 14, flexShrink: 0, borderRadius: 2 }} />
         )}
-        <Typography.Text size="sm" color="secondary" css={{ whiteSpace: 'nowrap' }}>
+        <Typography.Text
+          size="sm"
+          color="secondary"
+          css={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}
+        >
           {label}
         </Typography.Text>
       </div>
@@ -372,6 +377,7 @@ const PromptSuggestions = ({ onSelect }: { onSelect: (prompt: string) => void })
  */
 const ChatPanelContent = () => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const {
     messages,
     isStreaming,
@@ -554,7 +560,7 @@ const ChatPanelContent = () => {
             {tokenUsage.totalTokens > 0 && (
               <div css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
                 <Typography.Text size="sm" color="secondary" css={{ fontVariantNumeric: 'tabular-nums' }}>
-                  {formatCompactTokens(tokenUsage.totalTokens)}
+                  {formatCompactTokens(intl, tokenUsage.totalTokens)}
                 </Typography.Text>
                 <InfoTooltip
                   componentId="mlflow.assistant.chat_panel.usage_info"
@@ -572,26 +578,26 @@ const ChatPanelContent = () => {
                           defaultMessage="Input {input} · Output {output} tokens"
                           description="Breakdown of session token usage into input (prompt) and output (completion) tokens"
                           values={{
-                            input: (tokenUsage.promptTokens - tokenUsage.cacheReadTokens).toLocaleString(),
-                            output: tokenUsage.completionTokens.toLocaleString(),
+                            input: intl.formatNumber(tokenUsage.promptTokens - tokenUsage.cacheReadTokens),
+                            output: intl.formatNumber(tokenUsage.completionTokens),
                           }}
                         />
                       </span>
                       {tokenUsage.cacheReadTokens > 0 && (
                         <span>
                           <FormattedMessage
-                            defaultMessage="Cached {cached} tokens — reused conversation context, billed at a reduced rate"
+                            defaultMessage="Cached {cached} tokens, reused conversation context billed at a reduced rate"
                             description="Portion of input tokens re-read from the provider's prompt cache across turns"
-                            values={{ cached: tokenUsage.cacheReadTokens.toLocaleString() }}
+                            values={{ cached: intl.formatNumber(tokenUsage.cacheReadTokens) }}
                           />
                         </span>
                       )}
                       {tokenUsage.costUsd != null ? (
                         <span>
                           <FormattedMessage
-                            defaultMessage="Estimated cost ~{cost} — from public model pricing; actual may vary (provider and cache rates)."
+                            defaultMessage="Estimated cost ~{cost}, from public model pricing; actual may vary (provider and cache rates)."
                             description="Estimated session cost with a disclaimer that it is approximate"
-                            values={{ cost: formatCostUsd(tokenUsage.costUsd) }}
+                            values={{ cost: formatCostUsd(intl, tokenUsage.costUsd) }}
                           />
                         </span>
                       ) : (

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -19,7 +19,7 @@ import type { SendMessageStreamCallbacks } from './AssistantService';
 import { GatewayApi } from '../gateway/api';
 import type { AssistantConfig, ProviderConfig, AssistantPart, ChatMessage } from './types';
 
-const EMPTY_TOKEN_USAGE = { promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: null };
+const EMPTY_TOKEN_USAGE = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cacheReadTokens: 0, costUsd: null };
 
 const CHAT_STORAGE_KEY = buildStorageKey(CHAT_STORAGE_KEY_BASE, CHAT_STORAGE_VERSION);
 
@@ -574,6 +574,45 @@ describe('AssistantContext — localStorage chat persistence', () => {
     const stored = JSON.parse(localStorage.getItem(CHAT_STORAGE_KEY) ?? '{}');
     expect(stored.messages).toEqual([]);
     expect(stored.tokenUsage).toEqual(EMPTY_TOKEN_USAGE);
+  });
+
+  it('accumulates per-turn usage deltas, tracking cached tokens separately', async () => {
+    const { result } = await renderAssistant();
+
+    await act(async () => {
+      result.current.sendMessage('turn one');
+    });
+    // Turn 1: fresh context, nothing cached yet.
+    act(() => {
+      capturedCallbacks?.onUsage?.({
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        cache_read_tokens: 0,
+        total_cost_usd: 0.01,
+      });
+      capturedCallbacks?.onDone();
+    });
+
+    // Turn 2: the resent history shows up as cache reads folded into prompt_tokens.
+    act(() => {
+      capturedCallbacks?.onUsage?.({
+        prompt_tokens: 200,
+        completion_tokens: 30,
+        total_tokens: 230,
+        cache_read_tokens: 120,
+        total_cost_usd: 0.02,
+      });
+      capturedCallbacks?.onDone();
+    });
+
+    expect(result.current.tokenUsage).toEqual({
+      promptTokens: 300,
+      completionTokens: 50,
+      totalTokens: 350,
+      cacheReadTokens: 120,
+      costUsd: 0.03,
+    });
   });
 
   it('persists the interrupted turn when a stream is cancelled mid-stream', async () => {

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -594,7 +594,11 @@ describe('AssistantContext — localStorage chat persistence', () => {
       capturedCallbacks?.onDone();
     });
 
-    // Turn 2: the resent history shows up as cache reads folded into prompt_tokens.
+    // Turn 2: a genuine second turn — its delta lands during a live stream, and the
+    // resent history shows up as cache reads folded into prompt_tokens.
+    await act(async () => {
+      result.current.sendMessage('turn two');
+    });
     act(() => {
       capturedCallbacks?.onUsage?.({
         prompt_tokens: 200,

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -43,7 +43,13 @@ const MAX_PERSISTED_CHARS = 1_500_000;
 export const CHAT_STORAGE_KEY_BASE = 'mlflow.assistant.chat';
 export const CHAT_STORAGE_VERSION = 1;
 
-const EMPTY_TOKEN_USAGE: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: null };
+const EMPTY_TOKEN_USAGE: TokenUsage = {
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+  cacheReadTokens: 0,
+  costUsd: null,
+};
 
 interface PersistedChat {
   messages: ChatMessage[];
@@ -391,6 +397,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       prompt_tokens: number;
       completion_tokens: number;
       total_tokens: number;
+      cache_read_tokens?: number;
       total_cost_usd?: number | null;
     }) => {
       // Contract: each `usage` event is a per-turn / per-request *delta*, never a
@@ -402,6 +409,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
         promptTokens: prev.promptTokens + (usage.prompt_tokens ?? 0),
         completionTokens: prev.completionTokens + (usage.completion_tokens ?? 0),
         totalTokens: prev.totalTokens + (usage.total_tokens ?? 0),
+        cacheReadTokens: prev.cacheReadTokens + (usage.cache_read_tokens ?? 0),
         // Accumulate cost only from priced turns; stays null until the first
         // numeric estimate arrives so unpriced models render no cost at all.
         costUsd: usage.total_cost_usd == null ? prev.costUsd : (prev.costUsd ?? 0) + usage.total_cost_usd,
@@ -564,7 +572,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setError(null);
     setCurrentStatus(null);
     setActiveTools([]);
-    setTokenUsage({ promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: null });
+    setTokenUsage(EMPTY_TOKEN_USAGE);
     openTextBufferRef.current = '';
     setPendingPermission(null);
   }, []);
@@ -874,7 +882,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   pendingPrompt: null,
   pendingPermission: null,
   canUseAssistant: false,
-  tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: null },
+  tokenUsage: EMPTY_TOKEN_USAGE,
   openPanel: () => {},
   closePanel: () => {},
   sendMessage: () => {},

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -12,6 +12,7 @@ import {
   type AssistantPart,
   type ChatMessage,
   type PermissionRequest,
+  type SelectedProvider,
   type ToolUseInfo,
   type ToolResultInfo,
   type TokenUsage,
@@ -98,19 +99,31 @@ const generateMessageId = (): string => {
   return `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 };
 
-async function resolveSetupComplete(config: AssistantConfig): Promise<boolean> {
-  const selectedProvider = Object.entries(config.providers ?? {}).find(
+/**
+ * Resolve, from the config, whether setup is complete and which provider/model backs the
+ * session. `selectedProvider` is the config's selected entry (null when none); it's returned
+ * even when setup is incomplete so callers can surface it, but is only *usable* when
+ * `setupComplete` is true.
+ */
+async function resolveSetup(
+  config: AssistantConfig,
+): Promise<{ setupComplete: boolean; selectedProvider: SelectedProvider | null }> {
+  const selected = Object.entries(config.providers ?? {}).find(
     ([, providerConfig]) => providerConfig.selected === true,
   );
-  if (!selectedProvider) return false;
+  if (!selected) {
+    return { setupComplete: false, selectedProvider: null };
+  }
 
-  const [providerId, providerConfig] = selectedProvider;
+  const [providerId, providerConfig] = selected;
+  const selectedProvider: SelectedProvider = { id: providerId, model: providerConfig.model };
   if (providerId !== GATEWAY_PROVIDER_ID) {
-    return true;
+    return { setupComplete: true, selectedProvider };
   }
   // The endpoint must be the same as the model name
   const { endpoints } = await GatewayApi.listEndpoints();
-  return endpoints.some((endpoint) => endpoint.name === providerConfig.model);
+  const setupComplete = endpoints.some((endpoint) => endpoint.name === providerConfig.model);
+  return { setupComplete, selectedProvider };
 }
 
 /**
@@ -230,6 +243,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   // Setup state
   const [setupComplete, setSetupComplete] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<SelectedProvider | null>(null);
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
   const [remoteAccessAllowed, setRemoteAccessAllowed] = useState(false);
   const canUseAssistant = isLocalServer || remoteAccessAllowed;
@@ -405,13 +419,17 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setIsLoadingConfig(true);
     try {
       const config = await getConfig();
-      const isComplete = await resolveSetupComplete(config);
+      const { setupComplete: isComplete, selectedProvider: provider } = await resolveSetup(config);
       setSetupComplete(isComplete);
       setRemoteAccessAllowed(config.remote_access_allowed ?? false);
+      // Only expose the provider once setup is valid, so the composer never shows a
+      // half-configured (e.g. gateway with a stale endpoint) provider as active.
+      setSelectedProvider(isComplete ? provider : null);
     } catch {
       // On error, assume setup is not complete
       setSetupComplete(false);
       setRemoteAccessAllowed(false);
+      setSelectedProvider(null);
     } finally {
       setIsLoadingConfig(false);
     }
@@ -818,6 +836,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setupComplete,
     isLoadingConfig,
     isLocalServer,
+    selectedProvider,
     pendingPrompt,
     pendingPermission,
     canUseAssistant,
@@ -851,6 +870,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   setupComplete: false,
   isLoadingConfig: false,
   isLocalServer: false,
+  selectedProvider: null,
   pendingPrompt: null,
   pendingPermission: null,
   canUseAssistant: false,

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -107,9 +107,8 @@ const generateMessageId = (): string => {
 
 /**
  * Resolve, from the config, whether setup is complete and which provider/model backs the
- * session. `selectedProvider` is the config's selected entry (null when none); it's returned
- * even when setup is incomplete so callers can surface it, but is only *usable* when
- * `setupComplete` is true.
+ * session. `selectedProvider` is the config's selected entry (null when none), returned
+ * independently of `setupComplete`; the current caller only adopts it once setup is complete.
  */
 async function resolveSetup(
   config: AssistantConfig,

--- a/mlflow/server/js/src/assistant/AssistantContextTags.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContextTags.tsx
@@ -129,7 +129,7 @@ export function AssistantContextTags(): React.ReactElement | null {
   if (!hasContext) return null;
 
   return (
-    <div css={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs, paddingTop: theme.spacing.sm }}>
+    <div css={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs, paddingBottom: theme.spacing.md }}>
       <ContextTagGroup
         ids={traceIds}
         color="indigo"

--- a/mlflow/server/js/src/assistant/AssistantService.ts
+++ b/mlflow/server/js/src/assistant/AssistantService.ts
@@ -120,6 +120,7 @@ export interface SendMessageStreamCallbacks {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cache_read_tokens?: number;
     total_cost_usd?: number | null;
   }) => void;
 }

--- a/mlflow/server/js/src/assistant/providerRegistry.ts
+++ b/mlflow/server/js/src/assistant/providerRegistry.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared registry of assistant providers: the single source of truth for a provider id's
+ * human display name and brand logo. Used by the setup wizard (to pick one) and the composer
+ * (to show, read-only, which one is active). Keyed by the same provider ids the `/config`
+ * payload uses (see `GATEWAY_PROVIDER_ID` and the server-side provider names).
+ */
+import AnthropicLogo from '@mlflow/mlflow/src/common/static/logos/anthropic.svg';
+import OpenAiLogo from '@mlflow/mlflow/src/common/static/logos/openai.svg';
+import MLflowGatewayLogo from '@mlflow/mlflow/src/common/static/logos/mlflow-gateway.svg';
+import OllamaLogo from '@mlflow/mlflow/src/common/static/logos/ollama.png';
+
+export interface AssistantProvider {
+  id: string;
+  name: string;
+  /** Longer copy for the setup card; the composer only uses `name` + `logo`. */
+  description: string;
+  logo: string;
+  available: boolean;
+}
+
+export const ASSISTANT_PROVIDERS: AssistantProvider[] = [
+  {
+    id: 'claude_code',
+    name: 'Claude Code',
+    description: "AI assistant powered by Anthropic's Claude. Requires Claude Code CLI installed locally.",
+    logo: AnthropicLogo,
+    available: true,
+  },
+  {
+    id: 'mlflow_gateway',
+    name: 'MLflow AI Gateway',
+    description: 'AI assistant backed by an MLflow AI Gateway deployment. Routes to any configured chat endpoint.',
+    logo: MLflowGatewayLogo,
+    available: true,
+  },
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    description: 'AI assistant using a locally running Ollama server. Requires Ollama installed and running.',
+    logo: OllamaLogo,
+    available: true,
+  },
+  {
+    id: 'codex',
+    name: 'OpenAI Codex',
+    description:
+      'AI assistant powered by OpenAI via the Codex CLI. Requires the codex CLI to be installed and authenticated.',
+    logo: OpenAiLogo,
+    available: true,
+  },
+];
+
+/** Look up a provider's display metadata by id; undefined for unknown ids. */
+export const getAssistantProvider = (id: string): AssistantProvider | undefined =>
+  ASSISTANT_PROVIDERS.find((provider) => provider.id === id);

--- a/mlflow/server/js/src/assistant/setup/SetupStepProvider.tsx
+++ b/mlflow/server/js/src/assistant/setup/SetupStepProvider.tsx
@@ -2,51 +2,8 @@ import { useState } from 'react';
 import { Button, Typography, useDesignSystemTheme } from '@databricks/design-system';
 
 import { toRGBA } from '@mlflow/mlflow/src/common/utils/toRGBA';
-import AnthropicLogo from '@mlflow/mlflow/src/common/static/logos/anthropic.svg';
-import OpenAiLogo from '@mlflow/mlflow/src/common/static/logos/openai.svg';
 import GeminiLogo from '@mlflow/mlflow/src/common/static/logos/gemini.png';
-import MLflowGatewayLogo from '@mlflow/mlflow/src/common/static/logos/mlflow-gateway.svg';
-import OllamaLogo from '@mlflow/mlflow/src/common/static/logos/ollama.png';
-
-interface Provider {
-  id: string;
-  name: string;
-  description: string;
-  logo: string;
-  available: boolean;
-}
-
-const PROVIDERS: Provider[] = [
-  {
-    id: 'claude_code',
-    name: 'Claude Code',
-    description: "AI assistant powered by Anthropic's Claude. Requires Claude Code CLI installed locally.",
-    logo: AnthropicLogo,
-    available: true,
-  },
-  {
-    id: 'mlflow_gateway',
-    name: 'MLflow AI Gateway',
-    description: 'AI assistant backed by an MLflow AI Gateway deployment. Routes to any configured chat endpoint.',
-    logo: MLflowGatewayLogo,
-    available: true,
-  },
-  {
-    id: 'ollama',
-    name: 'Ollama',
-    description: 'AI assistant using a locally running Ollama server. Requires Ollama installed and running.',
-    logo: OllamaLogo,
-    available: true,
-  },
-  {
-    id: 'codex',
-    name: 'OpenAI Codex',
-    description:
-      'AI assistant powered by OpenAI via the Codex CLI. Requires the codex CLI to be installed and authenticated.',
-    logo: OpenAiLogo,
-    available: true,
-  },
-];
+import { ASSISTANT_PROVIDERS as PROVIDERS, type AssistantProvider } from '../providerRegistry';
 
 const COMING_SOON_LOGOS = [GeminiLogo];
 
@@ -65,7 +22,7 @@ export const SetupStepProvider = ({ selectedProvider, onContinue }: SetupStepPro
     }
   };
 
-  const renderProviderCard = (provider: Provider) => (
+  const renderProviderCard = (provider: AssistantProvider) => (
     <div
       key={provider.id}
       onClick={() => provider.available && setSelected(provider.id)}

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -112,6 +112,14 @@ export interface KnownAssistantContext {
 /** All known context keys */
 export type AssistantContextKey = keyof KnownAssistantContext;
 
+/** The provider/model backing the current session, resolved from the selected `/config` entry. */
+export interface SelectedProvider {
+  /** Provider id as keyed in `/config` (e.g. `claude_code`, `mlflow_gateway`). */
+  id: string;
+  /** Configured model / endpoint name for that provider. */
+  model: string;
+}
+
 /** Cumulative token usage reported by the provider for the current session. */
 export interface TokenUsage {
   promptTokens: number;
@@ -145,6 +153,8 @@ export interface AssistantAgentState {
   isLoadingConfig: boolean;
   /** Whether the server is running locally (localhost) */
   isLocalServer: boolean;
+  /** The provider/model backing the session, or null before setup completes */
+  selectedProvider: SelectedProvider | null;
   /** A prompt queued to seed the chat input the next time it becomes visible (null when none) */
   pendingPrompt: string | null;
   /** A tool call awaiting the user's Yes/No decision, or null */

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -126,6 +126,12 @@ export interface TokenUsage {
   completionTokens: number;
   totalTokens: number;
   /**
+   * Subset of `promptTokens` re-read from the provider's prompt cache. On multi-turn
+   * sessions the resent conversation history lands here (billed at a fraction of fresh
+   * input), so the UI can separate fresh input from cached context in the breakdown.
+   */
+  cacheReadTokens: number;
+  /**
    * Estimated cumulative cost in USD, or null when no turn could be priced
    * (e.g. local/unknown models absent from the pricing catalog).
    */

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -7831,6 +7831,10 @@
     "defaultMessage": "Add record",
     "description": "Primary button text for adding a new dataset record from the empty state"
   },
+  "aKVdS3": {
+    "defaultMessage": "Model: {model}",
+    "description": "Tooltip on the assistant composer showing the active provider's configured model name"
+  },
   "aKW54p": {
     "defaultMessage": "See it in action",
     "description": "Label on the click-to-play video preview in the traces empty state"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2831,6 +2831,10 @@
     "defaultMessage": "Confirm new password",
     "description": "Placeholder for the confirm-password input"
   },
+  "BOm6XU": {
+    "defaultMessage": "Input {input} · Output {output} tokens",
+    "description": "Breakdown of session token usage into input (prompt) and output (completion) tokens"
+  },
   "BOz0T2": {
     "defaultMessage": "Select metric",
     "description": "Placeholder text for a metric selector when configuring a line chart"
@@ -3538,6 +3542,10 @@
   "Ey+oLI": {
     "defaultMessage": "Request",
     "description": "Column label for request"
+  },
+  "F+8+Xo": {
+    "defaultMessage": "Estimated cost ~{cost} — from public model pricing; actual may vary (provider and cache rates).",
+    "description": "Estimated session cost with a disclaimer that it is approximate"
   },
   "F16DNA": {
     "defaultMessage": "Version {versionNum}",
@@ -5382,6 +5390,10 @@
   "Ob5d+s": {
     "defaultMessage": "System metrics",
     "description": "Run details page > tab selector > System metrics tab"
+  },
+  "OcN222": {
+    "defaultMessage": "Cost estimate unavailable for this model.",
+    "description": "Shown when the assistant's model is not in the pricing catalog so cost cannot be estimated"
   },
   "OcYzCN": {
     "defaultMessage": "Unresolved",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -575,6 +575,10 @@
     "defaultMessage": "No image logged at this step",
     "description": "Experiment tracking > runs charts > charts > image plot with history > no image text"
   },
+  "0Z9gG2": {
+    "defaultMessage": "Estimated cost ~{cost}, from public model pricing; actual may vary (provider and cache rates).",
+    "description": "Estimated session cost with a disclaimer that it is approximate"
+  },
   "0eoz8L": {
     "defaultMessage": "Hour",
     "description": "Time unit: hour"
@@ -3542,10 +3546,6 @@
   "Ey+oLI": {
     "defaultMessage": "Request",
     "description": "Column label for request"
-  },
-  "F+8+Xo": {
-    "defaultMessage": "Estimated cost ~{cost} — from public model pricing; actual may vary (provider and cache rates).",
-    "description": "Estimated session cost with a disclaimer that it is approximate"
   },
   "F16DNA": {
     "defaultMessage": "Version {versionNum}",
@@ -10246,6 +10246,10 @@
   "lCfyQO": {
     "defaultMessage": "Dataset",
     "description": "Label for the dataset column in the logged model details metrics table"
+  },
+  "lCp+DF": {
+    "defaultMessage": "Cached {cached} tokens, reused conversation context billed at a reduced rate",
+    "description": "Portion of input tokens re-read from the provider's prompt cache across turns"
   },
   "lDGQGa": {
     "defaultMessage": "Toggle detailed view",

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -238,6 +238,7 @@ async def test_astream_emits_usage_event_before_done():
         "prompt_tokens": 35257,
         "completion_tokens": 5,
         "total_tokens": 35262,
+        "cache_read_tokens": 100,
         "total_cost_usd": 0.1319,
     }
     # The usage event must precede the DONE event, which closes the client stream.
@@ -256,6 +257,7 @@ async def test_astream_emits_usage_event_before_done():
                 "prompt_tokens": 10,
                 "completion_tokens": 5,
                 "total_tokens": 15,
+                "cache_read_tokens": 0,
                 "total_cost_usd": 0.25,
             },
         ),
@@ -271,6 +273,7 @@ async def test_astream_emits_usage_event_before_done():
                 "prompt_tokens": 152,
                 "completion_tokens": 5,
                 "total_tokens": 157,
+                "cache_read_tokens": 50,
                 "total_cost_usd": None,
             },
         ),
@@ -281,6 +284,7 @@ async def test_astream_emits_usage_event_before_done():
                 "prompt_tokens": 0,
                 "completion_tokens": 0,
                 "total_tokens": 0,
+                "cache_read_tokens": 0,
                 "total_cost_usd": None,
             },
         ),

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -153,6 +153,7 @@ async def test_astream_emits_usage_event_from_turn_completed():
     assert usage["prompt_tokens"] == 10
     assert usage["completion_tokens"] == 5
     assert usage["total_tokens"] == 15
+    assert usage["cache_read_tokens"] == 4
     assert usage["total_cost_usd"] is None
     mock_cost.assert_called_once()
 

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -229,6 +229,7 @@ def test_build_usage_event_remaps_cache_tokens_and_prices():
         "prompt_tokens": 35257,
         "completion_tokens": 5,
         "total_tokens": 35262,
+        "cache_read_tokens": 100,
         "total_cost_usd": 0.1319,
     }
 


### PR DESCRIPTION
> **Stacked PR.** Part of the MLflow Assistant stack; branches off master (fork-only stack, so the diff is cumulative until the parent merges).
> - [1/N] #24099 (merged) — token usage accounting
> - [2/N] #24202 (merged) — chat persistence
> - [3/N] #24235 — tool-call views ← **parent**
> - **[4/N] this PR** — composer token usage + active provider
>
> Review only the top 5 commits; the rest belong to #24235 and will drop out once it merges.

### Related Issues/PRs

Relates to #24235

### What changes are proposed in this pull request?

Surfaces two read-only signals in the Assistant composer footer:
- Cumulative session **token usage**, with a hover breakdown of **fresh Input / Cached / Output** tokens and an estimated cost when the model is priced.
- The **active provider** for the current session.

**On the cached-token breakdown.** Multi-turn sessions resend the whole conversation each turn, which providers report as prompt-cache reads folded into the prompt-token total. Summing those into one "Input" number made the headline balloon with mostly cheap, re-read context (e.g. a single "hi" through the Claude Code CLI reports ~13k fresh + ~25k cache write on turn one, because the agent harness — system prompt + tool schemas — is large and gets cached). The footer now threads a `cache_read_tokens` field from all three providers (`claude_code`, `codex`, `openai_compatible`) through the token accumulator and splits the tooltip into fresh Input (prompt − cached) plus a separate Cached line (shown only when > 0), so the number is honest about what is new work vs. re-read cache.

Commits in this PR (top of the stack):
- `ad7ed751` — show session token usage in the composer
- `e8693b0d` — show the active provider
- `82ff3eca` — remove a redundant composer spacer
- `4168f8e7` — surface cached tokens separately in the footer (+ fix a `groupParts` double-append bug on the branch)
- `222cceb9` — address review comments (react-intl number/currency formatting, provider-label truncation, drop em-dashes)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual testing

`AssistantContext` gains a test that per-turn usage deltas accumulate and cached tokens are tracked separately; provider tests assert each emits `cache_read_tokens`. Manually verified the footer breakdown against the Claude Code CLI (cache reads appear on repeat turns) and a gateway route.

<img width="448" height="946" alt="tokenassistant" src="https://github.com/user-attachments/assets/81be4943-c119-4be5-b9f4-0c7bb054545d" />

With Cached Tokens

 
<img width="442" height="946" alt="Screenshot 2026-07-21 at 9 35 53 PM" src="https://github.com/user-attachments/assets/3d78b0df-1b3d-4c69-9b4b-d02c25bbcf23" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Assistant composer now shows session token usage (with a fresh/cached/output breakdown and estimated cost) and the active provider.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release