### PR TITLE
Remove the mandatory comment format from the code review instructions

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -14,19 +14,13 @@ Your training data has a cutoff. Treat anything you don't recognize as **new, no
 
 ## Comment Format (MANDATORY)
 
-Every comment MUST use this exact format: `<emoji> **<severity>:** <description>`
-
-| Severity | Emoji |
-| -------- | ----- |
-| CRITICAL | 🔴    |
-| MODERATE | 🟡    |
-| NIT      | 🟢    |
+Every comment MUST use this exact format: `**<severity>:** <description>`, where `<severity>` is one of `CRITICAL`, `MODERATE`, or `NIT`.
 
 Examples:
 
-- 🔴 **CRITICAL:** User input is passed directly into the SQL query without parameterization — SQL injection risk. Use a parameterized query instead.
-- 🟡 **MODERATE:** This loops over each item and issues a separate query — N+1 problem. Use a single batch query or a join.
-- 🟢 **NIT:** This nested `if/elif/else` is hard to follow. Consider using early returns to flatten the structure.
+- **CRITICAL:** User input is passed directly into the SQL query without parameterization — SQL injection risk. Use a parameterized query instead.
+- **MODERATE:** This loops over each item and issues a separate query — N+1 problem. Use a single batch query or a join.
+- **NIT:** This nested `if/elif/else` is hard to follow. Consider using early returns to flatten the structure.
 
 ## Do NOT Comment On
 

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -12,16 +12,6 @@ Your training data has a cutoff. Treat anything you don't recognize as **new, no
 - Model names (e.g., `gpt-5`)
 - GitHub runner types (e.g., `ubuntu-slim`)
 
-## Comment Format (MANDATORY)
-
-Every comment MUST use this exact format: `**<severity>:** <description>`, where `<severity>` is one of `CRITICAL`, `MODERATE`, or `NIT`.
-
-Examples:
-
-- **CRITICAL:** User input is passed directly into the SQL query without parameterization — SQL injection risk. Use a parameterized query instead.
-- **MODERATE:** This loops over each item and issues a separate query — N+1 problem. Use a single batch query or a join.
-- **NIT:** This nested `if/elif/else` is hard to follow. Consider using early returns to flatten the structure.
-
 ## Do NOT Comment On
 
 - Future dates, version numbers, model names, or runner types — your knowledge cutoff makes these unreliable


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

GitHub now renders a severity label in the top-right corner of Copilot code review comments, shipped in [Copilot code review: Comment experience improvements](https://github.blog/changelog/2026-05-12-copilot-code-review-comment-experience-improvements/) (2026-05-12):

> Comments will be categorized as `High`, `Medium`, or `Low` severity.
>
> You can find severity labels on the top-right corner of Copilot code review comments.

That makes the `Comment Format (MANDATORY)` section redundant, so this removes it along with the 🔴/🟡/🟢 severity table.

Worth noting that the native levels are `High`/`Medium`/`Low` while the instructions mandated `CRITICAL`/`MODERATE`/`NIT`, so the two vocabularies never lined up. Dropping the section is cleaner than restyling it to match.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Instructions file only.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


🤖 Generated with [Claude Code](https://claude.com/claude-code)
