### PR TITLE
Fix spurious path-traversal rejection for non-existent artifact leaf on Windows

### DIFF
--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -533,6 +533,14 @@ def validate_path_within_directory(base_dir: str, constructed_path: str) -> str:
     # valid destination look like it escapes the base dir. Resolve the leaf only when a
     # real file/dir or a (possibly dangling) symlink exists there; otherwise resolve the
     # existing parent and append the caller-sanitized leaf verbatim.
+    #
+    # The is_symlink()/exists() check followed by resolve() is not atomic: a racing thread
+    # could plant a symlink at the leaf in that window. This TOCTOU gap is an accepted
+    # limitation. Writing into the artifact directory already requires local write access
+    # to it, and an attacker with that access needs no symlink trick to read or write
+    # files there. The original guard had an equivalent TOCTOU between its two resolve()
+    # calls, and always calling target.resolve() here would reintroduce the Windows
+    # spurious-rejection race this branch exists to avoid.
     if target.is_symlink() or target.exists():
         real_constructed_path = target.resolve()
     else:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -525,7 +525,18 @@ def validate_path_within_directory(base_dir: str, constructed_path: str) -> str:
         The constructed_path if validation passes.
     """
     real_base_dir = pathlib.Path(base_dir).resolve()
-    real_constructed_path = pathlib.Path(constructed_path).resolve()
+    target = pathlib.Path(constructed_path)
+    # On Windows, resolve() canonicalizes the existing vs non-existing parts of a path
+    # differently (e.g. 8.3 short-name expansion only for the part that exists). With the
+    # async artifact queue's pool of worker threads sharing one repository, the boundary
+    # between existing/non-existing can shift between these two resolve() calls, making a
+    # valid destination look like it escapes the base dir. Resolve the leaf only when a
+    # real file/dir or a (possibly dangling) symlink exists there; otherwise resolve the
+    # existing parent and append the caller-sanitized leaf verbatim.
+    if target.is_symlink() or target.exists():
+        real_constructed_path = target.resolve()
+    else:
+        real_constructed_path = target.parent.resolve() / target.name
 
     if not real_constructed_path.is_relative_to(real_base_dir):
         raise MlflowException(

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -973,3 +973,43 @@ def test_validate_path_within_directory_allows_subdirectory_symlink(tmp_path):
     constructed_path = symlink_to_subdir / "file.txt"
     result = validate_path_within_directory(str(base_dir), str(constructed_path))
     assert result == str(constructed_path)
+
+
+def test_validate_path_within_directory_allows_nonexistent_file(tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    constructed_path = base_dir / "not_yet_written.txt"
+    assert not constructed_path.exists()
+    result = validate_path_within_directory(str(base_dir), str(constructed_path))
+    assert result == str(constructed_path)
+
+
+def test_validate_path_within_directory_allows_nonexistent_subdir(tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    constructed_path = base_dir / "not_yet_created_subdir"
+    assert not constructed_path.exists()
+    result = validate_path_within_directory(str(base_dir), str(constructed_path))
+    assert result == str(constructed_path)
+
+
+def test_validate_path_within_directory_blocks_dangling_symlink_escape(tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    external_target = tmp_path / "external" / "secret.txt"
+    symlink_path = base_dir / "dangling_leak"
+    os.symlink(str(external_target), str(symlink_path))
+    assert not symlink_path.exists()
+    with pytest.raises(MlflowException, match="resolved path is outside the artifact directory"):
+        validate_path_within_directory(str(base_dir), str(symlink_path))
+
+
+def test_validate_path_within_directory_allows_dangling_symlink_inside(tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    internal_target = base_dir / "not_yet_written.txt"
+    symlink_path = base_dir / "dangling_link"
+    os.symlink(str(internal_target), str(symlink_path))
+    assert not symlink_path.exists()
+    result = validate_path_within_directory(str(base_dir), str(symlink_path))
+    assert result == str(symlink_path)

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -1013,3 +1013,21 @@ def test_validate_path_within_directory_allows_dangling_symlink_inside(tmp_path)
     assert not symlink_path.exists()
     result = validate_path_within_directory(str(base_dir), str(symlink_path))
     assert result == str(symlink_path)
+
+
+def test_validate_path_within_directory_allows_multi_level_nonexistent_path(tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    constructed_path = base_dir / "a" / "b" / "c.txt"
+    assert not (base_dir / "a").exists()
+    result = validate_path_within_directory(str(base_dir), str(constructed_path))
+    assert result == str(constructed_path)
+
+
+def test_validate_path_within_directory_blocks_multi_level_dotdot_escape(tmp_path):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    constructed_path = base_dir / "a" / ".." / ".." / "evil.txt"
+    assert not (base_dir / "a").exists()
+    with pytest.raises(MlflowException, match="resolved path is outside the artifact directory"):
+        validate_path_within_directory(str(base_dir), str(constructed_path))


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24504

### What changes are proposed in this pull request?

On Windows, `validate_path_within_directory` in `mlflow/utils/uri.py` could spuriously reject a valid artifact path ("resolved path is outside the artifact directory") when artifacts are logged concurrently through the async artifact queue (its pool of worker threads shares a single `LocalArtifactRepository`).

Root cause: the guard `resolve()`s the constructed target whose leaf does not exist yet. On Windows, `resolve()` only canonicalizes the part of the path that already exists (e.g. 8.3 short-name expansion). When worker threads concurrently `mkdir` the shared directory, the boundary between the existing and non-existing parts of the path can shift between the `resolve()` of the base dir and the `resolve()` of the target, so their shared ancestor canonicalizes inconsistently and the valid destination looks like it escapes the base dir. POSIX is not affected.

Fix: resolve the leaf only when a real file/dir or a (possibly dangling) symlink actually exists there; otherwise resolve the existing parent and append the caller-sanitized leaf verbatim. This removes the dependence on the leaf existing while keeping the symlink path-traversal protection fully intact, including dangling symlinks whose target escapes the base directory.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New regression tests in `tests/utils/test_uri.py`: a not-yet-created destination file validates OK, a not-yet-created subdirectory validates OK, a dangling symlink whose target escapes the base is still blocked, and a dangling symlink pointing inside the base is allowed. The existing symlink-escape / parent-symlink / internal-symlink / subdirectory-symlink / base-dir tests remain green.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes concurrent artifact logging on Windows spuriously failing with "resolved path is outside the artifact directory".

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
