### PR TITLE
Surface truncated assistant streams as errors instead of a silent `done`

### DIFF
--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -484,6 +484,18 @@ class OpenAICompatibleProvider(AssistantProvider):
                             # gateway route backed by Anthropic makes /v1/messages reject the
                             # request with 400 "stream_options: Extra inputs are not permitted".
                         }
+                        # The gateway commits a 200 before proxying upstream, so an upstream
+                        # failure (e.g. a bad API key → 401) surfaces as a truncated body
+                        # rather than a non-200 status. We can't rely on a positive completion
+                        # signal to detect this: `[DONE]` is stripped by the gateway and not
+                        # every OpenAI-compatible server emits it or a `finish_reason`. So key
+                        # on whether the stream yielded anything meaningful — content, tool
+                        # calls, or a normal terminal. If it stays false the stream was empty
+                        # and unterminated (the common case: auth failure before any token
+                        # streams) and we surface an error instead of a silent `done`. Any
+                        # signal at all counts as success, so no productive turn is ever
+                        # falsely flagged whatever the server's terminator conventions.
+                        stream_had_signal = False
                         async with session.post(
                             chat_url,
                             json=payload,
@@ -506,6 +518,7 @@ class OpenAICompatibleProvider(AssistantProvider):
                                 if line.startswith(b"data:"):
                                     line = line[len(b"data:") :].strip()
                                 if line == b"[DONE]":
+                                    stream_had_signal = True
                                     continue
                                 if not line or line.startswith(b":"):
                                     continue
@@ -515,17 +528,43 @@ class OpenAICompatibleProvider(AssistantProvider):
                                     _logger.debug("Skipping non-JSON stream line: %r", line)
                                     continue
 
+                                # An error frame surfaces a mid-stream failure the gateway
+                                # committed a 200 before hitting (e.g. an upstream error caught
+                                # by safe_stream, which emits `{"error": {"message", "type"}}`).
+                                # Surface its real message rather than falling through to the
+                                # generic empty-response error below, which would both discard
+                                # the true cause and misattribute it.
+                                if error := chunk.get("error"):
+                                    stream_had_signal = True
+                                    message = (
+                                        error.get("message") if isinstance(error, dict) else error
+                                    )
+                                    yield Event.from_error(
+                                        f"{self._display_name} error: {message}"
+                                        if message
+                                        else f"{self._display_name} returned an error: {error}"
+                                    )
+                                    return
+
                                 # The usage-only chunk has no choices; emit it so the UI
-                                # can track token consumption and cost, then move on.
+                                # can track token consumption and cost, then move on. A usage
+                                # summary means the server processed the request and reported
+                                # real work, so it counts as a signal — a stream whose only
+                                # payload is usage (some backends send it after a [DONE] the
+                                # gateway strips) must not be flagged as truncated.
                                 if usage := chunk.get("usage"):
+                                    stream_had_signal = True
                                     yield _build_usage_event(usage, model)
 
                                 choices = chunk.get("choices") or []
+                                if choices and choices[0].get("finish_reason"):
+                                    stream_had_signal = True
                                 if not choices:
                                     continue
                                 delta = choices[0].get("delta") or {}
 
                                 if text := delta.get("content") or "":
+                                    stream_had_signal = True
                                     think_buf += text
                                     emit, think_buf, in_think = _strip_think_blocks(
                                         think_buf, in_think
@@ -538,8 +577,17 @@ class OpenAICompatibleProvider(AssistantProvider):
                                         })
 
                                 if tcs := delta.get("tool_calls"):
+                                    stream_had_signal = True
                                     for tc in tcs:
                                         _merge_tool_call_chunk(tool_calls_acc, tc)
+
+                        if not stream_had_signal:
+                            yield Event.from_error(
+                                f"{self._display_name} returned an empty response and ended "
+                                "unexpectedly. The upstream provider likely failed before "
+                                "producing any output (e.g. an invalid API key or a rate limit)."
+                            )
+                            return
 
                         if not tool_calls_acc:
                             if visible_text:

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -435,6 +435,134 @@ async def test_astream_yields_error_on_http_error(provider):
     assert "boom" in errors[0].data["error"]
 
 
+@pytest.mark.asyncio
+async def test_astream_yields_error_on_empty_truncated_stream(provider):
+    # The gateway commits a 200 before proxying upstream, so an upstream failure
+    # (e.g. a bad API key) truncates the body instead of returning a non-200. When
+    # the failure happens before any token streams, the body is empty and ends with
+    # no terminal signal: surface an error rather than a silent `done`.
+    lines: list[bytes] = []
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    errors = [e for e in events if e.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "empty response" in errors[0].data["error"]
+    assert not any(e.type == EventType.DONE for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_surfaces_gateway_error_chunk(provider):
+    # When an upstream failure happens mid-stream (after the gateway committed a
+    # 200), safe_stream emits `data: {"error": {"message", "type"}}`. We must
+    # surface that real message, not discard it and fall through to the generic
+    # empty-response error, which would misattribute the cause (e.g. blame a bad
+    # API key when the key was valid and something else failed).
+    lines = [_sse({"error": {"message": "Rate limit exceeded", "type": "RateLimitError"}})]
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    errors = [e for e in events if e.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "Rate limit exceeded" in errors[0].data["error"]
+    assert "empty response" not in errors[0].data["error"]
+    assert not any(e.type == EventType.DONE for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_error_chunk_without_message_falls_back_to_raw(provider):
+    # A malformed error frame (no usable "message") must still surface something
+    # concrete rather than "error: None" or the misleading generic empty-response text.
+    lines = [_sse({"error": {"code": 500}})]
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    errors = [e for e in events if e.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "None" not in errors[0].data["error"]
+    assert "500" in errors[0].data["error"]
+    assert not any(e.type == EventType.DONE for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_productive_stream_without_terminal_is_not_flagged(provider):
+    # Key false-positive guard: an OpenAI-compatible server that streams content but
+    # emits neither [DONE] nor a finish_reason (out of spec, but real) must NOT be
+    # flagged as truncated. Any produced output is treated as a successful turn.
+    lines = [_sse(_delta(content="a complete answer"))]
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    assert not any(e.type == EventType.ERROR for e in events)
+    assert any(e.type == EventType.DONE for e in events)
+    # Also assert the content actually streamed through — otherwise a regression that
+    # silently dropped the delta would still pass the no-error / done checks above.
+    deltas = [e.data["event"]["delta"]["text"] for e in events if e.type == EventType.STREAM_EVENT]
+    assert deltas == ["a complete answer"]
+
+
+@pytest.mark.asyncio
+async def test_astream_empty_stream_with_terminal_is_not_flagged(provider):
+    # An intentionally empty completion that still signals a normal terminal
+    # ([DONE] or finish_reason) is a valid turn, not a truncation.
+    lines = [_sse({"choices": [{"delta": {}, "index": 0, "finish_reason": "stop"}]})]
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    assert not any(e.type == EventType.ERROR for e in events)
+    assert any(e.type == EventType.DONE for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_usage_only_stream_is_not_flagged(provider):
+    # Some backends emit a trailing usage-summary chunk (choices empty) after a
+    # [DONE] the gateway strips. A usage report means the server did real work,
+    # so it counts as a signal and must not be flagged as truncated.
+    lines = [_sse({"choices": [], "usage": {"prompt_tokens": 3, "completion_tokens": 5}})]
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    assert not any(e.type == EventType.ERROR for e in events)
+    assert any(e.type == EventType.DONE for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_role_only_stream_is_flagged(provider):
+    # A stream whose ONLY chunk is a role preamble (no content, tool_calls,
+    # finish_reason, or [DONE]) and then closes is a truncation, not a completion:
+    # the server opened a message and dropped the connection before finishing it.
+    # This is intentionally flagged; a role delta alone is not treated as signal.
+    lines = [_sse({"choices": [{"delta": {"role": "assistant"}, "index": 0}]})]
+    session, _calls = _make_aiohttp_session([lines])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    errors = [e for e in events if e.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "empty response" in errors[0].data["error"]
+    assert not any(e.type == EventType.DONE for e in events)
+
+
 # ---------------------------------------------------------------------------
 # astream — tool call round trip
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/pull/24582

### What changes are proposed in this pull request?

I encountered this papercut while testing https://github.com/mlflow/mlflow/pull/24582

The MLflow AI Gateway commits a `200 OK` before proxying upstream, so an upstream failure mid-stream (e.g. an invalid API key returning 401, a rate limit, or a network drop) arrives as a **truncated response body** rather than a non-200 status. In `OpenAICompatibleProvider.astream`, the `resp.status != 200` guard only catches pre-stream failures, so the read loop fell through and emitted a plain `done` terminal with no content and no error — the chat UI showed a silent, empty turn.

This tracks whether the stream reaches a normal terminal (a `[DONE]` sentinel or a chunk carrying `finish_reason`); if the body ends without one, we assume an error. 



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

For testing, I applied the changes on top of https://github.com/mlflow/mlflow/pull/24582

Before

<img width="439" height="942" alt="Screenshot 2026-07-23 at 5 46 31 PM" src="https://github.com/user-attachments/assets/ba71f4aa-ec27-42a5-adc8-5caa2ddd12d8" />

After

<img width="442" height="939" alt="Screenshot 2026-07-24 at 12 47 25 AM" src="https://github.com/user-attachments/assets/37751ba5-d3d2-4015-b2e8-d938efa24e9d" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The assistant chat now shows an error when the upstream provider fails mid-stream, instead of silently returning an empty response.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with Claude Code