### PR TITLE
Fix $0.00 cost panel for bare Databricks serving-endpoint model names

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -403,6 +403,25 @@ def calculate_cost_by_model_and_token_usage(
             except Exception:
                 pass
 
+        # Infer "databricks" as the provider for bare Databricks serving-endpoint names
+        # (e.g. "databricks-claude-opus-4-8") when the MODEL_PROVIDER span attribute is
+        # absent.  Without this inference the cost returns None and the UI renders $0.00
+        # for traced tokens.  The inference is narrow: only names that start with
+        # "databricks-" or "databricks/" are assumed to be Databricks-hosted.
+        if result is None and isinstance(model_name, str) and not model_provider and (
+            model_name.startswith("databricks-") or model_name.startswith("databricks/")
+        ):
+            try:
+                result = cost_per_token(
+                    model=model_name,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    custom_llm_provider="databricks",
+                    **cache_kwargs,
+                )
+            except Exception:
+                pass
+
         # Fallback: try without provider (for litellm this may match by model name alone,
         # for builtin this scans bundled providers).
         if result is None:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -356,11 +356,11 @@ def calculate_cost_by_model_and_token_usage(
     if not model_name or not usage:
         return None
 
-    if not isinstance(model_name, str):
-        return None
-
     if model_name.startswith(_SKIP_COST_PREFIXES):
         return None
+
+    if not model_provider and model_name.startswith(("databricks-", "databricks/")):
+        model_provider = "databricks"
 
     prompt_tokens = usage.get(TokenUsageKey.INPUT_TOKENS, 0)
     completion_tokens = usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
@@ -401,28 +401,6 @@ def calculate_cost_by_model_and_token_usage(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     custom_llm_provider=model_provider.lower(),
-                    **cache_kwargs,
-                )
-            except Exception:
-                pass
-
-        # Infer "databricks" as the provider for bare Databricks serving-endpoint names
-        # (e.g. "databricks-claude-opus-4-8") when the MODEL_PROVIDER span attribute is
-        # absent.  Without this inference the cost returns None and the UI renders $0.00
-        # for traced tokens.  The inference is narrow: only names that start with
-        # "databricks-" or "databricks/" are assumed to be Databricks-hosted.
-        if (
-            result is None
-            and isinstance(model_name, str)
-            and not model_provider
-            and (model_name.startswith("databricks-") or model_name.startswith("databricks/"))
-        ):
-            try:
-                result = cost_per_token(
-                    model=model_name,
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    custom_llm_provider="databricks",
                     **cache_kwargs,
                 )
             except Exception:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -408,8 +408,11 @@ def calculate_cost_by_model_and_token_usage(
         # absent.  Without this inference the cost returns None and the UI renders $0.00
         # for traced tokens.  The inference is narrow: only names that start with
         # "databricks-" or "databricks/" are assumed to be Databricks-hosted.
-        if result is None and isinstance(model_name, str) and not model_provider and (
-            model_name.startswith("databricks-") or model_name.startswith("databricks/")
+        if (
+            result is None
+            and isinstance(model_name, str)
+            and not model_provider
+            and (model_name.startswith("databricks-") or model_name.startswith("databricks/"))
         ):
             try:
                 result = cost_per_token(

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -356,6 +356,9 @@ def calculate_cost_by_model_and_token_usage(
     if not model_name or not usage:
         return None
 
+    if not isinstance(model_name, str):
+        return None
+
     if model_name.startswith(_SKIP_COST_PREFIXES):
         return None
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -823,8 +823,21 @@ def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
     assert litellm.suppress_debug_info is False
 
 
-def test_litellm_provider_list_printed_when_debug_logging(capsys):
+def test_litellm_debug_unsuppressed_when_debug_logging(monkeypatch):
     litellm.suppress_debug_info = True
+
+    # Capture litellm.suppress_debug_info at the moment cost_per_token runs. Asserting on
+    # the flag is deterministic; asserting that litellm prints its "Provider List" is not,
+    # because that side effect depends on the litellm version and does not fire for every
+    # model (it never prints for databricks-claude-sonnet-4-5 in current litellm).
+    suppress_during_call = {}
+    real_cost_per_token = litellm.cost_per_token
+
+    def spy_cost_per_token(*args, **kwargs):
+        suppress_during_call["value"] = litellm.suppress_debug_info
+        return real_cost_per_token(*args, **kwargs)
+
+    monkeypatch.setattr(litellm, "cost_per_token", spy_cost_per_token)
 
     _logger = logging.getLogger("mlflow.tracing.utils")
     original_level = _logger.level
@@ -837,10 +850,10 @@ def test_litellm_provider_list_printed_when_debug_logging(capsys):
     finally:
         _logger.setLevel(original_level)
 
-    captured = capsys.readouterr()
-    assert "Provider List" in captured.out
-    # During the call to calculate cost, suppress was set to False
-    # We are asserting that suppress is reset to the original value after
+    # At DEBUG level the cost calculation un-suppresses litellm's debug output during the
+    # call so its diagnostics reach the logs...
+    assert suppress_during_call.get("value") is False
+    # ...and the original value is restored afterward.
     assert litellm.suppress_debug_info is True
 
 

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -902,8 +902,8 @@ def test_non_databricks_model_not_repriced_as_databricks():
     )
     assert result is not None, "gpt-4o cost must resolve without provider"
     assert result[CostKey.INPUT_COST] > 0
-    # sanity: gpt-4o input price is $2.50/1M, so 1k tokens => ~$0.0025
-    # databricks/... would give a completely different price; confirm it's not that
+    # Confirm the result matches what litellm returns directly, ruling out any
+    # accidental databricks-provider repricing:
     from litellm import cost_per_token as _cpt
 
     expected_input, _ = _cpt(model="gpt-4o", prompt_tokens=1_000, completion_tokens=500)

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -905,6 +905,7 @@ def test_non_databricks_model_not_repriced_as_databricks():
     # sanity: gpt-4o input price is $2.50/1M, so 1k tokens => ~$0.0025
     # databricks/... would give a completely different price; confirm it's not that
     from litellm import cost_per_token as _cpt
+
     expected_input, _ = _cpt(model="gpt-4o", prompt_tokens=1_000, completion_tokens=500)
     assert abs(result[CostKey.INPUT_COST] - expected_input) < 1e-9, (
         "gpt-4o price must not change due to the databricks-name fix"
@@ -913,7 +914,8 @@ def test_non_databricks_model_not_repriced_as_databricks():
 
 def test_databricks_slash_prefixed_name_resolves_cost():
     """'databricks/' prefix (e.g. 'databricks/databricks-claude-opus-4-8') must
-    return non-zero cost even when MODEL_PROVIDER attribute is absent."""
+    return non-zero cost even when MODEL_PROVIDER attribute is absent.
+    """
     result = calculate_cost_by_model_and_token_usage(
         model_name="databricks/databricks-claude-opus-4-8",
         usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
@@ -929,7 +931,8 @@ def test_databricks_slash_prefixed_name_resolves_cost():
 
 def test_explicit_model_provider_passed_through():
     """When model_provider='databricks' is supplied explicitly, cost resolves correctly.
-    Proves the effective_provider path still works after the model_provider rename."""
+    Proves the effective_provider path still works after the model_provider rename.
+    """
     result = calculate_cost_by_model_and_token_usage(
         model_name="databricks-claude-opus-4-8",
         usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
@@ -941,3 +944,21 @@ def test_explicit_model_provider_passed_through():
     assert result[CostKey.INPUT_COST] > 0, (
         "Input cost must be > 0 for 1M tokens with explicit databricks provider"
     )
+
+
+def test_non_string_model_name_does_not_raise():
+    """A non-string truthy model_name (e.g. an integer) must not raise AttributeError.
+
+    The isinstance(model_name, str) guard added alongside the startswith() check
+    prevents AttributeError when a caller passes a non-string value that slips past
+    the earlier falsy guard.
+    """
+    # An integer is truthy, so it passes `if not model_name`, but calling
+    # .startswith() on it would raise AttributeError without the isinstance guard.
+    result = calculate_cost_by_model_and_token_usage(
+        model_name=12345,  # type: ignore[arg-type]
+        usage={TokenUsageKey.INPUT_TOKENS: 1_000, TokenUsageKey.OUTPUT_TOKENS: 500},
+        model_provider=None,
+    )
+    # The function may return None (no matching model), but it must not raise.
+    assert result is None or isinstance(result, dict)

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -909,3 +909,35 @@ def test_non_databricks_model_not_repriced_as_databricks():
     assert abs(result[CostKey.INPUT_COST] - expected_input) < 1e-9, (
         "gpt-4o price must not change due to the databricks-name fix"
     )
+
+
+def test_databricks_slash_prefixed_name_resolves_cost():
+    """'databricks/' prefix (e.g. 'databricks/databricks-claude-opus-4-8') must
+    return non-zero cost even when MODEL_PROVIDER attribute is absent."""
+    result = calculate_cost_by_model_and_token_usage(
+        model_name="databricks/databricks-claude-opus-4-8",
+        usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
+        model_provider=None,
+    )
+    assert result is not None, (
+        "Cost must not be None for databricks/databricks-claude-opus-4-8 without provider"
+    )
+    assert result[CostKey.INPUT_COST] > 0, (
+        "Input cost must be > 0 for 1M tokens on databricks/databricks-claude-opus-4-8"
+    )
+
+
+def test_explicit_model_provider_passed_through():
+    """When model_provider='databricks' is supplied explicitly, cost resolves correctly.
+    Proves the effective_provider path still works after the model_provider rename."""
+    result = calculate_cost_by_model_and_token_usage(
+        model_name="databricks-claude-opus-4-8",
+        usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
+        model_provider="databricks",
+    )
+    assert result is not None, (
+        "Cost must not be None when model_provider='databricks' is explicitly supplied"
+    )
+    assert result[CostKey.INPUT_COST] > 0, (
+        "Input cost must be > 0 for 1M tokens with explicit databricks provider"
+    )

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -868,3 +868,44 @@ def test_dump_span_attribute_value_handles_type_error():
 
     # Must not raise; fall back result is a valid JSON string containing repr(value).
     assert result == json.dumps(repr(value), ensure_ascii=False)
+
+
+def test_databricks_bare_endpoint_name_resolves_cost():
+    """Bare Databricks endpoint name (no 'databricks/' prefix, no MODEL_PROVIDER attribute)
+    must return a non-zero cost.
+
+    Regression: cost_per_token('databricks-claude-opus-4-8') raises
+    BadRequestError because litellm cannot infer the provider from the bare
+    name alone.  MLflow's existing fallback only retries with a provider when
+    the MODEL_PROVIDER span attribute is present.  Without it the cost returns
+    None and the UI renders $0.00 for ~1.6M tracked tokens.
+    """
+    result = calculate_cost_by_model_and_token_usage(
+        model_name="databricks-claude-opus-4-8",
+        usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
+        model_provider=None,  # attribute absent from the span
+    )
+    assert result is not None, (
+        "Cost must not be None for databricks-claude-opus-4-8 even when MODEL_PROVIDER is absent"
+    )
+    assert result[CostKey.INPUT_COST] > 0, (
+        "Input cost must be > 0 for 1M tokens on databricks-claude-opus-4-8"
+    )
+
+
+def test_non_databricks_model_not_repriced_as_databricks():
+    """gpt-4o must still resolve correctly and must NOT receive the databricks provider."""
+    result = calculate_cost_by_model_and_token_usage(
+        model_name="gpt-4o",
+        usage={TokenUsageKey.INPUT_TOKENS: 1_000, TokenUsageKey.OUTPUT_TOKENS: 500},
+        model_provider=None,
+    )
+    assert result is not None, "gpt-4o cost must resolve without provider"
+    assert result[CostKey.INPUT_COST] > 0
+    # sanity: gpt-4o input price is $2.50/1M, so 1k tokens => ~$0.0025
+    # databricks/... would give a completely different price; confirm it's not that
+    from litellm import cost_per_token as _cpt
+    expected_input, _ = _cpt(model="gpt-4o", prompt_tokens=1_000, completion_tokens=500)
+    assert abs(result[CostKey.INPUT_COST] - expected_input) < 1e-9, (
+        "gpt-4o price must not change due to the databricks-name fix"
+    )

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -871,15 +871,6 @@ def test_dump_span_attribute_value_handles_type_error():
 
 
 def test_databricks_bare_endpoint_name_resolves_cost():
-    """Bare Databricks endpoint name (no 'databricks/' prefix, no MODEL_PROVIDER attribute)
-    must return a non-zero cost.
-
-    Regression: cost_per_token('databricks-claude-opus-4-8') raises
-    BadRequestError because litellm cannot infer the provider from the bare
-    name alone.  MLflow's existing fallback only retries with a provider when
-    the MODEL_PROVIDER span attribute is present.  Without it the cost returns
-    None and the UI renders $0.00 for ~1.6M tracked tokens.
-    """
     result = calculate_cost_by_model_and_token_usage(
         model_name="databricks-claude-opus-4-8",
         usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
@@ -894,7 +885,6 @@ def test_databricks_bare_endpoint_name_resolves_cost():
 
 
 def test_non_databricks_model_not_repriced_as_databricks():
-    """gpt-4o must still resolve correctly and must NOT receive the databricks provider."""
     result = calculate_cost_by_model_and_token_usage(
         model_name="gpt-4o",
         usage={TokenUsageKey.INPUT_TOKENS: 1_000, TokenUsageKey.OUTPUT_TOKENS: 500},
@@ -913,9 +903,6 @@ def test_non_databricks_model_not_repriced_as_databricks():
 
 
 def test_databricks_slash_prefixed_name_resolves_cost():
-    """'databricks/' prefix (e.g. 'databricks/databricks-claude-opus-4-8') must
-    return non-zero cost even when MODEL_PROVIDER attribute is absent.
-    """
     result = calculate_cost_by_model_and_token_usage(
         model_name="databricks/databricks-claude-opus-4-8",
         usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
@@ -930,9 +917,6 @@ def test_databricks_slash_prefixed_name_resolves_cost():
 
 
 def test_explicit_model_provider_passed_through():
-    """When model_provider='databricks' is supplied explicitly, cost resolves correctly.
-    Proves the effective_provider path still works after the model_provider rename.
-    """
     result = calculate_cost_by_model_and_token_usage(
         model_name="databricks-claude-opus-4-8",
         usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
@@ -947,12 +931,6 @@ def test_explicit_model_provider_passed_through():
 
 
 def test_non_string_model_name_does_not_raise():
-    """A non-string truthy model_name (e.g. an integer) must not raise AttributeError.
-
-    The isinstance(model_name, str) guard added alongside the startswith() check
-    prevents AttributeError when a caller passes a non-string value that slips past
-    the earlier falsy guard.
-    """
     # An integer is truthy, so it passes `if not model_name`, but calling
     # .startswith() on it would raise AttributeError without the isinstance guard.
     result = calculate_cost_by_model_and_token_usage(

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -814,7 +814,7 @@ def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
     litellm.suppress_debug_info = False
 
     calculate_cost_by_model_and_token_usage(
-        model_name="databricks-claude-sonnet-4-5",
+        model_name="unknown-model",
         usage={TokenUsageKey.INPUT_TOKENS: 10, TokenUsageKey.OUTPUT_TOKENS: 5},
     )
 
@@ -823,37 +823,22 @@ def test_litellm_provider_list_not_printed_during_cost_calculation(capsys):
     assert litellm.suppress_debug_info is False
 
 
-def test_litellm_debug_unsuppressed_when_debug_logging(monkeypatch):
+def test_litellm_provider_list_printed_when_debug_logging(capsys):
     litellm.suppress_debug_info = True
-
-    # Capture litellm.suppress_debug_info at the moment cost_per_token runs. Asserting on
-    # the flag is deterministic; asserting that litellm prints its "Provider List" is not,
-    # because that side effect depends on the litellm version and does not fire for every
-    # model (it never prints for databricks-claude-sonnet-4-5 in current litellm).
-    suppress_during_call = {}
-    real_cost_per_token = litellm.cost_per_token
-
-    def spy_cost_per_token(*args, **kwargs):
-        suppress_during_call["value"] = litellm.suppress_debug_info
-        return real_cost_per_token(*args, **kwargs)
-
-    monkeypatch.setattr(litellm, "cost_per_token", spy_cost_per_token)
 
     _logger = logging.getLogger("mlflow.tracing.utils")
     original_level = _logger.level
     _logger.setLevel(logging.DEBUG)
     try:
         calculate_cost_by_model_and_token_usage(
-            model_name="databricks-claude-sonnet-4-5",
+            model_name="unknown-model",
             usage={TokenUsageKey.INPUT_TOKENS: 10, TokenUsageKey.OUTPUT_TOKENS: 5},
         )
     finally:
         _logger.setLevel(original_level)
 
-    # At DEBUG level the cost calculation un-suppresses litellm's debug output during the
-    # call so its diagnostics reach the logs...
-    assert suppress_during_call.get("value") is False
-    # ...and the original value is restored afterward.
+    captured = capsys.readouterr()
+    assert "Provider List" in captured.out
     assert litellm.suppress_debug_info is True
 
 
@@ -883,73 +868,30 @@ def test_dump_span_attribute_value_handles_type_error():
     assert result == json.dumps(repr(value), ensure_ascii=False)
 
 
-def test_databricks_bare_endpoint_name_resolves_cost():
-    result = calculate_cost_by_model_and_token_usage(
-        model_name="databricks-claude-opus-4-8",
-        usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
-        model_provider=None,  # attribute absent from the span
-    )
-    assert result is not None, (
-        "Cost must not be None for databricks-claude-opus-4-8 even when MODEL_PROVIDER is absent"
-    )
-    assert result[CostKey.INPUT_COST] > 0, (
-        "Input cost must be > 0 for 1M tokens on databricks-claude-opus-4-8"
-    )
+@pytest.mark.parametrize(
+    ("model_name", "model_provider", "expected_provider"),
+    [
+        ("databricks-claude-opus-4-8", None, "databricks"),
+        ("databricks/databricks-claude-opus-4-8", None, "databricks"),
+        ("databricks-claude-opus-4-8", "databricks", "databricks"),
+        ("gpt-4o", None, None),
+    ],
+)
+def test_cost_calculation_uses_expected_provider(model_name, model_provider, expected_provider):
+    with mock.patch("litellm.cost_per_token", wraps=litellm.cost_per_token) as cost_per_token:
+        result = calculate_cost_by_model_and_token_usage(
+            model_name,
+            {TokenUsageKey.INPUT_TOKENS: 1_000, TokenUsageKey.OUTPUT_TOKENS: 500},
+            model_provider,
+        )
 
-
-def test_non_databricks_model_not_repriced_as_databricks():
-    result = calculate_cost_by_model_and_token_usage(
-        model_name="gpt-4o",
-        usage={TokenUsageKey.INPUT_TOKENS: 1_000, TokenUsageKey.OUTPUT_TOKENS: 500},
-        model_provider=None,
-    )
-    assert result is not None, "gpt-4o cost must resolve without provider"
-    assert result[CostKey.INPUT_COST] > 0
-    # Confirm the result matches what litellm returns directly, ruling out any
-    # accidental databricks-provider repricing:
-    from litellm import cost_per_token as _cpt
-
-    expected_input, _ = _cpt(model="gpt-4o", prompt_tokens=1_000, completion_tokens=500)
-    assert abs(result[CostKey.INPUT_COST] - expected_input) < 1e-9, (
-        "gpt-4o price must not change due to the databricks-name fix"
-    )
-
-
-def test_databricks_slash_prefixed_name_resolves_cost():
-    result = calculate_cost_by_model_and_token_usage(
-        model_name="databricks/databricks-claude-opus-4-8",
-        usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
-        model_provider=None,
-    )
-    assert result is not None, (
-        "Cost must not be None for databricks/databricks-claude-opus-4-8 without provider"
-    )
-    assert result[CostKey.INPUT_COST] > 0, (
-        "Input cost must be > 0 for 1M tokens on databricks/databricks-claude-opus-4-8"
-    )
-
-
-def test_explicit_model_provider_passed_through():
-    result = calculate_cost_by_model_and_token_usage(
-        model_name="databricks-claude-opus-4-8",
-        usage={TokenUsageKey.INPUT_TOKENS: 1_000_000, TokenUsageKey.OUTPUT_TOKENS: 0},
-        model_provider="databricks",
-    )
-    assert result is not None, (
-        "Cost must not be None when model_provider='databricks' is explicitly supplied"
-    )
-    assert result[CostKey.INPUT_COST] > 0, (
-        "Input cost must be > 0 for 1M tokens with explicit databricks provider"
-    )
-
-
-def test_non_string_model_name_does_not_raise():
-    # An integer is truthy, so it passes `if not model_name`, but calling
-    # .startswith() on it would raise AttributeError without the isinstance guard.
-    result = calculate_cost_by_model_and_token_usage(
-        model_name=12345,  # type: ignore[arg-type]
-        usage={TokenUsageKey.INPUT_TOKENS: 1_000, TokenUsageKey.OUTPUT_TOKENS: 500},
-        model_provider=None,
-    )
-    # The function may return None (no matching model), but it must not raise.
-    assert result is None or isinstance(result, dict)
+    kwargs = {
+        "model": model_name,
+        "prompt_tokens": 1_000,
+        "completion_tokens": 500,
+    }
+    if expected_provider:
+        kwargs["custom_llm_provider"] = expected_provider
+    cost_per_token.assert_called_once_with(**kwargs)
+    assert result is not None
+    assert result[CostKey.TOTAL_COST] > 0


### PR DESCRIPTION
### Related Issues/PRs

No existing OSS issue. This bug was discovered during a hands-on evaluation of tracing a LangGraph agent against a Databricks FMAPI endpoint.

### What changes are proposed in this pull request?

Fixes the `$0.00` cost panel for Databricks serving-endpoint model names (e.g. `databricks-claude-opus-4-8`) when the `MODEL_PROVIDER` span attribute is absent from the span.

**Root cause.** `calculate_cost_by_model_and_token_usage` calls `cost_per_token(model=model_name)` directly. For a bare Databricks endpoint name such as `databricks-claude-opus-4-8` (no `databricks/` prefix), litellm raises `BadRequestError: LLM Provider NOT provided` because it cannot infer the provider from the name alone. The existing exception handler retries with `custom_llm_provider=model_provider`, but only when the `MODEL_PROVIDER` span attribute is truthy. When it is absent, the handler logs a debug message, returns `None`, and the UI renders `$0.00` for all tracked tokens.

litellm already carries the correct price for `databricks/databricks-claude-opus-4-8` ($15/1M input tokens). No price table changes are needed.

**Fix (Option A, minimal).** In the exception fallback, if no provider was recorded but the model name starts with `databricks-` or `databricks/`, infer `custom_llm_provider="databricks"` before retrying. The inference is narrowly scoped: only names with those two prefixes are treated as Databricks-hosted. Non-Databricks models (e.g. `gpt-4o`) do not match either prefix and are unaffected.

```python
# Before
if model_provider:
    ...retry with custom_llm_provider=model_provider...

# After
effective_provider = model_provider
if not effective_provider and (
    model_name.startswith("databricks-") or model_name.startswith("databricks/")
):
    effective_provider = "databricks"
if effective_provider:
    ...retry with custom_llm_provider=effective_provider...
```

**Observed behavior before fix.** An agent tracing ~1.6M input tokens per run against `databricks-claude-opus-4-8` shows `$0.00 Total Cost / No cost data available` in the MLflow UI, while token-count charts show real usage.

**Observed behavior after fix.** `calculate_cost_by_model_and_token_usage("databricks-claude-opus-4-8", {input_tokens: 1_000_000, ...}, model_provider=None)` returns a non-None cost dict with `input_cost > 0`.

### How is this PR tested?

- [x] New unit/integration tests

Two new tests in `tests/tracing/utils/test_utils.py`:
- `test_databricks_bare_endpoint_name_resolves_cost`: feeds `model_name="databricks-claude-opus-4-8"` with `model_provider=None` and asserts cost is non-None and `input_cost > 0`. Confirmed RED on unmodified code, GREEN after the fix.
- `test_non_databricks_model_not_repriced_as_databricks`: feeds `model_name="gpt-4o"` with `model_provider=None` and asserts the cost matches the direct litellm result, confirming the databricks-prefix inference does not affect other providers.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The cost panel in the MLflow trace UI now shows correct dollar amounts for agents that call Databricks FMAPI serving endpoints (e.g. `databricks-claude-opus-4-8`). Previously these showed `$0.00` even when token usage was fully tracked.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

