### PR TITLE
Normalize reasoning content parts for `ChatAgentMessage` in `parse_message`

### DIFF
--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -41,6 +41,30 @@ from mlflow.langchain.utils.chat import convert_lc_message_to_chat_message
 from mlflow.types.agent import ChatAgentMessage
 
 
+def _normalize_content_for_chat_agent(content: Any) -> str | None:
+    """
+    Coerce ChatMessage content into the string schema required by ChatAgentMessage.
+
+    ``ChatMessage`` (post-#24176) may carry multimodal / reasoning content parts, but
+    ``ChatAgentMessage.content`` is ``str | None``. For list content we keep only
+    ``type="text"`` parts (joined with newlines) and drop reasoning / other parts so
+    LangGraph ChatAgent serving stays compatible with FMAPI reasoning models.
+    """
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                texts.append(part)
+            elif isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+        return "\n".join(texts)
+    return str(content)
+
+
 def _add_agent_messages(
     left: dict[str, Any] | list[dict[str, Any]],
     right: dict[str, Any] | list[dict[str, Any]],
@@ -281,6 +305,11 @@ def parse_message(
     chat_message_dict["attachments"] = attachments
     chat_message_dict["name"] = msg.name or name
     chat_message_dict["id"] = msg.id
+    # ChatAgentMessage requires string content; ChatMessage may return content parts
+    # (e.g. reasoning + text from FMAPI models). Normalize at this boundary only.
+    chat_message_dict["content"] = _normalize_content_for_chat_agent(
+        chat_message_dict.get("content")
+    )
     # _convert_to_message from langchain_core.messages.utils expects an empty string instead of None
     if not chat_message_dict.get("content"):
         chat_message_dict["content"] = ""

--- a/tests/langgraph/test_chat_agent_langgraph.py
+++ b/tests/langgraph/test_chat_agent_langgraph.py
@@ -113,6 +113,75 @@ def test_parse_message(lc_msg, chat_agent_msg, name, attachments):
     assert parse_message(lc_msg, name, attachments) == chat_agent_msg
 
 
+@pytest.mark.parametrize(
+    ("content", "expected_content"),
+    [
+        # FMAPI / reasoning-model shape from #24176: keep user-facing text only.
+        # Reasoning summary is intentionally dropped so ChatAgentMessage stays a string schema.
+        (
+            [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "No need to retrieve."}],
+                },
+                {"type": "text", "text": "How can I help you today?"},
+            ],
+            "How can I help you today?",
+        ),
+        (
+            [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "No need to retrieve."}],
+                },
+            ],
+            "",
+        ),
+        (
+            [
+                {"type": "text", "text": "First part"},
+                {"type": "text", "text": "Second part"},
+            ],
+            "First part\nSecond part",
+        ),
+        ("plain string content", "plain string content"),
+    ],
+)
+def test_parse_message_normalizes_list_content_for_chat_agent(content, expected_content):
+    lc_msg = AIMessage(content=content, id="msg-reasoning-1")
+    result = parse_message(lc_msg)
+    assert result["role"] == "assistant"
+    assert result["content"] == expected_content
+    assert result["id"] == "msg-reasoning-1"
+    # Must be ChatAgent-compatible (string content), not ChatMessage list content.
+    ChatAgentMessage(**result)
+
+
+def test_parse_message_reasoning_content_with_tool_calls():
+    lc_msg = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Need a tool."}],
+            },
+            {"type": "text", "text": "Calling the tool."},
+        ],
+        id="msg-tool-reasoning-1",
+        tool_calls=[
+            {
+                "name": "lookup",
+                "args": {"q": "x"},
+                "id": "call-1",
+                "type": "tool_call",
+            }
+        ],
+    )
+    result = parse_message(lc_msg)
+    assert result["content"] == "Calling the tool."
+    assert result["tool_calls"][0]["function"]["name"] == "lookup"
+    ChatAgentMessage(**result)
+
+
 def test_langgraph_chat_agent_save_as_code():
     # (role, content)
     expected_messages = [


### PR DESCRIPTION
### Related Issues/PRs

Fixes #24641
Related to / follow-up for #24176

### What changes are proposed in this pull request?

After #24176, `ChatMessage` / `convert_lc_message_to_chat_message` correctly accept FMAPI `ReasoningContent` parts. The LangGraph ChatAgent path still fails: `parse_message()` builds `ChatAgentMessage(**dict)`, and `ChatAgentMessage.content` is `str | None`, so list content like `[reasoning, text]` raises a validation error.

This PR takes **Option 1** (string normalization at the ChatAgent boundary only):

- Add `_normalize_content_for_chat_agent()` used by `parse_message`
- Keep only `type="text"` parts, joined with `\n`
- Drop reasoning / other non-text parts (ChatAgent ColSpecs remain string-only)
- Leave `ChatMessage` reasoning preservation from #24176 unchanged

Normalization examples:

| Input | ChatAgent `content` |
| --- | --- |
| `[reasoning("No need to retrieve."), text("How can I help you today?")]` | `"How can I help you today?"` |
| `[reasoning(...)]` only | `""` |
| `[text("First"), text("Second")]` | `"First\nSecond"` |
| plain string | unchanged |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New regression coverage in `tests/langgraph/test_chat_agent_langgraph.py` for reasoning+text (FMAPI/#24176 fixture shape), reasoning-only, text-only list, plain string, and tool-call + reasoning.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix LangGraph ChatAgent serving failures with FMAPI reasoning models by normalizing reasoning content parts to string content in `parse_message`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release