### PR TITLE
Resolve UC trace location from experiment context in `get_trace`/`delete_traces`

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -65,7 +65,12 @@ from mlflow.tracing.constant import (
     TraceTagKey,
 )
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags, parse_trace_id_v4
+from mlflow.tracing.utils import (
+    TraceJSONEncoder,
+    construct_trace_id_v4,
+    exclude_immutable_tags,
+    parse_trace_id_v4,
+)
 from mlflow.tracing.utils.artifact_utils import get_artifact_uri_for_trace
 from mlflow.tracking._tracking_service.utils import _get_store, _resolve_tracking_uri
 from mlflow.utils import is_uuid
@@ -128,6 +133,39 @@ class TracingClient:
             tracking_uri=self.tracking_uri if is_databricks_uri(self.tracking_uri) else None,
         )
 
+    def _resolve_uc_trace_location(self, experiment_id: str | None) -> str | None:
+        """
+        Resolve the Unity Catalog trace location for an experiment.
+
+        Traces stored in Unity Catalog are addressed by a
+        ``catalog.schema.table_prefix`` location rather than a plain trace ID. The
+        location is not derivable from the trace ID alone, so it is resolved from the
+        experiment's trace destination tag (see ``Experiment.trace_location``).
+
+        Returns the location string if the experiment stores traces in Unity Catalog, or
+        ``None`` otherwise (non-Databricks tracking, an experiment whose traces live in
+        the MLflow experiment itself, or a resolution failure).
+        """
+        if experiment_id is None or not is_databricks_uri(self.tracking_uri):
+            return None
+        try:
+            location = self.store.get_experiment(experiment_id).trace_location
+            return location.full_table_prefix if location is not None else None
+        except Exception as e:
+            _logger.debug(
+                f"Failed to resolve Unity Catalog trace location for experiment "
+                f"{experiment_id}: {e}"
+            )
+            return None
+
+    def _apply_uc_location_to_trace_ids(self, trace_ids: list[str], location: str) -> list[str]:
+        """Rewrite plain trace IDs to the V4 ``trace:/<location>/<id>`` form, leaving IDs
+        that already carry a location unchanged."""
+        return [
+            tid if parse_trace_id_v4(tid)[0] is not None else construct_trace_id_v4(location, tid)
+            for tid in trace_ids
+        ]
+
     def delete_traces(
         self,
         experiment_id: str,
@@ -135,6 +173,11 @@ class TracingClient:
         max_traces: int | None = None,
         trace_ids: list[str] | None = None,
     ) -> int:
+        # For Unity Catalog-backed experiments, plain trace IDs must be qualified with the
+        # experiment's UC location before being sent to the backend, which otherwise
+        # rejects them as malformed request IDs.
+        if trace_ids and (location := self._resolve_uc_trace_location(experiment_id)):
+            trace_ids = self._apply_uc_location_to_trace_ids(trace_ids, location)
         return self.store.delete_traces(
             experiment_id=experiment_id,
             max_timestamp_millis=max_timestamp_millis,

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -46,9 +46,11 @@ from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
     TraceJSONEncoder,
     capture_function_input_args,
+    construct_trace_id_v4,
     encode_span_id,
     exclude_immutable_tags,
     get_otel_attribute,
+    parse_trace_id_v4,
 )
 from mlflow.tracing.utils.search import traces_to_df
 from mlflow.utils import get_results_from_paginated_fn
@@ -816,6 +818,28 @@ def start_span_no_context(
     return mlflow_span
 
 
+def _resolve_uc_trace_id(trace_id: str) -> str:
+    """
+    Resolve a plain trace ID to its Unity Catalog V4 form using the active experiment.
+
+    If ``trace_id`` already carries a location (``trace:/<location>/<id>``) or the active
+    experiment does not store its traces in Unity Catalog, ``trace_id`` is returned
+    unchanged. Otherwise it is qualified with the experiment's UC location so it can be
+    routed to the UC-backed endpoints.
+    """
+    from mlflow.tracing.client import TracingClient
+    from mlflow.tracking.fluent import _get_experiment_id
+
+    if parse_trace_id_v4(trace_id)[0] is not None:
+        return trace_id
+
+    location = TracingClient()._resolve_uc_trace_location(_get_experiment_id())
+    if location is None:
+        return trace_id
+
+    return construct_trace_id_v4(location, trace_id)
+
+
 @deprecated_parameter("request_id", "trace_id")
 def get_trace(trace_id: str, silent: bool = False, flush: bool = False) -> Trace | None:
     """
@@ -851,6 +875,9 @@ def get_trace(trace_id: str, silent: bool = False, flush: bool = False) -> Trace
     """
     # Special handling for evaluation request ID.
     trace_id = _EVAL_REQUEST_ID_TO_TRACE_ID.get(trace_id) or trace_id
+    # A plain trace ID does not carry the Unity Catalog location needed to fetch traces
+    # stored in UC. Resolve it from the active experiment's trace destination.
+    trace_id = _resolve_uc_trace_id(trace_id)
 
     exc: MlflowException | None = None
     try:
@@ -872,6 +899,14 @@ def get_trace(trace_id: str, silent: bool = False, flush: bool = False) -> Trace
             if not flush
             else ""
         )
+        # If the ID is still a plain ID, the active experiment did not resolve a Unity
+        # Catalog location. Point the user to the fully-qualified form for UC traces.
+        if parse_trace_id_v4(trace_id)[0] is None:
+            hint += (
+                " If this trace is stored in Unity Catalog, pass the fully-qualified trace ID "
+                "in the form `trace:/<catalog>.<schema>.<table>/<trace_id>`, or set an active "
+                "experiment linked to the UC location."
+            )
         _logger.warning(
             f"Failed to get trace from the tracking store: {exc}.{hint} "
             "For full traceback, set logging level to debug.",

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -12,7 +12,7 @@ from mlflow.entities.span import create_mlflow_span
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_location import TraceLocation
+from mlflow.entities.trace_location import TraceLocation, UnityCatalog
 from mlflow.entities.trace_state import TraceState
 from mlflow.environment_variables import (
     MLFLOW_GET_TRACE_OTEL_INITIAL_RETRY_INTERVAL_SECONDS,
@@ -640,3 +640,126 @@ def test_tracing_client_get_trace_error_handling():
         MlflowException, match=rf"Trace with ID {trace_id} is not fully exported yet"
     ):
         client.get_trace(trace_id)
+
+
+def _uc_experiment(location):
+    return Mock(trace_location=location)
+
+
+def test_resolve_uc_trace_location_returns_full_table_prefix():
+    mock_store = Mock()
+    mock_store.get_experiment.return_value = _uc_experiment(UnityCatalog("cat", "sch", "tbl"))
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient(tracking_uri="databricks")
+        assert client._resolve_uc_trace_location("123") == "cat.sch.tbl"
+
+    mock_store.get_experiment.assert_called_once_with("123")
+
+
+def test_resolve_uc_trace_location_returns_none_for_non_uc_experiment():
+    mock_store = Mock()
+    mock_store.get_experiment.return_value = _uc_experiment(None)
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient(tracking_uri="databricks")
+        assert client._resolve_uc_trace_location("123") is None
+
+
+def test_resolve_uc_trace_location_skips_non_databricks_tracking():
+    mock_store = Mock()
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient(tracking_uri="sqlite:///mlflow.db")
+        assert client._resolve_uc_trace_location("123") is None
+
+    mock_store.get_experiment.assert_not_called()
+
+
+def test_resolve_uc_trace_location_handles_missing_experiment_id():
+    mock_store = Mock()
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient(tracking_uri="databricks")
+        assert client._resolve_uc_trace_location(None) is None
+
+    mock_store.get_experiment.assert_not_called()
+
+
+def test_delete_traces_qualifies_plain_ids_for_uc_experiment():
+    mock_store = Mock()
+    mock_store.get_experiment.return_value = _uc_experiment(UnityCatalog("cat", "sch", "tbl"))
+    mock_store.delete_traces.return_value = 2
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient(tracking_uri="databricks")
+        # A plain ID is qualified with the UC location; an already-qualified ID is left as-is.
+        deleted = client.delete_traces(
+            "123", trace_ids=["tr-abc", "trace:/cat.sch.tbl/tr-def"]
+        )
+
+    assert deleted == 2
+    mock_store.delete_traces.assert_called_once_with(
+        experiment_id="123",
+        max_timestamp_millis=None,
+        max_traces=None,
+        trace_ids=["trace:/cat.sch.tbl/tr-abc", "trace:/cat.sch.tbl/tr-def"],
+    )
+
+
+def test_delete_traces_leaves_plain_ids_for_non_uc_experiment():
+    mock_store = Mock()
+    mock_store.get_experiment.return_value = _uc_experiment(None)
+    mock_store.delete_traces.return_value = 1
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient(tracking_uri="databricks")
+        client.delete_traces("123", trace_ids=["tr-abc"])
+
+    mock_store.delete_traces.assert_called_once_with(
+        experiment_id="123",
+        max_timestamp_millis=None,
+        max_traces=None,
+        trace_ids=["tr-abc"],
+    )
+
+
+def test_get_trace_resolves_uc_location_from_active_experiment():
+    mock_store = Mock()
+    mock_store.get_experiment.return_value = _uc_experiment(UnityCatalog("cat", "sch", "tbl"))
+    mock_store.batch_get_traces.return_value = ["dummy_trace"]
+
+    with (
+        patch("mlflow.tracing.client._get_store", return_value=mock_store),
+        patch("mlflow.tracing.client._resolve_tracking_uri", return_value="databricks"),
+        patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+    ):
+        assert mlflow.get_trace("tr-abc") == "dummy_trace"
+
+    mock_store.batch_get_traces.assert_called_once_with(
+        ["trace:/cat.sch.tbl/tr-abc"], "cat.sch.tbl"
+    )
+
+
+def test_resolve_uc_trace_id_passes_through_already_qualified_id():
+    from mlflow.tracing.fluent import _resolve_uc_trace_id
+
+    with patch(
+        "mlflow.tracing.client.TracingClient._resolve_uc_trace_location"
+    ) as mock_resolve:
+        assert _resolve_uc_trace_id("trace:/cat.sch.tbl/tr-abc") == "trace:/cat.sch.tbl/tr-abc"
+
+    mock_resolve.assert_not_called()
+
+
+def test_resolve_uc_trace_id_passes_through_when_no_uc_location():
+    from mlflow.tracing.fluent import _resolve_uc_trace_id
+
+    with (
+        patch(
+            "mlflow.tracing.client.TracingClient._resolve_uc_trace_location", return_value=None
+        ),
+        patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        patch("mlflow.tracing.client._get_store", return_value=Mock()),
+    ):
+        assert _resolve_uc_trace_id("tr-abc") == "tr-abc"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24622

### What changes are proposed in this pull request?

For traces stored in Unity Catalog, `get_trace()` and `delete_traces()` did not accept a plain trace ID — a plain ID lacks the `catalog.schema.table_prefix` location needed to address UC-backed traces, so `get_trace` returned `NOT_FOUND` and `delete_traces` failed with a cryptic "request id must match pattern" error.

Rather than trying to infer the catalog/schema from the ID itself, this resolves the location from experiment context, mirroring how MLflow already models UC trace destinations (`Experiment.trace_location`, derived from the `mlflow.experiment.databricksTraceDestinationPath` tag):

- `TracingClient._resolve_uc_trace_location(experiment_id)`: returns the experiment's UC `catalog.schema.table_prefix`, or `None` for non-Databricks / non-UC experiments.
- `get_trace(plain_id)`: resolves the active experiment's UC location and qualifies the plain ID (`trace:/<location>/<id>`) before routing to the existing UC read path. On not-found, the warning now points users to the fully-qualified form.
- `delete_traces(experiment_id, trace_ids)`: resolves the experiment's UC location and qualifies plain IDs before issuing the delete. Already-qualified IDs are left untouched.
- When no UC location is resolvable, behavior is unchanged (plain IDs continue to work for non-UC experiments).

**Known limitation (feedback welcome):** there is no V4 delete endpoint in this client — normalized IDs are still sent to the V3 `DeleteTraces` RPC. The `get_trace` path uses the existing, working V4 read endpoints. If the backend does not accept the qualified form on the V3 delete path, a server-side delete endpoint would still be required to fully close #24622; this PR resolves the client-side ID/location handling. Automatic SQL warehouse resolution (`MLFLOW_TRACING_SQL_WAREHOUSE_ID`) is also out of scope.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added tests in `tests/tracing/test_tracing_client.py` covering location resolution (UC / non-UC / non-Databricks / missing experiment id), `delete_traces` ID qualification, `get_trace` end-to-end routing, and pass-through cases.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `get_trace` and `delete_traces` now accept plain trace IDs for Unity Catalog-backed experiments by resolving the trace location from experiment context.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
