### PR TITLE
Fix Assistant FAB icon centering and soften its shadow

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
@@ -121,7 +121,9 @@ export const AssistantFloatingButton = () => {
         height: fabSize,
         minWidth: fabSize,
         maxWidth: fabSize,
-        paddingInline: (fabSize - iconSize) / 2,
+        // No horizontal padding here: the icon lives in a fixed fabSize square (below)
+        // that keeps it centered in the collapsed circle regardless of the hidden label.
+        paddingInline: 0,
         paddingBlock: 0,
         border: '1px solid transparent',
         borderRadius: fabSize / 2,
@@ -129,7 +131,7 @@ export const AssistantFloatingButton = () => {
         appearance: 'none',
         background: bubbleBackground,
         color: theme.colors.textPrimary,
-        boxShadow: theme.general.shadowHigh,
+        boxShadow: theme.general.shadowLow,
         overflow: 'hidden',
         whiteSpace: 'nowrap',
         '@media (prefers-reduced-motion: no-preference)': {
@@ -141,7 +143,7 @@ export const AssistantFloatingButton = () => {
         },
         '& .assistant-fab-label': {
           opacity: 0,
-          marginLeft: 0,
+          marginRight: 0,
           fontWeight: theme.typography.typographyBoldFontWeight,
           fontSize: theme.typography.fontSizeMd,
           '@media (prefers-reduced-motion: no-preference)': {
@@ -150,11 +152,28 @@ export const AssistantFloatingButton = () => {
         },
         '&:hover .assistant-fab-label, &:focus-visible .assistant-fab-label': {
           opacity: 1,
-          marginLeft: theme.spacing.sm,
+          // Balance the icon square's centering with matching space on the label's right edge.
+          marginRight: (fabSize - iconSize) / 2,
         },
       }}
     >
-      <SparkleFillIcon color="ai" css={{ fontSize: iconSize, flexShrink: 0 }} />
+      {/* Fixed square keeps the icon dead-center in the collapsed circle; the hidden
+          label sits flush after it and only reveals on hover without shifting the icon. */}
+      <span
+        css={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: fabSize,
+          height: fabSize,
+          flexShrink: 0,
+        }}
+      >
+        {/* The sparkle glyph is geometrically centered, but its diagonal AI gradient
+            (cool top-left → warm bottom-right) makes it read as leaning right. A 1px
+            optical nudge left balances it; transform keeps the flex layout untouched. */}
+        <SparkleFillIcon color="ai" css={{ fontSize: iconSize, transform: 'translateX(-0.5px)' }} />
+      </span>
       <span className="assistant-fab-label">
         <FormattedMessage
           defaultMessage="MLflow Assistant"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Two style nits on the floating Assistant button (FAB), addressing PM feedback:

- **Icon centering:** the icon was not horizontally centered in the collapsed circle. The hidden hover label still occupied flex width, throwing off the button's padding-based centering. The icon is now wrapped in a fixed square that keeps it centered whether the button is collapsed or expanded, plus a 0.5px optical nudge left to counter the diagonal AI gradient (cool top-left → warm bottom-right), which otherwise makes the geometrically-centered glyph read as leaning right.
- **Shadow:** the button used `shadowHigh`, more prominent than comparable floating surfaces in MLflow (which use `shadowLow`). Softened to `shadowLow` to match.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


<img width="384" height="350" alt="Screenshot 2026-07-21 at 4 03 08 PM" src="https://github.com/user-attachments/assets/6a381b99-5204-43ff-8425-034945c39c5a" />


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes the floating Assistant button so its icon is horizontally centered and softens its shadow to match other floating surfaces in MLflow.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Claude.