### PR TITLE
[BUG] Enforce artifact authorization on presigned download route in basic-auth

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2848,6 +2848,11 @@ def _is_proxy_artifact_path(path: str) -> bool:
         f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/artifacts",
         f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/mpu/",
         f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/mpu/",
+        # GetPresignedDownloadUrl mints a direct cloud-storage download URL and must
+        # require the same experiment artifact READ permission as the proxied
+        # /mlflow-artifacts/artifacts download path.
+        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/presigned/",
+        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/presigned/",
     ]
     return any(path.startswith(prefix) for prefix in prefixes)
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -306,12 +306,19 @@ def test_proxy_artifact_authorization_required(client, monkeypatch):
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
 def test_proxy_artifact_presigned_authorization_required(client, monkeypatch):
     # Regression test for https://github.com/mlflow/mlflow/issues/24567:
     # GetPresignedDownloadUrl must enforce the same experiment artifact READ permission
     # as the proxied download route. Without authorization, a user with no grant would
     # reach the handler (returning a working presigned URL on cloud backends), leaking
     # artifacts. A denied user must receive 403 before the handler runs.
+    # Runs against ``default_permission=NO_PERMISSIONS`` so a GET (READ) without an
+    # explicit grant is denied — a READ-permission default would otherwise allow it.
     username1, password1 = create_user(client.tracking_uri)
     username2, password2 = create_user(client.tracking_uri)
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -318,13 +318,10 @@ def test_proxy_artifact_presigned_authorization_required(client, monkeypatch):
     with User(username1, password1, monkeypatch):
         experiment_id = client.create_experiment("proxy-artifact-presigned-authz-test")
 
-    response = requests.get(
-        url=(
-            client.tracking_uri
-            + f"/api/2.0/mlflow-artifacts/presigned/{experiment_id}/test.txt"
-        ),
-        auth=(username2, password2),
+    presigned_url = (
+        client.tracking_uri + f"/api/2.0/mlflow-artifacts/presigned/{experiment_id}/test.txt"
     )
+    response = requests.get(url=presigned_url, auth=(username2, password2))
     assert response.status_code == 403
 
 

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -239,6 +239,24 @@ def test_proxy_artifact_mpu_validator_returns_update_for_post():
     assert validator is auth_module.validate_can_update_experiment_artifact_proxy
 
 
+def test_proxy_artifact_presigned_path_detection():
+    # GetPresignedDownloadUrl paths must be recognized so basic-auth applies the same
+    # experiment artifact READ check it applies to /mlflow-artifacts/artifacts downloads.
+    assert auth_module._is_proxy_artifact_path(
+        "/api/2.0/mlflow-artifacts/presigned/1/run-id/artifacts/model.pkl"
+    )
+    assert auth_module._is_proxy_artifact_path(
+        "/ajax-api/2.0/mlflow-artifacts/presigned/1/run-id/artifacts/model.pkl"
+    )
+
+
+def test_proxy_artifact_presigned_validator_returns_read_for_get():
+    validator = auth_module._get_proxy_artifact_validator(
+        "GET", {"artifact_path": "1/run-id/artifacts/model.pkl"}
+    )
+    assert validator is auth_module.validate_can_read_experiment_artifact_proxy
+
+
 @pytest.mark.parametrize(
     ("path", "method"),
     [
@@ -283,6 +301,25 @@ def test_proxy_artifact_authorization_required(client, monkeypatch):
             + f"/ajax-api/2.0/mlflow-artifacts/artifacts/{experiment_id}/test.txt"
         ),
         data=b"forbidden",
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+
+
+def test_proxy_artifact_presigned_authorization_required(client, monkeypatch):
+    # Regression test for https://github.com/mlflow/mlflow/issues/24567:
+    # GetPresignedDownloadUrl must enforce the same experiment artifact READ permission
+    # as the proxied download route. Without authorization, a user with no grant would
+    # reach the handler (returning a working presigned URL on cloud backends), leaking
+    # artifacts. A denied user must receive 403 before the handler runs.
+    username1, password1 = create_user(client.tracking_uri)
+    username2, password2 = create_user(client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = client.create_experiment("proxy-artifact-presigned-authz-test")
+
+    response = requests.get(
+        url=(client.tracking_uri + f"/api/2.0/mlflow-artifacts/presigned/{experiment_id}/test.txt"),
         auth=(username2, password2),
     )
     assert response.status_code == 403

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -319,7 +319,10 @@ def test_proxy_artifact_presigned_authorization_required(client, monkeypatch):
         experiment_id = client.create_experiment("proxy-artifact-presigned-authz-test")
 
     response = requests.get(
-        url=(client.tracking_uri + f"/api/2.0/mlflow-artifacts/presigned/{experiment_id}/test.txt"),
+        url=(
+            client.tracking_uri
+            + f"/api/2.0/mlflow-artifacts/presigned/{experiment_id}/test.txt"
+        ),
         auth=(username2, password2),
     )
     assert response.status_code == 403


### PR DESCRIPTION
### Related Issues/PRs

Closes #24567

### What changes are proposed in this pull request?

The basic-auth plugin authorizes proxied artifact routes by matching the request path in `_is_proxy_artifact_path` and then dispatching to an experiment-scoped validator in `_before_request`. The allowlist covered `/mlflow-artifacts/artifacts` and
`/mlflow-artifacts/mpu/`, but **not** `/mlflow-artifacts/presigned/` (`GetPresignedDownloadUrl`, added in #20352).

As a result, for an authenticated non-admin request, `_before_request` performed **authentication only** and skipped artifact **authorization** on the presigned route. A user with no experiment grant (`default_permission = NO_PERMISSIONS`) is correctly denied `403` on `GET /mlflow-artifacts/artifacts/...`, but the same user reaches the handler on`GET /mlflow-artifacts/presigned/...`. On a cloud-backed artifact store this mints a working direct-download presigned URL, bypassing per-experiment RBAC and leaking artifacts.

This PR adds the `/mlflow-artifacts/presigned/` prefixes (both `/api/2.0` and `/ajax-api/2.0`) to `_is_proxy_artifact_path`. Because the presigned route is a `GET` carrying `artifact_path` in its view args, it now routes through the existing `validate_can_read_experiment_artifact_proxy` validator — the same experiment READ check already enforced on the proxied download route. No new validator or plumbing is required.

Change:

```python
def _is_proxy_artifact_path(path: str) -> bool:
    prefixes = [
        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/artifacts",
        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/artifacts",
        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/mpu/",
        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/mpu/",
        # GetPresignedDownloadUrl mints a direct cloud-storage download URL and must
        # require the same experiment artifact READ permission as the proxied
        # /mlflow-artifacts/artifacts download path.
        f"{_REST_API_PATH_PREFIX}/mlflow-artifacts/presigned/",
        f"{_AJAX_API_PATH_PREFIX}/mlflow-artifacts/presigned/",
    ]
    return any(path.startswith(prefix) for prefix in prefixes)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/server/auth/test_auth.py`:

- `test_proxy_artifact_presigned_path_detection` — the presigned path is recognized on
  both `/api/2.0` and `/ajax-api/2.0`.
- `test_proxy_artifact_presigned_validator_returns_read_for_get` — a `GET` on the
  presigned route maps to `validate_can_read_experiment_artifact_proxy`.
- `test_proxy_artifact_presigned_authorization_required` — end-to-end: a user with no
  experiment grant receives `403` on `GET /mlflow-artifacts/presigned/...` (mirrors the
  existing `test_proxy_artifact_authorization_required`).

Manual test (real `mlflow server --app-name basic-auth --serve-artifacts` with
`default_permission = NO_PERMISSIONS`), reproducing the scenario from #24567:

| Request (restricted user, no grant) | Before fix | After fix |
| --- | --- | --- |
| `GET /mlflow-artifacts/artifacts/...` | `403 Permission denied` | `403 Permission denied` |
| `GET /mlflow-artifacts/presigned/...` | `501 NOT_IMPLEMENTED` (authz skipped, handler reached) | `403 Permission denied` |
| `GET /mlflow-artifacts/presigned/...` (admin / authorized) | — | `501 NOT_IMPLEMENTED` (authz passes, handler reached) |

The authorized-user `501` confirms the change only adds the missing authorization check
and does not over-block users who legitimately have READ permission (on a cloud backend
that request returns a working presigned URL).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an authorization gap in the basic-auth plugin where `GET /mlflow-artifacts/presigned/<artifact_path>` (`GetPresignedDownloadUrl`) did not enforce experiment artifact READ permission, allowing an authenticated user without a grant to obtain a direct cloud-storage download URL for another experiment's artifacts. The presigned download route is now authorized with the same check as the proxied artifact download route.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
