### PR TITLE
Reuse cached migrated SQLite DB in MCP server and read/write routing tests

### DIFF
--- a/tests/server/test_mcp_server_api.py
+++ b/tests/server/test_mcp_server_api.py
@@ -67,10 +67,10 @@ def _create_registry_fastapi_app(route_prefixes=None):
 
 
 @pytest.fixture
-def store(tmp_path: Path):
+def store(tmp_path: Path, db_uri: str):
     artifact_uri = tmp_path / "artifacts"
     artifact_uri.mkdir()
-    return SqlAlchemyStore(f"sqlite:///{tmp_path / 'test.db'}", artifact_uri.as_uri())
+    return SqlAlchemyStore(db_uri, artifact_uri.as_uri())
 
 
 @pytest.fixture

--- a/tests/store/tracking/mcp_server_registry/test_rest_mixin.py
+++ b/tests/store/tracking/mcp_server_registry/test_rest_mixin.py
@@ -58,10 +58,10 @@ class _TestRestClient(WorkspaceRestStoreMixin, RestMCPServerRegistryMixin):
 
 
 @pytest.fixture
-def store(tmp_path: Path):
+def store(tmp_path: Path, db_uri: str):
     artifact_uri = tmp_path / "artifacts"
     artifact_uri.mkdir()
-    return SqlAlchemyStore(f"sqlite:///{tmp_path / 'test.db'}", artifact_uri.as_uri())
+    return SqlAlchemyStore(db_uri, artifact_uri.as_uri())
 
 
 @pytest.fixture

--- a/tests/store/tracking/test_read_write_routing.py
+++ b/tests/store/tracking/test_read_write_routing.py
@@ -16,7 +16,8 @@ ARTIFACT_URI = "artifact_folder"
 
 
 @pytest.fixture
-def write_db_uri(tmp_path: Path) -> str:
+def write_db_uri(tmp_path: Path, cached_db: Path) -> str:
+    shutil.copy(cached_db, tmp_path / "write.db")
     return f"sqlite:///{tmp_path / 'write.db'}"
 
 
@@ -271,16 +272,15 @@ def test_initialize_backend_stores_sets_env_var():
         )  # clint: disable=os-environ-delete-in-test
 
 
-def test_get_sqlalchemy_store_reads_env_var(tmp_path, monkeypatch):
+def test_get_sqlalchemy_store_reads_env_var(tmp_path, cached_db: Path, monkeypatch):
     from mlflow.server.constants import READ_REPLICA_BACKEND_STORE_URI_ENV_VAR
     from mlflow.server.handlers import TrackingStoreRegistryWrapper
 
     write_uri = f"sqlite:///{tmp_path / 'write.db'}"
     read_uri = f"sqlite:///{tmp_path / 'read.db'}"
 
-    init_store = SqlAlchemyStore(write_uri, str(tmp_path / "artifacts"))
-    init_store.engine.dispose()
-    shutil.copy(tmp_path / "write.db", tmp_path / "read.db")
+    shutil.copy(cached_db, tmp_path / "write.db")
+    shutil.copy(cached_db, tmp_path / "read.db")
 
     monkeypatch.setenv(READ_REPLICA_BACKEND_STORE_URI_ENV_VAR, read_uri)
     store = TrackingStoreRegistryWrapper._get_sqlalchemy_store(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24669

### What changes are proposed in this pull request?

`tests/server/test_mcp_server_api.py`, `tests/store/tracking/mcp_server_registry/test_rest_mixin.py`, and `tests/store/tracking/test_read_write_routing.py` each built a `SqlAlchemyStore` on a brand-new SQLite file in a function-scoped fixture, so **every test paid a full alembic migration**. On the Windows runner that dominated each file's runtime.

`tests/conftest.py` already has a `db_uri` fixture that copies a session-cached, pre-migrated database, and `tests/store/tracking/conftest.py` exposes the same via `cached_db`. This PR switches the three files over to them.

Measured on the `windows (2)` job, before ([run 30230618969](https://github.com/mlflow/mlflow/actions/runs/30230618969/job/89868681326)) and after ([run 30238377774](https://github.com/mlflow/mlflow/actions/runs/30238377774/job/89890431589)):

| File | Tests | Duration before | Duration after | Avg before | Avg after |
| ---- | ----- | --------------- | -------------- | ---------- | --------- |
| `tests/server/test_mcp_server_api.py` | 48 | 393.81s | below 23.58s (dropped off the top-30 table) | 8.204s | n/a |
| `tests/store/tracking/mcp_server_registry/test_rest_mixin.py` | 19 | 159.42s | 24.74s | 8.390s | 1.302s |
| `tests/store/tracking/test_read_write_routing.py` | 7 | 132.42s | 23.58s | 18.917s | 3.368s |

Job wall clock went from 59m16s to 42m18s.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


🤖 Generated with [Claude Code](https://claude.com/claude-code)
