### PR TITLE
[uiux] Show completed assistant tool calls as check icon

### DIFF
--- a/mlflow/server/js/src/assistant/ToolCallCard.test.tsx
+++ b/mlflow/server/js/src/assistant/ToolCallCard.test.tsx
@@ -138,10 +138,12 @@ describe('ToolCallGroup', () => {
     toolCall({ toolUseId: 't3', name: 'Bash', status: 'done', result: 'c' }),
   ];
 
-  test('renders the count, name summary, and a status label', () => {
+  test('renders the count, name summary, and a status icon', () => {
     renderGroup(calls);
     expect(screen.getByText('3 tool calls')).toBeInTheDocument();
     expect(screen.getByText('load_skill, Bash ×2')).toBeInTheDocument();
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+    expect(screen.getByTestId('tool-call-status-done')).toBeInTheDocument();
     expect(screen.getByTestId('tool-group-status-done')).toBeInTheDocument();
   });
 

--- a/mlflow/server/js/src/assistant/ToolCallCard.test.tsx
+++ b/mlflow/server/js/src/assistant/ToolCallCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect } from '@jest/globals';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { DesignSystemProvider } from '@databricks/design-system';
@@ -143,8 +143,8 @@ describe('ToolCallGroup', () => {
     expect(screen.getByText('3 tool calls')).toBeInTheDocument();
     expect(screen.getByText('load_skill, Bash ×2')).toBeInTheDocument();
     expect(screen.queryByText('Completed')).not.toBeInTheDocument();
-    expect(screen.getByTestId('tool-call-status-done')).toBeInTheDocument();
-    expect(screen.getByTestId('tool-group-status-done')).toBeInTheDocument();
+    const groupStatusIcon = screen.getByTestId('tool-group-status-done');
+    expect(within(groupStatusIcon).getByTestId('tool-call-status-done')).toBeInTheDocument();
   });
 
   test('treats a missing status as running', () => {

--- a/mlflow/server/js/src/assistant/ToolCallCard.tsx
+++ b/mlflow/server/js/src/assistant/ToolCallCard.tsx
@@ -3,7 +3,7 @@
  * collapsible card whose header shows the tool name, a status badge, and a one-line
  * input summary, and whose expanded body shows the full input and (truncated) output.
  */
-import { useMemo, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { useMemo, useState, type KeyboardEvent } from 'react';
 import {
   CheckCircleIcon,
   ChevronDownIcon,
@@ -90,18 +90,6 @@ export const toolNameSummary = (parts: ToolCallPart[]): string => {
   return [...counts.entries()].map(([name, n]) => (n > 1 ? `${name} ×${n}` : name)).join(', ');
 };
 
-const GROUP_STATUS_LABEL: Record<NonNullable<ToolCallPart['status']>, ReactNode> = {
-  [ToolCallStatus.Running]: (
-    <FormattedMessage defaultMessage="Running" description="Status for an in-progress run of assistant tool calls" />
-  ),
-  [ToolCallStatus.Done]: (
-    <FormattedMessage defaultMessage="Completed" description="Status for a finished run of assistant tool calls" />
-  ),
-  [ToolCallStatus.Error]: (
-    <FormattedMessage defaultMessage="Failed" description="Status for a failed run of assistant tool calls" />
-  ),
-};
-
 // Activate a role="button" disclosure row from the keyboard, matching native <button> semantics.
 const onDisclosureKeyDown = (toggle: () => void) => (event: KeyboardEvent) => {
   if (event.key === 'Enter' || event.key === ' ') {
@@ -121,12 +109,21 @@ export const ToolCallGroup = ({ parts }: { parts: ToolCallPart[] }) => {
   const [expanded, setExpanded] = useState(false);
   const status = groupStatus(parts);
   const summary = toolNameSummary(parts);
-  const statusColor =
+  const statusLabel =
     status === ToolCallStatus.Done
-      ? theme.colors.textValidationSuccess
+      ? intl.formatMessage({
+          defaultMessage: 'Completed',
+          description: 'Status for a finished run of assistant tool calls',
+        })
       : status === ToolCallStatus.Error
-        ? theme.colors.textValidationDanger
-        : theme.colors.textSecondary;
+        ? intl.formatMessage({
+            defaultMessage: 'Failed',
+            description: 'Status for a failed run of assistant tool calls',
+          })
+        : intl.formatMessage({
+            defaultMessage: 'Running',
+            description: 'Status for an in-progress run of assistant tool calls',
+          });
 
   const toggle = () => setExpanded((prev) => !prev);
 
@@ -136,10 +133,13 @@ export const ToolCallGroup = ({ parts }: { parts: ToolCallPart[] }) => {
         role="button"
         tabIndex={0}
         aria-expanded={expanded}
-        aria-label={intl.formatMessage({
-          defaultMessage: 'Tool calls',
-          description: 'Accessible label for the expandable summary row of a run of assistant tool calls',
-        })}
+        aria-label={intl.formatMessage(
+          {
+            defaultMessage: 'Tool calls: {status}',
+            description: 'Accessible label for the expandable summary row of a run of assistant tool calls',
+          },
+          { status: statusLabel },
+        )}
         onClick={toggle}
         onKeyDown={onDisclosureKeyDown(toggle)}
         css={{
@@ -180,13 +180,13 @@ export const ToolCallGroup = ({ parts }: { parts: ToolCallPart[] }) => {
             {summary}
           </Typography.Text>
         )}
-        <Typography.Text
-          size="sm"
+        <span
           data-testid={`tool-group-status-${status}`}
-          css={{ flexShrink: 0, marginLeft: 'auto', color: statusColor }}
+          aria-label={statusLabel}
+          css={{ flexShrink: 0, marginLeft: 'auto', display: 'inline-flex' }}
         >
-          {GROUP_STATUS_LABEL[status]}
-        </Typography.Text>
+          <StatusBadge status={status} />
+        </span>
       </div>
 
       {expanded && (

--- a/mlflow/server/js/src/assistant/ToolCallCard.tsx
+++ b/mlflow/server/js/src/assistant/ToolCallCard.tsx
@@ -41,7 +41,7 @@ const toolInputSummary = (part: ToolCallPart): string => {
 
 // Fixed-size badge box so done/error/running all occupy identical space and
 // keep every tool-call row's columns aligned.
-const StatusBadge = ({ status }: { status: ToolCallPart['status'] }) => {
+const StatusBadge = ({ status, ariaHidden }: { status: ToolCallPart['status']; ariaHidden?: boolean }) => {
   const { theme } = useDesignSystemTheme();
   const icon =
     status === ToolCallStatus.Done ? (
@@ -54,6 +54,7 @@ const StatusBadge = ({ status }: { status: ToolCallPart['status'] }) => {
   return (
     <span
       data-testid={`tool-call-status-${status ?? ToolCallStatus.Running}`}
+      aria-hidden={ariaHidden}
       css={{
         width: 16,
         height: 16,
@@ -182,10 +183,9 @@ export const ToolCallGroup = ({ parts }: { parts: ToolCallPart[] }) => {
         )}
         <span
           data-testid={`tool-group-status-${status}`}
-          aria-label={statusLabel}
           css={{ flexShrink: 0, marginLeft: 'auto', display: 'inline-flex' }}
         >
-          <StatusBadge status={status} />
+          <StatusBadge status={status} ariaHidden />
         </span>
       </div>
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5851,6 +5851,10 @@
     "defaultMessage": "Running session level scorers is not yet supported",
     "description": "Tooltip message when scorer is session-level"
   },
+  "R36wuk": {
+    "defaultMessage": "Tool calls: {status}",
+    "description": "Accessible label for the expandable summary row of a run of assistant tool calls"
+  },
   "R3Lb6z": {
     "defaultMessage": "The requested resource was not found.",
     "description": "Resource not found (HTTP STATUS 404) generic error message"
@@ -10190,10 +10194,6 @@
   "l119W9": {
     "defaultMessage": "No matching questions",
     "description": "Review queue: no questions match the search"
-  },
-  "l427IF": {
-    "defaultMessage": "Tool calls",
-    "description": "Accessible label for the expandable summary row of a run of assistant tool calls"
   },
   "l8Z2nP": {
     "defaultMessage": "Remove filter",


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Assistant transcript tool-call groups currently render the completed state as visible `Completed` text, while individual tool calls already use compact status icons. This PR reuses the existing tool-call status badge in the group header so completed tool-call groups display the green check icon instead of the word `Completed`.

The status text is still preserved in accessible labels, so screen readers can announce whether the group is running, completed, or failed even though the visual treatment is icon-only.

### How is this PR tested?

- [x] Existing unit/integration tests: `yarn test src/assistant/ToolCallCard.test.tsx --runInBand`
- [x] New unit/integration tests: updated `ToolCallCard.test.tsx` to assert the completed group status renders as an icon and does not show visible `Completed` text.

Additional checks:

```bash
yarn prettier --check src/assistant/ToolCallCard.tsx src/assistant/ToolCallCard.test.tsx
yarn eslint src/assistant/ToolCallCard.tsx src/assistant/ToolCallCard.test.tsx
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Assistant tool-call groups now show completed state as a green check icon instead of visible status text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
