### PR TITLE
fix: avoid 'table already exists' error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,11 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if _all_tables_exist(engine):
+        _logger.info("MLflow database tables already exist, skipping creation.")
+    else:
+        _logger.info("Creating initial MLflow database tables...")
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` unconditionally calls `InitialBase.metadata.create_all(engine)`, which attempts to create all tables defined in the base ORM models, including the `secrets` table that was added in a migration in 3.8.x. If the database already has some tables (e.g., from a partial upgrade or custom migration), `create_all` fails with 'already exists' errors.

## Fix
Modified `_initialize_tables` to first check if all expected tables already exist using the existing `_all_tables_exist` helper. If they do, we skip the `create_all` call (which would cause the error) and proceed directly to `_upgrade_db` to handle any pending migrations via Alembic. This ensures the upgrade path is idempotent and safe for incremental upgrades.

Closes #19943