### PR TITLE
Lift Assistant floating button above bottom-pinned action bars

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
@@ -8,6 +8,7 @@ import { AssistantFloatingButton } from './AssistantFloatingButton';
 const mockOpenPanel = jest.fn();
 let mockAssistant: { isLocalServer: boolean; isPanelOpen: boolean; openPanel: jest.Mock };
 let mockObstructionWidth: number;
+let mockObstructionHeight: number;
 
 jest.mock('./AssistantContext', () => ({
   useAssistant: () => mockAssistant,
@@ -15,6 +16,7 @@ jest.mock('./AssistantContext', () => ({
 
 jest.mock('./useFloatingObstruction', () => ({
   useFloatingObstructionWidth: () => mockObstructionWidth,
+  useFloatingObstructionHeight: () => mockObstructionHeight,
 }));
 
 jest.mock('../telemetry/hooks/useLogTelemetryEvent', () => ({
@@ -34,6 +36,7 @@ describe('AssistantFloatingButton', () => {
     mockOpenPanel.mockClear();
     mockAssistant = { isLocalServer: true, isPanelOpen: false, openPanel: mockOpenPanel };
     mockObstructionWidth = 0;
+    mockObstructionHeight = 0;
   });
 
   test('auto-opens the panel once on first load', () => {
@@ -78,6 +81,14 @@ describe('AssistantFloatingButton', () => {
   test('stays visible (repositioned) when a right-side surface is open', () => {
     mockObstructionWidth = 600;
     renderFab();
+    expect(screen.getByRole('button', { name: 'MLflow Assistant' })).toBeInTheDocument();
+  });
+
+  test('lifts (stays visible) when a bottom-pinned action bar is registered', () => {
+    mockObstructionHeight = 80;
+    renderFab();
+    // The button rises above the bar rather than hiding; the bottom-inset math runs with a
+    // real number (regression guard: an undefined height would make `bottom` NaN).
     expect(screen.getByRole('button', { name: 'MLflow Assistant' })).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
@@ -9,7 +9,7 @@ import {
 import { FormattedMessage } from 'react-intl';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { useAssistant } from './AssistantContext';
-import { useFloatingObstructionWidth } from './useFloatingObstruction';
+import { useFloatingObstructionHeight, useFloatingObstructionWidth } from './useFloatingObstruction';
 import { useLogTelemetryEvent } from '../telemetry/hooks/useLogTelemetryEvent';
 
 // Width the pill expands to on hover; also used to keep it on-screen when shifted left.
@@ -49,6 +49,7 @@ export const AssistantFloatingButton = () => {
   const { theme } = useDesignSystemTheme();
   const { isLocalServer, isPanelOpen, openPanel } = useAssistant();
   const obstructionWidth = useFloatingObstructionWidth();
+  const obstructionHeight = useFloatingObstructionHeight();
   const windowWidth = useWindowWidth();
   const logTelemetryEvent = useLogTelemetryEvent();
   const viewId = useMemo(() => uuidv4(), []);
@@ -85,6 +86,12 @@ export const AssistantFloatingButton = () => {
   // (expandable) button can't sit clear of it, yield entirely rather than float on top —
   // the surface has its own assistant entry (e.g. the trace drawer's header button).
   const rightInset = obstructionWidth > 0 ? obstructionWidth + theme.spacing.md : baseInset;
+  // Rise just above a bottom-pinned surface (e.g. a Cancel/Create action bar) so it never
+  // overlaps the page's primary buttons. Independent of the right shift above: with both a
+  // right drawer and a bottom bar open, the button shifts left AND lifts. No "does it fit"
+  // gate here — an action bar is short enough that lifting is always feasible (unlike a wide
+  // drawer, which can leave no horizontal room and forces the fade-out below).
+  const bottomInset = obstructionHeight > 0 ? obstructionHeight + theme.spacing.md : baseInset;
   const fitsClearOfObstruction = rightInset + FAB_EXPANDED_MAX_WIDTH + theme.spacing.md <= windowWidth;
   // When the surface is too wide for the button to sit clear, fade it out (kept mounted so
   // the transition can play) rather than overlapping the surface.
@@ -172,7 +179,8 @@ export const AssistantFloatingButton = () => {
       data-assistant-ui="true"
       css={{
         position: 'fixed',
-        bottom: baseInset,
+        // Rests on the bottom inset; rises above any bottom-pinned action bar that registers.
+        bottom: bottomInset,
         // Sits just left of any open right-side surface (e.g. a drawer) so it stays
         // visible without overlapping; otherwise rests in the bottom-right corner.
         right: rightInset,
@@ -184,7 +192,10 @@ export const AssistantFloatingButton = () => {
         visibility: hiddenByObstruction ? 'hidden' : 'visible',
         pointerEvents: hiddenByObstruction ? 'none' : 'auto',
         '@media (prefers-reduced-motion: no-preference)': {
-          transition: hiddenByObstruction ? 'opacity 0.15s ease, visibility 0s 0.15s' : 'opacity 0.15s ease',
+          // Animate the lift/shift (bottom/right) alongside the fade so repositioning is smooth.
+          transition: hiddenByObstruction
+            ? 'opacity 0.15s ease, visibility 0s 0.15s, bottom 0.2s ease, right 0.2s ease'
+            : 'opacity 0.15s ease, bottom 0.2s ease, right 0.2s ease',
         },
       }}
     >

--- a/mlflow/server/js/src/assistant/useFloatingObstruction.ts
+++ b/mlflow/server/js/src/assistant/useFloatingObstruction.ts
@@ -1,16 +1,22 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import type { RefObject } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { create } from '@databricks/web-shared/zustand';
 
 interface FloatingObstructionStore {
   /** id -> width (px) reserved on the right edge by an open surface (e.g. a drawer). */
   obstructions: Record<string, number>;
+  /** id -> height (px) reserved on the bottom edge by a pinned surface (e.g. an action bar). */
+  bottomObstructions: Record<string, number>;
   setObstruction: (id: string, reservedRightPx: number) => void;
   removeObstruction: (id: string) => void;
+  setBottomObstruction: (id: string, reservedBottomPx: number) => void;
+  removeBottomObstruction: (id: string) => void;
 }
 
 const useFloatingObstructionStore = create<FloatingObstructionStore>((set) => ({
   obstructions: {},
+  bottomObstructions: {},
   setObstruction: (id, reservedRightPx) =>
     set((state) => ({ obstructions: { ...state.obstructions, [id]: reservedRightPx } })),
   removeObstruction: (id) =>
@@ -21,6 +27,23 @@ const useFloatingObstructionStore = create<FloatingObstructionStore>((set) => ({
       const next = { ...state.obstructions };
       delete next[id];
       return { obstructions: next };
+    }),
+  setBottomObstruction: (id, reservedBottomPx) =>
+    set((state) => {
+      // No-op when unchanged so the per-render measure (useLayoutEffect) doesn't churn the store.
+      if (state.bottomObstructions[id] === reservedBottomPx) {
+        return state;
+      }
+      return { bottomObstructions: { ...state.bottomObstructions, [id]: reservedBottomPx } };
+    }),
+  removeBottomObstruction: (id) =>
+    set((state) => {
+      if (!(id in state.bottomObstructions)) {
+        return state;
+      }
+      const next = { ...state.bottomObstructions };
+      delete next[id];
+      return { bottomObstructions: next };
     }),
 }));
 
@@ -49,4 +72,86 @@ export const useFloatingObstructionWidth = (): number =>
   useFloatingObstructionStore((state) => {
     const widths = Object.values(state.obstructions);
     return widths.length > 0 ? Math.max(...widths) : 0;
+  });
+
+// Rough height of the corner zone the resting FAB occupies (its bottom inset + a control-sized
+// bubble + slack). A bar counts as obstructing only when its bottom edge reaches down into this
+// zone — i.e. it is genuinely pinned near the viewport bottom. A `position: sticky; bottom: 0`
+// footer floats mid-page while its scroll container has slack (bottom far above this zone) and
+// drops into it only once the content overflows and the footer sticks; a footer anchored to a
+// full-height container is always in the zone. This cleanly separates "pinned" from "floating"
+// without depending on the page's exact bottom inset.
+const FAB_CORNER_ZONE_PX = 64;
+
+/**
+ * Register that some surface (e.g. a bottom-pinned action bar) is currently occupying the
+ * bottom edge of the viewport, so the floating Assistant button can rise clear of it instead
+ * of overlapping its buttons. Pass a ref to the surface's outer element; while its bottom edge
+ * sits within the FAB's corner zone it reserves the distance from its TOP up to the viewport
+ * bottom (`innerHeight - rect.top`) — not its raw height, so the button clears the bar's top
+ * even when the bar's scroll container is inset above `bottom: 0`. Re-measures on resize
+ * (content-driven bars can wrap) and on scroll (a sticky footer pins/unpins as its container
+ * scrolls). Deregisters automatically on unmount or when it floats up off the bottom.
+ *
+ * Ref-based (not a raw px) on purpose: the bottom bars have dynamic heights (wrapping status
+ * text, conditional padding) and variable insets, so a hardcoded number would drift out of
+ * date. The store still holds a number internally, symmetric with the right-edge axis.
+ */
+export const useRegisterFloatingBottomObstruction = (ref: RefObject<HTMLElement>) => {
+  const id = useMemo(() => uuidv4(), []);
+  const setBottomObstruction = useFloatingObstructionStore((state) => state.setBottomObstruction);
+  const removeBottomObstruction = useFloatingObstructionStore((state) => state.removeBottomObstruction);
+
+  const measure = useCallback(() => {
+    const element = ref.current;
+    if (!element) {
+      removeBottomObstruction(id);
+      return;
+    }
+    const rect = element.getBoundingClientRect();
+    const pinnedToBottom = rect.bottom >= window.innerHeight - FAB_CORNER_ZONE_PX;
+    // Reserve up to the bar's top so the FAB clears it regardless of any inset below the bar.
+    const reservedBottomPx = window.innerHeight - rect.top;
+    if (pinnedToBottom && rect.height > 0 && reservedBottomPx > 0) {
+      setBottomObstruction(id, reservedBottomPx);
+    } else {
+      removeBottomObstruction(id);
+    }
+  }, [id, ref, setBottomObstruction, removeBottomObstruction]);
+
+  // Re-measure on every render (pre-paint, so the button never flashes overlapping). A sticky
+  // footer pins/unpins when *sibling* content grows or shrinks — e.g. adding a Playground
+  // message pushes the footer down until it sticks. That changes the bar's position but not its
+  // size and fires no scroll/resize event, so ResizeObserver and the listeners below can't see
+  // it; the host component re-renders on that content change, so a layout effect is what
+  // reliably catches it. measure() no-ops in the store when the reserved value is unchanged.
+  useLayoutEffect(measure);
+
+  // Backstops for changes that happen without a re-render of this component: the bar resizing
+  // its own content, and viewport scroll/resize.
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    // Capture-phase scroll so we also see scrolling inside nested scroll containers (a sticky
+    // footer lives in one), not just window scroll.
+    window.addEventListener('scroll', measure, true);
+    window.addEventListener('resize', measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', measure, true);
+      window.removeEventListener('resize', measure);
+      removeBottomObstruction(id);
+    };
+  }, [id, ref, measure, removeBottomObstruction]);
+};
+
+/** The tallest reservation (px) currently held on the bottom edge, or 0 if none. */
+export const useFloatingObstructionHeight = (): number =>
+  useFloatingObstructionStore((state) => {
+    const heights = Object.values(state.bottomObstructions);
+    return heights.length > 0 ? Math.max(...heights) : 0;
   });

--- a/mlflow/server/js/src/assistant/useFloatingObstruction.ts
+++ b/mlflow/server/js/src/assistant/useFloatingObstruction.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import type { RefObject } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { create } from '@databricks/web-shared/zustand';
@@ -111,7 +111,9 @@ export const useRegisterFloatingBottomObstruction = (ref: RefObject<HTMLElement>
     const rect = element.getBoundingClientRect();
     const pinnedToBottom = rect.bottom >= window.innerHeight - FAB_CORNER_ZONE_PX;
     // Reserve up to the bar's top so the FAB clears it regardless of any inset below the bar.
-    const reservedBottomPx = window.innerHeight - rect.top;
+    // Cap at the viewport height so a bar taller than the viewport (top above y=0) can't push
+    // the button off-screen — at most it rides at the very top.
+    const reservedBottomPx = Math.min(window.innerHeight - rect.top, window.innerHeight);
     if (pinnedToBottom && rect.height > 0 && reservedBottomPx > 0) {
       setBottomObstruction(id, reservedBottomPx);
     } else {
@@ -137,12 +139,13 @@ export const useRegisterFloatingBottomObstruction = (ref: RefObject<HTMLElement>
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     // Capture-phase scroll so we also see scrolling inside nested scroll containers (a sticky
-    // footer lives in one), not just window scroll.
-    window.addEventListener('scroll', measure, true);
+    // footer lives in one), not just window scroll. Passive: measure never preventDefaults.
+    const scrollOpts = { capture: true, passive: true } as const;
+    window.addEventListener('scroll', measure, scrollOpts);
     window.addEventListener('resize', measure);
     return () => {
       observer.disconnect();
-      window.removeEventListener('scroll', measure, true);
+      window.removeEventListener('scroll', measure, scrollOpts);
       window.removeEventListener('resize', measure);
       removeBottomObstruction(id);
     };

--- a/mlflow/server/js/src/common/components/AssistantAwareActionBar.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareActionBar.tsx
@@ -1,0 +1,31 @@
+/**
+ * AssistantAwareActionBar: a transparent wrapper for a bottom-pinned action bar (e.g. a
+ * Cancel/Create or Cancel/Save footer) that registers its height with the floating-obstruction
+ * store, so the Assistant floating button rises above it instead of overlapping its buttons.
+ *
+ * It is deliberately layout-neutral: it renders a single element, imposes no positioning of its
+ * own, and forwards the caller's `css`/props unchanged. Callers keep whatever pins the bar
+ * (`position: sticky; bottom: 0`, a flex `flexShrink: 0` footer, etc.) — this only measures the
+ * rendered element (via ResizeObserver, so wrapping status text or conditional padding stays in
+ * sync) and reports its height while mounted. When the bar unmounts (e.g. a footer that only
+ * renders while a form has changes), the reservation is released automatically.
+ *
+ * Mirrors the AssistantAwareDrawer convention on the vertical axis.
+ */
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
+import { useRegisterFloatingBottomObstruction } from '../../assistant/useFloatingObstruction';
+
+export const AssistantAwareActionBar = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
+  function AssistantAwareActionBar({ children, ...rest }, forwardedRef) {
+    const ref = useRef<HTMLDivElement>(null);
+    // Keep our own ref for measuring while still honoring a caller-provided ref.
+    useImperativeHandle(forwardedRef, () => ref.current as HTMLDivElement);
+    useRegisterFloatingBottomObstruction(ref);
+    return (
+      <div ref={ref} {...rest}>
+        {children}
+      </div>
+    );
+  },
+);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordDetailFooter.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordDetailFooter.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Button, Spinner, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
+import { AssistantAwareActionBar } from '../../../../common/components/AssistantAwareActionBar';
 
 export type SaveStatus = 'clean' | 'dirty' | 'invalid' | 'empty-inputs' | 'saving' | 'saved' | 'error';
 
@@ -98,7 +99,7 @@ export const DatasetRecordDetailFooter = ({
   const canDiscard = status === 'dirty' || status === 'invalid' || status === 'empty-inputs' || status === 'error';
 
   return (
-    <div
+    <AssistantAwareActionBar
       css={{
         // Horizontal padding comes from the side panel's footer wrapper; we only own the
         // top gap that separates the divider from the buttons here.
@@ -145,6 +146,6 @@ export const DatasetRecordDetailFooter = ({
           />
         )}
       </Button>
-    </div>
+    </AssistantAwareActionBar>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/playground/PlaygroundPage.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
+import { AssistantAwareActionBar } from '../../../common/components/AssistantAwareActionBar';
 import { PlaygroundTopBar } from './components/PlaygroundTopBar';
 import { PromptInputPanel } from './components/PromptInputPanel';
 import { PromptRegistryPicker } from './components/PromptRegistryPicker';
@@ -354,7 +355,7 @@ const PlaygroundPage = () => {
               />
             );
           })()}
-        <div
+        <AssistantAwareActionBar
           css={{
             display: 'flex',
             justifyContent: 'flex-end',
@@ -427,7 +428,7 @@ const PlaygroundPage = () => {
               />
             );
           })()}
-        </div>
+        </AssistantAwareActionBar>
       </div>
 
       <PromptRegistryPicker

--- a/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/edit-endpoint/EditEndpointFormRenderer.tsx
@@ -19,6 +19,7 @@ import GatewayRoutes from '../../routes';
 import Routes from '../../../experiment-tracking/routes';
 import { SETTINGS_SECTION_LLM_CONNECTIONS } from '../../../settings/settingsSectionConstants';
 import { GatewayLabel } from '../../../common/components/GatewayNewTag';
+import { AssistantAwareActionBar } from '../../../common/components/AssistantAwareActionBar';
 import { LongFormSummary } from '../../../common/components/long-form/LongFormSummary';
 import type { EditEndpointFormData } from '../../hooks/useEditEndpointForm';
 import { TrafficSplitConfigurator } from './TrafficSplitConfigurator';
@@ -583,7 +584,7 @@ export const EditEndpointFormRenderer = ({
       </Tabs.Root>
 
       {hasChanges && activeTab === 'overview' && (
-        <div
+        <AssistantAwareActionBar
           css={{
             display: 'flex',
             justifyContent: 'flex-end',
@@ -622,7 +623,7 @@ export const EditEndpointFormRenderer = ({
               <FormattedMessage defaultMessage="Save changes" description="Save changes button" />
             </Button>
           </Tooltip>
-        </div>
+        </AssistantAwareActionBar>
       )}
     </div>
   );

--- a/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
+++ b/mlflow/server/js/src/gateway/components/endpoint-form/EndpointFormRenderer.tsx
@@ -12,6 +12,7 @@ import type { ApiKeyConfiguration, SecretMode } from '../model-configuration/typ
 import { formatProviderName } from '../../utils/providerUtils';
 import { LongFormSection } from '../../../common/components/long-form/LongFormSection';
 import { LongFormSummary } from '../../../common/components/long-form/LongFormSummary';
+import { AssistantAwareActionBar } from '../../../common/components/AssistantAwareActionBar';
 import type { CodingAgentType, ProviderModel, SecretInfo } from '../../types';
 import { formatTokens, formatCost } from '../../utils/formatters';
 import { getModelCapabilities } from '../../utils/getModelCapabilities';
@@ -396,7 +397,7 @@ export const EndpointFormRenderer = ({
       </div>
 
       {/* Footer buttons */}
-      <div
+      <AssistantAwareActionBar
         css={{
           display: 'flex',
           justifyContent: 'flex-end',
@@ -424,7 +425,7 @@ export const EndpointFormRenderer = ({
             )}
           </Button>
         </Tooltip>
-      </div>
+      </AssistantAwareActionBar>
     </>
   );
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The global Assistant floating button (FAB) is pinned bottom-right and only knew how to dodge right-side drawers via a horizontal obstruction registry (`useFloatingObstruction`). It had no bottom-edge awareness, so it overlapped bottom-pinned action bars (`Cancel`/`Create`, `Cancel`/`Save`) and covered the page's primary button.

This PR adds a parallel **vertical axis** to the obstruction store so the FAB rises above the tallest registered action bar:

The measurement is geometry-aware, not presence-based:
- It reserves the distance up to the bar's **top** (`innerHeight - rect.top`), not the raw height, so the FAB clears the bar regardless of any page bottom-inset.

Registered collision sites (4): Create endpoint, Edit endpoint, Playground, and the eval-dataset record side panel. I'm not a big fan of this approach, because there's nothing enforcing the that FAB doesn't collide with the bottom action row. 

But the ideal solution would be: A container-scoped page-footer slot would make this collision structurally impossible (no measurement needed), but that is a much larger page-chrome refactor across ~30+ pages and is out of scope here.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Dataset Page

https://github.com/user-attachments/assets/2230568e-e094-4a65-b4d9-ce3dd82e731e

Playground Page

https://github.com/user-attachments/assets/809056da-194c-4720-a77f-4c0326be67a8


Endpoint Creation Page

https://github.com/user-attachments/assets/145822c4-3be8-4f56-a48e-a5df5920faf0

Endpoint Edit Page

https://github.com/user-attachments/assets/2a8775fe-0001-4c95-91ab-d364a67312e1


Tested that this new action bar is responsive to resizing

https://github.com/user-attachments/assets/381e11c3-bec7-4b48-8f34-f65d150b12d9






### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow Assistant floating button no longer overlaps bottom-of-page action bars (e.g. `Cancel`/`Create`); it now rises above them.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release