### PR TITLE
[Security] Deny Assistant Read tool file access when no project directory is configured

### DIFF
--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -64,8 +64,10 @@ def static_permission_error(
     if tool_name in {"Write", "Edit"} and not cwd:
         return f"Permission denied: {tool_name} requires a configured project directory"
 
-    if tool_name in _FILE_TOOLS and cwd:
+    if tool_name in _FILE_TOOLS:
         if raw_path := tool_input.get("file_path") or tool_input.get("path", ""):
+            if cwd is None:
+                return f"Permission denied: {tool_name} requires a configured project directory"
             target = _resolve_file_path(raw_path, cwd)
             if not _is_path_within(target, cwd):
                 return f"Permission denied: path {raw_path} is outside the workspace {cwd}"

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -25,10 +25,25 @@ def test_read_resolves_relative_path_against_cwd(workspace):
     assert "print('hello')" in result
 
 
-def test_read_absolute_path_works_without_cwd(workspace):
+def test_read_absolute_path_denied_without_cwd(workspace):
+    # Regression guard for GHSA-27c7-qx3r-x4f8: without a configured project
+    # directory (cwd=None, e.g. no experiment_id), Read must be denied rather
+    # than allowed to read an arbitrary absolute path on the filesystem.
     result, is_error = _run(execute_tool("Read", {"file_path": str(workspace / "README.md")}))
-    assert not is_error
-    assert "# project" in result
+    assert is_error
+    assert "Permission denied" in result
+
+
+def test_read_sensitive_file_denied_without_cwd(tmp_path):
+    # Regression guard for GHSA-27c7-qx3r-x4f8: an absolute path to a file
+    # completely outside any workspace (e.g. an .env or SSH key) must be
+    # denied when no cwd/experiment_id is configured, not read back verbatim.
+    secret = tmp_path / "secret.env"
+    secret.write_text("SECRET_API_KEY=sk-super-secret-12345")
+    result, is_error = _run(execute_tool("Read", {"file_path": str(secret)}))
+    assert is_error
+    assert "Permission denied" in result
+    assert "SECRET_API_KEY" not in result
 
 
 def test_write_denied_without_cwd():


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/security/advisories/GHSA-27c7-qx3r-x4f8

### What changes are proposed in this pull request?

The file tool boundary check in `static_permission_error` (`mlflow/assistant/providers/tool_executor.py`) was guarded by `tool_name in _FILE_TOOLS and cwd`. When a message is sent to the assistant without an `experiment_id`, `cwd` is `None`, Python short circuits the condition to `False`, and the entire boundary check is skipped. The `Read` tool would then read any absolute path the LLM asked for, including `.env` files, SSH keys, `~/.mlflow/` config, and `/etc/passwd`, with no restriction.

The fix always enters the file tool check for `Read`, `Write`, and `Edit`, and explicitly denies the call when `cwd is None` instead of silently allowing it. `Write` and `Edit` already required a configured `cwd` via a separate check earlier in the function, so this closes the same requirement for `Read`.

Checked the history of this code: the vulnerable check and its test were both added in the same PR (#22098, "Add Ollama as assistant provider"), by the same author, in the same commit. During review of that PR, an automated reviewer flagged this exact class of issue as critical, warning that `Read`/`Write`/`Edit` accepted arbitrary paths and did not restrict access to the session or project directory. The author's response was to add the `_is_path_within` boundary check, but it was gated with `and cwd`, so it silently no-ops when `cwd` is `None`. There is no reply in that review thread defending the `cwd is None` case, so this looks like an incomplete fix of the reviewer's original concern rather than a deliberate design choice.

`tests/assistant/test_tool_executor.py::test_read_absolute_path_works_without_cwd` previously asserted that an absolute path `Read` with no `cwd` should succeed, codifying the vulnerable behavior as expected. It is renamed and inverted to `test_read_absolute_path_denied_without_cwd`, and a new `test_read_sensitive_file_denied_without_cwd` regression test mirrors the advisory's proof of concept.

Reported via GitHub Security Advisory: https://github.com/mlflow/mlflow/security/advisories/GHSA-27c7-qx3r-x4f8

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Ran the full `tests/assistant/test_tool_executor.py` suite and the `static_permission_error` tests in `tests/assistant/providers/test_openai_compatible_provider.py` against the patched code, all passing. Also reproduced the advisory's proof of concept directly against the pre-patch code (an unauthenticated `Read` with `cwd=None` returned a fabricated secret file's contents verbatim), then confirmed the same call is denied after the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow Assistant's `Read` tool now requires a configured project directory (set via `experiment_id`) and denies file reads when none is configured, instead of allowing unrestricted filesystem access.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release