### PR TITLE
fix: prevent 'table already exists' error on db upgrade by checking Alembic revision (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -74,6 +74,18 @@ def _all_tables_exist(engine):
     actual_tables = {
         t for t in sqlalchemy.inspect(engine).get_table_names() if not t.startswith("alembic_")
     }
+    # Only check subset if we haven't already run migrations; otherwise, the DB is
+    # already managed and _all_tables_exist should not be used to decide initialization.
+    # Use Alembic version to determine if initialization is needed.
+    try:
+        with engine.connect() as conn:
+            context = MigrationContext.configure(conn)
+            current_rev = context.get_current_revision()
+        if current_rev is not None:
+            # DB has been migrated before, assume all needed tables exist or will be created by Alembic
+            return True
+    except Exception:
+        pass
     return expected_tables.issubset(actual_tables)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with:
```
pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")
```
This occurs because `_initialize_tables()` calls `InitialBase.metadata.create_all()` then immediately runs `_upgrade_db()` which attempts to create the `secrets` table again via Alembic migration.

The root cause is that `_all_tables_exist()` checks against `Base.metadata.tables` which includes all ORM models (including the new `secrets` model), but the database may have only the initial tables. This incorrectly triggers re-initialization.

## Fix
Modify `_all_tables_exist()` to check the Alembic migration version before deciding that tables need to be created. If a migration revision exists in the database, the DB is already under Alembic management and we should not fall back to `_initialize_tables` (which would re-run migrations).

Closes #19943