### PR TITLE
[Model Registry] Gate UC model-registry client on native `/api/2.1` endpoints

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -501,6 +501,16 @@ MLFLOW_ENABLE_UC_VOLUME_FUSE_ARTIFACT_REPO = _BooleanEnvironmentVariable(
     "MLFLOW_ENABLE_UC_VOLUME_FUSE_ARTIFACT_REPO", True
 )
 
+#: Specifies whether to route Unity Catalog model-registry calls to the native
+#: ``/api/2.1/unity-catalog/*`` endpoints. When ``True``, the ``databricks-uc`` scheme instantiates
+#: the native store that issues requests against the native surface; when ``False`` (default), the
+#: legacy store using the ``/api/2.0/mlflow/unity-catalog/*`` endpoints is used. This is a static
+#: per-process choice read when the store is constructed, not an adaptive runtime fallback.
+#: (default: ``False``)
+MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY = _BooleanEnvironmentVariable(
+    "MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY", False
+)
+
 #: Private environment variable that should be set to ``True`` when running autologging tests.
 #: (default: ``False``)
 _MLFLOW_AUTOLOGGING_TESTING = _BooleanEnvironmentVariable("MLFLOW_AUTOLOGGING_TESTING", False)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -493,11 +493,15 @@ class ModelRegistryStoreRegistryWrapper(ModelRegistryStoreRegistry):
     @classmethod
     def _get_databricks_uc_rest_store(cls, store_uri):
         from mlflow.environment_variables import MLFLOW_TRACKING_URI
-        from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
+        from mlflow.store._unity_catalog.registry.utils import (
+            get_uc_model_registry_store_class,
+        )
 
         # Get tracking URI from environment or use "databricks-uc" as default
         tracking_uri = MLFLOW_TRACKING_URI.get() or "databricks-uc"
-        return UcModelRegistryStore(store_uri, tracking_uri)
+        # The native /api/2.1 store and the legacy /api/2.0 store are separate classes; select
+        # which one to instantiate based on MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY.
+        return get_uc_model_registry_store_class()(store_uri, tracking_uri)
 
 
 _tracking_store_registry = TrackingStoreRegistryWrapper()

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -1115,9 +1115,6 @@ class UcModelRegistryStore(BaseRestStore):
         # legacy proto, which carries it directly.
         version = model_version.version
         credential_name = model_name if model_name is not None else model_version.name
-        resolved_storage_location = (
-            storage_location if storage_location is not None else model_version.storage_location
-        )
 
         def base_credential_refresh_def():
             return self._get_temporary_model_version_write_credentials(
@@ -1126,9 +1123,14 @@ class UcModelRegistryStore(BaseRestStore):
 
         if is_databricks_sdk_models_artifact_repository_enabled(self.get_host_creds()):
             return DatabricksSDKModelsArtifactRepository(
-                model_name, version, registry_uri=self.store_uri
+                credential_name, version, registry_uri=self.store_uri
             )
 
+        resolved_storage_location = (
+            storage_location
+            if storage_location is not None
+            else getattr(model_version, "storage_location", None)
+        )
         scoped_token = base_credential_refresh_def()
         if scoped_token.storage_mode == StorageMode.DEFAULT_STORAGE:
             return PresignedUrlArtifactRepository(self.get_host_creds(), credential_name, version)

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -186,6 +186,14 @@ _logger = logging.getLogger(__name__)
 _DELTA_TABLE = "delta_table"
 _MAX_LINEAGE_DATA_SOURCES = 10
 
+# Model-version dependency type labels emitted by ``get_model_version_dependencies`` and consumed
+# when translating them into the governance ``DependencyList`` on the native create path.
+_DEP_TYPE_VECTOR_INDEX = "DATABRICKS_VECTOR_INDEX"
+_DEP_TYPE_MODEL_ENDPOINT = "DATABRICKS_MODEL_ENDPOINT"
+_DEP_TYPE_UC_FUNCTION = "DATABRICKS_UC_FUNCTION"
+_DEP_TYPE_UC_CONNECTION = "DATABRICKS_UC_CONNECTION"
+_DEP_TYPE_TABLE = "DATABRICKS_TABLE"
+
 # Pre-compiled regex patterns for better performance in search operations
 _CATALOG_PATTERN = re.compile(r"catalog\s*=\s*['\"]([^'\"]+)['\"]", re.IGNORECASE)
 _SCHEMA_PATTERN = re.compile(r"schema\s*=\s*['\"]([^'\"]+)['\"]", re.IGNORECASE)
@@ -282,35 +290,35 @@ def get_model_version_dependencies(model_dir):
             _fetch_langchain_dependency_from_model_resources(
                 databricks_dependencies,
                 ResourceType.VECTOR_SEARCH_INDEX.value,
-                "DATABRICKS_VECTOR_INDEX",
+                _DEP_TYPE_VECTOR_INDEX,
             )
         )
         dependencies.extend(
             _fetch_langchain_dependency_from_model_resources(
                 databricks_dependencies,
                 ResourceType.SERVING_ENDPOINT.value,
-                "DATABRICKS_MODEL_ENDPOINT",
+                _DEP_TYPE_MODEL_ENDPOINT,
             )
         )
         dependencies.extend(
             _fetch_langchain_dependency_from_model_resources(
                 databricks_dependencies,
                 ResourceType.FUNCTION.value,
-                "DATABRICKS_UC_FUNCTION",
+                _DEP_TYPE_UC_FUNCTION,
             )
         )
         dependencies.extend(
             _fetch_langchain_dependency_from_model_resources(
                 databricks_dependencies,
                 ResourceType.UC_CONNECTION.value,
-                "DATABRICKS_UC_CONNECTION",
+                _DEP_TYPE_UC_CONNECTION,
             )
         )
         dependencies.extend(
             _fetch_langchain_dependency_from_model_resources(
                 databricks_dependencies,
                 ResourceType.TABLE.value,
-                "DATABRICKS_TABLE",
+                _DEP_TYPE_TABLE,
             )
         )
     else:
@@ -328,7 +336,7 @@ def get_model_version_dependencies(model_dir):
             databricks_dependencies, _DATABRICKS_VECTOR_SEARCH_INDEX_NAME_KEY
         )
         dependencies.extend(
-            {"type": "DATABRICKS_VECTOR_INDEX", "name": index_name} for index_name in index_names
+            {"type": _DEP_TYPE_VECTOR_INDEX, "name": index_name} for index_name in index_names
         )
         for key in (
             _DATABRICKS_EMBEDDINGS_ENDPOINT_NAME_KEY,
@@ -339,7 +347,7 @@ def get_model_version_dependencies(model_dir):
                 databricks_dependencies, key
             )
             dependencies.extend(
-                {"type": "DATABRICKS_MODEL_ENDPOINT", "name": endpoint_name}
+                {"type": _DEP_TYPE_MODEL_ENDPOINT, "name": endpoint_name}
                 for endpoint_name in endpoint_names
             )
     return dependencies
@@ -997,29 +1005,63 @@ class UcModelRegistryStore(BaseRestStore):
             other_model_deps = (
                 [] if model_id_cleared else get_model_version_dependencies(local_model_dir)
             )
-            req_body = message_to_json(
-                CreateModelVersionRequest(
-                    name=full_name,
-                    source=source,
-                    run_id=run_id,
-                    description=description,
-                    tags=uc_model_version_tag_from_mlflow_tags(tags),
-                    run_tracking_server_id=source_workspace_id,
-                    feature_deps=feature_deps,
-                    model_version_dependencies=other_model_deps,
-                    model_id=model_id,
-                )
+            return self._create_and_finalize_model_version(
+                full_name=full_name,
+                source=source,
+                description=description,
+                run_id=run_id,
+                tags=tags,
+                feature_deps=feature_deps,
+                other_model_deps=other_model_deps,
+                model_id=model_id,
+                source_workspace_id=source_workspace_id,
+                extra_headers=extra_headers,
+                local_model_dir=local_model_dir,
             )
-            model_version = self._call_endpoint(
-                CreateModelVersionRequest, req_body, extra_headers=extra_headers
-            ).model_version
 
-            store = self._get_artifact_repo(model_version, full_name)
-            store.log_artifacts(local_dir=local_model_dir, artifact_path="")
-            finalized_mv = self._finalize_model_version(
-                name=full_name, version=model_version.version
+    def _create_and_finalize_model_version(
+        self,
+        *,
+        full_name,
+        source,
+        description,
+        run_id,
+        tags,
+        feature_deps,
+        other_model_deps,
+        model_id,
+        source_workspace_id,
+        extra_headers,
+        local_model_dir,
+    ):
+        """Create a model version on the backend, upload its files, and finalize it.
+
+        Isolated as an overridable seam so backend-specific stores (e.g. the native UC store) can
+        swap the request/response protos and endpoints without duplicating the shared prep in
+        ``_create_model_version_with_optional_signature_validation`` (signature validation, weight
+        download, dependency/lineage collection).
+        """
+        req_body = message_to_json(
+            CreateModelVersionRequest(
+                name=full_name,
+                source=source,
+                run_id=run_id,
+                description=description,
+                tags=uc_model_version_tag_from_mlflow_tags(tags),
+                run_tracking_server_id=source_workspace_id,
+                feature_deps=feature_deps,
+                model_version_dependencies=other_model_deps,
+                model_id=model_id,
             )
-            return model_version_from_uc_proto(finalized_mv)
+        )
+        model_version = self._call_endpoint(
+            CreateModelVersionRequest, req_body, extra_headers=extra_headers
+        ).model_version
+
+        store = self._get_artifact_repo(model_version, full_name)
+        store.log_artifacts(local_dir=local_model_dir, artifact_path="")
+        finalized_mv = self._finalize_model_version(name=full_name, version=model_version.version)
+        return model_version_from_uc_proto(finalized_mv)
 
     def create_model_version(
         self,
@@ -1067,25 +1109,32 @@ class UcModelRegistryStore(BaseRestStore):
             bypass_signature_validation=False,
         )
 
-    def _get_artifact_repo(self, model_version, model_name=None):
+    def _get_artifact_repo(self, model_version, model_name=None, storage_location=None):
+        # The native model-version proto has no `name` field, so the caller supplies the full
+        # catalog.schema.model name via `model_name`; fall back to `model_version.name` for the
+        # legacy proto, which carries it directly.
+        version = model_version.version
+        credential_name = model_name if model_name is not None else model_version.name
+        resolved_storage_location = (
+            storage_location if storage_location is not None else model_version.storage_location
+        )
+
         def base_credential_refresh_def():
             return self._get_temporary_model_version_write_credentials(
-                name=model_version.name, version=model_version.version
+                name=credential_name, version=version
             )
 
         if is_databricks_sdk_models_artifact_repository_enabled(self.get_host_creds()):
             return DatabricksSDKModelsArtifactRepository(
-                model_name, model_version.version, registry_uri=self.store_uri
+                model_name, version, registry_uri=self.store_uri
             )
 
         scoped_token = base_credential_refresh_def()
         if scoped_token.storage_mode == StorageMode.DEFAULT_STORAGE:
-            return PresignedUrlArtifactRepository(
-                self.get_host_creds(), model_version.name, model_version.version
-            )
+            return PresignedUrlArtifactRepository(self.get_host_creds(), credential_name, version)
 
         return get_artifact_repo_from_storage_info(
-            storage_location=model_version.storage_location,
+            storage_location=resolved_storage_location,
             scoped_token=scoped_token,
             base_credential_refresh_def=base_credential_refresh_def,
         )
@@ -1821,7 +1870,9 @@ class UcModelRegistryStore(BaseRestStore):
         except Exception:
             _logger.debug("Failed to link prompt version to run in unity catalog", exc_info=True)
 
-    def _edit_endpoint_and_call(self, endpoint, method, req_body, proto_name, **kwargs):
+    def _edit_endpoint_and_call(
+        self, endpoint, method, req_body, proto_name, extra_headers=None, **kwargs
+    ):
         """
         Edit endpoint URL with parameters and make the call.
 
@@ -1830,6 +1881,7 @@ class UcModelRegistryStore(BaseRestStore):
             method: HTTP method
             req_body: Request body
             proto_name: Protobuf message class for response
+            extra_headers: Optional extra HTTP headers to send with the request.
             **kwargs: Parameters to substitute in the endpoint template
         """
         # Replace placeholders in endpoint with actual values
@@ -1844,4 +1896,5 @@ class UcModelRegistryStore(BaseRestStore):
             method=method,
             json_body=req_body,
             response_proto=self._get_response_from_method(proto_name),
+            extra_headers=extra_headers,
         )

--- a/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
@@ -1,0 +1,672 @@
+"""Unity Catalog model-registry store that talks to the native /api/2.1/unity-catalog/* surface.
+
+``UcNativeModelRegistryStore`` subclasses :class:`UcModelRegistryStore` and overrides the
+model-registry operations that have a native Unity Catalog equivalent so they issue requests
+against the native ``UnityCatalogService`` endpoints (flat ``RegisteredModelInfo`` /
+``ModelVersionInfo`` responses) and fold the enriched governance/metadata fields back into the
+MLflow entities. Every other operation -- prompts, the unsupported stage/latest-version methods,
+and all shared helpers -- is inherited unchanged from the legacy store.
+
+The store is selected (instead of the legacy ``UcModelRegistryStore``) when
+``MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY`` is enabled; see the ``databricks-uc`` store factories.
+"""
+
+from mlflow.entities.logged_model_parameter import LoggedModelParameter as ModelParam
+from mlflow.entities.metric import Metric
+from mlflow.entities.model_registry import (
+    ModelVersion,
+    ModelVersionDeploymentJobState,
+    ModelVersionTag,
+    RegisteredModel,
+    RegisteredModelAlias,
+    RegisteredModelDeploymentJobState,
+    RegisteredModelTag,
+)
+from mlflow.entities.model_registry.model_version_search import ModelVersionSearch
+from mlflow.entities.model_registry.registered_model_search import RegisteredModelSearch
+from mlflow.exceptions import MlflowException, RestException
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    ConnectionDependency,
+    CreateModelVersion,
+    CreateRegisteredModel,
+    DeleteModelVersion,
+    DeleteRegisteredModel,
+    DeleteRegisteredModelAlias,
+    DependencyList,
+    FinalizeModelVersion,
+    FunctionDependency,
+    GenerateTemporaryModelVersionCredential,
+    GetModelVersion,
+    GetModelVersionByAlias,
+    GetRegisteredModel,
+    ListModelVersions,
+    ListRegisteredModels,
+    ModelVersionDependency,
+    ModelVersionInfo,
+    ModelVersionOperation,
+    RegisteredModelInfo,
+    SetRegisteredModelAlias,
+    TableDependency,
+    TagAssignmentsChange,
+    TagKeyValue,
+    TemporaryCredentials,
+    UpdateModelVersion,
+    UpdateRegisteredModel,
+    UpdateTagSecurableAssignments,
+    UpdateTagSubentityAssignments,
+)
+from mlflow.protos.unity_catalog_service_pb2 import UnityCatalogService
+from mlflow.store._unity_catalog.registry.rest_store import (
+    _DEP_TYPE_TABLE,
+    _DEP_TYPE_UC_CONNECTION,
+    _DEP_TYPE_UC_FUNCTION,
+    _DEP_TYPE_VECTOR_INDEX,
+    UcModelRegistryStore,
+    _require_arg_unspecified,
+)
+from mlflow.store.entities.paged_list import PagedList
+from mlflow.utils._unity_catalog_oss_utils import parse_model_name
+from mlflow.utils._unity_catalog_utils import (
+    get_full_name_from_sc,
+    uc_model_version_status_to_string,
+)
+from mlflow.utils.databricks_utils import _print_databricks_deployment_job_url
+from mlflow.utils.proto_json_utils import message_to_json
+from mlflow.utils.rest_utils import (
+    _UC_OSS_REST_API_PATH_PREFIX,
+    extract_api_info_for_service,
+)
+
+# Native UC model-registry endpoints on the /api/2.1/unity-catalog/* surface.
+_NATIVE_METHOD_TO_INFO = extract_api_info_for_service(
+    UnityCatalogService, _UC_OSS_REST_API_PATH_PREFIX
+)
+
+
+def registered_model_from_uc_native_proto(uc_proto: RegisteredModelInfo) -> RegisteredModel:
+    """Convert a native UC ``RegisteredModelInfo`` (governance + enrichment fields) into a
+    :class:`~mlflow.entities.model_registry.RegisteredModel`."""
+    return RegisteredModel(
+        # ``full_name`` is the backend's output-only canonical <catalog>.<schema>.<model> name.
+        name=uc_proto.full_name,
+        creation_timestamp=uc_proto.created_at,
+        last_updated_timestamp=uc_proto.updated_at,
+        description=uc_proto.comment,
+        # Governance aliases are {alias_name, version_num}; the MLflow entity expects
+        # {alias, version} with a string version.
+        aliases=[
+            RegisteredModelAlias(alias=alias.alias_name, version=str(alias.version_num))
+            for alias in (uc_proto.aliases or [])
+        ],
+        tags=[RegisteredModelTag(key=tag.key, value=tag.value) for tag in (uc_proto.tags or [])],
+        deployment_job_id=uc_proto.deployment_job_id,
+        deployment_job_state=RegisteredModelDeploymentJobState.to_string(
+            uc_proto.deployment_job_state
+        ),
+    )
+
+
+def model_version_from_uc_native_proto(uc_proto: ModelVersionInfo) -> ModelVersion:
+    """Convert a native UC ``ModelVersionInfo`` (governance + enrichment fields) into a
+    :class:`~mlflow.entities.model_registry.ModelVersion`."""
+    return ModelVersion(
+        name=f"{uc_proto.catalog_name}.{uc_proto.schema_name}.{uc_proto.model_name}",
+        # The governance proto types version as int64; the MLflow entity's version is a string
+        # (matching the legacy MLflow-dialect surface, which sent it as a string field).
+        version=str(uc_proto.version),
+        creation_timestamp=uc_proto.created_at,
+        last_updated_timestamp=uc_proto.updated_at,
+        description=uc_proto.comment,
+        user_id=uc_proto.created_by,
+        source=uc_proto.source,
+        run_id=uc_proto.run_id,
+        status=uc_model_version_status_to_string(uc_proto.status),
+        aliases=[alias.alias_name for alias in (uc_proto.aliases or [])],
+        tags=[ModelVersionTag(key=tag.key, value=tag.value) for tag in (uc_proto.tags or [])],
+        model_id=uc_proto.model_id,
+        params=[
+            ModelParam(key=param.name, value=param.value) for param in (uc_proto.model_params or [])
+        ],
+        metrics=[
+            Metric(
+                key=metric.key,
+                value=metric.value,
+                timestamp=metric.timestamp,
+                step=metric.step,
+                dataset_name=metric.dataset_name,
+                dataset_digest=metric.dataset_digest,
+                model_id=metric.model_id,
+                run_id=metric.run_id,
+            )
+            for metric in (uc_proto.model_metrics or [])
+        ],
+        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
+            uc_proto.deployment_job_state
+        ),
+    )
+
+
+def registered_model_search_from_uc_native_proto(
+    uc_proto: RegisteredModelInfo,
+) -> RegisteredModelSearch:
+    """Convert a native UC ``RegisteredModelInfo`` search hit into a
+    :class:`~mlflow.entities.model_registry.registered_model_search.RegisteredModelSearch`.
+    Search results intentionally omit tags/aliases (``RegisteredModelSearch`` forces them empty)."""
+    return RegisteredModelSearch(
+        # ``full_name`` is the backend's output-only canonical <catalog>.<schema>.<model> name.
+        name=uc_proto.full_name,
+        creation_timestamp=uc_proto.created_at,
+        last_updated_timestamp=uc_proto.updated_at,
+        description=uc_proto.comment,
+        aliases=[],
+        tags=[],
+    )
+
+
+def model_version_search_from_uc_native_proto(
+    uc_proto: ModelVersionInfo,
+) -> ModelVersionSearch:
+    """Convert a native UC ``ModelVersionInfo`` search hit into a
+    :class:`~mlflow.entities.model_registry.model_version_search.ModelVersionSearch`.
+    Search results intentionally omit tags/aliases (``ModelVersionSearch`` forces them empty)."""
+    return ModelVersionSearch(
+        name=f"{uc_proto.catalog_name}.{uc_proto.schema_name}.{uc_proto.model_name}",
+        # int64 governance version -> string entity version (see the model-version converter).
+        version=str(uc_proto.version),
+        creation_timestamp=uc_proto.created_at,
+        last_updated_timestamp=uc_proto.updated_at,
+        description=uc_proto.comment,
+        user_id=uc_proto.created_by,
+        source=uc_proto.source,
+        run_id=uc_proto.run_id,
+        status=uc_model_version_status_to_string(uc_proto.status),
+        aliases=[],
+        tags=[],
+        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
+            uc_proto.deployment_job_state
+        ),
+    )
+
+
+def _split_uc_name(full_name):
+    match full_name.split("."):
+        case [catalog, schema, model] if all((catalog, schema, model)):
+            return catalog, schema, model
+        case _:
+            raise MlflowException(
+                f"Not a valid Unity Catalog model name: '{full_name}'. Unity Catalog model names "
+                "must have three levels (catalog.schema.model). If you are trying to use the "
+                "legacy Workspace Model Registry instead of the recommended Unity Catalog Model "
+                "Registry, set the Model Registry URI to 'databricks' (legacy) instead of "
+                "'databricks-uc'."
+            )
+
+
+class UcNativeModelRegistryStore(UcModelRegistryStore):
+    """UC model-registry store that routes operations to the native /api/2.1/unity-catalog/*
+    endpoints. See the module docstring for details."""
+
+    def _get_response_from_method(self, method):
+        # The server json_inlines the response wrapper, so each native body parses directly into
+        # the flat top-level proto (list responses parse into the message's nested `.Response`).
+        native_method_to_response = {
+            GetRegisteredModel: RegisteredModelInfo,
+            CreateRegisteredModel: RegisteredModelInfo,
+            UpdateRegisteredModel: RegisteredModelInfo,
+            ListRegisteredModels: ListRegisteredModels.Response,
+            DeleteRegisteredModel: DeleteRegisteredModel.Response,
+            GetModelVersion: ModelVersionInfo,
+            GetModelVersionByAlias: ModelVersionInfo,
+            CreateModelVersion: ModelVersionInfo,
+            UpdateModelVersion: ModelVersionInfo,
+            FinalizeModelVersion: ModelVersionInfo,
+            ListModelVersions: ListModelVersions.Response,
+            DeleteModelVersion: DeleteModelVersion.Response,
+            GenerateTemporaryModelVersionCredential: TemporaryCredentials,
+            SetRegisteredModelAlias: SetRegisteredModelAlias.Response,
+            DeleteRegisteredModelAlias: DeleteRegisteredModelAlias.Response,
+            UpdateTagSecurableAssignments: UpdateTagSecurableAssignments.Response,
+            UpdateTagSubentityAssignments: UpdateTagSubentityAssignments.Response,
+        }
+        if method in native_method_to_response:
+            return native_method_to_response[method]()
+        # Prompt operations (and anything else) are inherited and served by the legacy map.
+        return super()._get_response_from_method(method)
+
+    def _get_native_endpoint_from_method(self, method):
+        return _NATIVE_METHOD_TO_INFO[method]
+
+    # CRUD API for RegisteredModel objects
+
+    def create_registered_model(self, name, tags=None, description=None, deployment_job_id=None):
+        full_name = get_full_name_from_sc(name, self.spark)
+        catalog, schema, model = _split_uc_name(full_name)
+        req_body = message_to_json(
+            CreateRegisteredModel(
+                name=model,
+                catalog_name=catalog,
+                schema_name=schema,
+                comment=description,
+                tags=[TagKeyValue(key=t.key, value=t.value) for t in (tags or [])],
+                deployment_job_id=str(deployment_job_id) if deployment_job_id else None,
+            )
+        )
+        endpoint, method = self._get_native_endpoint_from_method(CreateRegisteredModel)
+        try:
+            resp = self._edit_endpoint_and_call(
+                endpoint=endpoint,
+                method=method,
+                req_body=req_body,
+                proto_name=CreateRegisteredModel,
+            )
+        except RestException as e:
+            if "METASTORE_DOES_NOT_EXIST" in e.message:
+                # The user is likely on a workspace without Unity Catalog enabled.
+                raise MlflowException(
+                    message=e.message.rstrip(".")
+                    + ". If you are trying to use the Model Registry in a Databricks workspace"
+                    " that does not have Unity Catalog enabled, either enable Unity Catalog in"
+                    " the workspace (recommended) or set the Model Registry URI to 'databricks'"
+                    " to use the legacy Workspace Model Registry.",
+                    error_code=e.error_code,
+                )
+            raise
+        if deployment_job_id:
+            _print_databricks_deployment_job_url(
+                model_name=full_name, job_id=str(deployment_job_id)
+            )
+        return registered_model_from_uc_native_proto(resp)
+
+    def update_registered_model(self, name, description=None, deployment_job_id=None):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            UpdateRegisteredModel(
+                full_name=full_name,
+                comment=description,
+                deployment_job_id=(
+                    str(deployment_job_id) if deployment_job_id is not None else None
+                ),
+            )
+        )
+        endpoint, method = self._get_native_endpoint_from_method(UpdateRegisteredModel)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateRegisteredModel,
+            full_name=full_name,
+        )
+        if deployment_job_id:
+            _print_databricks_deployment_job_url(
+                model_name=full_name, job_id=str(deployment_job_id)
+            )
+        return registered_model_from_uc_native_proto(native_resp)
+
+    def rename_registered_model(self, name, new_name):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(UpdateRegisteredModel(full_name=full_name, new_name=new_name))
+        endpoint, method = self._get_native_endpoint_from_method(UpdateRegisteredModel)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateRegisteredModel,
+            full_name=full_name,
+        )
+        return registered_model_from_uc_native_proto(native_resp)
+
+    def delete_registered_model(self, name):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(DeleteRegisteredModel(full_name=full_name))
+        endpoint, method = self._get_native_endpoint_from_method(DeleteRegisteredModel)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=DeleteRegisteredModel,
+            full_name=full_name,
+        )
+
+    def search_registered_models(
+        self, filter_string=None, max_results=None, order_by=None, page_token=None
+    ):
+        _require_arg_unspecified("filter_string", filter_string)
+        _require_arg_unspecified("order_by", order_by)
+        req_body = message_to_json(
+            ListRegisteredModels(max_results=max_results, page_token=page_token)
+        )
+        endpoint, method = self._get_native_endpoint_from_method(ListRegisteredModels)
+        resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=req_body,
+            proto_name=ListRegisteredModels,
+        )
+        registered_models = [
+            registered_model_search_from_uc_native_proto(rm) for rm in resp.registered_models
+        ]
+        return PagedList(registered_models, resp.next_page_token)
+
+    def get_registered_model(self, name):
+        full_name = get_full_name_from_sc(name, self.spark)
+        # include_aliases is a Databricks-backend opt-in; without it the response omits
+        # registered-model aliases (the OSS UC backend ignores the flag).
+        native_req = message_to_json(GetRegisteredModel(full_name=full_name, include_aliases=True))
+        endpoint, method = self._get_native_endpoint_from_method(GetRegisteredModel)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=GetRegisteredModel,
+            full_name=full_name,
+        )
+        return registered_model_from_uc_native_proto(native_resp)
+
+    def set_registered_model_tag(self, name, tag):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            UpdateTagSecurableAssignments(
+                changes=TagAssignmentsChange(add_tags=[TagKeyValue(key=tag.key, value=tag.value)])
+            )
+        )
+        endpoint, method = self._get_native_endpoint_from_method(UpdateTagSecurableAssignments)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateTagSecurableAssignments,
+            securable_type="FUNCTION",
+            securable_full_name=full_name,
+        )
+
+    def delete_registered_model_tag(self, name, key):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            UpdateTagSecurableAssignments(changes=TagAssignmentsChange(remove=[key]))
+        )
+        endpoint, method = self._get_native_endpoint_from_method(UpdateTagSecurableAssignments)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateTagSecurableAssignments,
+            securable_type="FUNCTION",
+            securable_full_name=full_name,
+        )
+
+    # CRUD API for ModelVersion objects
+
+    def _get_temporary_model_version_write_credentials(self, name, version) -> TemporaryCredentials:
+        catalog, schema, model = _split_uc_name(name)
+        req_body = message_to_json(
+            GenerateTemporaryModelVersionCredential(
+                catalog_name=catalog,
+                schema_name=schema,
+                model_name=model,
+                version=int(version),
+                operation=ModelVersionOperation.Value("READ_WRITE_MODEL_VERSION"),
+            )
+        )
+        # The response json_inlines the temporary credentials, so the flat body parses directly
+        # into the TemporaryCredentials proto.
+        endpoint, method = self._get_native_endpoint_from_method(
+            GenerateTemporaryModelVersionCredential
+        )
+        return self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=req_body,
+            proto_name=GenerateTemporaryModelVersionCredential,
+        )
+
+    def _create_and_finalize_model_version(
+        self,
+        *,
+        full_name,
+        source,
+        description,
+        run_id,
+        tags,
+        feature_deps,
+        other_model_deps,
+        model_id,
+        source_workspace_id,
+        extra_headers,
+        local_model_dir,
+    ):
+        catalog, schema, model = _split_uc_name(full_name)
+        # MLflow resource dependencies are translated to the governance DependencyList
+        # (vector-index/table -> table, UC function -> function, UC connection -> connection;
+        # model-endpoint and other kinds have no governance representation and are dropped, as on
+        # the legacy path).
+        deps = []
+        for dep in other_model_deps or []:
+            dep_type, dep_name = dep.get("type"), dep.get("name")
+            if dep_type in (_DEP_TYPE_VECTOR_INDEX, _DEP_TYPE_TABLE):
+                deps.append(
+                    ModelVersionDependency(table=TableDependency(table_full_name=dep_name))
+                )
+            elif dep_type == _DEP_TYPE_UC_FUNCTION:
+                deps.append(
+                    ModelVersionDependency(
+                        function=FunctionDependency(function_full_name=dep_name)
+                    )
+                )
+            elif dep_type == _DEP_TYPE_UC_CONNECTION:
+                deps.append(
+                    ModelVersionDependency(
+                        connection=ConnectionDependency(connection_name=dep_name)
+                    )
+                )
+        create_req = message_to_json(
+            CreateModelVersion(
+                model_name=model,
+                catalog_name=catalog,
+                schema_name=schema,
+                source=source,
+                comment=description,
+                run_id=run_id,
+                tags=[TagKeyValue(key=t.key, value=t.value) for t in (tags or [])],
+                model_version_dependencies=(DependencyList(dependencies=deps) if deps else None),
+                model_id=model_id,
+                feature_deps=feature_deps,
+                run_tracking_server_id=source_workspace_id,
+            )
+        )
+        endpoint, method = self._get_native_endpoint_from_method(CreateModelVersion)
+        model_version = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=create_req,
+            proto_name=CreateModelVersion,
+            extra_headers=extra_headers,
+        )
+        # The create response carries an int64 version; coerce so the finalize request (int64
+        # field) and the URL path segment are well-typed regardless of the source proto's Python
+        # type.
+        created_version = int(model_version.version)
+        store = self._get_artifact_repo(
+            model_version,
+            full_name,
+            storage_location=model_version.storage_location,
+        )
+        store.log_artifacts(local_dir=local_model_dir, artifact_path="")
+        finalize_req = message_to_json(
+            FinalizeModelVersion(full_name=full_name, version=created_version)
+        )
+        endpoint, method = self._get_native_endpoint_from_method(FinalizeModelVersion)
+        finalized = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=finalize_req,
+            proto_name=FinalizeModelVersion,
+            full_name=full_name,
+            version=created_version,
+        )
+        return model_version_from_uc_native_proto(finalized)
+
+    def update_model_version(self, name, version, description):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            UpdateModelVersion(full_name=full_name, version=int(version), comment=description)
+        )
+        endpoint, method = self._get_native_endpoint_from_method(UpdateModelVersion)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateModelVersion,
+            full_name=full_name,
+            version=version,
+        )
+        return model_version_from_uc_native_proto(native_resp)
+
+    def delete_model_version(self, name, version):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(DeleteModelVersion(full_name=full_name, version=int(version)))
+        endpoint, method = self._get_native_endpoint_from_method(DeleteModelVersion)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=DeleteModelVersion,
+            full_name=full_name,
+            version=version,
+        )
+
+    def get_model_version(self, name, version):
+        full_name = get_full_name_from_sc(name, self.spark)
+        # include_aliases is a Databricks-backend opt-in; without it the response omits
+        # registered-model aliases (the OSS UC backend ignores the flag).
+        native_req = message_to_json(
+            GetModelVersion(full_name=full_name, version=int(version), include_aliases=True)
+        )
+        endpoint, method = self._get_native_endpoint_from_method(GetModelVersion)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=GetModelVersion,
+            full_name=full_name,
+            version=version,
+        )
+        return model_version_from_uc_native_proto(native_resp)
+
+    def get_model_version_download_uri(self, name, version):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(GetModelVersion(full_name=full_name, version=int(version)))
+        endpoint, method = self._get_native_endpoint_from_method(GetModelVersion)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=GetModelVersion,
+            full_name=full_name,
+            version=version,
+        )
+        return native_resp.storage_location
+
+    def search_model_versions(
+        self, filter_string=None, max_results=None, order_by=None, page_token=None
+    ):
+        _require_arg_unspecified(arg_name="order_by", arg_value=order_by)
+        # UC model-version search supports only a `name = 'catalog.schema.model'` filter (per-model
+        # list); `parse_model_name` rejects any other filter (including `run_id`) with
+        # INVALID_PARAMETER_VALUE, matching the legacy registry, which never supported run_id
+        # search either.
+        full_name = parse_model_name(filter_string or "")
+        req_body = message_to_json(
+            ListModelVersions(full_name=full_name, page_token=page_token, max_results=max_results)
+        )
+        endpoint, method = self._get_native_endpoint_from_method(ListModelVersions)
+        resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=req_body,
+            proto_name=ListModelVersions,
+            full_name=full_name,
+        )
+        model_versions = [
+            model_version_search_from_uc_native_proto(mvd) for mvd in resp.model_versions
+        ]
+        return PagedList(model_versions, resp.next_page_token)
+
+    def set_model_version_tag(self, name, version, tag):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            UpdateTagSubentityAssignments(
+                changes=TagAssignmentsChange(add_tags=[TagKeyValue(key=tag.key, value=tag.value)])
+            )
+        )
+        endpoint, method = self._get_native_endpoint_from_method(UpdateTagSubentityAssignments)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateTagSubentityAssignments,
+            securable_type="FUNCTION",
+            securable_full_name=full_name,
+            subentity_name=version,
+        )
+
+    def delete_model_version_tag(self, name, version, key):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            UpdateTagSubentityAssignments(changes=TagAssignmentsChange(remove=[key]))
+        )
+        endpoint, method = self._get_native_endpoint_from_method(UpdateTagSubentityAssignments)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=UpdateTagSubentityAssignments,
+            securable_type="FUNCTION",
+            securable_full_name=full_name,
+            subentity_name=version,
+        )
+
+    def set_registered_model_alias(self, name, alias, version):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(
+            SetRegisteredModelAlias(full_name=full_name, alias=alias, version_num=int(version))
+        )
+        endpoint, method = self._get_native_endpoint_from_method(SetRegisteredModelAlias)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=SetRegisteredModelAlias,
+            full_name=full_name,
+            alias=alias,
+        )
+
+    def delete_registered_model_alias(self, name, alias):
+        full_name = get_full_name_from_sc(name, self.spark)
+        native_req = message_to_json(DeleteRegisteredModelAlias(full_name=full_name, alias=alias))
+        endpoint, method = self._get_native_endpoint_from_method(DeleteRegisteredModelAlias)
+        self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=DeleteRegisteredModelAlias,
+            full_name=full_name,
+            alias=alias,
+        )
+
+    def get_model_version_by_alias(self, name, alias):
+        full_name = get_full_name_from_sc(name, self.spark)
+        # include_aliases is a Databricks-backend opt-in; without it the response omits
+        # registered-model aliases (the OSS UC backend ignores the flag).
+        native_req = message_to_json(
+            GetModelVersionByAlias(full_name=full_name, alias=alias, include_aliases=True)
+        )
+        endpoint, method = self._get_native_endpoint_from_method(GetModelVersionByAlias)
+        native_resp = self._edit_endpoint_and_call(
+            endpoint=endpoint,
+            method=method,
+            req_body=native_req,
+            proto_name=GetModelVersionByAlias,
+            full_name=full_name,
+            alias=alias,
+        )
+        return model_version_from_uc_native_proto(native_resp)

--- a/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
@@ -85,7 +85,8 @@ _NATIVE_METHOD_TO_INFO = extract_api_info_for_service(
 
 def registered_model_from_uc_native_proto(uc_proto: RegisteredModelInfo) -> RegisteredModel:
     """Convert a native UC ``RegisteredModelInfo`` (governance + enrichment fields) into a
-    :class:`~mlflow.entities.model_registry.RegisteredModel`."""
+    :class:`~mlflow.entities.model_registry.RegisteredModel`.
+    """
     return RegisteredModel(
         # ``full_name`` is the backend's output-only canonical <catalog>.<schema>.<model> name.
         name=uc_proto.full_name,
@@ -108,7 +109,8 @@ def registered_model_from_uc_native_proto(uc_proto: RegisteredModelInfo) -> Regi
 
 def model_version_from_uc_native_proto(uc_proto: ModelVersionInfo) -> ModelVersion:
     """Convert a native UC ``ModelVersionInfo`` (governance + enrichment fields) into a
-    :class:`~mlflow.entities.model_registry.ModelVersion`."""
+    :class:`~mlflow.entities.model_registry.ModelVersion`.
+    """
     return ModelVersion(
         name=f"{uc_proto.catalog_name}.{uc_proto.schema_name}.{uc_proto.model_name}",
         # The governance proto types version as int64; the MLflow entity's version is a string
@@ -151,7 +153,8 @@ def registered_model_search_from_uc_native_proto(
 ) -> RegisteredModelSearch:
     """Convert a native UC ``RegisteredModelInfo`` search hit into a
     :class:`~mlflow.entities.model_registry.registered_model_search.RegisteredModelSearch`.
-    Search results intentionally omit tags/aliases (``RegisteredModelSearch`` forces them empty)."""
+    Search results intentionally omit tags/aliases (``RegisteredModelSearch`` forces them empty).
+    """
     return RegisteredModelSearch(
         # ``full_name`` is the backend's output-only canonical <catalog>.<schema>.<model> name.
         name=uc_proto.full_name,
@@ -168,7 +171,8 @@ def model_version_search_from_uc_native_proto(
 ) -> ModelVersionSearch:
     """Convert a native UC ``ModelVersionInfo`` search hit into a
     :class:`~mlflow.entities.model_registry.model_version_search.ModelVersionSearch`.
-    Search results intentionally omit tags/aliases (``ModelVersionSearch`` forces them empty)."""
+    Search results intentionally omit tags/aliases (``ModelVersionSearch`` forces them empty).
+    """
     return ModelVersionSearch(
         name=f"{uc_proto.catalog_name}.{uc_proto.schema_name}.{uc_proto.model_name}",
         # int64 governance version -> string entity version (see the model-version converter).
@@ -204,7 +208,8 @@ def _split_uc_name(full_name):
 
 class UcNativeModelRegistryStore(UcModelRegistryStore):
     """UC model-registry store that routes operations to the native /api/2.1/unity-catalog/*
-    endpoints. See the module docstring for details."""
+    endpoints. See the module docstring for details.
+    """
 
     def _get_response_from_method(self, method):
         # The server json_inlines the response wrapper, so each native body parses directly into
@@ -443,14 +448,10 @@ class UcNativeModelRegistryStore(UcModelRegistryStore):
         for dep in other_model_deps or []:
             dep_type, dep_name = dep.get("type"), dep.get("name")
             if dep_type in (_DEP_TYPE_VECTOR_INDEX, _DEP_TYPE_TABLE):
-                deps.append(
-                    ModelVersionDependency(table=TableDependency(table_full_name=dep_name))
-                )
+                deps.append(ModelVersionDependency(table=TableDependency(table_full_name=dep_name)))
             elif dep_type == _DEP_TYPE_UC_FUNCTION:
                 deps.append(
-                    ModelVersionDependency(
-                        function=FunctionDependency(function_full_name=dep_name)
-                    )
+                    ModelVersionDependency(function=FunctionDependency(function_full_name=dep_name))
                 )
             elif dep_type == _DEP_TYPE_UC_CONNECTION:
                 deps.append(

--- a/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
@@ -446,7 +446,8 @@ class UcNativeModelRegistryStore(UcModelRegistryStore):
         # the legacy path).
         deps = []
         for dep in other_model_deps or []:
-            dep_type, dep_name = dep.get("type"), dep.get("name")
+            dep_type = dep.get("type")
+            dep_name = dep.get("name")
             if dep_type in (_DEP_TYPE_VECTOR_INDEX, _DEP_TYPE_TABLE):
                 deps.append(ModelVersionDependency(table=TableDependency(table_full_name=dep_name)))
             elif dep_type == _DEP_TYPE_UC_FUNCTION:

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -135,3 +135,24 @@ def mlflow_prompt_to_proto(prompt: PromptVersion) -> ProtoPromptVersion:
             proto_version.aliases.append(alias_proto)
 
     return proto_version
+
+
+def get_uc_model_registry_store_class():
+    """Return the UC model-registry store class to use for the ``databricks-uc`` scheme:
+    ``UcNativeModelRegistryStore`` when ``MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY`` is enabled,
+    otherwise the legacy ``UcModelRegistryStore``.
+
+    The store classes are imported lazily because they import from this module.
+    """
+    from mlflow.environment_variables import MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY
+
+    if MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY.get():
+        from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
+            UcNativeModelRegistryStore,
+        )
+
+        return UcNativeModelRegistryStore
+
+    from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
+
+    return UcModelRegistryStore

--- a/mlflow/store/model_registry/databricks_workspace_model_registry_rest_store.py
+++ b/mlflow/store/model_registry/databricks_workspace_model_registry_rest_store.py
@@ -9,7 +9,6 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_ALREADY_EXISTS,
     ErrorCode,
 )
-from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.logging_utils import eprint
@@ -131,7 +130,11 @@ class DatabricksWorkspaceModelRegistryRestStore(RestStore):
                     f"exist and that you can download them via "
                     f"mlflow.artifacts.download_artifacts()"
                 ) from e
-            uc_store = UcModelRegistryStore(
+            from mlflow.store._unity_catalog.registry.utils import (
+                get_uc_model_registry_store_class,
+            )
+
+            uc_store = get_uc_model_registry_store_class()(
                 store_uri=_DATABRICKS_UNITY_CATALOG_SCHEME,
                 tracking_uri=self.tracking_uri,
             )

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -220,9 +220,16 @@ def _get_file_store(store_uri, **_):
     return FileStore(store_uri)
 
 
+def _get_databricks_uc_rest_store(store_uri, tracking_uri, **_):
+    from mlflow.store._unity_catalog.registry.utils import get_uc_model_registry_store_class
+
+    # The native /api/2.1 store and the legacy /api/2.0 store are separate classes; select which
+    # one to instantiate based on MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY.
+    return get_uc_model_registry_store_class()(store_uri, tracking_uri)
+
+
 def _get_store_registry():
     global _model_registry_store_registry
-    from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
     from mlflow.store._unity_catalog.registry.uc_oss_rest_store import UnityCatalogOssStore
 
     if _model_registry_store_registry is not None:
@@ -230,9 +237,9 @@ def _get_store_registry():
 
     _model_registry_store_registry = ModelRegistryStoreRegistry()
     _model_registry_store_registry.register("databricks", _get_databricks_rest_store)
-    # Register a placeholder function that raises if users pass a registry URI with scheme
-    # "databricks-uc"
-    _model_registry_store_registry.register(_DATABRICKS_UNITY_CATALOG_SCHEME, UcModelRegistryStore)
+    _model_registry_store_registry.register(
+        _DATABRICKS_UNITY_CATALOG_SCHEME, _get_databricks_uc_rest_store
+    )
     _model_registry_store_registry.register(_OSS_UNITY_CATALOG_SCHEME, UnityCatalogOssStore)
 
     for scheme in ["http", "https"]:

--- a/tests/store/_unity_catalog/model_registry/test_uc_native_credential_dispatch.py
+++ b/tests/store/_unity_catalog/model_registry/test_uc_native_credential_dispatch.py
@@ -1,16 +1,15 @@
-"""Offline coverage for the UC-native artifact credential-dispatch and enrichment-converter arms
-that a single (AWS, external-storage) live workspace does not exercise.
-
-These are the pieces that vary workspace-to-workspace:
-  * cloud-provider credential arms (AWS / Azure / GCP / R2) selected via TemporaryCredentials oneof
-  * SSE/KMS encryption-detail parsing (only populated on encryption-configured workspaces)
-  * storage_mode (default-storage vs customer-hosted)
-  * enrichment fields (params / metrics / deployment-job-state) that need extra logging setup
-
-We build synthetic protos and assert the client parses/dispatches each correctly, mocking the
-concrete ArtifactRepository classes (whose cloud SDKs may be absent) so we validate the dispatch
-logic itself, not the cloud transport.
-"""
+# Offline coverage for the UC-native artifact credential-dispatch and enrichment-converter arms
+# that a single (AWS, external-storage) live workspace does not exercise.
+#
+# These are the pieces that vary workspace-to-workspace:
+#  * cloud-provider credential arms (AWS / Azure / GCP / R2) selected via TemporaryCredentials oneof
+#  * SSE/KMS encryption-detail parsing (only populated on encryption-configured workspaces)
+#  * storage_mode (default-storage vs customer-hosted)
+#  * enrichment fields (params / metrics / deployment-job-state) that need extra logging setup
+#
+# We build synthetic protos and assert the client parses/dispatches each correctly, mocking the
+# concrete ArtifactRepository classes (whose cloud SDKs may be absent) so we validate the dispatch
+# logic itself, not the cloud transport.
 
 from unittest import mock
 

--- a/tests/store/_unity_catalog/model_registry/test_uc_native_credential_dispatch.py
+++ b/tests/store/_unity_catalog/model_registry/test_uc_native_credential_dispatch.py
@@ -1,0 +1,256 @@
+"""Offline coverage for the UC-native artifact credential-dispatch and enrichment-converter arms
+that a single (AWS, external-storage) live workspace does not exercise.
+
+These are the pieces that vary workspace-to-workspace:
+  * cloud-provider credential arms (AWS / Azure / GCP / R2) selected via TemporaryCredentials oneof
+  * SSE/KMS encryption-detail parsing (only populated on encryption-configured workspaces)
+  * storage_mode (default-storage vs customer-hosted)
+  * enrichment fields (params / metrics / deployment-job-state) that need extra logging setup
+
+We build synthetic protos and assert the client parses/dispatches each correctly, mocking the
+concrete ArtifactRepository classes (whose cloud SDKs may be absent) so we validate the dispatch
+logic itself, not the cloud transport.
+"""
+
+from unittest import mock
+
+import pytest
+
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    AwsCredentials,
+    AzureUserDelegationSAS,
+    DeploymentJobConnection,
+    EncryptionDetails,
+    GcpOauthToken,
+    ModelMetric,
+    ModelParam,
+    ModelVersionDeploymentJobState,
+    ModelVersionInfo,
+    R2Credentials,
+    RegisteredModelAliasInfo,
+    RegisteredModelInfo,
+    SseEncryptionAlgorithm,
+    SseEncryptionDetails,
+    StorageMode,
+    TagKeyValue,
+    TemporaryCredentials,
+)
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
+    model_version_from_uc_native_proto,
+    registered_model_from_uc_native_proto,
+)
+from mlflow.utils._unity_catalog_utils import (
+    _get_artifact_repo_from_storage_info,
+    _parse_aws_sse_credential,
+)
+
+STORAGE = "s3://bucket/models/abc"
+
+
+def _refresh_returning(token):
+    return lambda: token
+
+
+# ---------------------------------------------------------------------------
+# Credential oneof dispatch -- one arm per cloud provider
+# ---------------------------------------------------------------------------
+def test_dispatch_aws():
+    token = TemporaryCredentials(
+        aws_temp_credentials=AwsCredentials(
+            access_key_id="ak", secret_access_key="sk", session_token="st"
+        )
+    )
+    assert token.WhichOneof("credentials") == "aws_temp_credentials"
+    with mock.patch(
+        "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository"
+    ) as repo, mock.patch.dict("sys.modules", {"boto3": mock.MagicMock()}):
+        _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
+    repo.assert_called_once()
+    _, kwargs = repo.call_args
+    assert kwargs["access_key_id"] == "ak"
+    assert kwargs["secret_access_key"] == "sk"
+    assert kwargs["session_token"] == "st"
+
+
+def test_dispatch_azure():
+    token = TemporaryCredentials(
+        azure_user_delegation_sas=AzureUserDelegationSAS(sas_token="sas123")
+    )
+    assert token.WhichOneof("credentials") == "azure_user_delegation_sas"
+    fake_azure = mock.MagicMock()
+    with mock.patch(
+        "mlflow.store.artifact.azure_data_lake_artifact_repo.AzureDataLakeArtifactRepository"
+    ) as repo, mock.patch.dict(
+        "sys.modules", {"azure": mock.MagicMock(), "azure.core": mock.MagicMock(),
+                        "azure.core.credentials": fake_azure}
+    ):
+        _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
+    repo.assert_called_once()
+
+
+def test_dispatch_gcp():
+    token = TemporaryCredentials(gcp_oauth_token=GcpOauthToken(oauth_token="tok"))
+    assert token.WhichOneof("credentials") == "gcp_oauth_token"
+    gcs_mod = mock.MagicMock()
+    oauth_mod = mock.MagicMock()
+    with mock.patch(
+        "mlflow.store.artifact.gcs_artifact_repo.GCSArtifactRepository"
+    ) as repo, mock.patch.dict(
+        "sys.modules",
+        {
+            "google.cloud": mock.MagicMock(),
+            "google.cloud.storage": gcs_mod,
+            "google.oauth2": mock.MagicMock(),
+            "google.oauth2.credentials": oauth_mod,
+        },
+    ):
+        _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
+    repo.assert_called_once()
+
+
+def test_dispatch_r2():
+    token = TemporaryCredentials(
+        r2_temp_credentials=R2Credentials(
+            access_key_id="ak", secret_access_key="sk", session_token="st"
+        )
+    )
+    assert token.WhichOneof("credentials") == "r2_temp_credentials"
+    with mock.patch(
+        "mlflow.store.artifact.r2_artifact_repo.R2ArtifactRepository"
+    ) as repo:
+        _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
+    repo.assert_called_once()
+    _, kwargs = repo.call_args
+    assert kwargs["access_key_id"] == "ak"
+
+
+def test_dispatch_no_credential_raises():
+    token = TemporaryCredentials(expiration_time=123)  # no oneof arm set
+    assert token.WhichOneof("credentials") is None
+    with pytest.raises(Exception, match="unexpected credential type"):
+        _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
+
+
+# ---------------------------------------------------------------------------
+# SSE / KMS encryption parsing
+# ---------------------------------------------------------------------------
+def test_sse_empty_when_no_encryption():
+    assert _parse_aws_sse_credential(TemporaryCredentials()) == {}
+
+
+def test_sse_s3():
+    token = TemporaryCredentials(
+        encryption_details=EncryptionDetails(
+            sse_encryption_details=SseEncryptionDetails(
+                algorithm=SseEncryptionAlgorithm.AWS_SSE_S3
+            )
+        )
+    )
+    assert _parse_aws_sse_credential(token) == {"ServerSideEncryption": "AES256"}
+
+
+def test_sse_kms():
+    token = TemporaryCredentials(
+        encryption_details=EncryptionDetails(
+            sse_encryption_details=SseEncryptionDetails(
+                algorithm=SseEncryptionAlgorithm.AWS_SSE_KMS, aws_kms_key_arn="arn:aws:kms:key"
+            )
+        )
+    )
+    assert _parse_aws_sse_credential(token) == {
+        "ServerSideEncryption": "aws:kms",
+        "SSEKMSKeyId": "arn:aws:kms:key",
+    }
+
+
+def test_aws_dispatch_threads_sse_into_upload_args():
+    token = TemporaryCredentials(
+        aws_temp_credentials=AwsCredentials(access_key_id="ak"),
+        encryption_details=EncryptionDetails(
+            sse_encryption_details=SseEncryptionDetails(
+                algorithm=SseEncryptionAlgorithm.AWS_SSE_S3
+            )
+        ),
+    )
+    with mock.patch(
+        "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository"
+    ) as repo, mock.patch.dict("sys.modules", {"boto3": mock.MagicMock()}):
+        _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
+    _, kwargs = repo.call_args
+    assert kwargs["s3_upload_extra_args"] == {"ServerSideEncryption": "AES256"}
+
+
+# ---------------------------------------------------------------------------
+# storage_mode field
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (StorageMode.DEFAULT_STORAGE, StorageMode.DEFAULT_STORAGE),
+        (StorageMode.CUSTOMER_HOSTED, StorageMode.CUSTOMER_HOSTED),
+    ],
+)
+def test_storage_mode_roundtrip(mode, expected):
+    token = TemporaryCredentials(storage_mode=mode)
+    assert token.storage_mode == expected
+
+
+# ---------------------------------------------------------------------------
+# Enrichment converters -- fields needing extra logging setup
+# ---------------------------------------------------------------------------
+def test_native_model_version_params_metrics_deployment():
+    proto = ModelVersionInfo(
+        catalog_name="c",
+        schema_name="s",
+        model_name="m",
+        version=7,
+        model_id="mid",
+        aliases=[RegisteredModelAliasInfo(alias_name="champion", version_num=7)],
+        tags=[TagKeyValue(key="k", value="v")],
+        model_params=[ModelParam(name="lr", value="0.1")],
+        model_metrics=[
+            ModelMetric(key="acc", value=0.99, timestamp=123, step=2, run_id="r1", model_id="mid")
+        ],
+        deployment_job_state=ModelVersionDeploymentJobState(
+            job_id="j1",
+            run_id="run1",
+            run_state=ModelVersionDeploymentJobState.DeploymentJobRunState.RUNNING,
+        ),
+    )
+    mv = model_version_from_uc_native_proto(proto)
+    assert mv.name == "c.s.m"
+    assert mv.version == "7"
+    assert mv.model_id == "mid"
+    assert mv.aliases == ["champion"]
+    assert mv.tags == {"k": "v"}  # ModelVersion.tags is a dict
+    assert {p.key: p.value for p in mv.params} == {"lr": "0.1"}
+    assert mv.metrics[0].key == "acc"
+    assert mv.metrics[0].value == 0.99
+    assert mv.metrics[0].run_id == "r1"
+
+
+def test_native_model_version_empty_enrichment():
+    # A minimal response (no params/metrics/aliases) must not crash the converter.
+    proto = ModelVersionInfo(catalog_name="c", schema_name="s", model_name="m", version=1)
+    mv = model_version_from_uc_native_proto(proto)
+    assert mv.name == "c.s.m"
+    assert mv.aliases == []
+    assert list(mv.params) == []
+    assert list(mv.metrics) == []
+
+
+def test_native_registered_model_deployment_fields():
+    proto = RegisteredModelInfo(
+        full_name="c.s.m",
+        comment="desc",
+        aliases=[RegisteredModelAliasInfo(alias_name="prod", version_num=3)],
+        tags=[TagKeyValue(key="team", value="ml")],
+        deployment_job_id="42",
+        deployment_job_state=DeploymentJobConnection.State.CONNECTED,
+    )
+    rm = registered_model_from_uc_native_proto(proto)
+    assert rm.name == "c.s.m"
+    assert rm.description == "desc"
+    assert rm.aliases == {"prod": "3"}
+    assert rm.tags == {"team": "ml"}
+    assert rm.deployment_job_id == "42"

--- a/tests/store/_unity_catalog/model_registry/test_uc_native_credential_dispatch.py
+++ b/tests/store/_unity_catalog/model_registry/test_uc_native_credential_dispatch.py
@@ -61,9 +61,12 @@ def test_dispatch_aws():
         )
     )
     assert token.WhichOneof("credentials") == "aws_temp_credentials"
-    with mock.patch(
-        "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository"
-    ) as repo, mock.patch.dict("sys.modules", {"boto3": mock.MagicMock()}):
+    with (
+        mock.patch(
+            "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository"
+        ) as repo,
+        mock.patch.dict("sys.modules", {"boto3": mock.MagicMock()}),
+    ):
         _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
     repo.assert_called_once()
     _, kwargs = repo.call_args
@@ -78,11 +81,18 @@ def test_dispatch_azure():
     )
     assert token.WhichOneof("credentials") == "azure_user_delegation_sas"
     fake_azure = mock.MagicMock()
-    with mock.patch(
-        "mlflow.store.artifact.azure_data_lake_artifact_repo.AzureDataLakeArtifactRepository"
-    ) as repo, mock.patch.dict(
-        "sys.modules", {"azure": mock.MagicMock(), "azure.core": mock.MagicMock(),
-                        "azure.core.credentials": fake_azure}
+    with (
+        mock.patch(
+            "mlflow.store.artifact.azure_data_lake_artifact_repo.AzureDataLakeArtifactRepository"
+        ) as repo,
+        mock.patch.dict(
+            "sys.modules",
+            {
+                "azure": mock.MagicMock(),
+                "azure.core": mock.MagicMock(),
+                "azure.core.credentials": fake_azure,
+            },
+        ),
     ):
         _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
     repo.assert_called_once()
@@ -93,16 +103,17 @@ def test_dispatch_gcp():
     assert token.WhichOneof("credentials") == "gcp_oauth_token"
     gcs_mod = mock.MagicMock()
     oauth_mod = mock.MagicMock()
-    with mock.patch(
-        "mlflow.store.artifact.gcs_artifact_repo.GCSArtifactRepository"
-    ) as repo, mock.patch.dict(
-        "sys.modules",
-        {
-            "google.cloud": mock.MagicMock(),
-            "google.cloud.storage": gcs_mod,
-            "google.oauth2": mock.MagicMock(),
-            "google.oauth2.credentials": oauth_mod,
-        },
+    with (
+        mock.patch("mlflow.store.artifact.gcs_artifact_repo.GCSArtifactRepository") as repo,
+        mock.patch.dict(
+            "sys.modules",
+            {
+                "google.cloud": mock.MagicMock(),
+                "google.cloud.storage": gcs_mod,
+                "google.oauth2": mock.MagicMock(),
+                "google.oauth2.credentials": oauth_mod,
+            },
+        ),
     ):
         _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
     repo.assert_called_once()
@@ -115,9 +126,7 @@ def test_dispatch_r2():
         )
     )
     assert token.WhichOneof("credentials") == "r2_temp_credentials"
-    with mock.patch(
-        "mlflow.store.artifact.r2_artifact_repo.R2ArtifactRepository"
-    ) as repo:
+    with mock.patch("mlflow.store.artifact.r2_artifact_repo.R2ArtifactRepository") as repo:
         _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
     repo.assert_called_once()
     _, kwargs = repo.call_args
@@ -141,9 +150,7 @@ def test_sse_empty_when_no_encryption():
 def test_sse_s3():
     token = TemporaryCredentials(
         encryption_details=EncryptionDetails(
-            sse_encryption_details=SseEncryptionDetails(
-                algorithm=SseEncryptionAlgorithm.AWS_SSE_S3
-            )
+            sse_encryption_details=SseEncryptionDetails(algorithm=SseEncryptionAlgorithm.AWS_SSE_S3)
         )
     )
     assert _parse_aws_sse_credential(token) == {"ServerSideEncryption": "AES256"}
@@ -167,14 +174,15 @@ def test_aws_dispatch_threads_sse_into_upload_args():
     token = TemporaryCredentials(
         aws_temp_credentials=AwsCredentials(access_key_id="ak"),
         encryption_details=EncryptionDetails(
-            sse_encryption_details=SseEncryptionDetails(
-                algorithm=SseEncryptionAlgorithm.AWS_SSE_S3
-            )
+            sse_encryption_details=SseEncryptionDetails(algorithm=SseEncryptionAlgorithm.AWS_SSE_S3)
         ),
     )
-    with mock.patch(
-        "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository"
-    ) as repo, mock.patch.dict("sys.modules", {"boto3": mock.MagicMock()}):
+    with (
+        mock.patch(
+            "mlflow.store.artifact.optimized_s3_artifact_repo.OptimizedS3ArtifactRepository"
+        ) as repo,
+        mock.patch.dict("sys.modules", {"boto3": mock.MagicMock()}),
+    ):
         _get_artifact_repo_from_storage_info(STORAGE, token, _refresh_returning(token))
     _, kwargs = repo.call_args
     assert kwargs["s3_upload_extra_args"] == {"ServerSideEncryption": "AES256"}

--- a/tests/store/_unity_catalog/model_registry/test_uc_native_legacy_parity.py
+++ b/tests/store/_unity_catalog/model_registry/test_uc_native_legacy_parity.py
@@ -1,14 +1,13 @@
-"""Parity tests for the UC-native model-registry client migration.
-
-These assert that when the client reads a model / model version off the native governance
-surface (``/api/2.1/unity-catalog/*``, ``RegisteredModelInfo`` / ``ModelVersionInfo`` with the
-MLflow-enrichment fields as flattened siblings), it produces an MLflow entity that is
-**field-for-field identical** to the one produced from the legacy surface
-(``/api/2.0/mlflow/unity-catalog/*``, the legacy ``RegisteredModel`` / ``ModelVersion`` protos).
-
-The legacy converters are pinned inline (copied from the pre-migration converters) so the parity
-check is a stable oracle that does not depend on the legacy conversion code remaining in the tree.
-"""
+# Parity tests for the UC-native model-registry client migration.
+#
+# These assert that when the client reads a model / model version off the native governance
+# surface (``/api/2.1/unity-catalog/*``, ``RegisteredModelInfo`` / ``ModelVersionInfo`` with the
+# MLflow-enrichment fields as flattened siblings), it produces an MLflow entity that is
+# **field-for-field identical** to the one produced from the legacy surface
+# (``/api/2.0/mlflow/unity-catalog/*``, the legacy ``RegisteredModel`` / ``ModelVersion`` protos).
+#
+# The legacy converters are pinned inline (copied from the pre-migration converters) so the parity
+# check is a stable oracle that does not depend on the legacy conversion code remaining in the tree.
 
 from mlflow.entities import Metric
 from mlflow.entities.logged_model_parameter import LoggedModelParameter as ModelParam

--- a/tests/store/_unity_catalog/model_registry/test_uc_native_legacy_parity.py
+++ b/tests/store/_unity_catalog/model_registry/test_uc_native_legacy_parity.py
@@ -1,0 +1,344 @@
+"""Parity tests for the UC-native model-registry client migration.
+
+These assert that when the client reads a model / model version off the native governance
+surface (``/api/2.1/unity-catalog/*``, ``RegisteredModelInfo`` / ``ModelVersionInfo`` with the
+MLflow-enrichment fields as flattened siblings), it produces an MLflow entity that is
+**field-for-field identical** to the one produced from the legacy surface
+(``/api/2.0/mlflow/unity-catalog/*``, the legacy ``RegisteredModel`` / ``ModelVersion`` protos).
+
+The legacy converters are pinned inline (copied from the pre-migration converters) so the parity
+check is a stable oracle that does not depend on the legacy conversion code remaining in the tree.
+"""
+
+from mlflow.entities import Metric
+from mlflow.entities.logged_model_parameter import LoggedModelParameter as ModelParam
+from mlflow.entities.model_registry import (
+    ModelVersion,
+    ModelVersionSearch,
+    ModelVersionTag,
+    RegisteredModel,
+    RegisteredModelAlias,
+    RegisteredModelSearch,
+    RegisteredModelTag,
+)
+from mlflow.entities.model_registry.model_version_deployment_job_state import (
+    ModelVersionDeploymentJobState,
+)
+from mlflow.entities.model_registry.registered_model_deployment_job_state import (
+    RegisteredModelDeploymentJobState,
+)
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    ModelVersion as LegacyModelVersion,
+)
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    ModelVersionDeploymentJobState as LegacyProtoMVDeploymentJobState,
+)
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    ModelVersionTag as ProtoModelVersionTag,
+)
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    RegisteredModel as LegacyRegisteredModel,
+)
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    RegisteredModelAlias as LegacyRegisteredModelAlias,
+)
+from mlflow.protos.databricks_uc_registry_messages_pb2 import (
+    RegisteredModelTag as ProtoRegisteredModelTag,
+)
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    DeploymentJobConnection,
+    ModelVersionDeploymentJobState as NativeMVDeploymentJobState,
+    ModelVersionInfo,
+    ModelVersionStatus,
+    RegisteredModelAliasInfo,
+    RegisteredModelInfo,
+    TagKeyValue,
+)
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
+    model_version_from_uc_native_proto as model_version_from_uc_proto,
+    model_version_search_from_uc_native_proto as model_version_search_from_uc_proto,
+    registered_model_from_uc_native_proto as registered_model_from_uc_proto,
+    registered_model_search_from_uc_native_proto as registered_model_search_from_uc_proto,
+)
+from mlflow.utils._unity_catalog_utils import (
+    uc_model_version_status_to_string,
+)
+
+# ---------------------------------------------------------------------------
+# Pinned legacy converters (pre-migration mlflow/utils/_unity_catalog_utils.py) -- the oracle.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_registered_model_from_uc_proto(uc_proto: LegacyRegisteredModel) -> RegisteredModel:
+    return RegisteredModel(
+        name=uc_proto.name,
+        creation_timestamp=uc_proto.creation_timestamp,
+        last_updated_timestamp=uc_proto.last_updated_timestamp,
+        description=uc_proto.description,
+        aliases=[
+            RegisteredModelAlias(alias=alias.alias, version=alias.version)
+            for alias in (uc_proto.aliases or [])
+        ],
+        tags=[RegisteredModelTag(key=tag.key, value=tag.value) for tag in (uc_proto.tags or [])],
+        deployment_job_id=uc_proto.deployment_job_id,
+        deployment_job_state=RegisteredModelDeploymentJobState.to_string(
+            uc_proto.deployment_job_state
+        ),
+    )
+
+
+def _legacy_registered_model_search_from_uc_proto(
+    uc_proto: LegacyRegisteredModel,
+) -> RegisteredModelSearch:
+    return RegisteredModelSearch(
+        name=uc_proto.name,
+        creation_timestamp=uc_proto.creation_timestamp,
+        last_updated_timestamp=uc_proto.last_updated_timestamp,
+        description=uc_proto.description,
+        aliases=[],
+        tags=[],
+    )
+
+
+def _legacy_model_version_from_uc_proto(uc_proto: LegacyModelVersion) -> ModelVersion:
+    return ModelVersion(
+        name=uc_proto.name,
+        version=uc_proto.version,
+        creation_timestamp=uc_proto.creation_timestamp,
+        last_updated_timestamp=uc_proto.last_updated_timestamp,
+        description=uc_proto.description,
+        user_id=uc_proto.user_id,
+        source=uc_proto.source,
+        run_id=uc_proto.run_id,
+        status=uc_model_version_status_to_string(uc_proto.status),
+        status_message=uc_proto.status_message,
+        aliases=[alias.alias for alias in (uc_proto.aliases or [])],
+        tags=[ModelVersionTag(key=tag.key, value=tag.value) for tag in (uc_proto.tags or [])],
+        model_id=uc_proto.model_id,
+        params=[
+            ModelParam(key=param.name, value=param.value) for param in (uc_proto.model_params or [])
+        ],
+        metrics=[
+            Metric(
+                key=metric.key,
+                value=metric.value,
+                timestamp=metric.timestamp,
+                step=metric.step,
+                dataset_name=metric.dataset_name,
+                dataset_digest=metric.dataset_digest,
+                model_id=metric.model_id,
+                run_id=metric.run_id,
+            )
+            for metric in (uc_proto.model_metrics or [])
+        ],
+        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
+            uc_proto.deployment_job_state
+        ),
+    )
+
+
+def _legacy_model_version_search_from_uc_proto(uc_proto: LegacyModelVersion) -> ModelVersionSearch:
+    return ModelVersionSearch(
+        name=uc_proto.name,
+        version=uc_proto.version,
+        creation_timestamp=uc_proto.creation_timestamp,
+        last_updated_timestamp=uc_proto.last_updated_timestamp,
+        description=uc_proto.description,
+        user_id=uc_proto.user_id,
+        source=uc_proto.source,
+        run_id=uc_proto.run_id,
+        status=uc_model_version_status_to_string(uc_proto.status),
+        status_message=uc_proto.status_message,
+        aliases=[],
+        tags=[],
+        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
+            uc_proto.deployment_job_state
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registered model parity
+# ---------------------------------------------------------------------------
+
+
+def test_registered_model_native_legacy_parity():
+    full_name = "catalog.schema.model"
+    # Legacy MLflow-dialect response (what the pre-migration client received).
+    legacy = LegacyRegisteredModel(
+        name=full_name,
+        creation_timestamp=111,
+        last_updated_timestamp=222,
+        description="a model",
+        aliases=[LegacyRegisteredModelAlias(alias="champion", version="3")],
+        tags=[ProtoRegisteredModelTag(key="team", value="ml")],
+        deployment_job_id="job-9",
+        deployment_job_state=DeploymentJobConnection.CONNECTED,
+    )
+    # Native governance response with the same logical content (what the migrated client receives).
+    # Governance carries catalog/schema/full_name/created_at/... ; enrichment adds
+    # deployment_job_id / deployment_job_state as flattened siblings.
+    native = RegisteredModelInfo(
+        name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name=full_name,
+        comment="a model",
+        created_at=111,
+        updated_at=222,
+        aliases=[RegisteredModelAliasInfo(alias_name="champion", version_num=3)],
+        tags=[TagKeyValue(key="team", value="ml")],
+        deployment_job_id="job-9",
+        deployment_job_state=DeploymentJobConnection.CONNECTED,
+    )
+
+    legacy_entity = _legacy_registered_model_from_uc_proto(legacy)
+    native_entity = registered_model_from_uc_proto(native)
+
+    assert native_entity.name == legacy_entity.name == full_name
+    assert native_entity.creation_timestamp == legacy_entity.creation_timestamp == 111
+    assert native_entity.last_updated_timestamp == legacy_entity.last_updated_timestamp == 222
+    assert native_entity.description == legacy_entity.description == "a model"
+    assert dict(native_entity.tags) == dict(legacy_entity.tags) == {"team": "ml"}
+    assert dict(native_entity.aliases) == dict(legacy_entity.aliases) == {"champion": "3"}
+    assert native_entity.deployment_job_id == legacy_entity.deployment_job_id == "job-9"
+    assert native_entity.deployment_job_state == legacy_entity.deployment_job_state
+
+
+def test_registered_model_search_native_legacy_parity():
+    full_name = "catalog.schema.model"
+    legacy = LegacyRegisteredModel(
+        name=full_name, creation_timestamp=5, last_updated_timestamp=6, description="d"
+    )
+    native = RegisteredModelInfo(
+        name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name=full_name,
+        comment="d",
+        created_at=5,
+        updated_at=6,
+    )
+    legacy_entity = _legacy_registered_model_search_from_uc_proto(legacy)
+    native_entity = registered_model_search_from_uc_proto(native)
+
+    assert native_entity.name == legacy_entity.name == full_name
+    assert native_entity.creation_timestamp == legacy_entity.creation_timestamp == 5
+    assert native_entity.last_updated_timestamp == legacy_entity.last_updated_timestamp == 6
+    assert native_entity.description == legacy_entity.description == "d"
+
+
+# ---------------------------------------------------------------------------
+# Model version parity
+# ---------------------------------------------------------------------------
+
+
+def _legacy_mv_deployment_job_state():
+    return LegacyProtoMVDeploymentJobState(
+        job_id="42",
+        run_id="7",
+        job_state=DeploymentJobConnection.CONNECTED,
+    )
+
+
+def _native_mv_deployment_job_state():
+    return NativeMVDeploymentJobState(
+        job_id="42",
+        run_id="7",
+        job_state=DeploymentJobConnection.CONNECTED,
+    )
+
+
+def test_model_version_native_legacy_parity():
+    full_name = "catalog.schema.model"
+    legacy = LegacyModelVersion(
+        name=full_name,
+        version="4",
+        creation_timestamp=10,
+        last_updated_timestamp=20,
+        description="a version",
+        user_id="alice",
+        source="s3://bucket/model",
+        run_id="run-1",
+        status=ModelVersionStatus.READY,
+        aliases=[LegacyRegisteredModelAlias(alias="prod", version="4")],
+        tags=[ProtoModelVersionTag(key="stage", value="prod")],
+        model_id="logged-1",
+        deployment_job_state=_legacy_mv_deployment_job_state(),
+    )
+    native = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=4,
+        comment="a version",
+        source="s3://bucket/model",
+        run_id="run-1",
+        status=ModelVersionStatus.READY,
+        created_at=10,
+        updated_at=20,
+        created_by="alice",
+        aliases=[RegisteredModelAliasInfo(alias_name="prod", version_num=4)],
+        tags=[TagKeyValue(key="stage", value="prod")],
+        model_id="logged-1",
+        deployment_job_state=_native_mv_deployment_job_state(),
+    )
+
+    legacy_entity = _legacy_model_version_from_uc_proto(legacy)
+    native_entity = model_version_from_uc_proto(native)
+
+    assert native_entity.name == legacy_entity.name == full_name
+    assert native_entity.version == legacy_entity.version == "4"
+    assert native_entity.creation_timestamp == legacy_entity.creation_timestamp == 10
+    assert native_entity.last_updated_timestamp == legacy_entity.last_updated_timestamp == 20
+    assert native_entity.description == legacy_entity.description == "a version"
+    assert native_entity.user_id == legacy_entity.user_id == "alice"
+    assert native_entity.source == legacy_entity.source == "s3://bucket/model"
+    assert native_entity.run_id == legacy_entity.run_id == "run-1"
+    assert native_entity.status == legacy_entity.status
+    assert native_entity.aliases == legacy_entity.aliases == ["prod"]
+    assert dict(native_entity.tags) == dict(legacy_entity.tags) == {"stage": "prod"}
+    assert native_entity.model_id == legacy_entity.model_id == "logged-1"
+
+
+def test_model_version_search_native_legacy_parity():
+    full_name = "catalog.schema.model"
+    legacy = LegacyModelVersion(
+        name=full_name,
+        version="4",
+        creation_timestamp=10,
+        last_updated_timestamp=20,
+        description="a version",
+        user_id="alice",
+        source="s3://bucket/model",
+        run_id="run-1",
+        status=ModelVersionStatus.READY,
+        deployment_job_state=_legacy_mv_deployment_job_state(),
+    )
+    native = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=4,
+        comment="a version",
+        source="s3://bucket/model",
+        run_id="run-1",
+        status=ModelVersionStatus.READY,
+        created_at=10,
+        updated_at=20,
+        created_by="alice",
+        deployment_job_state=_native_mv_deployment_job_state(),
+    )
+
+    legacy_entity = _legacy_model_version_search_from_uc_proto(legacy)
+    native_entity = model_version_search_from_uc_proto(native)
+
+    assert native_entity.name == legacy_entity.name == full_name
+    assert native_entity.version == legacy_entity.version == "4"
+    assert native_entity.creation_timestamp == legacy_entity.creation_timestamp == 10
+    assert native_entity.last_updated_timestamp == legacy_entity.last_updated_timestamp == 20
+    assert native_entity.description == legacy_entity.description == "a version"
+    assert native_entity.user_id == legacy_entity.user_id == "alice"
+    assert native_entity.source == legacy_entity.source == "s3://bucket/model"
+    assert native_entity.run_id == legacy_entity.run_id == "run-1"
+    assert native_entity.status == legacy_entity.status

--- a/tests/store/_unity_catalog/model_registry/test_uc_native_legacy_parity.py
+++ b/tests/store/_unity_catalog/model_registry/test_uc_native_legacy_parity.py
@@ -47,17 +47,25 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 )
 from mlflow.protos.unity_catalog_messages_pb2 import (
     DeploymentJobConnection,
-    ModelVersionDeploymentJobState as NativeMVDeploymentJobState,
     ModelVersionInfo,
     ModelVersionStatus,
     RegisteredModelAliasInfo,
     RegisteredModelInfo,
     TagKeyValue,
 )
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    ModelVersionDeploymentJobState as NativeMVDeploymentJobState,
+)
 from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
     model_version_from_uc_native_proto as model_version_from_uc_proto,
+)
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
     model_version_search_from_uc_native_proto as model_version_search_from_uc_proto,
+)
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
     registered_model_from_uc_native_proto as registered_model_from_uc_proto,
+)
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
     registered_model_search_from_uc_native_proto as registered_model_search_from_uc_proto,
 )
 from mlflow.utils._unity_catalog_utils import (

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
@@ -451,7 +451,7 @@ def test_create_model_version_optional_signature_validation(store, tmp_path, byp
         mock.patch(f"{rest_store}.get_model_version_dependencies", return_value=[]),
         mock.patch.object(store, "_edit_endpoint_and_call", return_value=mock_mv),
         mock.patch.object(store, "_get_artifact_repo"),
-        mock.patch(f"{rest_store}.model_version_from_uc_proto", return_value=mock.Mock()),
+        mock.patch(f"{rest_store}.model_version_from_uc_proto"),
     ):
         mock_local_model_dir.return_value.__enter__.return_value = tmp_path
         mock_local_model_dir.return_value.__exit__.return_value = None
@@ -1801,7 +1801,7 @@ def test_create_model_version_translates_dependencies_to_governance(store, tmp_p
     rest_store = "mlflow.store._unity_catalog.registry.rest_store"
     with (
         mock.patch.object(store, "_edit_endpoint_and_call", return_value=native_mv) as native_call,
-        mock.patch.object(store, "_get_artifact_repo", return_value=mock.MagicMock()),
+        mock.patch.object(store, "_get_artifact_repo"),
         mock.patch.object(store, "_get_logged_model_from_model_id", return_value=None),
         mock.patch.object(store, "_get_run_and_headers", return_value=(None, None)),
         mock.patch.object(store, "_get_workspace_id", return_value=None),
@@ -1839,7 +1839,7 @@ def test_create_model_version_omits_dependencies_when_none_supported(store, tmp_
     rest_store = "mlflow.store._unity_catalog.registry.rest_store"
     with (
         mock.patch.object(store, "_edit_endpoint_and_call", return_value=native_mv) as native_call,
-        mock.patch.object(store, "_get_artifact_repo", return_value=mock.MagicMock()),
+        mock.patch.object(store, "_get_artifact_repo"),
         mock.patch.object(store, "_get_logged_model_from_model_id", return_value=None),
         mock.patch.object(store, "_get_run_and_headers", return_value=(None, None)),
         mock.patch.object(store, "_get_workspace_id", return_value=None),

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
@@ -67,7 +67,6 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_JOB_RUN_ID,
     MLFLOW_DATABRICKS_NOTEBOOK_ID,
 )
-from mlflow.utils.proto_json_utils import message_to_json
 
 from tests.helper_functions import mock_http_200
 from tests.resources.data.dataset_source import SampleDatasetSource

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
@@ -441,7 +441,6 @@ def test_create_model_version_optional_signature_validation(store, tmp_path, byp
     # decision. A three-level name is used because the native create flow rejects non-UC names
     # before issuing the CreateModelVersion request.
     store.spark = None
-    mock_mv = mock.Mock(version="1", storage_location="s3://blah/loc")
     rest_store = "mlflow.store._unity_catalog.registry.rest_store"
     with (
         mock.patch.object(store, "_validate_model_signature") as mock_validate_signature,
@@ -449,9 +448,7 @@ def test_create_model_version_optional_signature_validation(store, tmp_path, byp
         mock.patch.object(store, "_download_model_weights_if_not_saved"),
         mock.patch(f"{rest_store}.get_feature_dependencies", return_value=""),
         mock.patch(f"{rest_store}.get_model_version_dependencies", return_value=[]),
-        mock.patch.object(store, "_edit_endpoint_and_call", return_value=mock_mv),
-        mock.patch.object(store, "_get_artifact_repo"),
-        mock.patch(f"{rest_store}.model_version_from_uc_proto"),
+        mock.patch.object(store, "_create_and_finalize_model_version"),
     ):
         mock_local_model_dir.return_value.__enter__.return_value = tmp_path
         mock_local_model_dir.return_value.__exit__.return_value = None

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store_native.py
@@ -1,0 +1,1965 @@
+import json
+from itertools import combinations
+from unittest import mock
+from unittest.mock import ANY
+
+import pandas as pd
+import pytest
+import yaml
+from requests import Response
+
+from mlflow.data.dataset import Dataset
+from mlflow.data.delta_dataset_source import DeltaDatasetSource
+from mlflow.data.pandas_dataset import PandasDataset
+from mlflow.entities.logged_model import LoggedModel
+from mlflow.entities.logged_model_tag import LoggedModelTag
+from mlflow.entities.model_registry import (
+    ModelVersionTag,
+    RegisteredModelTag,
+)
+from mlflow.entities.model_registry.prompt import Prompt
+from mlflow.entities.model_registry.prompt_version import PromptVersion
+from mlflow.entities.run import Run
+from mlflow.entities.run_data import RunData
+from mlflow.entities.run_info import RunInfo
+from mlflow.entities.run_inputs import RunInputs
+from mlflow.entities.run_tag import RunTag
+from mlflow.exceptions import MlflowException, RestException
+from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models.signature import ModelSignature, Schema
+from mlflow.prompt.constants import (
+    PROMPT_MODEL_CONFIG_TAG_KEY,
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY,
+)
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    AwsCredentials,
+    CreateModelVersion,
+    DeploymentJobConnection,
+    ListModelVersions,
+    ModelVersionInfo,
+    RegisteredModelInfo,
+    StorageMode,
+    TemporaryCredentials,
+)
+from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
+    LinkPromptsToTracesRequest,
+    LinkPromptVersionsToModelsRequest,
+    LinkPromptVersionsToRunsRequest,
+)
+from mlflow.store._unity_catalog.lineage.constants import _DATABRICKS_ORG_ID_HEADER
+from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import UcNativeModelRegistryStore
+from mlflow.store.artifact.optimized_s3_artifact_repo import OptimizedS3ArtifactRepository
+from mlflow.store.artifact.presigned_url_artifact_repo import PresignedUrlArtifactRepository
+from mlflow.tracing.constant import TraceTagKey
+from mlflow.types.schema import ColSpec, DataType
+from mlflow.utils._unity_catalog_utils import (
+    _ACTIVE_CATALOG_QUERY,
+    _ACTIVE_SCHEMA_QUERY,
+    get_artifact_repo_from_storage_info,
+)
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_DATABRICKS_JOB_ID,
+    MLFLOW_DATABRICKS_JOB_RUN_ID,
+    MLFLOW_DATABRICKS_NOTEBOOK_ID,
+)
+from mlflow.utils.proto_json_utils import message_to_json
+
+from tests.helper_functions import mock_http_200
+from tests.resources.data.dataset_source import SampleDatasetSource
+
+
+@pytest.fixture
+def store(mock_databricks_uc_host_creds, monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY", "true")
+    with mock.patch("mlflow.utils.databricks_utils.get_databricks_host_creds"):
+        yield UcNativeModelRegistryStore(store_uri="databricks-uc", tracking_uri="databricks")
+
+
+@pytest.fixture
+def spark_session(request):
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store._get_active_spark_session"
+    ) as spark_session_getter:
+        spark = mock.MagicMock()
+        spark_session_getter.return_value = spark
+
+        # Define a custom side effect function for spark sql queries
+        def sql_side_effect(query):
+            if query == _ACTIVE_CATALOG_QUERY:
+                catalog_response_mock = mock.MagicMock()
+                catalog_response_mock.collect.return_value = [{"catalog": request.param}]
+                return catalog_response_mock
+            elif query == _ACTIVE_SCHEMA_QUERY:
+                schema_response_mock = mock.MagicMock()
+                schema_response_mock.collect.return_value = [{"schema": "default"}]
+                return schema_response_mock
+            else:
+                raise ValueError(f"Unexpected query: {query}")
+
+        spark.sql.side_effect = sql_side_effect
+        yield spark
+
+
+def _expected_unsupported_method_error_message(method):
+    return f"Method '{method}' is unsupported for models in the Unity Catalog"
+
+
+def _expected_unsupported_arg_error_message(arg):
+    return f"Argument '{arg}' is unsupported for models in the Unity Catalog"
+
+
+def test_create_registered_model_three_level_name_hint(store):
+    # The native create flow validates the three-level UC name client-side (before issuing any
+    # request) and raises with a legacy-registry hint when the name is not catalog.schema.model.
+    with pytest.raises(MlflowException, match="three levels") as exc_info:
+        store.create_registered_model(name="invalid_model")
+
+    error_message = str(exc_info.value)
+    assert "Not a valid Unity Catalog model name: 'invalid_model'" in error_message
+    assert "set the Model Registry URI to 'databricks' (legacy) instead of" in error_message
+
+
+def test_create_registered_model_two_level_name_hint(store):
+    # A two-level name is still not a valid UC (three-level) model name.
+    with pytest.raises(MlflowException, match="three levels") as exc_info:
+        store.create_registered_model(name="schema.invalid_model")
+
+    error_message = str(exc_info.value)
+    assert "Not a valid Unity Catalog model name: 'schema.invalid_model'" in error_message
+    # Should not have double periods
+    assert ". ." not in error_message
+
+
+def test_create_registered_model_metastore_does_not_exist_hint(store):
+    """
+    Test that creating a registered model when the metastore doesn't exist
+    provides a legacy registry hint. The name is three-level so it passes
+    client-side validation and reaches the native endpoint call.
+    """
+    original_error_message = "METASTORE_DOES_NOT_EXIST: Metastore not found"
+    rest_exception = RestException({
+        "error_code": "METASTORE_DOES_NOT_EXIST",
+        "message": original_error_message,
+    })
+
+    with mock.patch.object(store, "_edit_endpoint_and_call", side_effect=rest_exception):
+        with pytest.raises(MlflowException, match="METASTORE_DOES_NOT_EXIST") as exc_info:
+            store.create_registered_model(name="catalog.schema.test_model")
+
+    # Verify the exception message includes the original error and the legacy registry hint
+    expected_hint = (
+        "If you are trying to use the Model Registry in a Databricks workspace"
+        " that does not have Unity Catalog enabled, either enable Unity Catalog in"
+        " the workspace (recommended) or set the Model Registry URI to 'databricks'"
+        " to use the legacy Workspace Model Registry."
+    )
+    error_message = str(exc_info.value)
+    assert original_error_message in error_message
+    assert expected_hint in error_message
+
+
+def test_create_registered_model_other_rest_exceptions_not_modified(store):
+    """
+    Test that RestExceptions unrelated to bad UC model names are not modified
+    and are re-raised as-is.
+    """
+    original_error_message = "Some other error"
+    rest_exception = RestException({
+        "error_code": "INTERNAL_ERROR",
+        "message": original_error_message,
+    })
+
+    with mock.patch.object(store, "_edit_endpoint_and_call", side_effect=rest_exception):
+        with pytest.raises(RestException, match=original_error_message) as exc_info:
+            store.create_registered_model(name="catalog.schema.some_model")
+
+    # Verify the original RestException is re-raised without modification
+    assert str(exc_info.value) == "INTERNAL_ERROR: Some other error"
+
+
+@pytest.fixture
+def local_model_dir(tmp_path):
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.double)])
+    )
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "signature": fake_signature.to_dict(),
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+    return tmp_path
+
+
+@pytest.fixture
+def langchain_local_model_dir(tmp_path):
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.string)])
+    )
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "signature": fake_signature.to_dict(),
+        "flavors": {
+            "langchain": {
+                "databricks_dependency": {
+                    "databricks_vector_search_index_name": ["index1", "index2"],
+                    "databricks_embeddings_endpoint_name": ["embedding_endpoint"],
+                    "databricks_llm_endpoint_name": ["llm_endpoint"],
+                    "databricks_chat_endpoint_name": ["chat_endpoint"],
+                }
+            }
+        },
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+    return tmp_path
+
+
+@pytest.fixture(params=[True, False])  # True tests with resources and False tests with auth policy
+def langchain_local_model_dir_with_resources(request, tmp_path):
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.string)])
+    )
+    if request.param:
+        fake_mlmodel_contents = {
+            "artifact_path": "some-artifact-path",
+            "run_id": "abc123",
+            "signature": fake_signature.to_dict(),
+            "resources": {
+                "databricks": {
+                    "serving_endpoint": [
+                        {"name": "embedding_endpoint"},
+                        {"name": "llm_endpoint"},
+                        {"name": "chat_endpoint"},
+                    ],
+                    "vector_search_index": [{"name": "index1"}, {"name": "index2"}],
+                    "function": [
+                        {"name": "test.schema.test_function"},
+                        {"name": "test.schema.test_function_2"},
+                    ],
+                    "uc_connection": [{"name": "test_connection"}],
+                    "table": [
+                        {"name": "test.schema.test_table"},
+                        {"name": "test.schema.test_table_2"},
+                    ],
+                }
+            },
+        }
+    else:
+        fake_mlmodel_contents = {
+            "artifact_path": "some-artifact-path",
+            "run_id": "abc123",
+            "signature": fake_signature.to_dict(),
+            "auth_policy": {
+                "system_auth_policy": {
+                    "resources": {
+                        "databricks": {
+                            "serving_endpoint": [
+                                {"name": "embedding_endpoint"},
+                                {"name": "llm_endpoint"},
+                                {"name": "chat_endpoint"},
+                            ],
+                            "vector_search_index": [{"name": "index1"}, {"name": "index2"}],
+                            "function": [
+                                {"name": "test.schema.test_function"},
+                                {"name": "test.schema.test_function_2"},
+                            ],
+                            "uc_connection": [{"name": "test_connection"}],
+                            "table": [
+                                {"name": "test.schema.test_table"},
+                                {"name": "test.schema.test_table_2"},
+                            ],
+                        }
+                    },
+                },
+                "user_auth_policy": {
+                    "api_scopes": [
+                        "serving.serving-endpoints,vectorsearch.vector-search-endpoints,vectorsearch.vector-search-indexes"
+                    ]
+                },
+            },
+        }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+
+    model_version_dependencies = [
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index1"},
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index2"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "embedding_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "llm_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "chat_endpoint"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function_2"},
+        {"type": "DATABRICKS_UC_CONNECTION", "name": "test_connection"},
+        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table"},
+        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table_2"},
+    ]
+
+    return (tmp_path, model_version_dependencies)
+
+
+@pytest.fixture
+def langchain_local_model_dir_with_invoker_resources(tmp_path):
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.string)])
+    )
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "signature": fake_signature.to_dict(),
+        "resources": {
+            "databricks": {
+                "serving_endpoint": [
+                    {"name": "embedding_endpoint"},
+                    {"name": "llm_endpoint"},
+                    {"name": "chat_endpoint"},
+                ],
+                "vector_search_index": [
+                    {"name": "index1", "on_behalf_of_user": False},
+                    {"name": "index2"},
+                ],
+                "function": [
+                    {"name": "test.schema.test_function", "on_behalf_of_user": True},
+                    {"name": "test.schema.test_function_2"},
+                ],
+                "uc_connection": [{"name": "test_connection", "on_behalf_of_user": False}],
+                "table": [
+                    {"name": "test.schema.test_table", "on_behalf_of_user": True},
+                    {"name": "test.schema.test_table_2"},
+                ],
+            }
+        },
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+
+    model_version_dependencies = [
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index1"},
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "index2"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "embedding_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "llm_endpoint"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "chat_endpoint"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "test.schema.test_function_2"},
+        {"type": "DATABRICKS_UC_CONNECTION", "name": "test_connection"},
+        {"type": "DATABRICKS_TABLE", "name": "test.schema.test_table_2"},
+    ]
+
+    return (tmp_path, model_version_dependencies)
+
+
+@pytest.fixture
+def langchain_local_model_dir_no_dependencies(tmp_path):
+    fake_signature = ModelSignature(
+        inputs=Schema([ColSpec(DataType.string)]), outputs=Schema([ColSpec(DataType.string)])
+    )
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "signature": fake_signature.to_dict(),
+        "flavors": {"langchain": {}},
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+    return tmp_path
+
+
+def test_create_model_version_nonexistent_directory(store, tmp_path):
+    fake_directory = str(tmp_path.joinpath("myfakepath"))
+    with pytest.raises(
+        MlflowException,
+        match="Unable to download model artifacts from source artifact location",
+    ):
+        store.create_model_version(name="mymodel", source=fake_directory)
+
+
+_TEST_SIGNATURE = ModelSignature(
+    inputs=Schema([ColSpec(DataType.double)]), outputs=Schema([ColSpec(DataType.double)])
+)
+
+
+@pytest.fixture
+def feature_store_local_model_dir(tmp_path):
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "signature": _TEST_SIGNATURE.to_dict(),
+        "flavors": {"python_function": {"loader_module": "databricks.feature_store.mlflow_model"}},
+    }
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+    return tmp_path
+
+
+def test_create_model_version_fails_fs_packaged_model(store, feature_store_local_model_dir):
+    with pytest.raises(
+        MlflowException,
+        match="This model was packaged by Databricks Feature Store and can only be registered on "
+        "a Databricks cluster.",
+    ):
+        store.create_model_version(name="model_1", source=str(feature_store_local_model_dir))
+
+
+def test_create_model_version_missing_mlmodel(store, tmp_path):
+    with pytest.raises(
+        MlflowException,
+        match="Unable to load model metadata. Ensure the source path of the model "
+        "being registered points to a valid MLflow model directory ",
+    ):
+        store.create_model_version(name="mymodel", source=str(tmp_path))
+
+
+def test_create_model_version_missing_signature(store, tmp_path):
+    tmp_path.joinpath(MLMODEL_FILE_NAME).write_text(json.dumps({"a": "b"}))
+    with pytest.raises(
+        MlflowException,
+        match="Model passed for registration did not contain any signature metadata",
+    ):
+        store.create_model_version(name="mymodel", source=str(tmp_path))
+
+
+def test_create_model_version_missing_output_signature(store, tmp_path):
+    fake_signature = ModelSignature(inputs=Schema([ColSpec(DataType.integer)]))
+    fake_mlmodel_contents = {"signature": fake_signature.to_dict()}
+    with open(tmp_path.joinpath(MLMODEL_FILE_NAME), "w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+    with pytest.raises(
+        MlflowException,
+        match="Model passed for registration contained a signature that includes only inputs",
+    ):
+        store.create_model_version(name="mymodel", source=str(tmp_path))
+
+
+@pytest.mark.parametrize("bypass", [True, False])
+def test_create_model_version_optional_signature_validation(store, tmp_path, bypass):
+    # Mock the post-name-resolution create flow so the test isolates the signature-validation
+    # decision. A three-level name is used because the native create flow rejects non-UC names
+    # before issuing the CreateModelVersion request.
+    store.spark = None
+    mock_mv = mock.Mock(version="1", storage_location="s3://blah/loc")
+    rest_store = "mlflow.store._unity_catalog.registry.rest_store"
+    with (
+        mock.patch.object(store, "_validate_model_signature") as mock_validate_signature,
+        mock.patch.object(store, "_local_model_dir") as mock_local_model_dir,
+        mock.patch.object(store, "_download_model_weights_if_not_saved"),
+        mock.patch(f"{rest_store}.get_feature_dependencies", return_value=""),
+        mock.patch(f"{rest_store}.get_model_version_dependencies", return_value=[]),
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=mock_mv),
+        mock.patch.object(store, "_get_artifact_repo"),
+        mock.patch(f"{rest_store}.model_version_from_uc_proto", return_value=mock.Mock()),
+    ):
+        mock_local_model_dir.return_value.__enter__.return_value = tmp_path
+        mock_local_model_dir.return_value.__exit__.return_value = None
+
+        store._create_model_version_with_optional_signature_validation(
+            name="catalog.schema.test_model",
+            source=str(tmp_path),
+            bypass_signature_validation=bypass,
+        )
+
+    if bypass:
+        mock_validate_signature.assert_not_called()
+    else:
+        mock_validate_signature.assert_called_once_with(tmp_path)
+
+
+def test_get_logged_model_from_model_id_returns_none_on_resource_not_found(store):
+    with mock.patch(
+        "mlflow.get_logged_model",
+        side_effect=MlflowException("Node ID does not exist", error_code=RESOURCE_DOES_NOT_EXIST),
+    ):
+        result = store._get_logged_model_from_model_id("nonexistent_model_id")
+        assert result is None
+
+
+def test_get_logged_model_from_model_id_returns_logged_model_on_success(store):
+    mock_logged_model = LoggedModel(
+        experiment_id="exp123",
+        model_id="model123",
+        name="test_model",
+        artifact_location="runs:/run123/model",
+        source_run_id="run123",
+        creation_timestamp=1234567890,
+        last_updated_timestamp=1234567890,
+    )
+    with mock.patch("mlflow.get_logged_model", return_value=mock_logged_model):
+        result = store._get_logged_model_from_model_id("model123")
+        assert result == mock_logged_model
+
+
+def test_get_logged_model_from_model_id_returns_none_for_none_input(store):
+    result = store._get_logged_model_from_model_id(None)
+    assert result is None
+
+
+def test_get_logged_model_from_model_id_reraises_other_exceptions(store):
+    with mock.patch(
+        "mlflow.get_logged_model",
+        side_effect=MlflowException("Some other error", error_code=INTERNAL_ERROR),
+    ):
+        with pytest.raises(MlflowException, match="Some other error"):
+            store._get_logged_model_from_model_id("model123")
+
+
+@pytest.mark.parametrize(
+    ("flavor_config", "should_persist_api_called"),
+    [
+        # persist_pretrained_model should NOT be called for non-transformer models
+        (
+            {
+                "python_function": {},
+                "scikit-learn": {},
+            },
+            False,
+        ),
+        # persist_pretrained_model should NOT be called if model weights are saved locally
+        (
+            {
+                "transformers": {
+                    "model_binary": "model",
+                    "source_model_name": "SOME_REPO",
+                }
+            },
+            False,
+        ),
+        # persist_pretrained_model should be called if model weights are not saved locally
+        (
+            {
+                "transformers": {
+                    "source_model_name": "SOME_REPO",
+                    "source_model_revision": "SOME_COMMIT_HASH",
+                }
+            },
+            True,
+        ),
+    ],
+)
+def test_download_model_weights_if_not_saved(
+    flavor_config, should_persist_api_called, store, tmp_path
+):
+    fake_mlmodel_contents = {
+        "artifact_path": "some-artifact-path",
+        "run_id": "abc123",
+        "flavors": flavor_config,
+        "signature": _TEST_SIGNATURE.to_dict(),
+    }
+    with tmp_path.joinpath(MLMODEL_FILE_NAME).open("w") as handle:
+        yaml.dump(fake_mlmodel_contents, handle)
+
+    if model_binary_path := flavor_config.get("transformers", {}).get("model_binary"):
+        tmp_path.joinpath(model_binary_path).mkdir()
+
+    with mock.patch("mlflow.transformers") as transformers_mock:
+        store._download_model_weights_if_not_saved(str(tmp_path))
+
+        if should_persist_api_called:
+            transformers_mock.persist_pretrained_model.assert_called_once_with(str(tmp_path))
+        else:
+            transformers_mock.persist_pretrained_model.assert_not_called()
+
+
+def test_search_registered_models_invalid_args(store):
+    params_list = [
+        {"filter_string": "model = 'yo'"},
+        {"order_by": ["x", "Y"]},
+    ]
+    # test all combination of invalid params
+    for sz in range(1, 3):
+        for combination in combinations(params_list, sz):
+            params = {k: v for d in combination for k, v in d.items()}
+            with pytest.raises(
+                MlflowException, match="unsupported for models in the Unity Catalog"
+            ):
+                store.search_registered_models(**params)
+
+
+def test_get_latest_versions_unsupported(store):
+    name = "model_1"
+    with pytest.raises(
+        MlflowException,
+        match=f"{_expected_unsupported_method_error_message('get_latest_versions')}. "
+        "To load the latest version of a model in Unity Catalog, you can set "
+        "an alias on the model version and load it by alias",
+    ):
+        store.get_latest_versions(name=name)
+    with pytest.raises(
+        MlflowException,
+        match=f"{_expected_unsupported_method_error_message('get_latest_versions')}. "
+        "Detected attempt to load latest model version in stages",
+    ):
+        store.get_latest_versions(name=name, stages=["Production"])
+
+
+def test_get_notebook_id_returns_none_if_empty_run(store):
+    assert store._get_notebook_id(None) is None
+
+
+def test_get_notebook_id_returns_expected_id(store):
+    test_tag = RunTag(key=MLFLOW_DATABRICKS_NOTEBOOK_ID, value="123")
+    test_run_data = RunData(tags=[test_tag])
+    test_run_info = RunInfo(
+        "run_uuid",
+        "experiment_id",
+        "user_id",
+        "status",
+        "start_time",
+        "end_time",
+        "lifecycle_stage",
+    )
+    test_run = Run(run_data=test_run_data, run_info=test_run_info)
+    assert store._get_notebook_id(test_run) == "123"
+
+
+def test_get_job_id_returns_none_if_empty_run(store):
+    assert store._get_job_id(None) is None
+
+
+def test_get_job_id_returns_expected_id(store):
+    test_tag = RunTag(key=MLFLOW_DATABRICKS_JOB_ID, value="123")
+    test_run_data = RunData(tags=[test_tag])
+    test_run_info = RunInfo(
+        "run_uuid",
+        "experiment_id",
+        "user_id",
+        "status",
+        "start_time",
+        "end_time",
+        "lifecycle_stage",
+    )
+    test_run = Run(run_data=test_run_data, run_info=test_run_info)
+    assert store._get_job_id(test_run) == "123"
+
+
+def test_get_job_run_id_returns_none_if_empty_run(store):
+    assert store._get_job_run_id(None) is None
+
+
+def test_get_job_run_id_returns_expected_id(store):
+    test_tag = RunTag(key=MLFLOW_DATABRICKS_JOB_RUN_ID, value="123")
+    test_run_data = RunData(tags=[test_tag])
+    test_run_info = RunInfo(
+        "run_uuid",
+        "experiment_id",
+        "user_id",
+        "status",
+        "start_time",
+        "end_time",
+        "lifecycle_stage",
+    )
+    test_run = Run(run_data=test_run_data, run_info=test_run_info)
+    assert store._get_job_run_id(test_run) == "123"
+
+
+def test_get_workspace_id_returns_none_if_empty_headers(store):
+    assert store._get_workspace_id(None) is None
+    bad_headers = {}
+    assert store._get_workspace_id(bad_headers) is None
+
+
+def test_get_workspace_id_returns_expected_id(store):
+    good_headers = {_DATABRICKS_ORG_ID_HEADER: "123"}
+    assert store._get_workspace_id(good_headers) == "123"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "response_text"),
+    [
+        (403, "{}"),
+        (500, "<html><div>Not real json</div></html>"),
+    ],
+)
+def test_get_run_and_headers_returns_none_if_request_fails(store, status_code, response_text):
+    mock_response = mock.MagicMock(autospec=Response)
+    mock_response.status_code = status_code
+    mock_response.headers = {_DATABRICKS_ORG_ID_HEADER: 123}
+    mock_response.text = response_text
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.http_request", return_value=mock_response
+    ):
+        assert store._get_run_and_headers(run_id="some_run_id") == (None, None)
+
+
+def test_get_run_and_headers_returns_none_if_tracking_uri_not_databricks(
+    mock_databricks_uc_host_creds, tmp_path
+):
+    with mock.patch("mlflow.utils.databricks_utils.get_databricks_host_creds"):
+        store = UcModelRegistryStore(store_uri="databricks-uc", tracking_uri=str(tmp_path))
+        mock_response = mock.MagicMock(autospec=Response)
+        mock_response.status_code = 200
+        mock_response.headers = {_DATABRICKS_ORG_ID_HEADER: 123}
+        mock_response.text = "{}"
+        with mock.patch(
+            "mlflow.store._unity_catalog.registry.rest_store.http_request",
+            return_value=mock_response,
+        ):
+            assert store._get_run_and_headers(run_id="some_run_id") == (None, None)
+
+
+def _get_workspace_id_for_run(run_id=None):
+    return "123" if run_id is not None else None
+
+
+def test_local_model_dir_preserves_uc_volumes_path(tmp_path):
+    store = UcModelRegistryStore(store_uri="databricks-uc", tracking_uri="databricks-uc")
+    with (
+        mock.patch(
+            "mlflow.artifacts.download_artifacts", return_value=str(tmp_path)
+        ) as mock_download_artifacts,
+        mock.patch(
+            # Pretend that `tmp_path` is a UC Volumes path
+            "mlflow.store._unity_catalog.registry.rest_store.is_fuse_or_uc_volumes_uri",
+            return_value=True,
+        ) as mock_is_fuse_or_uc_volumes_uri,
+    ):
+        with store._local_model_dir(source=f"dbfs:{tmp_path}", local_model_path=None):
+            pass
+        mock_download_artifacts.assert_called_once()
+        mock_is_fuse_or_uc_volumes_uri.assert_called_once()
+        assert tmp_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("num_inputs", "expected_truncation_size"),
+    [
+        (1, 1),
+        (10, 10),
+        (11, 10),
+    ],
+)
+def test_input_source_truncation(num_inputs, expected_truncation_size, store):
+    test_notebook_tag = RunTag(key=MLFLOW_DATABRICKS_NOTEBOOK_ID, value="321")
+    test_job_tag = RunTag(key=MLFLOW_DATABRICKS_JOB_ID, value="456")
+    test_job_run_tag = RunTag(key=MLFLOW_DATABRICKS_JOB_RUN_ID, value="789")
+    test_run_data = RunData(tags=[test_notebook_tag, test_job_tag, test_job_run_tag])
+    test_run_info = RunInfo(
+        "run_uuid",
+        "experiment_id",
+        "user_id",
+        "status",
+        "start_time",
+        "end_time",
+        "lifecycle_stage",
+    )
+    source_uri = "test:/my/test/uri"
+    source = SampleDatasetSource._resolve(source_uri)
+    df = pd.DataFrame([1, 2, 3], columns=["Numbers"])
+    input_list = []
+    for count in range(num_inputs):
+        input_list.append(
+            Dataset(
+                source=DeltaDatasetSource(
+                    delta_table_name=f"temp_delta_versioned_with_id_{count}",
+                    delta_table_version=1,
+                    delta_table_id=f"uc_id_{count}",
+                )
+            )
+        )
+        # Let's double up the sources and verify non-Delta Datasets are filtered out
+        input_list.append(
+            Dataset(
+                source=PandasDataset(
+                    df=df,
+                    source=source,
+                    name=f"testname_{count}",
+                )
+            )
+        )
+    assert len(input_list) == num_inputs * 2
+    test_run_inputs = RunInputs(dataset_inputs=input_list)
+    test_run = Run(run_data=test_run_data, run_info=test_run_info, run_inputs=test_run_inputs)
+    filtered_inputs = store._get_lineage_input_sources(test_run)
+    assert len(filtered_inputs) == expected_truncation_size
+
+
+def test_create_model_version_unsupported_fields(store):
+    with pytest.raises(MlflowException, match=_expected_unsupported_arg_error_message("run_link")):
+        store.create_model_version(name="mymodel", source="mysource", run_link="https://google.com")
+
+
+def test_transition_model_version_stage_unsupported(store):
+    name = "model_1"
+    version = "5"
+    expected_error = (
+        f"{_expected_unsupported_method_error_message('transition_model_version_stage')}. "
+        f"We recommend using aliases instead of stages for more flexible model deployment "
+        f"management."
+    )
+    with pytest.raises(
+        MlflowException,
+        match=expected_error,
+    ):
+        store.transition_model_version_stage(
+            name=name, version=version, stage="prod", archive_existing_versions=True
+        )
+
+
+def test_search_model_versions_order_by_unsupported(store):
+    with pytest.raises(MlflowException, match=_expected_unsupported_arg_error_message("order_by")):
+        store.search_model_versions(
+            filter_string="name='model_12'", page_token="fake_page_token", order_by=["name ASC"]
+        )
+
+
+@pytest.mark.parametrize("tags", [None, []])
+def test_default_values_for_tags(store, tmp_path, tags):
+    # None/empty tags must be accepted without raising for both create paths. A three-level name
+    # is used because the native create flow rejects non-UC names, and the post-name-resolution
+    # request/upload/finalize flow is mocked so the test isolates tag handling.
+    store.spark = None
+    mock_mv = mock.Mock(version="1", storage_location="s3://blah/loc")
+    rest_store = "mlflow.store._unity_catalog.registry.rest_store"
+    native_store = "mlflow.store._unity_catalog.registry.uc_native_rest_store"
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=mock_mv),
+        mock.patch.object(store, "_validate_model_signature"),
+        mock.patch.object(store, "_local_model_dir") as mock_local_model_dir,
+        mock.patch.object(store, "_download_model_weights_if_not_saved"),
+        mock.patch.object(store, "_get_artifact_repo"),
+        mock.patch(f"{rest_store}.get_feature_dependencies", return_value=""),
+        mock.patch(f"{rest_store}.get_model_version_dependencies", return_value=[]),
+        mock.patch(f"{native_store}.registered_model_from_uc_native_proto"),
+        mock.patch(f"{native_store}.model_version_from_uc_native_proto"),
+    ):
+        mock_local_model_dir.return_value.__enter__.return_value = tmp_path
+        mock_local_model_dir.return_value.__exit__.return_value = None
+        # No unsupported arg exceptions should be thrown for None/empty tags.
+        store.create_registered_model(
+            name="catalog.schema.model_1", description="description", tags=tags
+        )
+        store.create_model_version(name="catalog.schema.model_1", source=str(tmp_path), tags=tags)
+
+
+@pytest.mark.parametrize("spark_session", ["main"], indirect=True)  # set the catalog name to "main"
+def test_store_uses_catalog_and_schema_from_spark_session(spark_session, store):
+    with mock.patch.object(
+        store, "_edit_endpoint_and_call", return_value=RegisteredModelInfo()
+    ) as native_call:
+        store.get_registered_model(name="model_1")
+    spark_session.sql.assert_any_call(_ACTIVE_CATALOG_QUERY)
+    spark_session.sql.assert_any_call(_ACTIVE_SCHEMA_QUERY)
+    assert spark_session.sql.call_count == 2
+    assert native_call.call_args.kwargs["full_name"] == "main.default.model_1"
+
+
+@pytest.mark.parametrize("spark_session", ["main"], indirect=True)
+def test_store_uses_catalog_from_spark_session(spark_session, store):
+    with mock.patch.object(
+        store, "_edit_endpoint_and_call", return_value=RegisteredModelInfo()
+    ) as native_call:
+        store.get_registered_model(name="default.model_1")
+    spark_session.sql.assert_any_call(_ACTIVE_CATALOG_QUERY)
+    assert spark_session.sql.call_count == 1
+    assert native_call.call_args.kwargs["full_name"] == "main.default.model_1"
+
+
+@pytest.mark.parametrize("spark_session", ["hive_metastore", "spark_catalog"], indirect=True)
+def test_store_ignores_hive_metastore_default_from_spark_session(spark_session, store):
+    with mock.patch.object(
+        store, "_edit_endpoint_and_call", return_value=RegisteredModelInfo()
+    ) as native_call:
+        store.get_registered_model(name="model_1")
+    spark_session.sql.assert_any_call(_ACTIVE_CATALOG_QUERY)
+    assert spark_session.sql.call_count == 1
+    assert native_call.call_args.kwargs["full_name"] == "model_1"
+
+
+def test_store_use_presigned_url_store_when_disabled(monkeypatch):
+    store_package = "mlflow.store._unity_catalog.registry.rest_store"
+    monkeypatch.setenv("MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", "false")
+    monkeypatch.setenv("DATABRICKS_HOST", "my-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "my-token")
+
+    uc_store = UcModelRegistryStore(store_uri="databricks-uc", tracking_uri="databricks-uc")
+    full_name = "catalog.schema.model_1"
+    storage_location = "s3://some/storage/location"
+    model_version = ModelVersionInfo(version=1, storage_location=storage_location)
+    creds = TemporaryCredentials(
+        aws_temp_credentials=AwsCredentials(
+            access_key_id="key", secret_access_key="secret", session_token="token"
+        )
+    )
+    with (
+        mock.patch(
+            f"{store_package}.UcModelRegistryStore._get_temporary_model_version_write_credentials",
+            return_value=creds,
+        ) as temp_cred_mock,
+        mock.patch(
+            f"{store_package}.get_artifact_repo_from_storage_info",
+            side_effect=get_artifact_repo_from_storage_info,
+        ) as get_repo_mock,
+    ):
+        aws_store = uc_store._get_artifact_repo(model_version, full_name, storage_location)
+
+        assert type(aws_store) is OptimizedS3ArtifactRepository
+        temp_cred_mock.assert_called_once_with(name=full_name, version=model_version.version)
+        get_repo_mock.assert_called_once_with(
+            storage_location=storage_location,
+            scoped_token=creds,
+            base_credential_refresh_def=ANY,
+        )
+
+
+def test_store_use_presigned_url_store_when_enabled(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "my-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "my-token")
+    monkeypatch.setenv("MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", "false")
+    store_package = "mlflow.store._unity_catalog.registry.rest_store"
+    creds = TemporaryCredentials(storage_mode=StorageMode.DEFAULT_STORAGE)
+    with mock.patch(
+        f"{store_package}.UcModelRegistryStore._get_temporary_model_version_write_credentials",
+        return_value=creds,
+    ):
+        uc_store = UcModelRegistryStore(store_uri="databricks-uc", tracking_uri="databricks-uc")
+        full_name = "catalog.schema.model_1"
+        model_version = ModelVersionInfo(version=1)
+        presigned_store = uc_store._get_artifact_repo(
+            model_version, full_name, model_version.storage_location
+        )
+
+    assert type(presigned_store) is PresignedUrlArtifactRepository
+
+
+@mock_http_200
+def test_create_and_update_registered_model_print_job_url(mock_http, store):
+    # UC model names must be three-level; the native create/update flow rejects non-UC names.
+    name = "catalog.schema.model_for_job_url_test"
+    description = "test model with job id"
+    deployment_job_id = "123"
+
+    with (
+        mock.patch(
+            "mlflow.store._unity_catalog.registry.uc_native_rest_store."
+            "_print_databricks_deployment_job_url",
+        ) as mock_print_url,
+    ):
+        # Should not print the job url when the deployment job id is None
+        store.create_registered_model(name=name, description=description, deployment_job_id=None)
+        store.create_registered_model(name=name, description=description, deployment_job_id="")
+        mock_print_url.assert_not_called()
+        # Should print the job url when the deployment job id is not None
+        store.create_registered_model(
+            name=name, description=description, deployment_job_id=deployment_job_id
+        )
+        mock_print_url.assert_called_once_with(model_name=name, job_id=deployment_job_id)
+        mock_print_url.reset_mock()
+
+        # Should not print the job url when the deployment job id is false-y
+        store.update_registered_model(name=name, description=description, deployment_job_id=None)
+        store.update_registered_model(name=name, description=description, deployment_job_id="")
+        mock_print_url.assert_not_called()
+        # Should print the job url when the deployment job id is not None
+        store.update_registered_model(
+            name=name, description=description, deployment_job_id=deployment_job_id
+        )
+        mock_print_url.assert_called_once_with(model_name=name, job_id=deployment_job_id)
+
+
+@mock_http_200
+def test_create_prompt_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    description = "A test prompt"
+    tags = {"foo": "bar"}
+    # Patch proto_info_to_mlflow_prompt_info to return a dummy Prompt
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
+        return_value=Prompt(name=name, description=description, tags=tags),
+    ) as proto_to_prompt:
+        store.create_prompt(name=name, description=description, tags=tags)
+        # Check that the endpoint was called correctly
+        assert any(c[1]["endpoint"].endswith("/prompts") for c in mock_http.call_args_list)
+        proto_to_prompt.assert_called()
+
+
+@mock_http_200
+def test_search_prompts_uc(mock_http, store, monkeypatch):
+    # Patch proto_info_to_mlflow_prompt_info to return a dummy Prompt
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
+        return_value=Prompt(name="prompt1", description="test prompt"),
+    ) as proto_to_prompt:
+        store.search_prompts(filter_string="catalog = 'test_catalog' AND schema = 'test_schema'")
+        # Should call the correct endpoint for SearchPromptsRequest
+        assert any("/prompts" in c[1]["endpoint"] for c in mock_http.call_args_list)
+        # The utility function should NOT be called when there are no results (empty list)
+        assert proto_to_prompt.call_count == 0  # Correct behavior for empty results
+
+
+def test_search_prompts_with_results_uc(store, monkeypatch):
+    # Create mock protobuf objects
+    from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
+        Prompt as ProtoPrompt,
+    )
+    from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
+        PromptTag as ProtoPromptTag,
+    )
+    from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
+        SearchPromptsResponse,
+    )
+
+    # Create mock prompt data
+    mock_prompt_1 = ProtoPrompt(
+        name="test_prompt_1",
+        description="First test prompt",
+        tags=[ProtoPromptTag(key="env", value="dev")],
+    )
+    mock_prompt_2 = ProtoPrompt(name="test_prompt_2", description="Second test prompt")
+
+    # Create mock response
+    mock_response = SearchPromptsResponse(
+        prompts=[mock_prompt_1, mock_prompt_2], next_page_token="next_token_123"
+    )
+
+    # Expected conversion results
+    expected_prompts = [
+        Prompt(name="test_prompt_1", description="First test prompt", tags={"env": "dev"}),
+        Prompt(name="test_prompt_2", description="Second test prompt", tags={}),
+    ]
+
+    with (
+        mock.patch.object(store, "_call_endpoint", return_value=mock_response),
+        mock.patch(
+            "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
+            side_effect=expected_prompts,
+        ) as mock_converter,
+    ):
+        # Call search_prompts
+        result = store.search_prompts(
+            max_results=10, filter_string="catalog = 'test_catalog' AND schema = 'test_schema'"
+        )
+
+        # Verify conversion function was called twice (once for each result)
+        assert mock_converter.call_count == 2
+
+        # Verify the results
+        assert len(result) == 2
+        assert result.token == "next_token_123"
+        assert result[0].name == "test_prompt_1"
+        assert result[1].name == "test_prompt_2"
+
+
+@mock_http_200
+def test_delete_prompt_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    store.delete_prompt(name=name)
+    # Should call the correct endpoint for DeletePromptRequest
+    assert any("/prompts" in c[1]["endpoint"] for c in mock_http.call_args_list)
+
+
+@mock_http_200
+def test_set_prompt_tag_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    key = "env"
+    value = "prod"
+    store.set_prompt_tag(name=name, key=key, value=value)
+    # Should call the exact endpoint for SetPromptTagRequest with substituted path
+    expected_endpoint = f"/api/2.0/mlflow/unity-catalog/prompts/{name}/tags"
+    assert any(c[1]["endpoint"] == expected_endpoint for c in mock_http.call_args_list)
+
+
+@mock_http_200
+def test_delete_prompt_tag_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    key = "env"
+    store.delete_prompt_tag(name=name, key=key)
+    # Should call the exact endpoint for DeletePromptTagRequest with substituted path
+    expected_endpoint = f"/api/2.0/mlflow/unity-catalog/prompts/{name}/tags/{key}"
+    assert any(c[1]["endpoint"] == expected_endpoint for c in mock_http.call_args_list)
+
+
+@mock_http_200
+def test_create_prompt_version_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    template = "Hello {name}!"
+    description = "A greeting prompt"
+    tags = {"env": "test"}
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name, version=1, template=template, commit_message=description, tags=tags
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name, template=template, description=description, tags=tags
+        )
+        # Should call the correct endpoint for CreatePromptVersionRequest
+        assert any(
+            "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+            for c in mock_http.call_args_list
+        )
+        proto_to_prompt.assert_called()
+
+
+@mock_http_200
+def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    template = "Generate a response for {query}"
+    description = "A response generation prompt"
+    tags = {"env": "test"}
+    response_format = {"type": "object", "properties": {"answer": {"type": "string"}}}
+
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name,
+            version=1,
+            template=template,
+            commit_message=description,
+            tags=tags,
+            response_format=response_format,
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name,
+            template=template,
+            description=description,
+            tags=tags,
+            response_format=response_format,
+        )
+
+    # Verify the correct endpoint is called
+    assert any(
+        "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+        for c in mock_http.call_args_list
+    )
+    proto_to_prompt.assert_called()
+
+    # Verify the HTTP request body contains the response_format in tags
+    http_call_args = [
+        c
+        for c in mock_http.call_args_list
+        if "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+    ]
+    assert len(http_call_args) == 1
+
+    request_body = http_call_args[0][1]["json"]
+    prompt_version = request_body["prompt_version"]
+
+    tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
+    assert RESPONSE_FORMAT_TAG_KEY in tags_in_request
+
+    expected_response_format = json.dumps(response_format)
+    assert tags_in_request[RESPONSE_FORMAT_TAG_KEY] == expected_response_format
+    assert tags_in_request["env"] == "test"
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY] == PROMPT_TYPE_TEXT
+
+
+@mock_http_200
+def test_create_prompt_version_with_multi_turn_template_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    template = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, can you help me with {task}?"},
+        {"role": "assistant", "content": "Of course! I'd be happy to help you with {task}."},
+        {"role": "user", "content": "Please provide a detailed explanation."},
+    ]
+    description = "A multi-turn conversation prompt"
+    tags = {"type": "conversation", "env": "test"}
+
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name, version=1, template=template, commit_message=description, tags=tags
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name, template=template, description=description, tags=tags
+        )
+
+    # Verify the correct endpoint is called
+    assert any(
+        "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+        for c in mock_http.call_args_list
+    )
+    proto_to_prompt.assert_called()
+
+    # Verify the HTTP request body contains the multi-turn template
+    http_call_args = [
+        c
+        for c in mock_http.call_args_list
+        if "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+    ]
+    assert len(http_call_args) == 1
+
+    request_body = http_call_args[0][1]["json"]
+    prompt_version = request_body["prompt_version"]
+
+    # Verify template was JSON-encoded properly
+    template_in_request = json.loads(prompt_version["template"])
+    assert template_in_request == template
+
+    tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
+    assert tags_in_request["type"] == "conversation"
+    assert tags_in_request["env"] == "test"
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY] == PROMPT_TYPE_CHAT
+
+
+@mock_http_200
+def test_create_prompt_version_with_model_config_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    template = "Generate a response for {query}"
+    description = "A prompt with model config"
+    tags = {"env": "test"}
+    model_config = {
+        "model_name": "databricks-meta-llama-3-1-70b-instruct",
+        "max_tokens": 100,
+        "temperature": 0.7,
+    }
+
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name,
+            version=1,
+            template=template,
+            commit_message=description,
+            tags=tags,
+            model_config=model_config,
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name,
+            template=template,
+            description=description,
+            tags=tags,
+            model_config=model_config,
+        )
+
+    # Verify the correct endpoint is called
+    assert any(
+        "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+        for c in mock_http.call_args_list
+    )
+    proto_to_prompt.assert_called()
+
+    # Verify the HTTP request body contains the model_config in tags
+    http_call_args = [
+        c
+        for c in mock_http.call_args_list
+        if "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+    ]
+    assert len(http_call_args) == 1
+
+    request_body = http_call_args[0][1]["json"]
+    prompt_version = request_body["prompt_version"]
+
+    tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
+    assert PROMPT_MODEL_CONFIG_TAG_KEY in tags_in_request
+
+    expected_model_config = json.dumps(model_config)
+    assert tags_in_request[PROMPT_MODEL_CONFIG_TAG_KEY] == expected_model_config
+    assert tags_in_request["env"] == "test"
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY] == PROMPT_TYPE_TEXT
+
+
+@mock_http_200
+def test_get_prompt_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    # Patch proto_info_to_mlflow_prompt_info to return a dummy Prompt
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
+        return_value=Prompt(name=name, description="test prompt", tags={}),
+    ) as proto_to_prompt:
+        store.get_prompt(name=name)
+        # Should call the correct endpoint for GetPromptRequest
+        assert any(
+            "/prompts/" in c[1]["endpoint"] and "/versions/" not in c[1]["endpoint"]
+            for c in mock_http.call_args_list
+        )
+        proto_to_prompt.assert_called()
+
+
+@mock_http_200
+def test_get_prompt_version_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    version = "1"
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(name=name, version=1, template="Hello {name}!"),
+    ) as proto_to_prompt:
+        store.get_prompt_version(name=name, version=version)
+        # Should call the correct endpoint for GetPromptVersionRequest
+        assert any(
+            "/prompts/" in c[1]["endpoint"] and "/versions/" in c[1]["endpoint"]
+            for c in mock_http.call_args_list
+        )
+        proto_to_prompt.assert_called()
+
+
+@mock_http_200
+def test_delete_prompt_version_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    version = "1"
+    store.delete_prompt_version(name=name, version=version)
+    # Should call the correct endpoint for DeletePromptVersionRequest
+    assert any(
+        "/prompts/" in c[1]["endpoint"] and "/versions/" in c[1]["endpoint"]
+        for c in mock_http.call_args_list
+    )
+
+
+@mock_http_200
+def test_get_prompt_version_by_alias_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    alias = "latest"
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(name=name, version=1, template="Hello {name}!"),
+    ) as proto_to_prompt:
+        store.get_prompt_version_by_alias(name=name, alias=alias)
+        # Should call the correct endpoint for GetPromptVersionByAliasRequest
+        assert any(
+            "/prompts/" in c[1]["endpoint"] and "/versions/by-alias/" in c[1]["endpoint"]
+            for c in mock_http.call_args_list
+        )
+        proto_to_prompt.assert_called()
+
+
+def test_link_prompt_version_to_model_success(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as mock_edit_call,
+        mock.patch.object(store, "_get_endpoint_from_method") as mock_get_endpoint,
+        mock.patch(
+            "mlflow.store.model_registry.abstract_store.AbstractStore.link_prompt_version_to_model"
+        ) as mock_super_call,
+    ):
+        # Setup
+        mock_get_endpoint.return_value = (
+            "/api/2.0/mlflow/unity-catalog/prompts/link-to-model",
+            "POST",
+        )
+
+        # Execute
+        store.link_prompt_version_to_model("test_prompt", "1", "model_123")
+
+        # Verify parent method was called
+        mock_super_call.assert_called_once_with(
+            name="test_prompt", version="1", model_id="model_123"
+        )
+
+        # Verify API call was made
+        mock_edit_call.assert_called_once()
+        call_args = mock_edit_call.call_args
+
+        assert call_args[1]["name"] == "test_prompt"
+        assert call_args[1]["version"] == "1"
+        assert call_args[1]["model_id"] == "model_123"
+        assert call_args[1]["proto_name"] == LinkPromptVersionsToModelsRequest
+
+
+def test_link_prompt_version_to_model_sets_tag(store):
+    # Mock the prompt version
+    mock_prompt_version = PromptVersion(
+        name="test_prompt",
+        version=1,
+        template="Test template",
+        creation_timestamp=1234567890,
+    )
+
+    with (
+        mock.patch("mlflow.tracking._get_store") as mock_get_tracking_store,
+        mock.patch.object(store, "get_prompt_version", return_value=mock_prompt_version),
+    ):
+        # Setup mocks
+        mock_tracking_store = mock.Mock()
+        mock_get_tracking_store.return_value = mock_tracking_store
+
+        # Mock the logged model
+        model_id = "model_123"
+        logged_model = LoggedModel(
+            experiment_id="exp_123",
+            model_id=model_id,
+            name="test_model",
+            artifact_location="/path/to/artifacts",
+            creation_timestamp=1234567890,
+            last_updated_timestamp=1234567890,
+            tags={},
+        )
+        mock_tracking_store.get_logged_model.return_value = logged_model
+
+        # Mock the UC-specific API call to avoid real API calls
+        with (
+            mock.patch.object(store, "_edit_endpoint_and_call"),
+            mock.patch.object(
+                store, "_get_endpoint_from_method", return_value=("/api/test", "POST")
+            ),
+        ):
+            # Execute
+            store.link_prompt_version_to_model("test_prompt", "1", model_id)
+
+        # Verify the tag was set
+        mock_tracking_store.set_logged_model_tags.assert_called_once()
+        call_args = mock_tracking_store.set_logged_model_tags.call_args
+        assert call_args[0][0] == model_id
+
+        logged_model_tags = call_args[0][1]
+        assert len(logged_model_tags) == 1
+        logged_model_tag = logged_model_tags[0]
+        assert isinstance(logged_model_tag, LoggedModelTag)
+        assert logged_model_tag.key == TraceTagKey.LINKED_PROMPTS
+
+        expected_value = [{"name": "test_prompt", "version": "1"}]
+        assert json.loads(logged_model_tag.value) == expected_value
+
+
+def test_link_prompts_to_trace_success(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as mock_edit_call,
+        mock.patch.object(store, "_get_endpoint_from_method") as mock_get_endpoint,
+    ):
+        # Setup
+        mock_get_endpoint.return_value = (
+            "/api/2.0/mlflow/unity-catalog/prompt-versions/links-to-traces",
+            "POST",
+        )
+
+        prompt_versions = [
+            PromptVersion(name="test_prompt", version=1, template="test", creation_timestamp=123)
+        ]
+        trace_id = "trace_123"
+
+        # Execute
+        store.link_prompts_to_trace(prompt_versions, trace_id)
+
+        # Verify API call was made
+        mock_edit_call.assert_called_once()
+        call_args = mock_edit_call.call_args
+
+        assert call_args[1]["proto_name"] == LinkPromptsToTracesRequest
+
+
+def test_link_prompt_version_to_run_success(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as mock_edit_call,
+        mock.patch.object(store, "_get_endpoint_from_method") as mock_get_endpoint,
+        mock.patch(
+            "mlflow.store.model_registry.abstract_store.AbstractStore.link_prompt_version_to_run"
+        ) as mock_super_call,
+    ):
+        # Setup
+        mock_get_endpoint.return_value = (
+            "/api/2.0/mlflow/unity-catalog/prompt-versions/links-to-runs",
+            "POST",
+        )
+
+        # Execute
+        store.link_prompt_version_to_run("test_prompt", "1", "run_123")
+
+        # Verify parent method was called
+        mock_super_call.assert_called_once_with(name="test_prompt", version="1", run_id="run_123")
+
+        # Verify API call was made
+        mock_edit_call.assert_called_once()
+        call_args = mock_edit_call.call_args
+
+        # Check that _edit_endpoint_and_call was called with correct parameters
+        assert (
+            call_args[1]["endpoint"]
+            == "/api/2.0/mlflow/unity-catalog/prompt-versions/links-to-runs"
+        )
+        assert call_args[1]["method"] == "POST"
+        assert call_args[1]["proto_name"] == LinkPromptVersionsToRunsRequest
+
+        # Verify the request body contains correct prompt and run information
+        req_body = json.loads(call_args[1]["req_body"])
+        assert len(req_body["prompt_versions"]) == 1
+        assert req_body["prompt_versions"][0]["name"] == "test_prompt"
+        assert req_body["prompt_versions"][0]["version"] == "1"
+        assert req_body["run_ids"] == ["run_123"]
+
+
+def test_link_prompt_version_to_run_sets_tag(store):
+    # Mock the prompt version
+    mock_prompt_version = PromptVersion(
+        name="test_prompt",
+        version=1,
+        template="Test template",
+        creation_timestamp=1234567890,
+    )
+
+    with (
+        mock.patch("mlflow.tracking._get_store") as mock_get_tracking_store,
+        mock.patch.object(store, "get_prompt_version", return_value=mock_prompt_version),
+    ):
+        # Setup mocks
+        mock_tracking_store = mock.Mock()
+        mock_get_tracking_store.return_value = mock_tracking_store
+
+        # Mock the run
+        run_id = "run_123"
+        run_data = RunData(metrics=[], params=[], tags={})
+        run_info = RunInfo(
+            run_id=run_id,
+            experiment_id="exp_123",
+            user_id="user_123",
+            status="FINISHED",
+            start_time=1234567890,
+            end_time=1234567890,
+            lifecycle_stage="active",
+        )
+        run = Run(run_info=run_info, run_data=run_data)
+        mock_tracking_store.get_run.return_value = run
+
+        # Mock the UC-specific API call to avoid real API calls
+        with (
+            mock.patch.object(store, "_edit_endpoint_and_call"),
+            mock.patch.object(
+                store, "_get_endpoint_from_method", return_value=("/api/test", "POST")
+            ),
+        ):
+            # Execute
+            store.link_prompt_version_to_run("test_prompt", "1", run_id)
+
+        # Verify the tag was set
+        mock_tracking_store.set_tag.assert_called_once()
+        call_args = mock_tracking_store.set_tag.call_args
+        assert call_args[0][0] == run_id
+
+        run_tag = call_args[0][1]
+        assert isinstance(run_tag, RunTag)
+        assert run_tag.key == TraceTagKey.LINKED_PROMPTS
+
+        expected_value = [{"name": "test_prompt", "version": "1"}]
+        assert json.loads(run_tag.value) == expected_value
+
+
+# ---------------------------------------------------------------------------
+# Native (/api/2.1/unity-catalog/*) path: governance + enrichment. Selected when
+# MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY is set; the legacy store is a separate class.
+# ---------------------------------------------------------------------------
+
+
+def test_get_registered_model_uses_native_endpoint(store):
+    native_info = RegisteredModelInfo(
+        name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name="catalog.schema.model",
+        comment="d",
+        deployment_job_id="42",
+        deployment_job_state=DeploymentJobConnection.State.Value("CONNECTED"),
+    )
+    with mock.patch.object(
+        store, "_edit_endpoint_and_call", return_value=native_info
+    ) as native_call:
+        result = store.get_registered_model("catalog.schema.model")
+    native_call.assert_called_once()
+    assert result.name == "catalog.schema.model"
+    assert result.deployment_job_id == "42"
+    assert result.deployment_job_state == "CONNECTED"
+
+
+def test_get_model_version_uses_native_endpoint(store):
+    native_info = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=3,
+        model_id="m-1",
+    )
+    with (
+        mock.patch.object(
+            store, "_edit_endpoint_and_call", return_value=native_info
+        ) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store.get_model_version("catalog.schema.model", 3)
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert result.name == "catalog.schema.model"
+    # MLflow entity version is a string (int64 governance version is stringified).
+    assert result.version == "3"
+    assert result.model_id == "m-1"
+
+
+def test_search_model_versions_uses_native_for_name_filter(store):
+    resp = ListModelVersions.Response(
+        model_versions=[
+            ModelVersionInfo(
+                model_name="model", catalog_name="catalog", schema_name="schema", version=1
+            )
+        ],
+        next_page_token="tok",
+    )
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=resp) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store.search_model_versions(filter_string="name = 'catalog.schema.model'")
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert [mv.name for mv in result] == ["catalog.schema.model"]
+    assert result.token == "tok"
+
+
+@pytest.mark.parametrize(
+    "filter_string",
+    [
+        # run_id search was never supported on UC (the legacy registry rejected it too); only a
+        # `name = '...'` filter maps to the native per-model list endpoint. The unsupported
+        # filter is rejected client-side (in parse_model_name) before any HTTP request, so no
+        # http mock is needed here.
+        "run_id = 'abc'",
+        "source_path = 's3://x'",
+    ],
+)
+def test_search_model_versions_rejects_unsupported_filter(store, filter_string):
+    with pytest.raises(MlflowException, match="name = 'model_name'"):
+        store.search_model_versions(filter_string=filter_string)
+
+
+def test_get_temporary_model_version_write_credentials_uses_native(store):
+    # The temp-credentials passthrough returns a json_inline'd TemporaryCredentials. The request
+    # sends the catalog/schema/model split, the version (int64 -> JSON string), and the
+    # READ_WRITE_MODEL_VERSION operation.
+    creds = TemporaryCredentials(storage_mode=StorageMode.DEFAULT_STORAGE)
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=creds) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store._get_temporary_model_version_write_credentials("catalog.schema.model", 2)
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert result is creds
+    body = json.loads(native_call.call_args.kwargs["req_body"])
+    assert body == {
+        "catalog_name": "catalog",
+        "schema_name": "schema",
+        "model_name": "model",
+        "version": 2,
+        "operation": "READ_WRITE_MODEL_VERSION",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Native write paths: the governance entity rides with the MLflow write inputs as
+# siblings (deployment_job_id / model_id / feature_deps / run_tracking_server_id).
+# ---------------------------------------------------------------------------
+
+
+def test_create_registered_model_uses_native(store):
+    native_info = RegisteredModelInfo(
+        name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name="catalog.schema.model",
+        deployment_job_id="9",
+    )
+    with (
+        mock.patch.object(
+            store, "_edit_endpoint_and_call", return_value=native_info
+        ) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store.create_registered_model("catalog.schema.model", description="d")
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert result.name == "catalog.schema.model"
+    assert result.deployment_job_id == "9"
+
+
+def test_create_registered_model_rejects_non_three_level_name(store):
+    # UC model names must be three-level; a non-three-level name errors with guidance.
+    # Validated client-side before any HTTP request, so no http mock is needed.
+    # Disable the Spark session so the name is not auto-qualified to three levels.
+    store.spark = None
+    with pytest.raises(MlflowException, match="three levels"):
+        store.create_registered_model(name="model_1", description="d")
+
+
+def test_update_registered_model_uses_native(store):
+    native_info = RegisteredModelInfo(
+        name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name="catalog.schema.model",
+        comment="new",
+    )
+    with (
+        mock.patch.object(
+            store, "_edit_endpoint_and_call", return_value=native_info
+        ) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store.update_registered_model("catalog.schema.model", description="new")
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert result.description == "new"
+
+
+def test_rename_registered_model_uses_native(store):
+    native_info = RegisteredModelInfo(
+        name="newname",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name="catalog.schema.newname",
+    )
+    with (
+        mock.patch.object(
+            store, "_edit_endpoint_and_call", return_value=native_info
+        ) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store.rename_registered_model(
+            "catalog.schema.model", new_name="catalog.schema.newname"
+        )
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert result.name == "catalog.schema.newname"
+
+
+def test_update_model_version_uses_native(store):
+    native_info = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=2,
+        comment="new",
+    )
+    with (
+        mock.patch.object(
+            store, "_edit_endpoint_and_call", return_value=native_info
+        ) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        result = store.update_model_version("catalog.schema.model", 2, "new")
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert result.version == "2"
+    assert result.description == "new"
+
+
+def test_create_model_version_uses_native_when_no_dependencies(store, tmp_path):
+    # With the flag on, a three-level name, and no model-version dependencies to translate, the
+    # create + finalize go through the native endpoints; the artifact upload happens in between.
+    native_mv = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=1,
+        storage_location="s3://blah",
+        source=str(tmp_path),
+    )
+    mock_repo = mock.MagicMock()
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=native_mv) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+        mock.patch.object(store, "_get_artifact_repo", return_value=mock_repo),
+        mock.patch.object(store, "_get_logged_model_from_model_id", return_value=None),
+        mock.patch.object(store, "_get_run_and_headers", return_value=(None, None)),
+        mock.patch.object(store, "_get_workspace_id", return_value=None),
+        mock.patch.object(store, "_get_notebook_id", return_value=None),
+        mock.patch.object(store, "_get_job_id", return_value=None),
+        mock.patch.object(store, "_validate_model_signature"),
+        mock.patch.object(store, "_download_model_weights_if_not_saved"),
+        mock.patch(
+            "mlflow.store._unity_catalog.registry.rest_store.get_feature_dependencies",
+            return_value="",
+        ),
+        mock.patch(
+            "mlflow.store._unity_catalog.registry.rest_store.get_model_version_dependencies",
+            return_value=[],
+        ),
+        mock.patch.object(store, "_local_model_dir") as local_model_dir,
+    ):
+        local_model_dir.return_value.__enter__.return_value = str(tmp_path)
+        result = store.create_model_version(name="catalog.schema.model", source=str(tmp_path))
+    # create + finalize both go native; the legacy create endpoint is never used.
+    assert native_call.call_count == 2
+    legacy_call.assert_not_called()
+    mock_repo.log_artifacts.assert_called_once()
+    assert result.name == "catalog.schema.model"
+    assert result.version == "1"
+
+
+def test_create_model_version_translates_dependencies_to_governance(store, tmp_path):
+    # The MLflow resource dependencies are translated into the governance DependencyList on the
+    # CreateModelVersion request, mirroring the legacy UCMR server: vector-index and table both
+    # become a table securable, UC function a function, UC connection a connection; model-endpoint
+    # (and any other kind) has no governance representation and is dropped.
+    mlflow_deps = [
+        {"type": "DATABRICKS_VECTOR_INDEX", "name": "catalog.schema.index"},
+        {"type": "DATABRICKS_TABLE", "name": "catalog.schema.table"},
+        {"type": "DATABRICKS_UC_FUNCTION", "name": "catalog.schema.fn"},
+        {"type": "DATABRICKS_UC_CONNECTION", "name": "my_connection"},
+        {"type": "DATABRICKS_MODEL_ENDPOINT", "name": "my_endpoint"},
+        {"type": "SOME_UNKNOWN_KIND", "name": "whatever"},
+    ]
+    native_mv = ModelVersionInfo(
+        model_name="model", catalog_name="catalog", schema_name="schema", version=1
+    )
+    rest_store = "mlflow.store._unity_catalog.registry.rest_store"
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=native_mv) as native_call,
+        mock.patch.object(store, "_get_artifact_repo", return_value=mock.MagicMock()),
+        mock.patch.object(store, "_get_logged_model_from_model_id", return_value=None),
+        mock.patch.object(store, "_get_run_and_headers", return_value=(None, None)),
+        mock.patch.object(store, "_get_workspace_id", return_value=None),
+        mock.patch.object(store, "_get_notebook_id", return_value=None),
+        mock.patch.object(store, "_get_job_id", return_value=None),
+        mock.patch.object(store, "_validate_model_signature"),
+        mock.patch.object(store, "_download_model_weights_if_not_saved"),
+        mock.patch(f"{rest_store}.get_feature_dependencies", return_value=""),
+        mock.patch(f"{rest_store}.get_model_version_dependencies", return_value=mlflow_deps),
+        mock.patch.object(store, "_local_model_dir") as local_model_dir,
+    ):
+        local_model_dir.return_value.__enter__.return_value = str(tmp_path)
+        store.create_model_version(name="catalog.schema.model", source=str(tmp_path))
+
+    # The first native call is CreateModelVersion; inspect its serialized request body.
+    create_call = native_call.call_args_list[0]
+    assert create_call.kwargs["proto_name"] is CreateModelVersion
+    body = json.loads(create_call.kwargs["req_body"])
+    deps = body["model_version_dependencies"]["dependencies"]
+    assert deps == [
+        {"table": {"table_full_name": "catalog.schema.index"}},
+        {"table": {"table_full_name": "catalog.schema.table"}},
+        {"function": {"function_full_name": "catalog.schema.fn"}},
+        {"connection": {"connection_name": "my_connection"}},
+    ]
+
+
+def test_create_model_version_omits_dependencies_when_none_supported(store, tmp_path):
+    # When every dependency is an unsupported kind, no DependencyList is attached (the field is
+    # left unset rather than sent as an empty list).
+    mlflow_deps = [{"type": "DATABRICKS_MODEL_ENDPOINT", "name": "my_endpoint"}]
+    native_mv = ModelVersionInfo(
+        model_name="model", catalog_name="catalog", schema_name="schema", version=1
+    )
+    rest_store = "mlflow.store._unity_catalog.registry.rest_store"
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=native_mv) as native_call,
+        mock.patch.object(store, "_get_artifact_repo", return_value=mock.MagicMock()),
+        mock.patch.object(store, "_get_logged_model_from_model_id", return_value=None),
+        mock.patch.object(store, "_get_run_and_headers", return_value=(None, None)),
+        mock.patch.object(store, "_get_workspace_id", return_value=None),
+        mock.patch.object(store, "_get_notebook_id", return_value=None),
+        mock.patch.object(store, "_get_job_id", return_value=None),
+        mock.patch.object(store, "_validate_model_signature"),
+        mock.patch.object(store, "_download_model_weights_if_not_saved"),
+        mock.patch(f"{rest_store}.get_feature_dependencies", return_value=""),
+        mock.patch(f"{rest_store}.get_model_version_dependencies", return_value=mlflow_deps),
+        mock.patch.object(store, "_local_model_dir") as local_model_dir,
+    ):
+        local_model_dir.return_value.__enter__.return_value = str(tmp_path)
+        store.create_model_version(name="catalog.schema.model", source=str(tmp_path))
+
+    body = json.loads(native_call.call_args_list[0].kwargs["req_body"])
+    assert "model_version_dependencies" not in body
+
+
+# ---------------------------------------------------------------------------
+# Native passthrough (delete / alias), the generic UC tag API, and client-side
+# download-uri derivation.
+# ---------------------------------------------------------------------------
+
+
+def test_delete_registered_model_uses_native(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        store.delete_registered_model("catalog.schema.model")
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+
+
+def test_delete_model_version_uses_native(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        store.delete_model_version("catalog.schema.model", 3)
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert native_call.call_args.kwargs["version"] == 3
+
+
+def test_set_registered_model_alias_uses_native(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        store.set_registered_model_alias("catalog.schema.model", "champion", 3)
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    kwargs = native_call.call_args.kwargs
+    assert kwargs["alias"] == "champion"
+    # The request body carries the full name and the version_num (int64, serialized as a
+    # JSON number by mlflow's message_to_json).
+    body = json.loads(kwargs["req_body"])
+    assert body["full_name"] == "catalog.schema.model"
+    assert body["version_num"] == 3
+
+
+def test_delete_registered_model_alias_uses_native(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        store.delete_registered_model_alias("catalog.schema.model", "champion")
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+
+
+def test_set_registered_model_tag_uses_native_tag_api(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        store.set_registered_model_tag(
+            "catalog.schema.model", RegisteredModelTag(key="k", value="v")
+        )
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    # Targets the FUNCTION securable by full name via the generic UC tag API.
+    kwargs = native_call.call_args.kwargs
+    assert kwargs["securable_type"] == "FUNCTION"
+    assert kwargs["securable_full_name"] == "catalog.schema.model"
+    body = json.loads(kwargs["req_body"])
+    assert body["changes"]["add_tags"] == [{"key": "k", "value": "v"}]
+
+
+def test_set_model_version_tag_uses_native_subentity_tag_api(store):
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call") as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        store.set_model_version_tag("catalog.schema.model", 2, ModelVersionTag(key="k", value="v"))
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    kwargs = native_call.call_args.kwargs
+    assert kwargs["securable_type"] == "FUNCTION"
+    assert kwargs["securable_full_name"] == "catalog.schema.model"
+    assert kwargs["subentity_name"] == 2
+    body = json.loads(kwargs["req_body"])
+    assert body["changes"]["add_tags"] == [{"key": "k", "value": "v"}]
+
+
+def test_get_model_version_download_uri_native_derives_storage_location(store):
+    native_mv = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=1,
+        storage_location="s3://blah/loc",
+    )
+    with (
+        mock.patch.object(store, "_edit_endpoint_and_call", return_value=native_mv) as native_call,
+        mock.patch.object(store, "_call_endpoint") as legacy_call,
+    ):
+        uri = store.get_model_version_download_uri("catalog.schema.model", 1)
+    native_call.assert_called_once()
+    legacy_call.assert_not_called()
+    assert uri == "s3://blah/loc"

--- a/tests/store/model_registry/test_databricks_workspace_model_registry_store.py
+++ b/tests/store/model_registry/test_databricks_workspace_model_registry_store.py
@@ -9,6 +9,10 @@ from mlflow.store.model_registry.databricks_workspace_model_registry_rest_store 
     _extract_workspace_id_from_run_link,
 )
 
+UC_STORE_CLASS_SELECTOR = (
+    "mlflow.store._unity_catalog.registry.utils.get_uc_model_registry_store_class"
+)
+
 
 @pytest.fixture
 def store():
@@ -17,7 +21,6 @@ def store():
 
 @pytest.fixture
 def sample_model_version() -> ModelVersion:
-    """Common ModelVersion object for testing copy_model_version"""
     return ModelVersion(
         name="test_model",
         version="1",
@@ -33,6 +36,14 @@ def sample_model_version() -> ModelVersion:
 
 def _expected_unsupported_method_error_message(method):
     return f"Method '{method}' is unsupported for models in the Workspace Model Registry"
+
+
+def _mock_uc_store_selector(mock_get_uc_store_class):
+    mock_uc_store_class = mock.MagicMock()
+    mock_uc_store = mock.MagicMock()
+    mock_uc_store_class.return_value = mock_uc_store
+    mock_get_uc_store_class.return_value = mock_uc_store_class
+    return mock_uc_store_class, mock_uc_store
 
 
 @pytest.mark.parametrize(
@@ -153,17 +164,13 @@ def test_copy_model_version_regular_path(store, sample_model_version):
 def test_copy_model_version_unity_catalog_success(store, sample_model_version):
     dst_name = "catalog.schema.model"
 
-    # Mock multiple dependencies in a single context manager
     with (
         mock.patch(
             "mlflow.artifacts.download_artifacts", return_value="/tmp/local_model_dir"
         ) as mock_download,
-        mock.patch(
-            "mlflow.store.model_registry.databricks_workspace_model_registry_rest_store.UcModelRegistryStore"
-        ) as mock_uc_store_class,
+        mock.patch(UC_STORE_CLASS_SELECTOR) as mock_get_uc_store_class,
     ):
-        mock_uc_store = mock.MagicMock()
-        mock_uc_store_class.return_value = mock_uc_store
+        mock_uc_store_class, mock_uc_store = _mock_uc_store_selector(mock_get_uc_store_class)
 
         # Mock create_registered_model to succeed (model doesn't exist)
         mock_uc_store.create_registered_model.return_value = mock.MagicMock(name=dst_name)
@@ -185,7 +192,7 @@ def test_copy_model_version_unity_catalog_success(store, sample_model_version):
 
         result = store.copy_model_version(sample_model_version, dst_name)
 
-        # Verify UcModelRegistryStore was created with correct parameters
+        mock_get_uc_store_class.assert_called_once_with()
         mock_uc_store_class.assert_called_once_with(
             store_uri="databricks-uc", tracking_uri="databricks"
         )
@@ -218,7 +225,6 @@ def test_copy_model_version_unity_catalog_success(store, sample_model_version):
 def test_copy_model_version_unity_catalog_migration_download_failure(store, sample_model_version):
     dst_name = "catalog.schema.model"
 
-    # Mock multiple dependencies in a single context manager
     with mock.patch(
         "mlflow.artifacts.download_artifacts", side_effect=Exception("Download failed")
     ) as mock_download:
@@ -238,17 +244,13 @@ def test_copy_model_version_unity_catalog_registered_model_already_exists(
 ):
     dst_name = "catalog.schema.existing_model"
 
-    # Mock multiple dependencies in a single context manager
     with (
         mock.patch(
             "mlflow.artifacts.download_artifacts", return_value="/tmp/local_model_dir"
         ) as mock_download,
-        mock.patch(
-            "mlflow.store.model_registry.databricks_workspace_model_registry_rest_store.UcModelRegistryStore"
-        ) as mock_uc_store_class,
+        mock.patch(UC_STORE_CLASS_SELECTOR) as mock_get_uc_store_class,
     ):
-        mock_uc_store = mock.MagicMock()
-        mock_uc_store_class.return_value = mock_uc_store
+        mock_uc_store_class, mock_uc_store = _mock_uc_store_selector(mock_get_uc_store_class)
 
         # Mock create_registered_model to raise RESOURCE_ALREADY_EXISTS error
         from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
@@ -274,7 +276,7 @@ def test_copy_model_version_unity_catalog_registered_model_already_exists(
 
         result = store.copy_model_version(sample_model_version, dst_name)
 
-        # Verify UcModelRegistryStore was created with correct parameters
+        mock_get_uc_store_class.assert_called_once_with()
         mock_uc_store_class.assert_called_once_with(
             store_uri="databricks-uc", tracking_uri="databricks"
         )
@@ -309,17 +311,13 @@ def test_copy_model_version_unity_catalog_registered_model_creation_failure(
 ):
     dst_name = "catalog.schema.failing_model"
 
-    # Mock multiple dependencies in a single context manager
     with (
         mock.patch(
             "mlflow.artifacts.download_artifacts", return_value="/tmp/local_model_dir"
         ) as mock_download,
-        mock.patch(
-            "mlflow.store.model_registry.databricks_workspace_model_registry_rest_store.UcModelRegistryStore"
-        ) as mock_uc_store_class,
+        mock.patch(UC_STORE_CLASS_SELECTOR) as mock_get_uc_store_class,
     ):
-        mock_uc_store = mock.MagicMock()
-        mock_uc_store_class.return_value = mock_uc_store
+        mock_uc_store_class, mock_uc_store = _mock_uc_store_selector(mock_get_uc_store_class)
         mock_uc_store.create_registered_model.side_effect = MlflowException(
             "Permission denied", error_code="PERMISSION_DENIED"
         )
@@ -328,7 +326,7 @@ def test_copy_model_version_unity_catalog_registered_model_creation_failure(
         with pytest.raises(MlflowException, match="Permission denied"):
             store.copy_model_version(sample_model_version, dst_name)
 
-        # Verify UcModelRegistryStore was created with correct parameters
+        mock_get_uc_store_class.assert_called_once_with()
         mock_uc_store_class.assert_called_once_with(
             store_uri="databricks-uc", tracking_uri="databricks"
         )
@@ -351,15 +349,11 @@ def test_copy_model_version_unity_catalog_signature_validation_bypass(
     store, sample_model_version, monkeypatch
 ):
     dst_name = "catalog.schema.model"
-    # Mock multiple dependencies in a single context manager
     with (
         mock.patch("mlflow.artifacts.download_artifacts", return_value="/tmp/local_model_dir"),
-        mock.patch(
-            "mlflow.store.model_registry.databricks_workspace_model_registry_rest_store.UcModelRegistryStore"
-        ) as mock_uc_store_class,
+        mock.patch(UC_STORE_CLASS_SELECTOR) as mock_get_uc_store_class,
     ):
-        mock_uc_store = mock.MagicMock()
-        mock_uc_store_class.return_value = mock_uc_store
+        mock_uc_store_class, mock_uc_store = _mock_uc_store_selector(mock_get_uc_store_class)
 
         # Mock create_registered_model to succeed
         mock_uc_store.create_registered_model.return_value = mock.MagicMock(name=dst_name)
@@ -382,6 +376,11 @@ def test_copy_model_version_unity_catalog_signature_validation_bypass(
         # Mock environment variable to enable signature validation bypass
         monkeypatch.setenv("MLFLOW_SKIP_SIGNATURE_CHECK_FOR_UC_REGISTRY_MIGRATION", "True")
         store.copy_model_version(sample_model_version, dst_name)
+
+        mock_get_uc_store_class.assert_called_once_with()
+        mock_uc_store_class.assert_called_once_with(
+            store_uri="databricks-uc", tracking_uri="databricks"
+        )
 
         # Verify the UC store method was called with bypass_signature_validation=True
         mock_uc_store._create_model_version_with_optional_signature_validation.assert_called_once_with(

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -6,10 +6,12 @@ import pytest
 
 from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import UcNativeModelRegistryStore
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracking._model_registry.utils import (
+    _get_databricks_uc_rest_store,
     _get_store,
     _resolve_registry_uri,
     get_registry_uri,
@@ -328,6 +330,20 @@ def test_get_store_caches_on_store_uri(tmp_path):
 @pytest.mark.parametrize("store_uri", ["databricks-uc", "databricks-uc://profile"])
 def test_get_store_uc_registry_uri(store_uri):
     assert isinstance(_get_store(store_uri), UcModelRegistryStore)
+
+
+def test_databricks_uc_store_defaults_to_legacy(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY", raising=False)
+    store = _get_databricks_uc_rest_store("databricks-uc", "databricks-uc")
+    assert type(store) is UcModelRegistryStore
+
+
+def test_databricks_uc_store_selects_native_when_enabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY", "true")
+    store = _get_databricks_uc_rest_store("databricks-uc", "databricks-uc")
+    assert type(store) is UcNativeModelRegistryStore
+    # The native store is a subclass of the legacy store (shared prompt / helper behavior).
+    assert isinstance(store, UcModelRegistryStore)
 
 
 def test_store_object_can_be_serialized_by_pickle():

--- a/tests/utils/test_unity_catalog_utils.py
+++ b/tests/utils/test_unity_catalog_utils.py
@@ -1,5 +1,7 @@
 import pytest
 
+from mlflow.entities.logged_model_parameter import LoggedModelParameter as ModelParam
+from mlflow.entities.metric import Metric
 from mlflow.entities.model_registry import (
     ModelVersion,
     ModelVersionDeploymentJobState,
@@ -31,6 +33,31 @@ from mlflow.protos.databricks_uc_registry_messages_pb2 import (
 )
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     RegisteredModelTag as ProtoRegisteredModelTag,
+)
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    DeploymentJobConnection,
+    ModelVersionInfo,
+    RegisteredModelAliasInfo,
+    RegisteredModelInfo,
+    TagKeyValue,
+)
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    ModelMetric as OssProtoModelMetric,
+)
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    ModelParam as OssProtoModelParam,
+)
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    ModelVersionDeploymentJobState as OssProtoModelVersionDeploymentJobState,
+)
+from mlflow.protos.unity_catalog_messages_pb2 import (
+    ModelVersionStatus as OssProtoModelVersionStatus,
+)
+from mlflow.store._unity_catalog.registry.uc_native_rest_store import (
+    model_version_from_uc_native_proto,
+    model_version_search_from_uc_native_proto,
+    registered_model_from_uc_native_proto,
+    registered_model_search_from_uc_native_proto,
 )
 from mlflow.utils._unity_catalog_utils import (
     _parse_aws_sse_credential,
@@ -345,3 +372,184 @@ def test_registered_model_and_registered_model_search_equality():
 )
 def test_parse_aws_sse_credential(temp_credentials, parsed):
     assert _parse_aws_sse_credential(temp_credentials) == parsed
+
+
+# ---------------------------------------------------------------------------
+# Enriched converters (native /api/2.1 governance + MLflow-enrichment surface). The governance
+# entity is flattened together with the enrichment fields, so these read the info proto directly.
+# ---------------------------------------------------------------------------
+
+
+def test_registered_model_from_uc_native_proto():
+    expected_registered_model = RegisteredModel(
+        name="catalog.schema.name",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        aliases=[
+            RegisteredModelAlias(alias="champion", version="3"),
+            RegisteredModelAlias(alias="challenger", version="5"),
+        ],
+        tags=[
+            RegisteredModelTag(key="key1", value="value"),
+            RegisteredModelTag(key="key2", value=""),
+        ],
+        deployment_job_id="job_42",
+        deployment_job_state="CONNECTED",
+    )
+    uc_proto = RegisteredModelInfo(
+        name="name",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name="catalog.schema.name",
+        comment="description",
+        created_at=1,
+        updated_at=2,
+        aliases=[
+            RegisteredModelAliasInfo(alias_name="champion", version_num=3),
+            RegisteredModelAliasInfo(alias_name="challenger", version_num=5),
+        ],
+        tags=[
+            TagKeyValue(key="key1", value="value"),
+            TagKeyValue(key="key2", value=""),
+        ],
+        deployment_job_id="job_42",
+        deployment_job_state=DeploymentJobConnection.State.Value("CONNECTED"),
+    )
+    assert registered_model_from_uc_native_proto(uc_proto) == expected_registered_model
+
+
+def test_model_version_from_uc_native_proto():
+    expected_model_version = ModelVersion(
+        name="catalog.schema.model",
+        version="3",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        user_id="creator",
+        source="source",
+        run_id="run_id",
+        status="READY",
+        aliases=["champion"],
+        tags=[ModelVersionTag(key="k", value="v")],
+        model_id="m-123",
+        params=[ModelParam(key="p", value="1")],
+        metrics=[
+            Metric(
+                key="acc",
+                value=0.9,
+                timestamp=10,
+                step=1,
+                dataset_name="d",
+                dataset_digest="dig",
+                model_id="m-123",
+                run_id="run_id",
+            )
+        ],
+        deployment_job_state=ModelVersionDeploymentJobState(
+            "job_1",
+            "run_1",
+            "CONNECTED",
+            "RUNNING",
+            "task",
+        ),
+    )
+    uc_proto = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        comment="description",
+        source="source",
+        run_id="run_id",
+        status=OssProtoModelVersionStatus.Value("READY"),
+        version=3,
+        created_at=1,
+        updated_at=2,
+        created_by="creator",
+        aliases=[RegisteredModelAliasInfo(alias_name="champion", version_num=3)],
+        tags=[TagKeyValue(key="k", value="v")],
+        model_id="m-123",
+        model_params=[OssProtoModelParam(name="p", value="1")],
+        model_metrics=[
+            OssProtoModelMetric(
+                key="acc",
+                value=0.9,
+                timestamp=10,
+                step=1,
+                dataset_name="d",
+                dataset_digest="dig",
+                model_id="m-123",
+                run_id="run_id",
+            )
+        ],
+        deployment_job_state=OssProtoModelVersionDeploymentJobState(
+            job_id="job_1",
+            run_id="run_1",
+            job_state=DeploymentJobConnection.State.Value("CONNECTED"),
+            run_state=OssProtoModelVersionDeploymentJobState.DeploymentJobRunState.Value("RUNNING"),
+            current_task_name="task",
+        ),
+    )
+    assert model_version_from_uc_native_proto(uc_proto) == expected_model_version
+
+
+def test_registered_model_search_from_uc_native_proto():
+    expected_registered_model = RegisteredModelSearch(
+        name="catalog.schema.name",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        aliases=[],
+        tags=[],
+    )
+    uc_proto = RegisteredModelInfo(
+        name="name",
+        catalog_name="catalog",
+        schema_name="schema",
+        full_name="catalog.schema.name",
+        comment="description",
+        created_at=1,
+        updated_at=2,
+        aliases=[RegisteredModelAliasInfo(alias_name="champion", version_num=3)],
+        tags=[TagKeyValue(key="key1", value="value")],
+    )
+    assert registered_model_search_from_uc_native_proto(uc_proto) == expected_registered_model
+
+
+def test_model_version_search_from_uc_native_proto():
+    expected_model_version = ModelVersionSearch(
+        name="catalog.schema.model",
+        version="3",
+        creation_timestamp=1,
+        last_updated_timestamp=2,
+        description="description",
+        user_id="creator",
+        source="source",
+        run_id="run_id",
+        status="READY",
+        aliases=[],
+        tags=[],
+        deployment_job_state=ModelVersionDeploymentJobState(
+            "",
+            "",
+            "DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED",
+            "DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED",
+            "",
+        ),
+    )
+    uc_proto = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        comment="description",
+        source="source",
+        run_id="run_id",
+        status=OssProtoModelVersionStatus.Value("READY"),
+        version=3,
+        created_at=1,
+        updated_at=2,
+        created_by="creator",
+        aliases=[RegisteredModelAliasInfo(alias_name="champion", version_num=3)],
+        tags=[TagKeyValue(key="k", value="v")],
+    )
+    assert model_version_search_from_uc_native_proto(uc_proto) == expected_model_version


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24412, #24489

### What changes are proposed in this pull request?

Adds a per-operation switch that lets the Unity Catalog model-registry client issue requests against the native `/api/2.1/unity-catalog/*` surface instead of the legacy `/api/2.0` endpoints, without a separate store class.

The behavior is folded directly into the single `UcModelRegistryStore`. Each native-relevant operation branches on the `MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY` environment variable:

- **enabled** — issues the request against the native surface (`UnityCatalogService`, flat `RegisteredModelInfo` / `ModelVersionInfo` responses) and folds the enriched governance/metadata back into the MLflow entities;
- **disabled (default)** — uses the existing legacy `/api/2.0` implementation unchanged.

Changes:

- `mlflow/store/_unity_catalog/registry/rest_store.py`: add a native method→endpoint map (`UnityCatalogService` on the `/api/2.1` prefix), widen the endpoint helper with `extra_headers`, extend the response map with the native flat/list response protos, and gate the ~21 create/read/update/delete/search/tag/alias methods. Prompt methods and the unsupported stage/latest-version methods are unchanged.
- `mlflow/utils/_unity_catalog_utils.py`: add `enriched_*` converters that fold the native governance + enrichment info protos back into the MLflow entities.
- `mlflow/environment_variables.py`: add `MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY` (default `False`; static per-operation switch).

The `oneof` restoration on `TemporaryCredentials` that the native artifact path depends on landed separately in #24489.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests: a native-mode suite (env var enabled), a native/legacy converter parity oracle, and enriched-converter unit tests covering the AWS/Azure/GCP/R2 credential arms, SSE/KMS parsing, storage-mode round-trip, and the enrichment converters. The end-to-end native path was also exercised live against a Databricks workspace across the full CRUD + alias + tag + artifact surface.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds an opt-in `MLFLOW_ENABLE_UC_NATIVE_MODEL_REGISTRY` environment variable that routes the Unity Catalog model-registry client to the native `/api/2.1/unity-catalog/*` endpoints. Disabled by default; existing behavior is unchanged.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release