### PR TITLE
Avoid re-serializing unmodified LazySpan JSON on get-trace-artifact.

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -619,6 +619,7 @@ mlflow.entities.TraceArchivalConfig
 mlflow.entities.TraceData
 mlflow.entities.TraceData.from_dict
 mlflow.entities.TraceData.to_dict
+mlflow.entities.TraceData.to_json_bytes
 mlflow.entities.TraceInfo
 mlflow.entities.TraceInfo.from_dict
 mlflow.entities.TraceInfo.from_proto

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1280,16 +1280,38 @@ class LazySpan(Span):
     from the store avoids an eager ``json.loads`` → ``Span.from_dict`` →
     ``to_dict``/``to_otel_proto`` round-trip when the consumer only needs the
     dict (for example ``get-trace-artifact`` or ``TraceData.to_dict``).
+
+    When ``raw_json`` is provided and load-time translation did not modify the
+    payload, artifact responses can emit that string directly and skip
+    ``json.dumps``.
     """
 
-    def __init__(self, span_dict: dict[str, Any]):
+    def __init__(self, span_dict: dict[str, Any], *, raw_json: str | None = None):
         # Skip Span.__init__: we intentionally avoid constructing an OTel span
         # until a caller needs property access or OTLP conversion.
         self.__dict__["_span_dict"] = span_dict
+        self.__dict__["_raw_json"] = raw_json
         self.__dict__["_materialized"] = False
+
+    @classmethod
+    def from_stored_content(cls, content: str) -> "LazySpan":
+        """Build a ``LazySpan`` from a TRACKING_STORE ``spans.content`` value."""
+        # Deferred to avoid a circular import with mlflow.tracing.otel.translation.
+        from mlflow.tracing.otel.translation import translate_loaded_span_with_status
+
+        span_dict = json.loads(content)
+        modified = translate_loaded_span_with_status(span_dict)
+        return cls(span_dict, raw_json=None if modified else content)
 
     def to_dict(self) -> dict[str, Any]:
         return self.__dict__["_span_dict"]
+
+    def json_for_export(self) -> str:
+        """Return JSON text for artifact export without an unnecessary re-dump."""
+        raw_json = self.__dict__["_raw_json"]
+        if raw_json is not None:
+            return raw_json
+        return json.dumps(self.__dict__["_span_dict"], separators=(",", ":"))
 
     def _ensure_materialized(self) -> None:
         if self.__dict__["_materialized"]:

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1291,16 +1291,41 @@ class LazySpan(Span):
     from the store avoids an eager ``json.loads`` → ``Span.from_dict`` →
     ``to_dict``/``to_otel_proto`` round-trip when the consumer only needs the
     dict (for example ``get-trace-artifact`` or ``TraceData.to_dict``).
+
+    When ``raw_json`` is provided and load-time translation did not modify the
+    payload, artifact responses can emit that string directly and skip
+    ``json.dumps``.
     """
 
-    def __init__(self, span_dict: dict[str, Any]):
+    def __init__(self, span_dict: dict[str, Any], *, raw_json: str | None = None):
         # Skip Span.__init__: we intentionally avoid constructing an OTel span
         # until a caller needs property access or OTLP conversion.
         self.__dict__["_span_dict"] = span_dict
+        self.__dict__["_raw_json"] = raw_json
         self.__dict__["_materialized"] = False
 
+    @classmethod
+    def from_stored_content(cls, content: str) -> "LazySpan":
+        """Build a ``LazySpan`` from a TRACKING_STORE ``spans.content`` value."""
+        # Deferred to avoid a circular import with mlflow.tracing.otel.translation.
+        from mlflow.tracing.otel.translation import translate_loaded_span_with_status
+
+        span_dict = json.loads(content)
+        modified = translate_loaded_span_with_status(span_dict)
+        return cls(span_dict, raw_json=None if modified else content)
+
     def to_dict(self) -> dict[str, Any]:
+        # to_dict() returns the live mutable dict. Once a caller can mutate it,
+        # raw JSON passthrough is no longer safe for subsequent exports.
+        self.__dict__["_raw_json"] = None
         return self.__dict__["_span_dict"]
+
+    def json_for_export(self) -> str:
+        """Return JSON text for artifact export without an unnecessary re-dump."""
+        raw_json = self.__dict__["_raw_json"]
+        if raw_json is not None:
+            return raw_json
+        return json.dumps(self.__dict__["_span_dict"], separators=(",", ":"))
 
     def _ensure_materialized(self) -> None:
         if self.__dict__["_materialized"]:

--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -1,8 +1,9 @@
+import json
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any
 
-from mlflow.entities import Span
+from mlflow.entities.span import LazySpan, Span
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.utils.annotations import deprecated
 
@@ -30,6 +31,26 @@ class TraceData:
 
     def to_dict(self) -> dict[str, Any]:
         return {"spans": [span.to_dict() for span in self.spans]}
+
+    def to_json_bytes(self) -> bytes:
+        """
+        Serialize span payloads to ``{"spans": [...]}`` JSON bytes.
+
+        For ``LazySpan`` instances that still have unmodified stored JSON, the
+        raw DB string is emitted directly to avoid a ``json.dumps`` round-trip.
+        When no ``LazySpan``s are present, falls back to a single dump of
+        ``to_dict()`` so archived / eager-span traces avoid N separate dumps.
+        """
+        if not any(isinstance(span, LazySpan) for span in self.spans):
+            return json.dumps(self.to_dict(), separators=(",", ":")).encode("utf-8")
+
+        parts: list[bytes] = []
+        for span in self.spans:
+            if isinstance(span, LazySpan):
+                parts.append(span.json_for_export().encode("utf-8"))
+            else:
+                parts.append(json.dumps(span.to_dict(), separators=(",", ":")).encode("utf-8"))
+        return b'{"spans":[' + b",".join(parts) + b"]}"
 
     # TODO: remove this property in 3.7.0
     @property

--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -40,6 +40,9 @@ class TraceData:
         raw DB string is emitted directly to avoid a ``json.dumps`` round-trip.
         When no ``LazySpan``s are present, falls back to a single dump of
         ``to_dict()`` so archived / eager-span traces avoid N separate dumps.
+
+        Call this before ``to_dict()``: ``LazySpan.to_dict()`` drops the raw
+        JSON, so spans touched by ``to_dict()`` are re-serialized instead.
         """
         if not any(isinstance(span, LazySpan) for span in self.spans):
             return json.dumps(self.to_dict(), separators=(",", ":")).encode("utf-8")

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4341,13 +4341,11 @@ def _link_prompts_to_trace():
     return _wrap_response(LinkPromptsToTrace.Response())
 
 
-def _fetch_trace_data_from_store(
-    store: AbstractTrackingStore, request_id: str
-) -> dict[str, Any] | None:
+def _fetch_trace_data_from_store(store: AbstractTrackingStore, request_id: str) -> bytes | None:
     try:
         # allow partial so the frontend can render in-progress traces
         trace = store.get_trace(request_id, allow_partial=True)
-        return trace.data.to_dict()
+        return trace.data.to_json_bytes()
     except MlflowTraceDataException:
         raise
     except MlflowTracingException:
@@ -4360,7 +4358,7 @@ def _fetch_trace_data_from_store(
         traces = store.batch_get_traces([request_id], None)
         match traces:
             case [trace]:
-                return trace.data.to_dict()
+                return trace.data.to_json_bytes()
             case _:
                 raise MlflowException(
                     f"Trace with id={request_id} not found.",
@@ -4434,7 +4432,7 @@ def get_trace_artifact_handler() -> Response:
         trace_info = store.get_trace_info(request_id)
         if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.ARCHIVE_REPO.value:
             trace_data = (
-                _get_trace_archive_repo(trace_info).download_archived_trace_data().to_dict()
+                _get_trace_archive_repo(trace_info).download_archived_trace_data().to_json_bytes()
             )
         else:
             repo = _get_trace_artifact_repo(trace_info)
@@ -4461,7 +4459,7 @@ def get_trace_artifact_handler() -> Response:
                 raise
 
     buf = io.BytesIO()
-    buf.write(json.dumps(trace_data).encode())
+    buf.write(trace_data)
     buf.seek(0)
 
     file_sender_response = send_file(

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4387,13 +4387,11 @@ def _link_prompts_to_trace():
     return _wrap_response(LinkPromptsToTrace.Response())
 
 
-def _fetch_trace_data_from_store(
-    store: AbstractTrackingStore, request_id: str
-) -> dict[str, Any] | None:
+def _fetch_trace_data_from_store(store: AbstractTrackingStore, request_id: str) -> bytes | None:
     try:
         # allow partial so the frontend can render in-progress traces
         trace = store.get_trace(request_id, allow_partial=True)
-        return trace.data.to_dict()
+        return trace.data.to_json_bytes()
     except MlflowTraceDataException:
         raise
     except MlflowTracingException:
@@ -4406,7 +4404,7 @@ def _fetch_trace_data_from_store(
         traces = store.batch_get_traces([request_id], None)
         match traces:
             case [trace]:
-                return trace.data.to_dict()
+                return trace.data.to_json_bytes()
             case _:
                 raise MlflowException(
                     f"Trace with id={request_id} not found.",
@@ -4480,7 +4478,7 @@ def get_trace_artifact_handler() -> Response:
         trace_info = store.get_trace_info(request_id)
         if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.ARCHIVE_REPO.value:
             trace_data = (
-                _get_trace_archive_repo(trace_info).download_archived_trace_data().to_dict()
+                _get_trace_archive_repo(trace_info).download_archived_trace_data().to_json_bytes()
             )
         else:
             repo = _get_trace_artifact_repo(trace_info)
@@ -4507,7 +4505,7 @@ def get_trace_artifact_handler() -> Response:
                 raise
 
     buf = io.BytesIO()
-    buf.write(json.dumps(trace_data).encode())
+    buf.write(trace_data)
     buf.seek(0)
 
     file_sender_response = send_file(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6916,10 +6916,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
         # Defer OTel Span reconstruction until a caller needs properties or
         # to_otel_proto(). Callers that only need dicts (e.g. TraceData.to_dict /
-        # get-trace-artifact) skip Span.from_dict entirely.
-        return [
-            LazySpan(translate_loaded_span(json.loads(span.content))) for span in span_snapshots
-        ]
+        # get-trace-artifact) skip Span.from_dict entirely. Unmodified stored
+        # JSON is retained for artifact passthrough via TraceData.to_json_bytes().
+        return [LazySpan.from_stored_content(span.content) for span in span_snapshots]
 
     def _load_tracking_store_span_snapshots(
         self, session: Session, trace_ids: Iterable[str]

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -6988,10 +6988,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
         # Defer OTel Span reconstruction until a caller needs properties or
         # to_otel_proto(). Callers that only need dicts (e.g. TraceData.to_dict /
-        # get-trace-artifact) skip Span.from_dict entirely.
-        return [
-            LazySpan(translate_loaded_span(json.loads(span.content))) for span in span_snapshots
-        ]
+        # get-trace-artifact) skip Span.from_dict entirely. Unmodified stored
+        # JSON is retained for artifact passthrough via TraceData.to_json_bytes().
+        return [LazySpan.from_stored_content(span.content) for span in span_snapshots]
 
     def _load_tracking_store_span_snapshots(
         self, session: Session, trace_ids: Iterable[str]

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -373,8 +373,23 @@ def translate_loaded_span(span_dict: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Modified span dictionary
     """
-    attributes = span_dict.get("attributes", {})
+    translate_loaded_span_with_status(span_dict)
+    return span_dict
 
+
+def translate_loaded_span_with_status(span_dict: dict[str, Any]) -> bool:
+    """
+    Apply load-time span translations and report whether the dict changed.
+
+    Returns:
+        True if ``span_dict`` was modified, False otherwise.
+    """
+    attributes = span_dict.get("attributes")
+    created_attributes = attributes is None
+    if created_attributes:
+        attributes = {}
+
+    modified = False
     try:
         if current_raw := attributes.get(SpanAttributeKey.SPAN_TYPE):
             current_type = try_json_loads(current_raw)
@@ -383,11 +398,15 @@ def translate_loaded_span(span_dict: dict[str, Any]) -> dict[str, Any]:
         if current_type in (None, SpanType.UNKNOWN):
             if mlflow_type := translate_span_type_from_otel(attributes):
                 attributes[SpanAttributeKey.SPAN_TYPE] = dump_span_attribute_value(mlflow_type)
+                modified = True
     except Exception:
         _logger.debug("Failed to translate span type", exc_info=True)
 
-    span_dict["attributes"] = attributes
-    return span_dict
+    # Avoid injecting an empty attributes object when nothing changed so stored
+    # JSON can be passed through unchanged for artifact responses.
+    if modified or not created_attributes:
+        span_dict["attributes"] = attributes
+    return modified
 
 
 def update_token_usage(

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -1252,3 +1252,99 @@ def test_lazy_span_matches_eager_span_after_materialization():
     assert lazy.status == eager.status
     assert lazy.events == eager.events
     assert lazy.to_otel_proto().SerializeToString() == eager.to_otel_proto().SerializeToString()
+
+
+def test_lazy_span_from_stored_content_preserves_unmodified_raw_json():
+    from mlflow.entities.span import LazySpan
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    raw_json = json.dumps(span.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+
+    assert lazy.__dict__["_raw_json"] == raw_json
+    assert lazy.json_for_export() == raw_json
+    assert lazy.__dict__["_materialized"] is False
+
+
+def test_lazy_span_from_stored_content_drops_raw_json_when_translated():
+    from mlflow.entities.span import LazySpan
+    from mlflow.tracing.constant import SpanAttributeKey
+
+    # Missing/unknown span type + OpenInference kind triggers translate_loaded_span.
+    span_dict = {
+        "trace_id": "AAAAAAAAAAAAAAAAAAAAAQ==",
+        "span_id": "AAAAAAAAAAI=",
+        "parent_span_id": None,
+        "name": "translated",
+        "start_time_unix_nano": 1,
+        "end_time_unix_nano": 2,
+        "events": [],
+        "status": {"code": "STATUS_CODE_OK", "message": ""},
+        "attributes": {
+            SpanAttributeKey.REQUEST_ID: json.dumps("tr-1"),
+            SpanAttributeKey.SPAN_TYPE: json.dumps(SpanType.UNKNOWN),
+            "openinference.span.kind": "LLM",
+        },
+        "links": [],
+    }
+    raw_json = json.dumps(span_dict, separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+
+    assert lazy.__dict__["_raw_json"] is None
+    assert json.loads(lazy.json_for_export())["attributes"][
+        SpanAttributeKey.SPAN_TYPE
+    ] == json.dumps(SpanType.LLM)
+
+
+def test_trace_data_to_json_bytes_passthrough_for_unmodified_lazy_spans():
+    from mlflow.entities.span import LazySpan
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    raw_json = json.dumps(span.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+    payload = TraceData(spans=[lazy]).to_json_bytes()
+
+    assert payload == b'{"spans":[' + raw_json.encode("utf-8") + b"]}"
+    assert lazy.__dict__["_materialized"] is False
+    assert json.loads(payload)["spans"][0]["name"] == "child"
+
+
+def test_trace_data_to_json_bytes_mixed_lazy_and_eager_spans():
+    from mlflow.entities.span import LazySpan
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    immutable = span.to_immutable_span()
+    raw_json = json.dumps(immutable.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+    payload = TraceData(spans=[lazy, immutable]).to_json_bytes()
+    parsed = json.loads(payload)
+
+    assert len(parsed["spans"]) == 2
+    assert parsed["spans"][0]["name"] == "child"
+    assert parsed["spans"][1]["name"] == "child"
+
+
+def test_trace_data_to_json_bytes_uses_single_dump_for_eager_spans_only():
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    immutable = span.to_immutable_span()
+    trace_data = TraceData(spans=[immutable])
+    payload = trace_data.to_json_bytes()
+
+    assert payload == json.dumps(trace_data.to_dict(), separators=(",", ":")).encode("utf-8")
+    assert json.loads(payload)["spans"][0]["name"] == "child"

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -1274,3 +1274,137 @@ def test_lazy_span_matches_eager_span_after_materialization():
     assert lazy.status == eager.status
     assert lazy.events == eager.events
     assert lazy.to_otel_proto().SerializeToString() == eager.to_otel_proto().SerializeToString()
+
+
+def test_lazy_span_from_stored_content_preserves_unmodified_raw_json():
+    from mlflow.entities.span import LazySpan
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    raw_json = json.dumps(span.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+
+    assert lazy.__dict__["_raw_json"] == raw_json
+    assert lazy.json_for_export() == raw_json
+    assert lazy.__dict__["_materialized"] is False
+
+
+def test_lazy_span_to_dict_clears_raw_json_after_top_level_mutation():
+    from mlflow.entities.span import LazySpan
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    raw_json = json.dumps(span.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+    span_dict = lazy.to_dict()
+    span_dict["name"] = "mutated"
+
+    assert lazy.__dict__["_raw_json"] is None
+    assert json.loads(lazy.json_for_export())["name"] == "mutated"
+    payload = TraceData(spans=[lazy]).to_json_bytes()
+    assert json.loads(payload)["spans"][0]["name"] == "mutated"
+
+
+def test_lazy_span_to_dict_clears_raw_json_after_nested_mutation():
+    from mlflow.entities.span import LazySpan
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    raw_json = json.dumps(span.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+    span_dict = lazy.to_dict()
+    span_dict["attributes"]["custom"] = "mutated"
+
+    assert lazy.__dict__["_raw_json"] is None
+    assert json.loads(lazy.json_for_export())["attributes"]["custom"] == "mutated"
+    payload = TraceData(spans=[lazy]).to_json_bytes()
+    assert json.loads(payload)["spans"][0]["attributes"]["custom"] == "mutated"
+
+
+def test_lazy_span_from_stored_content_drops_raw_json_when_translated():
+    from mlflow.entities.span import LazySpan
+    from mlflow.tracing.constant import SpanAttributeKey
+
+    # Missing/unknown span type + OpenInference kind triggers translate_loaded_span.
+    span_dict = {
+        "trace_id": "AAAAAAAAAAAAAAAAAAAAAQ==",
+        "span_id": "AAAAAAAAAAI=",
+        "parent_span_id": None,
+        "name": "translated",
+        "start_time_unix_nano": 1,
+        "end_time_unix_nano": 2,
+        "events": [],
+        "status": {"code": "STATUS_CODE_OK", "message": ""},
+        "attributes": {
+            SpanAttributeKey.REQUEST_ID: json.dumps("tr-1"),
+            SpanAttributeKey.SPAN_TYPE: json.dumps(SpanType.UNKNOWN),
+            "openinference.span.kind": "LLM",
+        },
+        "links": [],
+    }
+    raw_json = json.dumps(span_dict, separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+
+    assert lazy.__dict__["_raw_json"] is None
+    assert json.loads(lazy.json_for_export())["attributes"][
+        SpanAttributeKey.SPAN_TYPE
+    ] == json.dumps(SpanType.LLM)
+
+
+def test_trace_data_to_json_bytes_passthrough_for_unmodified_lazy_spans():
+    from mlflow.entities.span import LazySpan
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    raw_json = json.dumps(span.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+    payload = TraceData(spans=[lazy]).to_json_bytes()
+
+    assert payload == b'{"spans":[' + raw_json.encode("utf-8") + b"]}"
+    assert lazy.__dict__["_materialized"] is False
+    assert json.loads(payload)["spans"][0]["name"] == "child"
+
+
+def test_trace_data_to_json_bytes_mixed_lazy_and_eager_spans():
+    from mlflow.entities.span import LazySpan
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    immutable = span.to_immutable_span()
+    raw_json = json.dumps(immutable.to_dict(), separators=(",", ":"))
+    lazy = LazySpan.from_stored_content(raw_json)
+    payload = TraceData(spans=[lazy, immutable]).to_json_bytes()
+    parsed = json.loads(payload)
+
+    assert len(parsed["spans"]) == 2
+    assert parsed["spans"][0]["name"] == "child"
+    assert parsed["spans"][1]["name"] == "child"
+
+
+def test_trace_data_to_json_bytes_uses_single_dump_for_eager_spans_only():
+    from mlflow.entities.trace_data import TraceData
+
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+
+    immutable = span.to_immutable_span()
+    trace_data = TraceData(spans=[immutable])
+    payload = trace_data.to_json_bytes()
+
+    assert payload == json.dumps(trace_data.to_dict(), separators=(",", ":")).encode("utf-8")
+    assert json.loads(payload)["spans"][0]["name"] == "child"

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5742,10 +5742,16 @@ def test_get_trace_returns_lazy_spans_that_skip_materialization_on_to_dict(
     trace = store.get_trace(trace_id)
     assert all(isinstance(span, LazySpan) for span in trace.data.spans)
     assert all(span.__dict__["_materialized"] is False for span in trace.data.spans)
+    assert all(span.__dict__["_raw_json"] is not None for span in trace.data.spans)
 
     dumped = trace.data.to_dict()
     assert dumped["spans"][0]["name"] == "root_span"
     assert all(span.__dict__["_materialized"] is False for span in trace.data.spans)
+
+    payload = trace.data.to_json_bytes()
+    assert payload.startswith(b'{"spans":[')
+    assert all(span.__dict__["_materialized"] is False for span in trace.data.spans)
+    assert json.loads(payload)["spans"][0]["name"] == "root_span"
 
     # Property access still works and materializes only when needed.
     assert trace.data.spans[0].name == "root_span"

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -5787,10 +5787,16 @@ def test_get_trace_returns_lazy_spans_that_skip_materialization_on_to_dict(
     trace = store.get_trace(trace_id)
     assert all(isinstance(span, LazySpan) for span in trace.data.spans)
     assert all(span.__dict__["_materialized"] is False for span in trace.data.spans)
+    assert all(span.__dict__["_raw_json"] is not None for span in trace.data.spans)
 
     dumped = trace.data.to_dict()
     assert dumped["spans"][0]["name"] == "root_span"
     assert all(span.__dict__["_materialized"] is False for span in trace.data.spans)
+
+    payload = trace.data.to_json_bytes()
+    assert payload.startswith(b'{"spans":[')
+    assert all(span.__dict__["_materialized"] is False for span in trace.data.spans)
+    assert json.loads(payload)["spans"][0]["name"] == "root_span"
 
     # Property access still works and materializes only when needed.
     assert trace.data.spans[0].name == "root_span"


### PR DESCRIPTION
Keep raw DB span.content on LazySpan when load-time translation is a no-op, and emit it via TraceData.to_json_bytes() so artifact responses skip an unnecessary json.dumps round-trip.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24399 
Relates to #24331 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Follow-up to #24331. After lazy span deserialization, `get-trace-artifact` still paid for `json.loads` on read and `json.dumps` on write even when stored span JSON was unchanged.

This PR:
- Keeps the raw DB `span.content` string on `LazySpan` when `translate_loaded_span` does not modify the payload
- Adds `TraceData.to_json_bytes()` to emit raw JSON for unmodified `LazySpan`s and fall back to `json.dumps` otherwise
- Updates `get-trace-artifact` to write those bytes directly instead of `json.dumps(trace.data.to_dict())`
- Uses `LazySpan.from_stored_content()` in the SQLAlchemy TRACKING_STORE read path
This reduces per-span serialization cost for spans that are sent. Pagination (which spans are sent) remains separate from #24314.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Tests run:
- `tests/entities/test_span.py` (LazySpan + `to_json_bytes` coverage)
- `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py::test_get_trace_returns_lazy_spans_that_skip_materialization_on_to_dict`
- `tests/server/test_handlers.py` (`get_trace_artifact` cases)
- `tests/tracing/otel/test_span_translation.py` (`translate_loaded_span`)

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
