### PR TITLE
Fix xdist `databricks` `sys.modules` leak in import-scoping test

### DIFF
--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -289,7 +289,28 @@ def test_infer_requirements_excludes_mlflow():
         assert _infer_requirements("path/to/model", "sklearn") == [f"pytest=={pytest.__version__}"]
 
 
-def test_capture_imported_modules_scopes_databricks_imports(monkeypatch, tmp_path):
+@pytest.fixture
+def _restore_databricks_modules():
+    """Restore the real `databricks*` entries in `sys.modules` after the test.
+
+    The test below deletes `databricks` from `sys.modules` (a manual `del`, which
+    `monkeypatch` does not track) and imports a fake `databricks` package from `tmp_path`.
+    Without restoration the fake module — and the `databricks.*` submodules imported after
+    it — leak into the interpreter; under pytest-xdist a later test on the same worker then
+    sees the stale fake and fails with `module 'databricks' has no attribute 'sdk'`.
+    """
+    saved = {
+        k: v for k, v in sys.modules.items() if k == "databricks" or k.startswith("databricks.")
+    }
+    yield
+    for key in [k for k in sys.modules if k == "databricks" or k.startswith("databricks.")]:
+        del sys.modules[key]
+    sys.modules.update(saved)
+
+
+def test_capture_imported_modules_scopes_databricks_imports(
+    monkeypatch, tmp_path, _restore_databricks_modules
+):
     from mlflow.utils._capture_modules import _CaptureImportedModules
 
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24459 (two-pass pytest-xdist `python` job)

### What changes are proposed in this pull request?

`tests/utils/test_requirements_utils.py::test_capture_imported_modules_scopes_databricks_imports` deletes `databricks` from `sys.modules` (a manual `del`, which `monkeypatch` does **not** track) and imports a fake `databricks` package from `tmp_path`. The fake module — and the `databricks.*` submodules imported after it — leaked into the interpreter.

Under pytest-xdist a later test on the same worker then imported the stale fake and failed:

```
AttributeError: module 'databricks' has no attribute 'sdk'
thing = <module 'databricks' from '.../popen-gw1/test_capture_imported_modules_0/databricks/__init__.py'>
```

This has been failing on `master` in `tests/store/artifact/test_databricks_sdk_models_artifact_repo.py` across multiple commits since the two-pass xdist job (#24459) landed.

Fix it at the source: add a fixture that snapshots the real `databricks*` `sys.modules` entries and restores them on teardown. This fixes the leak for **all** victims at once, rather than quarantining each affected file into the serial pass.

Verified with a same-process reproduction: without the fix `sys.modules['databricks']` points at the `tmp_path` fake after the test; with it, the real site-packages module is restored.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The affected test still passes standalone; the fixture is a teardown-only restoration with no behavior change to the assertions.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release