### PR TITLE
fix: Prevent 'Table already exists' error when upgrading database (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,14 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Get tables that don't already exist in the database
+    existing_tables = set(sqlalchemy.inspect(engine).get_table_names())
+    tables_to_create = {}
+    for table_name, table in InitialBase.metadata.tables.items():
+        if table_name not in existing_tables:
+            tables_to_create[table_name] = table
+    if tables_to_create:
+        InitialBase.metadata.create_all(engine, tables=list(tables_to_create.values()))
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` which attempts to create all tables defined in the initial models, including ones that already exist from previous Alembic migrations.

## Fix
Instead of blindly creating all tables, we first check which tables already exist in the database and only create the missing ones. This ensures we don't attempt to recreate tables that were added by previous migrations.

Closes #19943