### PR TITLE
fix: prevent 'Table already exists' error during DB upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,9 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Use checkfirst=True to avoid 'Table already exists' errors if any tables
+    # were already created by a previous migration or partial initialization.
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after updating from 3.7.0 to 3.8.x, the upgrade fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)`, which attempts to create all tables defined in the ORM models, including those already created by a previous migration (e.g., the `secrets` table added in a 3.8.x migration).

## Fix
Use `checkfirst=True` in the `create_all` call, which makes SQLAlchemy check if each table exists before attempting to create it. This is the standard way to safely create tables in SQLAlchemy and avoids the conflict with existing tables.

Closes #19943