### PR TITLE
docs: troubleshoot $0 trace cost for unknown model names

### DIFF
--- a/docs/docs/genai/tracing/token-usage-cost/index.mdx
+++ b/docs/docs/genai/tracing/token-usage-cost/index.mdx
@@ -70,7 +70,6 @@ When using Databricks managed MLflow, the cost computation requires the client a
 Cost can appear as $0.00 even when token counts are tracked correctly. This happens when the model name recorded on the span has no matching entry in LiteLLM's price table. Databricks serving-endpoint names (for example, `databricks-claude-opus-4-8`) are one such case: LiteLLM cannot infer the provider from the bare endpoint name, so it returns no price.
 
 To fix this, [set the cost attributes directly on the span](#manually-setting-token-and-cost-information).
-
 :::
 
 ## Viewing in the UI

--- a/docs/docs/genai/tracing/token-usage-cost/index.mdx
+++ b/docs/docs/genai/tracing/token-usage-cost/index.mdx
@@ -65,6 +65,14 @@ When using Databricks managed MLflow, the cost computation requires the client a
 
 :::
 
+:::note Troubleshooting: cost shows $0.00 while token counts are tracked
+
+Cost can appear as $0.00 even when token counts are tracked correctly. This happens when the model name recorded on the span has no matching entry in LiteLLM's price table. Databricks serving-endpoint names (for example, `databricks-claude-opus-4-8`) are one such case: LiteLLM cannot infer the provider from the bare endpoint name, so it returns no price.
+
+To fix this, [set the cost attributes directly on the span](#manually-setting-token-and-cost-information).
+
+:::
+
 ## Viewing in the UI
 
 Token usage and cost information is displayed in the MLflow Trace UI.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24620

### What changes are proposed in this pull request?

Adds a troubleshooting callout to the token-usage/cost page explaining why
cost can show $0.00 even when token counts are tracked correctly.

Root cause: MLflow computes cost by looking up the model name in LiteLLM's
price table. When the model name on the span has no entry in that table,
LiteLLM returns no price and cost renders as $0.00. Databricks serving-endpoint
names (for example, `databricks-claude-opus-4-8`) are not in LiteLLM's table
by default, so users of Databricks-hosted models are commonly affected.

The fix (set cost attributes manually) is already documented. This callout
connects the $0.00 symptom to that existing guidance.

### How is this PR tested?

- [x] Manual tests

Docs-only change. The admonition syntax (`:::note Title`) matches the pattern
used elsewhere on the same page and in the docs site.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds a troubleshooting note to the token-usage/cost page: cost shows $0.00
when the model name on the span is not in LiteLLM's price table (common for
Databricks serving-endpoint names). Points to the existing manual cost-override
section as the fix.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
