### PR TITLE
fix: use Base.metadata.create_all in _initialize_tables to avoid 'table already exists' error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` from MLflow 3.7.x to 3.8.x, the database upgrade fails with:
```
pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")
```

This happens because `_initialize_tables` uses `InitialBase.metadata.create_all(engine)`, which creates the `secrets` table unconditionally. If the database already has that table (e.g., from a prior migration in 3.7.x), the operation fails.

## Fix
Changed `InitialBase.metadata.create_all(engine)` to `Base.metadata.create_all(engine)`. `Base.metadata` includes all registered ORM tables and leverages SQLAlchemy's automatic `checkfirst=True` behavior (default), which skips creation of existing tables. This prevents the duplicate table error during upgrades.

Closes #19943