### PR TITLE
Fix MemAlign guideline distillation against Databricks structured-output models

### DIFF
--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import re
@@ -145,17 +146,15 @@ def truncate_to_token_limit(text: str, model: str, model_type: str) -> str:
     return truncated
 
 
-# These models are sent as a structured-output ``response_format``. Databricks' endpoint
-# enforces OpenAI strict-schema rules on every object:
-#   - ``additionalProperties: false`` — supplied via ``extra="forbid"`` (Pydantic omits it
-#     by default).
-#   - every property listed in ``required`` — so ``source_trace_ids`` must NOT have a default
-#     (a default drops it from ``required``). It stays nullable via ``| None`` so ``None``
-#     remains a valid value; callers always pass it explicitly.
+# These models describe the structured-output ``response_format`` for guideline distillation.
+# ``extra="forbid"`` and the absence of field defaults are load-bearing: see
+# ``_build_strict_response_format`` for the full set of schema constraints Databricks enforces.
 class Guideline(BaseModel):
     model_config = {"extra": "forbid"}
 
     guideline_text: str
+    # No default: a default drops the field from the schema's ``required`` list, which the
+    # strict endpoint rejects. Stays nullable via ``| None`` so ``None`` remains valid.
     source_trace_ids: list[str | int] | None
 
 
@@ -163,6 +162,44 @@ class Guidelines(BaseModel):
     model_config = {"extra": "forbid"}
 
     guidelines: list[Guideline]
+
+
+def _build_strict_response_format(model: type[BaseModel]) -> dict[str, Any]:
+    """Build an OpenAI-strict ``json_schema`` response_format from a pydantic model.
+
+    Databricks' structured-output endpoint enforces the strict-schema rules on every object
+    and, unlike the OpenAI API, does not resolve ``$ref``/``$defs`` indirection ("reference
+    can only point to definitions defined at the top level of the schema"). Pydantic's
+    ``model_json_schema()`` emits nested models as ``$ref`` into ``$defs`` and omits
+    ``additionalProperties``/full ``required``. This inlines every ``$ref`` and enforces
+    ``additionalProperties: false`` plus a complete ``required`` list on each object, so the
+    resulting schema is accepted regardless of whether the litellm version normalizes it.
+    """
+    schema = model.model_json_schema()
+    defs = schema.pop("$defs", {})
+
+    def resolve(node: Any) -> Any:
+        if isinstance(node, dict):
+            if "$ref" in node:
+                name = node["$ref"].split("/")[-1]
+                resolved = resolve(copy.deepcopy(defs[name]))
+                # Merge any sibling keys (e.g. description) over the resolved definition.
+                resolved.update({k: resolve(v) for k, v in node.items() if k != "$ref"})
+                return resolved
+            node = {k: resolve(v) for k, v in node.items()}
+            if node.get("type") == "object" or "properties" in node:
+                node["additionalProperties"] = False
+                if "properties" in node:
+                    node["required"] = list(node["properties"].keys())
+            return node
+        if isinstance(node, list):
+            return [resolve(item) for item in node]
+        return node
+
+    return {
+        "type": "json_schema",
+        "json_schema": {"name": model.__name__, "schema": resolve(schema), "strict": True},
+    }
 
 
 def get_default_embedding_model() -> str:
@@ -430,7 +467,9 @@ def distill_guidelines(
         messages = [{"role": "user", "content": prompt}]
         try:
             try:
-                response = distillation_lm(messages=messages, response_format=Guidelines)[0]
+                response = distillation_lm(
+                    messages=messages, response_format=_build_strict_response_format(Guidelines)
+                )[0]
             except Exception as e:
                 # Some models (e.g. some Databricks-served endpoints) reject or error on
                 # structured-output requests. The prompt already specifies the exact JSON

--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
@@ -144,12 +145,20 @@ def truncate_to_token_limit(text: str, model: str, model_type: str) -> str:
     return truncated
 
 
+# ``extra="forbid"`` makes ``model_json_schema()`` emit ``additionalProperties: false`` on
+# every object. Databricks' structured-output endpoint rejects a ``response_format`` schema
+# that omits it (Pydantic does not add it by default), so this keeps distillation working
+# against ``databricks:/`` reflection models.
 class Guideline(BaseModel):
+    model_config = {"extra": "forbid"}
+
     guideline_text: str
     source_trace_ids: list[str | int] | None = None
 
 
 class Guidelines(BaseModel):
+    model_config = {"extra": "forbid"}
+
     guidelines: list[Guideline]
 
 
@@ -246,6 +255,26 @@ def _create_batches(
     return batches
 
 
+def _extract_json_object(response: str) -> str:
+    """Extract the JSON object from an LLM response.
+
+    Structured-output (``response_format``) responses are raw JSON, but the unstructured
+    fallback relies on the prompt to elicit JSON and models often wrap it in a
+    ```` ```json ... ``` ```` fence and/or surround it with prose. Strips a fence when
+    present, then narrows to the outermost ``{...}`` so leading/trailing text does not
+    break parsing. Returns the original (stripped) string when no object is found, so the
+    caller's ``json.loads`` raises a meaningful error.
+    """
+    stripped = response.strip()
+    if match := re.match(r"^```(?:json)?\s*\n?(.*?)\n?```$", stripped, re.DOTALL):
+        stripped = match.group(1).strip()
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start != -1 and end > start:
+        return stripped[start : end + 1]
+    return stripped
+
+
 def _parse_batch_response(
     response: str,
     index_to_trace_id: dict[int, str],
@@ -261,7 +290,7 @@ def _parse_batch_response(
     Returns:
         List of Guideline objects parsed from the response, excluding duplicates
     """
-    response_data = json.loads(response)
+    response_data = json.loads(_extract_json_object(response))
     guidelines = []
     trace_ids_set = set(index_to_trace_id.values())
 
@@ -395,11 +424,22 @@ def distill_guidelines(
             len=len,
         )
 
+        messages = [{"role": "user", "content": prompt}]
         try:
-            response = distillation_lm(
-                messages=[{"role": "user", "content": prompt}],
-                response_format=Guidelines,
-            )[0]
+            try:
+                response = distillation_lm(messages=messages, response_format=Guidelines)[0]
+            except Exception as e:
+                # Some models (e.g. some Databricks-served endpoints) reject or error on
+                # structured-output requests. The prompt already specifies the exact JSON
+                # format, so fall back to an unstructured request rather than dropping the
+                # batch. Mirrors the judge adapter's response_format fallback (see
+                # mlflow/genai/judges/adapters/litellm_adapter.py).
+                _logger.debug(
+                    f"Structured-output distillation failed for batch {batch_indices}; "
+                    f"retrying without response_format. Error: {e}",
+                    exc_info=True,
+                )
+                response = distillation_lm(messages=messages)[0]
 
             return _parse_batch_response(
                 response=response,

--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -145,15 +145,18 @@ def truncate_to_token_limit(text: str, model: str, model_type: str) -> str:
     return truncated
 
 
-# ``extra="forbid"`` makes ``model_json_schema()`` emit ``additionalProperties: false`` on
-# every object. Databricks' structured-output endpoint rejects a ``response_format`` schema
-# that omits it (Pydantic does not add it by default), so this keeps distillation working
-# against ``databricks:/`` reflection models.
+# These models are sent as a structured-output ``response_format``. Databricks' endpoint
+# enforces OpenAI strict-schema rules on every object:
+#   - ``additionalProperties: false`` — supplied via ``extra="forbid"`` (Pydantic omits it
+#     by default).
+#   - every property listed in ``required`` — so ``source_trace_ids`` must NOT have a default
+#     (a default drops it from ``required``). It stays nullable via ``| None`` so ``None``
+#     remains a valid value; callers always pass it explicitly.
 class Guideline(BaseModel):
     model_config = {"extra": "forbid"}
 
     guideline_text: str
-    source_trace_ids: list[str | int] | None = None
+    source_trace_ids: list[str | int] | None
 
 
 class Guidelines(BaseModel):

--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -295,7 +295,7 @@ def _create_batches(
     return batches
 
 
-def _extract_json_object(response: str) -> str:
+def _extract_json_object(response: str | dict[str, Any]) -> str:
     """Extract the JSON object from an LLM response.
 
     Structured-output (``response_format``) responses are raw JSON, but the unstructured
@@ -304,7 +304,13 @@ def _extract_json_object(response: str) -> str:
     present, then narrows to the outermost ``{...}`` so leading/trailing text does not
     break parsing. Returns the original (stripped) string when no object is found, so the
     caller's ``json.loads`` raises a meaningful error.
+
+    Reasoning models (e.g. ``gpt-oss``) make DSPy return the completion as a
+    ``{"text": ..., "reasoning_content": ...}`` dict rather than a plain string, so pull the
+    ``text`` field out first.
     """
+    if isinstance(response, dict):
+        response = response.get("text", "")
     stripped = response.strip()
     if match := re.match(r"^```(?:json)?\s*\n?(.*?)\n?```$", stripped, re.DOTALL):
         stripped = match.group(1).strip()
@@ -316,14 +322,15 @@ def _extract_json_object(response: str) -> str:
 
 
 def _parse_batch_response(
-    response: str,
+    response: str | dict[str, Any],
     index_to_trace_id: dict[int, str],
     existing_guideline_texts: set[str],
 ) -> list[Guideline]:
     """Parse LM response and convert to Guideline objects, filtering duplicates.
 
     Args:
-        response: LM response in JSON format
+        response: LM response as a JSON string, or a DSPy ``{"text": ...}`` dict for
+            reasoning models
         index_to_trace_id: Mapping from example indices to trace IDs
         existing_guideline_texts: Set of already existing guideline texts to avoid duplicates
 

--- a/tests/genai/judges/optimizers/memalign/test_utils.py
+++ b/tests/genai/judges/optimizers/memalign/test_utils.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import dspy
@@ -5,8 +6,11 @@ import pytest
 
 import mlflow
 from mlflow.genai.judges.optimizers.memalign.utils import (
+    Guideline,
+    Guidelines,
     _count_tokens,
     _create_batches,
+    _extract_json_object,
     distill_guidelines,
     get_default_embedding_model,
     retrieve_relevant_examples,
@@ -17,6 +21,82 @@ from mlflow.genai.judges.optimizers.memalign.utils import (
 
 def test_get_default_embedding_model():
     assert get_default_embedding_model() == "openai:/text-embedding-3-small"
+
+
+@pytest.mark.parametrize("model", [Guideline, Guidelines])
+def test_guideline_schemas_forbid_additional_properties(model):
+    # Databricks' structured-output endpoint rejects a response_format schema unless every
+    # object declares additionalProperties=false, which Pydantic only emits under extra=forbid.
+    schema = model.model_json_schema()
+    assert schema["additionalProperties"] is False
+    for definition in schema.get("$defs", {}).values():
+        assert definition["additionalProperties"] is False
+
+
+def _assert_objects_forbid_additional_properties(node):
+    """Recursively assert every object schema declares additionalProperties=false."""
+    if isinstance(node, dict):
+        if node.get("type") == "object" or "properties" in node:
+            assert node.get("additionalProperties") is False, node
+        for value in node.values():
+            _assert_objects_forbid_additional_properties(value)
+    elif isinstance(node, list):
+        for item in node:
+            _assert_objects_forbid_additional_properties(item)
+
+
+# Databricks-served foundation models split into two response_format routing paths in
+# litellm: OpenAI-compatible models emit a strict `json_schema`, while Claude models are
+# rewritten into a forced tool call whose parameter schema is derived from the same model.
+# These tests verify that Guidelines produces a valid payload (every object declaring
+# additionalProperties=false) on both paths across a representative model per family.
+# NOTE: the version-independent regression guard for the additionalProperties fix is
+# test_guideline_schemas_forbid_additional_properties above - recent litellm also injects
+# additionalProperties on the json_schema path, so these routing tests alone would not
+# catch a removal of extra="forbid" on older litellm. See the Databricks docs:
+# https://docs.databricks.com/aws/en/machine-learning/model-serving/score-foundation-models
+_JSON_SCHEMA_MODELS = [
+    "databricks-gpt-5",
+    "databricks-gpt-5-mini",
+    "databricks-gpt-oss-120b",
+    "databricks-gemini-2-5-flash",
+    "databricks-qwen35-122b-a10b",
+    "databricks-glm-5-2",
+    "databricks-gemma-3-12b",
+    "databricks-llama-4-maverick",
+    "databricks-meta-llama-3-1-8b-instruct",
+]
+_TOOL_CALL_MODELS = [
+    "databricks-claude-sonnet-5",
+    "databricks-claude-opus-4-8",
+    "databricks-claude-haiku-4-5",
+]
+
+
+@pytest.mark.parametrize("model", _JSON_SCHEMA_MODELS)
+def test_guidelines_response_format_json_schema_families(model):
+    import litellm
+
+    params = litellm.get_optional_params(
+        model=model, custom_llm_provider="databricks", response_format=Guidelines
+    )
+    response_format = params.get("response_format")
+    assert response_format is not None, f"{model} dropped response_format"
+    assert response_format["type"] == "json_schema"
+    _assert_objects_forbid_additional_properties(response_format["json_schema"]["schema"])
+
+
+@pytest.mark.parametrize("model", _TOOL_CALL_MODELS)
+def test_guidelines_response_format_tool_call_families(model):
+    import litellm
+
+    params = litellm.get_optional_params(
+        model=model, custom_llm_provider="databricks", response_format=Guidelines
+    )
+    # Claude routes structured output through a forced tool call rather than json_schema.
+    tools = params.get("tools")
+    assert tools, f"{model} produced neither response_format nor tools"
+    _assert_objects_forbid_additional_properties(tools[0]["function"]["parameters"])
 
 
 def test_distill_guidelines_empty_examples():
@@ -130,6 +210,66 @@ def test_distill_guidelines_handles_lm_error():
             existing_guidelines=[],
         )
         assert result == []
+
+
+def test_distill_guidelines_falls_back_to_unstructured_on_structured_output_error():
+    # Some models error on structured-output (response_format) requests. The distiller
+    # should retry without response_format rather than dropping the batch.
+    with (
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils.construct_dspy_lm"
+        ) as mock_construct_lm,
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils._create_batches",
+            return_value=[[0]],
+        ),
+    ):
+        example1 = MagicMock(spec=dspy.Example)
+        example1.__iter__ = lambda self: iter([("input", "test"), ("output", "good")])
+        example1._trace_id = "trace_1"
+
+        def lm_side_effect(messages, **kwargs):
+            if "response_format" in kwargs:
+                raise Exception("INTERNAL_ERROR: invalid response from upstream server")
+            # Unstructured fallback returns JSON wrapped in a markdown fence.
+            return [
+                '```json\n{"guidelines": [{"guideline_text": "Be concise", '
+                '"source_trace_ids": [0]}]}\n```'
+            ]
+
+        mock_lm = MagicMock(side_effect=lm_side_effect)
+        mock_construct_lm.return_value = mock_lm
+
+        result = distill_guidelines(
+            examples=[example1],
+            judge_instructions="Evaluate quality",
+            reflection_lm="databricks:/databricks-gpt-oss-120b",
+            existing_guidelines=[],
+        )
+
+        assert len(result) == 1
+        assert result[0].guideline_text == "Be concise"
+        assert result[0].source_trace_ids == ["trace_1"]
+        # Structured attempt + unstructured fallback = two calls.
+        assert mock_lm.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        '{"guidelines": []}',
+        '```json\n{"guidelines": []}\n```',
+        '```\n{"guidelines": []}\n```',
+        '  {"guidelines": []}  ',
+        'Here are the guidelines:\n```json\n{"guidelines": []}\n```',
+        'Sure! {"guidelines": []}',
+        '{"guidelines": []}\nLet me know if you need more.',
+    ],
+)
+def test_extract_json_object(response):
+    # The unstructured fallback path yields JSON that may be fenced and/or wrapped in
+    # prose; the extracted string must be valid JSON with the expected shape.
+    assert json.loads(_extract_json_object(response)) == {"guidelines": []}
 
 
 def test_retrieve_relevant_examples_empty():

--- a/tests/genai/judges/optimizers/memalign/test_utils.py
+++ b/tests/genai/judges/optimizers/memalign/test_utils.py
@@ -8,6 +8,7 @@ import mlflow
 from mlflow.genai.judges.optimizers.memalign.utils import (
     Guideline,
     Guidelines,
+    _build_strict_response_format,
     _count_tokens,
     _create_batches,
     _extract_json_object,
@@ -46,6 +47,37 @@ def test_guideline_accepts_none_source_trace_ids():
     # source_trace_ids is required (no default) but must remain nullable, since guidelines
     # loaded from persisted memory and filtering logic rely on None being a valid value.
     assert Guideline(guideline_text="x", source_trace_ids=None).source_trace_ids is None
+
+
+def _walk_schema(node):
+    """Yield every dict node in a JSON schema tree."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _walk_schema(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_schema(item)
+
+
+def test_build_strict_response_format_satisfies_databricks_rules():
+    # Databricks' structured-output endpoint enforces the full OpenAI strict-schema contract
+    # AND (unlike OpenAI) rejects $ref/$defs indirection. Assert the built response_format:
+    #   - is a strict json_schema envelope
+    #   - contains no $ref / $defs (fully inlined)
+    #   - declares additionalProperties=false and complete `required` on every object
+    rf = _build_strict_response_format(Guidelines)
+
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["strict"] is True
+    schema = rf["json_schema"]["schema"]
+
+    for node in _walk_schema(schema):
+        assert "$ref" not in node
+        assert "$defs" not in node
+        if node.get("type") == "object" or "properties" in node:
+            assert node.get("additionalProperties") is False
+            assert set(node["required"]) == set(node["properties"])
 
 
 def _assert_objects_forbid_additional_properties(node):

--- a/tests/genai/judges/optimizers/memalign/test_utils.py
+++ b/tests/genai/judges/optimizers/memalign/test_utils.py
@@ -23,14 +23,29 @@ def test_get_default_embedding_model():
     assert get_default_embedding_model() == "openai:/text-embedding-3-small"
 
 
+def _iter_object_schemas(schema):
+    """Yield every object schema node (top-level and nested $defs) in a JSON schema."""
+    yield schema
+    yield from schema.get("$defs", {}).values()
+
+
 @pytest.mark.parametrize("model", [Guideline, Guidelines])
-def test_guideline_schemas_forbid_additional_properties(model):
-    # Databricks' structured-output endpoint rejects a response_format schema unless every
-    # object declares additionalProperties=false, which Pydantic only emits under extra=forbid.
+def test_guideline_schemas_satisfy_strict_structured_output(model):
+    # Databricks' structured-output endpoint enforces OpenAI strict-schema rules on every
+    # object: additionalProperties=false (emitted via extra=forbid) AND every property listed
+    # in `required` (so no field may declare a default). Assert both, since either omission
+    # produces a BadRequestError from the endpoint.
     schema = model.model_json_schema()
-    assert schema["additionalProperties"] is False
-    for definition in schema.get("$defs", {}).values():
-        assert definition["additionalProperties"] is False
+    for obj in _iter_object_schemas(schema):
+        if "properties" in obj:
+            assert obj.get("additionalProperties") is False
+            assert set(obj["required"]) == set(obj["properties"])
+
+
+def test_guideline_accepts_none_source_trace_ids():
+    # source_trace_ids is required (no default) but must remain nullable, since guidelines
+    # loaded from persisted memory and filtering logic rely on None being a valid value.
+    assert Guideline(guideline_text="x", source_trace_ids=None).source_trace_ids is None
 
 
 def _assert_objects_forbid_additional_properties(node):

--- a/tests/genai/judges/optimizers/memalign/test_utils.py
+++ b/tests/genai/judges/optimizers/memalign/test_utils.py
@@ -301,9 +301,33 @@ def test_distill_guidelines_falls_back_to_unstructured_on_structured_output_erro
         assert mock_lm.call_count == 2
 
 
-def test_distill_guidelines_handles_dict_response_from_reasoning_model():
-    # Reasoning models (e.g. gpt-oss) make DSPy return a {"text": ..., "reasoning_content": ...}
-    # dict rather than a string; distillation must parse it, not choke on .strip().
+_GUIDELINE_JSON = '{"guidelines": [{"guideline_text": "Be concise", "source_trace_ids": [0]}]}'
+
+
+# The DSPy response shape varies by Databricks foundation-model family. Verified against a
+# live endpoint (litellm 1.75.9): most families return the completion as a plain string,
+# while reasoning models (gpt-oss-*) return a {"text": ..., "reasoning_content": ...} dict
+# because DSPy only collapses single-key outputs to str. Distillation must parse both,
+# including the fenced/prose variants the unstructured fallback can produce.
+@pytest.mark.parametrize(
+    ("reflection_lm", "lm_response"),
+    [
+        # str responses (gpt-5, gemini, claude, llama, gemma, qwen, ...)
+        ("databricks:/databricks-gpt-5-mini", _GUIDELINE_JSON),
+        ("databricks:/databricks-claude-sonnet-4-5", _GUIDELINE_JSON),
+        ("databricks:/databricks-meta-llama-3-3-70b-instruct", f"```json\n{_GUIDELINE_JSON}\n```"),
+        # dict responses from reasoning models (gpt-oss-*)
+        (
+            "databricks:/databricks-gpt-oss-120b",
+            {"text": _GUIDELINE_JSON, "reasoning_content": "thinking..."},
+        ),
+        (
+            "databricks:/databricks-gpt-oss-20b",
+            {"text": f"```json\n{_GUIDELINE_JSON}\n```", "reasoning_content": "thinking..."},
+        ),
+    ],
+)
+def test_distill_guidelines_handles_family_response_shapes(reflection_lm, lm_response):
     with (
         patch(
             "mlflow.genai.judges.optimizers.memalign.utils.construct_dspy_lm"
@@ -317,21 +341,13 @@ def test_distill_guidelines_handles_dict_response_from_reasoning_model():
         example1.__iter__ = lambda self: iter([("input", "test"), ("output", "good")])
         example1._trace_id = "trace_1"
 
-        mock_lm = MagicMock(
-            return_value=[
-                {
-                    "text": '{"guidelines": [{"guideline_text": "Be concise", '
-                    '"source_trace_ids": [0]}]}',
-                    "reasoning_content": "thinking...",
-                }
-            ]
-        )
+        mock_lm = MagicMock(return_value=[lm_response])
         mock_construct_lm.return_value = mock_lm
 
         result = distill_guidelines(
             examples=[example1],
             judge_instructions="Evaluate quality",
-            reflection_lm="databricks:/databricks-gpt-oss-120b",
+            reflection_lm=reflection_lm,
             existing_guidelines=[],
         )
 

--- a/tests/genai/judges/optimizers/memalign/test_utils.py
+++ b/tests/genai/judges/optimizers/memalign/test_utils.py
@@ -301,6 +301,45 @@ def test_distill_guidelines_falls_back_to_unstructured_on_structured_output_erro
         assert mock_lm.call_count == 2
 
 
+def test_distill_guidelines_handles_dict_response_from_reasoning_model():
+    # Reasoning models (e.g. gpt-oss) make DSPy return a {"text": ..., "reasoning_content": ...}
+    # dict rather than a string; distillation must parse it, not choke on .strip().
+    with (
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils.construct_dspy_lm"
+        ) as mock_construct_lm,
+        patch(
+            "mlflow.genai.judges.optimizers.memalign.utils._create_batches",
+            return_value=[[0]],
+        ),
+    ):
+        example1 = MagicMock(spec=dspy.Example)
+        example1.__iter__ = lambda self: iter([("input", "test"), ("output", "good")])
+        example1._trace_id = "trace_1"
+
+        mock_lm = MagicMock(
+            return_value=[
+                {
+                    "text": '{"guidelines": [{"guideline_text": "Be concise", '
+                    '"source_trace_ids": [0]}]}',
+                    "reasoning_content": "thinking...",
+                }
+            ]
+        )
+        mock_construct_lm.return_value = mock_lm
+
+        result = distill_guidelines(
+            examples=[example1],
+            judge_instructions="Evaluate quality",
+            reflection_lm="databricks:/databricks-gpt-oss-120b",
+            existing_guidelines=[],
+        )
+
+        assert len(result) == 1
+        assert result[0].guideline_text == "Be concise"
+        assert result[0].source_trace_ids == ["trace_1"]
+
+
 @pytest.mark.parametrize(
     "response",
     [
@@ -311,11 +350,13 @@ def test_distill_guidelines_falls_back_to_unstructured_on_structured_output_erro
         'Here are the guidelines:\n```json\n{"guidelines": []}\n```',
         'Sure! {"guidelines": []}',
         '{"guidelines": []}\nLet me know if you need more.',
+        # Reasoning models (e.g. gpt-oss) return a DSPy dict rather than a string.
+        {"text": '{"guidelines": []}', "reasoning_content": "let me think..."},
     ],
 )
 def test_extract_json_object(response):
     # The unstructured fallback path yields JSON that may be fenced and/or wrapped in
-    # prose; the extracted string must be valid JSON with the expected shape.
+    # prose; reasoning models return a {"text": ...} dict. Either must extract to valid JSON.
     assert json.loads(_extract_json_object(response)) == {"guidelines": []}
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Fixes MemAlign judge-alignment guideline distillation failing with `databricks:/` reflection models. The distillation call sends the `Guidelines` pydantic model as a structured-output `response_format`; on Databricks-served models this failed in four distinct ways, uncovered one at a time as each prior fix let the request progress further.

**Request-side (schema) — three layers.** Databricks' structured-output endpoint enforces the full OpenAI strict-schema contract, and older litellm versions (e.g. `1.75.9`, shipped in current DBR) forward Pydantic's raw `model_json_schema()` **without normalizing it**:

1. **`additionalProperties` must be `false` on every object.** Pydantic omits it by default →
   `Invalid schema for response_format 'Guidelines': ... 'additionalProperties' is required to be supplied and to be false.`
   Fixed by adding `model_config = {"extra": "forbid"}` to `Guideline`/`Guidelines`.

2. **Every property must appear in `required`.** A field with a default is dropped from `required` →
   `... 'required' is required to be supplied and to be an array including every key in properties. Missing 'source_trace_ids'.`
   Fixed by removing the default on `source_trace_ids` (kept nullable via `| None`; all call sites pass it explicitly, and `None` remains valid for persisted-memory loading and guideline filtering).

3. **No `$ref`/`$defs` indirection.** Pydantic emits the nested `Guideline` model as a `$ref` into `$defs`, which the endpoint rejects →
   `... reference can only point to definitions defined at the top level of the schema.` (also surfaces intermittently as a `502 INTERNAL_ERROR`).
   Fixed by building the `response_format` from a fully-inlined schema via `_build_strict_response_format()`, which resolves every `$ref` and enforces `additionalProperties: false` + a complete `required` list on each object.

**Response-side (parsing) — one layer.** Once the request succeeded, reasoning models surfaced a separate bug:

4. **Reasoning models return a dict, not a string.** For `databricks-gpt-oss-*`, DSPy returns the completion as `{"text": ..., "reasoning_content": ...}` (DSPy only collapses single-key outputs to `str`), so parsing raised `'dict' object has no attribute 'strip'`.
   Fixed by extracting the `text` field in `_extract_json_object` when the response is a dict — applies to both the structured path and the unstructured fallback.

Because the schema fixes enforce the whole contract at the source, they are correct regardless of whether the installed litellm normalizes the schema. As defense-in-depth, distillation also falls back to an unstructured request (the prompt already specifies the JSON format) if the structured call still fails, mirroring the judge adapter's fallback in `mlflow/genai/judges/adapters/litellm_adapter.py`; parsing tolerates fenced/prose-wrapped JSON.

**Why the layers surfaced one at a time:** newer litellm (e.g. `1.80.11`) runs the schema through the OpenAI SDK's `to_strict_json_schema`, which repairs the three schema issues before the request is sent — so the bug is invisible on newer litellm and only reproduces on the un-normalizing versions shipped in the notebook environments where this was reported.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New/updated tests in `tests/genai/judges/optimizers/memalign/test_utils.py`:
- `test_guideline_schemas_satisfy_strict_structured_output` — asserts `additionalProperties: false` **and** `required == properties` on every object (version-independent).
- `test_build_strict_response_format_satisfies_databricks_rules` — asserts the built `response_format` is a strict `json_schema` with **no** `$ref`/`$defs` and strict objects throughout.
- `test_guideline_accepts_none_source_trace_ids` — guards that the required field stays nullable.
- `test_distill_guidelines_handles_family_response_shapes` — parametrized over the DSPy response shapes observed per family (plain-string JSON, fenced JSON, and the `{text, reasoning_content}` dict from `gpt-oss` reasoning models), so the response-parsing path is exercised, not just request building.
- `test_distill_guidelines_falls_back_to_unstructured_on_structured_output_error` / `test_extract_json_object` — unstructured fallback + lenient/dict-aware parsing.
- `test_guidelines_response_format_json_schema_families` / `test_guidelines_response_format_tool_call_families` — representative model per Databricks foundation-model family across both litellm routing paths (OpenAI-compatible `json_schema` and the Claude tool-call rewrite).

These are all mocked and deterministic (no credentials/network); the full memalign suite runs in a few seconds.

**Manual validation against a live Databricks endpoint** (litellm `1.75.9` + openai `2.14.0`, the notebook's versions), exercising the full request -> endpoint -> parse cycle with the real code:
- Replaying litellm's exact wire body with the raw `$ref` schema → `HTTP 502`, reproducing the reported failure.
- The inlined `_build_strict_response_format(Guidelines)` schema + fixed parsing → success across 11 families: `gpt-5`, `gpt-5-mini`, `gpt-oss-120b`, `gpt-oss-20b`, `gemini-2-5-flash`, `claude-sonnet-4-5`, `claude-opus-4-8`, `meta-llama-3-3-70b-instruct`, `meta-llama-3-1-8b-instruct`, `gemma-3-12b`, `qwen3-next-80b`. Only the `gpt-oss-*` models returned the dict response shape, confirming the isolation of fix #4.
- Confirmed end-to-end: the reporting notebook's distillation now succeeds on the structured path.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed judge alignment (MemAlign) guideline distillation failing with Databricks-served reflection models, caused by structured-output schemas that did not conform to the endpoint's strict-schema requirements and by unhandled response shapes from reasoning models.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.