### PR TITLE
fix(db): prevent 'Table already exists' error during database upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,9 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use create_all with checkfirst=True to avoid 'Table already exists' errors
+    # when some tables were already created by a previous migration or partial upgrade.
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Running `mlflow db upgrade` from 3.7.0 to 3.8.x fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")` because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` unconditionally, which tries to create the 'secrets' table even if it already exists from a prior migration.

## Fix
Add `checkfirst=True` to the `create_all` call so that SQLAlchemy will only create tables if they do not already exist. This prevents the duplicate table error while still ensuring the base tables are present before running Alembic migrations.

Closes #19943