### PR TITLE
Honor explicit set_outputs() inside the @mlflow.trace decorator

### DIFF
--- a/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
@@ -261,6 +261,13 @@ class MyClass {
 </Tabs>
 </TabsWrapper>
 
+:::warning `set_outputs()` inside `@mlflow.trace` is overwritten by the return value
+
+`span.set_inputs()` called inside a `@mlflow.trace`-decorated function correctly overrides the auto-captured inputs. `span.set_outputs()` called inside the function body does not persist: the decorator records the function's actual return value after the function returns, overwriting your value.
+
+To control the stored output, use `mlflow.start_span()` as a context manager (see [Code Block](#code-block)), which gives you full control over both inputs and outputs. To control what appears in the `Response` column of the Traces UI without changing the stored span output, use `mlflow.update_current_trace(response_preview=...)` (see [Customizing Request and Response Previews in the UI](#customizing-request-and-response-previews-in-the-ui)).
+:::
+
 ## Adding Trace Tags
 
 Tags can be added to traces to provide additional metadata at the trace level. There are a few different ways to set tags on a trace. Please refer to the [how-to guide](/genai/tracing/attach-tags) for the other methods.

--- a/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
@@ -261,11 +261,11 @@ class MyClass {
 </Tabs>
 </TabsWrapper>
 
-:::warning `set_outputs()` / `setOutputs()` inside a trace decorator is overwritten by the return value
+:::note Overriding auto-captured inputs and outputs inside a decorated function
 
-`span.set_inputs()` (Python) / `span.setInputs()` (TypeScript) called inside a decorated function correctly overrides the auto-captured inputs. `span.set_outputs()` / `span.setOutputs()` called inside the function body does not persist: the decorator records the function's actual return value after the function returns, overwriting your value.
+`span.set_inputs()` / `span.set_outputs()` (Python) and `span.setInputs()` / `span.setOutputs()` (TypeScript) called inside a decorated function override the values the decorator captures automatically. If you set the outputs explicitly, the decorator keeps your value. If you leave them unset, it records the function's return value as before. Inputs behave the same way.
 
-To control the stored output in Python, use `mlflow.start_span()` as a context manager (see [Code Block](#code-block)), which gives you full control over both inputs and outputs. In TypeScript, use `withSpan()`. To control what appears in the `Response` column of the Traces UI without changing the stored span output, use `mlflow.update_current_trace(response_preview=...)` in Python or `updateCurrentTrace(...)` in TypeScript (see [Customizing Request and Response Previews in the UI](#customizing-request-and-response-previews-in-the-ui)).
+To change only what appears in the `Response` column of the Traces UI without changing the stored span output, use `mlflow.update_current_trace(response_preview=...)` in Python or `updateCurrentTrace(...)` in TypeScript (see [Customizing Request and Response Previews in the UI](#customizing-request-and-response-previews-in-the-ui)).
 :::
 
 ## Adding Trace Tags

--- a/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
@@ -261,11 +261,11 @@ class MyClass {
 </Tabs>
 </TabsWrapper>
 
-:::warning `set_outputs()` inside `@mlflow.trace` is overwritten by the return value
+:::warning `set_outputs()` / `setOutputs()` inside a trace decorator is overwritten by the return value
 
-`span.set_inputs()` called inside a `@mlflow.trace`-decorated function correctly overrides the auto-captured inputs. `span.set_outputs()` called inside the function body does not persist: the decorator records the function's actual return value after the function returns, overwriting your value.
+`span.set_inputs()` (Python) / `span.setInputs()` (TypeScript) called inside a decorated function correctly overrides the auto-captured inputs. `span.set_outputs()` / `span.setOutputs()` called inside the function body does not persist: the decorator records the function's actual return value after the function returns, overwriting your value.
 
-To control the stored output, use `mlflow.start_span()` as a context manager (see [Code Block](#code-block)), which gives you full control over both inputs and outputs. To control what appears in the `Response` column of the Traces UI without changing the stored span output, use `mlflow.update_current_trace(response_preview=...)` (see [Customizing Request and Response Previews in the UI](#customizing-request-and-response-previews-in-the-ui)).
+To control the stored output in Python, use `mlflow.start_span()` as a context manager (see [Code Block](#code-block)), which gives you full control over both inputs and outputs. In TypeScript, use `withSpan()`. To control what appears in the `Response` column of the Traces UI without changing the stored span output, use `mlflow.update_current_trace(response_preview=...)` in Python or `updateCurrentTrace(...)` in TypeScript (see [Customizing Request and Response Previews in the UI](#customizing-request-and-response-previews-in-the-ui)).
 :::
 
 ## Adding Trace Tags

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -321,7 +321,13 @@ def _wrap_function(
                 inputs = capture_function_input_args(fn, args, kwargs)
                 span.set_inputs(inputs)
                 result = yield  # sync/async function output to be sent here
-                span.set_outputs(result)
+                # Honor an explicit set_outputs() call made inside the function body.
+                # set_inputs() can already be overridden this way because the decorator
+                # captures inputs before the body runs, while outputs are captured after
+                # it returns. Fall back to the return value only when the user did not
+                # set outputs themselves, so the two are symmetric.
+                if span.outputs is None:
+                    span.set_outputs(result)
                 try:
                     yield result
                 except GeneratorExit:

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1344,21 +1344,6 @@ def test_trace_decorator_honors_explicit_set_outputs():
 
 
 @skip_when_testing_trace_sdk
-def test_trace_decorator_captures_return_value_when_outputs_not_set():
-    @mlflow.trace
-    def predict(x):
-        return {"returned": x * 10}
-
-    predict(3)
-
-    traces = get_traces()
-    assert len(traces) == 1
-    span = traces[0].data.spans[0]
-    # Without an explicit set_outputs() call, the return value is still captured.
-    assert span.outputs == {"returned": 30}
-
-
-@skip_when_testing_trace_sdk
 def test_search_traces_extract_fields_preserves_standard_columns():
     with mlflow.start_span(name="test_span") as span:
         span.set_inputs({"x": 1})

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1327,6 +1327,38 @@ def test_search_traces_with_non_dict_span_inputs_outputs():
 
 
 @skip_when_testing_trace_sdk
+def test_trace_decorator_honors_explicit_set_outputs():
+    @mlflow.trace
+    def predict(x):
+        mlflow.get_current_active_span().set_outputs({"explicit": x * 2})
+        return {"returned": x * 10}
+
+    # The function's real return value is unchanged.
+    assert predict(3) == {"returned": 30}
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    # The explicit set_outputs() call wins over the auto-captured return value.
+    assert span.outputs == {"explicit": 6}
+
+
+@skip_when_testing_trace_sdk
+def test_trace_decorator_captures_return_value_when_outputs_not_set():
+    @mlflow.trace
+    def predict(x):
+        return {"returned": x * 10}
+
+    predict(3)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    # Without an explicit set_outputs() call, the return value is still captured.
+    assert span.outputs == {"returned": 30}
+
+
+@skip_when_testing_trace_sdk
 def test_search_traces_extract_fields_preserves_standard_columns():
     with mlflow.start_span(name="test_span") as span:
         span.set_inputs({"x": 1})


### PR DESCRIPTION
### Related Issues/PRs

No linked issue.

### What changes are proposed in this pull request?

Makes `span.set_outputs()` called inside a `@mlflow.trace`-decorated function persist, resolving an asymmetry with `set_inputs()`.

The decorator captures inputs before running the function body and outputs after it returns. As a result, an explicit `span.set_inputs()` call inside the body took effect, but an explicit `span.set_outputs()` call was silently overwritten by the auto-captured return value. This PR makes the decorator fall back to the return value only when the user did not set outputs, so inputs and outputs behave the same way.

Changes:

- `mlflow/tracing/fluent.py`: the wrapping logic now records the return value only when `span.outputs` is unset, preserving an explicit `set_outputs()` call.
- `tests/tracing/test_fluent.py`: adds `test_trace_decorator_honors_explicit_set_outputs` (explicit value wins) and `test_trace_decorator_captures_return_value_when_outputs_not_set` (return value is still captured when nothing is set).
- `docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx`: replaces the earlier warning with a note describing that both `set_inputs()` and `set_outputs()` override the auto-captured values.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`tests/tracing/test_fluent.py` passes in full (170 tests). The two new tests fail on the previous behavior and pass with this change.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`span.set_outputs()` called inside a `@mlflow.trace`-decorated function is now honored instead of being overwritten by the function's return value, matching how `set_inputs()` already behaves. The return value is still captured automatically when outputs are not set explicitly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
