### PR TITLE
docs: note Databricks Anthropic cache-token field placement

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/databricks.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/databricks.mdx
@@ -117,6 +117,16 @@ Browse to your MLflow UI (for example, http://localhost:5000) and open the `Data
 
 <ImageBox src="/images/llms/tracing/basic-openai-trace.png" alt="Databricks Tracing" />
 
+:::note[Prompt-cache token counts for Databricks-served Anthropic models]
+
+Databricks-served Anthropic (Claude) models return prompt-cache token counts as top-level fields in the `usage` object: `cache_read_input_tokens` and `cache_creation_input_tokens`. These fields are not nested under `usage.prompt_tokens_details` as in the standard OpenAI response shape.
+
+`mlflow.openai.autolog()` reads cache counts from `usage.prompt_tokens_details.cached_tokens` (the OpenAI-standard path), which is absent on Databricks-served Anthropic responses. Cache read and write metrics appear as n/a on traces recorded via `mlflow.openai.autolog()`.
+
+`mlflow.langchain.autolog()` maps the top-level Anthropic fields directly, so cache counts are captured when tracing through a LangChain client.
+
+:::
+
 -> View <u>[Next Steps](#next-steps)</u> for learning about more MLflow features like user feedback tracking, prompt management, and evaluation.
 
 ## Streaming and Async Support


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24618

### What changes are proposed in this pull request?

Adds a `:::note` callout to the Databricks tracing integration page. The note explains that Databricks-served Anthropic (Claude) models return prompt-cache token counts as top-level `usage` fields: `cache_read_input_tokens` and `cache_creation_input_tokens`. These fields are not nested under `usage.prompt_tokens_details` as in the standard OpenAI response shape.

`mlflow.openai.autolog()` reads `usage.prompt_tokens_details.cached_tokens` (the OpenAI-standard path), which is absent on Databricks-served Anthropic responses. Cache read and write metrics appear as n/a on traces recorded via `mlflow.openai.autolog()`. `mlflow.langchain.autolog()` maps the top-level Anthropic fields directly.

### How is this PR tested?

- [x] Manual tests

Docs-only change. Verified the note placement against `mlflow/openai/utils/chat_schema.py` (reads `usage.prompt_tokens_details.cached_tokens`) and `mlflow/langchain/utils/chat.py` (`_TOKEN_USAGE_KEY_MAPPING` maps top-level Anthropic keys).

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds a note on the Databricks tracing page: Anthropic (Claude) cache token counts are top-level `usage` fields. `mlflow.openai.autolog()` reads the nested OpenAI-standard path, which is absent on Databricks-served Anthropic responses, so cache metrics show n/a.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
