### PR TITLE
Remove duplicate Assistant button from the global sidebar

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -2150,9 +2150,6 @@ module.exports = {
 
   // -- mlflow.sidebar --
   "mlflow.sidebar.account": "",
-  "mlflow.sidebar.assistant_beta_tag": "",
-  "mlflow.sidebar.assistant_button": "",
-  "mlflow.sidebar.assistant_tooltip": "",
   "mlflow.sidebar.docs_link": "",
   "mlflow.sidebar.experiments_tab_link": "",
   "mlflow.sidebar.gateway_budgets_tab_link": "",

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import React, { useCallback, useMemo, useRef } from 'react';
 import {
   Avatar,
   BeakerIcon,
@@ -9,16 +8,12 @@ import {
   GearIcon,
   HomeIcon,
   ModelsIcon,
-  Tag,
   TextBoxIcon,
   Typography,
   useDesignSystemTheme,
-  DesignSystemEventProviderComponentTypes,
-  DesignSystemEventProviderAnalyticsEventTypes,
   SidebarCollapseIcon,
   SidebarExpandIcon,
   InfoBookIcon,
-  Tooltip,
   NewWindowIcon,
 } from '@databricks/design-system';
 import { useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
@@ -33,11 +28,8 @@ import { useCurrentUserIsAdmin, useCurrentUserQuery, useIsBasicAuth } from '../.
 import { performLogout } from '../../account/auth-utils';
 import { GatewayLabel, GatewayNewTag } from './GatewayNewTag';
 import { FormattedMessage } from 'react-intl';
-import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 import { useWorkflowType, WorkflowType } from '../contexts/WorkflowTypeContext';
 import { shouldEnableWorkflowBasedNavigation, shouldEnableWorkspaces } from '../utils/FeatureUtils';
-import { AssistantSparkleIcon } from '../../assistant/AssistantIconButton';
-import { useAssistant } from '../../assistant/AssistantContext';
 import { extractWorkspaceFromSearchParams, useActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 import { SETTINGS_RETURN_TO_PARAM, SETTINGS_SECTION_GENERAL } from '../../settings/settingsSectionConstants';
 import { getSidebarItemStyles, MlflowSidebarLink } from './MlflowSidebarLink';
@@ -101,12 +93,10 @@ export function MlflowSidebar({
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const { theme } = useDesignSystemTheme();
-  const viewId = useMemo(() => uuidv4(), []);
   const enableWorkflowBasedNavigation = shouldEnableWorkflowBasedNavigation();
   // WorkflowType context is always available, but UI is guarded by feature flag
   const { workflowType, setWorkflowType } = useWorkflowType();
   const { experimentId } = useParams();
-  const logTelemetryEvent = useLogTelemetryEvent();
   const toggleSidebar = useCallback(() => {
     setShowSidebar(!showSidebar);
   }, [setShowSidebar, showSidebar]);
@@ -149,28 +139,10 @@ export function MlflowSidebar({
   const isAdmin = useCurrentUserIsAdmin();
   const canManage = isAdmin;
 
-  const { openPanel, closePanel, isPanelOpen, canUseAssistant } = useAssistant();
-  const [isAssistantHovered, setIsAssistantHovered] = useState(false);
-
   // Radix restores focus to the trigger on dismiss, but the browser
   // keeps ``:focus-visible`` - leaving a stale outline. Skip auto-focus
   // return on pointer dismiss; keyboard dismiss still restores focus.
   const accountDropdownClosedByPointerRef = useRef(false);
-
-  const handleAssistantToggle = useCallback(() => {
-    if (isPanelOpen) {
-      closePanel();
-    } else {
-      openPanel();
-    }
-    logTelemetryEvent({
-      componentId: 'mlflow.sidebar.assistant_button',
-      componentViewId: viewId,
-      componentType: DesignSystemEventProviderComponentTypes.Button,
-      componentSubType: null,
-      eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
-    });
-  }, [isPanelOpen, closePanel, openPanel, logTelemetryEvent, viewId]);
 
   const menuItems: MenuItemWithNested[] = useMemo(
     () => [
@@ -380,56 +352,6 @@ export function MlflowSidebar({
             ))}
         </ul>
         <div>
-          {canUseAssistant && (
-            <Tooltip
-              componentId="mlflow.sidebar.assistant_tooltip"
-              content={<FormattedMessage defaultMessage="Assistant" description="Tooltip for assistant button" />}
-              open={isAssistantHovered && !showSidebar}
-              side="right"
-              delayDuration={0}
-            >
-              <div
-                role="button"
-                tabIndex={0}
-                aria-pressed={isPanelOpen}
-                css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: theme.spacing.sm,
-                  paddingInline: showSidebar ? theme.spacing.sm : theme.spacing.xs,
-                  paddingBlock: theme.spacing.sm,
-                  borderRadius: theme.borders.borderRadiusMd - 2,
-                  justifyContent: showSidebar ? 'flex-start' : 'center',
-                  cursor: 'pointer',
-                  color: isPanelOpen ? theme.colors.actionDefaultIconHover : theme.colors.actionDefaultIconDefault,
-                  '&:hover': {
-                    color: theme.colors.actionLinkHover,
-                    backgroundColor: theme.colors.actionDefaultBackgroundHover,
-                  },
-                }}
-                onClick={handleAssistantToggle}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    handleAssistantToggle();
-                  }
-                }}
-                onMouseEnter={() => setIsAssistantHovered(true)}
-                onMouseLeave={() => setIsAssistantHovered(false)}
-              >
-                <AssistantSparkleIcon isHovered={isAssistantHovered} />
-                {showSidebar && (
-                  <>
-                    <Typography.Text color="primary">
-                      <FormattedMessage defaultMessage="Assistant" description="Sidebar button for AI assistant" />
-                    </Typography.Text>
-                    <Tag componentId="mlflow.sidebar.assistant_beta_tag" color="turquoise" css={{ marginLeft: 'auto' }}>
-                      Beta
-                    </Tag>
-                  </>
-                )}
-              </div>
-            </Tooltip>
-          )}
           <MlflowSidebarLink
             disableWorkspacePrefix
             css={{ paddingBlock: theme.spacing.sm }}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The global left sidebar's "Assistant" button now duplicates the right-side Assistant toggle (the floating action button), which is the primary entry point. This removes the sidebar button for clarity, addressing PM feedback.

Also removes the now-unused telemetry wiring (`viewId`, `logTelemetryEvent`) and imports (`Tag`, `Tooltip`, `AssistantSparkleIcon`, `useAssistant`, the event-provider enums, `useState`, `uuidv4`) that only the sidebar button relied on.

The experiment-page side-nav Assistant button (`ExperimentPageSideNavAssistantButton`) is intentionally left in place; it shares the same i18n strings, so no message keys are removed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked that it's gone from the sidebar

<img width="1701" height="946" alt="It's gone" src="https://github.com/user-attachments/assets/9d452006-ca27-4809-ae62-7824b0bd81ae" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Removes the duplicate "Assistant" button from the global sidebar; the Assistant is still reachable via the floating action button.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.