### PR TITLE
Don't send `stream_options` from the Assistant to the gateway

### DIFF
--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -474,12 +474,12 @@ class OpenAICompatibleProvider(AssistantProvider):
                             "messages": messages,
                             "tools": tools,
                             "stream": True,
-                            # Strict OpenAI-compatible servers (vLLM, LM Studio, raw
-                            # OpenAI) only emit the final usage chunk when asked;
-                            # without this they stream no token counts at all. Servers
-                            # that already report usage (the MLflow gateway, Ollama)
-                            # ignore or harmlessly echo the option.
-                            "stream_options": {"include_usage": True},
+                            # NB: intentionally no `stream_options`. It's an OpenAI-only field,
+                            # and the assistant only targets the MLflow AI Gateway (which
+                            # self-injects it per-provider for backends that accept it) or
+                            # Ollama (which reports usage unconditionally). Forwarding it to a
+                            # gateway route backed by Anthropic makes /v1/messages reject the
+                            # request with 400 "stream_options: Extra inputs are not permitted".
                         }
                         async with session.post(
                             chat_url,

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -276,7 +276,10 @@ async def test_astream_emits_content_deltas(provider):
 
 
 @pytest.mark.asyncio
-async def test_astream_requests_usage_via_stream_options(provider):
+async def test_astream_omits_stream_options(provider):
+    # stream_options is an OpenAI-only field. The assistant must not send it: a
+    # gateway route backed by Anthropic forwards it to /v1/messages, which 400s on
+    # the unknown field. The gateway self-injects it per-provider where accepted.
     lines = [_sse(_delta(content="hi")), b"data: [DONE]\n"]
     session, calls = _make_aiohttp_session([lines])
 
@@ -286,7 +289,7 @@ async def test_astream_requests_usage_via_stream_options(provider):
     ):
         _ = [e async for e in provider.astream("hi", "http://localhost:5000")]
 
-    assert calls[0]["json"]["stream_options"] == {"include_usage": True}
+    assert "stream_options" not in calls[0]["json"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24507

### What changes are proposed in this pull request?

The Assistant always tacked `stream_options: {"include_usage": true}` onto its streaming request. Point it at a gateway route backed by Anthropic and the gateway hands that field to `/v1/messages`, which 400s: `stream_options: Extra inputs are not permitted`.

The Assistant never needed to send it. Its only two OpenAI-compatible presets are the MLflow AI Gateway (which adds `stream_options` itself, per backend, where the backend accepts it) and Ollama (which returns usage whether you ask or not). So: drop it. Usage tracking is unaffected on both; the Anthropic route stops erroring.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Flipped the existing `stream_options` test to assert the field is *absent* from the outgoing payload. Also confirmed by hand against a live Anthropic gateway route.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a 400 when using the Assistant against an Anthropic-backed MLflow AI Gateway endpoint.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release