### PR TITLE
Fix Evaluation Runs `Actions` dropdown remaining clickable when no runs are selected

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.test.tsx
@@ -1,0 +1,95 @@
+import { jest, describe, beforeEach, afterEach, it, expect } from '@jest/globals';
+import type { RowSelectionState } from '@tanstack/react-table';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { renderWithIntl, screen, waitFor, within } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import userEvent from '@testing-library/user-event';
+
+import { ExperimentEvaluationRunsTableActions } from './ExperimentEvaluationRunsTableActions';
+
+const mockDeleteMutate = jest.fn();
+jest.mock('../../components/experiment-page/hooks/useDeleteRuns', () => ({
+  __esModule: true,
+  useDeleteRuns: () => ({ mutate: mockDeleteMutate, isLoading: false }),
+}));
+
+// The Actions Button renders a native `disabled` attribute; disable userEvent's
+// pointer-events check so we can still fire clicks against it and assert the menu stays closed.
+const setupUserEvent = () => userEvent.setup({ pointerEventsCheck: 0 });
+
+const renderActions = (rowSelection: RowSelectionState) =>
+  renderWithIntl(
+    <DesignSystemProvider>
+      <ExperimentEvaluationRunsTableActions
+        rowSelection={rowSelection}
+        setRowSelection={jest.fn()}
+        refetchRuns={jest.fn()}
+        onCompare={jest.fn()}
+      />
+    </DesignSystemProvider>,
+  );
+
+const getActionsButton = () => screen.getByRole('button', { name: 'Actions' });
+
+describe('ExperimentEvaluationRunsTableActions', () => {
+  let user: ReturnType<typeof setupUserEvent>;
+
+  beforeEach(() => {
+    user = setupUserEvent();
+    mockDeleteMutate.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('disables the Actions trigger when no runs are selected', () => {
+    renderActions({});
+    expect(getActionsButton()).toBeDisabled();
+  });
+
+  it('does not open the menu when the disabled trigger is clicked with zero selections', async () => {
+    renderActions({});
+
+    await user.click(getActionsButton());
+
+    // The Trigger is disabled, so no menu items should appear.
+    expect(screen.queryByText('Delete runs')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('enables the Actions trigger and opens the menu once a run is selected', async () => {
+    renderActions({ 'run-1': true });
+
+    const button = getActionsButton();
+    expect(button).toBeEnabled();
+
+    await user.click(button);
+
+    expect(await screen.findByText('Delete runs')).toBeInTheDocument();
+  });
+
+  it('opens the delete confirmation modal when Delete runs is clicked with a selection', async () => {
+    renderActions({ 'run-1': true });
+
+    await user.click(getActionsButton());
+    await user.click(await screen.findByText('Delete runs'));
+
+    expect(await screen.findByRole('dialog', { name: /Delete 1 run/ })).toBeInTheDocument();
+    // The mutation only fires on confirmation, not on opening the modal.
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+
+  it('deletes the selected runs when the modal is confirmed', async () => {
+    renderActions({ 'run-1': true, 'run-2': true });
+
+    await user.click(getActionsButton());
+    await user.click(await screen.findByText('Delete runs'));
+
+    const dialog = await screen.findByRole('dialog', { name: /Delete 2 runs/ });
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(mockDeleteMutate).toHaveBeenCalledWith({ runUuids: ['run-1', 'run-2'] });
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.test.tsx
@@ -7,26 +7,35 @@ import userEvent from '@testing-library/user-event';
 import { ExperimentEvaluationRunsTableActions } from './ExperimentEvaluationRunsTableActions';
 
 const mockDeleteMutate = jest.fn();
+// Capture the options passed to useDeleteRuns so tests can drive its onSuccess callback.
+const mockDeleteRunsOptions: { onSuccess?: () => void } = {};
 jest.mock('../../components/experiment-page/hooks/useDeleteRuns', () => ({
   __esModule: true,
-  useDeleteRuns: () => ({ mutate: mockDeleteMutate, isLoading: false }),
+  useDeleteRuns: ({ onSuccess }: { onSuccess: () => void }) => {
+    mockDeleteRunsOptions.onSuccess = onSuccess;
+    return { mutate: mockDeleteMutate, isLoading: false };
+  },
 }));
 
 // The Actions Button renders a native `disabled` attribute; disable userEvent's
 // pointer-events check so we can still fire clicks against it and assert the menu stays closed.
 const setupUserEvent = () => userEvent.setup({ pointerEventsCheck: 0 });
 
-const renderActions = (rowSelection: RowSelectionState) =>
+const renderActions = (rowSelection: RowSelectionState) => {
+  const setRowSelection = jest.fn();
+  const refetchRuns = jest.fn();
   renderWithIntl(
     <DesignSystemProvider>
       <ExperimentEvaluationRunsTableActions
         rowSelection={rowSelection}
-        setRowSelection={jest.fn()}
-        refetchRuns={jest.fn()}
+        setRowSelection={setRowSelection}
+        refetchRuns={refetchRuns}
         onCompare={jest.fn()}
       />
     </DesignSystemProvider>,
   );
+  return { setRowSelection, refetchRuns };
+};
 
 const getActionsButton = () => screen.getByRole('button', { name: 'Actions' });
 
@@ -35,7 +44,12 @@ describe('ExperimentEvaluationRunsTableActions', () => {
 
   beforeEach(() => {
     user = setupUserEvent();
+    mockDeleteRunsOptions.onSuccess = undefined;
     mockDeleteMutate.mockReset();
+    // Simulate a successful delete by invoking the hook's onSuccess callback.
+    mockDeleteMutate.mockImplementation(() => {
+      mockDeleteRunsOptions.onSuccess?.();
+    });
   });
 
   afterEach(() => {
@@ -79,8 +93,8 @@ describe('ExperimentEvaluationRunsTableActions', () => {
     expect(mockDeleteMutate).not.toHaveBeenCalled();
   });
 
-  it('deletes the selected runs when the modal is confirmed', async () => {
-    renderActions({ 'run-1': true, 'run-2': true });
+  it('deletes the selected runs and clears the selection when the modal is confirmed', async () => {
+    const { setRowSelection, refetchRuns } = renderActions({ 'run-1': true, 'run-2': true });
 
     await user.click(getActionsButton());
     await user.click(await screen.findByText('Delete runs'));
@@ -91,5 +105,9 @@ describe('ExperimentEvaluationRunsTableActions', () => {
     await waitFor(() => {
       expect(mockDeleteMutate).toHaveBeenCalledWith({ runUuids: ['run-1', 'run-2'] });
     });
+
+    // On success the component refetches and clears the row selection.
+    expect(refetchRuns).toHaveBeenCalledTimes(1);
+    expect(setRowSelection).toHaveBeenCalledWith({});
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.tsx
@@ -101,6 +101,12 @@ export const ExperimentEvaluationRunsTableActions = ({
               <FormattedMessage defaultMessage="Compare" description="Compare evaluation runs action" />
             </DropdownMenu.Item>
           )}
+          {/*
+            The Trigger above is disabled when no runs are selected, so this item is normally
+            unreachable in that state. We keep the item-level disabled guard (and tooltip, matching
+            Compare) as defense-in-depth: it stays correct if the Trigger is ever re-enabled, and it
+            prevents opening a "Delete 0 runs" modal.
+          */}
           <DropdownMenu.Item
             componentId="mlflow.eval-runs.actions.delete"
             onClick={() => setDeleteModalVisible(true)}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableActions.tsx
@@ -74,7 +74,7 @@ export const ExperimentEvaluationRunsTableActions = ({
   return (
     <>
       <DropdownMenu.Root>
-        <DropdownMenu.Trigger asChild>
+        <DropdownMenu.Trigger asChild disabled={noRunsSelected}>
           <Button
             type="primary"
             componentId="mlflow.eval-runs.actions-button"
@@ -101,7 +101,17 @@ export const ExperimentEvaluationRunsTableActions = ({
               <FormattedMessage defaultMessage="Compare" description="Compare evaluation runs action" />
             </DropdownMenu.Item>
           )}
-          <DropdownMenu.Item componentId="mlflow.eval-runs.actions.delete" onClick={() => setDeleteModalVisible(true)}>
+          <DropdownMenu.Item
+            componentId="mlflow.eval-runs.actions.delete"
+            onClick={() => setDeleteModalVisible(true)}
+            disabled={noRunsSelected}
+            disabledReason={
+              <FormattedMessage
+                defaultMessage="Please select at least 1 run to delete"
+                description="Tooltip for disabled delete action in evaluation runs table actions"
+              />
+            }
+          >
             <FormattedMessage defaultMessage="Delete runs" description="Delete evaluation runs action" />
           </DropdownMenu.Item>
         </DropdownMenu.Content>

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -13011,6 +13011,10 @@
     "defaultMessage": "Traces show you how your LLM calls behave: what they cost, how they perform, and where things go wrong. Get started in a few minutes.",
     "description": "Subtitle for the empty state when no traces are recorded"
   },
+  "yYLKl8": {
+    "defaultMessage": "Please select at least 1 run to delete",
+    "description": "Tooltip for disabled delete action in evaluation runs table actions"
+  },
   "yd6Poj": {
     "defaultMessage": "No traces to analyze. Log traces to this experiment first.",
     "description": "Tooltip on the disabled Run button when the experiment has no traces"


### PR DESCRIPTION
### Related Issues/PRs

Closes #24667

### What changes are proposed in this pull request?

The Evaluation Runs **Actions** dropdown (`ExperimentEvaluationRunsTableActions`) was only setting `disabled` on the inner DuBois `Button`, not on the `DropdownMenu.Trigger`. Because the trigger uses `asChild`, Radix's `DropdownMenuTrigger` gates the menu-open behavior on its **own** `disabled` prop (see `onPointerDown`/`onKeyDown` in `@radix-ui/react-dropdown-menu`), so the menu still opened via click/keyboard when no runs were selected — even though the button appeared greyed out.

This PR makes two changes:

1. Propagate `disabled={noRunsSelected}` to `DropdownMenu.Trigger` so the menu genuinely will not open when no runs are selected. This matches the existing pattern in `ExperimentLoggedModelListPageColumnSelector`, which passes `disabled` to both the `Trigger` and the `Button`.
2. Add `disabled={noRunsSelected}` and a `disabledReason` tooltip to the **Delete runs** `DropdownMenu.Item`, mirroring the adjacent **Compare** item, so the destructive action is explicitly disabled when there is nothing selected.

### How is this PR tested?

- [x] Manual tests

Verified locally in the dev server: with no runs selected, the **Actions** button is greyed out and no longer opens the menu on click or keyboard; with one or more runs selected, the menu opens and **Delete runs** is enabled. Prettier and the ForkTsChecker type-check pass in a full dev build.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed the Evaluation Runs "Actions" dropdown so it can no longer be opened when no runs are selected, and disabled the "Delete runs" option in that state.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.