### PR TITLE
Document the `db_uri` test fixture in the Python style guide

### DIFF
--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -298,9 +298,7 @@ def test_list_items():
 
 ## Use the `db_uri` Fixture Instead of Creating a SQLite Database
 
-Any test that needs a SQLite-backed MLflow database should take the `db_uri` fixture from `tests/conftest.py` rather than building its own path. Pointing anything at a brand-new SQLite file runs the full alembic migration chain, and in a function-scoped fixture that cost is paid by _every_ test in the file. It is slow everywhere and crippling on the Windows CI runners (~8s per test). `db_uri` copies a session-cached, pre-migrated database, so each test still gets an isolated database without re-running migrations.
-
-This applies however the database is reached: directly, or through a store, a client, or a server fixture. For example:
+A brand-new SQLite file runs the full alembic migration chain, so a function-scoped fixture pays that cost on every test (~8s each on Windows CI). The `db_uri` fixture in `tests/conftest.py` copies a session-cached, pre-migrated database, keeping tests isolated without re-running migrations.
 
 ```python
 # Bad
@@ -319,7 +317,7 @@ def store(tmp_path: Path, db_uri: str):
     return SqlAlchemyStore(db_uri, artifact_uri.as_uri())
 ```
 
-When a test needs more than one database (for example a write primary plus a read replica), depend on the `cached_db` fixture and copy it to each path yourself:
+For multiple databases (e.g. a write primary plus a read replica), depend on `cached_db` and copy it to each path:
 
 ```python
 @pytest.fixture
@@ -327,8 +325,6 @@ def write_db_uri(tmp_path: Path, cached_db: Path) -> str:
     shutil.copy(cached_db, tmp_path / "write.db")
     return f"sqlite:///{tmp_path / 'write.db'}"
 ```
-
-Note that `tests/store/tracking/conftest.py` defines its own module-scoped `cached_db` that shadows the session-scoped one, so tests under that directory rebuild the database once per module.
 
 ## Preserve function metadata and type information in decorators
 

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -296,6 +296,40 @@ def test_list_items():
     assert len(items) == 3
 ```
 
+## Use the `db_uri` Fixture Instead of Creating a SQLite Database
+
+Any test that needs a SQLite-backed MLflow database should take the `db_uri` fixture from `tests/conftest.py` rather than building its own path. Pointing anything at a brand-new SQLite file runs the full alembic migration chain, and in a function-scoped fixture that cost is paid by _every_ test in the file. It is slow everywhere and crippling on the Windows CI runners (~8s per test). `db_uri` copies a session-cached, pre-migrated database, so each test still gets an isolated database without re-running migrations.
+
+This applies however the database is reached: directly, or through a store, a client, or a server fixture. For example:
+
+```python
+# Bad
+@pytest.fixture
+def store(tmp_path: Path):
+    artifact_uri = tmp_path / "artifacts"
+    artifact_uri.mkdir()
+    return SqlAlchemyStore(f"sqlite:///{tmp_path / 'test.db'}", artifact_uri.as_uri())
+
+
+# Good
+@pytest.fixture
+def store(tmp_path: Path, db_uri: str):
+    artifact_uri = tmp_path / "artifacts"
+    artifact_uri.mkdir()
+    return SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+```
+
+When a test needs more than one database (for example a write primary plus a read replica), depend on the `cached_db` fixture and copy it to each path yourself:
+
+```python
+@pytest.fixture
+def write_db_uri(tmp_path: Path, cached_db: Path) -> str:
+    shutil.copy(cached_db, tmp_path / "write.db")
+    return f"sqlite:///{tmp_path / 'write.db'}"
+```
+
+Note that `tests/store/tracking/conftest.py` defines its own module-scoped `cached_db` that shadows the session-scoped one, so tests under that directory rebuild the database once per module.
+
 ## Preserve function metadata and type information in decorators
 
 When writing decorators, always use `@functools.wraps` to preserve function metadata (like `__name__` and `__doc__`), and use `typing.ParamSpec` and `typing.TypeVar` to preserve the function's type information for accurate type checking and autocompletion in IDEs.

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -298,7 +298,7 @@ def test_list_items():
 
 ## Use the `db_uri` Fixture Instead of Creating a SQLite Database
 
-A brand-new SQLite file runs the full alembic migration chain, so a function-scoped fixture pays that cost on every test (~8s each on Windows CI). The `db_uri` fixture in `tests/conftest.py` copies a session-cached, pre-migrated database, keeping tests isolated without re-running migrations.
+A brand-new SQLite file runs the full migration, so a function-scoped fixture pays that cost on every test (~8s each on Windows CI). The `db_uri` fixture in `tests/conftest.py` copies a session-cached, pre-migrated database, keeping tests isolated without re-running migrations.
 
 ```python
 # Bad

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -317,15 +317,6 @@ def store(tmp_path: Path, db_uri: str):
     return SqlAlchemyStore(db_uri, artifact_uri.as_uri())
 ```
 
-For multiple databases (e.g. a write primary plus a read replica), depend on `cached_db` and copy it to each path:
-
-```python
-@pytest.fixture
-def write_db_uri(tmp_path: Path, cached_db: Path) -> str:
-    shutil.copy(cached_db, tmp_path / "write.db")
-    return f"sqlite:///{tmp_path / 'write.db'}"
-```
-
 ## Preserve function metadata and type information in decorators
 
 When writing decorators, always use `@functools.wraps` to preserve function metadata (like `__name__` and `__doc__`), and use `typing.ParamSpec` and `typing.TypeVar` to preserve the function's type information for accurate type checking and autocompletion in IDEs.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24672

### What changes are proposed in this pull request?

#24672 sped up three test files by ~10x on the Windows runner. The cause was a function-scoped fixture pointing `SqlAlchemyStore` at a brand-new SQLite file, so every test paid a full alembic migration. `tests/conftest.py` already has a `db_uri` fixture that avoids this, but nothing documented it, so the anti-pattern keeps getting reintroduced.

This adds a section to the Python style guide covering `db_uri`, the `cached_db` variant for multi-database tests, and the module-scoped shadow in `tests/store/tracking/conftest.py`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Documentation only.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


🤖 Generated with [Claude Code](https://claude.com/claude-code)
