### PR TITLE
Add temporary google-adk CI diagnostics

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -322,6 +322,62 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --extra genai
+          echo "::group::google-adk resolver diagnostics before overlay install"
+          uv --version
+          python - <<'PY'
+          import importlib.metadata as md
+          import os
+
+          for name in [
+              "PIP_INDEX_URL",
+              "PIP_EXTRA_INDEX_URL",
+              "PIP_CONSTRAINT",
+              "UV_INDEX_URL",
+              "UV_EXTRA_INDEX_URL",
+              "UV_INDEX_STRATEGY",
+              "UV_EXCLUDE_NEWER",
+          ]:
+              print(f"{name}={os.environ.get(name, '<unset>')}")
+
+          print("\nInstalled resolver-relevant packages:")
+          for package in [
+              "fastapi",
+              "starlette",
+              "opentelemetry-api",
+              "opentelemetry-sdk",
+              "opentelemetry-exporter-otlp-proto-http",
+              "opentelemetry-exporter-otlp-proto-grpc",
+              "google-adk",
+          ]:
+              try:
+                  print(f"{package}=={md.version(package)}")
+              except md.PackageNotFoundError:
+                  print(f"{package}=<not installed>")
+
+          print("\nInstalled distributions declaring google-adk requirements:")
+          found = False
+          for dist in sorted(md.distributions(), key=lambda d: (d.metadata.get("Name") or "").lower()):
+              requirements = [
+                  req
+                  for req in (dist.metadata.get_all("Requires-Dist") or [])
+                  if "google-adk" in req.lower()
+              ]
+              if requirements:
+                  found = True
+                  print(f"{dist.metadata['Name']}=={dist.version}")
+                  for req in requirements:
+                      print(f"  {req}")
+          if not found:
+              print("<none>")
+          PY
+          python -m pip index versions google-adk || true
+          echo "Direct google-adk[gcp] dry-run:"
+          uv pip install --dry-run 'google-adk[gcp]' || true
+          echo "Full GenAI overlay dry-run:"
+          uv pip install --dry-run \
+            -r requirements/test-requirements.txt \
+            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]' || true
+          echo "::endgroup::"
           # TODO: migrate mlflow/genai/scorers/phoenix to arize-phoenix-evals 3.x API
           # (removed HallucinationEvaluator/RelevanceEvaluator/etc. and LiteLLMModel)
           # TODO: drop the langchain-community<0.4.2 pin once ragas releases a
@@ -337,6 +393,34 @@ jobs:
           uv pip install \
             -r requirements/test-requirements.txt \
             deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]'
+          echo "::group::google-adk diagnostics after overlay install"
+          python - <<'PY'
+          import importlib.metadata as md
+          import traceback
+
+          try:
+              dist = md.distribution("google-adk")
+          except md.PackageNotFoundError:
+              print("google-adk=<not installed>")
+          else:
+              print(f"google-adk=={dist.version}")
+              print("Requires-Dist:")
+              for req in dist.metadata.get_all("Requires-Dist") or []:
+                  print(f"  {req}")
+              print("Provides-Extra:")
+              for extra in dist.metadata.get_all("Provides-Extra") or []:
+                  print(f"  {extra}")
+
+          try:
+              import google.adk  # noqa: F401
+
+              print("import google.adk: ok")
+          except Exception:
+              print("import google.adk: failed")
+              traceback.print_exc()
+          PY
+          uv pip tree --package google-adk || true
+          echo "::endgroup::"
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -421,6 +421,8 @@ jobs:
           PY
           uv pip tree --package google-adk || true
           echo "::endgroup::"
+          echo "Failing intentionally after google-adk CI diagnostics."
+          exit 1
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -375,6 +375,13 @@ jobs:
           uv run --no-sync python -m pip index versions google-adk || true
           echo "Direct google-adk[gcp] dry-run:"
           uv pip install --dry-run 'google-adk[gcp]' || true
+          echo "Direct google-adk[gcp] dry-run without PyTorch extra index:"
+          PIP_EXTRA_INDEX_URL= uv pip install --dry-run 'google-adk[gcp]' || true
+          echo "Direct google-adk[gcp] verbose dry-run:"
+          uv -v pip install --dry-run 'google-adk[gcp]' || true
+          echo "PyTorch extra index google-adk candidates:"
+          PIP_EXTRA_INDEX_URL= python -m pip index versions \
+            --index-url https://download.pytorch.org/whl/cpu google-adk || true
           echo "Direct google-adk[gcp]==2.4.0 dry-run:"
           uv pip install --dry-run 'google-adk[gcp]==2.4.0' || true
           echo "Direct google-adk[gcp] dry-run with --upgrade:"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -373,6 +373,33 @@ jobs:
               print("<none>")
           PY
           uv run --no-sync python -m pip index versions google-adk || true
+          echo "opentelemetry-resourcedetector-gcp candidates:"
+          python -m pip index versions --pre opentelemetry-resourcedetector-gcp || true
+          uv pip install --dry-run 'opentelemetry-resourcedetector-gcp>=1.9.0a0,<2' || true
+          uv pip install --dry-run --prerelease=allow 'opentelemetry-resourcedetector-gcp>=1.9.0a0,<2' || true
+          python - <<'PY'
+          import json
+          import urllib.request
+
+          package = "opentelemetry-resourcedetector-gcp"
+          with urllib.request.urlopen(f"https://pypi.org/pypi/{package}/json", timeout=30) as response:
+              data = json.load(response)
+
+          print(f"{package} PyPI JSON release metadata:")
+          for version in ["1.8.0a0", "1.9.0a0", "1.10.0a0", "1.11.0a0", "1.12.0a0"]:
+              files = data["releases"].get(version, [])
+              if not files:
+                  print(f"  {version}: <no files>")
+                  continue
+              for file in files:
+                  print(
+                      "  "
+                      f"{version}: yanked={file.get('yanked')} "
+                      f"requires_python={file.get('requires_python')!r} "
+                      f"upload_time={file.get('upload_time_iso_8601')} "
+                      f"filename={file.get('filename')}"
+                  )
+          PY
           echo "Direct google-adk[gcp] dry-run:"
           uv pip install --dry-run 'google-adk[gcp]' || true
           echo "Direct google-adk[gcp] dry-run without PyTorch extra index:"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -386,7 +386,14 @@ jobs:
               data = json.load(response)
 
           print(f"{package} PyPI JSON release metadata:")
-          for version in ["1.8.0a0", "1.9.0a0", "1.10.0a0", "1.11.0a0", "1.12.0a0"]:
+          for version in [
+              "1.8.0a0",
+              "1.9.0a0",
+              "1.10.0a0",
+              "1.11.0a0",
+              "1.12.0a0",
+              "1.13.0",
+          ]:
               files = data["releases"].get(version, [])
               if not files:
                   print(f"  {version}: <no files>")
@@ -411,6 +418,8 @@ jobs:
             --index-url https://download.pytorch.org/whl/cpu google-adk || true
           echo "Direct google-adk[gcp]==2.4.0 dry-run:"
           uv pip install --dry-run 'google-adk[gcp]==2.4.0' || true
+          echo "Direct google-adk[gcp]==2.4.0 dry-run with --prerelease=allow:"
+          uv pip install --dry-run --prerelease=allow 'google-adk[gcp]==2.4.0' || true
           echo "Direct google-adk[gcp] dry-run with --upgrade:"
           uv pip install --dry-run --upgrade 'google-adk[gcp]' || true
           echo "Direct google-adk[gcp] dry-run forcing compatible Starlette/OTel:"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -324,10 +324,12 @@ jobs:
           uv sync --extra genai
           echo "::group::google-adk resolver diagnostics before overlay install"
           uv --version
-          python - <<'PY'
+          uv run --no-sync python - <<'PY'
           import importlib.metadata as md
           import os
+          import sys
 
+          print(f"sys.executable={sys.executable}")
           for name in [
               "PIP_INDEX_URL",
               "PIP_EXTRA_INDEX_URL",
@@ -370,9 +372,15 @@ jobs:
           if not found:
               print("<none>")
           PY
-          python -m pip index versions google-adk || true
+          uv run --no-sync python -m pip index versions google-adk || true
           echo "Direct google-adk[gcp] dry-run:"
           uv pip install --dry-run 'google-adk[gcp]' || true
+          echo "Direct google-adk[gcp]==2.4.0 dry-run:"
+          uv pip install --dry-run 'google-adk[gcp]==2.4.0' || true
+          echo "Direct google-adk[gcp] dry-run with --upgrade:"
+          uv pip install --dry-run --upgrade 'google-adk[gcp]' || true
+          echo "Direct google-adk[gcp] dry-run forcing compatible Starlette/OTel:"
+          uv pip install --dry-run 'google-adk[gcp]' 'starlette<1' 'opentelemetry-api<=1.42.1' 'opentelemetry-sdk<=1.42.1' || true
           echo "Full GenAI overlay dry-run:"
           uv pip install --dry-run \
             -r requirements/test-requirements.txt \
@@ -394,10 +402,12 @@ jobs:
             -r requirements/test-requirements.txt \
             deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]'
           echo "::group::google-adk diagnostics after overlay install"
-          python - <<'PY'
+          uv run --no-sync python - <<'PY'
           import importlib.metadata as md
+          import sys
           import traceback
 
+          print(f"sys.executable={sys.executable}")
           try:
               dist = md.distribution("google-adk")
           except md.PackageNotFoundError:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24590

### What changes are proposed in this pull request?

This is a temporary diagnostics-only PR to capture real GitHub Actions resolver state for the GenAI CI failure where `google-adk[gcp]` installs as `google-adk==0.0.1` and `import google.adk` fails.

The GenAI dependency install step now prints resolver-relevant environment variables, installed versions before the overlay install, installed distributions that declare `Requires-Dist` entries containing `google-adk`, `pip index versions google-adk`, a direct `uv pip install --dry-run 'google-adk[gcp]'`, the full GenAI overlay dry-run, and the final installed `google-adk` metadata/import/tree after the real install.

This should tell us whether CI is seeing a different package index/candidate set, a constraint from the installed environment, or a resolver behavior difference that is not reproduced locally.

### How is this PR tested?

- [x] Manual tests

Inspected the workflow diff and pushed the diagnostics branch. The purpose of this PR is to run the real GenAI CI job and collect the emitted diagnostics.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
