### PR TITLE
Accept MCP registry server envelopes

### DIFF
--- a/mlflow/server/mcp_server_api.py
+++ b/mlflow/server/mcp_server_api.py
@@ -207,6 +207,35 @@ class CreateMCPServerVersionRequest(BaseModel):
         default=None, max_length=_MAX_MCP_TOOLS_PER_LIST
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _unwrap_registry_server_json_envelope(cls, value):
+        """Accept either raw server.json or a registry response envelope."""
+        if not isinstance(value, dict):
+            return value
+
+        server_json = value.get("server_json")
+        if not isinstance(server_json, dict):
+            return value
+
+        # Prefer the canonical raw server.json shape when both are present.
+        if "name" in server_json and "version" in server_json:
+            return value
+
+        if "server" not in server_json:
+            return value
+
+        envelope_server = server_json.get("server")
+        if not isinstance(envelope_server, dict):
+            raise ValueError("server_json.server: Input should be a valid dictionary")
+
+        if "name" not in envelope_server or "version" not in envelope_server:
+            return value
+
+        normalized = dict(value)
+        normalized["server_json"] = envelope_server
+        return normalized
+
 
 class UpdateMCPServerVersionRequest(BaseModel):
     display_name: str | None = None

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -713,6 +713,78 @@ def test_create_version_rejects_risky_server_json_icon_urls(client):
     assert "Icon URL" in r.text
 
 
+def test_create_version_accepts_registry_server_json_envelope(client):
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/enveloped-server')}/versions",
+        json={
+            "server_json": {
+                "server": {
+                    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+                    "name": "com.example/enveloped-server",
+                    "version": "1.0.0",
+                    "description": "Server copied from a registry API response",
+                    "_meta": {
+                        "io.modelcontextprotocol.registry/publisher-provided": {
+                            "copied_from": "registry response"
+                        }
+                    },
+                },
+                "_meta": {
+                    "io.modelcontextprotocol.registry/official": {
+                        "status": "active",
+                        "publishedAt": "2025-10-06T19:14:32.797821Z",
+                        "isLatest": False,
+                    }
+                },
+            },
+            "status": "active",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["server_json"] == {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+        "name": "com.example/enveloped-server",
+        "version": "1.0.0",
+        "description": "Server copied from a registry API response",
+        "_meta": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
+                "copied_from": "registry response"
+            }
+        },
+    }
+
+
+def test_create_version_rejects_registry_server_json_envelope_with_non_object_server(client):
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/bad-envelope')}/versions",
+        json={"server_json": {"server": "not-an-object"}},
+    )
+    assert r.status_code == 400
+    assert "server_json.server" in r.json()["message"]
+
+
+def test_create_version_prefers_top_level_server_json_shape_over_nested_server_key(client):
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param('com.example/raw-wins')}/versions",
+        json={
+            "server_json": {
+                "name": "com.example/raw-wins",
+                "version": "1.0.0",
+                "description": "Raw server_json shape should win",
+                "server": {"name": "com.example/nested", "version": "9.9.9"},
+            },
+            "status": "active",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == "com.example/raw-wins"
+    assert r.json()["version"] == "1.0.0"
+    assert r.json()["server_json"]["server"] == {
+        "name": "com.example/nested",
+        "version": "9.9.9",
+    }
+
+
 def test_create_version_accepts_remote_with_null_type(client):
     sj = _server_json(
         "com.example/null-remote-type",


### PR DESCRIPTION
Allow MCP server version creation to accept registry API envelope-shaped payloads by unwrapping the top-level server object before validation.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [ ] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
