### PR TITLE
Download UI artifacts directly from cloud storage via presigned URLs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
@@ -5,7 +5,7 @@
  * annotations are already looking good, please remove this comment.
  */
 
-import { jest, describe, beforeEach, test, expect } from '@jest/globals';
+import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globals';
 import React from 'react';
 import { DesignSystemProvider, Typography } from '@databricks/design-system';
 import { shallowWithIntl, mountWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.enzyme';
@@ -24,6 +24,8 @@ import promiseMiddleware from 'redux-promise-middleware';
 import thunk from 'redux-thunk';
 import Utils from '../../common/utils/Utils';
 import { getArtifactBlob } from '../../common/utils/ArtifactUtils';
+import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
+import { MlflowService } from '../sdk/MlflowService';
 
 const { Text } = Typography;
 
@@ -190,46 +192,126 @@ describe('ArtifactView', () => {
     geojsonFileElement.simulate('click');
     expect(wrapper.find(LazyShowArtifactMapView)).toHaveLength(1);
   });
-  test('should download artifact via fetch and blob URL', async () => {
-    const rootNode = new ArtifactNode(true, undefined, undefined);
-    rootNode.isLoaded = true;
-    const textFile = new ArtifactNode(
-      false,
-      {
-        path: 'summary.txt',
-        is_dir: false,
-        file_size: '100',
+  describe('artifact download', () => {
+    let assignMock: jest.Mock;
+    let originalLocation: Location;
+    let createObjectURLSpy: any;
+    let revokeObjectURLMock: jest.Mock;
+    let anchor: any;
+    let presignedSpy: any;
+
+    const getImplInstance = () => {
+      const rootNode = new ArtifactNode(true, undefined, undefined);
+      rootNode.isLoaded = true;
+      const textFile = new ArtifactNode(
+        false,
+        {
+          path: 'summary.txt',
+          is_dir: false,
+          file_size: '100',
+        },
+        undefined,
+      );
+      rootNode.setChildren([textFile.fileInfo]);
+      wrapper = getWrapper(getMockStore(rootNode), minimalProps);
+      wrapper.find('NodeHeader').at(0).simulate('click');
+      wrapper.update();
+      // Mock the DOM download plumbing only after enzyme has mounted the component:
+      // enzyme itself needs the real document.createElement to create its container.
+      createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake-url');
+      revokeObjectURLMock = jest.fn();
+      URL.revokeObjectURL = revokeObjectURLMock;
+      anchor = { href: '', download: '', click: jest.fn() };
+      jest.spyOn(document, 'createElement').mockReturnValue(anchor);
+      jest.spyOn(document.body, 'appendChild').mockImplementation(() => anchor);
+      jest.spyOn(document.body, 'removeChild').mockImplementation(() => anchor);
+      return wrapper.find('ArtifactViewImpl').instance() as any;
+    };
+
+    const expectBlobDownload = (expectedUrlPart: string) => {
+      expect(getArtifactBlob).toHaveBeenCalledWith(expect.stringContaining(expectedUrlPart));
+      expect(createObjectURLSpy).toHaveBeenCalled();
+      expect(anchor.download).toBe('summary.txt');
+      expect(anchor.click).toHaveBeenCalled();
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:fake-url');
+    };
+
+    beforeEach(() => {
+      originalLocation = window.location;
+      assignMock = jest.fn();
+      // The download navigates the top-level page to a cross-origin (cloud storage) URL,
+      // which no router test utility models — mock `location.assign` directly.
+      // eslint-disable-next-line @databricks/no-mock-location
+      Object.defineProperty(window, 'location', {
+        value: { ...originalLocation, assign: assignMock },
+        writable: true,
+      });
+      presignedSpy = jest.spyOn(MlflowService, 'createPresignedDownloadUrl');
+      jest.mocked(getArtifactBlob).mockClear();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      // eslint-disable-next-line @databricks/no-mock-location
+      Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    });
+
+    test('should navigate to the presigned URL when the server provides one', async () => {
+      presignedSpy.mockResolvedValue({ presigned_url: 'https://s3.example.com/signed', file_size: 100 });
+
+      const implInstance = getImplInstance();
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(presignedSpy).toHaveBeenCalledWith({ run_id: 'fakeUuid', path: 'summary.txt' });
+      expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/signed');
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test.each([400, 404, 501, 503])(
+      'should fall back to the proxied download when the presigned request fails with %s',
+      async (status) => {
+        presignedSpy.mockRejectedValue(new ErrorWrapper('unavailable', status));
+
+        const implInstance = getImplInstance();
+        await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+        expect(assignMock).not.toHaveBeenCalled();
+        expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
       },
-      undefined,
     );
-    rootNode.setChildren([textFile.fileInfo]);
-    wrapper = getWrapper(getMockStore(rootNode), minimalProps);
 
-    const fileElement = wrapper.find('NodeHeader').at(0);
-    fileElement.simulate('click');
-    wrapper.update();
+    test('should fail closed without fallback when the presigned request is denied with 403', async () => {
+      const notifySpy = jest.spyOn(Utils, 'logErrorAndNotifyUser').mockImplementation(() => {});
+      presignedSpy.mockRejectedValue(new ErrorWrapper('permission denied', 403));
 
-    const createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake-url');
-    const revokeObjectURLMock = jest.fn();
-    URL.revokeObjectURL = revokeObjectURLMock;
+      const implInstance = getImplInstance();
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
 
-    const anchor = { href: '', download: '', click: jest.fn() } as any;
-    const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue(anchor);
-    jest.spyOn(document.body, 'appendChild').mockImplementation(() => anchor);
-    jest.spyOn(document.body, 'removeChild').mockImplementation(() => anchor);
+      expect(notifySpy).toHaveBeenCalled();
+      expect(assignMock).not.toHaveBeenCalled();
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
 
-    const implInstance = wrapper.find('ArtifactViewImpl').instance() as any;
-    await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+    test('should use the proxied download when the presigned URL requires request headers', async () => {
+      presignedSpy.mockResolvedValue({
+        presigned_url: 'https://s3.example.com/signed',
+        headers: { 'x-required-header': 'value' },
+      });
 
-    expect(getArtifactBlob).toHaveBeenCalledWith(
-      expect.stringContaining('get-artifact?path=summary.txt&run_uuid=fakeUuid'),
-    );
-    expect(createObjectURLSpy).toHaveBeenCalled();
-    expect(anchor.download).toBe('summary.txt');
-    expect(anchor.click).toHaveBeenCalled();
-    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:fake-url');
+      const implInstance = getImplInstance();
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
 
-    createObjectURLSpy.mockRestore();
-    createElementSpy.mockRestore();
+      expect(assignMock).not.toHaveBeenCalled();
+      expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
+    });
+
+    test('should download logged-model artifacts via the proxied path without a presigned request', async () => {
+      const implInstance = getImplInstance();
+      await implInstance.onDownloadClick(undefined, 'summary.txt', 'model-123');
+
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).not.toHaveBeenCalled();
+      expectBlobDownload('model-123');
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
@@ -195,6 +195,7 @@ describe('ArtifactView', () => {
   describe('artifact download', () => {
     let assignMock: jest.Mock;
     let originalLocation: Location;
+    let originalRevokeObjectURL: any;
     let createObjectURLSpy: any;
     let revokeObjectURLMock: jest.Mock;
     let anchor: any;
@@ -219,6 +220,8 @@ describe('ArtifactView', () => {
       // Mock the DOM download plumbing only after enzyme has mounted the component:
       // enzyme itself needs the real document.createElement to create its container.
       createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake-url');
+      // jsdom does not implement URL.revokeObjectURL (and the test setup does not polyfill
+      // it), so jest.spyOn cannot be used here; the original value is restored in afterEach.
       revokeObjectURLMock = jest.fn();
       URL.revokeObjectURL = revokeObjectURLMock;
       anchor = { href: '', download: '', click: jest.fn() };
@@ -238,6 +241,7 @@ describe('ArtifactView', () => {
 
     beforeEach(() => {
       originalLocation = window.location;
+      originalRevokeObjectURL = (URL as any).revokeObjectURL;
       assignMock = jest.fn();
       // The download navigates the top-level page to a cross-origin (cloud storage) URL,
       // which no router test utility models — mock `location.assign` directly.
@@ -252,6 +256,7 @@ describe('ArtifactView', () => {
 
     afterEach(() => {
       jest.restoreAllMocks();
+      (URL as any).revokeObjectURL = originalRevokeObjectURL;
       // eslint-disable-next-line @databricks/no-mock-location
       Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
     });
@@ -290,6 +295,20 @@ describe('ArtifactView', () => {
       expect(notifySpy).toHaveBeenCalled();
       expect(assignMock).not.toHaveBeenCalled();
       expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test('should notify the user when the proxied fallback download itself fails', async () => {
+      const notifySpy = jest.spyOn(Utils, 'logErrorAndNotifyUser').mockImplementation(() => {});
+      presignedSpy.mockRejectedValue(new ErrorWrapper('older server', 404));
+
+      const implInstance = getImplInstance();
+      jest.mocked(getArtifactBlob).mockRejectedValueOnce(new ErrorWrapper('missing artifact', 404));
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(getArtifactBlob).toHaveBeenCalled();
+      expect(notifySpy).toHaveBeenCalled();
+      expect(assignMock).not.toHaveBeenCalled();
+      expect(createObjectURLSpy).not.toHaveBeenCalled();
     });
 
     test('should use the proxied download when the presigned URL requires request headers', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -223,15 +223,25 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
   }
 
   async downloadArtifactViaBlob(url: string, artifactPath: string) {
-    const blob = await getArtifactBlob(url);
-    const blobUrl = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = blobUrl;
-    anchor.download = getBasename(artifactPath);
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-    URL.revokeObjectURL(blobUrl);
+    try {
+      const blob = await getArtifactBlob(url);
+      const blobUrl = URL.createObjectURL(blob);
+      try {
+        const anchor = document.createElement('a');
+        anchor.href = blobUrl;
+        anchor.download = getBasename(artifactPath);
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+      } finally {
+        URL.revokeObjectURL(blobUrl);
+      }
+    } catch (e) {
+      // Surface proxied-download failures (e.g. a genuinely missing artifact reached via
+      // the presigned 404 fallback) instead of leaving an unhandled rejection with no
+      // user-visible feedback.
+      Utils.logErrorAndNotifyUser(e);
+    }
   }
 
   async onDownloadClick(

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -47,6 +47,7 @@ import {
   getArtifactLocationUrl,
   getLoggedModelArtifactLocationUrl,
 } from '../../common/utils/ArtifactUtils';
+import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
 import { ArtifactViewTree } from './ArtifactViewTree';
 import { useDesignSystemTheme } from '@databricks/design-system';
 import { Button } from '@databricks/design-system';
@@ -221,22 +222,7 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
     );
   }
 
-  async onDownloadClick(
-    // comment for copybara formatting
-    runUuid: any,
-    artifactPath: any,
-    loggedModelId?: string,
-    isFallbackToLoggedModelArtifacts?: boolean,
-  ) {
-    let url: string;
-    if (runUuid && !isFallbackToLoggedModelArtifacts) {
-      url = getArtifactLocationUrl(artifactPath, runUuid);
-    } else if (loggedModelId) {
-      url = getLoggedModelArtifactLocationUrl(artifactPath, loggedModelId);
-    } else {
-      return;
-    }
-
+  async downloadArtifactViaBlob(url: string, artifactPath: string) {
     const blob = await getArtifactBlob(url);
     const blobUrl = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
@@ -246,6 +232,51 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
     anchor.click();
     document.body.removeChild(anchor);
     URL.revokeObjectURL(blobUrl);
+  }
+
+  async onDownloadClick(
+    // comment for copybara formatting
+    runUuid: any,
+    artifactPath: any,
+    loggedModelId?: string,
+    isFallbackToLoggedModelArtifacts?: boolean,
+  ) {
+    if (runUuid && !isFallbackToLoggedModelArtifacts) {
+      // Prefer a presigned URL minted by the tracking server: the browser then downloads
+      // directly from cloud storage via top-level navigation, so artifact bytes are
+      // neither proxied through the tracking server nor buffered in browser memory.
+      try {
+        const response = await MlflowService.createPresignedDownloadUrl({
+          run_id: runUuid,
+          path: artifactPath,
+        });
+        // A top-level navigation cannot attach request headers; if the backend requires
+        // any, use the proxied download instead.
+        if (response.presigned_url && Object.keys(response.headers ?? {}).length === 0) {
+          window.location.assign(response.presigned_url);
+          return;
+        }
+      } catch (e) {
+        const canFallBack =
+          e instanceof ErrorWrapper &&
+          // 400: the server rejects presigned downloads for proxied artifact storage
+          // (`mlflow-artifacts:` URIs — the default `mlflow server` configuration), where
+          // the proxied download IS the correct path. 404: older server without the
+          // endpoint (for a genuinely missing artifact the proxied path surfaces the same
+          // error). 501: artifact repository without presigned support. 503:
+          // artifacts-only server mode.
+          [400, 404, 501, 503].includes(e.getStatus());
+        if (!canFallBack) {
+          // Fail closed on everything else — notably 403, where falling back to the
+          // proxied path would sidestep a permission denial.
+          Utils.logErrorAndNotifyUser(e);
+          return;
+        }
+      }
+      await this.downloadArtifactViaBlob(getArtifactLocationUrl(artifactPath, runUuid), artifactPath);
+    } else if (loggedModelId) {
+      await this.downloadArtifactViaBlob(getLoggedModelArtifactLocationUrl(artifactPath, loggedModelId), artifactPath);
+    }
   }
 
   renderControls() {

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
@@ -100,6 +100,16 @@ export class MlflowService {
   static deleteRun = (data: { run_id: string }) => postJson({ relativeUrl: 'ajax-api/2.0/mlflow/runs/delete', data });
 
   /**
+   * Create a presigned URL for downloading a run artifact directly from cloud storage.
+   */
+  static createPresignedDownloadUrl = (data: { run_id: string; path: string }) =>
+    postJson({ relativeUrl: 'ajax-api/2.0/mlflow/artifacts/presigned-download-url', data }) as Promise<{
+      presigned_url?: string;
+      headers?: Record<string, string>;
+      file_size?: number;
+    }>;
+
+  /**
    * Search datasets used in experiments
    */
   static searchDatasets = (data: any) =>


### PR DESCRIPTION
### Related Issues/PRs

Closes #24311

### What changes are proposed in this pull request?

This is the UI follow-up to #24435 (merged), completing #24311. The artifact view's download button now asks the tracking server for a presigned download URL and, when one is available, downloads via **top-level navigation to cloud storage** instead of the current fetch → blob → object-URL flow. Artifact bytes no longer stream through the tracking server (the cause of `/tmp`-exhaustion and gateway-timeout failures for large artifacts) and are no longer buffered in browser memory, so downloads are bounded by neither server disk nor browser memory. The URL minted by #24435 carries an `attachment` Content-Disposition, so the navigation saves the file under its artifact filename and the page stays put.

Concretely:

- **`MlflowService.createPresignedDownloadUrl`**: new service method calling `POST /ajax-api/2.0/mlflow/artifacts/presigned-download-url` through the existing `postJson` (same-origin UI auth).
- **`ArtifactView.onDownloadClick` (runs branch)**: try the presigned URL first; on success with no required headers, `window.location.assign(presigned_url)`. The existing proxied fetch/blob download remains as an **automatic fallback** when the presigned request fails with:
  - **400** — proxied artifact storage (`mlflow-artifacts:` URIs, the default `mlflow server` configuration), where the proxied download is the correct path;
  - **404** — older server without the endpoint (for a genuinely missing artifact the proxied path surfaces the same error);
  - **501** — artifact repository without presigned support (e.g. GCS/Azure today);
  - **503** — artifacts-only server mode;
  - or when the response carries required request headers, which a top-level navigation cannot attach.
- **Fail closed on everything else** — notably **403**, where falling back to the proxied path would sidestep a permission denial. The error surfaces via the standard notification.
- **Logged-model artifact downloads are unchanged** (they use a different artifact location; run-scoped presigned URLs do not apply).

Existing UI deployments against older servers keep working identically: the 404 fallback makes the feature progressive.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests (`ArtifactView.enzyme.test.tsx`): the single download test became a 9-case matrix — presigned success navigates (and does not fetch a blob); 400/404/501/503 (parametrized) fall back to the proxied blob download; 403 fails closed (notification, no navigation, no fallback); a failure in the proxied fallback itself surfaces an error notification instead of an unhandled rejection; a response with required headers uses the proxied path; logged-model downloads never issue a presigned request.

Manual: end-to-end HTTP-level replay of the exact UI sequence against a live tracking server built from master (artifact proxy disabled) with an S3-compatible backend — the `ajax-api` route returns the expected shape, the URL carries the signed `attachment` disposition, an unauthenticated browser-style GET returns the artifact bytes, a missing artifact returns 404 (the fallback trigger), and the proxied `/get-artifact` fallback path serves the same file.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow UI's artifact download button now downloads artifacts directly from cloud storage via a short-lived presigned URL when the tracking server supports it, removing the tracking server from the download data path for large artifacts. When presigned downloads are unavailable (proxied artifact storage, older servers, or unsupported artifact repositories), the UI automatically falls back to the existing proxied download.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

