### PR TITLE
Enforce experiment permission on online scoring config endpoints

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -270,6 +270,8 @@ from mlflow.server.auth.routes import (
     AJAX_LIST_USER_PERMISSIONS,
     AJAX_LIST_USER_ROLES,
     AJAX_LIST_USERS,
+    AJAX_ONLINE_SCORING_CONFIG,
+    AJAX_ONLINE_SCORING_CONFIGS,
     AJAX_REMOVE_ROLE_PERMISSION,
     AJAX_REVOKE_USER_PERMISSION,
     AJAX_UNASSIGN_ROLE,
@@ -309,6 +311,8 @@ from mlflow.server.auth.routes import (
     LIST_USER_PERMISSIONS,
     LIST_USER_ROLES,
     LIST_USERS,
+    ONLINE_SCORING_CONFIG,
+    ONLINE_SCORING_CONFIGS,
     REMOVE_ROLE_PERMISSION,
     REVOKE_USER_PERMISSION,
     SEARCH_DATASETS,
@@ -1286,6 +1290,29 @@ def validate_can_manage_scorer():
 
 def validate_can_manage_scorer_permission():
     return _get_permission_from_scorer_permission_request().can_manage
+
+
+def validate_can_update_online_scoring_config():
+    body = request.get_json(silent=True) or {}
+    experiment_id = body.get("experiment_id")
+    if not experiment_id:
+        return False
+    username = authenticate_request().username
+    return _get_experiment_permission(experiment_id, username).can_update
+
+
+def validate_can_read_online_scoring_configs():
+    # The request only carries scorer_ids, so ownership is resolved via the
+    # stored config rows and checked against each referenced experiment.
+    scorer_ids = request.args.getlist("scorer_ids")
+    if not scorer_ids:
+        return True
+    username = authenticate_request().username
+    configs = _get_tracking_store().get_online_scoring_configs(scorer_ids)
+    for config in configs:
+        if not _get_experiment_permission(config.experiment_id, username).can_read:
+            return False
+    return True
 
 
 def sender_is_admin():
@@ -2676,6 +2703,9 @@ BEFORE_REQUEST_VALIDATORS = {
     (http_path, method): handler
     for http_path, handler, methods in get_endpoints(get_before_request_handler)
     for method in methods
+    # Online scoring config endpoints are registered with view functions in the
+    # handler slot, so they cannot flow through this comprehension. Explicit
+    # validators for them are added in the update block below.
     if "/scorers/online-config" not in http_path
     # ``get_endpoints`` hardcodes the view function as the handler for explicitly
     # defined endpoints (e.g. ``/mlflow/issues/invoke``), ignoring the selector we
@@ -2769,6 +2799,11 @@ BEFORE_REQUEST_VALIDATORS.update({
     (GATEWAY_PROXY, "GET"): validate_gateway_proxy,
     (GATEWAY_PROXY, "POST"): validate_gateway_proxy,
     (INVOKE_SCORER, "POST"): validate_gateway_proxy,
+    # Online scoring configuration (excluded from the auto generated map above).
+    (ONLINE_SCORING_CONFIGS, "GET"): validate_can_read_online_scoring_configs,
+    (AJAX_ONLINE_SCORING_CONFIGS, "GET"): validate_can_read_online_scoring_configs,
+    (ONLINE_SCORING_CONFIG, "PUT"): validate_can_update_online_scoring_config,
+    (AJAX_ONLINE_SCORING_CONFIG, "PUT"): validate_can_update_online_scoring_config,
 })
 
 # Trace endpoints with path parameters (e.g. /mlflow/traces/<request_id>/tags) require

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -328,10 +328,13 @@ from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
 from mlflow.server.fastapi_app import create_fastapi_app
 from mlflow.server.handlers import (
     _add_static_prefix,
+    _assert_array,
+    _assert_item_type_string,
     _get_ajax_path,
     _get_model_registry_store,
     _get_request_message,
     _get_tracking_store,
+    _get_validated_flask_request_json,
     catch_mlflow_exception,
     get_endpoints,
     get_service_endpoints,
@@ -1302,9 +1305,14 @@ def validate_can_update_online_scoring_config():
 
 
 def validate_can_read_online_scoring_configs():
-    # The request only carries scorer_ids, so ownership is resolved via the
-    # stored config rows and checked against each referenced experiment.
-    scorer_ids = request.args.getlist("scorer_ids")
+    # Parse scorer_ids the same way the handler does (query params OR JSON body)
+    # so this gate can't be bypassed by moving scorer_ids into a GET request body.
+    # Omit _assert_required: an absent scorer_ids falls through to allow here and
+    # is handled by the handler's own validation, rather than raising in the gate.
+    request_json = _get_validated_flask_request_json(
+        request, schema={"scorer_ids": [_assert_array, _assert_item_type_string]}
+    )
+    scorer_ids = request_json.get("scorer_ids") or []
     if not scorer_ids:
         return True
     username = authenticate_request().username

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -75,6 +75,13 @@ AJAX_LIST_USER_ROLES = _get_ajax_path("/mlflow/users/roles/list", version=3)
 LIST_ROLE_USERS = _get_rest_path("/mlflow/roles/users/list", version=3)
 AJAX_LIST_ROLE_USERS = _get_ajax_path("/mlflow/roles/users/list", version=3)
 
+# Online scoring configuration routes. Registered explicitly in auth because
+# they live outside the protobuf service registry.
+ONLINE_SCORING_CONFIGS = _get_rest_path("/mlflow/scorers/online-configs", version=3)
+AJAX_ONLINE_SCORING_CONFIGS = _get_ajax_path("/mlflow/scorers/online-configs", version=3)
+ONLINE_SCORING_CONFIG = _get_rest_path("/mlflow/scorers/online-config", version=3)
+AJAX_ONLINE_SCORING_CONFIG = _get_ajax_path("/mlflow/scorers/online-config", version=3)
+
 # Gateway AJAX-only routes
 GATEWAY_SUPPORTED_PROVIDERS = _get_ajax_path("/mlflow/gateway/supported-providers", version=3)
 GATEWAY_SUPPORTED_MODELS = _get_ajax_path("/mlflow/gateway/supported-models", version=3)

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3209,7 +3209,6 @@ def test_get_online_scoring_configs_with_auth(client, monkeypatch):
     with User(username, password, monkeypatch):
         experiment_id = client.create_experiment("test_experiment")
 
-        # Register a scorer
         scorer_json = '{"name": "test_scorer", "type": "pyfunc"}'
         response = _send_rest_tracking_post_request(
             client.tracking_uri,
@@ -3223,20 +3222,107 @@ def test_get_online_scoring_configs_with_auth(client, monkeypatch):
         )
         scorer_id = response.json()["scorer_id"]
 
-        # Test the online scoring configs endpoint (GET)
-        # This should not raise a TypeError as it did before when the endpoint
-        # was incorrectly included in AFTER_REQUEST_HANDLERS
         response = requests.get(
             url=client.tracking_uri + "/ajax-api/3.0/mlflow/scorers/online-configs",
             params={"scorer_ids": scorer_id},
             auth=(username, password),
         )
 
-        # Should return 200 (not 500 with TypeError)
         assert response.status_code == 200
         data = response.json()
         assert "configs" in data
         assert isinstance(data["configs"], list)
+
+
+def test_online_scoring_config_endpoints_reject_unauthorized_user(client, monkeypatch):
+    owner_user, owner_pw = create_user(client.tracking_uri)
+    attacker_user, attacker_pw = create_user(client.tracking_uri)
+
+    with User(owner_user, owner_pw, monkeypatch):
+        experiment_id = client.create_experiment("online_scoring_auth_exp")
+
+        scorer_json = '{"name": "target_scorer", "type": "pyfunc"}'
+        register_resp = _send_rest_tracking_post_request(
+            client.tracking_uri,
+            "/api/3.0/mlflow/scorers/register",
+            json_payload={
+                "experiment_id": experiment_id,
+                "name": "target_scorer",
+                "serialized_scorer": scorer_json,
+            },
+            auth=(owner_user, owner_pw),
+        )
+        scorer_id = register_resp.json()["scorer_id"]
+
+        _send_rest_tracking_post_request(
+            client.tracking_uri,
+            "/api/2.0/mlflow/experiments/permissions/create",
+            json_payload={
+                "experiment_id": experiment_id,
+                "username": attacker_user,
+                "permission": "NO_PERMISSIONS",
+            },
+            auth=(owner_user, owner_pw),
+        )
+
+        # Seed a config so validate_can_read_online_scoring_configs has a row
+        # to resolve ownership against (empty results short circuit to allow).
+        # sample_rate=0.0 skips the handler's gateway model check on the scorer.
+        seed_resp = requests.put(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-config",
+            json={
+                "experiment_id": experiment_id,
+                "name": "target_scorer",
+                "sample_rate": 0.0,
+            },
+            auth=(owner_user, owner_pw),
+        )
+        assert seed_resp.status_code == 200
+
+    for path in (
+        "/api/3.0/mlflow/scorers/online-configs",
+        "/ajax-api/3.0/mlflow/scorers/online-configs",
+    ):
+        response = requests.get(
+            url=client.tracking_uri + path,
+            params={"scorer_ids": scorer_id},
+            auth=(attacker_user, attacker_pw),
+        )
+        assert response.status_code == 403
+
+    for path in (
+        "/api/3.0/mlflow/scorers/online-config",
+        "/ajax-api/3.0/mlflow/scorers/online-config",
+    ):
+        response = requests.put(
+            url=client.tracking_uri + path,
+            json={
+                "experiment_id": experiment_id,
+                "name": "target_scorer",
+                "sample_rate": 0.0,
+            },
+            auth=(attacker_user, attacker_pw),
+        )
+        assert response.status_code == 403
+
+    with User(owner_user, owner_pw, monkeypatch):
+        response = requests.get(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-configs",
+            params={"scorer_ids": scorer_id},
+            auth=(owner_user, owner_pw),
+        )
+        assert response.status_code == 200
+
+        response = requests.put(
+            url=client.tracking_uri + "/api/3.0/mlflow/scorers/online-config",
+            json={
+                "experiment_id": experiment_id,
+                "name": "target_scorer",
+                "sample_rate": 0.0,
+            },
+            auth=(owner_user, owner_pw),
+        )
+        assert response.status_code == 200
 
 
 def test_list_users(client):

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -3234,6 +3234,11 @@ def test_get_online_scoring_configs_with_auth(client, monkeypatch):
         assert isinstance(data["configs"], list)
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_online_scoring_config_endpoints_reject_unauthorized_user(client, monkeypatch):
     owner_user, owner_pw = create_user(client.tracking_uri)
     attacker_user, attacker_pw = create_user(client.tracking_uri)
@@ -3254,16 +3259,9 @@ def test_online_scoring_config_endpoints_reject_unauthorized_user(client, monkey
         )
         scorer_id = register_resp.json()["scorer_id"]
 
-        _send_rest_tracking_post_request(
-            client.tracking_uri,
-            "/api/2.0/mlflow/experiments/permissions/create",
-            json_payload={
-                "experiment_id": experiment_id,
-                "username": attacker_user,
-                "permission": "NO_PERMISSIONS",
-            },
-            auth=(owner_user, owner_pw),
-        )
+        # Under no_permission_auth.ini the default permission is NO_PERMISSIONS, so the
+        # attacker (who is never granted access to this experiment) is unauthorized by
+        # default. The owner auto-receives MANAGE on the experiment they create.
 
         # Seed a config so validate_can_read_online_scoring_configs has a row
         # to resolve ownership against (empty results short circuit to allow).


### PR DESCRIPTION
### Related Issues/PRs

Relates to GHSA-rwwp-m285-vjfj

Related PR:
- https://github.com/mlflow/mlflow/pull/20783

### What changes are proposed in this pull request?

GET `/api/3.0/mlflow/scorers/online-configs` and PUT `/api/3.0/mlflow/scorers/online-config` (plus their `/ajax-api/` variants) were excluded from the auth validator map to work around a `TypeError` raised when the comprehension tried to invoke a view function as a validator. The exclusion also removed all experiment level authorization, letting any authenticated user read and modify another experiment's online scoring configuration.

This PR registers explicit validators for both endpoints and checks `can_read` / `can_update` against the owning experiment, matching the permission model used by `RegisterScorer` and `ListScorers`. The comprehension filter stays to keep the hand registered endpoint tuples from flowing through the broken path; a comment explains why.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

The existing `test_get_online_scoring_configs_with_auth` (added in #20783 for the original `TypeError` regression) still passes. A new test `test_online_scoring_config_endpoints_reject_unauthorized_user` asserts that a user with `NO_PERMISSIONS` on the owning experiment is rejected with 403 on both REST and AJAX variants of each endpoint, while the owner still gets 200. Manually verified end to end against a real `mlflow server --app-name basic-auth` process with `default_permission = NO_PERMISSIONS`: the unauthorized caller now receives 403 on both endpoints and the attacker's write does not persist.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Online scoring configuration endpoints now require the same experiment-level permission as other scorer routes. Callers without `can_read` / `can_update` on the owning experiment will start receiving 403 on these endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release

Original PR authored by @Nadav0077 to address GHSA-rwwp-m285-vjfj

@aaronteo-db - from the original commit/PR, I modified changes on top of original author to address comments I had in his original PR + comments from AI review