### PR TITLE
Support GitHub Actions parallel step groups in workflow checks

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -36,7 +36,7 @@ deny_unsafe_checkout contains msg if {
 	input["true"].pull_request_target
 	not safe_pull_request_target_workflow
 	some job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/checkout@")
 	step["with"].ref
 	msg := concat("", [
@@ -53,7 +53,7 @@ safe_pull_request_target_workflow if {
 
 deny_create_app_token_without_permissions contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/create-github-app-token@")
 	not step_has_app_token_permissions(step)
 	msg := sprintf(
@@ -69,7 +69,7 @@ deny_create_app_token_without_permissions contains msg if {
 
 deny_create_app_token_with_app_id contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/create-github-app-token@")
 	step["with"]["app-id"]
 	msg := sprintf(
@@ -85,7 +85,7 @@ step_has_app_token_permissions(step) if {
 
 deny_unnecessary_github_token contains msg if {
 	some job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/github-script@")
 	regex.match(`\$\{\{\s*(secrets\.GITHUB_TOKEN|github\.token)\s*\}\}`, step["with"]["github-token"])
 	msg := "Unnecessary use of github-token for actions/github-script."
@@ -93,7 +93,7 @@ deny_unnecessary_github_token contains msg if {
 
 deny_github_token_env_var contains msg if {
 	some job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	step.env.GITHUB_TOKEN
 	msg := "Use GH_TOKEN instead of GITHUB_TOKEN for environment variable names."
 }
@@ -106,7 +106,7 @@ deny_github_token_env_var contains msg if {
 
 deny_github_token_shorthand contains msg if {
 	some job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	some key, value in step["with"]
 	contains_github_token(value)
 	msg := sprintf(
@@ -117,7 +117,7 @@ deny_github_token_shorthand contains msg if {
 
 deny_github_token_shorthand contains msg if {
 	some job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	some key, value in step.env
 	contains_github_token(value)
 	msg := sprintf(
@@ -197,7 +197,7 @@ deny_wrong_shell_defaults contains msg if {
 
 deny_github_script_without_retries contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/github-script@")
 	not step["with"].retries
 	msg := sprintf(
@@ -229,7 +229,7 @@ deny_push_without_branches contains msg if {
 
 deny_interpolation_in_run contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	regex.match(`\$\{\{`, step.run)
 	msg := sprintf(
 		concat("", [
@@ -256,7 +256,7 @@ deny_interpolation_in_run contains msg if {
 
 deny_interpolation_in_github_script contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/github-script@")
 	regex.match(`\$\{\{`, step["with"].script)
 	msg := sprintf(
@@ -295,7 +295,7 @@ deny_interpolation_in_job_if contains msg if {
 
 deny_interpolation_in_step_if contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	is_string(step["if"])
 	regex.match(`\$\{\{`, step["if"])
 	msg := sprintf(
@@ -310,6 +310,13 @@ deny_interpolation_in_step_if contains msg if {
 contains_github_token(value) if {
 	regex.match(`\$\{\{\s*github\.token\s*\}\}`, value)
 }
+
+# All steps in a job, including steps nested inside `parallel` groups.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel
+job_steps(job) := array.concat(
+	[step | some step in job.steps],
+	[step | some group in job.steps; some step in group.parallel],
+)
 
 jobs_without_permissions(jobs) := {job_id |
 	some job_id, job in jobs
@@ -337,7 +344,7 @@ unpinned_actions(inp) := unpinned if {
 	inp.jobs
 	unpinned := {step.uses |
 		some job in inp.jobs
-		some step in job.steps
+		some step in job_steps(job)
 		is_step_unpinned(step)
 	}
 }
@@ -386,7 +393,7 @@ contains_secret(value) if {
 
 deny_checkout_missing_persist_credentials contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/checkout@")
 	not has_explicit_persist_credentials(step)
 	msg := sprintf(
@@ -405,7 +412,7 @@ has_explicit_persist_credentials(step) if {
 
 deny_upload_artifact_without_retention contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/upload-artifact@")
 	not step["with"]["retention-days"]
 	msg := sprintf(
@@ -416,7 +423,7 @@ deny_upload_artifact_without_retention contains msg if {
 
 deny_upload_artifact_without_if_no_files_found contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	startswith(step.uses, "actions/upload-artifact@")
 	not step["with"]["if-no-files-found"]
 	msg := sprintf(
@@ -445,7 +452,7 @@ has_explicit_fail_fast(strategy) if {
 
 deny_mutable_install contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	some line in split(step.run, "\n")
 	regex.match(`\bnpm install\b`, line)
 	not regex.match(`--package-lock-only\b`, line)
@@ -457,7 +464,7 @@ deny_mutable_install contains msg if {
 
 deny_mutable_install contains msg if {
 	some job_id, job in input.jobs
-	some step in job.steps
+	some step in job_steps(job)
 	regex.match(`(?m)^\s*yarn(\s+install)?\s*(?:#.*)?$`, step.run)
 	not regex.match(`\byarn install\s+--immutable\b`, step.run)
 	msg := sprintf(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ lint = [
   "aiohttp",
   "pytest",
   "requests",
-  "check-jsonschema==0.37.2",
+  "check-jsonschema==0.37.4",
 ]
 pytest = [
   "pytest==9.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1101,7 +1101,7 @@ wheels = [
 
 [[package]]
 name = "check-jsonschema"
-version = "0.37.2"
+version = "0.37.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1111,9 +1111,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/b5/2f4b66ac68e5dcf999f2df7d7d72d474b8f9d17ddd1ae2159ba81c55652a/check_jsonschema-0.37.2.tar.gz", hash = "sha256:2977f31ebbd3e4eb37325057b83b56c0041b2b520e12818ec84da1f6c7c60363", size = 414564, upload-time = "2026-05-03T03:41:48.453Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/dd/27b7f575586505c3d71b66b1fd60076feeba1ba7ffd1303fbf5a70cedad6/check_jsonschema-0.37.4.tar.gz", hash = "sha256:f933521f14cbeaaf113270751185b01379f453ac9ce9fb01d6190ce1352ccaa6", size = 428594, upload-time = "2026-06-29T21:10:23.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/89/0c8eebd5d9439abb38a79edca7a93c96e67e0d1e14ab1f6db016d27b15ad/check_jsonschema-0.37.2-py3-none-any.whl", hash = "sha256:0840dc56219922f7a34d4e4a4364f96bbf05983850dbb64149f4c6f17b3affd1", size = 399181, upload-time = "2026-05-03T03:41:46.81Z" },
+    { url = "https://files.pythonhosted.org/packages/92/82/6a929238ec352eadd4f4ce6e1be98c575fa8cbebe45b7c519f8016ad2860/check_jsonschema-0.37.4-py3-none-any.whl", hash = "sha256:e4d1647992674d6b1ed2ca46eee6697760d17a5cc0c167ba09c5b503b883d041", size = 412508, upload-time = "2026-06-29T21:10:22.041Z" },
 ]
 
 [[package]]
@@ -4343,7 +4343,7 @@ build = [
 dev = [
     { name = "aiohttp" },
     { name = "build" },
-    { name = "check-jsonschema", specifier = "==0.37.2" },
+    { name = "check-jsonschema", specifier = "==0.37.4" },
     { name = "clint", editable = "dev/clint" },
     { name = "flavors", editable = "dev/flavors" },
     { name = "mlflow-test-plugin", editable = "tests/resources/mlflow-test-plugin" },
@@ -4404,7 +4404,7 @@ docs = [
 ]
 lint = [
     { name = "aiohttp" },
-    { name = "check-jsonschema", specifier = "==0.37.2" },
+    { name = "check-jsonschema", specifier = "==0.37.4" },
     { name = "clint", editable = "dev/clint" },
     { name = "flavors", editable = "dev/flavors" },
     { name = "mypy", specifier = "==1.17.1" },


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

GitHub Actions recently added [parallel step execution](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) (`parallel:` groups, `background: true`). Two of our workflow checks don't handle the new syntax yet:

- `check-jsonschema` 0.37.2 vendors a workflow schema that predates the feature and rejects any workflow using it. Bumped to 0.37.4, which vendors the updated SchemaStore schema.
- `policy.rego` iterates `job.steps` flatly, so steps nested inside a `parallel` group silently escape every step-level rule (unpinned actions, `persist-credentials`, `${{ }}` interpolation in `run`, etc.). Added a `job_steps` helper that expands `parallel` groups and switched all step-level rules to it.

This is groundwork for actually parallelizing steps in our workflows (e.g. the cache restores in `lint.yml`), which will come in a follow-up PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified with a scratch workflow containing six violations nested in a `parallel:` block: the old policy passed all checks (fail-open), the updated policy reports all six. `conftest`, `regal lint`, and `check-github-workflows` pass on all existing workflows.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)