### PR TITLE
refactor: Centralize Python `/server-info` fetching and caching

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -324,10 +324,6 @@ from mlflow.store.artifact.artifact_repo import (
     StreamUploadMixin,
 )
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.artifact.mlflow_artifacts_repo import (
-    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
-    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
-)
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.jobs.abstract_store import AbstractJobStore
 from mlflow.store.model_registry.abstract_store import AbstractStore as AbstractModelRegistryStore
@@ -382,6 +378,13 @@ from mlflow.utils.providers import (
     get_all_providers,
     get_models,
     get_provider_config_response,
+)
+from mlflow.utils.server_info import (
+    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
+    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
+    SERVER_INFO_STORE_TYPE,
+    SERVER_INFO_TRACE_ARCHIVAL_ENABLED,
+    SERVER_INFO_WORKSPACES_ENABLED,
 )
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.time import get_current_time_millis
@@ -6783,9 +6786,9 @@ def _get_server_info():
             )
 
     return jsonify({
-        "store_type": store_type,
-        "workspaces_enabled": MLFLOW_ENABLE_WORKSPACES.get(),
-        "trace_archival_enabled": trace_archival_enabled,
+        SERVER_INFO_STORE_TYPE: store_type,
+        SERVER_INFO_WORKSPACES_ENABLED: MLFLOW_ENABLE_WORKSPACES.get(),
+        SERVER_INFO_TRACE_ARCHIVAL_ENABLED: trace_archival_enabled,
         SERVER_INFO_MULTIPART_UPLOADS_ENABLED: multipart_uploads_enabled,
         SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED: multipart_downloads_enabled,
     })

--- a/mlflow/store/artifact/mlflow_artifacts_repo.py
+++ b/mlflow/store/artifact/mlflow_artifacts_repo.py
@@ -17,13 +17,15 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.http_artifact_repo import HttpArtifactRepository
 from mlflow.tracking._tracking_service.utils import get_tracking_uri
 from mlflow.utils.credentials import get_default_host_creds
-from mlflow.utils.rest_utils import http_request
+from mlflow.utils.server_info import (
+    SERVER_INFO_ENDPOINT,
+    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
+    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
+    fetch_server_info,
+)
 
 _logger = logging.getLogger(__name__)
 
-_SERVER_INFO_ENDPOINT = "/api/3.0/mlflow/server-info"
-SERVER_INFO_MULTIPART_UPLOADS_ENABLED = "multipart_uploads_enabled"
-SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED = "multipart_downloads_enabled"
 # resolve_uri always embeds this service root; strip it to recover the deployment base URL
 # used for /server-info (which lives beside /api/2.0, not under it).
 _ARTIFACTS_SERVICE_ROOT = "/api/2.0/mlflow-artifacts/artifacts"
@@ -142,16 +144,9 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
                 return self._server_capabilities
 
             try:
-                response = http_request(
-                    host_creds=self._artifact_server_host_creds,
-                    endpoint=_SERVER_INFO_ENDPOINT,
-                    method="GET",
-                    timeout=3,
-                    max_retries=0,
-                    raise_on_status=False,
-                )
+                response = fetch_server_info(self._artifact_server_host_creds)
                 if response.status_code == 200:
-                    data = response.json()
+                    data = response.data
                     self._server_capabilities = {
                         SERVER_INFO_MULTIPART_UPLOADS_ENABLED: data.get(
                             SERVER_INFO_MULTIPART_UPLOADS_ENABLED, False
@@ -164,14 +159,14 @@ class MlflowArtifactsRepository(HttpArtifactRepository):
                     _logger.debug(
                         "Failed to fetch multipart capabilities from %s (status=%s); "
                         "defaulting to disabled.",
-                        _SERVER_INFO_ENDPOINT,
+                        SERVER_INFO_ENDPOINT,
                         response.status_code,
                     )
                     self._server_capabilities = {}
             except Exception:
                 _logger.debug(
                     "Failed to fetch multipart capabilities from %s; defaulting to disabled.",
-                    _SERVER_INFO_ENDPOINT,
+                    SERVER_INFO_ENDPOINT,
                     exc_info=True,
                 )
                 self._server_capabilities = {}

--- a/mlflow/store/workspace_rest_store_mixin.py
+++ b/mlflow/store/workspace_rest_store_mixin.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
-from mlflow.utils.rest_utils import http_request
+from mlflow.utils.server_info import (
+    SERVER_INFO_ENDPOINT,
+    SERVER_INFO_WORKSPACES_ENABLED,
+    ServerInfoRequestError,
+    fetch_server_info,
+)
 from mlflow.utils.uri import is_databricks_uri
 from mlflow.utils.workspace_context import get_request_workspace
 
@@ -12,7 +17,6 @@ class WorkspaceRestStoreMixin:
     Shared workspace capability detection for REST-based stores.
     """
 
-    _SERVER_INFO_ENDPOINT = "/api/3.0/mlflow/server-info"
     _WORKSPACE_UNSUPPORTED_ERROR = (
         "Active workspace '{workspace}' cannot be used because the remote server does not "
         "support workspaces. Restart the server with --enable-workspaces or unset the active "
@@ -54,17 +58,10 @@ class WorkspaceRestStoreMixin:
     def _probe_workspace_support(self) -> bool:
         host_creds = self.get_host_creds()
         try:
-            response = http_request(
-                host_creds=host_creds,
-                endpoint=self._SERVER_INFO_ENDPOINT,
-                method="GET",
-                timeout=3,
-                max_retries=0,
-                raise_on_status=False,
-            )
-        except Exception as exc:  # pragma: no cover - network errors vary
+            response = fetch_server_info(host_creds)
+        except ServerInfoRequestError as exc:  # pragma: no cover - network errors vary
             raise MlflowException(
-                message=f"Failed to query {self._SERVER_INFO_ENDPOINT}: {exc}",
+                message=f"Failed to query {SERVER_INFO_ENDPOINT}: {exc}",
                 error_code=databricks_pb2.INTERNAL_ERROR,
             ) from exc
 
@@ -75,10 +72,10 @@ class WorkspaceRestStoreMixin:
         if response.status_code != 200:
             raise MlflowException(
                 message=(
-                    f"Failed to query {self._SERVER_INFO_ENDPOINT}: "
+                    f"Failed to query {SERVER_INFO_ENDPOINT}: "
                     f"{response.status_code} {response.text}"
                 ),
                 error_code=databricks_pb2.TEMPORARILY_UNAVAILABLE,
             )
 
-        return response.json().get("workspaces_enabled", False)
+        return response.data.get(SERVER_INFO_WORKSPACES_ENABLED, False)

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -35,25 +35,19 @@ from mlflow.telemetry.utils import (
 from mlflow.utils.credentials import get_default_host_creds
 from mlflow.utils.logging_utils import should_suppress_logs_in_thread, suppress_logs_in_thread
 from mlflow.utils.rest_utils import http_request
+from mlflow.utils.server_info import SERVER_INFO_STORE_TYPE, fetch_server_info
 
 _DATABRICKS_SCHEMES = ("databricks", "databricks-uc", "uc")
 
 
-# Cache per tracking URI; 16 is more than enough for any realistic number of
-# distinct tracking URIs within a single process.
 @lru_cache(maxsize=16)
 def _fetch_server_info(tracking_uri: str) -> dict[str, Any] | None:
+    # Telemetry intentionally caches failures so its background consumer does not repeatedly
+    # block on an unavailable server. Other callers should use the shared helper directly.
     try:
-        response = http_request(
-            host_creds=get_default_host_creds(tracking_uri),
-            endpoint="/api/3.0/mlflow/server-info",
-            method="GET",
-            timeout=3,
-            max_retries=0,
-            raise_on_status=False,
-        )
+        response = fetch_server_info(get_default_host_creds(tracking_uri))
         if response.status_code == 200:
-            return response.json()
+            return response.data
     except Exception:
         pass
     return None
@@ -475,7 +469,7 @@ class TelemetryClient:
         from mlflow.tracking._tracking_service.utils import get_tracking_uri
 
         server_info = _fetch_server_info(get_tracking_uri())
-        store_type = server_info.get("store_type") if server_info else None
+        store_type = server_info.get(SERVER_INFO_STORE_TYPE) if server_info else None
         return _enrich_http_scheme(scheme, store_type)
 
     def _update_backend_store(self):

--- a/mlflow/utils/server_info.py
+++ b/mlflow/utils/server_info.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+from mlflow.utils.rest_utils import MlflowHostCreds, http_request
+
+SERVER_INFO_ENDPOINT = "/api/3.0/mlflow/server-info"
+
+SERVER_INFO_STORE_TYPE = "store_type"
+SERVER_INFO_WORKSPACES_ENABLED = "workspaces_enabled"
+SERVER_INFO_TRACE_ARCHIVAL_ENABLED = "trace_archival_enabled"
+SERVER_INFO_MULTIPART_UPLOADS_ENABLED = "multipart_uploads_enabled"
+SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED = "multipart_downloads_enabled"
+
+_SERVER_INFO_CACHE_MAXSIZE = 16
+_SERVER_INFO_CACHE_TTL_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class ServerInfoResponse:
+    status_code: int
+    data: dict[str, Any] | None = None
+    text: str | None = None
+
+
+class ServerInfoRequestError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class _ServerInfoCacheEntry:
+    response: ServerInfoResponse
+    expires_at_monotonic: float
+
+
+@dataclass
+class _InFlightRequest:
+    event: threading.Event = field(default_factory=threading.Event)
+    response: ServerInfoResponse | None = None
+    error: BaseException | None = None
+
+
+_SERVER_INFO_CACHE: OrderedDict[str, _ServerInfoCacheEntry] = OrderedDict()
+_SERVER_INFO_CACHE_LOCK = threading.Lock()
+_SERVER_INFO_IN_FLIGHT: dict[str, _InFlightRequest] = {}
+
+
+def _reset_server_info_state_after_fork() -> None:
+    global _SERVER_INFO_CACHE, _SERVER_INFO_CACHE_LOCK, _SERVER_INFO_IN_FLIGHT
+
+    # A child cannot safely reuse locks or in-flight requests owned by threads
+    # that only exist in the parent process.
+    _SERVER_INFO_CACHE = OrderedDict()
+    _SERVER_INFO_CACHE_LOCK = threading.Lock()
+    _SERVER_INFO_IN_FLIGHT = {}
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_server_info_state_after_fork)
+
+
+def _normalize_server_info_cache_key(host: str) -> str:
+    return host.removesuffix("/")
+
+
+def _cache_success_locked(key: str, response: ServerInfoResponse) -> None:
+    _SERVER_INFO_CACHE[key] = _ServerInfoCacheEntry(
+        response=response,
+        expires_at_monotonic=time.monotonic() + _SERVER_INFO_CACHE_TTL_SECONDS,
+    )
+    _SERVER_INFO_CACHE.move_to_end(key)
+    if len(_SERVER_INFO_CACHE) > _SERVER_INFO_CACHE_MAXSIZE:
+        _SERVER_INFO_CACHE.popitem(last=False)
+
+
+def _fetch_server_info_uncached(host_creds: MlflowHostCreds) -> ServerInfoResponse:
+    try:
+        response = http_request(
+            host_creds=host_creds,
+            endpoint=SERVER_INFO_ENDPOINT,
+            method="GET",
+            timeout=3,
+            max_retries=0,
+            raise_on_status=False,
+        )
+    except Exception as exc:  # pragma: no cover - behavior validated by callers
+        raise ServerInfoRequestError(str(exc)) from exc
+
+    if response.status_code == 200:
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ServerInfoRequestError(
+                f"Invalid JSON returned by {SERVER_INFO_ENDPOINT}"
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise ServerInfoRequestError(
+                f"Expected a JSON object from {SERVER_INFO_ENDPOINT}, got {type(data).__name__}"
+            )
+
+        return ServerInfoResponse(status_code=200, data=data)
+
+    return ServerInfoResponse(status_code=response.status_code, text=response.text)
+
+
+def fetch_server_info(host_creds: MlflowHostCreds) -> ServerInfoResponse:
+    key = _normalize_server_info_cache_key(host_creds.host)
+    with _SERVER_INFO_CACHE_LOCK:
+        if cache_entry := _SERVER_INFO_CACHE.get(key):
+            if time.monotonic() < cache_entry.expires_at_monotonic:
+                _SERVER_INFO_CACHE.move_to_end(key)
+                return cache_entry.response
+            _SERVER_INFO_CACHE.pop(key)
+
+        if in_flight := _SERVER_INFO_IN_FLIGHT.get(key):
+            leader = False
+        else:
+            in_flight = _InFlightRequest()
+            _SERVER_INFO_IN_FLIGHT[key] = in_flight
+            leader = True
+
+    if not leader:
+        in_flight.event.wait()
+        if in_flight.error is not None:
+            raise in_flight.error
+        return in_flight.response
+
+    try:
+        response = _fetch_server_info_uncached(host_creds)
+        with _SERVER_INFO_CACHE_LOCK:
+            if response.status_code == 200:
+                _cache_success_locked(key, response)
+            in_flight.response = response
+    except BaseException as exc:
+        in_flight.error = exc
+        raise
+    finally:
+        with _SERVER_INFO_CACHE_LOCK:
+            _SERVER_INFO_IN_FLIGHT.pop(key, None)
+            in_flight.event.set()
+
+    return response
+
+
+def _clear_server_info_cache() -> None:
+    with _SERVER_INFO_CACHE_LOCK:
+        _SERVER_INFO_CACHE.clear()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -252,10 +252,6 @@ from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
-from mlflow.store.artifact.mlflow_artifacts_repo import (
-    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
-    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
-)
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry import (
@@ -271,6 +267,13 @@ from mlflow.tracing.constant import SpansLocation, TraceTagKey
 from mlflow.tracing.utils import build_otel_context
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 from mlflow.utils.proto_json_utils import message_to_json
+from mlflow.utils.server_info import (
+    SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
+    SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
+    SERVER_INFO_STORE_TYPE,
+    SERVER_INFO_TRACE_ARCHIVAL_ENABLED,
+    SERVER_INFO_WORKSPACES_ENABLED,
+)
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
 from mlflow.utils.workspace_context import WorkspaceContext
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
@@ -428,9 +431,9 @@ def test_server_info():
         response = c.get("/api/3.0/mlflow/server-info")
         assert response.status_code == 200
         data = response.get_json()
-        assert data["store_type"] == "SqlStore"
-        assert data["workspaces_enabled"] is False
-        assert data["trace_archival_enabled"] is False
+        assert data[SERVER_INFO_STORE_TYPE] == "SqlStore"
+        assert data[SERVER_INFO_WORKSPACES_ENABLED] is False
+        assert data[SERVER_INFO_TRACE_ARCHIVAL_ENABLED] is False
 
 
 def test_server_info_trace_archival_enabled(monkeypatch):
@@ -444,7 +447,7 @@ def test_server_info_trace_archival_enabled(monkeypatch):
         response = c.get("/api/3.0/mlflow/server-info")
         assert response.status_code == 200
         data = response.get_json()
-        assert data["trace_archival_enabled"] is True
+        assert data[SERVER_INFO_TRACE_ARCHIVAL_ENABLED] is True
 
 
 def test_server_info_handles_invalid_trace_archival_config(monkeypatch):
@@ -459,7 +462,7 @@ def test_server_info_handles_invalid_trace_archival_config(monkeypatch):
         response = c.get("/api/3.0/mlflow/server-info")
         assert response.status_code == 200
         data = response.get_json()
-        assert data["trace_archival_enabled"] is False
+        assert data[SERVER_INFO_TRACE_ARCHIVAL_ENABLED] is False
 
 
 def test_server_info_handles_unexpected_trace_archival_config_error(monkeypatch):
@@ -472,7 +475,7 @@ def test_server_info_handles_unexpected_trace_archival_config_error(monkeypatch)
         response = c.get("/api/3.0/mlflow/server-info")
         assert response.status_code == 200
         data = response.get_json()
-        assert data["trace_archival_enabled"] is False
+        assert data[SERVER_INFO_TRACE_ARCHIVAL_ENABLED] is False
 
 
 def test_server_info_multipart_capabilities_disabled_by_default():

--- a/tests/store/artifact/test_mlflow_artifact_repo.py
+++ b/tests/store/artifact/test_mlflow_artifact_repo.py
@@ -8,12 +8,14 @@ import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.artifact.mlflow_artifacts_repo import (
+from mlflow.store.artifact.mlflow_artifacts_repo import MlflowArtifactsRepository
+from mlflow.utils.credentials import get_default_host_creds
+from mlflow.utils.server_info import (
+    SERVER_INFO_ENDPOINT,
     SERVER_INFO_MULTIPART_DOWNLOADS_ENABLED,
     SERVER_INFO_MULTIPART_UPLOADS_ENABLED,
-    MlflowArtifactsRepository,
+    _clear_server_info_cache,
 )
-from mlflow.utils.credentials import get_default_host_creds
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -23,6 +25,13 @@ def set_tracking_uri():
         return_value="http://localhost:5000/",
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def clear_server_info_cache():
+    _clear_server_info_cache()
+    yield
+    _clear_server_info_cache()
 
 
 def test_artifact_uri_factory():
@@ -364,7 +373,7 @@ def test_auto_detects_multipart_upload_from_server_info(monkeypatch):
     monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
     repo = _make_multipart_repo()
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=_mock_server_info_response(uploads=True),
     ):
         assert repo._is_multipart_upload_enabled() is True
@@ -374,7 +383,7 @@ def test_auto_detects_multipart_download_from_server_info(monkeypatch):
     monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD", raising=False)
     repo = _make_multipart_repo()
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=_mock_server_info_response(downloads=True),
     ):
         assert repo._is_multipart_download_enabled() is True
@@ -411,7 +420,7 @@ def test_old_server_without_fields_defaults_to_disabled(monkeypatch):
     }
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=resp,
     ):
         assert repo._is_multipart_upload_enabled() is False
@@ -426,7 +435,7 @@ def test_server_info_404_defaults_to_disabled(monkeypatch):
     resp.status_code = 404
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=resp,
     ):
         assert repo._is_multipart_upload_enabled() is False
@@ -437,7 +446,7 @@ def test_server_info_network_error_defaults_to_disabled(monkeypatch):
     repo = _make_multipart_repo()
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         side_effect=ConnectionError("connection refused"),
     ):
         assert repo._is_multipart_upload_enabled() is False
@@ -448,7 +457,7 @@ def test_capabilities_cached_per_instance(monkeypatch):
     repo = _make_multipart_repo()
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=_mock_server_info_response(uploads=True, downloads=True),
     ) as mock_request:
         assert repo._is_multipart_upload_enabled() is True
@@ -456,18 +465,18 @@ def test_capabilities_cached_per_instance(monkeypatch):
         mock_request.assert_called_once()
 
 
-def test_separate_instances_fetch_independently(monkeypatch):
+def test_separate_instances_share_successful_probe(monkeypatch):
     monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
     repo1 = _make_multipart_repo()
     repo2 = _make_multipart_repo()
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=_mock_server_info_response(uploads=True),
     ) as mock_request:
         repo1._is_multipart_upload_enabled()
         repo2._is_multipart_upload_enabled()
-        assert mock_request.call_count == 2
+        mock_request.assert_called_once()
 
 
 def test_capability_probe_uses_artifact_host_and_preserves_path_prefix(monkeypatch):
@@ -479,14 +488,14 @@ def test_capability_probe_uses_artifact_host_and_preserves_path_prefix(monkeypat
         repo = MlflowArtifactsRepository("mlflow-artifacts://artifacts.example.com:9000/exp")
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=_mock_server_info_response(uploads=True),
     ) as mock_request:
         assert repo._is_multipart_upload_enabled() is True
 
     host_creds = mock_request.call_args.kwargs["host_creds"]
     assert host_creds.host == "http://artifacts.example.com:9000/mlflow"
-    assert mock_request.call_args.kwargs["endpoint"] == "/api/3.0/mlflow/server-info"
+    assert mock_request.call_args.kwargs["endpoint"] == SERVER_INFO_ENDPOINT
 
 
 def test_small_upload_skips_server_info_capability_probe(monkeypatch, tmp_path):
@@ -500,7 +509,7 @@ def test_small_upload_skips_server_info_capability_probe(monkeypatch, tmp_path):
 
     with (
         mock.patch(
-            "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+            "mlflow.utils.server_info.http_request",
         ) as mock_server_info_request,
         mock.patch(
             "mlflow.store.artifact.http_artifact_repo.http_request",
@@ -512,10 +521,11 @@ def test_small_upload_skips_server_info_capability_probe(monkeypatch, tmp_path):
     mock_server_info_request.assert_not_called()
 
 
-def test_capabilities_fetch_is_thread_safe(monkeypatch):
+def test_capabilities_fetch_is_thread_safe_across_repo_instances(monkeypatch):
     monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
     monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_DOWNLOAD", raising=False)
-    repo = _make_multipart_repo()
+    repo1 = _make_multipart_repo()
+    repo2 = _make_multipart_repo()
     results = []
 
     def slow_server_info(*_args, **_kwargs):
@@ -523,18 +533,18 @@ def test_capabilities_fetch_is_thread_safe(monkeypatch):
         return _mock_server_info_response(uploads=True, downloads=True)
 
     with mock.patch(
-        "mlflow.store.artifact.mlflow_artifacts_repo.http_request",
+        "mlflow.utils.server_info.http_request",
         side_effect=slow_server_info,
     ) as mock_request:
         threads = [
             threading.Thread(
-                target=lambda: results.append(repo._is_multipart_upload_enabled()),
+                target=lambda: results.append(repo1._is_multipart_upload_enabled()),
                 name=f"multipart-upload-probe-{idx}",
             )
             for idx in range(4)
         ] + [
             threading.Thread(
-                target=lambda: results.append(repo._is_multipart_download_enabled()),
+                target=lambda: results.append(repo2._is_multipart_download_enabled()),
                 name=f"multipart-download-probe-{idx}",
             )
             for idx in range(4)
@@ -546,3 +556,39 @@ def test_capabilities_fetch_is_thread_safe(monkeypatch):
 
     assert mock_request.call_count == 1
     assert results == [True] * 8
+
+
+def test_capabilities_do_not_share_across_artifact_hosts(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo1 = MlflowArtifactsRepository("mlflow-artifacts://artifacts-1.example.com/exp")
+    repo2 = MlflowArtifactsRepository("mlflow-artifacts://artifacts-2.example.com/exp")
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_server_info_response(uploads=True),
+    ) as mock_request:
+        assert repo1._is_multipart_upload_enabled() is True
+        assert repo2._is_multipart_upload_enabled() is True
+
+    assert mock_request.call_count == 2
+
+
+def test_capabilities_do_not_share_across_path_prefixes(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD", raising=False)
+    repo1 = MlflowArtifactsRepository(
+        "mlflow-artifacts:/exp",
+        tracking_uri="http://tracking.example.com",
+    )
+    repo2 = MlflowArtifactsRepository(
+        "mlflow-artifacts:/exp",
+        tracking_uri="http://tracking.example.com/mlflow",
+    )
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_server_info_response(uploads=True),
+    ) as mock_request:
+        assert repo1._is_multipart_upload_enabled() is True
+        assert repo2._is_multipart_upload_enabled() is True
+
+    assert mock_request.call_count == 2

--- a/tests/store/tracking/test_rest_store_workspace.py
+++ b/tests/store/tracking/test_rest_store_workspace.py
@@ -6,8 +6,16 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import Experiment, GetExperiment
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.utils.rest_utils import MlflowHostCreds
+from mlflow.utils.server_info import SERVER_INFO_ENDPOINT, _clear_server_info_cache
 
 ACTIVE_WORKSPACE = "team-a"
+
+
+@pytest.fixture(autouse=True)
+def clear_server_info_cache():
+    _clear_server_info_cache()
+    yield
+    _clear_server_info_cache()
 
 
 def test_supports_workspaces_queries_endpoint():
@@ -17,9 +25,7 @@ def test_supports_workspaces_queries_endpoint():
     response.status_code = 200
     response.json.return_value = {"workspaces_enabled": True}
 
-    with mock.patch(
-        "mlflow.store.workspace_rest_store_mixin.http_request", return_value=response
-    ) as mock_http:
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response) as mock_http:
         assert store.supports_workspaces is True
         # Cached result prevents additional requests
         assert store.supports_workspaces is True
@@ -27,7 +33,7 @@ def test_supports_workspaces_queries_endpoint():
     mock_http.assert_called_once()
     _, kwargs = mock_http.call_args
     assert kwargs["host_creds"] is creds
-    assert kwargs["endpoint"] == "/api/3.0/mlflow/server-info"
+    assert kwargs["endpoint"] == SERVER_INFO_ENDPOINT
     assert kwargs["method"] == "GET"
     assert kwargs["timeout"] == 3
     assert kwargs["max_retries"] == 0
@@ -41,7 +47,7 @@ def test_supports_workspaces_returns_false_on_failure():
     response.status_code = 404
     response.text = "not found"
 
-    with mock.patch("mlflow.store.workspace_rest_store_mixin.http_request", return_value=response):
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response):
         assert store.supports_workspaces is False
 
 
@@ -52,7 +58,7 @@ def test_supports_workspaces_handles_missing_json_keys():
     response.status_code = 200
     response.json.return_value = {}
 
-    with mock.patch("mlflow.store.workspace_rest_store_mixin.http_request", return_value=response):
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response):
         assert store.supports_workspaces is False
 
 
@@ -60,7 +66,7 @@ def test_supports_workspaces_returns_false_for_databricks_uri():
     creds = MlflowHostCreds("databricks")
     store = RestStore(lambda: creds)
 
-    with mock.patch("mlflow.store.workspace_rest_store_mixin.http_request") as mock_http:
+    with mock.patch("mlflow.utils.server_info.http_request") as mock_http:
         assert store.supports_workspaces is False
         # Should not probe the server for Databricks URIs
         mock_http.assert_not_called()
@@ -73,9 +79,60 @@ def test_supports_workspaces_raises_on_server_error():
     response.status_code = 500
     response.text = "Internal Server Error"
 
-    with mock.patch("mlflow.store.workspace_rest_store_mixin.http_request", return_value=response):
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response):
         with pytest.raises(MlflowException, match="Failed to query.*500"):
             store.supports_workspaces
+
+
+def test_supports_workspaces_raises_internal_error_on_request_exception():
+    creds = MlflowHostCreds("https://example")
+    store = RestStore(lambda: creds)
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        side_effect=ConnectionError("connection refused"),
+    ):
+        with pytest.raises(MlflowException, match="Failed to query.*connection refused"):
+            store.supports_workspaces
+
+
+def test_supports_workspaces_raises_internal_error_on_malformed_json():
+    creds = MlflowHostCreds("https://example")
+    store = RestStore(lambda: creds)
+    response = mock.MagicMock(status_code=200)
+    response.json.side_effect = ValueError("bad json")
+
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response):
+        with pytest.raises(MlflowException, match="Invalid JSON returned"):
+            store.supports_workspaces
+
+
+def test_supports_workspaces_shares_successful_result_across_store_instances():
+    creds1 = MlflowHostCreds("https://example")
+    creds2 = MlflowHostCreds("https://example")
+    store1 = RestStore(lambda: creds1)
+    store2 = RestStore(lambda: creds2)
+    response = mock.MagicMock(status_code=200)
+    response.json.return_value = {"workspaces_enabled": True}
+
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response) as mock_http:
+        assert store1.supports_workspaces is True
+        assert store2.supports_workspaces is True
+
+    mock_http.assert_called_once()
+
+
+def test_supports_workspaces_does_not_share_different_path_prefixes():
+    store1 = RestStore(lambda: MlflowHostCreds("https://example"))
+    store2 = RestStore(lambda: MlflowHostCreds("https://example/mlflow"))
+    response = mock.MagicMock(status_code=200)
+    response.json.return_value = {"workspaces_enabled": True}
+
+    with mock.patch("mlflow.utils.server_info.http_request", return_value=response) as mock_http:
+        assert store1.supports_workspaces is True
+        assert store2.supports_workspaces is True
+
+    assert mock_http.call_count == 2
 
 
 def test_rest_store_workspace_guard():

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -9,14 +9,17 @@ from mlflow.telemetry.client import (
     _set_telemetry_client,
     get_telemetry_client,
 )
+from mlflow.utils.server_info import _clear_server_info_cache
 from mlflow.version import VERSION
 
 
 @pytest.fixture(autouse=True)
 def clear_server_store_type_cache():
     _fetch_server_info.cache_clear()
+    _clear_server_info_cache()
     yield
     _fetch_server_info.cache_clear()
+    _clear_server_info_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/telemetry/test_track.py
+++ b/tests/telemetry/test_track.py
@@ -133,7 +133,7 @@ def test_backend_store_info_http_scheme_enrichment_cached(
             return_value=("http", True),
         ) as mock_uri_info,
         mock.patch(
-            "mlflow.telemetry.client.http_request",
+            "mlflow.utils.server_info.http_request",
             return_value=mock_response,
         ) as mock_req,
     ):
@@ -142,7 +142,7 @@ def test_backend_store_info_http_scheme_enrichment_cached(
 
     assert mock_telemetry_client.info["tracking_uri_scheme"] == "http-sql"
     assert mock_uri_info.call_count == 2
-    # http_request is called only once due to lru_cache
+    # Successful responses are shared through the centralized server-info cache.
     mock_req.assert_called_once()
 
 
@@ -195,7 +195,7 @@ def test_fetch_server_info(
         mock_response.json.return_value = json_body
 
     with mock.patch(
-        "mlflow.telemetry.client.http_request",
+        "mlflow.utils.server_info.http_request",
         return_value=mock_response,
     ) as mock_req:
         result = _fetch_server_info("http://localhost:5000")
@@ -206,13 +206,68 @@ def test_fetch_server_info(
 
 def test_fetch_server_info_connection_error():
     with mock.patch(
-        "mlflow.telemetry.client.http_request",
+        "mlflow.utils.server_info.http_request",
         side_effect=ConnectionError,
     ) as mock_req:
-        result = _fetch_server_info("http://localhost:5000")
+        assert _fetch_server_info("http://localhost:5000") is None
+        assert _fetch_server_info("http://localhost:5000") is None
 
-    assert result is None
     mock_req.assert_called_once()
+
+
+def test_fetch_server_info_caches_non_200_response():
+    mock_response = mock.Mock(status_code=404)
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=mock_response,
+    ) as mock_req:
+        assert _fetch_server_info("http://localhost:5000") is None
+        assert _fetch_server_info("http://localhost:5000") is None
+
+    mock_req.assert_called_once()
+
+
+def test_fetch_server_info_caches_invalid_json_failure():
+    mock_response = mock.Mock(status_code=200)
+    mock_response.json.side_effect = ValueError("bad json")
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=mock_response,
+    ) as mock_req:
+        assert _fetch_server_info("http://localhost:5000") is None
+        assert _fetch_server_info("http://localhost:5000") is None
+
+    mock_req.assert_called_once()
+
+
+def test_fetch_server_info_caches_successful_responses():
+    mock_response = mock.Mock(status_code=200)
+    mock_response.json.return_value = {"store_type": "SqlStore"}
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=mock_response,
+    ) as mock_req:
+        assert _fetch_server_info("http://localhost:5000") == {"store_type": "SqlStore"}
+        assert _fetch_server_info("http://localhost:5000") == {"store_type": "SqlStore"}
+
+    mock_req.assert_called_once()
+
+
+def test_fetch_server_info_keeps_distinct_effective_uris_separate():
+    mock_response = mock.Mock(status_code=200)
+    mock_response.json.return_value = {"store_type": "SqlStore"}
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=mock_response,
+    ) as mock_req:
+        _fetch_server_info("http://localhost:5000")
+        _fetch_server_info("http://localhost:5000/mlflow")
+
+    assert mock_req.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_server_info.py
+++ b/tests/utils/test_server_info.py
@@ -1,0 +1,569 @@
+import os
+import select
+import signal
+import threading
+from unittest import mock
+
+import pytest
+
+from mlflow.utils import server_info
+from mlflow.utils.rest_utils import MlflowHostCreds
+from mlflow.utils.server_info import (
+    SERVER_INFO_ENDPOINT,
+    ServerInfoRequestError,
+    ServerInfoResponse,
+    _clear_server_info_cache,
+    fetch_server_info,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_server_info_cache():
+    _clear_server_info_cache()
+    yield
+    _clear_server_info_cache()
+
+
+def _mock_response(status_code=200, json_body=None, text=""):
+    response = mock.Mock(status_code=status_code, text=text)
+    if json_body is not None:
+        response.json.return_value = json_body
+    return response
+
+
+def test_fetch_server_info_uses_expected_request_arguments():
+    creds = MlflowHostCreds("https://example.com")
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ) as mock_http:
+        response = fetch_server_info(creds)
+
+    assert response.status_code == 200
+    assert response.data == {"store_type": "SqlStore"}
+    _, kwargs = mock_http.call_args
+    assert kwargs["host_creds"] is creds
+    assert kwargs["endpoint"] == SERVER_INFO_ENDPOINT
+    assert kwargs["method"] == "GET"
+    assert kwargs["timeout"] == 3
+    assert kwargs["max_retries"] == 0
+    assert kwargs["raise_on_status"] is False
+
+
+def test_fetch_server_info_caches_successful_response():
+    creds = MlflowHostCreds("https://example.com")
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ) as mock_http:
+        assert fetch_server_info(creds).data == {"store_type": "SqlStore"}
+        assert fetch_server_info(creds).data == {"store_type": "SqlStore"}
+
+    mock_http.assert_called_once()
+
+
+def test_fetch_server_info_refreshes_expired_success():
+    creds = MlflowHostCreds("https://example.com")
+    now = 0.0
+    responses = [
+        _mock_response(status_code=200, json_body={"store_type": "FileStore"}),
+        _mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ]
+
+    with (
+        mock.patch("mlflow.utils.server_info.time.monotonic", side_effect=lambda: now),
+        mock.patch("mlflow.utils.server_info.http_request", side_effect=responses) as mock_http,
+    ):
+        assert fetch_server_info(creds).data == {"store_type": "FileStore"}
+
+        now = server_info._SERVER_INFO_CACHE_TTL_SECONDS - 1
+        assert fetch_server_info(creds).data == {"store_type": "FileStore"}
+
+        now = server_info._SERVER_INFO_CACHE_TTL_SECONDS
+        assert fetch_server_info(creds).data == {"store_type": "SqlStore"}
+
+    assert mock_http.call_count == 2
+
+
+def test_fetch_server_info_caches_empty_json_response():
+    creds = MlflowHostCreds("https://example.com")
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={}),
+    ) as mock_http:
+        assert fetch_server_info(creds).data == {}
+        assert fetch_server_info(creds).data == {}
+
+    mock_http.assert_called_once()
+
+
+def test_fetch_server_info_normalizes_trailing_slash():
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ) as mock_http:
+        assert fetch_server_info(MlflowHostCreds("https://example.com")).data == {
+            "store_type": "SqlStore"
+        }
+        assert fetch_server_info(MlflowHostCreds("https://example.com/")).data == {
+            "store_type": "SqlStore"
+        }
+
+    mock_http.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("host_1", "host_2"),
+    [
+        ("https://example.com", "http://example.com"),
+        ("https://example.com", "https://example.com:5000"),
+        ("https://example.com", "https://example.com/mlflow"),
+        ("https://tracking.example.com/mlflow", "https://artifacts.example.com/mlflow"),
+    ],
+)
+def test_fetch_server_info_keeps_distinct_hosts_separate(host_1, host_2):
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ) as mock_http:
+        fetch_server_info(MlflowHostCreds(host_1))
+        fetch_server_info(MlflowHostCreds(host_2))
+
+    assert mock_http.call_count == 2
+
+
+def test_fetch_server_info_evicts_oldest_success_after_cache_limit():
+    calls = 0
+
+    def mock_http_request(host_creds, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return _mock_response(status_code=200, json_body={"host": host_creds.host})
+
+    with mock.patch("mlflow.utils.server_info.http_request", side_effect=mock_http_request):
+        first = "https://example-0.com"
+        for idx in range(16):
+            fetch_server_info(MlflowHostCreds(f"https://example-{idx}.com"))
+
+        fetch_server_info(MlflowHostCreds("https://example-16.com"))
+        fetch_server_info(MlflowHostCreds(first))
+
+    assert calls == 18
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_exception"),
+    [
+        (_mock_response(status_code=404, text="not found"), None),
+        (_mock_response(status_code=500, text="server error"), None),
+        (
+            mock.Mock(status_code=200, json=mock.Mock(side_effect=ValueError("bad json"))),
+            ServerInfoRequestError,
+        ),
+        (ConnectionError("connection refused"), ServerInfoRequestError),
+    ],
+)
+def test_fetch_server_info_does_not_cache_failures(response, expected_exception):
+    creds = MlflowHostCreds("https://example.com")
+    http_side_effect = response if isinstance(response, Exception) else None
+    http_return_value = None if http_side_effect else response
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        side_effect=http_side_effect,
+        return_value=http_return_value,
+    ) as mock_http:
+        for _ in range(2):
+            if expected_exception is None:
+                fetch_server_info(creds)
+            else:
+                with pytest.raises(expected_exception):
+                    fetch_server_info(creds)
+
+    assert mock_http.call_count == 2
+
+
+@pytest.mark.parametrize("json_body", [None, [], "not an object", 1])
+def test_fetch_server_info_rejects_and_does_not_cache_non_object_json(json_body):
+    creds = MlflowHostCreds("https://example.com")
+    response = mock.Mock(status_code=200)
+    response.json.return_value = json_body
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=response,
+    ) as mock_http:
+        for _ in range(2):
+            with pytest.raises(ServerInfoRequestError, match="Expected a JSON object"):
+                fetch_server_info(creds)
+
+    assert mock_http.call_count == 2
+
+
+def test_fetch_server_info_single_flights_same_key_success():
+    creds = MlflowHostCreds("https://example.com")
+    call_started = threading.Event()
+    release_request = threading.Event()
+    call_count = 0
+    count_lock = threading.Lock()
+    results = []
+
+    def mock_http_request(**_kwargs):
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+        call_started.set()
+        assert release_request.wait(timeout=5)
+        return _mock_response(status_code=200, json_body={"store_type": "SqlStore"})
+
+    def worker():
+        results.append(fetch_server_info(creds).data)
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        side_effect=mock_http_request,
+    ):
+        threads = [
+            threading.Thread(target=worker, name=f"server-info-success-{idx}") for idx in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        assert call_started.wait(timeout=5)
+        release_request.set()
+        for thread in threads:
+            thread.join(timeout=5)
+
+    assert call_count == 1
+    assert results == [{"store_type": "SqlStore"}] * 2
+
+
+def test_fetch_server_info_single_flights_expired_success():
+    creds = MlflowHostCreds("https://example.com")
+    now = 0.0
+
+    with (
+        mock.patch("mlflow.utils.server_info.time.monotonic", side_effect=lambda: now),
+        mock.patch(
+            "mlflow.utils.server_info.http_request",
+            return_value=_mock_response(status_code=200, json_body={"version": 1}),
+        ),
+    ):
+        fetch_server_info(creds)
+
+    now = server_info._SERVER_INFO_CACHE_TTL_SECONDS
+    call_started = threading.Event()
+    release_request = threading.Event()
+    call_count = 0
+    results = []
+
+    def mock_http_request(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        call_started.set()
+        assert release_request.wait(timeout=5)
+        return _mock_response(status_code=200, json_body={"version": 2})
+
+    def worker():
+        results.append(fetch_server_info(creds).data)
+
+    with (
+        mock.patch("mlflow.utils.server_info.time.monotonic", side_effect=lambda: now),
+        mock.patch("mlflow.utils.server_info.http_request", side_effect=mock_http_request),
+    ):
+        threads = [
+            threading.Thread(target=worker, name=f"server-info-expired-{idx}") for idx in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        assert call_started.wait(timeout=5)
+        release_request.set()
+        for thread in threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+    assert call_count == 1
+    assert results == [{"version": 2}] * 2
+
+
+def test_fetch_server_info_single_flights_same_key_non_200_and_retries_later():
+    creds = MlflowHostCreds("https://example.com")
+    release_request = threading.Event()
+    call_started = threading.Event()
+    call_count = 0
+    count_lock = threading.Lock()
+
+    def mock_http_request(**_kwargs):
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+        call_started.set()
+        assert release_request.wait(timeout=5)
+        return _mock_response(status_code=500, text="server error")
+
+    responses = []
+
+    def worker():
+        responses.append(fetch_server_info(creds).status_code)
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        side_effect=mock_http_request,
+    ):
+        leader = threading.Thread(target=worker, name="server-info-status-leader")
+        leader.start()
+        assert call_started.wait(timeout=5)
+
+        in_flight = server_info._SERVER_INFO_IN_FLIGHT["https://example.com"]
+        follower_waiting = threading.Event()
+        original_wait = in_flight.event.wait
+
+        def wait_for_leader(*args, **kwargs):
+            follower_waiting.set()
+            return original_wait(*args, **kwargs)
+
+        with mock.patch.object(in_flight.event, "wait", side_effect=wait_for_leader):
+            follower = threading.Thread(target=worker, name="server-info-status-follower")
+            follower.start()
+            assert follower_waiting.wait(timeout=5)
+            release_request.set()
+
+        threads = [leader, follower]
+        for thread in threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+        assert fetch_server_info(creds).status_code == 500
+
+    assert call_count == 2
+    assert responses == [500, 500]
+
+
+def test_fetch_server_info_single_flights_same_key_exceptions():
+    creds = MlflowHostCreds("https://example.com")
+    release_request = threading.Event()
+    call_started = threading.Event()
+    call_count = 0
+    count_lock = threading.Lock()
+    errors = []
+
+    def mock_http_request(**_kwargs):
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+        call_started.set()
+        assert release_request.wait(timeout=5)
+        raise ConnectionError("connection refused")
+
+    def worker():
+        try:
+            fetch_server_info(creds)
+        except Exception as exc:  # pragma: no branch - each worker must error
+            errors.append(type(exc))
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        side_effect=mock_http_request,
+    ):
+        leader = threading.Thread(target=worker, name="server-info-error-leader")
+        leader.start()
+        assert call_started.wait(timeout=5)
+
+        in_flight = server_info._SERVER_INFO_IN_FLIGHT["https://example.com"]
+        follower_waiting = threading.Event()
+        original_wait = in_flight.event.wait
+
+        def wait_for_leader(*args, **kwargs):
+            follower_waiting.set()
+            return original_wait(*args, **kwargs)
+
+        with mock.patch.object(in_flight.event, "wait", side_effect=wait_for_leader):
+            follower = threading.Thread(target=worker, name="server-info-error-follower")
+            follower.start()
+            assert follower_waiting.wait(timeout=5)
+            release_request.set()
+
+        threads = [leader, follower]
+        for thread in threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+    assert call_count == 1
+    assert errors == [ServerInfoRequestError, ServerInfoRequestError]
+
+
+@pytest.mark.parametrize("failure_stage", ["fetch", "cache"])
+def test_fetch_server_info_signals_followers_when_leader_raises_base_exception(failure_stage):
+    class LeaderExit(BaseException):
+        pass
+
+    creds = MlflowHostCreds("https://example.com")
+    release_request = threading.Event()
+    call_started = threading.Event()
+    errors = []
+
+    def mock_fetch_uncached(_host_creds):
+        call_started.set()
+        assert release_request.wait(timeout=5)
+        if failure_stage == "fetch":
+            raise LeaderExit
+        return ServerInfoResponse(status_code=200, data={})
+
+    def mock_cache_success(*_args):
+        raise LeaderExit
+
+    def worker():
+        try:
+            fetch_server_info(creds)
+        except BaseException as exc:
+            errors.append(type(exc))
+
+    with (
+        mock.patch(
+            "mlflow.utils.server_info._fetch_server_info_uncached",
+            side_effect=mock_fetch_uncached,
+        ) as mock_fetch,
+        mock.patch(
+            "mlflow.utils.server_info._cache_success_locked",
+            side_effect=mock_cache_success,
+        ) as mock_cache,
+    ):
+        leader = threading.Thread(target=worker, name="server-info-base-exception-leader")
+        leader.start()
+        assert call_started.wait(timeout=5)
+
+        in_flight = server_info._SERVER_INFO_IN_FLIGHT["https://example.com"]
+        follower_waiting = threading.Event()
+        original_wait = in_flight.event.wait
+
+        def wait_for_leader(*args, **kwargs):
+            follower_waiting.set()
+            return original_wait(*args, **kwargs)
+
+        with mock.patch.object(in_flight.event, "wait", side_effect=wait_for_leader):
+            follower = threading.Thread(target=worker, name="server-info-base-exception-follower")
+            follower.start()
+            assert follower_waiting.wait(timeout=5)
+            release_request.set()
+
+        for thread in (leader, follower):
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+    mock_fetch.assert_called_once()
+    assert mock_cache.call_count == (failure_stage == "cache")
+    assert errors == [LeaderExit, LeaderExit]
+    assert server_info._SERVER_INFO_IN_FLIGHT == {}
+
+
+def test_fetch_server_info_allows_different_keys_to_fetch_concurrently():
+    barrier = threading.Barrier(2)
+
+    def mock_http_request(**_kwargs):
+        barrier.wait(timeout=5)
+        return _mock_response(status_code=200, json_body={"store_type": "SqlStore"})
+
+    errors = []
+
+    def worker(host):
+        try:
+            fetch_server_info(MlflowHostCreds(host))
+        except Exception as exc:  # pragma: no cover - failure would fail assertions below
+            errors.append(exc)
+
+    with mock.patch("mlflow.utils.server_info.http_request", side_effect=mock_http_request):
+        threads = [
+            threading.Thread(
+                target=worker,
+                args=("https://example-1.com",),
+                name="server-info-concurrent-1",
+            ),
+            threading.Thread(
+                target=worker,
+                args=("https://example-2.com",),
+                name="server-info-concurrent-2",
+            ),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+    assert errors == []
+
+
+def test_clear_server_info_cache_forces_refetch():
+    creds = MlflowHostCreds("https://example.com")
+
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ) as mock_http:
+        fetch_server_info(creds)
+        _clear_server_info_cache()
+        fetch_server_info(creds)
+
+    assert mock_http.call_count == 2
+
+
+def test_reset_server_info_state_after_fork_replaces_inherited_state():
+    creds = MlflowHostCreds("https://example.com")
+    with mock.patch(
+        "mlflow.utils.server_info.http_request",
+        return_value=_mock_response(status_code=200, json_body={"store_type": "SqlStore"}),
+    ):
+        fetch_server_info(creds)
+
+    key = "https://in-flight.example.com"
+    server_info._SERVER_INFO_IN_FLIGHT[key] = server_info._InFlightRequest()
+    old_cache = server_info._SERVER_INFO_CACHE
+    old_lock = server_info._SERVER_INFO_CACHE_LOCK
+    old_in_flight = server_info._SERVER_INFO_IN_FLIGHT
+
+    old_lock.acquire()
+    try:
+        server_info._reset_server_info_state_after_fork()
+    finally:
+        old_lock.release()
+
+    assert server_info._SERVER_INFO_CACHE is not old_cache
+    assert server_info._SERVER_INFO_CACHE == {}
+    assert server_info._SERVER_INFO_CACHE_LOCK is not old_lock
+    assert server_info._SERVER_INFO_CACHE_LOCK.acquire(blocking=False)
+    server_info._SERVER_INFO_CACHE_LOCK.release()
+    assert server_info._SERVER_INFO_IN_FLIGHT is not old_in_flight
+    assert server_info._SERVER_INFO_IN_FLIGHT == {}
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+def test_registered_at_fork_handler_prevents_inherited_lock_deadlock():
+    read_fd, write_fd = os.pipe()
+    old_lock = server_info._SERVER_INFO_CACHE_LOCK
+    child_reaped = False
+    old_lock.acquire()
+    try:
+        pid = os.fork()
+        if pid == 0:
+            os.close(read_fd)
+            try:
+                _clear_server_info_cache()
+                os.write(write_fd, b"ok")
+                os._exit(0)
+            except BaseException:
+                os._exit(1)
+
+        os.close(write_fd)
+        ready, _, _ = select.select([read_fd], [], [], 5)
+        assert ready, "child blocked on an inherited server-info cache lock"
+        assert os.read(read_fd, 2) == b"ok"
+        _, status = os.waitpid(pid, 0)
+        child_reaped = True
+        assert os.waitstatus_to_exitcode(status) == 0
+    finally:
+        old_lock.release()
+        os.close(read_fd)
+        if "pid" in locals() and pid != 0 and not child_reaped:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24633

Follow-up to #24341.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Python currently fetches `/api/3.0/mlflow/server-info` independently for telemetry, workspace support, and artifact capability detection. Each caller owns some combination of the endpoint path, response keys, request execution, and caching, which causes duplicate requests and inconsistent cache scopes.

This PR adds `mlflow.utils.server_info` as the shared Python implementation:

- Centralize the endpoint path and the response-key constants used by Python producers and consumers.
- Add a bounded process-wide LRU cache with a 60-second TTL, keyed by the effective server URL while preserving scheme, host, port, and deployment path prefixes.
- Cache only successful HTTP 200 responses containing a JSON object, so transient failures, malformed payloads, and older-server 404 responses do not poison shared state.
- Deduplicate concurrent misses and refreshes for the same server with per-key in-flight records while allowing different servers to fetch concurrently.
- Reset cache and synchronization state after `fork()` so child processes cannot inherit parent-owned locks or in-flight requests.
- Migrate telemetry, `WorkspaceRestStoreMixin`, `MlflowArtifactsRepository`, and the server handler to the shared utility.

Caller-specific behavior remains scoped to each consumer: telemetry returns `None` on failures and intentionally retains a bounded negative cache, workspace support preserves its Databricks/404/non-200 handling and translates request or payload validation errors, and artifact capability detection retains environment-variable precedence plus per-repository fallback memoization.

This change is Python-only and does not change the `/server-info` HTTP contract or frontend behavior.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

- `uv run pytest tests/utils/test_server_info.py tests/telemetry/test_track.py tests/store/tracking/test_rest_store_workspace.py tests/store/artifact/test_mlflow_artifact_repo.py` — 106 passed.
- `uv run --with httpx2 pytest tests/server/test_handlers.py tests/server/test_workspace_middleware.py -k server_info` — 11 passed.
- `uv run pre-commit run --files ...` for all changed files — passed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

This refactors internal Python `/server-info` fetching and caching without changing public APIs or the endpoint contract.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes and improvements. Non-critical bug fixes and doc updates can be included as well. By default, a PR targets the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For stability, this PR should not be included in a patch release unless it is critical or exceedingly low risk.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release