### PR TITLE
docs: warn that delete_traces() does not support Databricks Unity Catalog traces

### DIFF
--- a/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
@@ -9,8 +9,8 @@ You can delete traces based on specific criteria using the <APILink fn="mlflow.c
 Deleting a trace cannot be undone. Ensure that the parameters provided to the `delete_traces` API meet the intended range for deletion.
 :::
 
-:::warning Not supported for Unity Catalog traces
-`delete_traces()` does not support traces stored in Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying Unity Catalog table using SQL. Target the base OTel spans table (for example `<prefix>_otel_spans`), not `_trace_metadata` or `_trace_unified`, which are views and cannot be deleted from.
+:::warning Not supported for Databricks Unity Catalog traces
+`delete_traces()` does not support traces stored in Databricks Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying table using SQL. Target the base OTel spans table (for example `<prefix>_otel_spans`), not `_trace_metadata` or `_trace_unified`, which are views and cannot be deleted from.
 :::
 
 ## Deleting traces from MLflow UI

--- a/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
@@ -10,7 +10,7 @@ Deleting a trace cannot be undone. Ensure that the parameters provided to the `d
 :::
 
 :::warning Not supported for Databricks Unity Catalog traces
-`delete_traces()` does not support traces stored in Databricks Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying table using SQL. Target the base OTel spans table (for example `<prefix>_otel_spans`), not `_trace_metadata` or `_trace_unified`, which are views and cannot be deleted from.
+`delete_traces()` does not support traces stored in Databricks Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying table using SQL.
 :::
 
 ## Deleting traces from MLflow UI

--- a/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
@@ -10,7 +10,7 @@ Deleting a trace cannot be undone. Ensure that the parameters provided to the `d
 :::
 
 :::warning Not supported for Unity Catalog traces
-`delete_traces()` does not support traces stored in Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying Unity Catalog table using SQL.
+`delete_traces()` does not support traces stored in Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying Unity Catalog table using SQL. Target the base OTel spans table (for example `<prefix>_otel_spans`), not `_trace_metadata` or `_trace_unified`, which are views and cannot be deleted from.
 :::
 
 ## Deleting traces from MLflow UI

--- a/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/delete-traces.mdx
@@ -9,6 +9,10 @@ You can delete traces based on specific criteria using the <APILink fn="mlflow.c
 Deleting a trace cannot be undone. Ensure that the parameters provided to the `delete_traces` API meet the intended range for deletion.
 :::
 
+:::warning Not supported for Unity Catalog traces
+`delete_traces()` does not support traces stored in Unity Catalog. To remove UC-stored traces, delete rows directly from the underlying Unity Catalog table using SQL.
+:::
+
 ## Deleting traces from MLflow UI
 
 <ImageBox src="/images/llms/tracing/trace-ui-delete.png" alt="Delete Traces from MLflow UI" />

--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -12,6 +12,14 @@ MLflow's trace search functionality allows you to leverage SQL-like syntax to fi
 **Local File Store offers only limited search capabilities and can become slow as data volume grows.** As of MLflow 3.6.0, the FileStore is deprecated. We recommend migrating to a SQL-backed store or Databricks for improved performance and more robust search functionality.
 :::
 
+::::note
+**Archived traces and content search**.
+Archived traces remain viewable in MLflow, but filters that depend on stored span payloads, such as
+`trace.text` and `span.content`, no longer match once that payload has been archived out of the SQL
+store. Tag, metadata, status, and other trace-level filters continue to work. See
+[Archive Traces](/genai/tracing/observe-with-traces/archive-traces) for details.
+::::
+
 ## Search Traces Overview
 
 When working with MLflow tracing in production environments, you'll often have thousands of traces across different experiments representing various model inferences, LLM calls, or ML pipeline executions. The `search_traces` API helps you find specific traces based on their execution characteristics, metadata, tags, and other attributes - making trace analysis and debugging much more efficient.
@@ -55,19 +63,19 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 
 ### Supported Filters and Comparators
 
-| Field Type           | Fields                                                               | Operators                                                     | Examples                           |
-| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- |
-| **Trace Status**     | `trace.status`                                                       | `=`, `!=`                                                     | trace.status = "OK"                |
-| **Trace Timestamps** | `trace.timestamp_ms`, `trace.execution_time_ms`, `trace.end_time_ms` | `=`, `!=`, `>`, `<`, `>=`, `<=`                               | trace.end_time_ms > 1762408895531  |
-| **Trace IDs**        | `trace.run_id`                                                       | `=`                                                           | trace.run_id = "run_id"            |
-| **String Fields**    | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"       |
-| **Linked Prompts**   | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"      |
-| **Span Name/Type**   | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"             |
-| **Tags**             | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                  |
-| **Metadata**         | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.user_id LIKE "user%"      |
-| **Feedback**         | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"      |
-| **Expectations**     | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"        |
-| **Full Text**        | `trace.text`                                                         | `LIKE` (with `%` wildcards)                                   | trace.text LIKE "%tell me a story" |
+| Field Type                                | Fields                                                               | Operators                                                     | Examples                                    |
+| ----------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------- |
+| **Trace Status**                          | `trace.status`                                                       | `=`, `!=`                                                     | trace.status = "OK"                         |
+| **Trace Timestamps**                      | `trace.timestamp_ms`, `trace.execution_time_ms`, `trace.end_time_ms` | `=`, `!=`, `>`, `<`, `>=`, `<=`                               | trace.end_time_ms > 1762408895531           |
+| **Trace IDs**                             | `trace.run_id`                                                       | `=`                                                           | trace.run_id = "run_id"                     |
+| **String Fields**                         | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"                |
+| **Linked Prompts**                        | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"               |
+| **Span Name/Type**                        | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"                      |
+| **Tags**                                  | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                           |
+| **Metadata**                              | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.\`mlflow.trace.user\` = "user_123" |
+| **Feedback**                              | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"               |
+| **Expectations**                          | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"                 |
+| **Full Text** (OSS SQLAlchemy store only) | `trace.text`                                                         | `LIKE` (with `%` wildcards)                                   | trace.text LIKE "%tell me a story"          |
 
 **Value Syntax:**
 
@@ -84,7 +92,7 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 
 ### Example Queries
 
-#### Full Text Search
+#### Full Text Search (OSS SQLAlchemy store only)
 
 Search for any contents existing in your trace.
 
@@ -187,10 +195,10 @@ mlflow.search_traces(filter_string="tag.environment IS NOT NULL AND tag.model_na
 
 ```python
 # Exact match
-mlflow.search_traces(filter_string="metadata.user_id = 'user_123'")
+mlflow.search_traces(filter_string="metadata.`mlflow.trace.user` = 'user_123'")
 
 # Find traces where metadata key exists
-mlflow.search_traces(filter_string="metadata.session_id IS NOT NULL")
+mlflow.search_traces(filter_string="metadata.`mlflow.trace.session` IS NOT NULL")
 
 # Find traces where metadata key is missing
 mlflow.search_traces(filter_string="metadata.region IS NULL")
@@ -411,7 +419,7 @@ print(f"Found {len(all_traces)} total traces")
 
 ### MLflow Version Compatibility
 
-:::note Schema Changes in MLflow 3
+:::note[Schema Changes in MLflow 3]
 **DataFrame Schema**: The format depends on the MLflow version used to **call** the `search_traces` API, not the version used to log the traces. MLflow 3.x uses different column names than 2.x.
 :::
 

--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -448,8 +448,8 @@ import mlflow
 trace = mlflow.get_trace(trace_id="tr-abc123")
 ```
 
-:::warning Unity Catalog traces require a full location URI
-If MLflow is configured to store traces in Unity Catalog, `mlflow.get_trace()` requires the full `trace:/` location URI. Passing a plain trace ID raises a NOT_FOUND error (`NOT_FOUND: Trace '<id>' not found.`) with no hint that a different format is needed.
+:::warning Databricks Unity Catalog traces require a full location URI
+If MLflow is configured to store traces in Databricks Unity Catalog, `mlflow.get_trace()` requires the full `trace:/` location URI. Passing a plain trace ID raises a NOT_FOUND error (`NOT_FOUND: Trace '<id>' not found.`) with no hint that a different format is needed.
 
 Use the `trace:/` URI format, which encodes the UC catalog, schema, and table prefix:
 
@@ -458,7 +458,7 @@ import mlflow
 
 # Format: trace:/{catalog}.{schema}.{table_prefix}/{trace_id}
 trace = mlflow.get_trace(
-    trace_id="trace:/my_catalog.my_schema.my_table_prefix/tr-abc123"
+    trace_id="trace:/my_catalog.my_schema.my_table_prefix/abc123"
 )
 ```
 

--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -449,18 +449,18 @@ trace = mlflow.get_trace(trace_id="tr-abc123")
 ```
 
 :::warning Unity Catalog traces require a full location URI
-If MLflow is configured to store traces in Unity Catalog, `mlflow.get_trace()` requires the full `trace:/` location URI. Passing a plain trace ID returns `None` with a "Failed to get trace" warning and no indication that a different format is needed.
+If MLflow is configured to store traces in Unity Catalog, `mlflow.get_trace()` requires the full `trace:/` location URI. Passing a plain trace ID raises a NOT_FOUND error (`NOT_FOUND: Trace '<id>' not found.`) with no hint that a different format is needed.
 
-Use the `trace:/` URI format, which encodes the UC catalog, schema, and experiment name:
+Use the `trace:/` URI format, which encodes the UC catalog, schema, and table prefix:
 
 ```python
 import mlflow
 
-# Format: trace:/{catalog}.{schema}.{experiment_name}/{trace_id}
+# Format: trace:/{catalog}.{schema}.{table_prefix}/{trace_id}
 trace = mlflow.get_trace(
-    trace_id="trace:/my_catalog.my_schema.my_experiment/tr-abc123"
+    trace_id="trace:/my_catalog.my_schema.my_table_prefix/tr-abc123"
 )
 ```
 
-Replace `my_catalog`, `my_schema`, and `my_experiment` with the catalog name, schema name, and experiment name where your traces are stored.
+Replace `my_catalog`, `my_schema`, and `my_table_prefix` with the catalog, schema, and table prefix used when the UC-backed experiment was created.
 :::

--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -12,14 +12,6 @@ MLflow's trace search functionality allows you to leverage SQL-like syntax to fi
 **Local File Store offers only limited search capabilities and can become slow as data volume grows.** As of MLflow 3.6.0, the FileStore is deprecated. We recommend migrating to a SQL-backed store or Databricks for improved performance and more robust search functionality.
 :::
 
-::::note
-**Archived traces and content search**.
-Archived traces remain viewable in MLflow, but filters that depend on stored span payloads, such as
-`trace.text` and `span.content`, no longer match once that payload has been archived out of the SQL
-store. Tag, metadata, status, and other trace-level filters continue to work. See
-[Archive Traces](/genai/tracing/observe-with-traces/archive-traces) for details.
-::::
-
 ## Search Traces Overview
 
 When working with MLflow tracing in production environments, you'll often have thousands of traces across different experiments representing various model inferences, LLM calls, or ML pipeline executions. The `search_traces` API helps you find specific traces based on their execution characteristics, metadata, tags, and other attributes - making trace analysis and debugging much more efficient.
@@ -63,19 +55,19 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 
 ### Supported Filters and Comparators
 
-| Field Type                                | Fields                                                               | Operators                                                     | Examples                                    |
-| ----------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------- |
-| **Trace Status**                          | `trace.status`                                                       | `=`, `!=`                                                     | trace.status = "OK"                         |
-| **Trace Timestamps**                      | `trace.timestamp_ms`, `trace.execution_time_ms`, `trace.end_time_ms` | `=`, `!=`, `>`, `<`, `>=`, `<=`                               | trace.end_time_ms > 1762408895531           |
-| **Trace IDs**                             | `trace.run_id`                                                       | `=`                                                           | trace.run_id = "run_id"                     |
-| **String Fields**                         | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"                |
-| **Linked Prompts**                        | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"               |
-| **Span Name/Type**                        | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"                      |
-| **Tags**                                  | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                           |
-| **Metadata**                              | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.\`mlflow.trace.user\` = "user_123" |
-| **Feedback**                              | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"               |
-| **Expectations**                          | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"                 |
-| **Full Text** (OSS SQLAlchemy store only) | `trace.text`                                                         | `LIKE` (with `%` wildcards)                                   | trace.text LIKE "%tell me a story"          |
+| Field Type           | Fields                                                               | Operators                                                     | Examples                           |
+| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- |
+| **Trace Status**     | `trace.status`                                                       | `=`, `!=`                                                     | trace.status = "OK"                |
+| **Trace Timestamps** | `trace.timestamp_ms`, `trace.execution_time_ms`, `trace.end_time_ms` | `=`, `!=`, `>`, `<`, `>=`, `<=`                               | trace.end_time_ms > 1762408895531  |
+| **Trace IDs**        | `trace.run_id`                                                       | `=`                                                           | trace.run_id = "run_id"            |
+| **String Fields**    | `trace.client_request_id`, `trace.name`                              | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | trace.name LIKE "%Generate%"       |
+| **Linked Prompts**   | `prompt`                                                             | `=` (format: `"name/version"`)                                | prompt = "qa-system-prompt/4"      |
+| **Span Name/Type**   | `span.name`, `span.type`                                             | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | span.type RLIKE "^LLM"             |
+| **Tags**             | `tag.<key>`                                                          | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | tag.key = "value"                  |
+| **Metadata**         | `metadata.<key>`                                                     | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, `IS NULL`, `IS NOT NULL` | metadata.user_id LIKE "user%"      |
+| **Feedback**         | `feedback.<name>`                                                    | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | feedback.rating = "excellent"      |
+| **Expectations**     | `expectation.<name>`                                                 | `=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`                           | expectation.result = "pass"        |
+| **Full Text**        | `trace.text`                                                         | `LIKE` (with `%` wildcards)                                   | trace.text LIKE "%tell me a story" |
 
 **Value Syntax:**
 
@@ -92,7 +84,7 @@ The `search_traces` API uses a SQL-like Domain Specific Language (DSL) for query
 
 ### Example Queries
 
-#### Full Text Search (OSS SQLAlchemy store only)
+#### Full Text Search
 
 Search for any contents existing in your trace.
 
@@ -195,10 +187,10 @@ mlflow.search_traces(filter_string="tag.environment IS NOT NULL AND tag.model_na
 
 ```python
 # Exact match
-mlflow.search_traces(filter_string="metadata.`mlflow.trace.user` = 'user_123'")
+mlflow.search_traces(filter_string="metadata.user_id = 'user_123'")
 
 # Find traces where metadata key exists
-mlflow.search_traces(filter_string="metadata.`mlflow.trace.session` IS NOT NULL")
+mlflow.search_traces(filter_string="metadata.session_id IS NOT NULL")
 
 # Find traces where metadata key is missing
 mlflow.search_traces(filter_string="metadata.region IS NULL")
@@ -419,7 +411,7 @@ print(f"Found {len(all_traces)} total traces")
 
 ### MLflow Version Compatibility
 
-:::note[Schema Changes in MLflow 3]
+:::note Schema Changes in MLflow 3
 **DataFrame Schema**: The format depends on the MLflow version used to **call** the `search_traces` API, not the version used to log the traces. MLflow 3.x uses different column names than 2.x.
 :::
 
@@ -437,30 +429,3 @@ print(f"Found {len(all_traces)} total traces")
   - Full text search with `trace.text`
   - Optimized performance with proper indexing on timestamp
 - **Local File Store**: Limited search capabilities. May be slower with large datasets. Not recommended, only suitable for storing small number of traces.
-
-## Retrieving a Single Trace by ID
-
-Use <APILink fn="mlflow.get_trace" /> to fetch one trace by its ID.
-
-```python
-import mlflow
-
-trace = mlflow.get_trace(trace_id="tr-abc123")
-```
-
-:::warning Databricks Unity Catalog traces require a full location URI
-If MLflow is configured to store traces in Databricks Unity Catalog, `mlflow.get_trace()` requires the full `trace:/` location URI. Passing a plain trace ID raises a NOT_FOUND error (`NOT_FOUND: Trace '<id>' not found.`) with no hint that a different format is needed.
-
-Use the `trace:/` URI format, which encodes the UC catalog, schema, and table prefix:
-
-```python
-import mlflow
-
-# Format: trace:/{catalog}.{schema}.{table_prefix}/{trace_id}
-trace = mlflow.get_trace(
-    trace_id="trace:/my_catalog.my_schema.my_table_prefix/abc123"
-)
-```
-
-Replace `my_catalog`, `my_schema`, and `my_table_prefix` with the catalog, schema, and table prefix used when the UC-backed experiment was created.
-:::

--- a/docs/docs/genai/tracing/search-traces.mdx
+++ b/docs/docs/genai/tracing/search-traces.mdx
@@ -437,3 +437,30 @@ print(f"Found {len(all_traces)} total traces")
   - Full text search with `trace.text`
   - Optimized performance with proper indexing on timestamp
 - **Local File Store**: Limited search capabilities. May be slower with large datasets. Not recommended, only suitable for storing small number of traces.
+
+## Retrieving a Single Trace by ID
+
+Use <APILink fn="mlflow.get_trace" /> to fetch one trace by its ID.
+
+```python
+import mlflow
+
+trace = mlflow.get_trace(trace_id="tr-abc123")
+```
+
+:::warning Unity Catalog traces require a full location URI
+If MLflow is configured to store traces in Unity Catalog, `mlflow.get_trace()` requires the full `trace:/` location URI. Passing a plain trace ID returns `None` with a "Failed to get trace" warning and no indication that a different format is needed.
+
+Use the `trace:/` URI format, which encodes the UC catalog, schema, and experiment name:
+
+```python
+import mlflow
+
+# Format: trace:/{catalog}.{schema}.{experiment_name}/{trace_id}
+trace = mlflow.get_trace(
+    trace_id="trace:/my_catalog.my_schema.my_experiment/tr-abc123"
+)
+```
+
+Replace `my_catalog`, `my_schema`, and `my_experiment` with the catalog name, schema name, and experiment name where your traces are stored.
+:::


### PR DESCRIPTION
### Related Issues/PRs

Relates to no existing issue (surfaced during developer testing of Unity Catalog trace storage).

### What changes are proposed in this pull request?

Adds a `:::warning` admonition in `delete-traces.mdx` noting that `delete_traces()` does not support Unity Catalog-backed traces and that the workaround is deleting rows directly with SQL.

Per maintainer feedback, the UC get_trace guidance originally in `search-traces.mdx` belongs in Databricks documentation and the [mlflow/skills](https://github.com/mlflow/skills/pull/27/files) repo rather than OSS docs. That section has been removed; only the delete-traces warning remains.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Docs-only change.

### Does this PR require documentation update?

- [x] No. This PR IS the documentation update.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [ ] Yes. Separate PR: [mlflow/skills#27](https://github.com/mlflow/skills/pull/27/files)
- [x] No. The delete-traces behavior does not require a skills update.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Developers calling `delete_traces()` against a Unity Catalog-backed MLflow tracking server now see a clear warning about the limitation, along with the SQL workaround.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release