### PR TITLE
Support clickable URLs in Traces view cells (ML-63660)

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/TraceInfoCellValue.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/TraceInfoCellValue.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import { TraceInfoCellValue } from './TraceInfoCellValue';
+
+const renderValue = (value: string) =>
+  render(
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <TraceInfoCellValue value={value} />
+      </DesignSystemProvider>
+    </IntlProvider>,
+  );
+
+describe('TraceInfoCellValue', () => {
+  it('renders an https value as a clickable link that opens in a new tab', () => {
+    const url = 'https://example.com/traces/abc/rendering.html';
+    renderValue(url);
+
+    const link = screen.getByRole('link', { name: url });
+    expect(link).toHaveAttribute('href', url);
+    expect(link).toHaveAttribute('target', '_blank');
+    // openInNewTab links should be safe against reverse tabnabbing
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('renders an http value as a clickable link', () => {
+    const url = 'http://localhost:8080/artifacts/trace.html';
+    renderValue(url);
+
+    expect(screen.getByRole('link', { name: url })).toHaveAttribute('href', url);
+  });
+
+  it('renders a non-URL string as plain text (no link)', () => {
+    renderValue('production');
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+  });
+
+  it('does not treat non-http(s) schemes such as javascript: as a link', () => {
+    // eslint-disable-next-line no-script-url
+    const value = 'javascript:alert(1)';
+    renderValue(value);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText(value)).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/TraceInfoCellValue.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/TraceInfoCellValue.tsx
@@ -1,0 +1,39 @@
+import { Typography } from '@databricks/design-system';
+
+import { isValidHttpUrl } from '../utils/DisplayUtils';
+
+const ELLIPSIS_CSS = {
+  display: 'block',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+} as const;
+
+/**
+ * Renders a trace-info cell value (attribute / tag / custom metadata). When the
+ * value is an http(s) URL it is rendered as a clickable hyperlink that opens in
+ * a new tab (e.g. a link to a custom HTML rendering of a trace uploaded as an
+ * artifact); otherwise it falls back to the plain ellipsized text used
+ * elsewhere in the traces table.
+ */
+export const TraceInfoCellValue = ({ value }: { value: string }) => {
+  if (isValidHttpUrl(value)) {
+    return (
+      <Typography.Link
+        componentId="mlflow.genai_traces_table.trace_info_cell_url_link"
+        href={value}
+        title={value}
+        css={ELLIPSIS_CSS}
+        openInNewTab
+      >
+        {value}
+      </Typography.Link>
+    );
+  }
+
+  return (
+    <div title={value} css={ELLIPSIS_CSS}>
+      {value}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/cellRenderers/rendererFunctions.tsx
@@ -36,6 +36,7 @@ import { StackedComponents } from './StackedComponents';
 import { StatusCellRenderer } from './StatusRenderer';
 import { TagsCellRenderer } from './Tags/TagsCellRenderer';
 import { TokensCell } from './TokensCell';
+import { TraceInfoCellValue } from './TraceInfoCellValue';
 import { getTraceInfoValueWithColId } from '../GenAiTracesTable.utils';
 import { compareAssessmentValues, formatResponseTitle } from '../GenAiTracesTableBody.utils';
 import { readTraceTag, RESULT_ASSESSMENT_NAME } from '../utils/TraceUtils';
@@ -680,40 +681,10 @@ export const traceInfoCellRenderer = (
     const otherTagValue = otherTraceInfo?.tags?.[tagKey];
     return (
       <StackedComponents
-        first={
-          tagValue ? (
-            <span
-              title={tagValue}
-              css={{
-                display: 'block',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {tagValue}
-            </span>
-          ) : (
-            <NullCell isComparing={isComparing} />
-          )
-        }
+        first={tagValue ? <TraceInfoCellValue value={tagValue} /> : <NullCell isComparing={isComparing} />}
         second={
           isComparing &&
-          (otherTagValue ? (
-            <span
-              title={tagValue}
-              css={{
-                display: 'block',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {otherTagValue}
-            </span>
-          ) : (
-            <NullCell isComparing={isComparing} />
-          ))
+          (otherTagValue ? <TraceInfoCellValue value={otherTagValue} /> : <NullCell isComparing={isComparing} />)
         }
       />
     );
@@ -1034,24 +1005,10 @@ export const traceInfoCellRenderer = (
     const otherValue = otherTraceInfo?.trace_metadata?.[metadataKey];
     return (
       <StackedComponents
-        first={
-          value ? (
-            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={value}>
-              {value}
-            </div>
-          ) : (
-            <NullCell isComparing={isComparing} />
-          )
-        }
+        first={value ? <TraceInfoCellValue value={value} /> : <NullCell isComparing={isComparing} />}
         second={
           isComparing &&
-          (otherValue ? (
-            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={otherValue}>
-              {otherValue}
-            </div>
-          ) : (
-            <NullCell isComparing={isComparing} />
-          ))
+          (otherValue ? <TraceInfoCellValue value={otherValue} /> : <NullCell isComparing={isComparing} />)
         }
       />
     );
@@ -1138,24 +1095,9 @@ export const traceInfoCellRenderer = (
 
   return (
     <StackedComponents
-      first={
-        value ? (
-          <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={value}>
-            {value}
-          </div>
-        ) : (
-          <NullCell isComparing={isComparing} />
-        )
-      }
+      first={value ? <TraceInfoCellValue value={value} /> : <NullCell isComparing={isComparing} />}
       second={
-        isComparing &&
-        (otherValue ? (
-          <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={otherValue}>
-            {otherValue}
-          </div>
-        ) : (
-          <NullCell isComparing={isComparing} />
-        ))
+        isComparing && (otherValue ? <TraceInfoCellValue value={otherValue} /> : <NullCell isComparing={isComparing} />)
       }
     />
   );

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/DisplayUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/DisplayUtils.tsx
@@ -211,6 +211,25 @@ export function timeSinceStr(date: any, referenceDate = new Date()) {
   );
 }
 
+/**
+ * Returns true when the given value is a string that parses to an http(s) URL.
+ * Used to decide whether a trace tag / metadata / attribute cell value should
+ * render as a clickable hyperlink (e.g. a link to a custom HTML rendering of a
+ * trace uploaded as an artifact).
+ */
+export function isValidHttpUrl(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  // The URL() constructor throws on an invalid URL.
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 // Function to escape CSS Special characters by adding \\ before them. Needed when inserting CSS variables.
 export function escapeCssSpecialCharacters(str: string) {
   // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

### What changes are proposed in this pull request?

Trace-info cells in the GenAI Traces table (tag / trace-metadata / attribute values) now render http(s) URL values as clickable hyperlinks that open in a new tab, instead of plain text. This is useful, for example, when a trace tag or custom metadata field points to a custom HTML rendering of a trace uploaded as an artifact — the user can click straight through to it rather than copy-pasting the URL.

Specifically:

- Added `isValidHttpUrl(value)` to `genai-traces-table/utils/DisplayUtils.tsx`. It parses the value with the `URL()` constructor and returns `true` only for the `http:`/`https:` protocols, so non-URL strings and unsafe schemes (e.g. `javascript:`) are never linkified.
- Added a new `TraceInfoCellValue` cell-value component that renders a `Typography.Link` (`openInNewTab`, so it gets `rel="noopener"` for reverse-tabnabbing safety) when the value is a valid http(s) URL, and falls back to the existing ellipsized plain-text rendering otherwise.
- Refactored `traceInfoCellRenderer` in `rendererFunctions.tsx` to route all three value paths (tag, trace metadata, generic attribute — both the primary and the comparison column) through `TraceInfoCellValue`, replacing three duplicated inline ellipsis blocks. Net −65 lines of duplicated markup.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `TraceInfoCellValue.test.tsx` covers: an `https` value renders as a link (`href`, `target="_blank"`, `rel` contains `noopener`), an `http` value renders as a link, a non-URL string renders as plain text (no link), and a `javascript:` value is **not** linkified.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. URL-valued tags, trace metadata, and attributes shown in the Traces table are now rendered as clickable links that open in a new tab.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release