### PR TITLE
Parallelize cache restore steps in `lint.yml`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,33 +67,34 @@ jobs:
       - name: Install Python dependencies
         run: |
           uv sync --locked --only-group lint --only-group pytest
-      - name: Cache action pins
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: .cache/action-pins.json
-          key: action-pins-${{ hashFiles('dev/check_actions.py') }}
-      - name: Cache mypy
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: .mypy_cache
-          key: mypy-${{ matrix.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
-          restore-keys: mypy-${{ matrix.os }}-
-      - name: Cache install-bin tools
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: |
-            bin/*
-            !bin/install.py
-            !bin/README.md
-            !bin/.gitignore
-          key: install-bin-${{ matrix.os }}-${{ hashFiles('bin/install.py') }}
-          restore-keys: install-bin-${{ matrix.os }}-
-      - name: Cache pre-commit hooks
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ matrix.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: pre-commit-${{ matrix.os }}-
+      - parallel:
+          - name: Cache action pins
+            uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+            with:
+              path: .cache/action-pins.json
+              key: action-pins-${{ hashFiles('dev/check_actions.py') }}
+          - name: Cache mypy
+            uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+            with:
+              path: .mypy_cache
+              key: mypy-${{ matrix.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+              restore-keys: mypy-${{ matrix.os }}-
+          - name: Cache install-bin tools
+            uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+            with:
+              path: |
+                bin/*
+                !bin/install.py
+                !bin/README.md
+                !bin/.gitignore
+              key: install-bin-${{ matrix.os }}-${{ hashFiles('bin/install.py') }}
+              restore-keys: install-bin-${{ matrix.os }}-
+          - name: Cache pre-commit hooks
+            uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+            with:
+              path: ~/.cache/pre-commit
+              key: pre-commit-${{ matrix.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+              restore-keys: pre-commit-${{ matrix.os }}-
       - name: Install pre-commit hooks
         run: |
           uv run --no-sync pre-commit install --install-hooks


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24627

### What changes are proposed in this pull request?

Wrap the four independent `actions/cache` restore steps in `lint.yml` (action pins, mypy, install-bin, pre-commit) in a `parallel:` group so they run concurrently instead of sequentially, using GitHub Actions' [native parallel steps](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) (shipped in runner v2.335.0; GitHub-hosted runners already have it). The group has an implicit wait, so all restores complete before the following steps run, and a failed restore still fails the job at the join point.

Stacked on #24627, which updated `check-jsonschema` and `policy.rego` to understand the new syntax; the diff will reduce to just `lint.yml` once that merges. This PR's own lint run exercises the new syntax directly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The `lint` / `lint-macos` jobs on this PR run the parallelized workflow themselves. Locally, `check-github-workflows`, `conftest`, and `check-actions` all pass on the updated file.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)