### PR TITLE
Read top-level cache_read/creation token counts in `openai` autolog

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -12,14 +12,13 @@ from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatusCode
 from mlflow.exceptions import MlflowException
 from mlflow.openai.constant import FLAVOR_NAME
-from mlflow.openai.utils.chat_schema import set_span_chat_attributes
+from mlflow.openai.utils.chat_schema import _parse_chat_completion_usage, set_span_chat_attributes
 from mlflow.telemetry.events import AutologgingEvent
 from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_NAME_FORMAT,
     STREAM_CHUNK_EVENT_VALUE_KEY,
     SpanAttributeKey,
-    TokenUsageKey,
     TraceMetadataKey,
 )
 from mlflow.tracing.distributed import _get_tracing_headers_from_span
@@ -392,17 +391,7 @@ def _process_last_chunk(
             output = _reconstruct_completion_from_stream(completion_chunks)
             # Set usage information on span if available
             if usage := _get_completion_stream_usage(completion_chunks):
-                usage_dict = {
-                    TokenUsageKey.INPUT_TOKENS: usage.prompt_tokens,
-                    TokenUsageKey.OUTPUT_TOKENS: usage.completion_tokens,
-                    TokenUsageKey.TOTAL_TOKENS: usage.total_tokens,
-                }
-
-                # Extract cached tokens if available in the streaming chunk
-                if details := getattr(usage, "prompt_tokens_details", None):
-                    if (cached := getattr(details, "cached_tokens", None)) is not None:
-                        usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
-                span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
+                span.set_attribute(SpanAttributeKey.CHAT_USAGE, _parse_chat_completion_usage(usage))
 
         _end_span_on_success(span, inputs, output, is_responses_api)
     except Exception as e:

--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -149,6 +149,16 @@ def _parse_usage(output: Any) -> dict[str, Any] | None:
             if details := getattr(usage, "prompt_tokens_details", None):
                 if (cached := getattr(details, "cached_tokens", None)) is not None:
                     usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+            # Databricks-served Anthropic endpoints return cache counts as top-level
+            # usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
+            # prompt_tokens_details is None.  Read these when present and not already set
+            # via prompt_tokens_details.cached_tokens above.
+            if TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage_dict:
+                if (v := getattr(usage, "cache_read_input_tokens", None)) is not None:
+                    usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = v
+            if TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage_dict:
+                if (v := getattr(usage, "cache_creation_input_tokens", None)) is not None:
+                    usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = v
             return usage_dict
     except ImportError:
         pass

--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -141,25 +141,7 @@ def _parse_usage(output: Any) -> dict[str, Any] | None:
         from openai.types.chat import ChatCompletion
 
         if isinstance(output, ChatCompletion) and (usage := output.usage):
-            usage_dict = {
-                TokenUsageKey.INPUT_TOKENS: usage.prompt_tokens,
-                TokenUsageKey.OUTPUT_TOKENS: usage.completion_tokens,
-                TokenUsageKey.TOTAL_TOKENS: usage.total_tokens,
-            }
-            if details := getattr(usage, "prompt_tokens_details", None):
-                if (cached := getattr(details, "cached_tokens", None)) is not None:
-                    usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
-            # Databricks-served Anthropic endpoints return cache counts as top-level
-            # usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
-            # prompt_tokens_details is None.  Read these when present and not already set
-            # via prompt_tokens_details.cached_tokens above.
-            if TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage_dict:
-                if (v := getattr(usage, "cache_read_input_tokens", None)) is not None:
-                    usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = v
-            if TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage_dict:
-                if (v := getattr(usage, "cache_creation_input_tokens", None)) is not None:
-                    usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = v
-            return usage_dict
+            return _parse_chat_completion_usage(usage)
     except ImportError:
         pass
 
@@ -181,3 +163,20 @@ def _parse_usage(output: Any) -> dict[str, Any] | None:
         pass
 
     return None
+
+
+def _parse_chat_completion_usage(usage: Any) -> dict[str, Any]:
+    usage_dict = {
+        TokenUsageKey.INPUT_TOKENS: usage.prompt_tokens,
+        TokenUsageKey.OUTPUT_TOKENS: usage.completion_tokens,
+        TokenUsageKey.TOTAL_TOKENS: usage.total_tokens,
+    }
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = getattr(details, "cached_tokens", None)
+    if cached is None:
+        cached = getattr(usage, "cache_read_input_tokens", None)
+    if cached is not None:
+        usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+    if (created := getattr(usage, "cache_creation_input_tokens", None)) is not None:
+        usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = created
+    return usage_dict

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -17,7 +17,7 @@ from mlflow.entities import SpanLogLevel
 from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.openai.autolog import _get_span_type
-from mlflow.openai.utils.chat_schema import _parse_tools
+from mlflow.openai.utils.chat_schema import _parse_tools, _parse_usage
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_VALUE_KEY,
     CostKey,
@@ -240,6 +240,103 @@ async def test_chat_completions_autolog_with_cached_tokens(client, mock_litellm_
         TokenUsageKey.TOTAL_TOKENS: 70,
         TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30,
     }
+
+
+def test_parse_usage_reads_anthropic_top_level_cache_counts():
+    """
+    Databricks-served Anthropic endpoints return cache counts as top-level
+    usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
+    prompt_tokens_details is None.  _parse_usage must extract those counts
+    even when the OpenAI-standard prompt_tokens_details path is absent.
+
+    Numbers come from a warm prompt-cache hit:
+      cache_read=9203, cache_creation=0,
+      prompt_tokens=9208, completion_tokens=24, total_tokens=9232
+    """
+    from openai.types.chat import ChatCompletion
+
+    response = ChatCompletion.model_validate({
+        "id": "chatcmpl-anthropic-warm",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "databricks-claude-opus-4-8",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello"},
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9208,
+            "completion_tokens": 24,
+            "total_tokens": 9232,
+            "prompt_tokens_details": None,
+            "cache_read_input_tokens": 9203,
+            "cache_creation_input_tokens": 0,
+        },
+    })
+
+    usage = _parse_usage(response)
+
+    assert usage is not None
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 9208
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 24
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 9232
+    # Cache counts from top-level fields must be extracted
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 9203
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 0
+
+
+def test_parse_usage_top_level_cache_fields_do_not_clobber_openai_standard_values():
+    """
+    When both prompt_tokens_details.cached_tokens (OpenAI-standard) and the
+    top-level cache_read_input_tokens / cache_creation_input_tokens (Anthropic
+    extension) are present with different values, the OpenAI-standard value wins
+    for cache_read (the guard prevents clobbering).  For cache_creation, which
+    prompt_tokens_details does not set, the top-level value is used.
+    """
+    from openai.types.chat import ChatCompletion
+
+    response = ChatCompletion.model_validate({
+        "id": "chatcmpl-both-paths",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "databricks-claude-opus-4-8",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello"},
+                "logprobs": None,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+            # OpenAI-standard path sets CACHE_READ_INPUT_TOKENS = 50
+            "prompt_tokens_details": {"cached_tokens": 50, "audio_tokens": 0},
+            # Top-level Anthropic fields carry different values. cache_read is
+            # already set by the OpenAI-standard path, so its top-level value
+            # must be ignored. cache_creation is not set there, so its top-level
+            # value is the one that gets used.
+            "cache_read_input_tokens": 9999,
+            "cache_creation_input_tokens": 8888,
+        },
+    })
+
+    usage = _parse_usage(response)
+
+    assert usage is not None
+    # OpenAI-standard value wins for cache_read (guard prevents clobber)
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 50
+    # Top-level cache_creation must also be guarded; CACHE_CREATION_INPUT_TOKENS
+    # was NOT set by prompt_tokens_details, so the top-level value IS used here.
+    # The key assertion is that it is present and equals the top-level value
+    # (not silently dropped), confirming the guard logic is symmetric.
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 8888
 
 
 @pytest.mark.asyncio

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -9,6 +9,7 @@ import pytest
 from openai.resources.chat.completions import Completions as ChatCompletions
 from openai.resources.completions import Completions
 from openai.resources.embeddings import Embeddings
+from openai.types.chat import ChatCompletion
 from packaging.version import Version
 from pydantic import BaseModel
 
@@ -242,101 +243,50 @@ async def test_chat_completions_autolog_with_cached_tokens(client, mock_litellm_
     }
 
 
-def test_parse_usage_reads_anthropic_top_level_cache_counts():
-    """
-    Databricks-served Anthropic endpoints return cache counts as top-level
-    usage fields (cache_read_input_tokens, cache_creation_input_tokens) while
-    prompt_tokens_details is None.  _parse_usage must extract those counts
-    even when the OpenAI-standard prompt_tokens_details path is absent.
-
-    Numbers come from a warm prompt-cache hit:
-      cache_read=9203, cache_creation=0,
-      prompt_tokens=9208, completion_tokens=24, total_tokens=9232
-    """
-    from openai.types.chat import ChatCompletion
-
+@pytest.mark.parametrize(
+    ("cache_usage", "expected_cache_usage"),
+    [
+        (
+            {"cache_read_input_tokens": 9203, "cache_creation_input_tokens": 0},
+            {
+                TokenUsageKey.CACHE_READ_INPUT_TOKENS: 9203,
+                TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 0,
+            },
+        ),
+        (
+            {
+                "prompt_tokens_details": {"cached_tokens": 50},
+                "cache_read_input_tokens": 9999,
+                "cache_creation_input_tokens": 8888,
+            },
+            {
+                TokenUsageKey.CACHE_READ_INPUT_TOKENS: 50,
+                TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 8888,
+            },
+        ),
+    ],
+)
+def test_parse_usage_cache_tokens(cache_usage, expected_cache_usage):
     response = ChatCompletion.model_validate({
-        "id": "chatcmpl-anthropic-warm",
+        "id": "chatcmpl-cache",
         "object": "chat.completion",
         "created": 1677652288,
         "model": "databricks-claude-opus-4-8",
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": "Hello"},
-                "logprobs": None,
-                "finish_reason": "stop",
-            }
-        ],
-        "usage": {
-            "prompt_tokens": 9208,
-            "completion_tokens": 24,
-            "total_tokens": 9232,
-            "prompt_tokens_details": None,
-            "cache_read_input_tokens": 9203,
-            "cache_creation_input_tokens": 0,
-        },
-    })
-
-    usage = _parse_usage(response)
-
-    assert usage is not None
-    assert usage[TokenUsageKey.INPUT_TOKENS] == 9208
-    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 24
-    assert usage[TokenUsageKey.TOTAL_TOKENS] == 9232
-    # Cache counts from top-level fields must be extracted
-    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 9203
-    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 0
-
-
-def test_parse_usage_top_level_cache_fields_do_not_clobber_openai_standard_values():
-    """
-    When both prompt_tokens_details.cached_tokens (OpenAI-standard) and the
-    top-level cache_read_input_tokens / cache_creation_input_tokens (Anthropic
-    extension) are present with different values, the OpenAI-standard value wins
-    for cache_read (the guard prevents clobbering).  For cache_creation, which
-    prompt_tokens_details does not set, the top-level value is used.
-    """
-    from openai.types.chat import ChatCompletion
-
-    response = ChatCompletion.model_validate({
-        "id": "chatcmpl-both-paths",
-        "object": "chat.completion",
-        "created": 1677652288,
-        "model": "databricks-claude-opus-4-8",
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": "Hello"},
-                "logprobs": None,
-                "finish_reason": "stop",
-            }
-        ],
+        "choices": [],
         "usage": {
             "prompt_tokens": 100,
             "completion_tokens": 20,
             "total_tokens": 120,
-            # OpenAI-standard path sets CACHE_READ_INPUT_TOKENS = 50
-            "prompt_tokens_details": {"cached_tokens": 50, "audio_tokens": 0},
-            # Top-level Anthropic fields carry different values. cache_read is
-            # already set by the OpenAI-standard path, so its top-level value
-            # must be ignored. cache_creation is not set there, so its top-level
-            # value is the one that gets used.
-            "cache_read_input_tokens": 9999,
-            "cache_creation_input_tokens": 8888,
+            **cache_usage,
         },
     })
 
-    usage = _parse_usage(response)
-
-    assert usage is not None
-    # OpenAI-standard value wins for cache_read (guard prevents clobber)
-    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 50
-    # Top-level cache_creation must also be guarded; CACHE_CREATION_INPUT_TOKENS
-    # was NOT set by prompt_tokens_details, so the top-level value IS used here.
-    # The key assertion is that it is present and equals the top-level value
-    # (not silently dropped), confirming the guard logic is symmetric.
-    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 8888
+    assert _parse_usage(response) == {
+        TokenUsageKey.INPUT_TOKENS: 100,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 120,
+        **expected_cache_usage,
+    }
 
 
 @pytest.mark.asyncio
@@ -1287,7 +1237,25 @@ async def test_tracing_headers_preserve_user_headers(client):
 @pytest.mark.skipif(
     Version(openai.__version__) < Version("1.66"), reason="Cost tracking does not work before 1.66"
 )
-async def test_chat_completions_autolog_streaming_with_cached_tokens(client, mock_litellm_cost):
+@pytest.mark.parametrize(
+    ("cache_usage", "expected_cache_usage"),
+    [
+        (
+            {"prompt_tokens_details": {"cached_tokens": 30, "audio_tokens": 0}},
+            {TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30},
+        ),
+        (
+            {"cache_read_input_tokens": 30, "cache_creation_input_tokens": 10},
+            {
+                TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30,
+                TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 10,
+            },
+        ),
+    ],
+)
+async def test_chat_completions_autolog_streaming_with_cached_tokens(
+    client, mock_litellm_cost, cache_usage, expected_cache_usage
+):
     mlflow.openai.autolog()
 
     mock_chunk = {
@@ -1300,8 +1268,8 @@ async def test_chat_completions_autolog_streaming_with_cached_tokens(client, moc
             "prompt_tokens": 50,
             "completion_tokens": 20,
             "total_tokens": 70,
-            "prompt_tokens_details": {"cached_tokens": 30, "audio_tokens": 0},
             "completion_tokens_details": {"reasoning_tokens": 0},
+            **cache_usage,
         },
     }
 
@@ -1341,5 +1309,5 @@ async def test_chat_completions_autolog_streaming_with_cached_tokens(client, moc
         TokenUsageKey.INPUT_TOKENS: 50,
         TokenUsageKey.OUTPUT_TOKENS: 20,
         TokenUsageKey.TOTAL_TOKENS: 70,
-        TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30,
+        **expected_cache_usage,
     }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24615

### What changes are proposed in this pull request?

`mlflow.openai.autolog()` drops Anthropic prompt-cache token counts for Databricks-served Claude endpoints, so the trace Usage panel shows cache read and write as n/a even on a real cache hit.

Root cause: a Databricks-served Anthropic endpoint returns the cache counts as top-level usage fields:

```
resp.usage (warm): cache_read_input_tokens=9203, cache_creation_input_tokens=0
resp.usage.prompt_tokens_details: None
```

The autolog usage extractor in `mlflow/openai/utils/chat_schema.py` reads cache usage only from the OpenAI-standard location `usage.prompt_tokens_details.cached_tokens`, which is `None` on this endpoint. So the span records input, output, and total tokens but omits the cache counts.

This PR makes the extractor also read the top-level `cache_read_input_tokens` and `cache_creation_input_tokens` when the OpenAI-standard path did not already populate them. The existing `prompt_tokens_details.cached_tokens` path is unchanged and still takes priority when present. Cache counts then land on the span for Databricks-served Anthropic models with no hand-written code.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

A new unit test in `tests/openai/test_openai_autolog.py` feeds a usage object shaped like the Databricks-served warm response (top-level `cache_read_input_tokens=9203`, `cache_creation_input_tokens=0`, `prompt_tokens_details=None`) and asserts the extracted token-usage dict carries the cache-read and cache-creation counts. The test fails on the unmodified extractor and passes after the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. `openai` autolog now records Anthropic prompt-cache token counts (cache read and cache creation) for Databricks-served Claude endpoints that return them as top-level usage fields.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
