### PR TITLE
Fix MCP registry telemetry dropping records when `tools` is omitted

### DIFF
--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -445,12 +445,14 @@ class McpRegistryCreateServerVersionEvent(Event):
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
         server_json = arguments.get("server_json") or {}
+        # `tools` may be omitted (a NOT_SET sentinel), explicitly None, or a list.
+        # Only a real sequence has a meaningful count; anything else is "not provided".
         tools = arguments.get("tools")
         status = arguments.get("status") or MCPStatus.DRAFT
         return {
             "status": status.value if hasattr(status, "value") else status,
             "has_source": arguments.get("source") is not None,
-            "num_tools": len(tools) if tools is not None else None,
+            "num_tools": len(tools) if isinstance(tools, (list, tuple)) else None,
             "has_remotes": bool(server_json.get("remotes")),
         }
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24477

### What changes are proposed in this pull request?

`McpRegistryCreateServerVersionEvent.parse` crashed and silently dropped the telemetry record whenever `create_mcp_server_version` was called without a `tools` argument.

The `@record_usage_event` decorator binds the call arguments and applies defaults **before** the store method body runs. `create_mcp_server_version`'s `tools` parameter defaults to a `NOT_SET` sentinel (a bare `object()`), which the method body normalizes to `None` — but `parse` sees the raw sentinel. The old check `len(tools) if tools is not None else None` evaluated `NOT_SET is not None` as `True` and called `len(NOT_SET)`, raising `TypeError`. The decorator's `try/except` swallowed that error and discarded the entire record, so no telemetry event was emitted for the omitted-tools case.

This surfaced as a failing test on `master`:

```
FAILED tests/telemetry/test_tracked_events.py::test_mcp_registry_create_server_version_telemetry
  - ValueError: 'mcp_registry_create_server_version' is not in list
```

The fix counts `tools` only when it is an actual sequence, so both the omitted (`NOT_SET` sentinel) and explicit-`None` cases report `num_tools=None` instead of crashing.

### How did this bug come about?

This was a semantic merge conflict between two PRs that each passed CI in isolation. #24520 changed the `tools` parameter default from `None` to a `NOT_SET` sentinel (to distinguish "omitted → auto-discover" from "explicit null → store none"). #24477 then added the `parse` method a few hours later with a `tools is not None` check — a check that is *correct* against a `None` default, but not against the `NOT_SET` sentinel introduced by #24520. Neither PR's CI exercised the broken combination: #24520 had no telemetry test to fail, and #24477's check was only wrong once #24520's sentinel was also present. Because the two changes touch different lines, git merged them without a textual conflict, and the incompatibility only surfaced on the next full `master` run.

### How is this PR tested?

- [x] Existing unit/integration tests

`test_mcp_registry_create_server_version_telemetry` (and the rest of the MCP registry telemetry tests) now pass:

```
uv run pytest tests/telemetry/test_tracked_events.py -k mcp
4 passed, 54 deselected
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
