### PR TITLE
Quarantine `databricks` import-scoping test to the serial xdist pass

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,13 @@ _logger = logging.getLogger(__name__)
 #     workers.
 #   - tests/gateway/providers/test_databricks.py: mocks the global `databricks.sdk` module;
 #     import/mock state leaks across workers ("module 'databricks' has no attribute 'sdk'").
+#   - tests/utils/test_requirements_utils.py: `test_capture_imported_modules_scopes_databricks
+#     _imports` deletes `databricks` from `sys.modules` (a manual `del`, untracked by
+#     monkeypatch) and imports a fake `databricks` package from tmp_path. The fake leaks onto
+#     the worker, so a later victim (e.g. tests/store/artifact/test_databricks_sdk_models
+#     _artifact_repo.py) then hits "module 'databricks' has no attribute 'sdk'". Quarantining
+#     the *polluter* here removes the leak source for every victim; a source-level sys.modules
+#     restoration is the eventual fix.
 #   - tests/projects/test_virtualenv_projects.py, test_projects_cli.py, test_projects.py,
 #     test_docker_projects.py: spawn real env-building / docker subprocesses that contend for
 #     CPU/disk, time out, race on the shared conda env list or docker daemon, and (for docker)
@@ -102,6 +109,7 @@ _XDIST_SERIAL_PATHS = (
     "tests/server/test_handlers.py",
     "tests/server/test_workspace_middleware.py",
     "tests/gateway/providers/test_databricks.py",
+    "tests/utils/test_requirements_utils.py",
     "tests/projects/test_virtualenv_projects.py",
     "tests/projects/test_projects_cli.py",
     "tests/projects/test_docker_projects.py",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24459 (two-pass pytest-xdist `python` job)

### What changes are proposed in this pull request?

`tests/utils/test_requirements_utils.py::test_capture_imported_modules_scopes_databricks_imports` deletes `databricks` from `sys.modules` (a manual `del`, which `monkeypatch` does **not** track) and imports a fake `databricks` package from `tmp_path`. The fake module leaks onto the xdist worker, so a later test on the same worker fails:

```
AttributeError: module 'databricks' has no attribute 'sdk'
thing = <module 'databricks' from '.../popen-gw1/test_capture_imported_modules_0/databricks/__init__.py'>
```

This has been failing on `master` in `tests/store/artifact/test_databricks_sdk_models_artifact_repo.py` across multiple commits since the two-pass xdist job (#24459) landed.

Add the **polluter** to `_XDIST_SERIAL_PATHS` so it runs in the serial pass and never constructs the fake module on a parallel worker — removing the leak source for every potential victim. This is the low-risk, consistent-with-existing-quarantines fix; a source-level `sys.modules` restoration is the preferred longer-term fix and can replace this later.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Verified the polluter now classifies serial and the victim stays parallel (safe, since the leak source is gone); the existing partition guard tests (`tests/test_xdist_serial_partition.py`, 36) still pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release