### PR TITLE
Preserve explicit expectations in `mlflow.genai.evaluate`

### DIFF
--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -270,7 +270,7 @@ def _extract_expectations_from_trace(df: "pd.DataFrame") -> "pd.DataFrame":
     Add `expectations` columns to the dataframe from assessments
     stored in the traces, if the "expectations" column is not already present.
     """
-    if "trace" not in df.columns:
+    if "trace" not in df.columns or "expectations" in df.columns:
         return df
 
     expectations_column = []

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -237,6 +237,20 @@ def test_convert_to_legacy_eval_traces(input_type):
     assert "feedback" not in data.columns
 
 
+@pytest.mark.parametrize("input_type", ["list", "pandas"])
+def test_convert_to_eval_set_preserves_explicit_expectations(input_type):
+    sample_data = get_test_traces(type=input_type)
+    explicit_expectations = {"expected_response": "updated response"}
+    if input_type == "list":
+        sample_data[0]["expectations"] = explicit_expectations
+    else:
+        sample_data["expectations"] = [explicit_expectations]
+
+    data = _convert_to_eval_set(sample_data)
+
+    assert data["expectations"][0] == explicit_expectations
+
+
 @pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
 def test_convert_to_eval_set_has_no_errors(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24527

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Preserve explicitly provided `expectations` when evaluation data also contains traces with expectation assessments. Trace assessments are still used when the evaluation data does not provide an `expectations` column.

Add regression coverage for list and pandas DataFrame inputs containing both explicit expectations and trace assessments.

### How is this PR tested?

- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Added `test_convert_to_eval_set_preserves_explicit_expectations`, parameterized for list and pandas DataFrame inputs, to verify that trace assessments do not overwrite explicit expectations.

Manually re-evaluated a trace and confirmed that the updated explicit expectation is used for scoring.

### Does this PR require documentation update?

- [X] No.
- 
### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [X] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

When evaluating traces, MLflow now uses expectations provided in the evaluation data instead of replacing them with expectation assessments from the traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [X] This PR can wait for the next minor release
