### PR TITLE
Read top-level Anthropic cache token counts in `openai` autolog

### DIFF
--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -149,6 +149,15 @@ def _parse_usage(output: Any) -> dict[str, Any] | None:
             if details := getattr(usage, "prompt_tokens_details", None):
                 if (cached := getattr(details, "cached_tokens", None)) is not None:
                     usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+            # Databricks-served Anthropic endpoints return cache counts as top-level
+            # usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
+            # prompt_tokens_details is None.  Read these when present and not already set
+            # via prompt_tokens_details.cached_tokens above.
+            if TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage_dict:
+                if (v := getattr(usage, "cache_read_input_tokens", None)) is not None:
+                    usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = v
+            if (v := getattr(usage, "cache_creation_input_tokens", None)) is not None:
+                usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = v
             return usage_dict
     except ImportError:
         pass

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 import mlflow
 from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
-from mlflow.openai.utils.chat_schema import _parse_tools
+from mlflow.openai.utils.chat_schema import _parse_tools, _parse_usage
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_VALUE_KEY,
     CostKey,
@@ -218,6 +218,53 @@ async def test_chat_completions_autolog_with_cached_tokens(client, mock_litellm_
         TokenUsageKey.TOTAL_TOKENS: 70,
         TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30,
     }
+
+
+def test_parse_usage_reads_anthropic_top_level_cache_counts():
+    """
+    Databricks-served Anthropic endpoints return cache counts as top-level
+    usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
+    prompt_tokens_details is None.  _parse_usage must extract those counts
+    even when the OpenAI-standard prompt_tokens_details path is absent.
+
+    Numbers are from the CUJ repro packet (expected-output.txt, Bug 2 section):
+      warm call: cache_read=9203, cache_creation=0,
+                 prompt_tokens=9208, completion_tokens=24, total_tokens=9232
+    """
+    from openai.types.chat import ChatCompletion
+
+    response = ChatCompletion.model_validate({
+        "id": "chatcmpl-anthropic-warm",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "databricks-claude-opus-4-8",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello"},
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9208,
+            "completion_tokens": 24,
+            "total_tokens": 9232,
+            "prompt_tokens_details": None,
+            "cache_read_input_tokens": 9203,
+            "cache_creation_input_tokens": 0,
+        },
+    })
+
+    usage = _parse_usage(response)
+
+    assert usage is not None
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 9208
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 24
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 9232
+    # Cache counts from top-level fields must be extracted
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 9203
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues/PRs

Closes #24615

### What changes are proposed in this pull request?

Databricks-served Anthropic endpoints (for example `databricks-claude-opus-4-8`) return prompt-caching counts as top-level `usage` fields, `cache_read_input_tokens` and `cache_creation_input_tokens`, while `usage.prompt_tokens_details` is null. `mlflow.openai.autolog()` read cache usage only from `usage.prompt_tokens_details.cached_tokens`, so on these endpoints the cache counts were silently dropped from the span's `mlflow.chat.tokenUsage`. The trace showed cache read and write as n/a even on a genuine cache hit.

This change updates the usage parsing in `mlflow/openai/utils/chat_schema.py`: after the existing `prompt_tokens_details` path, it also reads the top-level `cache_read_input_tokens` and `cache_creation_input_tokens` when present and not already populated. The existing OpenAI-standard path is unchanged, so non-Databricks OpenAI usage parsing behaves exactly as before.

This was reproduced with a standalone repro packet against a Databricks-served Claude endpoint. The warm-call `resp.usage` carried `cache_read_input_tokens = 9203` with `prompt_tokens_details = None`, and the autolog span carried only input/output/total before this fix.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Adds `test_parse_usage_reads_anthropic_top_level_cache_counts` in `tests/openai/test_openai_autolog.py`, using the exact numbers from the repro packet (`cache_read_input_tokens=9203`, `cache_creation_input_tokens=0`, `prompt_tokens=9208`, `completion_tokens=24`, `total_tokens=9232`). The test fails before the fix and passes after.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.openai.autolog()` now records Anthropic prompt-cache read and write token counts on the span for Databricks-served Claude endpoints, which return those counts as top-level usage fields.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
