### PR TITLE
fix: check all tables exist before initializing DB to avoid duplicate table error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -92,9 +92,13 @@ def _initialize_tables(engine):
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     from mlflow.utils.file_utils import ExclusiveFileLock
 
+    if _all_tables_exist(engine):
+        # All tables already exist, just run pending migrations
+        _upgrade_db(engine)
+        return
+
     if os.name == "nt":
-        if not _all_tables_exist(engine):
-            _initialize_tables(engine)
+        _initialize_tables(engine)
         return
 
     url_hash = hashlib.md5(
@@ -102,8 +106,7 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
         usedforsecurity=False,
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
-        if not _all_tables_exist(engine):
-            _initialize_tables(engine)
+        _initialize_tables(engine)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, `mlflow db upgrade` fails with `Table 'secrets' already exists`. This happens because the `_safe_initialize_tables` function only calls `_initialize_tables` (which runs initial table creation and then calls `_upgrade_db`) when not all tables exist. However, the 'secrets' table is part of the ORM metadata but is created by a migration, not during initial table creation. When the database has existing tables but is missing the new 'secrets' table, `_all_tables_exist()` returns False, leading to an attempt to create all initial tables again (including 'secrets' from ORM metadata), which conflicts with Alembic's own creation during upgrade.

## Fix
Modify `_safe_initialize_tables` to check `_all_tables_exist()` first. If all tables already exist, directly call `_upgrade_db()` to only run pending Alembic migrations, bypassing the initial table creation that duplicates tables. This ensures that the migration that adds the 'secrets' table is applied without conflict.

Closes #19943