### PR TITLE
Read top-level cache_read/creation token counts in openai autolog

### DIFF
--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -149,6 +149,15 @@ def _parse_usage(output: Any) -> dict[str, Any] | None:
             if details := getattr(usage, "prompt_tokens_details", None):
                 if (cached := getattr(details, "cached_tokens", None)) is not None:
                     usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+            # Databricks-served Anthropic endpoints return cache counts as top-level
+            # usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
+            # prompt_tokens_details is None.  Read these when present and not already set
+            # via prompt_tokens_details.cached_tokens above.
+            if TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage_dict:
+                if (v := getattr(usage, "cache_read_input_tokens", None)) is not None:
+                    usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = v
+            if (v := getattr(usage, "cache_creation_input_tokens", None)) is not None:
+                usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = v
             return usage_dict
     except ImportError:
         pass

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 import mlflow
 from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
-from mlflow.openai.utils.chat_schema import _parse_tools
+from mlflow.openai.utils.chat_schema import _parse_tools, _parse_usage
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_VALUE_KEY,
     CostKey,
@@ -218,6 +218,55 @@ async def test_chat_completions_autolog_with_cached_tokens(client, mock_litellm_
         TokenUsageKey.TOTAL_TOKENS: 70,
         TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30,
     }
+
+
+def test_parse_usage_reads_anthropic_top_level_cache_counts():
+    """
+    Databricks-served Anthropic endpoints return cache counts as top-level
+    usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
+    prompt_tokens_details is None.  _parse_usage must extract those counts
+    even when the OpenAI-standard prompt_tokens_details path is absent.
+
+    Numbers are from the CUJ repro packet (expected-output.txt, Bug 2 section):
+      warm call: cache_read=9203, cache_creation=0,
+                 prompt_tokens=9208, completion_tokens=24, total_tokens=9232
+    """
+    from openai.types.chat import ChatCompletion
+
+    response = ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-anthropic-warm",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": "databricks-claude-opus-4-8",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello"},
+                    "logprobs": None,
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 9208,
+                "completion_tokens": 24,
+                "total_tokens": 9232,
+                "prompt_tokens_details": None,
+                "cache_read_input_tokens": 9203,
+                "cache_creation_input_tokens": 0,
+            },
+        }
+    )
+
+    usage = _parse_usage(response)
+
+    assert usage is not None
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 9208
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 24
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 9232
+    # Cache counts from top-level fields must be extracted
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 9203
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues/PRs

Closes #24615

### What changes are proposed in this pull request?

`mlflow.openai.autolog()` drops Anthropic prompt-cache token counts for Databricks-served Claude endpoints, so the trace Usage panel shows cache read and write as n/a even on a real cache hit.

Root cause: a Databricks-served Anthropic endpoint returns the cache counts as top-level usage fields:

```
resp.usage (warm): cache_read_input_tokens=9203, cache_creation_input_tokens=0
resp.usage.prompt_tokens_details: None
```

The autolog usage extractor in `mlflow/openai/utils/chat_schema.py` reads cache usage only from the OpenAI-standard location `usage.prompt_tokens_details.cached_tokens`, which is `None` on this endpoint. So the span records input, output, and total tokens but omits the cache counts.

This PR makes the extractor also read the top-level `cache_read_input_tokens` and `cache_creation_input_tokens` when the OpenAI-standard path did not already populate them. The existing `prompt_tokens_details.cached_tokens` path is unchanged and still takes priority when present. Cache counts then land on the span for Databricks-served Anthropic models with no hand-written code.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

A new unit test in `tests/openai/test_openai_autolog.py` feeds a usage object shaped like the Databricks-served warm response (top-level `cache_read_input_tokens=9203`, `cache_creation_input_tokens=0`, `prompt_tokens_details=None`) and asserts the extracted token-usage dict carries the cache-read and cache-creation counts. The test fails on the unmodified extractor and passes after the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. `openai` autolog now records Anthropic prompt-cache token counts (cache read and cache creation) for Databricks-served Claude endpoints that return them as top-level usage fields.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
