### PR TITLE
Fix model version string to int cast in registry stores

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -846,7 +846,7 @@ class FileStore(AbstractStore):
 
     def _fetch_file_model_version_if_exists(self, name, version) -> FileModelVersion:
         _validate_model_name(name)
-        _validate_model_version(version)
+        version = _validate_model_version(version)
         registered_model_version_dir = self._get_model_version_dir(name, version)
         if not exists(registered_model_version_dir):
             raise MlflowException(

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1135,7 +1135,7 @@ class SqlAlchemyStore(AbstractStore):
                 are accessed from the resulting ``SqlModelVersion`` object.
         """
         _validate_model_name(name)
-        _validate_model_version(version)
+        version = _validate_model_version(version)
         query_options = self._get_eager_model_version_query_options() if eager else []
         conditions = [
             SqlModelVersion.name == name,
@@ -1458,7 +1458,7 @@ class SqlAlchemyStore(AbstractStore):
             None
         """
         _validate_model_name(name)
-        _validate_model_version(version)
+        version = _validate_model_version(version)
         _validate_model_version_tag(tag.key, tag.value)
         with self.ManagedSessionMaker(read_only=False) as session:
             # check if model version exists
@@ -1486,7 +1486,7 @@ class SqlAlchemyStore(AbstractStore):
             None
         """
         _validate_model_name(name)
-        _validate_model_version(version)
+        version = _validate_model_version(version)
         _validate_tag_name(key)
         with self.ManagedSessionMaker(read_only=False) as session:
             # check if model version exists
@@ -1521,7 +1521,7 @@ class SqlAlchemyStore(AbstractStore):
         _validate_model_name(name)
         _validate_model_alias_name(alias)
         _validate_model_alias_name_reserved(alias)
-        _validate_model_version(version)
+        version = _validate_model_version(version)
         with self.ManagedSessionMaker(read_only=False) as session:
             # check if model version exists
             sql_model_version = self._get_sql_model_version(session, name, version)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -694,7 +694,7 @@ def _validate_model_renaming(model_new_name: str) -> None:
 
 def _validate_model_version(model_version):
     try:
-        model_version = int(model_version)
+        return int(model_version)
     except ValueError:
         raise MlflowException(
             not_integer_value("version", model_version), error_code=INVALID_PARAMETER_VALUE

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1709,6 +1709,18 @@ def test_set_model_version_tag(store):
     assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
+def test_get_model_version_accepts_string_version(store):
+    # Regression test: a string version (e.g. as parsed from a REST request) must be
+    # coerced to int before being used in the SqlModelVersion query filter. Otherwise
+    # the VARCHAR-vs-INTEGER comparison fails on backends like PostgreSQL that don't
+    # apply implicit type coercion the way SQLite does.
+    name = "GetModelVersionStringVersion_TestMod"
+    _rm_maker(store, name)
+    _mv_maker(store, name)
+    mv = store.get_model_version(name, "1")
+    assert mv.version == 1
+
+
 def test_delete_model_version_tag(store):
     name1 = "DeleteModelVersionTag_TestMod"
     name2 = "DeleteModelVersionTag_TestMod 2"


### PR DESCRIPTION
### Related Issues/PRs

Closes #24515

### What changes are proposed in this pull request?

The validator function converted the model version to an integer but never returned the converted value, so callers kept using the original string. This caused a type mismatch in the SQLAlchemy query filter on PostgreSQL, since the version column is an integer. SQLite tolerated the mismatch silently, which hid the bug in normal testing.

Replaces #24522, which GitHub will not let me reopen because it says the branch was force-pushed/recreated. The branch content and commit are unchanged (`6a501483f`); issue #24515 now has the `ready` label as noted in the closed PR.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a bug where model version lookups could fail on PostgreSQL-backed tracking stores due to a string/int type mismatch.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - The PR will be mentioned in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release