### PR TITLE
Remove `WeichenXu123` from team-review reviewer rotation

### DIFF
--- a/.github/workflows/team-review.js
+++ b/.github/workflows/team-review.js
@@ -7,7 +7,6 @@ const MEMBERS = [
   "PattaraS",
   "serena-ruan",
   "TomeHirata",
-  "WeichenXu123",
   "aaronteo-db",
 ];
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #19428

### What changes are proposed in this pull request?

Remove `WeichenXu123` from the `MEMBERS` list in `.github/workflows/team-review.js`. They are no longer a collaborator on this repository, so every reviewer-assignment request that includes them fails with a 422 (`Reviews may only be requested from collaborators`) and no reviewers get assigned at all.

This has been silently breaking reviewer auto-assignment on every PR: `WeichenXu123` has the lowest review count in the stats issue (#19428), so the fairness algorithm always selects them first, the request fails, the counts never update, and the same selection repeats on the next PR. Example failure: https://github.com/mlflow/mlflow/actions/runs/29983529528/job/89130333446

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified the failure mode from the workflow logs above; the fix removes the non-collaborator from the selection pool.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)