### PR TITLE
Bump `pytest` from 9.0.2 to 9.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ lint = [
   "check-jsonschema==0.37.4",
 ]
 pytest = [
-  "pytest==9.0.2",
+  "pytest==9.1.1",
   "pytest-asyncio",
   "pytest-benchmark",
   "pytest-repeat",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -564,6 +564,8 @@ filterwarnings = [
   "ignore:The filesystem (tracking|model registry) backend.*is deprecated:FutureWarning",
   # Prevent deprecated generator.throw(type, value, tb) signature from being used (Python 3.12+)
   "error:the \\(type, exc, tb\\) signature of throw\\(\\) is deprecated:DeprecationWarning",
+  # Prevent usage of features that will be removed in pytest 10
+  "error::pytest.PytestRemovedIn10Warning",
 ]
 # Use string for pytest-timeout compatibility (https://github.com/pytest-dev/pytest-timeout/issues/194)
 timeout = "1200"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,4 +1,4 @@
-pytest==9.0.2
+pytest==9.1.1
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0

--- a/requirements/lint-requirements.txt
+++ b/requirements/lint-requirements.txt
@@ -2,6 +2,6 @@ ruff==0.15.17
 pre-commit==4.0.1
 toml==0.10.2
 mypy==1.17.1
-pytest==9.0.2
+pytest==9.1.1
 pydantic==2.11.7
 -e ./dev/clint

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,6 +1,6 @@
 ## Dependencies required to run tests
 ## Test-only dependencies
-pytest==9.0.2
+pytest==9.1.1
 pytest-asyncio
 pytest-repeat
 pytest-cov

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -191,7 +191,7 @@ CREATE TABLE table (
     yield pytest.param(a, b, False, id="different column names")
 
 
-@pytest.mark.parametrize(("a", "b", "expected"), iter_parameter_sets())
+@pytest.mark.parametrize(("a", "b", "expected"), list(iter_parameter_sets()))
 def test_schema_equal(a, b, expected):
     assert schema_equal(a, b) is expected
 

--- a/tests/entities/test_trace_metrics.py
+++ b/tests/entities/test_trace_metrics.py
@@ -11,7 +11,7 @@ from mlflow.protos import service_pb2 as pb
 
 @pytest.mark.parametrize(
     ("view_type", "expected_proto"),
-    zip(MetricViewType, pb.MetricViewType.values(), strict=True),
+    list(zip(MetricViewType, pb.MetricViewType.values(), strict=True)),
 )
 def test_trace_metrics_view_type(view_type: MetricViewType, expected_proto: pb.MetricViewType):
     assert view_type.to_proto() == expected_proto
@@ -19,7 +19,7 @@ def test_trace_metrics_view_type(view_type: MetricViewType, expected_proto: pb.M
 
 @pytest.mark.parametrize(
     ("aggregation_type", "expected_proto"),
-    zip(AggregationType, pb.AggregationType.values(), strict=True),
+    list(zip(AggregationType, pb.AggregationType.values(), strict=True)),
 )
 def test_trace_metrics_aggregation_type_to_proto(
     aggregation_type: AggregationType, expected_proto: pb.AggregationType
@@ -105,7 +105,7 @@ def test_trace_metrics_metric_data_point_to_proto():
 
 @pytest.mark.parametrize(
     ("view_type", "expected_proto"),
-    zip(MetricViewType, pb.MetricViewType.values(), strict=True),
+    list(zip(MetricViewType, pb.MetricViewType.values(), strict=True)),
 )
 def test_trace_metrics_view_type_from_proto(view_type: MetricViewType, expected_proto: int):
     assert MetricViewType.from_proto(expected_proto) == view_type

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -33,7 +33,7 @@ def _build_uri(base_uri, subdirectory):
     return base_uri
 
 
-@pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
+@pytest.mark.parametrize("use_start_run", ["0", "1"])
 def test_docker_project_execution(use_start_run, docker_example_base_image):
     expected_params = {"use_start_run": use_start_run}
     submitted_run = mlflow.projects.run(

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -100,7 +100,7 @@ def test_expected_tags_logged_when_using_conda():
 
 
 @pytest.mark.usefixtures("patch_user")
-@pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
+@pytest.mark.parametrize("use_start_run", ["0", "1"])
 @pytest.mark.parametrize("version", [None, "master", "git-commit"])
 def test_run_local_git_repo(
     local_git_repo, local_git_repo_uri, use_start_run, version, monkeypatch
@@ -170,7 +170,7 @@ def test_invalid_version_local_git_repo(local_git_repo_uri):
         )
 
 
-@pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
+@pytest.mark.parametrize("use_start_run", ["0", "1"])
 @pytest.mark.usefixtures("patch_user")
 def test_run(use_start_run):
     submitted_run = mlflow.projects.run(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_core.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_core.py
@@ -68,7 +68,7 @@ def db_types_and_drivers():
             yield db_type, driver
 
 
-@pytest.mark.parametrize(("db_type", "driver"), db_types_and_drivers())
+@pytest.mark.parametrize(("db_type", "driver"), list(db_types_and_drivers()))
 def test_correct_db_type_from_uri(db_type, driver):
     assert extract_db_type_from_uri(f"{db_type}+{driver}://...") == db_type
     # try the driver-less version, which will revert SQLAlchemy to the default driver

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -12,7 +12,7 @@ bool_values = [True, False]
 
 @pytest.mark.parametrize(
     ("is_in_databricks_notebook", "is_in_databricks_job", "is_in_cluster"),
-    itertools.product(bool_values, bool_values, bool_values),
+    list(itertools.product(bool_values, bool_values, bool_values)),
 )
 def test_databricks_request_header_provider_in_context(
     is_in_databricks_notebook, is_in_databricks_job, is_in_cluster
@@ -37,7 +37,7 @@ def test_databricks_request_header_provider_in_context(
 # test that request_headers returns whatever is available
 @pytest.mark.parametrize(
     ("is_in_databricks_notebook", "is_in_databricks_job", "is_in_cluster"),
-    itertools.product(bool_values, bool_values, bool_values),
+    list(itertools.product(bool_values, bool_values, bool_values)),
 )
 def test_databricks_request_header_provider_request_headers(
     is_in_databricks_notebook, is_in_databricks_job, is_in_cluster

--- a/uv.lock
+++ b/uv.lock
@@ -4358,7 +4358,7 @@ dev = [
     { name = "pypi", editable = "dev/pypi" },
     { name = "pyspark" },
     { name = "pytest" },
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -4422,7 +4422,7 @@ lint = [
     { name = "types-toml" },
 ]
 pytest = [
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -4434,7 +4434,7 @@ test = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "psutil" },
     { name = "pyspark" },
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -6664,7 +6664,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/27b5316543a4d724e
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -6675,9 +6675,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/pytest-dev/pytest/releases/tag/9.1.1

### What changes are proposed in this pull request?

Bump `pytest` from 9.0.2 to 9.1.1 everywhere it is pinned: `requirements/test-requirements.txt`, `requirements/constraints.txt`, `requirements/lint-requirements.txt`, the `pytest` dependency group in `pyproject.toml`, and `uv.lock`.

pytest 9.1 introduces `PytestRemovedIn10Warning` for passing non-Collection iterables (`zip`, `map`, `itertools.product`, generators) to `parametrize`, which will break in pytest 10. This PR also:

- Adds `error::pytest.PytestRemovedIn10Warning` to `filterwarnings` so new violations fail CI instead of scrolling by as warnings.
- Fixes all 10 existing violations (6 test files), found by sweeping the warning summaries of every job in a full `MLflow tests` run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`uv lock --check` passes; affected test files collect cleanly with warnings-as-errors; smoke test (`uv run --frozen pytest tests/test_version.py`) passes with pytest 9.1.1.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)