### PR TITLE
[build] Fix Google ADK dependency install in GenAI CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -334,9 +334,13 @@ jobs:
           # unpinned install backtracks to the ancient 0.1.8 (imports the
           # removed openai.error). Restore it once upstream lifts the pins.
           # https://github.com/guardrails-ai/guardrails/issues/1505
+          # Avoid google-adk[gcp] here: its OTel GCP deps include prereleases,
+          # and UV_EXCLUDE_NEWER=P7D can make uv backtrack to google-adk==0.0.1
+          # when a new stable OTel GCP release is still cooldown-excluded. These
+          # tests need google-adk plus vertexai imports from google-cloud-aiplatform.
           uv pip install \
             -r requirements/test-requirements.txt \
-            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm 'google-adk[gcp]'
+            deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm google-adk google-cloud-aiplatform
       - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24599

### What changes are proposed in this pull request?

This updates the GenAI CI dependency install to avoid `google-adk[gcp]`. That extra pulls Google Cloud OpenTelemetry packages, including `opentelemetry-resourcedetector-gcp` and the GCP exporters such as `opentelemetry-exporter-gcp-logging` / `opentelemetry-exporter-gcp-monitoring`.

The CI failure was triggered after `opentelemetry-resourcedetector-gcp==1.13.0` was published as the first stable release for that package. MLflow CI runs with `UV_EXCLUDE_NEWER=P7D`, so uv could see that stable release but could not install it yet. The previously working resolution for current `google-adk[gcp]` used prerelease OTel GCP packages, for example `opentelemetry-resourcedetector-gcp==1.12.0a0`. Once a stable version existed but was cooldown-excluded, uv no longer accepted the transitive prerelease path by default and backtracked all the way to `google-adk==0.0.1`, which does not provide `google.adk`.

The GenAI tests do not need the full `google-adk[gcp]` extra. They need ADK evaluation APIs plus the `vertexai` import used by ADK's safety evaluator, so CI now installs base `google-adk` plus `google-cloud-aiplatform` instead of the broader `gcp` extra.

### How is this PR tested?

- [x] Manual tests

```bash
git diff --check
uv run --no-project --exclude-newer P7D --with google-adk --with google-cloud-aiplatform --with pandas python -c "import pandas; import google.adk; import vertexai; from google.adk.evaluation.safety_evaluator import SafetyEvaluatorV1; from google.adk.evaluation.hallucinations_v1 import HallucinationsV1Evaluator; print('ok')"
```

The import probe includes `pandas` because it is part of MLflow's core test environment and ADK's safety evaluator imports it before reaching the `vertexai` dependency.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release