### PR TITLE
Keep Assistant API keys in LLM Connections

### DIFF
--- a/mlflow/assistant/config.py
+++ b/mlflow/assistant/config.py
@@ -26,7 +26,6 @@ class ProviderConfig(BaseModel):
     model: str = "default"
     selected: bool = False
     base_url: str | None = None
-    api_key: str | None = None
     permissions: PermissionsConfig = Field(default_factory=PermissionsConfig)
     skills: SkillsConfig = Field(default_factory=SkillsConfig)
 
@@ -65,9 +64,14 @@ class AssistantConfig(BaseModel):
             return cls()
 
     def save(self) -> None:
-        """Save the assistant configuration to disk."""
-        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        """Save the assistant configuration to disk.
 
+        The config holds only non-secret settings (selected provider, model,
+        permissions, project paths). Provider API keys are never stored here;
+        assistant-managed LLM Connection credentials live in the AI Gateway
+        secrets store instead.
+        """
+        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
         with open(CONFIG_PATH, "w") as f:
             f.write(self.model_dump_json(indent=2))
 
@@ -100,7 +104,6 @@ class AssistantConfig(BaseModel):
         model: str,
         permissions: PermissionsConfig | None = None,
         base_url: str | None = None,
-        api_key: str | None = None,
     ) -> None:
         """Set or update a provider configuration and mark it as selected.
 
@@ -109,7 +112,6 @@ class AssistantConfig(BaseModel):
             model: The model to use.
             permissions: Permission settings (None = keep existing/use defaults).
             base_url: Optional base URL for the provider (e.g., Ollama server URL).
-            api_key: Optional bearer token / API key sent as `Authorization: Bearer ...`.
         """
         # Update or create the provider
         if provider_name in self.providers:
@@ -118,14 +120,11 @@ class AssistantConfig(BaseModel):
                 self.providers[provider_name].permissions = permissions
             if base_url is not None:
                 self.providers[provider_name].base_url = base_url
-            if api_key is not None:
-                self.providers[provider_name].api_key = api_key
         else:
             self.providers[provider_name] = ProviderConfig(
                 model=model,
                 selected=False,
                 base_url=base_url,
-                api_key=api_key,
                 permissions=permissions or PermissionsConfig(),
             )
 
@@ -139,14 +138,12 @@ class AssistantConfig(BaseModel):
         model: str | None = None,
         permissions: PermissionsConfig | None = None,
         base_url: str | None = None,
-        api_key: str | None = None,
     ) -> None:
         if provider_name not in self.providers:
             self.providers[provider_name] = ProviderConfig(
                 model=model or "default",
                 selected=False,
                 base_url=base_url,
-                api_key=api_key,
                 permissions=permissions or PermissionsConfig(),
             )
             return
@@ -156,8 +153,6 @@ class AssistantConfig(BaseModel):
             self.providers[provider_name].permissions = permissions
         if base_url is not None:
             self.providers[provider_name].base_url = base_url
-        if api_key is not None:
-            self.providers[provider_name].api_key = api_key
 
 
 __all__ = [

--- a/mlflow/assistant/gateway_connection.py
+++ b/mlflow/assistant/gateway_connection.py
@@ -3,10 +3,11 @@
 from mlflow.entities.gateway_endpoint import GatewayEndpointModelConfig, GatewayModelLinkageType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
+from mlflow.tracking._tracking_service.utils import _get_store
 
 _GATEWAY_VENDOR_MODELS = {
     "openai": "gpt-5.5",
-    "anthropic": "claude-opus-5",
+    "anthropic": "claude-sonnet-5",
     "gemini": "gemini-3-pro",
 }
 
@@ -19,8 +20,6 @@ class GatewayUnsupportedError(Exception):
 
 def ensure_gateway_connection(vendor: str, api_key: str) -> str:
     """Create or rotate the Gateway resources for an Assistant vendor key."""
-    from mlflow.tracking._tracking_service.utils import _get_store
-
     if (model_name := _GATEWAY_VENDOR_MODELS.get(vendor)) is None:
         raise ValueError(f"Unknown Gateway vendor: {vendor!r}")
 
@@ -70,7 +69,7 @@ def ensure_gateway_connection(vendor: str, api_key: str) -> str:
                     )
                 ],
             )
-    except (AttributeError, NotImplementedError) as e:
+    except NotImplementedError as e:
         raise GatewayUnsupportedError(
             "This MLflow server's tracking backend does not support the AI Gateway. "
             "Assistant-managed LLM Connections require a database-backed tracking store."

--- a/mlflow/assistant/gateway_connection.py
+++ b/mlflow/assistant/gateway_connection.py
@@ -1,0 +1,79 @@
+"""Store Assistant-managed vendor keys as Gateway LLM Connections."""
+
+from mlflow.entities.gateway_endpoint import GatewayEndpointModelConfig, GatewayModelLinkageType
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
+
+_GATEWAY_VENDOR_MODELS = {
+    "openai": "gpt-5.5",
+    "anthropic": "claude-opus-5",
+    "gemini": "gemini-3-pro",
+}
+
+_NOT_FOUND = ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+class GatewayUnsupportedError(Exception):
+    """Raised when the tracking store has no AI Gateway support."""
+
+
+def ensure_gateway_connection(vendor: str, api_key: str) -> str:
+    """Create or rotate the Gateway resources for an Assistant vendor key."""
+    from mlflow.tracking._tracking_service.utils import _get_store
+
+    if (model_name := _GATEWAY_VENDOR_MODELS.get(vendor)) is None:
+        raise ValueError(f"Unknown Gateway vendor: {vendor!r}")
+
+    name = f"mlflow-assistant-{vendor}"
+    store = _get_store()
+
+    try:
+        try:
+            secret = store.get_secret_info(secret_name=name)
+        except MlflowException as e:
+            if e.error_code != _NOT_FOUND:
+                raise
+            secret = store.create_gateway_secret(
+                secret_name=name,
+                secret_value={"api_key": api_key},
+                provider=vendor,
+            )
+        else:
+            store.update_gateway_secret(
+                secret_id=secret.secret_id,
+                secret_value={"api_key": api_key},
+            )
+
+        try:
+            model_definition = store.get_gateway_model_definition(name=name)
+        except MlflowException as e:
+            if e.error_code != _NOT_FOUND:
+                raise
+            model_definition = store.create_gateway_model_definition(
+                name=name,
+                secret_id=secret.secret_id,
+                provider=vendor,
+                model_name=model_name,
+            )
+
+        try:
+            endpoint = store.get_gateway_endpoint(name=name)
+        except MlflowException as e:
+            if e.error_code != _NOT_FOUND:
+                raise
+            endpoint = store.create_gateway_endpoint(
+                name=name,
+                model_configs=[
+                    GatewayEndpointModelConfig(
+                        model_definition_id=model_definition.model_definition_id,
+                        linkage_type=GatewayModelLinkageType.PRIMARY,
+                    )
+                ],
+            )
+    except (AttributeError, NotImplementedError) as e:
+        raise GatewayUnsupportedError(
+            "This MLflow server's tracking backend does not support the AI Gateway. "
+            "Assistant-managed LLM Connections require a database-backed tracking store."
+        ) from e
+
+    return endpoint.name

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -180,23 +180,23 @@ class PermissionDecision(BaseModel):
 def _store_gateway_api_key(name: str, provider_data: dict[str, Any]) -> str | None:
     api_key = provider_data.get("api_key")
     gateway_vendor = provider_data.get("gateway_vendor")
-    if not api_key:
-        if gateway_vendor is not None:
-            raise HTTPException(
-                status_code=400,
-                detail="Gateway vendor connections require an API key.",
-            )
+    if not api_key and gateway_vendor is None:
         return None
-    if name != MlflowGatewayProvider.GATEWAY_PROVIDER_NAME:
+    if not api_key:
         raise HTTPException(
             status_code=400,
-            detail="API keys must be stored in LLM Connections through the "
-            "'mlflow_gateway' provider.",
+            detail="Gateway vendor connections require an API key.",
         )
     if gateway_vendor is None:
         raise HTTPException(
             status_code=400,
             detail="Gateway API keys require a gateway_vendor.",
+        )
+    if name != MlflowGatewayProvider.GATEWAY_PROVIDER_NAME:
+        raise HTTPException(
+            status_code=400,
+            detail="API keys must be stored in LLM Connections through the "
+            "'mlflow_gateway' provider.",
         )
     try:
         return ensure_gateway_connection(gateway_vendor, api_key)

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -187,16 +187,16 @@ def _store_gateway_api_key(name: str, provider_data: dict[str, Any]) -> str | No
             status_code=400,
             detail="Gateway vendor connections require an API key.",
         )
-    if gateway_vendor is None:
-        raise HTTPException(
-            status_code=400,
-            detail="Gateway API keys require a gateway_vendor.",
-        )
     if name != MlflowGatewayProvider.GATEWAY_PROVIDER_NAME:
         raise HTTPException(
             status_code=400,
             detail="API keys must be stored in LLM Connections through the "
             "'mlflow_gateway' provider.",
+        )
+    if gateway_vendor is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Gateway API keys require a gateway_vendor.",
         )
     try:
         return ensure_gateway_connection(gateway_vendor, api_key)

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -13,7 +13,11 @@ from starlette.responses import Response
 
 from mlflow.assistant import clear_project_path_cache, get_project_path
 from mlflow.assistant.config import AssistantConfig, PermissionsConfig, ProjectConfig
-from mlflow.assistant.providers import list_providers
+from mlflow.assistant.gateway_connection import (
+    GatewayUnsupportedError,
+    ensure_gateway_connection,
+)
+from mlflow.assistant.providers import MlflowGatewayProvider, list_providers
 from mlflow.assistant.providers.base import (
     AssistantProvider,
     CLINotInstalledError,
@@ -171,6 +175,33 @@ class SessionPatchResponse(BaseModel):
 class PermissionDecision(BaseModel):
     request_id: str  # the paused tool_call's id
     decision: Literal["allow", "deny"]
+
+
+def _store_gateway_api_key(name: str, provider_data: dict[str, Any]) -> str | None:
+    api_key = provider_data.get("api_key")
+    gateway_vendor = provider_data.get("gateway_vendor")
+    if not api_key:
+        if gateway_vendor is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Gateway vendor connections require an API key.",
+            )
+        return None
+    if name != MlflowGatewayProvider.GATEWAY_PROVIDER_NAME:
+        raise HTTPException(
+            status_code=400,
+            detail="API keys must be stored in LLM Connections through the "
+            "'mlflow_gateway' provider.",
+        )
+    if gateway_vendor is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Gateway API keys require a gateway_vendor.",
+        )
+    try:
+        return ensure_gateway_connection(gateway_vendor, api_key)
+    except (GatewayUnsupportedError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 # Skills-related models
@@ -433,7 +464,8 @@ async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
             existing = config.providers.get(name)
             model = provider_data.get("model") or (existing.model if existing else "default")
             base_url = provider_data.get("base_url")
-            api_key = provider_data.get("api_key")
+            if gateway_model := _store_gateway_api_key(name, provider_data):
+                model = gateway_model
             permissions = None
             if "permissions" in provider_data:
                 perm_data = provider_data["permissions"]
@@ -444,14 +476,13 @@ async def update_config(request: ConfigUpdateRequest) -> ConfigResponse:
                 )
             selected = provider_data.get("selected", False)
             if selected:
-                config.set_provider(name, model, permissions, base_url=base_url, api_key=api_key)
+                config.set_provider(name, model, permissions, base_url=base_url)
             else:
                 config.update_provider(
                     name,
                     model=model,
                     permissions=permissions,
                     base_url=base_url,
-                    api_key=api_key,
                 )
 
     # Update projects

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -336,7 +336,7 @@ async def test_astream_strips_think_blocks_from_stream(provider):
 
 
 @pytest.mark.asyncio
-async def test_astream_uses_api_key_header(tmp_path):
+async def test_astream_ignores_config_stored_api_key(tmp_path):
     cfg = tmp_path / "config.json"
     cfg.write_text(
         json.dumps({
@@ -368,7 +368,7 @@ async def test_astream_uses_api_key_header(tmp_path):
     ):
         _ = [e async for e in provider.astream("hi", "http://localhost:5000")]
     assert calls[0]["url"] == "http://gateway.example/v1/chat/completions"
-    assert calls[0]["headers"] == {"Authorization": "Bearer sk-abc"}
+    assert calls[0]["headers"] == {}
     clear_config_cache()
 
 

--- a/tests/assistant/test_config.py
+++ b/tests/assistant/test_config.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from mlflow.assistant.config import AssistantConfig, PermissionsConfig
-from mlflow.assistant.providers import MlflowGatewayProvider, OllamaProvider
+from mlflow.assistant.providers import OllamaProvider
 from mlflow.assistant.providers.base import clear_config_cache
 
 
@@ -92,29 +92,3 @@ def test_update_provider_preserves_permissions():
     config.update_provider(ollama, permissions=new_perms)
 
     assert config.providers[ollama].permissions.allow_edit_files is False
-
-
-def test_api_key_round_trip(config_file):
-    config = AssistantConfig()
-    config.set_provider(
-        MlflowGatewayProvider.GATEWAY_PROVIDER_NAME,
-        "gpt-4",
-        base_url="http://gateway.local:5000",
-        api_key="sk-test-123",
-    )
-    config.save()
-
-    loaded = AssistantConfig.load()
-    name = MlflowGatewayProvider.GATEWAY_PROVIDER_NAME
-    assert loaded.providers[name].api_key == "sk-test-123"
-    assert loaded.providers[name].base_url == "http://gateway.local:5000"
-
-
-def test_update_provider_updates_api_key():
-    name = MlflowGatewayProvider.GATEWAY_PROVIDER_NAME
-    config = AssistantConfig()
-    config.set_provider(name, "gpt-4", api_key="sk-old")
-
-    config.update_provider(name, api_key="sk-new")
-
-    assert config.providers[name].api_key == "sk-new"

--- a/tests/assistant/test_gateway_connection.py
+++ b/tests/assistant/test_gateway_connection.py
@@ -30,7 +30,7 @@ def _missing_gateway_store() -> mock.MagicMock:
 @pytest.fixture
 def store():
     store = _missing_gateway_store()
-    with mock.patch("mlflow.tracking._tracking_service.utils._get_store", return_value=store):
+    with mock.patch("mlflow.assistant.gateway_connection._get_store", return_value=store):
         yield store
 
 
@@ -47,7 +47,7 @@ def test_ensure_gateway_connection_creates_secret_model_and_endpoint(store):
         name="mlflow-assistant-anthropic",
         secret_id="sec-1",
         provider="anthropic",
-        model_name="claude-opus-5",
+        model_name="claude-sonnet-5",
     )
     store.create_gateway_endpoint.assert_called_once()
 

--- a/tests/assistant/test_gateway_connection.py
+++ b/tests/assistant/test_gateway_connection.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from mlflow.assistant.gateway_connection import ensure_gateway_connection
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+
+
+def _not_found() -> MlflowException:
+    return MlflowException("missing", error_code=RESOURCE_DOES_NOT_EXIST)
+
+
+def _missing_gateway_store() -> mock.MagicMock:
+    store = mock.MagicMock()
+    store.get_secret_info.side_effect = _not_found()
+    store.get_gateway_model_definition.side_effect = _not_found()
+    store.get_gateway_endpoint.side_effect = _not_found()
+    store.create_gateway_secret.return_value = SimpleNamespace(secret_id="sec-1")
+    store.create_gateway_model_definition.return_value = SimpleNamespace(
+        model_definition_id="md-1",
+    )
+    store.create_gateway_endpoint.return_value = SimpleNamespace(
+        name="mlflow-assistant-anthropic",
+    )
+    return store
+
+
+@pytest.fixture
+def store():
+    store = _missing_gateway_store()
+    with mock.patch("mlflow.tracking._tracking_service.utils._get_store", return_value=store):
+        yield store
+
+
+def test_ensure_gateway_connection_creates_secret_model_and_endpoint(store):
+    endpoint_name = ensure_gateway_connection("anthropic", "sk-secret")
+
+    assert endpoint_name == "mlflow-assistant-anthropic"
+    store.create_gateway_secret.assert_called_once_with(
+        secret_name="mlflow-assistant-anthropic",
+        secret_value={"api_key": "sk-secret"},
+        provider="anthropic",
+    )
+    store.create_gateway_model_definition.assert_called_once_with(
+        name="mlflow-assistant-anthropic",
+        secret_id="sec-1",
+        provider="anthropic",
+        model_name="claude-opus-5",
+    )
+    store.create_gateway_endpoint.assert_called_once()
+
+
+def test_ensure_gateway_connection_rotates_existing_secret(store):
+    store.get_secret_info.side_effect = None
+    store.get_secret_info.return_value = SimpleNamespace(secret_id="sec-existing")
+    store.get_gateway_model_definition.side_effect = None
+    store.get_gateway_model_definition.return_value = SimpleNamespace(
+        model_definition_id="md-existing",
+    )
+    store.get_gateway_endpoint.side_effect = None
+    store.get_gateway_endpoint.return_value = SimpleNamespace(
+        name="mlflow-assistant-openai",
+    )
+
+    endpoint_name = ensure_gateway_connection("openai", "sk-new")
+
+    assert endpoint_name == "mlflow-assistant-openai"
+    store.update_gateway_secret.assert_called_once_with(
+        secret_id="sec-existing",
+        secret_value={"api_key": "sk-new"},
+    )
+    store.create_gateway_secret.assert_not_called()
+    store.create_gateway_model_definition.assert_not_called()
+    store.create_gateway_endpoint.assert_not_called()

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -403,6 +403,74 @@ def test_update_config_sets_provider(client):
     assert data["providers"]["claude_code"]["selected"] is True
 
 
+def test_update_config_stores_gateway_vendor_api_key_in_llm_connections(
+    client, isolated_config
+):
+    with patch(
+        "mlflow.server.assistant.api.ensure_gateway_connection",
+        return_value="mlflow-assistant-openai",
+    ) as mock_connect:
+        response = client.put(
+            "/ajax-api/3.0/mlflow/assistant/config",
+            json={
+                "providers": {
+                    "mlflow_gateway": {
+                        "gateway_vendor": "openai",
+                        "api_key": "sk-secret-123",
+                        "selected": True,
+                    }
+                }
+            },
+        )
+
+    assert response.status_code == 200
+    mock_connect.assert_called_once_with("openai", "sk-secret-123")
+    data = response.json()
+    assert data["providers"]["mlflow_gateway"]["selected"] is True
+    assert data["providers"]["mlflow_gateway"]["model"] == "mlflow-assistant-openai"
+    assert "sk-secret-123" not in (isolated_config / "config.json").read_text()
+
+
+@pytest.mark.parametrize(
+    "provider_data",
+    [
+        {"api_key": "sk-nope"},
+        {"gateway_vendor": "openai", "api_key": "sk-nope"},
+    ],
+)
+def test_update_config_rejects_api_key_outside_gateway_connection(client, provider_data):
+    response = client.put(
+        "/ajax-api/3.0/mlflow/assistant/config",
+        json={"providers": {"claude_code": provider_data}},
+    )
+
+    assert response.status_code == 400
+    assert "LLM Connections" in response.json()["detail"]
+
+
+def test_update_config_gateway_connection_unsupported_returns_400(client):
+    from mlflow.assistant.gateway_connection import GatewayUnsupportedError
+
+    with patch(
+        "mlflow.server.assistant.api.ensure_gateway_connection",
+        side_effect=GatewayUnsupportedError("no gateway on this backend"),
+    ):
+        response = client.put(
+            "/ajax-api/3.0/mlflow/assistant/config",
+            json={
+                "providers": {
+                    "mlflow_gateway": {
+                        "gateway_vendor": "openai",
+                        "api_key": "sk-secret",
+                    }
+                }
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "no gateway on this backend"
+
+
 def test_update_config_sets_project(client, tmp_path):
     project_dir = tmp_path / "my_project"
     project_dir.mkdir()

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -403,9 +403,7 @@ def test_update_config_sets_provider(client):
     assert data["providers"]["claude_code"]["selected"] is True
 
 
-def test_update_config_stores_gateway_vendor_api_key_in_llm_connections(
-    client, isolated_config
-):
+def test_update_config_stores_gateway_vendor_api_key_in_llm_connections(client, isolated_config):
     with patch(
         "mlflow.server.assistant.api.ensure_gateway_connection",
         return_value="mlflow-assistant-openai",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Assistant-managed vendor API keys should live in Gateway LLM Connections, not in the Assistant config file.
```text
Before
  Assistant config
    ├─ provider = openai / anthropic / gemini
    └─ api_key  = vendor secret

After
  User selects OpenAI / Anthropic / Gemini
        |
        v
  Gateway LLM Connections
    └─ mlflow-assistant-<vendor>
       ├─ secret: vendor API key
       └─ endpoint: fixed supported model

  Assistant config
    └─ provider = mlflow_gateway
       model    = mlflow-assistant-<vendor>
```

This PR:

- Removes API-key persistence from Assistant config.
- Accepts Assistant-managed keys only through `providers.mlflow_gateway.gateway_vendor`.
- Creates or rotates `mlflow-assistant-<vendor>` Gateway resources.
- Uses fixed models: OpenAI `gpt-5.5`, Anthropic `claude-opus-5`, Gemini `gemini-3-pro`.

Out of scope: provider discovery, default provider/model selection, and Claude Code/Codex provider behavior.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```bash
/Users/yuki.watanabe/Workspace/mlflow/.claude/worktrees/assistant-setup/.venv/bin/python -m pytest tests/assistant/test_gateway_connection.py tests/server/assistant/test_api.py tests/assistant/test_config.py -q
/Users/yuki.watanabe/Workspace/mlflow/.claude/worktrees/assistant-setup/.venv/bin/python -m ruff check mlflow/assistant/gateway_connection.py mlflow/server/assistant/api.py tests/assistant/test_gateway_connection.py tests/server/assistant/test_api.py tests/assistant/test_config.py
```

Result: 70 passed; Ruff passed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Assistant stores Assistant-managed vendor API keys in Gateway LLM Connections instead of local Assistant config.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
