### PR TITLE
fix: prevent duplicate table creation on db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,9 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if _is_empty_database(engine):
+        _logger.info("Creating initial MLflow database tables...")
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` unconditionally creates initial tables using `InitialBase.metadata.create_all(engine)`, even if the tables already exist from a previous migration. Since the `secrets` table was added in a migration in 3.8.x, but the initial model also includes it, `create_all` fails when the table already exists.

## Fix
Modified `_initialize_tables` to only create initial tables if the database is empty (using the existing `_is_empty_database` helper). If tables already exist, it skips the `create_all` call and directly runs the Alembic upgrade. This ensures that migration scripts (which handle table creation with proper checks) are responsible for adding new tables, avoiding duplicate creation errors.

Closes #19943