### PR TITLE
fix: bound duplicate-metric recovery cost by batch size, not run history

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -28,6 +28,11 @@ from mlflow.utils.crypto import KEKManager, _decrypt_secret
 
 _SqlAlchemyStatement = TypeVar("_SqlAlchemyStatement", Select, Query)
 
+# Chunk size for exact-identity dedup queries in the IntegrityError recovery
+# path of _log_metrics. 100 rows × 5 identity columns + 1 run_uuid = 501 bind
+# params, safely under the tightest supported dialect limit (SQLite, 999).
+_METRIC_DEDUP_CHUNK_SIZE = 100
+
 import mlflow.store.db.utils
 from mlflow.entities import (
     Assessment,
@@ -1260,32 +1265,61 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 # continue using the session. In this case, we re-use the session to query
                 # SqlMetric
                 session.rollback()
-                # Divide metric keys into batches of 100 to avoid loading too much metric
-                # history data into memory at once
-                metric_keys = list({m.key for m in metric_instances})
-                metric_key_batches = [
-                    metric_keys[i : i + 100] for i in range(0, len(metric_keys), 100)
-                ]
-                # Iteratively filter out metric_instances per batch to avoid
-                # loading all metric history into memory at once
-                # (see https://github.com/mlflow/mlflow/issues/19144)
-                for metric_key_batch in metric_key_batches:
-                    # obtain the metric history corresponding to the given metrics
-                    metric_history = (
-                        session
-                        .query(SqlMetric)
+
+                # Query exact metric identities instead of per-key history to bound
+                # recovery cost by batch size, not run history. See
+                # https://github.com/mlflow/mlflow/issues/24577
+                def _metric_id(key, timestamp, step, value, is_nan):
+                    # metric_pk minus the (constant) run_uuid. Key on the stored
+                    # is_nan flag, not float("nan"): NaN rows are persisted as
+                    # value=0, is_nan=True, and nan != nan in Python would
+                    # otherwise make NaN rows never match.
+                    return (key, timestamp, step, value, is_nan)
+
+                # Build an ordered identity -> instance map. This deduplicates
+                # candidates (including distinct in-batch NaN objects that
+                # sanitize to the same identity) and preserves insertion order
+                # for the retry list below.
+                metrics_by_id = {}
+                for m in metric_instances:
+                    metrics_by_id.setdefault(
+                        _metric_id(m.key, m.timestamp, m.step, m.value, m.is_nan), m
+                    )
+
+                candidates = list(metrics_by_id)
+                existing_ids = set()
+                for i in range(0, len(candidates), _METRIC_DEDUP_CHUNK_SIZE):
+                    chunk = candidates[i : i + _METRIC_DEDUP_CHUNK_SIZE]
+                    row_predicates = [
+                        and_(
+                            SqlMetric.key == key,
+                            SqlMetric.timestamp == timestamp,
+                            SqlMetric.step == step,
+                            SqlMetric.value == value,
+                            SqlMetric.is_nan == is_nan,
+                        )
+                        for key, timestamp, step, value, is_nan in chunk
+                    ]
+                    rows = (
+                        session.query(
+                            SqlMetric.key,
+                            SqlMetric.timestamp,
+                            SqlMetric.step,
+                            SqlMetric.value,
+                            SqlMetric.is_nan,
+                        )
                         .filter(
-                            SqlMetric.run_uuid == run_id,
-                            SqlMetric.key.in_(metric_key_batch),
+                            SqlMetric.run_uuid == run_id,  # constant -> factored out of the OR
+                            or_(*row_predicates),
                         )
                         .all()
                     )
-                    metric_history = {m.to_mlflow_entity() for m in metric_history}
-                    metric_instances = [
-                        m for m in metric_instances if m.to_mlflow_entity() not in metric_history
-                    ]
-                # if there exist metrics that were tried to be logged & rolled back even
-                # though they were not violating the PK, log them
+                    existing_ids.update(_metric_id(*row) for row in rows)
+
+                # Re-insert only the metrics that are genuinely new.
+                metric_instances = [
+                    m for metric_id, m in metrics_by_id.items() if metric_id not in existing_ids
+                ]
                 if non_existing_metrics := metric_instances:
                     _insert_metrics(non_existing_metrics)
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
@@ -2496,6 +2496,66 @@ def test_log_batch_duplicate_metrics_mixed_with_new_across_key_batches(store: Sq
     )
 
 
+def test_log_batch_duplicate_nan_metric_retry(store: SqlAlchemyStore):
+    """Regression test for https://github.com/mlflow/mlflow/issues/24577
+
+    NaN metrics are persisted as value=0, is_nan=True. The old dedup used
+    to_mlflow_entity() which compares float values, and nan != nan in Python,
+    so a retried NaN metric was never recognized as a duplicate and re-raised
+    IntegrityError. The fix keys on the stored is_nan flag instead.
+    """
+    run = _run_factory(store)
+    nan_metric = Metric(key="nan-key", value=float("nan"), timestamp=1, step=0)
+    # First log succeeds
+    store.log_batch(run.info.run_id, params=[], metrics=[nan_metric], tags=[])
+    # Retry the same NaN metric — should be deduplicated, not raise
+    store.log_batch(run.info.run_id, params=[], metrics=[nan_metric], tags=[])
+    _verify_logged(store, run.info.run_id, params=[], metrics=[nan_metric], tags=[])
+
+
+def test_log_batch_duplicate_mixed_with_new_and_nan(store: SqlAlchemyStore):
+    """Regression test for https://github.com/mlflow/mlflow/issues/24577
+
+    A batch with duplicates (including NaN), plus genuinely new metrics,
+    should insert only the new ones without raising.
+    """
+    run = _run_factory(store)
+    metric_a = Metric(key="key-a", value=1.0, timestamp=1, step=0)
+    metric_b = Metric(key="key-b", value=2.0, timestamp=2, step=1)
+    nan_metric = Metric(key="nan-key", value=float("nan"), timestamp=3, step=2)
+    # Log initial batch
+    store.log_batch(run.info.run_id, params=[], metrics=[metric_a, metric_b, nan_metric], tags=[])
+    # Retry with duplicates + one new metric
+    new_metric = Metric(key="key-c", value=3.0, timestamp=4, step=3)
+    retry_batch = [metric_a, metric_b, nan_metric, new_metric]
+    store.log_batch(run.info.run_id, params=[], metrics=retry_batch, tags=[])
+    _verify_logged(
+        store,
+        run.info.run_id,
+        params=[],
+        metrics=[metric_a, metric_b, nan_metric, new_metric],
+        tags=[],
+    )
+
+
+def test_log_batch_duplicate_across_dedup_chunk_boundary(store: SqlAlchemyStore):
+    """Regression test for https://github.com/mlflow/mlflow/issues/24577
+
+    Ensure dedup works when the number of candidate identities exceeds
+    _METRIC_DEDUP_CHUNK_SIZE (100), exercising the chunking logic.
+    """
+    run = _run_factory(store)
+    num_metrics = 250  # spans 3 chunks of 100
+    metrics = [
+        Metric(key=f"chunk-key-{i}", value=float(i), timestamp=i, step=i)
+        for i in range(num_metrics)
+    ]
+    store.log_batch(run.info.run_id, params=[], metrics=metrics, tags=[])
+    # Retry all — all duplicates, should not raise
+    store.log_batch(run.info.run_id, params=[], metrics=metrics, tags=[])
+    _verify_logged(store, run.info.run_id, params=[], metrics=metrics, tags=[])
+
+
 def test_log_batch_null_metrics(store: SqlAlchemyStore):
     run = _run_factory(store)
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24577

### What changes are proposed in this pull request?

When `log_batch` hits a duplicate-key `IntegrityError` on the `metrics` table, `_log_metrics` enters a recovery path that queries the **entire per-key metric history** to determine which metrics already exist. For long-running experiments this is pathological — a run with millions of rows for a key reads millions of rows and allocates gigabytes to dedup a batch of at most 1,000 metrics.

This PR replaces the per-key history scan with exact-identity queries that pin every PK column (`key`, `timestamp`, `step`, `value`, `is_nan`). Each query returns at most batch-size rows, so recovery cost is bounded by the batch size (at most 1,000 metrics → at most 10 queries of 100 rows each), not the run's accumulated history.

Keying the dedup on the stored `is_nan` flag rather than the float value also fixes two NaN correctness issues:
1. Retried NaN metrics were never recognized as duplicates (`nan != nan` in Python), so they were re-inserted and re-raised `IntegrityError`.
2. Distinct in-batch NaN `Metric` objects that sanitize to the same stored identity (`value=0, is_nan=True`) were not deduped against each other.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New regression tests added to `test_sqlalchemy_store_runs.py`:
- `test_log_batch_duplicate_nan_metric_retry` — verifies a retried NaN metric is deduplicated, not re-inserted
- `test_log_batch_duplicate_mixed_with_new_and_nan` — verifies a batch with duplicates (including NaN) plus new metrics inserts only the new ones
- `test_log_batch_duplicate_across_dedup_chunk_boundary` — verifies dedup works when candidate identities exceed `_METRIC_DEDUP_CHUNK_SIZE` (250 metrics, spanning 3 chunks)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Duplicate-metric recovery in `log_batch` is now bounded by batch size instead of run history, preventing timeouts and OOM on large runs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release