### PR TITLE
fix: register secrets table metadata to prevent duplicate table creation (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -32,6 +32,7 @@ from sqlalchemy.pool import (
 import mlflow.store.model_registry.dbmodels.models  # noqa: F401
 import mlflow.store.tracking.dbmodels.models  # noqa: F401
 import mlflow.store.workspace.dbmodels.models  # noqa: F401
+import mlflow.store.secrets.dbmodels.models  # noqa: F401
 from mlflow.environment_variables import (
     MLFLOW_MYSQL_SSL_CA,
     MLFLOW_MYSQL_SSL_CERT,


### PR DESCRIPTION
## What
When upgrading from 3.7.0 to 3.8.x, the `mlflow db upgrade` command fails with "Table 'secrets' already exists". This happens because the new 'secrets' table was added by a migration but its ORM model was not imported in `utils.py`, so `_all_tables_exist()` did not consider it when checking if all tables exist. Consequently, the code incorrectly attempted to create the table again via `create_all()`.

## Fix
Add `import mlflow.store.secrets.dbmodels.models` so that the 'secrets' table metadata is registered in `Base.metadata.tables`. This ensures `_all_tables_exist()` properly detects that the table already exists and skips the creation step, preventing the "already exists" error.

Closes #19943