### PR TITLE
Free more disk space in CI to fix flaky slow docker tests

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -10,12 +10,14 @@ runs:
         # Remove large pre-installed toolchains that MLflow jobs never use so that
         # disk-heavy steps (e.g. Docker image builds) have enough headroom. The
         # deletions run in parallel to save time, but we `wait` for them to finish
-        # so subsequent steps observe the reclaimed space.
-        sudo rm -rf /usr/local/lib/android &
-        sudo rm -rf /usr/share/dotnet &
-        sudo rm -rf /opt/ghc /usr/local/.ghcup &
-        sudo rm -rf /opt/hostedtoolcache/CodeQL &
-        sudo rm -rf /usr/local/share/boost &
+        # so subsequent steps observe the reclaimed space. Cleanup is best-effort:
+        # `|| true` keeps a failed removal from failing the job (GitHub Actions runs
+        # `shell: bash` with `-e`).
+        sudo rm -rf /usr/local/lib/android || true &
+        sudo rm -rf /usr/share/dotnet || true &
+        sudo rm -rf /opt/ghc /usr/local/.ghcup || true &
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true &
+        sudo rm -rf /usr/local/share/boost || true &
         wait
         echo "Disk usage after cleanup:"
         df -h /

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -5,5 +5,17 @@ runs:
   steps:
     - shell: bash
       run: |
-        # Run in background to save time
+        echo "Disk usage before cleanup:"
+        df -h /
+        # Remove large pre-installed toolchains that MLflow jobs never use so that
+        # disk-heavy steps (e.g. Docker image builds) have enough headroom. The
+        # deletions run in parallel to save time, but we `wait` for them to finish
+        # so subsequent steps observe the reclaimed space.
         sudo rm -rf /usr/local/lib/android &
+        sudo rm -rf /usr/share/dotnet &
+        sudo rm -rf /opt/ghc /usr/local/.ghcup &
+        sudo rm -rf /opt/hostedtoolcache/CodeQL &
+        sudo rm -rf /usr/local/share/boost &
+        wait
+        echo "Disk usage after cleanup:"
+        df -h /


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `MLflow Slow Tests` workflow (`docker-build` group 1) has been failing almost every day because the CI runner **runs out of disk space** during the pyfunc docker image builds. Two tests fail, both from the same root cause:

- `test_build_image_and_serve[transformers_pt]` → `RuntimeError: Docker build failed.`, caused by `OSError: [Errno 28] No space left on device` during the in-image `pip install`.
- `test_build_image_and_serve[spark]` → `Failed: Timeout (>1200.0s)` while blocked in `docker build`, as the build stalls under disk pressure and never completes.

The disk telemetry in the logs shows the runner starting at ~58/72 GB used (~13 GB free) before any test runs. The heaviest torch-based builds (`pytorch`, `spark`, `transformers_pt`) all cluster into pytest-split group 1 and exhaust the remaining space.

The `free-disk-space` composite action was the bottleneck — it only removed the Android SDK, and even that ran in a background subshell (`&`) that was **never waited on**, so it might not finish before the disk-heavy docker builds start.

This PR expands the action to also remove the large pre-installed toolchains that MLflow's jobs never use (.NET, Haskell/GHC, CodeQL, boost) and adds a `wait` so the deletions complete before subsequent steps run. `df -h` output is printed before and after for observability. I verified via grep that no workflow or action in the repo references any of the removed toolchains, so this is safe for all consumers of the shared action.

### How is this PR tested?

- [x] Existing unit/integration tests

The change is CI infrastructure only. The existing `MLflow Slow Tests` workflow exercises it; the failing `docker-build` group 1 should go green once the runner has enough disk headroom.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.