### PR TITLE
Support Databricks scorer versioned registration and scheduling

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -905,7 +905,12 @@ class Scorer(BaseModel):
 
         self._check_can_be_registered()
 
-        if sampling_config.sample_rate is not None and sampling_config.sample_rate <= 0:
+        sample_rate = sampling_config.sample_rate
+        if not isinstance(sample_rate, (int, float)):
+            raise MlflowException.invalid_parameter_value(
+                "When starting a scorer, provided sample rate must be a number"
+            )
+        if sample_rate <= 0:
             raise MlflowException.invalid_parameter_value(
                 "When starting a scorer, provided sample rate must be greater than 0"
             )
@@ -914,10 +919,10 @@ class Scorer(BaseModel):
         store = _get_scorer_store()
 
         if isinstance(store, DatabricksStore):
-            return DatabricksStore.update_registered_scorer(
+            return store.update_registered_scorer(
                 name=scorer_name,
                 scorer=self,
-                sample_rate=sampling_config.sample_rate,
+                sample_rate=sample_rate,
                 filter_string=sampling_config.filter_string,
                 experiment_id=experiment_id,
             )
@@ -930,7 +935,7 @@ class Scorer(BaseModel):
         return store.upsert_online_scoring_config(
             scorer=self,
             experiment_id=exp_id,
-            sample_rate=sampling_config.sample_rate,
+            sample_rate=sample_rate,
             filter_string=sampling_config.filter_string,
         )
 
@@ -993,14 +998,20 @@ class Scorer(BaseModel):
 
         self._check_can_be_registered()
 
+        sample_rate = sampling_config.sample_rate
+        if sample_rate is not None and not isinstance(sample_rate, (int, float)):
+            raise MlflowException.invalid_parameter_value(
+                "When updating a scorer, provided sample rate must be a number"
+            )
+
         scorer_name = name or self.name
         store = _get_scorer_store()
 
         if isinstance(store, DatabricksStore):
-            return DatabricksStore.update_registered_scorer(
+            return store.update_registered_scorer(
                 name=scorer_name,
                 scorer=self,
-                sample_rate=sampling_config.sample_rate,
+                sample_rate=sample_rate,
                 filter_string=sampling_config.filter_string,
                 experiment_id=experiment_id,
             )
@@ -1013,7 +1024,7 @@ class Scorer(BaseModel):
         return store.upsert_online_scoring_config(
             scorer=self,
             experiment_id=exp_id,
-            sample_rate=sampling_config.sample_rate,
+            sample_rate=sample_rate,
             filter_string=sampling_config.filter_string,
         )
 

--- a/mlflow/genai/scorers/registry.py
+++ b/mlflow/genai/scorers/registry.py
@@ -11,20 +11,27 @@ from abc import ABCMeta, abstractmethod
 from base64 import urlsafe_b64encode
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NoReturn, Optional, TypeVar, cast
 from urllib.parse import quote
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 from typing_extensions import Self
 
-from mlflow.exceptions import MlflowException
+from mlflow.entities import LifecycleStage
+from mlflow.exceptions import MlflowException, RestException
 from mlflow.genai.scorers.base import (
     SCORER_BACKEND_DATABRICKS,
     SCORER_BACKEND_TRACKING,
     Scorer,
     ScorerSamplingConfig,
 )
-from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import (
+    ALREADY_EXISTS,
+    INTERNAL_ERROR,
+    NOT_FOUND,
+    RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
+)
 from mlflow.tracking._tracking_service.utils import _get_store
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.databricks_utils import get_databricks_host_creds
@@ -75,6 +82,32 @@ class _DatabricksScheduledScorerConfig(_DatabricksManagedScorerPayload):
     sample_rate: float | None = None
     filter_string: str | None = None
     scorer_version: int = 1
+
+    @classmethod
+    def from_scorer(
+        cls,
+        *,
+        name: str,
+        scorer: Scorer,
+        sample_rate: float | None,
+        filter_string: str | None,
+    ) -> Self:
+        serialized_scorer = scorer.model_dump()
+        # Preserve registration-time validation that the serialized scorer can be reconstructed.
+        Scorer.model_validate(serialized_scorer)
+        config: dict[str, Any] = {
+            "name": name,
+            "serialized_scorer": json.dumps(serialized_scorer),
+        }
+        if serialized_scorer.get("builtin_scorer_class"):
+            config["builtin"] = {"name": name}
+        else:
+            config["custom"] = {}
+        if sample_rate is not None:
+            config["sample_rate"] = sample_rate
+        if filter_string is not None:
+            config["filter_string"] = filter_string
+        return cls.model_validate(config)
 
     @classmethod
     def from_list_response(cls, response: dict[str, Any]) -> list[Self]:
@@ -425,6 +458,7 @@ class DatabricksStore(AbstractScorerStore):
     _MANAGED_EVALS_SCHEDULED_SCORERS_BASE = f"{_MANAGED_EVALS_BASE}/scheduled-scorers"
 
     def __init__(self, tracking_uri=None):
+        self._tracking_uri = tracking_uri
         self.get_host_creds = partial(get_databricks_host_creds, tracking_uri)
 
     @staticmethod
@@ -435,6 +469,43 @@ class DatabricksStore(AbstractScorerStore):
             "No active experiment found. Set an experiment using `mlflow.set_experiment`, "
             "or pass `experiment_id`."
         )
+
+    @staticmethod
+    def _scorer_not_found(
+        experiment_id: str, name: str, version: int | None = None
+    ) -> MlflowException:
+        version_description = f" and version {version}" if version is not None else ""
+        return MlflowException(
+            f"Scorer with name '{name}'{version_description} not found for experiment "
+            f"{experiment_id}.",
+            RESOURCE_DOES_NOT_EXIST,
+        )
+
+    @classmethod
+    def _raise_scorer_rest_error(
+        cls,
+        error: RestException,
+        *,
+        experiment_id: str,
+        name: str,
+        version: int | None = None,
+    ) -> NoReturn:
+        message = str(error.json.get("message", ""))
+        if (
+            error.error_code != ErrorCode.Name(NOT_FOUND)
+            or "versioning is not enabled" in message.lower()
+        ):
+            raise error
+        missing_version = version if "scorer version " in message.lower() else None
+        raise cls._scorer_not_found(experiment_id, name, missing_version) from error
+
+    def _validate_experiment_is_active(self, experiment_id: str) -> None:
+        experiment = _get_store(self._tracking_uri).get_experiment(experiment_id)
+        if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
+            raise MlflowException.invalid_parameter_value(
+                f"The experiment {experiment.experiment_id} must be in the 'active' state. "
+                f"Current state is {experiment.lifecycle_stage}."
+            )
 
     @staticmethod
     def _encode_path_param(value: str) -> str:
@@ -472,12 +543,14 @@ class DatabricksStore(AbstractScorerStore):
         method: str,
         endpoint: str,
         *,
+        json_body: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         response = http_request(
             host_creds=self.get_host_creds(),
             endpoint=endpoint,
             method=method,
+            json=json_body,
             params=params,
         )
         verify_rest_response(response, endpoint)
@@ -519,49 +592,100 @@ class DatabricksStore(AbstractScorerStore):
             _DatabricksScheduledScorerConfig.from_list_response,
         )
 
+    def _patch_current_scorer_configs(
+        self, experiment_id: str, configs: list[_DatabricksScheduledScorerConfig]
+    ) -> list[_DatabricksScheduledScorerConfig]:
+        response = self._request(
+            "PATCH",
+            self._scheduled_scorers_endpoint(experiment_id),
+            json_body={
+                "scheduled_scorers": {
+                    "scorers": [config.model_dump(exclude_unset=True) for config in configs]
+                },
+                "update_mask": "scheduled_scorers.scorers",
+            },
+        )
+        return _DatabricksScheduledScorerConfig.from_list_response(response)
+
+    def _create_current_scorer_configs(
+        self, experiment_id: str, configs: list[_DatabricksScheduledScorerConfig]
+    ) -> list[_DatabricksScheduledScorerConfig]:
+        response = self._request(
+            "POST",
+            self._scheduled_scorers_endpoint(experiment_id),
+            json_body={
+                "scheduled_scorers": {
+                    "scorers": [config.model_dump(exclude_unset=True) for config in configs]
+                }
+            },
+        )
+        return _DatabricksScheduledScorerConfig.from_list_response(response)
+
+    def _upsert_registered_scorer_config(
+        self,
+        experiment_id: str,
+        registered_config: _DatabricksScheduledScorerConfig,
+    ) -> list[_DatabricksScheduledScorerConfig]:
+        configs = self._merge_registered_scorer_config(
+            self._list_current_scorer_configs(experiment_id), registered_config
+        )
+        try:
+            return self._patch_current_scorer_configs(experiment_id, configs)
+        except RestException as e:
+            if e.error_code != ErrorCode.Name(NOT_FOUND):
+                raise
+        try:
+            return self._create_current_scorer_configs(experiment_id, configs)
+        except RestException as e:
+            if e.error_code != ErrorCode.Name(ALREADY_EXISTS):
+                raise
+
+        configs = self._merge_registered_scorer_config(
+            self._list_current_scorer_configs(experiment_id), registered_config
+        )
+        return self._patch_current_scorer_configs(experiment_id, configs)
+
     def _find_current_scorer_config(
         self, experiment_id: str, name: str
     ) -> _DatabricksScheduledScorerConfig:
-        for config in self._list_current_scorer_configs(experiment_id):
-            if config.name == name:
-                return config
+        configs = self._list_current_scorer_configs(experiment_id)
+        if (index := self._find_scorer_config_index(configs, name)) is not None:
+            return configs[index]
         raise MlflowException(
             f"Scorer with name '{name}' not found for experiment {experiment_id}.",
             RESOURCE_DOES_NOT_EXIST,
         )
 
-    # Private functions for internal use by Scorer methods
     @staticmethod
-    def add_registered_scorer(
-        *,
-        name: str,
-        scorer: Scorer,
-        sample_rate: float,
-        filter_string: str | None = None,
-        experiment_id: str | None = None,
-    ) -> Scorer:
-        """Internal function to add a registered scorer."""
-        try:
-            from databricks.agents.scorers import add_scheduled_scorer
-        except ImportError as e:
-            raise ImportError(_ERROR_MSG) from e
+    def _find_scorer_config_index(
+        configs: list[_DatabricksScheduledScorerConfig], name: str
+    ) -> int | None:
+        return next((i for i, config in enumerate(configs) if config.name == name), None)
 
-        scheduled_scorer = add_scheduled_scorer(
-            experiment_id=experiment_id,
-            scheduled_scorer_name=name,
-            scorer=scorer,
-            sample_rate=sample_rate,
-            filter_string=filter_string,
-        )
-        return scheduled_scorer.scorer._set_registration_metadata(
-            backend=SCORER_BACKEND_DATABRICKS,
-            experiment_id=experiment_id,
-            sampling_config=ScorerSamplingConfig(
-                sample_rate=scheduled_scorer.sample_rate,
-                filter_string=scheduled_scorer.filter_string,
-            ),
-        )
+    @classmethod
+    def _merge_registered_scorer_config(
+        cls,
+        configs: list[_DatabricksScheduledScorerConfig],
+        registered_config: _DatabricksScheduledScorerConfig,
+    ) -> list[_DatabricksScheduledScorerConfig]:
+        configs = list(configs)
+        index = cls._find_scorer_config_index(configs, registered_config.name)
+        if index is None:
+            configs.append(registered_config)
+            return configs
 
+        current_payload = configs[index].model_dump(exclude_unset=True)
+        registered_payload = registered_config.model_dump(exclude_unset=True)
+        for field in ("sample_rate", "filter_string"):
+            if field in current_payload:
+                registered_payload[field] = current_payload[field]
+            else:
+                registered_payload.pop(field, None)
+        registered_payload["scorer_version"] = configs[index].scorer_version
+        configs[index] = _DatabricksScheduledScorerConfig.model_validate(registered_payload)
+        return configs
+
+    # Private functions for internal use by Scorer methods
     @staticmethod
     def list_scheduled_scorers(experiment_id):
         try:
@@ -595,8 +719,8 @@ class DatabricksStore(AbstractScorerStore):
             scheduled_scorer_name=name,
         )
 
-    @staticmethod
     def update_registered_scorer(
+        self,
         *,
         name: str,
         scorer: Scorer | None = None,
@@ -604,46 +728,69 @@ class DatabricksStore(AbstractScorerStore):
         filter_string: str | None = None,
         experiment_id: str | None = None,
     ) -> Scorer:
-        """Internal function to update a registered scorer."""
-        try:
-            from databricks.agents.scorers import update_scheduled_scorer
-        except ImportError as e:
-            raise ImportError(_ERROR_MSG) from e
+        """Update scheduling fields without changing the current scorer definition."""
+        experiment_id = self._resolve_experiment_id(
+            experiment_id or (scorer._experiment_id if scorer is not None else None)
+        )
+        configs = self._list_current_scorer_configs(experiment_id)
+        index = self._find_scorer_config_index(configs, name)
+        if index is None:
+            raise MlflowException(
+                f"Scorer with name '{name}' not found for experiment {experiment_id}.",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+        updates = {}
+        if sample_rate is not None:
+            updates["sample_rate"] = sample_rate
+        if filter_string is not None:
+            updates["filter_string"] = filter_string
+        configs[index] = configs[index].model_copy(update=updates)
 
-        scheduled_scorer = update_scheduled_scorer(
-            experiment_id=experiment_id,
-            scheduled_scorer_name=name,
-            scorer=scorer,
-            sample_rate=sample_rate,
-            filter_string=filter_string,
-        )
-        return scheduled_scorer.scorer._set_registration_metadata(
-            backend=SCORER_BACKEND_DATABRICKS,
-            experiment_id=experiment_id,
-            sampling_config=ScorerSamplingConfig(
-                sample_rate=scheduled_scorer.sample_rate,
-                filter_string=scheduled_scorer.filter_string,
-            ),
-        )
+        for config in self._patch_current_scorer_configs(experiment_id, configs):
+            if config.name == name:
+                return Scorer.model_validate_json(
+                    config.serialized_scorer
+                )._set_registration_metadata(
+                    backend=SCORER_BACKEND_DATABRICKS,
+                    experiment_id=experiment_id,
+                    sampling_config=ScorerSamplingConfig(
+                        sample_rate=config.sample_rate,
+                        filter_string=config.filter_string,
+                    ),
+                )
+        raise MlflowException(f"Updated scheduled scorer response did not include '{name}'.")
 
     def register_scorer(self, experiment_id: str | None, scorer: Scorer) -> int | None:
-        # Add the scorer to the server with sample_rate=0 (not actively sampling)
-        DatabricksStore.add_registered_scorer(
+        experiment_id = self._resolve_experiment_id(experiment_id)
+        registered_config = _DatabricksScheduledScorerConfig.from_scorer(
             name=scorer.name,
             scorer=scorer,
             sample_rate=0.0,
             filter_string=None,
-            experiment_id=experiment_id,
         )
+        response_configs = self._upsert_registered_scorer_config(experiment_id, registered_config)
 
-        # Set the sampling config on the new instance
-        scorer._sampling_config = ScorerSamplingConfig(sample_rate=0.0, filter_string=None)
+        response_config = next(
+            (config for config in response_configs if config.name == scorer.name), None
+        )
+        if response_config is None:
+            raise MlflowException(f"Scheduled scorer response did not include '{scorer.name}'.")
 
-        return None
+        scorer._set_registration_metadata(
+            backend=SCORER_BACKEND_DATABRICKS,
+            experiment_id=experiment_id,
+            sampling_config=ScorerSamplingConfig(
+                sample_rate=response_config.sample_rate,
+                filter_string=response_config.filter_string,
+            ),
+        )
+        return response_config.scorer_version
 
     def list_scorers(self, experiment_id) -> list["Scorer"]:
+        experiment_id = self._resolve_experiment_id(experiment_id)
         # Get scheduled scorers from the server
-        scheduled_scorers = DatabricksStore.list_scheduled_scorers(experiment_id)
+        scheduled_scorers = self.list_scheduled_scorers(experiment_id)
+        self._validate_experiment_is_active(experiment_id)
 
         # Convert to Scorer instances with registration info
         return [
@@ -661,9 +808,18 @@ class DatabricksStore(AbstractScorerStore):
     def get_scorer(self, experiment_id, name, version=None) -> "Scorer":
         if version is not None:
             experiment_id = self._resolve_experiment_id(experiment_id)
-            version_config = _DatabricksScorerVersion.from_response(
-                self._request("GET", self._scorer_version_endpoint(experiment_id, name, version))
-            )
+            try:
+                response = self._request(
+                    "GET", self._scorer_version_endpoint(experiment_id, name, version)
+                )
+            except RestException as e:
+                self._raise_scorer_rest_error(
+                    e,
+                    experiment_id=experiment_id,
+                    name=name,
+                    version=version,
+                )
+            version_config = _DatabricksScorerVersion.from_response(response)
             current_config = self._find_current_scorer_config(experiment_id, name)
             return Scorer.model_validate_json(
                 version_config.serialized_scorer
@@ -677,7 +833,13 @@ class DatabricksStore(AbstractScorerStore):
             )
 
         # Get the scheduled scorer from the server
-        scheduled_scorer = DatabricksStore.get_scheduled_scorer(name, experiment_id)
+        experiment_id = self._resolve_experiment_id(experiment_id)
+        try:
+            scheduled_scorer = self.get_scheduled_scorer(name, experiment_id)
+        except ValueError as e:
+            if "No registered scorer found with name" not in str(e):
+                raise
+            raise self._scorer_not_found(experiment_id, name) from e
 
         # Extract the scorer and set registration fields
         return scheduled_scorer.scorer._set_registration_metadata(
@@ -691,10 +853,13 @@ class DatabricksStore(AbstractScorerStore):
 
     def list_scorer_versions(self, experiment_id, name) -> list[tuple["Scorer", int]]:
         experiment_id = self._resolve_experiment_id(experiment_id)
-        configs = self._get_paginated_results(
-            self._scorer_versions_endpoint(experiment_id, name),
-            _DatabricksScorerVersion.from_list_response,
-        )
+        try:
+            configs = self._get_paginated_results(
+                self._scorer_versions_endpoint(experiment_id, name),
+                _DatabricksScorerVersion.from_list_response,
+            )
+        except RestException as e:
+            self._raise_scorer_rest_error(e, experiment_id=experiment_id, name=name)
 
         current_config = self._find_current_scorer_config(experiment_id, name)
         return [
@@ -714,13 +879,27 @@ class DatabricksStore(AbstractScorerStore):
 
     def delete_scorer(self, experiment_id, name, version):
         if version is None or version == "all":
-            return DatabricksStore.delete_scheduled_scorer(experiment_id, name)
+            experiment_id = self._resolve_experiment_id(experiment_id)
+            try:
+                return DatabricksStore.delete_scheduled_scorer(experiment_id, name)
+            except ValueError as e:
+                if "No registered scorer found with name" not in str(e):
+                    raise
+                raise self._scorer_not_found(experiment_id, name) from e
 
         experiment_id = self._resolve_experiment_id(experiment_id)
-        self._request(
-            "DELETE",
-            self._scorer_version_endpoint(experiment_id, name, version),
-        )
+        try:
+            self._request(
+                "DELETE",
+                self._scorer_version_endpoint(experiment_id, name, version),
+            )
+        except RestException as e:
+            self._raise_scorer_rest_error(
+                e,
+                experiment_id=experiment_id,
+                name=name,
+                version=version,
+            )
 
 
 # Create the global scorer store registry instance

--- a/tests/genai/scorers/test_builtin_scorers_registration.py
+++ b/tests/genai/scorers/test_builtin_scorers_registration.py
@@ -40,34 +40,34 @@ def test_non_databricks_model_cannot_register(
 
 def test_safety_with_databricks_model_can_register(mock_databricks_tracking_uri: mock.Mock):
     with mock.patch(
-        "mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"
-    ) as mock_add:
+        "mlflow.genai.scorers.registry.DatabricksStore.register_scorer"
+    ) as mock_register:
         scorer = Safety(model="databricks:/my-judge-model")
         registered = scorer.register()
 
     assert registered.name == "safety"
-    mock_add.assert_called_once()
+    mock_register.assert_called_once()
     mock_databricks_tracking_uri.assert_called()
 
 
 def test_builtin_scorer_without_custom_model_can_register(mock_databricks_tracking_uri: mock.Mock):
     with mock.patch(
-        "mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"
-    ) as mock_add:
+        "mlflow.genai.scorers.registry.DatabricksStore.register_scorer"
+    ) as mock_register:
         # Safety with default model (None)
         scorer = Safety()
         registered = scorer.register()
         assert registered.name == "safety"
-        mock_add.assert_called_once()
+        mock_register.assert_called_once()
 
-        mock_add.reset_mock()
+        mock_register.reset_mock()
 
         # RetrievalRelevance with default model (None)
         scorer = RetrievalRelevance()
         registered = scorer.register()
 
     assert registered.name == "retrieval_relevance"
-    mock_add.assert_called_once()
+    mock_register.assert_called_once()
     mock_databricks_tracking_uri.assert_called()
 
 

--- a/tests/genai/scorers/test_registered_scorers_scheduling.py
+++ b/tests/genai/scorers/test_registered_scorers_scheduling.py
@@ -24,6 +24,20 @@ def mock_databricks_runtime():
         yield
 
 
+@pytest.fixture
+def mock_register_scorer():
+    def register_scorer(experiment_id, scorer):
+        scorer._experiment_id = experiment_id
+        scorer._sampling_config = ScorerSamplingConfig(sample_rate=0.0, filter_string=None)
+        return 1
+
+    with patch(
+        "mlflow.genai.scorers.registry.DatabricksStore.register_scorer",
+        side_effect=register_scorer,
+    ) as mock_register:
+        yield mock_register
+
+
 @scorer
 def length_check(outputs):
     """Check if response is adequately detailed"""
@@ -36,10 +50,9 @@ def serialization_scorer(outputs) -> bool:
     return len(outputs) > 5
 
 
-def test_scorer_register():
+def test_scorer_register(mock_register_scorer):
     my_scorer = length_check
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
-        registered = my_scorer.register(name="my_length_check")
+    registered = my_scorer.register(name="my_length_check")
 
     # Check immutability - returns new instance
     assert registered is not my_scorer
@@ -51,22 +64,17 @@ def test_scorer_register():
     assert my_scorer.name == "length_check"
     assert my_scorer._sampling_config is None
 
-    # Check the mock was called correctly
-    mock_add.assert_called_once()
-    call_args = mock_add.call_args.kwargs
-    assert call_args["scorer"].name == "my_length_check"
-    assert call_args["sample_rate"] == 0.0
-    assert call_args["filter_string"] is None
+    mock_register_scorer.assert_called_once()
+    assert mock_register_scorer.call_args.args[1].name == "my_length_check"
 
 
-def test_scorer_register_default_name():
+def test_scorer_register_default_name(mock_register_scorer):
     my_scorer = length_check
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
-        registered = my_scorer.register()
+    registered = my_scorer.register()
 
     assert registered.name == "length_check"  # Uses scorer's name
-    mock_add.assert_called_once()
-    assert mock_add.call_args.kwargs["scorer"].name == "length_check"
+    mock_register_scorer.assert_called_once()
+    assert mock_register_scorer.call_args.args[1].name == "length_check"
 
 
 def test_scorer_start():
@@ -114,6 +122,19 @@ def test_scorer_start_with_zero_sample_rate_raises_error(sample_rate):
         length_check.start(sampling_config=ScorerSamplingConfig(sample_rate=sample_rate))
 
 
+@pytest.mark.parametrize("sample_rate", [None, "0.5"])
+def test_scorer_start_requires_numeric_sample_rate(sample_rate):
+    with (
+        patch(
+            "mlflow.genai.scorers.registry.DatabricksStore.update_registered_scorer"
+        ) as mock_update,
+        pytest.raises(MlflowException, match="sample rate must be a number"),
+    ):
+        length_check.start(sampling_config=ScorerSamplingConfig(sample_rate=sample_rate))
+
+    mock_update.assert_not_called()
+
+
 def test_scorer_start_not_registered():
     my_scorer = length_check
 
@@ -158,6 +179,31 @@ def test_scorer_update():
     assert call_args["filter_string"] == "old filter"
 
 
+def test_scorer_update_rejects_nonnumeric_sample_rate():
+    with (
+        patch(
+            "mlflow.genai.scorers.registry.DatabricksStore.update_registered_scorer"
+        ) as mock_update,
+        pytest.raises(MlflowException, match="sample rate must be a number"),
+    ):
+        length_check.update(sampling_config=ScorerSamplingConfig(sample_rate="0.5"))
+
+    mock_update.assert_not_called()
+
+
+def test_scorer_update_allows_omitted_sample_rate():
+    with patch(
+        "mlflow.genai.scorers.registry.DatabricksStore.update_registered_scorer"
+    ) as mock_update:
+        mock_update.return_value = length_check._create_copy()
+        length_check.update(
+            sampling_config=ScorerSamplingConfig(filter_string="trace.status = 'OK'")
+        )
+
+    mock_update.assert_called_once()
+    assert mock_update.call_args.kwargs["sample_rate"] is None
+
+
 def test_scorer_stop():
     my_scorer = length_check
     my_scorer = my_scorer._create_copy()
@@ -178,15 +224,13 @@ def test_scorer_stop():
     assert mock_update.call_args.kwargs["sample_rate"] == 0.0
 
 
-def test_scorer_register_with_experiment_id():
+def test_scorer_register_with_experiment_id(mock_register_scorer):
     my_scorer = length_check
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
-        my_scorer.register(name="test_scorer", experiment_id="exp123")
+    my_scorer.register(name="test_scorer", experiment_id="exp123")
 
-    mock_add.assert_called_once()
-    call_args = mock_add.call_args.kwargs
-    assert call_args["experiment_id"] == "exp123"
-    assert call_args["scorer"].name == "test_scorer"
+    mock_register_scorer.assert_called_once()
+    assert mock_register_scorer.call_args.args[0] == "exp123"
+    assert mock_register_scorer.call_args.args[1].name == "test_scorer"
 
 
 def test_scorer_start_with_name_param():
@@ -238,16 +282,14 @@ def test_scorer_update_with_all_params():
     assert call_args["filter_string"] == "new_filter"
 
 
-def test_builtin_scorer_register():
+def test_builtin_scorer_register(mock_register_scorer):
     guidelines_scorer = Guidelines(guidelines="Be helpful")
 
     # Verify original serialization
     original_dump = guidelines_scorer.model_dump()
     assert original_dump["name"] == "guidelines"
 
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
-        # Register with custom name
-        registered = guidelines_scorer.register(name="my_guidelines")
+    registered = guidelines_scorer.register(name="my_guidelines")
 
     assert registered is not guidelines_scorer
     assert registered.name == "my_guidelines"
@@ -285,7 +327,7 @@ def test_builtin_scorer_update():
     assert updated.guidelines == "Be helpful"  # Original field preserved
 
 
-def test_all_methods_are_immutable():
+def test_all_methods_are_immutable(mock_register_scorer):
     original = length_check
 
     # Set up some state
@@ -294,10 +336,9 @@ def test_all_methods_are_immutable():
     original._sampling_config = ScorerSamplingConfig(sample_rate=0.1, filter_string="original")
 
     # Test each method
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
-        registered = original.register(name="new_name")
-        assert registered is not original
-        assert original.name == "original_name"  # Unchanged
+    registered = original.register(name="new_name")
+    assert registered is not original
+    assert original.name == "original_name"  # Unchanged
 
     with patch(
         "mlflow.genai.scorers.registry.DatabricksStore.update_registered_scorer"
@@ -352,7 +393,7 @@ def test_class_scorer_cannot_be_registered():
         custom_scorer.stop()
 
 
-def test_register_with_custom_name_updates_serialization():
+def test_register_with_custom_name_updates_serialization(mock_register_scorer):
     # Use the pre-defined scorer to avoid source extraction issues
     test_scorer = serialization_scorer
 
@@ -360,9 +401,7 @@ def test_register_with_custom_name_updates_serialization():
     original_dump = test_scorer.model_dump()
     assert original_dump["name"] == "serialization_scorer"
 
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
-        # Register with custom name
-        registered = test_scorer.register(name="custom_test_name")
+    registered = test_scorer.register(name="custom_test_name")
 
     # Verify the registered scorer has the correct name
     assert registered.name == "custom_test_name"
@@ -375,5 +414,5 @@ def test_register_with_custom_name_updates_serialization():
     assert test_scorer.name == "serialization_scorer"
 
     # Verify the server was called with the correct name
-    mock_add.assert_called_once()
-    assert mock_add.call_args.kwargs["scorer"].name == "custom_test_name"
+    mock_register_scorer.assert_called_once()
+    assert mock_register_scorer.call_args.args[1].name == "custom_test_name"

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -1,23 +1,30 @@
 import json
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 import mlflow
 import mlflow.genai
-from mlflow.entities import GatewayEndpointModelConfig, GatewayModelLinkageType
+from mlflow.entities import GatewayEndpointModelConfig, GatewayModelLinkageType, LifecycleStage
 from mlflow.entities.gateway_endpoint import GatewayEndpoint
 from mlflow.exceptions import MlflowException
-from mlflow.genai.scorers import Guidelines, scorer
+from mlflow.genai.scorers import Guidelines, Scorer, scorer
 from mlflow.genai.scorers.base import ScorerSamplingConfig, ScorerStatus
 from mlflow.genai.scorers.registry import (
     DatabricksStore,
+    _DatabricksScheduledScorerConfig,
     delete_scorer,
     get_scorer,
     list_scorer_versions,
     list_scorers,
 )
-from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST, ErrorCode
+from mlflow.protos.databricks_pb2 import (
+    INTERNAL_ERROR,
+    INVALID_PARAMETER_VALUE,
+    NOT_FOUND,
+    RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
+)
 from mlflow.tracking._tracking_service.utils import _get_store
 
 
@@ -100,7 +107,7 @@ def test_mlflow_backend_scorer_operations():
         mlflow.delete_experiment(experiment_id)
 
 
-def test_databricks_backend_scorer_operations():
+def test_databricks_backend_list_and_get_use_databricks_agents():
     # Mock the scheduled scorer responses
     mock_scheduled_scorer = Mock()
     mock_scheduled_scorer.scorer = Guidelines(
@@ -112,10 +119,8 @@ def test_databricks_backend_scorer_operations():
     mock_scheduled_scorer.filter_string = "test_filter"
 
     with (
-        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
-        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
         patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
-        patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add,
+        patch("mlflow.genai.scorers.registry._get_store") as mock_tracking_store,
         patch(
             "mlflow.genai.scorers.registry.DatabricksStore.list_scheduled_scorers",
             return_value=[mock_scheduled_scorer],
@@ -124,53 +129,30 @@ def test_databricks_backend_scorer_operations():
             "mlflow.genai.scorers.registry.DatabricksStore.get_scheduled_scorer",
             return_value=mock_scheduled_scorer,
         ) as mock_get,
-        patch(
-            "mlflow.genai.scorers.registry.DatabricksStore.delete_scheduled_scorer",
-            return_value=None,
-        ) as mock_delete,
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
     ):
-        # Set up the store mock
         mock_store = DatabricksStore()
         mock_get_store.return_value = mock_store
-
-        # Test register operation
-        @scorer
-        def test_databricks_scorer(outputs) -> bool:
-            return len(outputs) > 0
-
-        assert test_databricks_scorer.status == ScorerStatus.UNREGISTERED
-        registered_scorer = test_databricks_scorer.register(experiment_id="exp_123")
-        assert registered_scorer.name == "test_databricks_scorer"
-        assert registered_scorer.status == ScorerStatus.STOPPED
-
-        # Verify add_registered_scorer was called during registration
-        mock_add.assert_called_once_with(
-            name="test_databricks_scorer",
-            scorer=ANY,
-            sample_rate=0.0,
-            filter_string=None,
+        mock_tracking_store.return_value.get_experiment.return_value = Mock(
             experiment_id="exp_123",
+            lifecycle_stage=LifecycleStage.ACTIVE,
         )
 
-        # Test list operation
         scorers = list_scorers(experiment_id="exp_123")
-
         assert scorers[0].name == "test_databricks_scorer"
         assert scorers[0]._sampling_config == ScorerSamplingConfig(
             sample_rate=0.5, filter_string="test_filter"
         )
-
+        assert scorers[0]._experiment_id == "exp_123"
         assert len(scorers) == 1
         mock_list.assert_called_once_with("exp_123")
+        mock_tracking_store.return_value.get_experiment.assert_called_once_with("exp_123")
 
-        # Test get operation
         retrieved_scorer = get_scorer(name="test_databricks_scorer", experiment_id="exp_123")
         assert retrieved_scorer.name == "test_databricks_scorer"
         mock_get.assert_called_once_with("test_databricks_scorer", "exp_123")
 
-        # Test delete operation
-        delete_scorer(name="test_databricks_scorer", experiment_id="exp_123")
-        mock_delete.assert_called_once_with("exp_123", "test_databricks_scorer")
+        mock_http.assert_not_called()
 
 
 def _mock_response(payload):
@@ -181,6 +163,24 @@ def _mock_response(payload):
 
 def _scheduled_scorers_response(configs):
     return _mock_response({"scheduled_scorers": {"scorers": configs}})
+
+
+def _not_found_response():
+    response = _mock_response({"error_code": "NOT_FOUND", "message": "Not found"})
+    response.status_code = 404
+    return response
+
+
+def _rest_error_response(error_code, message, status_code):
+    response = _mock_response({"error_code": error_code, "message": message})
+    response.status_code = status_code
+    return response
+
+
+def _already_exists_response():
+    response = _mock_response({"error_code": "ALREADY_EXISTS", "message": "Already exists"})
+    response.status_code = 409
+    return response
 
 
 def _scorer_config(scorer, *, version=1, sample_rate=0.0, filter_string=None):
@@ -206,6 +206,183 @@ def _scorer_version_config(scorer, *, experiment_id="exp_123", version=1):
         "create_time": "2026-07-20T00:00:00Z",
         "builtin": {"name": scorer.name},
     }
+
+
+def test_databricks_backend_registers_with_patch_and_post_fallback():
+    scorer_v1 = Guidelines(
+        name="test_databricks_scorer",
+        guidelines=["Be concise"],
+        model="databricks:/judge",
+    )
+    scorer_v2 = Guidelines(
+        name="test_databricks_scorer",
+        guidelines=["Be precise"],
+        model="databricks:/judge",
+    )
+    v1_config = _scorer_config(scorer_v1, version=1)
+    scheduled_v1_config = _scorer_config(
+        scorer_v1,
+        version=1,
+        sample_rate=0.4,
+        filter_string="trace.status = 'OK'",
+    )
+    v2_config = _scorer_config(
+        scorer_v2,
+        version=2,
+        sample_rate=0.4,
+        filter_string="trace.status = 'OK'",
+    )
+
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.side_effect = [
+            _scheduled_scorers_response([]),
+            _not_found_response(),
+            _scheduled_scorers_response([v1_config]),
+            _scheduled_scorers_response([scheduled_v1_config]),
+            _scheduled_scorers_response([v2_config]),
+        ]
+        store = DatabricksStore(tracking_uri="databricks")
+
+        assert store.register_scorer("exp_123", scorer_v1) == 1
+        assert store.register_scorer("exp_123", scorer_v2) == 2
+
+    assert scorer_v2._sampling_config == ScorerSamplingConfig(
+        sample_rate=0.4,
+        filter_string="trace.status = 'OK'",
+    )
+
+    patch_body = mock_http.call_args_list[1].kwargs["json"]
+    assert mock_http.call_args_list[1].kwargs["method"] == "PATCH"
+    assert patch_body["scheduled_scorers"]["scorers"][0]["name"] == scorer_v1.name
+    assert patch_body["scheduled_scorers"]["scorers"][0]["builtin"] == {"name": scorer_v1.name}
+
+    post_call = mock_http.call_args_list[2]
+    assert post_call.kwargs["method"] == "POST"
+    assert post_call.kwargs["json"] == {"scheduled_scorers": patch_body["scheduled_scorers"]}
+
+    registered_v2_config = mock_http.call_args_list[4].kwargs["json"]["scheduled_scorers"][
+        "scorers"
+    ][0]
+    assert registered_v2_config["serialized_scorer"] == v2_config["serialized_scorer"]
+    assert registered_v2_config["sample_rate"] == 0.4
+    assert registered_v2_config["filter_string"] == "trace.status = 'OK'"
+
+
+def test_databricks_backend_register_reconciles_post_create_race():
+    scorer_v1 = Guidelines(
+        name="test_databricks_scorer",
+        guidelines=["Be concise"],
+        model="databricks:/judge",
+    )
+    scorer_v2 = Guidelines(
+        name="test_databricks_scorer",
+        guidelines=["Be precise"],
+        model="databricks:/judge",
+    )
+    concurrent_scorer = Guidelines(
+        name="concurrent_scorer",
+        guidelines=["Be safe"],
+        model="databricks:/judge",
+    )
+    current_v1_config = _scorer_config(
+        scorer_v1,
+        version=1,
+        sample_rate=0.4,
+        filter_string="trace.status = 'OK'",
+    )
+    concurrent_config = _scorer_config(concurrent_scorer, version=1)
+    v2_config = _scorer_config(
+        scorer_v2,
+        version=2,
+        sample_rate=0.4,
+        filter_string="trace.status = 'OK'",
+    )
+
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.side_effect = [
+            _scheduled_scorers_response([]),
+            _not_found_response(),
+            _already_exists_response(),
+            _scheduled_scorers_response([concurrent_config, current_v1_config]),
+            _scheduled_scorers_response([concurrent_config, v2_config]),
+        ]
+
+        assert DatabricksStore(tracking_uri="databricks").register_scorer("exp_123", scorer_v2) == 2
+
+    assert [call.kwargs["method"] for call in mock_http.call_args_list] == [
+        "GET",
+        "PATCH",
+        "POST",
+        "GET",
+        "PATCH",
+    ]
+    reconciled_configs = mock_http.call_args_list[4].kwargs["json"]["scheduled_scorers"]["scorers"]
+    assert [config["name"] for config in reconciled_configs] == [
+        concurrent_scorer.name,
+        scorer_v2.name,
+    ]
+    assert reconciled_configs[1]["serialized_scorer"] == json.dumps(scorer_v2.model_dump())
+    assert reconciled_configs[1]["sample_rate"] == 0.4
+    assert reconciled_configs[1]["filter_string"] == "trace.status = 'OK'"
+    assert reconciled_configs[1]["scorer_version"] == 1
+
+
+def test_scheduled_scorer_config_uses_managed_scorer_type_oneof():
+    builtin_scorer = Guidelines(
+        name="test_databricks_scorer",
+        guidelines=["Be concise"],
+        model="databricks:/judge",
+    )
+
+    @scorer
+    def custom_scorer(outputs) -> bool:
+        return bool(outputs)
+
+    builtin_config = _DatabricksScheduledScorerConfig.from_scorer(
+        name="registered_alias",
+        scorer=builtin_scorer,
+        sample_rate=0.0,
+        filter_string=None,
+    )
+    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
+        custom_config = _DatabricksScheduledScorerConfig.from_scorer(
+            name=custom_scorer.name,
+            scorer=custom_scorer,
+            sample_rate=0.0,
+            filter_string=None,
+        )
+
+    assert builtin_config.builtin == {"name": "registered_alias"}
+    assert custom_config.custom == {}
+
+
+def test_databricks_backend_register_validates_scorer_round_trip_before_request():
+    registered_scorer = Guidelines(
+        name="test_databricks_scorer",
+        guidelines=["Be concise"],
+        model="databricks:/judge",
+    )
+    serialized_scorer = registered_scorer.model_dump()
+
+    with (
+        patch.object(
+            Scorer,
+            "model_validate",
+            side_effect=MlflowException("Scorer cannot be reconstructed."),
+        ) as mock_validate,
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+        pytest.raises(MlflowException, match="cannot be reconstructed"),
+    ):
+        DatabricksStore(tracking_uri="databricks").register_scorer("exp_123", registered_scorer)
+
+    mock_validate.assert_called_once_with(serialized_scorer)
+    mock_http.assert_not_called()
 
 
 def test_databricks_backend_version_resource_names_use_unpadded_base64url():
@@ -277,6 +454,94 @@ def test_databricks_backend_missing_current_scorer_uses_oss_error_code():
     ):
         store._find_current_scorer_config("exp_123", "test_scorer")
     assert missing.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+    with (
+        patch.object(store, "_list_current_scorer_configs", return_value=[]),
+        pytest.raises(MlflowException, match="not found") as update_missing,
+    ):
+        store.update_registered_scorer(name="test_scorer", experiment_id="exp_123")
+    assert update_missing.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+@pytest.mark.parametrize(
+    ("operation", "kwargs", "agents_method"),
+    [
+        ("get_scorer", {}, "get_scheduled_scorer"),
+        ("delete_scorer", {"version": "all"}, "delete_scheduled_scorer"),
+    ],
+)
+def test_databricks_backend_agents_missing_scorer_uses_oss_error(operation, kwargs, agents_method):
+    store = DatabricksStore(tracking_uri="databricks")
+    with patch.object(
+        DatabricksStore,
+        agents_method,
+        side_effect=ValueError("No registered scorer found with name 'missing'"),
+    ):
+        with pytest.raises(MlflowException, match="Scorer with name 'missing' not found") as error:
+            getattr(store, operation)("exp_123", "missing", **kwargs)
+
+    assert error.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+@pytest.mark.parametrize(
+    ("operation", "kwargs", "version"),
+    [
+        ("get_scorer", {"version": 2}, 2),
+        ("list_scorer_versions", {}, None),
+        ("delete_scorer", {"version": 2}, 2),
+    ],
+)
+def test_databricks_backend_rest_missing_scorer_uses_oss_error(operation, kwargs, version):
+    message = (
+        "Scheduled scorer missing does not exist."
+        if version is None
+        else "Scheduled scorer version 2 for scorer missing does not exist."
+    )
+
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.return_value = _rest_error_response("NOT_FOUND", message, 404)
+        store = DatabricksStore(tracking_uri="databricks")
+        with pytest.raises(MlflowException, match="Scorer with name 'missing'.*not found") as error:
+            getattr(store, operation)("exp_123", "missing", **kwargs)
+
+    assert error.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+    if version is not None:
+        assert f"version {version}" in str(error.value)
+
+
+def test_databricks_backend_versioning_disabled_error_is_preserved():
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.return_value = _rest_error_response(
+            "NOT_FOUND", "Scheduled scorer versioning is not enabled.", 404
+        )
+        store = DatabricksStore(tracking_uri="databricks")
+        with pytest.raises(MlflowException, match="versioning is not enabled") as error:
+            store.list_scorer_versions("exp_123", "missing")
+
+    assert error.value.error_code == ErrorCode.Name(NOT_FOUND)
+
+
+def test_databricks_backend_list_scorers_rejects_deleted_experiment():
+    tracking_store = Mock()
+    tracking_store.get_experiment.return_value = Mock(
+        experiment_id="exp_123",
+        lifecycle_stage=LifecycleStage.DELETED,
+    )
+    with (
+        patch("mlflow.genai.scorers.registry._get_store", return_value=tracking_store),
+        patch.object(DatabricksStore, "list_scheduled_scorers", return_value=[]) as mock_list,
+        pytest.raises(MlflowException, match="must be in the 'active' state") as error,
+    ):
+        DatabricksStore(tracking_uri="databricks").list_scorers("exp_123")
+
+    assert error.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    mock_list.assert_called_once_with("exp_123")
 
 
 def test_databricks_backend_version_operations_use_managed_resource_endpoints():
@@ -382,6 +647,80 @@ def test_databricks_backend_current_scorer_configs_paginate():
     assert [config.name for config in configs] == ["scorer_v1", "scorer_v2"]
     assert mock_http.call_args_list[0].kwargs["params"] is None
     assert mock_http.call_args_list[1].kwargs["params"] == {"page_token": "page-2"}
+
+
+def test_databricks_backend_legacy_current_config_defaults_to_version_one():
+    scorer = Guidelines(name="test_databricks_scorer", guidelines=["v1"], model="databricks:/judge")
+    config = _scorer_config(scorer)
+    config.pop("scorer_version")
+
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.return_value = _scheduled_scorers_response([config])
+        parsed_config = DatabricksStore(tracking_uri="databricks")._list_current_scorer_configs(
+            "exp_123"
+        )[0]
+
+    assert parsed_config.scorer_version == 1
+
+
+def test_databricks_backend_historical_scorer_scheduling_preserves_current_definition():
+    scorer_name = "folder/test_databricks_scorer"
+    scorer_v1 = Guidelines(name=scorer_name, guidelines=["v1"], model="databricks:/judge")
+    scorer_v2 = Guidelines(name=scorer_name, guidelines=["v2"], model="databricks:/judge")
+    historical_config = _scorer_version_config(scorer_v1, version=1)
+    current_config = _scorer_config(
+        scorer_v2,
+        version=2,
+        sample_rate=0.2,
+        filter_string="trace.status = 'OK'",
+    )
+    started_config = {
+        **current_config,
+        "sample_rate": 0.6,
+        "filter_string": "trace.status = 'IN_PROGRESS'",
+    }
+    updated_config = {**started_config, "filter_string": "trace.status = 'ERROR'"}
+    stopped_config = {**updated_config, "sample_rate": 0.0}
+
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.side_effect = [
+            _mock_response(historical_config),
+            _scheduled_scorers_response([current_config]),
+            _scheduled_scorers_response([current_config]),
+            _scheduled_scorers_response([started_config]),
+            _scheduled_scorers_response([started_config]),
+            _scheduled_scorers_response([updated_config]),
+            _scheduled_scorers_response([updated_config]),
+            _scheduled_scorers_response([stopped_config]),
+        ]
+        store = DatabricksStore(tracking_uri="databricks://profile")
+
+        with patch("mlflow.genai.scorers.registry._get_scorer_store", return_value=store):
+            historical = store.get_scorer("exp_123", scorer_name, version=1)
+            started = historical.start(
+                sampling_config=ScorerSamplingConfig(
+                    sample_rate=0.6,
+                    filter_string="trace.status = 'IN_PROGRESS'",
+                )
+            )
+            updated = historical.update(
+                sampling_config=ScorerSamplingConfig(filter_string="trace.status = 'ERROR'")
+            )
+            stopped = historical.stop()
+
+    patch_calls = [call for call in mock_http.call_args_list if call.kwargs["method"] == "PATCH"]
+    assert [call.kwargs["json"]["scheduled_scorers"]["scorers"][0] for call in patch_calls] == [
+        started_config,
+        updated_config,
+        stopped_config,
+    ]
+    assert [started.guidelines, updated.guidelines, stopped.guidelines] == [["v2"]] * 3
 
 
 def _mock_gateway_endpoint():

--- a/tests/genai/test_genai_import_without_agent_sdk.py
+++ b/tests/genai/test_genai_import_without_agent_sdk.py
@@ -156,3 +156,19 @@ def test_versioned_scorer_operations_do_not_require_agents_sdk(scorer_http):
     assert exact.name == "test_scorer"
     assert [version for _, version in versions] == [1]
     assert scorer_http.call_args_list[-1].kwargs["method"] == "DELETE"
+
+
+def test_register_scorer_does_not_require_agents_sdk(scorer_http):
+    config = _scorer_config()
+    scorer_http.side_effect = [
+        _scheduled_scorers_response([]),
+        _scheduled_scorers_response([config]),
+    ]
+
+    registered = Guidelines(
+        name="test_scorer",
+        guidelines=["Be helpful"],
+        model="databricks:/judge",
+    ).register(experiment_id="test_experiment")
+
+    assert registered.name == "test_scorer"


### PR DESCRIPTION
### Related Issues/PRs

Depends on #24596. This is the second PR in the Databricks managed scorer versioning stack.

### What changes are proposed in this pull request?

Add Databricks support for scorer registry writes that must preserve or create managed scorer
versions:

- Register scorers through the managed scheduled-scorer API so registering an existing name creates
  the next version instead of raising the legacy duplicate-name error.
- Update the whole current-scorer list with `GET` plus `PATCH`, falling back to `POST` when an
  experiment has no scheduled-scorer entity yet.
- Start, update, and stop scheduled scorers without serializing a historical scorer version back into
  the current definition or clearing omitted sampling fields.
- Implement `delete_scorer(version="all")` and the Databricks-compatible `version=None` behavior by
  removing the scorer from the current list and patching the remaining configs.

Current/latest `list_scorers()` and `get_scorer()` behavior remains backed by `databricks-agents`.
The direct version-resource operations are introduced by #24596.

This PR targets `scorer-versioning`. It remains stacked on #24596; after #24596 merges,
this branch will be rebased onto the updated target so GitHub shows only the write layer.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Focused validation:

```bash
uv run --frozen pytest \
  tests/genai/scorers/test_scorer_CRUD.py \
  tests/genai/scorers/test_builtin_scorers_registration.py \
  tests/genai/scorers/test_registered_scorers_scheduling.py \
  tests/genai/test_genai_import_without_agent_sdk.py
```

The full stacked focused and legacy suite passes (97 tests). A wheel built from the stacked head was
also exercised against the Databricks LiteSwap backend for fresh registration, duplicate-name
version creation, exact version reads/deletes, historical scheduling, delete fallback, encoded scorer
names, and agentless direct operations.

This is a notebook with some e2e tests. This also includes the [followup PR](https://github.com/mlflow/mlflow/pull/24611): 
https://dogfood.staging.databricks.com/editor/notebooks/2522867610395241?o=6051921418418893

### Does this PR require documentation update?

- [ ] Yes. I've updated:
  - [ ] API references

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Registering the same scorer name on Databricks now creates a new scorer version, and
  version-aware scheduling and deletion preserve managed scorer history.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: A release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes such as new features and improvements.
- Patch release: A release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are reserved for critical regressions and security fixes.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
