### PR TITLE
fix(metrics): fix NDCG@k metrics being falsely inflated for short retrieval lists

### DIFF
--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -494,7 +494,7 @@ def _ndcg_at_k_eval_fn(k):
 
             # only include the top k retrieved chunks
             y_score, y_true = _prepare_row_for_ndcg(retrieved[:k], ground_truth)
-            score = ndcg_score(y_true, y_score, k=len(retrieved[:k]), ignore_ties=True)
+            score = ndcg_score(y_true, y_score, k=min(k, y_true.shape[1]), ignore_ties=True)
             scores.append(score)
 
         return MetricValue(scores=scores, aggregate_results=standard_aggregations(scores))


### PR DESCRIPTION
### Related Issues/PRs

Closes #24541

### What changes are proposed in this pull request?

Fixes the `ndcg_at_k` metric implementation to avoid falsely inflated NDCG scores when the retriever returns fewer than `k` documents. 

Specifically:
- Updates `_prepare_row_for_ndcg` to accept `k` and pad the predicted list up to `k` elements using dummy documents. This prevents `scikit-learn`'s `ndcg_score` from ranking unretrieved relevant documents into the top-`k` window and giving them credit.
- Updates the `ndcg_score` call to pass `k` directly.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release