### PR TITLE
Add regression test for serve_stdin shell-quoting

### DIFF
--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -1006,3 +1007,26 @@ def test_update_model_requirements_remove():
 
     reqs = _get_requirements_from_file(local_paths.conda)
     assert reqs == [Requirement(f"cloudpickle=={cloudpickle.__version__}")]
+
+
+def test_serve_stdin_shell_quotes_model_path():
+    # Regression test for GHSA-5r29-ccg5-cf9g / GHSA-cw8f-5wj5-grm3: the model path
+    # (an attacker-influenceable artifact directory name) must be shell-quoted before
+    # being interpolated into the `bash -c` command string, so metacharacters such as
+    # $(...) are passed as a literal argument instead of executed by the shell.
+    malicious_path = "/tmp/model$(touch /tmp/mlflow_stdin_pwned)"
+    backend = PyFuncBackend(config={}, env_manager=_EnvManager.LOCAL)
+
+    with (
+        mock.patch(
+            "mlflow.pyfunc.backend._download_artifact_from_uri", return_value=malicious_path
+        ) as mock_download,
+        mock.patch.object(backend, "prepare_env") as mock_prepare_env,
+    ):
+        backend.serve_stdin(model_uri="models:/m/1")
+
+    mock_download.assert_called_once()
+    command = mock_prepare_env.return_value.execute.call_args.kwargs["command"]
+    assert f"--model-uri {shlex.quote(malicious_path)}" in command
+    # The pre-fix code interpolated the path unquoted, letting the shell evaluate $(...).
+    assert f"--model-uri {malicious_path}" not in command

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -44,6 +43,7 @@ from mlflow.utils.environment import (
 )
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.process import ShellCommandException
+from mlflow.utils.string_utils import quote
 
 from tests.helper_functions import (
     RestEndpoint,
@@ -1015,6 +1015,8 @@ def test_serve_stdin_shell_quotes_model_path():
     # being interpolated into the `bash -c` command string, so metacharacters such as
     # $(...) are passed as a literal argument instead of executed by the shell.
     malicious_path = "/tmp/model$(touch /tmp/mlflow_stdin_pwned)"
+    # The env manager is arbitrary here: serve_stdin never branches on it and prepare_env
+    # is mocked below, so this does not exercise the LOCAL code path (which raises in prod).
     backend = PyFuncBackend(config={}, env_manager=_EnvManager.LOCAL)
 
     with (
@@ -1027,6 +1029,8 @@ def test_serve_stdin_shell_quotes_model_path():
 
     mock_download.assert_called_once()
     command = mock_prepare_env.return_value.execute.call_args.kwargs["command"]
-    assert f"--model-uri {shlex.quote(malicious_path)}" in command
+    # `quote` matches the production shell-escaping (shlex.quote on POSIX, mslex on Windows),
+    # so this assertion holds on both platforms.
+    assert f"--model-uri {quote(malicious_path)}" in command
     # The pre-fix code interpolated the path unquoted, letting the shell evaluate $(...).
     assert f"--model-uri {malicious_path}" not in command


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to security advisory - https://github.com/mlflow/mlflow/security/advisories/GHSA-cw8f-5wj5-grm3

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The fix already shipped in [#23180](https://github.com/mlflow/mlflow/pull/23180) but had no test. This adds a small regression guard so the shell-quoting in serve_stdin can't be silently reverted.

Change (tests/models/test_cli.py):
- Added import shlex.
- Added test_serve_stdin_shell_quotes_model_path (tests/models/test_cli.py:1012).

What the test does. It mocks the two seams around the sink at mlflow/pyfunc/backend.py:346:
- _download_artifact_from_uri → returns a malicious path "/tmp/model$(touch /tmp/mlflow_stdin_pwned)";
- PyFuncBackend.prepare_env → a mock whose .execute captures the constructed command.

It then calls serve_stdin and asserts the command contains --model-uri {shlex.quote(malicious_path)} (path passed as a single quoted literal) and does not contain the raw unquoted --model-uri {malicious_path} form. No PoC is detonated — correctness is argued via the command string, consistent with the skill's no-execution rule.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
