### PR TITLE
docs: improve LangGraph tracing guidance

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -162,7 +162,7 @@ def get_weather(city: Literal["nyc", "sf"]):
 # Replace the model name with your Databricks serving endpoint.
 # See the Databricks integration page for endpoint setup:
 # /genai/tracing/integrations/listing/databricks
-llm = ChatDatabricks(model="databricks-claude-opus-4")
+llm = ChatDatabricks(endpoint="databricks-claude-opus-4")
 tools = [get_weather]
 graph = create_react_agent(llm, tools)
 
@@ -305,6 +305,7 @@ with mlflow.start_span(name="retrieve", span_type=SpanType.RETRIEVER) as span:
 
 # Avoid: a count leaves nothing to debug
 with mlflow.start_span(name="retrieve", span_type=SpanType.RETRIEVER) as span:
+    span.set_inputs({"query": query})
     docs = retriever.invoke(query)
     span.set_outputs({"count": len(docs)})
 ```

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -43,6 +43,11 @@ LangGraph.js tracing is supported via the OpenTelemetry ingestion. See the [Gett
 </Tabs>
 </TabsWrapper>
 
+:::warning Use `mlflow.langchain.autolog()` for LangGraph, not `mlflow.openai.autolog()`
+
+`mlflow.openai.autolog()` captures only raw LLM call spans. It cannot see LangGraph node boundaries, conditional edges, or graph state. All graph node spans will be missing from the trace. Call `mlflow.langchain.autolog()` to capture the full graph execution.
+:::
+
 ## Getting Started
 
 MLflow support tracing for LangGraph in both Python and TypeScript/JavaScript. Please select the appropriate tab below to get started.
@@ -115,6 +120,58 @@ result = graph.invoke({"messages": [{"role": "user", "content": "what is the wea
 ### 5. View the trace in the MLflow UI
 
 Visit `http://localhost:5000` (or your custom MLflow tracking server URL) to view the trace in the MLflow UI.
+
+  </TabItem>
+  <TabItem value="databricks" label="Databricks (ChatDatabricks)">
+
+### 1. Start MLflow
+
+Use [Databricks managed MLflow](https://docs.databricks.com/aws/en/mlflow3/genai/) or start a local MLflow server following the [Self-Hosting Guide](/self-hosting).
+
+### 2. Install dependencies
+
+```bash
+pip install langgraph databricks-langchain mlflow
+```
+
+### 3. Enable tracing and build the agent
+
+```python
+import mlflow
+from databricks_langchain import ChatDatabricks
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+from typing import Literal
+
+# mlflow.langchain.autolog() captures all LangGraph node spans.
+# Do not use mlflow.openai.autolog() here. It misses graph structure.
+mlflow.langchain.autolog()
+
+mlflow.set_experiment("LangGraph-Databricks")
+
+
+@tool
+def get_weather(city: Literal["nyc", "sf"]):
+    """Use this to get weather information."""
+    if city == "nyc":
+        return "It might be cloudy in nyc"
+    elif city == "sf":
+        return "It's always sunny in sf"
+
+
+# Replace the model name with your Databricks serving endpoint.
+# See the Databricks integration page for endpoint setup:
+# /genai/tracing/integrations/listing/databricks
+llm = ChatDatabricks(model="databricks-claude-opus-4")
+tools = [get_weather]
+graph = create_react_agent(llm, tools)
+
+result = graph.invoke({"messages": [{"role": "user", "content": "what is the weather in sf?"}]})
+```
+
+### 4. View the trace in the MLflow UI
+
+Open the MLflow UI to see the full graph trace, including all node spans and LLM call spans.
 
   </TabItem>
   <TabItem value="typescript" label="JS / TS">
@@ -235,7 +292,22 @@ def code_check(state: GraphState):
     }
 ```
 
-This way, the span for the `check_code` node will have child spans, which record whether the each validation fails or not, with their exception details.
+This way, the span for the `check_code` node will have child spans, which record whether each validation fails or not, with their exception details.
+
+When a node or tool returns retrieved content such as documents, search results, or messages, record the actual content on the span rather than a count. A count like `{"matches": 20}` shows how many results arrived but does not reveal why the answer was wrong. The trace store accepts large string attributes, so full content is the default and makes traces debuggable.
+
+```python
+# Prefer: record the content
+with mlflow.start_span(name="retrieve", span_type=SpanType.RETRIEVER) as span:
+    span.set_inputs({"query": query})
+    docs = retriever.invoke(query)
+    span.set_outputs({"documents": [{"id": d.id, "text": d.page_content} for d in docs]})
+
+# Avoid: a count leaves nothing to debug
+with mlflow.start_span(name="retrieve", span_type=SpanType.RETRIEVER) as span:
+    docs = retriever.invoke(query)
+    span.set_outputs({"count": len(docs)})
+```
 
 ![LangGraph Child Span](/images/llms/tracing/langgraph-child-span.png)
 

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -45,7 +45,7 @@ LangGraph.js tracing is supported via the OpenTelemetry ingestion. See the [Gett
 
 :::warning Use `mlflow.langchain.autolog()` for LangGraph, not `mlflow.openai.autolog()`
 
-`mlflow.openai.autolog()` captures only raw LLM call spans. It cannot see LangGraph node boundaries, conditional edges, or graph state. All graph node spans will be missing from the trace. Call `mlflow.langchain.autolog()` to capture the full graph execution.
+If your LangGraph agent uses an OpenAI model, it is tempting to call `mlflow.openai.autolog()`. That call captures only raw LLM call spans and cannot see LangGraph node boundaries, conditional edges, or graph state. All graph node spans will be missing from the trace. Call `mlflow.langchain.autolog()` instead to capture the full graph execution.
 :::
 
 ## Getting Started
@@ -120,58 +120,6 @@ result = graph.invoke({"messages": [{"role": "user", "content": "what is the wea
 ### 5. View the trace in the MLflow UI
 
 Visit `http://localhost:5000` (or your custom MLflow tracking server URL) to view the trace in the MLflow UI.
-
-  </TabItem>
-  <TabItem value="databricks" label="Databricks (ChatDatabricks)">
-
-### 1. Start MLflow
-
-Use [Databricks managed MLflow](https://docs.databricks.com/aws/en/mlflow3/genai/) or start a local MLflow server following the [Self-Hosting Guide](/self-hosting).
-
-### 2. Install dependencies
-
-```bash
-pip install langgraph databricks-langchain mlflow
-```
-
-### 3. Enable tracing and build the agent
-
-```python
-import mlflow
-from databricks_langchain import ChatDatabricks
-from langchain_core.tools import tool
-from langgraph.prebuilt import create_react_agent
-from typing import Literal
-
-# mlflow.langchain.autolog() captures all LangGraph node spans.
-# Do not use mlflow.openai.autolog() here. It misses graph structure.
-mlflow.langchain.autolog()
-
-mlflow.set_experiment("LangGraph-Databricks")
-
-
-@tool
-def get_weather(city: Literal["nyc", "sf"]):
-    """Use this to get weather information."""
-    if city == "nyc":
-        return "It might be cloudy in nyc"
-    elif city == "sf":
-        return "It's always sunny in sf"
-
-
-# Replace the model name with your Databricks serving endpoint.
-# See the Databricks integration page for endpoint setup:
-# /genai/tracing/integrations/listing/databricks
-llm = ChatDatabricks(endpoint="databricks-claude-opus-4")
-tools = [get_weather]
-graph = create_react_agent(llm, tools)
-
-result = graph.invoke({"messages": [{"role": "user", "content": "what is the weather in sf?"}]})
-```
-
-### 4. View the trace in the MLflow UI
-
-Open the MLflow UI to see the full graph trace, including all node spans and LLM call spans.
 
   </TabItem>
   <TabItem value="typescript" label="JS / TS">
@@ -293,22 +241,6 @@ def code_check(state: GraphState):
 ```
 
 This way, the span for the `check_code` node will have child spans, which record whether each validation fails or not, with their exception details.
-
-When a node or tool returns retrieved content such as documents, search results, or messages, record the actual content on the span rather than a count. A count like `{"matches": 20}` shows how many results arrived but does not reveal why the answer was wrong. The trace store accepts large string attributes, so full content is the default and makes traces debuggable.
-
-```python
-# Prefer: record the content
-with mlflow.start_span(name="retrieve", span_type=SpanType.RETRIEVER) as span:
-    span.set_inputs({"query": query})
-    docs = retriever.invoke(query)
-    span.set_outputs({"documents": [{"id": d.id, "text": d.page_content} for d in docs]})
-
-# Avoid: a count leaves nothing to debug
-with mlflow.start_span(name="retrieve", span_type=SpanType.RETRIEVER) as span:
-    span.set_inputs({"query": query})
-    docs = retriever.invoke(query)
-    span.set_outputs({"count": len(docs)})
-```
 
 ![LangGraph Child Span](/images/llms/tracing/langgraph-child-span.png)
 

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -43,9 +43,9 @@ LangGraph.js tracing is supported via the OpenTelemetry ingestion. See the [Gett
 </Tabs>
 </TabsWrapper>
 
-:::warning Use `mlflow.langchain.autolog()` for LangGraph, not `mlflow.openai.autolog()`
+:::note
 
-If your LangGraph agent uses an OpenAI model, it is tempting to call `mlflow.openai.autolog()`. That call captures only raw LLM call spans and cannot see LangGraph node boundaries, conditional edges, or graph state. All graph node spans will be missing from the trace. Call `mlflow.langchain.autolog()` instead to capture the full graph execution.
+`mlflow.langchain.autolog()` is what captures the graph itself: node boundaries, conditional edges, and state. Enabling only a per-client autolog such as `mlflow.openai.autolog()` records the raw LLM calls but no graph structure, so the node spans are absent from the trace.
 :::
 
 ## Getting Started


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

No related issue.

### What changes are proposed in this pull request?

Three additions to `docs/docs/genai/tracing/integrations/listing/langgraph.mdx`:

**1. `mlflow.openai.autolog()` warning (Addition A)**

Adds a `:::warning` admonition immediately after the intro autolog snippet. `mlflow.openai.autolog()` captures only raw LLM call spans on a LangGraph app. It cannot see LangGraph node boundaries, conditional edges, or graph state. The correct call is `mlflow.langchain.autolog()`. This is the most common wrong-autolog mistake for developers starting from the Databricks integration page, which shows `openai.autolog()` for direct FMAPI calls.

**2. Record full retrieval content, not a count (Addition B)**

Adds guidance and a before/after code example in "Adding spans within a node or a tool". When a node returns retrieved documents or search results, recording `{"count": len(docs)}` leaves nothing to debug. The trace store accepts large string attributes, so recording the full content is the right default. The example shows `span.set_outputs({"documents": [{"id": d.id, "text": d.page_content} for d in docs]})`.

**3. Databricks endpoint tab in Getting Started (Addition C)**

Adds a third tab to the Getting Started `<TabsWrapper>` block showing `ChatDatabricks` from `databricks-langchain` with `mlflow.langchain.autolog()`. The tab points to the existing Databricks integration page for endpoint setup rather than duplicating it. This closes the gap for developers building a LangGraph agent against a Databricks-served model who land on this page first.

### How is this PR tested?

- [x] Manual tests

Docs-only change. Rendered markdown verified locally. `prettier` reports the file unchanged (already formatted). No code paths affected.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

This PR is the documentation update.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [ ] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds three improvements to the LangGraph tracing page. First, a warning that `mlflow.openai.autolog()` drops all graph node spans on a LangGraph app. Use `mlflow.langchain.autolog()` instead. Second, guidance to record full retrieved content on retrieval spans rather than a count. Third, a Getting Started tab for LangGraph agents using `ChatDatabricks` from `databricks-langchain`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
