### PR TITLE
fix(metrics): prevent `ndcg_at_k` inflation when retrieved docs < k

### DIFF
--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -306,8 +306,12 @@ def ndcg_at_k(k) -> EvaluationMetric:
     we use binary relevance here. The relevance score for documents in the ground truth is 1,
     and the relevance score for documents not in the ground truth is 0.
 
-    The NDCG score is calculated using sklearn.metrics.ndcg_score with the following edge cases
-    on top of the sklearn implementation:
+    The score is binary NDCG@k: retrieved docs contribute relevance 1 if present in the
+    ground truth and 0 otherwise. DCG only sums over the ranked retrieval list (truncated
+    to ``k``). IDCG uses up to ``min(|ground truth|, k)`` ideal relevant hits, so a short
+    retrieval list is not inflated by shrinking the ideal baseline.
+
+    Edge cases:
 
     1. If no ground truth doc IDs are provided and no documents are retrieved, the score is 1.
     2. If no ground truth doc IDs are provided and documents are retrieved, the score is 0.
@@ -317,7 +321,7 @@ def ndcg_at_k(k) -> EvaluationMetric:
        [1, 2] and the retrieved doc IDs are [1, 1, 1, 3], the score will be equivalent to
        ground truth doc IDs [10, 11, 12, 2] and retrieved doc IDs [10, 11, 12, 3].
 
-    .. _NDCG@k: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.ndcg_score.html
+    .. _NDCG@k: https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG
     """
     return make_metric(
         eval_fn=_ndcg_at_k_eval_fn(k),

--- a/mlflow/metrics/metric_definitions.py
+++ b/mlflow/metrics/metric_definitions.py
@@ -426,39 +426,30 @@ def _expand_duplicate_retrieved_docs(predictions, targets):
     return expanded_predictions, expanded_targets
 
 
-def _prepare_row_for_ndcg(predictions, targets):
-    """Prepare data one row from predictions and targets to y_score, y_true for ndcg calculation.
+def _binary_ndcg_at_k(retrieved, ground_truth, k):
+    """Compute binary NDCG@k for one prediction/target row.
 
-    Args:
-        predictions: A list of strings of at most k doc IDs retrieved.
-        targets: A list of strings of ground-truth doc IDs.
-
-    Returns:
-        y_true : ndarray of shape (1, n_docs) Representing the ground-truth relevant docs.
-            n_docs is the number of unique docs in union of predictions and targets.
-        y_score : ndarray of shape (1, n_docs) Representing the retrieved docs.
-            n_docs is the number of unique docs in union of predictions and targets.
+    Only the ranked retrieved documents contribute to DCG. IDCG is built from
+    up to ``min(|ground_truth|, k)`` ideal relevant hits so that short retrieval
+    lists are penalized (sklearn.metrics.ndcg_score cannot express this when
+    unretrieved relevant docs still have positive labels).
     """
-    # sklearn does an internal sort of y_score, so to preserve the order of our retrieved
-    # docs, we need to modify the relevance value slightly
-    eps = 1e-6
+    retrieved = list(retrieved[:k])
+    targets = set(ground_truth)
+    # Expand duplicate retrieved IDs the same way as before so repeated hits
+    # against a ground-truth ID still count as distinct ranked positions.
+    retrieved, targets = _expand_duplicate_retrieved_docs(retrieved, targets)
 
-    # support predictions containing duplicate doc ID
-    targets = set(targets)
-    predictions, targets = _expand_duplicate_retrieved_docs(predictions, targets)
+    dcg = 0.0
+    for i, doc_id in enumerate(retrieved):
+        if doc_id in targets:
+            dcg += 1.0 / np.log2(i + 2)
 
-    all_docs = targets.union(predictions)
-    doc_id_to_index = {doc_id: i for i, doc_id in enumerate(all_docs)}
-    n_labels = max(len(doc_id_to_index), 2)  # sklearn.metrics.ndcg_score requires at least 2 labels
-    y_true = np.zeros((1, n_labels), dtype=np.float32)
-    y_score = np.zeros((1, n_labels), dtype=np.float32)
-    for i, doc_id in enumerate(predictions):
-        # "1 - i * eps" means we assign higher score to docs that are ranked higher,
-        # but all scores are still approximately 1.
-        y_score[0, doc_id_to_index[doc_id]] = 1 - i * eps
-    for doc_id in targets:
-        y_true[0, doc_id_to_index[doc_id]] = 1
-    return y_score, y_true
+    ideal_hits = min(len(targets), k)
+    if ideal_hits == 0:
+        return 0.0
+    idcg = sum(1.0 / np.log2(i + 2) for i in range(ideal_hits))
+    return float(dcg / idcg)
 
 
 def _ndcg_at_k_eval_fn(k):
@@ -470,8 +461,6 @@ def _ndcg_at_k_eval_fn(k):
         return noop
 
     def _fn(predictions, targets):
-        from sklearn.metrics import ndcg_score
-
         if not _validate_array_like_id_data(
             predictions, "ndcg_at_k", predictions_col_specifier
         ) or not _validate_array_like_id_data(targets, "ndcg_at_k", targets_col_specifier):
@@ -492,10 +481,7 @@ def _ndcg_at_k_eval_fn(k):
                 scores.append(0)
                 continue
 
-            # only include the top k retrieved chunks
-            y_score, y_true = _prepare_row_for_ndcg(retrieved[:k], ground_truth)
-            score = ndcg_score(y_true, y_score, k=len(retrieved[:k]), ignore_ties=True)
-            scores.append(score)
+            scores.append(_binary_ndcg_at_k(retrieved, ground_truth, k))
 
         return MetricValue(scores=scores, aggregate_results=standard_aggregations(scores))
 

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -360,6 +360,15 @@ def test_ndcg_at_k():
     result = ndcg_at_k(k=3).eval_fn(predictions, targets)
     assert result.scores[0] == 0.0
 
+    # When fewer than k docs are retrieved, IDCG must still use k so scores
+    # are not inflated to 1.0 for a single relevant hit (issue #24541).
+    predictions = pd.Series([["1"]])
+    targets = pd.Series([["1", "2", "3", "4", "5"]])
+    result = ndcg_at_k(5).eval_fn(predictions, targets)
+    # DCG@5 = 1; IDCG@5 = sum 1/log2(i+2) for i in 0..4 ≈ 2.948459
+    assert result.scores[0] == pytest.approx(1.0 / 2.948459122426006, rel=1e-5)
+    assert result.scores[0] < 0.5
+
 
 def test_bleu():
     predictions = ["hello world", "this is a test"]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24541

### What changes are proposed in this pull request?

`ndcg_at_k` previously called `sklearn.metrics.ndcg_score` with `k=len(retrieved[:k])`. When a retriever returned fewer than `k` documents, that shrunk the IDCG baseline and inflated NDCG (e.g. one relevant hit at k=5 scored `1.0` instead of ~`0.339`).

Simply passing the original `k` into sklearn is not enough: unretrieved ground-truth docs still have positive labels and can enter the top-`k` ranking via score ties.

This PR replaces the sklearn path with an explicit binary NDCG@k:
- DCG only sums over the ranked retrieval list (truncated to `k`)
- IDCG uses up to `min(|ground_truth|, k)` ideal relevant hits
- Existing empty-list / duplicate-ID edge cases are preserved

Docs for `ndcg_at_k` are updated to match the new computation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New regression case in `tests/metrics/test_metric_definitions.py`:
- retrieved `["1"]`, ground truth `["1","2","3","4","5"]`, `k=5`
- expects `≈ 1 / IDCG@5 ≈ 0.339` and asserts score `< 0.5`

Existing NDCG cases (empty inputs, different k, ranking order, duplicate predictions/targets) were re-run against the new helper and still match.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

(`ndcg_at_k` docstring was updated in-tree; no separate docs site change.)

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`ndcg_at_k` no longer inflates scores when a retriever returns fewer than `k` documents.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
