### PR TITLE
Return resolved MCP server icons on list and get

### DIFF
--- a/mlflow/server/mcp_server_api.py
+++ b/mlflow/server/mcp_server_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from fastapi import APIRouter, Query, Request
 from fastapi.exceptions import RequestValidationError
@@ -29,6 +29,7 @@ from mlflow.protos.databricks_pb2 import PERMISSION_DENIED, RESOURCE_ALREADY_EXI
 from mlflow.utils.validation import (
     _MAX_MCP_ICONS_PER_LIST,
     _MAX_MCP_TOOLS_PER_LIST,
+    _strip_mcp_icon_response_fields,
     _validate_mcp_icon_mime_type,
     _validate_mcp_icon_url,
 )
@@ -74,6 +75,8 @@ class _BaseMCPIconPayload(BaseModel):
             icon["mimeType"] = self.mimeType
         if self.theme is not None:
             icon["theme"] = self.theme
+        if getattr(self, "source", None) is not None:
+            icon["source"] = self.source
         return icon
 
 
@@ -92,7 +95,13 @@ class MCPIconRequestPayload(_BaseMCPIconPayload):
 
 
 class MCPIconResponsePayload(_BaseMCPIconPayload):
-    pass
+    """Icon payload used by nested surfaces such as tool icons."""
+
+
+class MCPServerIconResponsePayload(_BaseMCPIconPayload):
+    """Resolved server icon, including response-only provenance."""
+
+    source: Literal["server", "version"] | None = None
 
 
 class ServerJSONRepositoryPayload(BaseModel):
@@ -321,7 +330,7 @@ class MCPServerResponse(BaseModel):
     name: str
     display_name: str | None = None
     description: str | None = None
-    icons: list[MCPIconResponsePayload] | None = None
+    icons: list[MCPServerIconResponsePayload] | None = None
     workspace: str | None = None
     status: str | None = None
     access_endpoints: list[MCPAccessEndpointSummaryResponse] = Field(default_factory=list)
@@ -502,7 +511,7 @@ def _icon_payloads_to_entities(
 ) -> list[MCPIcon] | None:
     if icons is None:
         return None
-    return [icon.model_dump(exclude_none=True) for icon in icons]
+    return _strip_mcp_icon_response_fields([icon.model_dump(exclude_none=True) for icon in icons])
 
 
 def _update_mcp_server_kwargs(name: str, body: UpdateMCPServerRequest) -> dict[str, Any]:

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -127,6 +127,34 @@ RunStatusTypes = [
 MutableJSON = MutableDict.as_mutable(JSON)
 
 
+def _resolve_mcp_server_icons(
+    server_icons: list[dict[str, Any]] | None,
+    version_icons: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    # Explicit empty server overrides must not fall back to version icons, matching
+    # description resolution where only ``None`` (not empty) triggers fallback.
+    if server_icons is not None and len(server_icons) == 0:
+        return []
+
+    resolved_icons = []
+    server_icons = server_icons or []
+    version_icons = version_icons or []
+    server_themes = set()
+
+    for icon in server_icons:
+        if not isinstance(icon, dict):
+            continue
+        server_themes.add(icon.get("theme"))
+        resolved_icons.append({**icon, "source": "server"})
+
+    for icon in version_icons:
+        if not isinstance(icon, dict) or icon.get("theme") in server_themes:
+            continue
+        resolved_icons.append({**icon, "source": "version"})
+
+    return resolved_icons or None
+
+
 class SqlExperiment(Base):
     """
     DB model for :py:class:`mlflow.entities.Experiment`. These are recorded in ``experiment`` table.
@@ -3934,18 +3962,24 @@ class SqlMCPServer(Base):
         )
         resolved_status = self.resolved_status if resolved_status is None else resolved_status
         status = MCPStatus(resolved_status) if resolved_status is not None else None
-        description = self.description
-        if description is None and self.resolved_parent_server_json is not None:
+        parent_server_json = None
+        if self.resolved_parent_server_json is not None:
             parent_server_json = self.resolved_parent_server_json
             if not isinstance(parent_server_json, dict):
                 parent_server_json = json.loads(parent_server_json)
+        description = self.description
+        if description is None and parent_server_json is not None:
             description = parent_server_json.get("description")
+        icons = _resolve_mcp_server_icons(
+            self.icons,
+            parent_server_json.get("icons") if parent_server_json is not None else None,
+        )
 
         return MCPServer(
             name=self.name,
             display_name=self.display_name,
             description=description,
-            icons=self.icons,
+            icons=icons,
             workspace=self.workspace,
             status=status,
             tags=tags,

--- a/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/abstract_mixin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -14,12 +14,18 @@ NOT_SET = object()
 
 
 class MCPIcon(TypedDict):
-    """Icon following the upstream MCP server.json icon schema."""
+    """Icon following the upstream MCP server.json icon schema.
+
+    The read path may also annotate resolved server icons with a response-only
+    ``source`` field indicating whether the icon came from the server override
+    or the resolved latest version.
+    """
 
     src: str
     sizes: NotRequired[list[str]]
     mimeType: NotRequired[str]
     theme: NotRequired[str]
+    source: NotRequired[Literal["server", "version"]]
 
 
 class MCPServerRegistryMixin:

--- a/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/mcp_server_registry/sqlalchemy_mixin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import uuid
+from dataclasses import replace
 from typing import Any
 
 import sqlalchemy as sa
@@ -50,6 +51,7 @@ from mlflow.utils.search_utils import (
 from mlflow.utils.semver_utils import encode_prerelease_sort_key, parse_semver
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.validation import (
+    _strip_mcp_icon_response_fields,
     _validate_mcp_icon_payloads,
     _validate_mcp_initial_status,
     _validate_mcp_tool_payloads,
@@ -64,6 +66,27 @@ def _validate_server_json_icon_fields(server_json: dict[str, Any]) -> None:
     # Keep validation aligned with schema-defined icon locations only. Extra free-form
     # metadata (for example under ``_meta``) must continue to round-trip untouched.
     _validate_mcp_icon_payloads(server_json.get("icons"), "server_json.icons")
+
+
+def _strip_server_json_icon_response_fields(server_json: dict[str, Any]) -> dict[str, Any]:
+    if "icons" not in server_json:
+        return server_json
+    return {
+        **server_json,
+        "icons": _strip_mcp_icon_response_fields(server_json.get("icons"), "server_json.icons"),
+    }
+
+
+def _strip_tool_icon_response_fields(tools: list[MCPTool] | None) -> list[MCPTool] | None:
+    if tools is None:
+        return None
+    return [
+        replace(
+            tool,
+            icons=_strip_mcp_icon_response_fields(tool.icons, f"tools[{idx}].icons"),
+        )
+        for idx, tool in enumerate(tools)
+    ]
 
 
 def _validate_tool_icons(tools: list[MCPTool] | None, field_name: str = "tools") -> None:
@@ -95,6 +118,7 @@ class SqlAlchemyMCPServerRegistryMixin:
         created_by: str | None = None,
     ) -> MCPServer:
         validate_mcp_server_name(name)
+        icons = _strip_mcp_icon_response_fields(icons)
         _validate_mcp_icon_payloads(icons, "icons")
         now = get_current_time_millis()
         with self.ManagedSessionMaker(read_only=False) as session:
@@ -206,6 +230,7 @@ class SqlAlchemyMCPServerRegistryMixin:
         last_updated_by: str | None = None,
     ) -> MCPServer:
         if icons is not NOT_SET:
+            icons = _strip_mcp_icon_response_fields(icons)
             _validate_mcp_icon_payloads(icons, "icons")
         with self.ManagedSessionMaker(read_only=False) as session:
             server = self._get_entity_or_raise(session, SqlMCPServer, {"name": name}, "MCPServer")
@@ -263,6 +288,7 @@ class SqlAlchemyMCPServerRegistryMixin:
                 error_code=INVALID_PARAMETER_VALUE,
             )
         validate_mcp_server_name(name)
+        server_json = _strip_server_json_icon_response_fields(server_json)
         _validate_server_json_icon_fields(server_json)
         parsed_version = parse_semver(version, param_name="server_json.version")
 
@@ -272,7 +298,7 @@ class SqlAlchemyMCPServerRegistryMixin:
 
         # Store/server create does not perform remote discovery. Omitted tools
         # are stored as null; client-side callers may resolve before create.
-        tools = None if tools is NOT_SET else tools
+        tools = None if tools is NOT_SET else _strip_tool_icon_response_fields(tools)
         _validate_tool_icons(tools)
         tools_json = None if tools is None else [t.to_dict() for t in tools]
 
@@ -460,6 +486,7 @@ class SqlAlchemyMCPServerRegistryMixin:
         last_updated_by: str | None = None,
     ) -> MCPServerVersion:
         if tools is not NOT_SET:
+            tools = _strip_tool_icon_response_fields(tools)
             _validate_tool_icons(tools)
         with self.ManagedSessionMaker(read_only=False) as session:
             sv = self._get_live_mcp_server_version_or_raise(session, name, version)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -1090,6 +1090,39 @@ def _validate_mcp_icon_payloads(icons: Any, field_name: str = "icons") -> None:
         _validate_mcp_icon_mime_type(icon.get("mimeType"))
 
 
+def _strip_mcp_icon_response_fields(
+    icons: list[dict[str, Any]] | None,
+    field_name: str = "icons",
+) -> list[dict[str, Any]] | None:
+    """Sanitize response-only icon fields before persisting write payloads.
+
+    ``source="server"`` is ignored (stripped) so clients can echo resolved server
+    icons on update. ``source="version"`` is rejected because writing it would
+    persist a version-resolved icon as an explicit server override.
+    """
+    if icons is None:
+        return None
+
+    sanitized: list[dict[str, Any]] = []
+    for idx, icon in enumerate(icons):
+        if not isinstance(icon, dict):
+            sanitized.append(icon)
+            continue
+
+        source = icon.get("source")
+        if source == "version":
+            raise MlflowException.invalid_parameter_value(
+                f"Invalid {field_name}[{idx}].source: 'version' is response-only and "
+                "cannot be written. Writing it would persist a version-resolved icon "
+                "as a server override. Omit source, or send source='server' when "
+                "echoing a server icon."
+            )
+
+        # Ignore response-only source="server" (and drop any other source key).
+        sanitized.append({key: value for key, value in icon.items() if key != "source"})
+    return sanitized
+
+
 def _validate_mcp_tool_payloads(tools: Any, field_name: str = "tools") -> None:
     if tools is None:
         return

--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -19,6 +19,7 @@ from mlflow.server.mcp_server_api import (
     get_mcp_server_api_route_prefixes,
     mcp_server_router,
 )
+from mlflow.store.tracking.dbmodels.models import SqlMCPServer
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
 PREFIX = "/ajax-api/3.0/mlflow/mcp-servers"
@@ -109,7 +110,7 @@ def test_create_server_with_icons(client):
     icons = [{"src": "https://example.com/icon.png", "sizes": ["32x32"]}]
     r = client.post(PREFIX, json={"name": "com.example/icon-server", "icons": icons})
     assert r.status_code == 200
-    assert r.json()["icons"] == icons
+    assert r.json()["icons"] == [{**icons[0], "source": "server"}]
 
 
 def test_create_server_rejects_too_many_icons(client):
@@ -132,7 +133,41 @@ def test_create_server_with_icons_preserves_extra_fields(client):
         json={"name": "com.example/icon-extra-server", "icons": icons},
     )
     assert r.status_code == 200
-    assert r.json()["icons"] == icons
+    assert r.json()["icons"] == [{**icons[0], "source": "server"}]
+
+
+def test_create_server_ignores_server_icon_source_on_write(client, store):
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-source-server",
+            "icons": [{"src": "https://example.com/icon.png", "source": "server"}],
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["icons"] == [{"src": "https://example.com/icon.png", "source": "server"}]
+
+    with store.ManagedSessionMaker() as session:
+        persisted = (
+            session
+            .query(SqlMCPServer)
+            .filter(SqlMCPServer.name == "com.example/icon-source-server")
+            .one()
+        )
+        assert persisted.icons == [{"src": "https://example.com/icon.png"}]
+
+
+def test_create_server_rejects_version_icon_source_on_write(client):
+    r = client.post(
+        PREFIX,
+        json={
+            "name": "com.example/icon-version-source",
+            "icons": [{"src": "https://example.com/icon.png", "source": "version"}],
+        },
+    )
+    assert r.status_code == 400
+    assert "source" in r.text
+    assert "version" in r.text
 
 
 @pytest.mark.parametrize(
@@ -350,6 +385,22 @@ def test_search_servers(client):
     assert len(r2.json()["mcp_servers"]) == 1
 
 
+def test_search_servers_returns_resolved_icon_source(client):
+    _create_version(
+        client,
+        "com.example/icon-search",
+        "1.0.0",
+        status="active",
+        icons=[{"src": "https://example.com/version.png"}],
+    )
+
+    r = client.get(PREFIX, params={"filter_string": "name = 'com.example/icon-search'"})
+    assert r.status_code == 200
+    assert r.json()["mcp_servers"][0]["icons"] == [
+        {"src": "https://example.com/version.png", "source": "version"}
+    ]
+
+
 def test_server_responses_include_nested_endpoint_server_name(client):
     sj = _server_json("com.example/nested-bind-srv", "1.0.0")
     client.post(
@@ -395,6 +446,132 @@ def test_update_server_rejects_risky_icon_urls(client):
     )
     assert r.status_code == 400
     assert "Icon URL" in r.text
+
+
+def test_update_server_ignores_server_icon_source_on_write(client, store):
+    client.post(PREFIX, json={"name": "com.example/upd-icons-source"})
+    r = client.patch(
+        f"{PREFIX}/{_encode_path_param('com.example/upd-icons-source')}",
+        json={"icons": [{"src": "https://example.com/icon.png", "source": "server"}]},
+    )
+    assert r.status_code == 200
+    assert r.json()["icons"] == [{"src": "https://example.com/icon.png", "source": "server"}]
+
+    with store.ManagedSessionMaker() as session:
+        persisted = (
+            session
+            .query(SqlMCPServer)
+            .filter(SqlMCPServer.name == "com.example/upd-icons-source")
+            .one()
+        )
+        assert persisted.icons == [{"src": "https://example.com/icon.png"}]
+
+
+def test_update_server_rejects_version_icon_source_on_write(client):
+    client.post(PREFIX, json={"name": "com.example/upd-icons-version"})
+    r = client.patch(
+        f"{PREFIX}/{_encode_path_param('com.example/upd-icons-version')}",
+        json={"icons": [{"src": "https://example.com/icon.png", "source": "version"}]},
+    )
+    assert r.status_code == 400
+    assert "source" in r.text
+    assert "version" in r.text
+
+
+def test_create_version_ignores_server_icon_source_on_write(client):
+    name = "com.example/icon-version-source"
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param(name)}/versions",
+        json={
+            "server_json": _server_json(
+                name,
+                "1.0.0",
+                icons=[{"src": "https://example.com/icon.png", "source": "server"}],
+            ),
+            "tools": [
+                {
+                    "name": "search",
+                    "icons": [{"src": "https://example.com/tool.png", "source": "server"}],
+                }
+            ],
+            "status": "active",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["server_json"]["icons"] == [{"src": "https://example.com/icon.png"}]
+    assert r.json()["tools"][0]["icons"] == [{"src": "https://example.com/tool.png"}]
+
+
+def test_create_version_rejects_version_icon_source_on_write(client):
+    name = "com.example/icon-version-rejected"
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param(name)}/versions",
+        json={
+            "server_json": _server_json(
+                name,
+                "1.0.0",
+                icons=[{"src": "https://example.com/icon.png", "source": "version"}],
+            ),
+            "status": "active",
+        },
+    )
+    assert r.status_code == 400
+    assert "source" in r.text
+    assert "version" in r.text
+
+
+def test_create_version_rejects_tool_version_icon_source_on_write(client):
+    name = "com.example/icon-tool-version-rejected"
+    r = client.post(
+        f"{PREFIX}/{_encode_path_param(name)}/versions",
+        json={
+            "server_json": _server_json(name, "1.0.0"),
+            "tools": [
+                {
+                    "name": "search",
+                    "icons": [{"src": "https://example.com/tool.png", "source": "version"}],
+                }
+            ],
+            "status": "active",
+        },
+    )
+    assert r.status_code == 400
+    assert "source" in r.text
+    assert "version" in r.text
+
+
+def test_update_version_ignores_server_tool_icon_source_on_write(client):
+    name = "com.example/icon-tool-source"
+    _create_version(client, name, "1.0.0", status="draft")
+    r = client.patch(
+        f"{PREFIX}/{_encode_path_param(name)}/versions/1.0.0",
+        json={
+            "tools": [
+                {
+                    "name": "search",
+                    "icons": [{"src": "https://example.com/tool.png", "source": "server"}],
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["tools"][0]["icons"] == [{"src": "https://example.com/tool.png"}]
+
+
+def test_create_server_empty_icons_do_not_fall_back_to_version(client):
+    name = "com.example/empty-icons"
+    client.post(PREFIX, json={"name": name, "icons": []})
+    _create_version(
+        client,
+        name,
+        "1.0.0",
+        status="active",
+        icons=[{"src": "https://example.com/version.png"}],
+    )
+
+    r = client.get(f"{PREFIX}/{_encode_path_param(name)}")
+    assert r.status_code == 200
+    assert r.json()["icons"] == []
 
 
 def test_update_server_rejects_latest_version_field(client):
@@ -1724,6 +1901,25 @@ def test_server_response_includes_endpoint_resolved_version(client):
     server = client.get(f"{PREFIX}/{_encode_path_param('com.example/sbrv-srv')}").json()
     assert len(server["access_endpoints"]) == 1
     assert server["access_endpoints"][0]["resolved_version"]["version"] == "1.0.0"
+
+
+def test_server_response_resolves_icon_source_from_latest_version(client):
+    _create_version(
+        client,
+        "com.example/icon-get",
+        "1.0.0",
+        status="active",
+        icons=[{"src": "https://example.com/version.png", "theme": "dark"}],
+    )
+
+    server = client.get(f"{PREFIX}/{_encode_path_param('com.example/icon-get')}").json()
+    assert server["icons"] == [
+        {
+            "src": "https://example.com/version.png",
+            "theme": "dark",
+            "source": "version",
+        }
+    ]
 
 
 def test_server_json_extra_fields_preserved(client):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -128,7 +128,7 @@ def test_create_mcp_server_accepts_upstream_name_shapes(store, name):
 def test_create_mcp_server_with_icons(store):
     icons = [{"src": "https://example.com/icon.png", "sizes": "32x32"}]
     server = store.create_mcp_server("io.github.test/servererver", icons=icons)
-    assert server.icons == icons
+    assert server.icons == [{**icons[0], "source": "server"}]
 
 
 def test_create_mcp_server_rejects_risky_icons(store):
@@ -404,10 +404,165 @@ def test_get_mcp_server_description_falls_back_to_highest_non_deleted_version(st
     assert server.latest_version == "2.0.0"
 
 
+def test_get_mcp_server_icons_fall_back_to_highest_active_semver(store):
+    store.create_mcp_server_version(
+        _server_json(
+            "io.github.test/server",
+            "1.0.0",
+            icons=[{"src": "https://example.com/active.png", "theme": "dark"}],
+        ),
+        status=MCPStatus.ACTIVE,
+    )
+    _create_version(
+        store,
+        "io.github.test/server",
+        "2.0.0",
+        icons=[{"src": "https://example.com/deprecated.png", "theme": "dark"}],
+        status=MCPStatus.DEPRECATED,
+    )
+
+    server = store.get_mcp_server("io.github.test/server")
+    assert server.icons == [
+        {
+            "src": "https://example.com/active.png",
+            "theme": "dark",
+            "source": "version",
+        }
+    ]
+
+
+def test_get_mcp_server_icons_fall_back_to_highest_non_deleted_version(store):
+    _create_version(
+        store,
+        "io.github.test/server",
+        "2.0.0",
+        icons=[{"src": "https://example.com/deprecated.png", "theme": "dark"}],
+        status=MCPStatus.DEPRECATED,
+    )
+
+    server = store.get_mcp_server("io.github.test/server")
+    assert server.icons == [
+        {
+            "src": "https://example.com/deprecated.png",
+            "theme": "dark",
+            "source": "version",
+        }
+    ]
+
+
+def test_get_mcp_server_icons_merge_server_and_version_by_theme(store):
+    store.create_mcp_server(
+        "io.github.test/server",
+        icons=[{"src": "https://example.com/server-dark.png", "theme": "dark"}],
+    )
+    store.create_mcp_server_version(
+        _server_json(
+            "io.github.test/server",
+            "1.0.0",
+            icons=[
+                {"src": "https://example.com/version-dark.png", "theme": "dark"},
+                {"src": "https://example.com/version-light.png", "theme": "light"},
+            ],
+        ),
+        status=MCPStatus.ACTIVE,
+    )
+
+    server = store.get_mcp_server("io.github.test/server")
+    assert server.icons == [
+        {
+            "src": "https://example.com/server-dark.png",
+            "theme": "dark",
+            "source": "server",
+        },
+        {
+            "src": "https://example.com/version-light.png",
+            "theme": "light",
+            "source": "version",
+        },
+    ]
+
+
+def test_get_mcp_server_empty_icons_do_not_fall_back_to_version(store):
+    store.create_mcp_server(
+        "io.github.test/server",
+        icons=[],
+    )
+    store.create_mcp_server_version(
+        _server_json(
+            "io.github.test/server",
+            "1.0.0",
+            icons=[{"src": "https://example.com/version.png", "theme": "dark"}],
+        ),
+        status=MCPStatus.ACTIVE,
+    )
+
+    server = store.get_mcp_server("io.github.test/server")
+    assert server.icons == []
+
+
+def test_get_mcp_server_empty_icons_remain_empty_without_version(store):
+    store.create_mcp_server("io.github.test/server", icons=[])
+    server = store.get_mcp_server("io.github.test/server")
+    assert server.icons == []
+
+
+def test_create_mcp_server_version_ignores_server_icon_source(store):
+    version = store.create_mcp_server_version(
+        _server_json(
+            "io.github.test/server",
+            "1.0.0",
+            icons=[{"src": "https://example.com/icon.png", "source": "server"}],
+        ),
+        tools=[
+            MCPTool(
+                name="search",
+                icons=[{"src": "https://example.com/tool.png", "source": "server"}],
+            )
+        ],
+        status=MCPStatus.ACTIVE,
+    )
+    assert version.server_json["icons"] == [{"src": "https://example.com/icon.png"}]
+    assert version.tools[0].icons == [{"src": "https://example.com/tool.png"}]
+
+
+def test_create_mcp_server_version_rejects_version_icon_source(store):
+    with pytest.raises(MlflowException, match="source.*version"):
+        store.create_mcp_server_version(
+            _server_json(
+                "io.github.test/server",
+                "1.0.0",
+                icons=[{"src": "https://example.com/icon.png", "source": "version"}],
+            ),
+            status=MCPStatus.ACTIVE,
+        )
+
+
+def test_create_mcp_server_rejects_version_icon_source(store):
+    with pytest.raises(MlflowException, match="source.*version"):
+        store.create_mcp_server(
+            "io.github.test/server",
+            icons=[{"src": "https://example.com/icon.png", "source": "version"}],
+        )
+
+
 def test_get_mcp_server_resolved_status_no_versions(store):
     store.create_mcp_server("io.github.test/server")
     server = store.get_mcp_server("io.github.test/server")
     assert server.status is None
+
+
+def test_search_mcp_servers_resolves_icons_from_latest_version(store):
+    store.create_mcp_server_version(
+        _server_json(
+            "io.github.test/server",
+            "1.0.0",
+            icons=[{"src": "https://example.com/icon.png"}],
+        ),
+        status=MCPStatus.ACTIVE,
+    )
+
+    servers = store.search_mcp_servers()
+    assert servers[0].icons == [{"src": "https://example.com/icon.png", "source": "version"}]
 
 
 def test_delete_mcp_server(store):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Relates to #22625

### What changes are proposed in this pull request?

Merge server icon overrides with the latest version's icons so clients can render icons from the initial search without a follow-up version fetch, and strip response-only source on write.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
