### PR TITLE
Strip `(1M context)` from model name in statusline

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -7,6 +7,7 @@ input=$(cat)
 cwd=$(echo "$input" | jq -r '.workspace.current_dir')
 dir=$(basename "$cwd")
 model=$(echo "$input" | jq -r '.model.display_name // empty')
+model=${model/ (1M context)/}
 
 cd "$cwd" 2>/dev/null || cd /
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -7,7 +7,7 @@ input=$(cat)
 cwd=$(echo "$input" | jq -r '.workspace.current_dir')
 dir=$(basename "$cwd")
 model=$(echo "$input" | jq -r '.model.display_name // empty')
-model=${model/ (1M context)/}
+model=${model% (1M context)}
 
 cd "$cwd" 2>/dev/null || cd /
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`.claude/scripts/statusline.sh` renders `.model.display_name` verbatim, so the 1M-context model shows as `Opus 5 (1M context)`. The suffix eats statusline width without adding information, so strip it.

### How is this PR tested?

- [x] Manual tests

```console
$ echo '{"workspace":{"current_dir":"."},"model":{"display_name":"Opus 5 (1M context)"},"context_window":{"used_percentage":12.3},"rate_limits":{"five_hour":{"used_percentage":4}}}' | bash .claude/scripts/statusline.sh
mlflow (master*) | Opus 5 | ctx 12% | 5h 4%
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release