### PR TITLE
Fix flaky sagemaker S3 test hitting `NoCredentialsError` under xdist

### DIFF
--- a/tests/sagemaker/conftest.py
+++ b/tests/sagemaker/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from mlflow.store.artifact.s3_artifact_repo import _cached_get_s3_client
+
+
+@pytest.fixture(autouse=True)
+def reset_cached_get_s3_client():
+    # `_cached_get_s3_client` is a process-global lru_cache whose key does not include the
+    # resolved AWS credentials. Under pytest-xdist a worker runs many modules, so a boto3 S3
+    # client cached by an earlier test (potentially with no credentials in the environment)
+    # would be reused here and raise `NoCredentialsError`. Clearing the cache before each test
+    # forces a fresh client that picks up the fake credentials from `set_boto_credentials`.
+    _cached_get_s3_client.cache_clear()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Seeing a lot of flaky test runs

`test_create_deployment_creates_sagemaker_and_s3_resources_with_expected_names_and_env_from_s3` intermittently fails with `NoCredentialsError` under pytest-xdist ([example run](https://github.com/mlflow/mlflow/actions/runs/30214366270/job/89825803967)) because [`_cached_get_s3_client`](https://github.com/mlflow/mlflow/blob/8e680541b931f246dcb9a425ae2c8a96db067649/mlflow/store/artifact/s3_artifact_repo.py#L123-L133) is a process-global `lru_cache` keyed on a 300s-bucketed timestamp but **not** on the resolved AWS credentials — so on a worker that earlier built a client while no creds were in the env (the fake ones from `set_boto_credentials` are reverted per-test), that credential-less client is reused here, and this PR adds a `tests/sagemaker/conftest.py` autouse fixture that clears the cache before each test (mirroring the existing [`reset_cached_get_s3_client`](https://github.com/mlflow/mlflow/blob/8e680541b931f246dcb9a425ae2c8a96db067649/tests/store/artifact/test_s3_artifact_repo.py#L45-L47) in the S3 repo tests).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release