### PR TITLE
Add Swagger UI API docs for MCP Server Registry

### DIFF
--- a/docs/api_reference/Makefile
+++ b/docs/api_reference/Makefile
@@ -76,9 +76,13 @@ test-examples:
 gateway-api-docs:
 	@python gateway_api_docs.py
 
+.PHONY: mcp-server-registry-api-docs
+mcp-server-registry-api-docs:
+	@python mcp_server_registry_api_docs.py
+
 # Builds only the RST-based documentation (i.e., everything but Java & R docs)
 .PHONY: rsthtml
-rsthtml: gateway-api-docs
+rsthtml: gateway-api-docs mcp-server-registry-api-docs
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/api_reference/gateway_api_docs.py
+++ b/docs/api_reference/gateway_api_docs.py
@@ -19,7 +19,7 @@ API_HTML = """
     />
     <link
       rel="shortcut icon"
-      href="../_static/favicon.ico"
+      href="../../_static/favicon.ico"
     />
     <title>MLflow AI Gateway - Swagger UI</title>
   </head>

--- a/docs/api_reference/mcp_server_registry_api_docs.py
+++ b/docs/api_reference/mcp_server_registry_api_docs.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from mlflow.server.mcp_server_api import mcp_server_router
+
+API_HTML = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <link
+      type="text/css"
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
+    />
+    <link
+      rel="shortcut icon"
+      href="../../_static/favicon.ico"
+    />
+    <title>MLflow MCP Server Registry - Swagger UI</title>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <!-- `SwaggerUIBundle` is now available on the page -->
+    <script>
+      const ui = SwaggerUIBundle({
+        supportedSubmitMethods: [],
+        url: "./openapi.json",
+        dom_id: "#swagger-ui",
+        layout: "BaseLayout",
+        deepLinking: true,
+        showExtensions: true,
+        showCommonExtensions: true,
+        oauth2RedirectUrl: window.location.origin + "/docs/oauth2-redirect",
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIBundle.SwaggerUIStandalonePreset,
+        ],
+      });
+    </script>
+  </body>
+</html>
+"""
+
+
+def main():
+    app = FastAPI(title="MLflow MCP Server Registry")
+    app.include_router(mcp_server_router, prefix="/api/3.0/mlflow/mcp-servers")
+
+    docs_build = Path("build/html/genai/mcp-server-registry")
+    docs_build.mkdir(parents=True, exist_ok=True)
+    with docs_build.joinpath("openapi.json").open("w") as f:
+        json.dump(app.openapi(), f)
+
+    with docs_build.joinpath("api.html").open("w") as f:
+        f.write(API_HTML)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/update-api-modules.ts
+++ b/docs/scripts/update-api-modules.ts
@@ -22,6 +22,7 @@ fileMap['mlflow.python'] = 'api_reference/python_api/index.html';
 fileMap['mlflow.rest'] = 'api_reference/rest-api.html';
 fileMap['mlflow.typescript'] = 'api_reference/typescript_api/index.html';
 fileMap['mlflow.llms.deployments.api'] = 'api_reference/llms/deployments/api.html';
+fileMap['mlflow.genai.mcp_server_registry.api'] = 'api_reference/genai/mcp-server-registry/api.html';
 
 // write filemap to json file
 fs.writeFileSync('src/api_modules.json', JSON.stringify(fileMap, null, 2));

--- a/docs/src/api_modules.json
+++ b/docs/src/api_modules.json
@@ -64,5 +64,6 @@
   "mlflow.python": "api_reference/python_api/index.html",
   "mlflow.rest": "api_reference/rest-api.html",
   "mlflow.typescript": "api_reference/typescript_api/index.html",
-  "mlflow.llms.deployments.api": "api_reference/llms/deployments/api.html"
+  "mlflow.llms.deployments.api": "api_reference/llms/deployments/api.html",
+  "mlflow.genai.mcp_server_registry.api": "api_reference/genai/mcp-server-registry/api.html"
 }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24485

### What changes are proposed in this pull request?

Adds Swagger UI API documentation for the MCP Server Registry, following the existing AI Gateway docs pattern (`gateway_api_docs.py`):

After merging the swagger doc would be available at `/genai/mcp-server-registry/api.html` i.e. https://mlflow.org/docs/latest/api_reference/genai/mcp-server-registry/api.html

Note: The gateway and mcp server registry swagger docs aren't directly discoverable  from https://mlflow.org/docs/latest/api_reference/

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified locally that `make mcp-server-registry-api-docs` generates the expected `openapi.json` and `api.html` files under `build/html/genai/mcp-server-registry/`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added Swagger UI API documentation for the MCP Server Registry endpoints, accessible at `genai/mcp-server-registry/api.html` in the built docs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release