### PR TITLE
feat: Add `LocalJobExecutor`

### DIFF
--- a/mlflow/server/jobs/_job_env_setup.py
+++ b/mlflow/server/jobs/_job_env_setup.py
@@ -1,0 +1,68 @@
+import argparse
+import shutil
+from pathlib import Path
+
+from mlflow.utils.file_utils import ExclusiveFileLock
+from mlflow.utils.process import _exec_cmd, _join_commands
+from mlflow.utils.virtualenv import (
+    _get_uv_env_creation_command,
+    _get_virtualenv_activate_cmd,
+    _get_virtualenv_extra_env_vars,
+)
+
+
+def _get_incomplete_marker_path(env_dir: Path) -> Path:
+    return env_dir.with_name(f".{env_dir.name}.mlflow-job-setup-incomplete")
+
+
+def _setup_job_environment(
+    env_dir: Path,
+    python_version: str,
+    requirements_file: Path,
+) -> None:
+    env_dir.parent.mkdir(parents=True, exist_ok=True)
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+
+    with ExclusiveFileLock(f"{env_dir}.lock"):
+        if env_dir.exists() and not incomplete_marker.exists():
+            return
+
+        if env_dir.exists():
+            shutil.rmtree(env_dir)
+        incomplete_marker.touch()
+
+        try:
+            _exec_cmd(
+                _get_uv_env_creation_command(env_dir, python_version),
+                capture_output=False,
+            )
+            install_command = _join_commands(
+                _get_virtualenv_activate_cmd(env_dir),
+                f"uv pip install -r {requirements_file.name}",
+            )
+            _exec_cmd(
+                install_command,
+                cwd=str(requirements_file.parent),
+                extra_env=_get_virtualenv_extra_env_vars(),
+                capture_output=False,
+            )
+        except Exception:
+            if env_dir.exists():
+                shutil.rmtree(env_dir)
+            incomplete_marker.unlink(missing_ok=True)
+            raise
+        else:
+            incomplete_marker.unlink()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env-dir", type=Path, required=True)
+    parser.add_argument("--python-version", required=True)
+    parser.add_argument("--requirements-file", type=Path, required=True)
+    args = parser.parse_args()
+    _setup_job_environment(args.env_dir, args.python_version, args.requirements_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/server/jobs/_job_env_setup.py
+++ b/mlflow/server/jobs/_job_env_setup.py
@@ -1,0 +1,99 @@
+import argparse
+import os
+import shutil
+import threading
+from pathlib import Path
+
+from mlflow.server.jobs.utils import MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR, _exit_when_orphaned
+from mlflow.utils.file_utils import ExclusiveFileLock
+from mlflow.utils.process import _exec_cmd, _join_commands
+from mlflow.utils.virtualenv import (
+    _get_uv_env_creation_command,
+    _get_virtualenv_activate_cmd,
+    _get_virtualenv_extra_env_vars,
+)
+
+
+def _get_incomplete_marker_path(env_dir: Path) -> Path:
+    return env_dir.with_name(f".{env_dir.name}.mlflow-job-setup-incomplete")
+
+
+def _pip_install(env_dir: Path, requirements_file: Path) -> None:
+    install_command = _join_commands(
+        _get_virtualenv_activate_cmd(env_dir),
+        f"uv pip install -r {requirements_file.name}",
+    )
+    _exec_cmd(
+        install_command,
+        cwd=str(requirements_file.parent),
+        extra_env=_get_virtualenv_extra_env_vars(),
+        capture_output=False,
+    )
+
+
+def _setup_job_environment(
+    env_dir: Path,
+    python_version: str,
+    requirements_file: Path,
+    build_requirements_file: Path | None = None,
+) -> None:
+    env_dir.parent.mkdir(parents=True, exist_ok=True)
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+
+    with ExclusiveFileLock(f"{env_dir}.lock"):
+        if env_dir.exists() and not incomplete_marker.exists():
+            return
+
+        if env_dir.exists():
+            shutil.rmtree(env_dir)
+        incomplete_marker.touch()
+
+        try:
+            _exec_cmd(
+                _get_uv_env_creation_command(env_dir, python_version),
+                capture_output=False,
+            )
+            # Install build dependencies (pinned pip/setuptools/wheel, etc.)
+            # before the regular dependencies, mirroring the canonical MLflow
+            # environment-restore ordering.
+            if build_requirements_file is not None:
+                _pip_install(env_dir, build_requirements_file)
+            _pip_install(env_dir, requirements_file)
+        except Exception:
+            if env_dir.exists():
+                shutil.rmtree(env_dir)
+            incomplete_marker.unlink(missing_ok=True)
+            raise
+        else:
+            incomplete_marker.unlink()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env-dir", type=Path, required=True)
+    parser.add_argument("--python-version", required=True)
+    parser.add_argument("--requirements-file", type=Path, required=True)
+    parser.add_argument("--build-requirements-file", type=Path, default=None)
+    args = parser.parse_args()
+
+    # Exit (releasing the environment lock) if the server that launched this
+    # setup process dies and the process is reparented. The lock is held via
+    # fcntl.flock, which the kernel releases automatically when the process
+    # exits, so a stuck setup cannot block future jobs after a server crash.
+    if os.environ.get(MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR):
+        threading.Thread(
+            target=_exit_when_orphaned,
+            name="exit_when_orphaned",
+            daemon=True,
+        ).start()
+
+    _setup_job_environment(
+        args.env_dir,
+        args.python_version,
+        args.requirements_file,
+        args.build_requirements_file,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/server/jobs/_job_subproc_entry.py
+++ b/mlflow/server/jobs/_job_subproc_entry.py
@@ -23,9 +23,9 @@ from mlflow.server.jobs.utils import (
     MLFLOW_SERVER_JOB_PARAMS_ENV_VAR,
     MLFLOW_SERVER_JOB_RESULT_DUMP_PATH_ENV_VAR,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_CLASSES_PATH_ENV_VAR,
-    JobResult,
     _exit_when_orphaned,
     _load_function,
+    _SubprocessJobResult,
 )
 from mlflow.telemetry.client import get_telemetry_client, set_telemetry_client
 from mlflow.utils.workspace_context import WorkspaceContext
@@ -74,7 +74,7 @@ def _main():
     try:
         with ctx:
             value = function(**params)
-        job_result = JobResult(
+        job_result = _SubprocessJobResult(
             succeeded=True,
             result=json.dumps(value),
         )
@@ -84,7 +84,7 @@ def _main():
             f"Job function {os.environ[MLFLOW_SERVER_JOB_FUNCTION_FULLNAME_ENV_VAR]} failed with "
             f"error:\n{traceback.format_exc()}"
         )
-        JobResult.from_error(e, transient_error_classes).dump(result_dump_path)
+        _SubprocessJobResult.from_error(e, transient_error_classes).dump(result_dump_path)
     finally:
         if job_id:
             _set_job_tracker(None)

--- a/mlflow/server/jobs/executor.py
+++ b/mlflow/server/jobs/executor.py
@@ -86,6 +86,12 @@ class AbstractJobExecutor(ABC):
     ) -> None:
         """Submit a job for execution.
 
+        Every successful ``submit_job`` call must be paired with exactly one
+        ``wait_for_job`` call for the same ``job_id``: executors may retain
+        per-job resources (subprocesses, temporary directories, in-memory
+        records) until ``wait_for_job`` observes the terminal state and releases
+        them. ``stop_executor``/``recover_jobs`` reclaim any that are left behind.
+
         Args:
             job_id: Unique job identifier.
             job_name: Static name of the decorated job function.
@@ -93,7 +99,9 @@ class AbstractJobExecutor(ABC):
             params: Job parameters (JSON-serialisable).
             context: Execution metadata including tracking URI and auth.
             python_env: Optional Python environment specification.
-            timeout: Optional per-job timeout in seconds.
+            timeout: Optional per-job timeout in seconds. For executors that
+                provision a Python environment, the timeout covers environment
+                setup in addition to job execution.
         """
 
     @abstractmethod

--- a/mlflow/server/jobs/local_executor.py
+++ b/mlflow/server/jobs/local_executor.py
@@ -1,7 +1,17 @@
 """Built-in local subprocess job executor."""
 
+import os
+import select
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
 from typing import Any
 
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_GATEWAY_URI, MLFLOW_TRACKING_URI
+from mlflow.exceptions import MlflowException
 from mlflow.server.jobs.executor import (
     AbstractJobExecutor,
     JobExecutionContext,
@@ -9,7 +19,143 @@ from mlflow.server.jobs.executor import (
     JobRecoveryResult,
     JobResult,
 )
+from mlflow.server.jobs.utils import (
+    _kill_process,
+    _load_function,
+    _normalize_python_env,
+    _prepare_job_subprocess,
+    _PreparedJobSetupCommand,
+    _reap_process,
+    _SubprocessJobResult,
+)
 from mlflow.utils.environment import _PythonEnv
+from mlflow.utils.process import ShellCommandException, _exec_cmd
+
+
+class _LocalJobSubmissionCanceled(Exception):
+    pass
+
+
+class _LocalJobSubmissionTimedOut(Exception):
+    """Raised internally when the hard deadline elapses during environment setup."""
+
+
+_STDERR_TAIL_MAX_CHARS = 4000
+
+
+class _BoundedStderrReader:
+    """Drain a subprocess's stderr into a bounded in-memory tail.
+
+    A background thread reads the stream continuously so a job that emits a large
+    volume of stderr can neither deadlock ``process.wait()`` (as an unread PIPE
+    would once its buffer fills) nor force the server to hold all of it in memory.
+    Only the trailing ``max_bytes`` bytes are retained.
+
+    The drain loop polls the raw fd with ``select`` on a short interval and reads
+    with ``os.read`` rather than blocking in ``stream.read()``. This keeps the
+    thread interruptible: if a job spawns a descendant that inherits the PIPE
+    write end and outlives the job (so the pipe never reaches EOF), ``close()``
+    can stop the reader within one poll interval instead of stalling. Closing the
+    stream to interrupt a blocked ``BufferedReader.read`` is deliberately avoided:
+    the close would itself block on the buffered-IO lock the in-flight read holds,
+    so it would hang until the descendant exited rather than unblocking anything.
+    """
+
+    _POLL_INTERVAL = 0.5
+
+    def __init__(self, stream: Any, max_bytes: int = _STDERR_TAIL_MAX_CHARS * 4) -> None:
+        self._stream = stream
+        self._max_bytes = max_bytes
+        self._buffer = bytearray()
+        self._truncated = False
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._drain, name="local-job-stderr-reader", daemon=True
+        )
+        self._thread.start()
+
+    def _drain(self) -> None:
+        try:
+            fd = self._stream.fileno()
+        except (OSError, ValueError, AttributeError):
+            return
+        if not isinstance(fd, int):
+            # A mocked stream (in tests) whose fileno() is not a real descriptor.
+            return
+        try:
+            while True:
+                try:
+                    ready, _, _ = select.select([fd], [], [], self._POLL_INTERVAL)
+                except (OSError, ValueError):
+                    break
+                if ready:
+                    # Drain everything currently available before honoring a stop
+                    # request, so stderr the job wrote right before exiting is not
+                    # dropped when close()/tail() races the final read.
+                    try:
+                        chunk = os.read(fd, 4096)
+                    except (OSError, ValueError):
+                        break
+                    if not chunk:
+                        break  # EOF: every write end (job and descendants) closed.
+                    with self._lock:
+                        self._buffer.extend(chunk)
+                        overflow = len(self._buffer) - self._max_bytes
+                        if overflow > 0:
+                            del self._buffer[:overflow]
+                            self._truncated = True
+                    continue
+                # No data right now: stop if asked, otherwise keep polling.
+                if self._stop.is_set():
+                    break
+        finally:
+            try:
+                self._stream.close()
+            except (OSError, ValueError):
+                pass
+
+    def close(self) -> None:
+        """Stop the reader and wait for it, so no daemon thread lingers."""
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    def tail(self, max_chars: int = _STDERR_TAIL_MAX_CHARS) -> str:
+        """Return the trailing captured stderr, stopping the reader first."""
+        # The process has exited by the time this is called. In the common case
+        # the pipe is already at EOF and the reader has finished; close() just
+        # joins it. If a descendant still holds the write end, close() stops the
+        # reader within one poll interval rather than waiting for that descendant.
+        self.close()
+        with self._lock:
+            data = bytes(self._buffer)
+            truncated = self._truncated
+        content = data.decode("utf-8", errors="replace").strip()
+        if len(content) > max_chars:
+            content = content[-max_chars:]
+            truncated = True
+        if truncated:
+            return "...(truncated)...\n" + content
+        return content
+
+
+@dataclass
+class _LocalJobProcess:
+    active_process: subprocess.Popen | None
+    temporary_directory: tempfile.TemporaryDirectory
+    result_path: str
+    function_fullname: str
+    timeout: float
+    # Hard deadline (monotonic clock) armed at submit-entry so the timeout covers
+    # environment setup in addition to job execution. Always set at construction.
+    deadline: float
+    stderr_reader: _BoundedStderrReader | None = None
+    cancel_requested: bool = False
+    timed_out: bool = False
+    # Set True only once the job subprocess (not a setup subprocess) has been
+    # launched. Used by cancel_job to decide whether a failed cancellation should
+    # roll back cancel_requested.
+    job_process_launched: bool = False
 
 
 class LocalJobExecutor(AbstractJobExecutor):
@@ -21,6 +167,75 @@ class LocalJobExecutor(AbstractJobExecutor):
 
     def __init__(self, config: JobExecutorConfig) -> None:
         super().__init__(config)
+        self._processes: dict[str, _LocalJobProcess] = {}
+        # Protects:
+        # - self._processes
+        # - self._stopped
+        # - mutable fields on _LocalJobProcess stored in self._processes
+        # Never hold while blocking on process.wait().
+        self._state_lock = threading.RLock()
+        self._stopped = False
+
+    def _effective_timeout(self, timeout: float | None) -> float:
+        return timeout if timeout is not None else self.config.default_timeout
+
+    def _finalize_record(self, job_id: str, record: _LocalJobProcess) -> None:
+        with self._state_lock:
+            if self._processes.get(job_id) is record:
+                self._processes.pop(job_id, None)
+        if record.stderr_reader is not None:
+            record.stderr_reader.close()
+        record.temporary_directory.cleanup()
+
+    def _run_setup_command(
+        self,
+        job_id: str,
+        record: _LocalJobProcess,
+        setup_command: _PreparedJobSetupCommand,
+    ) -> None:
+        with self._state_lock:
+            if self._processes.get(job_id) is not record or record.cancel_requested:
+                raise _LocalJobSubmissionCanceled
+            if time.monotonic() >= record.deadline:
+                record.timed_out = True
+                raise _LocalJobSubmissionTimedOut
+
+            process = _exec_cmd(
+                setup_command.command,
+                cwd=setup_command.cwd,
+                extra_env=setup_command.extra_env,
+                capture_output=False,
+                synchronous=False,
+                start_new_session=True,
+            )
+            record.active_process = process
+
+        # The hard deadline was armed at submission start, so it bounds the total
+        # setup + execution time. Enforce the remaining budget on this setup phase.
+        remaining_timeout = max(record.deadline - time.monotonic(), 0.0)
+        try:
+            returncode = process.wait(timeout=remaining_timeout)
+        except subprocess.TimeoutExpired:
+            with self._state_lock:
+                record.timed_out = True
+                _kill_process(process)
+                if record.active_process is process:
+                    record.active_process = None
+            _reap_process(process)
+            raise _LocalJobSubmissionTimedOut
+
+        with self._state_lock:
+            if record.active_process is process:
+                record.active_process = None
+            is_active = self._processes.get(job_id) is record
+            cancel_requested = record.cancel_requested
+
+        if not is_active or cancel_requested:
+            raise _LocalJobSubmissionCanceled
+        if returncode != 0:
+            raise ShellCommandException.from_completed_process(
+                subprocess.CompletedProcess(process.args, returncode)
+            )
 
     def submit_job(
         self,
@@ -32,13 +247,259 @@ class LocalJobExecutor(AbstractJobExecutor):
         python_env: _PythonEnv | None = None,
         timeout: float | None = None,
     ) -> None:
-        raise NotImplementedError("LocalJobExecutor.submit_job() is not implemented yet.")
+        if context.job_id != job_id:
+            raise MlflowException.invalid_parameter_value(
+                f"Job ID mismatch: context.job_id={context.job_id!r} does not match {job_id!r}"
+            )
+
+        effective_timeout = self._effective_timeout(timeout)
+        record = _LocalJobProcess(
+            active_process=None,
+            temporary_directory=tempfile.TemporaryDirectory(),
+            result_path="",
+            function_fullname=fn_fullname,
+            timeout=effective_timeout,
+            # Arm the hard deadline before any setup work so the timeout covers
+            # environment setup in addition to job execution.
+            deadline=time.monotonic() + effective_timeout,
+        )
+        with self._state_lock:
+            if self._stopped:
+                record.temporary_directory.cleanup()
+                raise MlflowException("LocalJobExecutor is stopped and cannot accept new jobs.")
+            if job_id in self._processes:
+                record.temporary_directory.cleanup()
+                raise MlflowException.invalid_parameter_value(
+                    f"Job {job_id!r} is already being managed by LocalJobExecutor."
+                )
+            self._processes[job_id] = record
+
+        try:
+            function = _load_function(fn_fullname)
+            if not hasattr(function, "_job_fn_metadata"):
+                raise MlflowException.invalid_parameter_value(
+                    f"The job function {fn_fullname} is not decorated by 'mlflow.server.jobs.job'."
+                )
+            transient_error_classes = function._job_fn_metadata.transient_error_classes
+
+            normalized_python_env = _normalize_python_env(python_env)
+            extra_envs = {
+                MLFLOW_TRACKING_URI.name: context.tracking_uri,
+                MLFLOW_GATEWAY_URI.name: context.gateway_uri or context.tracking_uri,
+            }
+
+            with self._state_lock:
+                if self._processes.get(job_id) is not record or record.cancel_requested:
+                    raise _LocalJobSubmissionCanceled
+
+            # _prepare_job_subprocess only reads this record's own temporary
+            # directory and never mutates shared executor state, so it runs
+            # outside _state_lock. Holding the lock across its file I/O (and the
+            # module import already performed above) would serialize other jobs'
+            # submit/cancel behind this job's setup. A cancel that races in is
+            # still honored: _run_setup_command re-checks cancellation under the
+            # lock before launching anything.
+            prepared_subprocess = _prepare_job_subprocess(
+                function_fullname=fn_fullname,
+                params=params,
+                python_env=normalized_python_env,
+                transient_error_classes=transient_error_classes,
+                tmpdir=record.temporary_directory.name,
+                job_id=job_id,
+                job_name=job_name,
+                workspace=context.workspace,
+                extra_envs=extra_envs,
+            )
+            record.result_path = prepared_subprocess.result_path
+
+            for setup_command in prepared_subprocess.setup_commands:
+                self._run_setup_command(job_id, record, setup_command)
+
+            with self._state_lock:
+                if self._processes.get(job_id) is not record or record.cancel_requested:
+                    raise _LocalJobSubmissionCanceled
+                if time.monotonic() >= record.deadline:
+                    record.timed_out = True
+                    raise _LocalJobSubmissionTimedOut
+
+                # Capture the job subprocess stderr so a diagnostic tail can be
+                # surfaced if the subprocess crashes. A background reader drains
+                # the pipe into a bounded buffer, which both avoids deadlocking
+                # process.wait() (an unread PIPE stalls once its buffer fills) and
+                # caps how much stderr the server holds in memory.
+                process = subprocess.Popen(
+                    prepared_subprocess.command,
+                    env=prepared_subprocess.env,
+                    stderr=subprocess.PIPE,
+                    start_new_session=True,
+                )
+                record.stderr_reader = _BoundedStderrReader(process.stderr)
+                record.active_process = process
+                record.job_process_launched = True
+        except _LocalJobSubmissionCanceled:
+            return
+        except _LocalJobSubmissionTimedOut:
+            # The record is intentionally left in place (with timed_out=True) so
+            # wait_for_job can report a TIMEOUT result to the caller.
+            return
+        except Exception:
+            self._finalize_record(job_id, record)
+            raise
 
     def wait_for_job(self, job_id: str) -> JobResult:
-        raise NotImplementedError("LocalJobExecutor.wait_for_job() is not implemented yet.")
+        with self._state_lock:
+            record = self._processes.get(job_id)
+
+        if record is None:
+            raise MlflowException.invalid_parameter_value(
+                f"Unknown job ID for LocalJobExecutor: {job_id!r}"
+            )
+
+        process = record.active_process
+        if process is None:
+            if record.cancel_requested:
+                self._finalize_record(job_id, record)
+                return JobResult(status=JobStatus.CANCELED)
+
+            if record.timed_out:
+                self._finalize_record(job_id, record)
+                return JobResult(
+                    status=JobStatus.TIMEOUT,
+                    error_message=(
+                        f"Local job {job_id!r} ({record.function_fullname}) timed out after "
+                        f"{record.timeout} seconds during environment setup."
+                    ),
+                )
+
+            self._finalize_record(job_id, record)
+            return JobResult(
+                status=JobStatus.FAILED,
+                error_message=(
+                    f"The local subprocess for job {job_id!r} "
+                    f"({record.function_fullname}) was never started."
+                ),
+            )
+
+        remaining_timeout = max(record.deadline - time.monotonic(), 0.0)
+        timed_out = False
+        try:
+            process.wait(timeout=remaining_timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+
+        if timed_out:
+            with self._state_lock:
+                cancel_requested = record.cancel_requested
+                _kill_process(process)
+            status = JobStatus.CANCELED if cancel_requested else JobStatus.TIMEOUT
+            _reap_process(process)
+            self._finalize_record(job_id, record)
+            return JobResult(
+                status=status,
+                error_message=(
+                    None
+                    if cancel_requested
+                    else (
+                        f"Local job {job_id!r} ({record.function_fullname}) "
+                        f"timed out after {record.timeout} seconds."
+                    )
+                ),
+            )
+
+        with self._state_lock:
+            cancel_requested = record.cancel_requested
+
+        if cancel_requested:
+            self._finalize_record(job_id, record)
+            return JobResult(status=JobStatus.CANCELED)
+
+        if process.returncode != 0:
+            # Read the captured stderr before _finalize_record joins the reader.
+            stderr_tail = record.stderr_reader.tail() if record.stderr_reader else ""
+            self._finalize_record(job_id, record)
+            error_message = (
+                "The subprocess that executes job function "
+                f"{record.function_fullname} exited with error code {process.returncode}"
+            )
+            if stderr_tail:
+                error_message += f"\nSubprocess stderr (tail):\n{stderr_tail}"
+            return JobResult(status=JobStatus.FAILED, error_message=error_message)
+
+        try:
+            subprocess_result = _SubprocessJobResult.load(record.result_path)
+        except Exception as exc:
+            stderr_tail = record.stderr_reader.tail() if record.stderr_reader else ""
+            self._finalize_record(job_id, record)
+            error_message = (
+                "Failed to load the local subprocess result for "
+                f"{record.function_fullname}: {exc!r}"
+            )
+            if stderr_tail:
+                error_message += f"\nSubprocess stderr (tail):\n{stderr_tail}"
+            return JobResult(status=JobStatus.FAILED, error_message=error_message)
+
+        self._finalize_record(job_id, record)
+        if subprocess_result.succeeded:
+            return JobResult(status=JobStatus.SUCCEEDED, result=subprocess_result.result)
+
+        return JobResult(
+            status=JobStatus.FAILED,
+            error_message=subprocess_result.error,
+            is_transient_error=bool(subprocess_result.is_transient_error),
+        )
 
     def cancel_job(self, job_id: str) -> None:
-        raise NotImplementedError("LocalJobExecutor.cancel_job() is not implemented yet.")
+        with self._state_lock:
+            record = self._processes.get(job_id)
+            if record is None or record.cancel_requested:
+                return
+
+            record.cancel_requested = True
+            process = record.active_process
+            cancellation_delivered = _kill_process(process)
+            # Only roll back the cancellation when a live job subprocess failed to
+            # receive the signal. During environment setup active_process may be a
+            # transient setup subprocess (or briefly None between setup steps), so
+            # a rolled-back flag there would let submit_job go on to launch the job
+            # after cancel_job returned, leaking a process the caller asked to stop.
+            # Latch cancellation until the job subprocess itself is running.
+            if record.job_process_launched and process is not None and not cancellation_delivered:
+                record.cancel_requested = False
 
     def recover_jobs(self, unfinished_job_ids: list[str]) -> list[JobRecoveryResult]:
-        raise NotImplementedError("LocalJobExecutor.recover_jobs() is not implemented yet.")
+        """Best-effort cleanup for unfinished local jobs.
+
+        LocalJobExecutor cannot reattach to prior subprocesses. Recovery therefore
+        always returns ``action="requeue"`` after killing/reaping any still-tracked
+        local process and removing its in-memory record.
+        """
+        recovery_results = []
+        for job_id in unfinished_job_ids:
+            with self._state_lock:
+                record = self._processes.get(job_id)
+                if record is not None:
+                    record.cancel_requested = True
+                    _kill_process(record.active_process)
+
+            if record is not None:
+                _reap_process(record.active_process)
+                self._finalize_record(job_id, record)
+
+            recovery_results.append(JobRecoveryResult(job_id=job_id, action="requeue"))
+        return recovery_results
+
+    def stop_executor(self) -> None:
+        with self._state_lock:
+            self._stopped = True
+            records = list(self._processes.items())
+            for _, record in records:
+                record.cancel_requested = True
+                _kill_process(record.active_process)
+
+        for job_id, record in records:
+            _reap_process(record.active_process)
+            self._finalize_record(job_id, record)
+
+    def check_requirements(self) -> None:
+        if os.name == "nt":
+            raise MlflowException("MLflow job backend does not support Windows system.")

--- a/mlflow/server/jobs/local_executor.py
+++ b/mlflow/server/jobs/local_executor.py
@@ -1,7 +1,17 @@
 """Built-in local subprocess job executor."""
 
+import os
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
 from typing import Any
 
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_GATEWAY_URI, MLFLOW_TRACKING_URI
+from mlflow.exceptions import MlflowException
 from mlflow.server.jobs.executor import (
     AbstractJobExecutor,
     JobExecutionContext,
@@ -9,7 +19,32 @@ from mlflow.server.jobs.executor import (
     JobRecoveryResult,
     JobResult,
 )
+from mlflow.server.jobs.utils import (
+    JobResult as LegacyJobResult,
+)
+from mlflow.server.jobs.utils import (
+    _load_function,
+    _prepare_job_subprocess,
+    _PreparedJobSetupCommand,
+)
+from mlflow.utils import PYTHON_VERSION
 from mlflow.utils.environment import _PythonEnv
+from mlflow.utils.process import ShellCommandException, _exec_cmd
+
+
+class _LocalJobSubmissionCanceled(Exception):
+    pass
+
+
+@dataclass
+class _LocalJobProcess:
+    process: subprocess.Popen | None
+    temporary_directory: tempfile.TemporaryDirectory
+    result_path: str
+    function_fullname: str
+    timeout: float
+    deadline: float | None
+    cancel_requested: bool = False
 
 
 class LocalJobExecutor(AbstractJobExecutor):
@@ -21,6 +56,81 @@ class LocalJobExecutor(AbstractJobExecutor):
 
     def __init__(self, config: JobExecutorConfig) -> None:
         super().__init__(config)
+        self._processes: dict[str, _LocalJobProcess] = {}
+        self._lock = threading.RLock()
+        self._stopped = False
+
+    def _effective_timeout(self, timeout: float | None) -> float:
+        return timeout if timeout is not None else self.config.default_timeout
+
+    def _normalize_python_env(self, python_env: _PythonEnv | None) -> _PythonEnv | None:
+        if python_env is None:
+            return None
+
+        return _PythonEnv(
+            python=PYTHON_VERSION,
+            build_dependencies=list(python_env.build_dependencies),
+            dependencies=list(python_env.dependencies),
+        )
+
+    def _finalize_record(self, job_id: str, record: _LocalJobProcess) -> None:
+        with self._lock:
+            if self._processes.get(job_id) is record:
+                self._processes.pop(job_id, None)
+        record.temporary_directory.cleanup()
+
+    def _kill_process(self, process: subprocess.Popen | None) -> bool:
+        if process is None or process.returncode is not None:
+            return False
+        try:
+            if os.getpgid(process.pid) == process.pid:
+                os.killpg(process.pid, signal.SIGKILL)
+                return True
+        except ProcessLookupError:
+            return False
+        return False
+
+    def _reap_process(self, process: subprocess.Popen | None) -> None:
+        if process is None:
+            return
+        try:
+            process.wait()
+        except ChildProcessError:
+            pass
+
+    def _run_setup_command(
+        self,
+        job_id: str,
+        record: _LocalJobProcess,
+        setup_command: _PreparedJobSetupCommand,
+    ) -> None:
+        with self._lock:
+            if self._processes.get(job_id) is not record or record.cancel_requested:
+                raise _LocalJobSubmissionCanceled
+
+            process = _exec_cmd(
+                setup_command.command,
+                cwd=setup_command.cwd,
+                extra_env=setup_command.extra_env,
+                capture_output=False,
+                synchronous=False,
+                start_new_session=True,
+            )
+            record.process = process
+
+        returncode = process.wait()
+        with self._lock:
+            if record.process is process:
+                record.process = None
+            is_active = self._processes.get(job_id) is record
+            cancel_requested = record.cancel_requested
+
+        if not is_active or cancel_requested:
+            raise _LocalJobSubmissionCanceled
+        if returncode != 0:
+            raise ShellCommandException.from_completed_process(
+                subprocess.CompletedProcess(process.args, returncode)
+            )
 
     def submit_job(
         self,
@@ -32,13 +142,211 @@ class LocalJobExecutor(AbstractJobExecutor):
         python_env: _PythonEnv | None = None,
         timeout: float | None = None,
     ) -> None:
-        raise NotImplementedError("LocalJobExecutor.submit_job() is not implemented yet.")
+        if context.job_id != job_id:
+            raise MlflowException.invalid_parameter_value(
+                f"Job ID mismatch: context.job_id={context.job_id!r} does not match {job_id!r}"
+            )
+
+        effective_timeout = self._effective_timeout(timeout)
+        record = _LocalJobProcess(
+            process=None,
+            temporary_directory=tempfile.TemporaryDirectory(),
+            result_path="",
+            function_fullname=fn_fullname,
+            timeout=effective_timeout,
+            deadline=None,
+        )
+        with self._lock:
+            if self._stopped:
+                record.temporary_directory.cleanup()
+                raise MlflowException("LocalJobExecutor is stopped and cannot accept new jobs.")
+            if job_id in self._processes:
+                record.temporary_directory.cleanup()
+                raise MlflowException.invalid_parameter_value(
+                    f"Job {job_id!r} is already being managed by LocalJobExecutor."
+                )
+            self._processes[job_id] = record
+
+        try:
+            function = _load_function(fn_fullname)
+            if not hasattr(function, "_job_fn_metadata"):
+                raise MlflowException.invalid_parameter_value(
+                    f"The job function {fn_fullname} is not decorated by 'mlflow.server.jobs.job'."
+                )
+            transient_error_classes = function._job_fn_metadata.transient_error_classes
+
+            normalized_python_env = self._normalize_python_env(python_env)
+            extra_envs = {
+                MLFLOW_TRACKING_URI.name: context.tracking_uri,
+                MLFLOW_GATEWAY_URI.name: context.gateway_uri or context.tracking_uri,
+            }
+
+            with self._lock:
+                if self._processes.get(job_id) is not record or record.cancel_requested:
+                    raise _LocalJobSubmissionCanceled
+
+                prepared_subprocess = _prepare_job_subprocess(
+                    function_fullname=fn_fullname,
+                    params=params,
+                    python_env=normalized_python_env,
+                    transient_error_classes=transient_error_classes,
+                    tmpdir=record.temporary_directory.name,
+                    job_id=job_id,
+                    job_name=job_name,
+                    workspace=context.workspace,
+                    extra_envs=extra_envs,
+                )
+                record.result_path = prepared_subprocess.result_path
+
+            for setup_command in prepared_subprocess.setup_commands:
+                self._run_setup_command(job_id, record, setup_command)
+
+            with self._lock:
+                if self._processes.get(job_id) is not record or record.cancel_requested:
+                    raise _LocalJobSubmissionCanceled
+
+                record.deadline = time.monotonic() + effective_timeout
+                process = subprocess.Popen(
+                    prepared_subprocess.command,
+                    env=prepared_subprocess.env,
+                    start_new_session=True,
+                )
+                record.process = process
+        except _LocalJobSubmissionCanceled:
+            return
+        except Exception:
+            self._finalize_record(job_id, record)
+            raise
 
     def wait_for_job(self, job_id: str) -> JobResult:
-        raise NotImplementedError("LocalJobExecutor.wait_for_job() is not implemented yet.")
+        with self._lock:
+            record = self._processes.get(job_id)
+
+        if record is None:
+            raise MlflowException.invalid_parameter_value(
+                f"Unknown job ID for LocalJobExecutor: {job_id!r}"
+            )
+
+        process = record.process
+        if process is None:
+            if record.cancel_requested:
+                self._finalize_record(job_id, record)
+                return JobResult(status=JobStatus.CANCELED)
+
+            self._finalize_record(job_id, record)
+            return JobResult(
+                status=JobStatus.FAILED,
+                error_message=(
+                    f"The local subprocess for job {job_id!r} "
+                    f"({record.function_fullname}) was never started."
+                ),
+            )
+
+        remaining_timeout = max(record.deadline - time.monotonic(), 0.0)
+        timed_out = False
+        try:
+            process.wait(timeout=remaining_timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+
+        if timed_out:
+            with self._lock:
+                cancel_requested = record.cancel_requested
+                self._kill_process(process)
+            status = JobStatus.CANCELED if cancel_requested else JobStatus.TIMEOUT
+            self._reap_process(process)
+            self._finalize_record(job_id, record)
+            return JobResult(
+                status=status,
+                error_message=(
+                    None
+                    if cancel_requested
+                    else (
+                        f"Local job {job_id!r} ({record.function_fullname}) "
+                        f"timed out after {record.timeout} seconds."
+                    )
+                ),
+            )
+
+        with self._lock:
+            cancel_requested = record.cancel_requested
+
+        if cancel_requested:
+            self._finalize_record(job_id, record)
+            return JobResult(status=JobStatus.CANCELED)
+
+        if process.returncode != 0:
+            self._finalize_record(job_id, record)
+            return JobResult(
+                status=JobStatus.FAILED,
+                error_message=(
+                    "The subprocess that executes job function "
+                    f"{record.function_fullname} exited with error code {process.returncode}"
+                ),
+            )
+
+        try:
+            legacy_result = LegacyJobResult.load(record.result_path)
+        except Exception as exc:
+            self._finalize_record(job_id, record)
+            return JobResult(
+                status=JobStatus.FAILED,
+                error_message=(
+                    "Failed to load the local subprocess result for "
+                    f"{record.function_fullname}: {exc!r}"
+                ),
+            )
+
+        self._finalize_record(job_id, record)
+        if legacy_result.succeeded:
+            return JobResult(status=JobStatus.SUCCEEDED, result=legacy_result.result)
+
+        return JobResult(
+            status=JobStatus.FAILED,
+            error_message=legacy_result.error,
+            is_transient_error=bool(legacy_result.is_transient_error),
+        )
 
     def cancel_job(self, job_id: str) -> None:
-        raise NotImplementedError("LocalJobExecutor.cancel_job() is not implemented yet.")
+        with self._lock:
+            record = self._processes.get(job_id)
+            if record is None or record.cancel_requested:
+                return
+
+            record.cancel_requested = True
+            process = record.process
+            cancellation_delivered = self._kill_process(process)
+            if record.deadline is not None and process is not None and not cancellation_delivered:
+                record.cancel_requested = False
 
     def recover_jobs(self, unfinished_job_ids: list[str]) -> list[JobRecoveryResult]:
-        raise NotImplementedError("LocalJobExecutor.recover_jobs() is not implemented yet.")
+        recovery_results = []
+        for job_id in unfinished_job_ids:
+            with self._lock:
+                record = self._processes.get(job_id)
+                if record is not None:
+                    record.cancel_requested = True
+                    self._kill_process(record.process)
+
+            if record is not None:
+                self._reap_process(record.process)
+                self._finalize_record(job_id, record)
+
+            recovery_results.append(JobRecoveryResult(job_id=job_id, action="requeue"))
+        return recovery_results
+
+    def stop_executor(self) -> None:
+        with self._lock:
+            self._stopped = True
+            records = list(self._processes.items())
+            for _, record in records:
+                record.cancel_requested = True
+                self._kill_process(record.process)
+
+        for job_id, record in records:
+            self._reap_process(record.process)
+            self._finalize_record(job_id, record)
+
+    def check_requirements(self) -> None:
+        if os.name == "nt":
+            raise MlflowException("MLflow job backend does not support Windows system.")

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -176,33 +176,41 @@ _JOB_ENTRY_MODULE = "mlflow.server.jobs._job_subproc_entry"
 _JOB_STATUS_POLL_INTERVAL = 1
 
 
-def _exec_job_in_subproc(
+@dataclass(frozen=True)
+class _PreparedJobSetupCommand:
+    command: list[str]
+    cwd: str | None = None
+    extra_env: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class _PreparedJobSubprocess:
+    command: list[str]
+    env: dict[str, str]
+    result_path: str
+    setup_commands: tuple[_PreparedJobSetupCommand, ...] = ()
+
+
+def _prepare_job_subprocess(
     function_fullname: str,
     params: dict[str, Any],
     python_env: _PythonEnv | None,
     transient_error_classes: list[type[Exception]] | None,
-    timeout: float | None,
     tmpdir: str,
-    job_store: "AbstractJobStore",
     job_id: str,
     job_name: str,
     workspace: str | None,
     extra_envs: dict[str, str] | None = None,
-) -> JobResult | None:
-    """
-    Executes the job function in a subprocess,
-    If the job execution time exceeds timeout, the subprocess is killed and return None,
-    otherwise return `JobResult` instance,
-    """
-    from mlflow.utils.process import _exec_cmd, _join_commands
+) -> _PreparedJobSubprocess:
+    from mlflow.server.jobs._job_env_setup import _get_incomplete_marker_path
+    from mlflow.utils.process import _join_commands
     from mlflow.utils.virtualenv import (
         _get_mlflow_virtualenv_root,
-        _get_uv_env_creation_command,
         _get_virtualenv_activate_cmd,
-        _get_virtualenv_extra_env_vars,
         _get_virtualenv_name,
     )
 
+    setup_commands = []
     if python_env is not None:
         if shutil.which("uv") is None:
             raise MlflowException(
@@ -210,27 +218,30 @@ def _exec_job_in_subproc(
                 "but 'uv' is not installed."
             )
 
-        # set up virtual python environment
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
         env_name = _get_virtualenv_name(python_env, None)
         env_dir = virtual_envs_root_path / env_name
         activate_cmd = _get_virtualenv_activate_cmd(env_dir)
 
-        if not env_dir.exists():
-            _logger.info(f"Creating a python virtual environment in {env_dir}.")
-            # create python environment
-            env_creation_cmd = _get_uv_env_creation_command(env_dir, python_env.python)
-            _exec_cmd(env_creation_cmd, capture_output=False)
-
-            # install dependencies
+        if not env_dir.exists() or _get_incomplete_marker_path(env_dir).exists():
+            _logger.info(f"Creating or repairing a python virtual environment in {env_dir}.")
             tmp_req_file = "requirements.txt"
-            (Path(tmpdir) / tmp_req_file).write_text("\n".join(python_env.dependencies))
-            cmd = _join_commands(activate_cmd, f"uv pip install -r {tmp_req_file}")
-            _exec_cmd(
-                cmd,
-                cwd=tmpdir,
-                extra_env=_get_virtualenv_extra_env_vars(),
-                capture_output=False,
+            requirements_file = Path(tmpdir) / tmp_req_file
+            requirements_file.write_text("\n".join(python_env.dependencies))
+            setup_commands.append(
+                _PreparedJobSetupCommand(
+                    command=[
+                        sys.executable,
+                        "-m",
+                        "mlflow.server.jobs._job_env_setup",
+                        "--env-dir",
+                        str(env_dir),
+                        "--python-version",
+                        python_env.python,
+                        "--requirements-file",
+                        str(requirements_file),
+                    ],
+                )
             )
         else:
             _logger.debug(f"The python environment {env_dir} already exists.")
@@ -258,12 +269,60 @@ def _exec_job_in_subproc(
         **(extra_envs or {}),
     }
 
-    if workspace:
+    if workspace is None:
+        job_env.pop(MLFLOW_WORKSPACE.name, None)
+    else:
         job_env[MLFLOW_WORKSPACE.name] = workspace
 
-    with subprocess.Popen(
-        job_cmd,
+    return _PreparedJobSubprocess(
+        command=job_cmd,
         env=job_env,
+        result_path=result_file,
+        setup_commands=tuple(setup_commands),
+    )
+
+
+def _exec_job_in_subproc(
+    function_fullname: str,
+    params: dict[str, Any],
+    python_env: _PythonEnv | None,
+    transient_error_classes: list[type[Exception]] | None,
+    timeout: float | None,
+    tmpdir: str,
+    job_store: "AbstractJobStore",
+    job_id: str,
+    job_name: str,
+    workspace: str | None,
+    extra_envs: dict[str, str] | None = None,
+) -> JobResult | None:
+    """
+    Executes the job function in a subprocess,
+    If the job execution time exceeds timeout, the subprocess is killed and return None,
+    otherwise return `JobResult` instance,
+    """
+    prepared_subprocess = _prepare_job_subprocess(
+        function_fullname=function_fullname,
+        params=params,
+        python_env=python_env,
+        transient_error_classes=transient_error_classes,
+        tmpdir=tmpdir,
+        job_id=job_id,
+        job_name=job_name,
+        workspace=workspace,
+        extra_envs=extra_envs,
+    )
+
+    for setup_command in prepared_subprocess.setup_commands:
+        _exec_cmd(
+            setup_command.command,
+            cwd=setup_command.cwd,
+            extra_env=setup_command.extra_env,
+            capture_output=False,
+        )
+
+    with subprocess.Popen(
+        prepared_subprocess.command,
+        env=prepared_subprocess.env,
     ) as popen:
         beg_time = time.time()
         while popen.poll() is None:
@@ -282,12 +341,12 @@ def _exec_job_in_subproc(
                     return None
 
         if popen.returncode == 0:
-            return JobResult.load(result_file)
+            return JobResult.load(prepared_subprocess.result_path)
 
         return JobResult.from_error(
             RuntimeError(
                 f"The subprocess that executes job function {function_fullname} "
-                f"exists with error code {popen.returncode}"
+                f"exited with error code {popen.returncode}"
             )
         )
 

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -29,6 +29,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.server.constants import HUEY_STORAGE_PATH_ENV_VAR, MLFLOW_SERVER_UP_TIME
 from mlflow.tracing.trace_archival_service import run_trace_archival_scheduler
+from mlflow.utils import PYTHON_VERSION
 from mlflow.utils.environment import _PythonEnv
 from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.process import _exec_cmd
@@ -71,7 +72,7 @@ def _exponential_backoff_retry(retry_count: int) -> None:
 
 
 @dataclass
-class JobResult:
+class _SubprocessJobResult:
     succeeded: bool
     result: str | None = None  # serialized JSON string
     is_transient_error: bool | None = None
@@ -80,17 +81,19 @@ class JobResult:
     @classmethod
     def from_error(
         cls, e: Exception, transient_error_classes: list[type[Exception]] | None = None
-    ) -> "JobResult":
+    ) -> "_SubprocessJobResult":
         from mlflow.server.jobs import TransientError
 
         if isinstance(e, TransientError):
-            return JobResult(succeeded=False, is_transient_error=True, error=repr(e.origin_error))
+            return _SubprocessJobResult(
+                succeeded=False, is_transient_error=True, error=repr(e.origin_error)
+            )
 
         if transient_error_classes:
             if e.__class__ in transient_error_classes:
-                return JobResult(succeeded=False, is_transient_error=True, error=repr(e))
+                return _SubprocessJobResult(succeeded=False, is_transient_error=True, error=repr(e))
 
-        return JobResult(
+        return _SubprocessJobResult(
             succeeded=False,
             is_transient_error=False,
             error=repr(e),
@@ -101,9 +104,29 @@ class JobResult:
             json.dump(asdict(self), fp)
 
     @classmethod
-    def load(cls, path: str) -> "JobResult":
+    def load(cls, path: str) -> "_SubprocessJobResult":
         with open(path) as fp:
-            return JobResult(**json.load(fp))
+            return _SubprocessJobResult(**json.load(fp))
+
+
+def _kill_own_process_group() -> None:
+    """SIGKILL the caller's process group when the caller leads that group.
+
+    Local-executor job subprocesses are started with ``start_new_session=True``,
+    so each leads its own process group; killing that group tears down any
+    descendants the job spawned. ``killpg`` delivers ``SIGKILL`` to the caller
+    too, so callers that also need to guarantee termination of a non-leader
+    process should still fall back to ``os._exit`` afterwards.
+    """
+    try:
+        pgid = os.getpgid(0)
+    except OSError:
+        return
+    if pgid == os.getpid():
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except OSError:
+            pass
 
 
 def _exit_when_orphaned(poll_interval: float = 1) -> None:
@@ -116,9 +139,59 @@ def _exit_when_orphaned(poll_interval: float = 1) -> None:
         parent_pid = os.getppid()
     while True:
         current_parent_pid = os.getppid()
-        if current_parent_pid == 1 or current_parent_pid != parent_pid:
+        # Detect orphaning by comparing against the original parent pid rather than
+        # testing ``current_parent_pid == 1``: when the original parent legitimately
+        # runs as PID 1 (e.g. the MLflow server as a container's init process) a
+        # healthy child also observes ``getppid() == 1``, and treating that as
+        # orphaned would kill a running job's whole process group.
+        if current_parent_pid != parent_pid:
+            # Kill the whole process group so descendants spawned by an orphaned
+            # job do not outlive it. For non-leaders this is a no-op and os._exit
+            # still terminates this process.
+            _kill_own_process_group()
             os._exit(1)
         time.sleep(poll_interval)
+
+
+def _normalize_python_env(python_env: _PythonEnv | None) -> _PythonEnv | None:
+    """Pin the interpreter to the server's Python version, preserving deps.
+
+    Returns a copy so callers never mutate the caller-supplied ``_PythonEnv``.
+    """
+    if python_env is None:
+        return None
+
+    return _PythonEnv(
+        python=PYTHON_VERSION,
+        build_dependencies=list(python_env.build_dependencies),
+        dependencies=list(python_env.dependencies),
+    )
+
+
+def _kill_process(process: subprocess.Popen | None) -> bool:
+    """SIGKILL the process group led by ``process``.
+
+    Returns True only when a signal was delivered to a still-running group leader.
+    """
+    if process is None or process.returncode is not None:
+        return False
+    try:
+        if os.getpgid(process.pid) == process.pid:
+            os.killpg(process.pid, signal.SIGKILL)
+            return True
+    except ProcessLookupError:
+        return False
+    return False
+
+
+def _reap_process(process: subprocess.Popen | None) -> None:
+    """Wait on ``process`` to release its zombie entry, ignoring double-reap."""
+    if process is None:
+        return
+    try:
+        process.wait()
+    except ChildProcessError:
+        pass
 
 
 def is_process_alive(pid: int) -> bool:
@@ -173,36 +246,47 @@ def _start_huey_consumer_proc(
 _JOB_ENTRY_MODULE = "mlflow.server.jobs._job_subproc_entry"
 
 
+_JOB_ENV_SETUP_MODULE = "mlflow.server.jobs._job_env_setup"
+
+
 _JOB_STATUS_POLL_INTERVAL = 1
 
 
-def _exec_job_in_subproc(
+@dataclass(frozen=True)
+class _PreparedJobSetupCommand:
+    command: list[str]
+    cwd: str | None = None
+    extra_env: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class _PreparedJobSubprocess:
+    command: list[str]
+    env: dict[str, str]
+    result_path: str
+    setup_commands: tuple[_PreparedJobSetupCommand, ...] = ()
+
+
+def _prepare_job_subprocess(
     function_fullname: str,
     params: dict[str, Any],
     python_env: _PythonEnv | None,
     transient_error_classes: list[type[Exception]] | None,
-    timeout: float | None,
     tmpdir: str,
-    job_store: "AbstractJobStore",
     job_id: str,
     job_name: str,
     workspace: str | None,
     extra_envs: dict[str, str] | None = None,
-) -> JobResult | None:
-    """
-    Executes the job function in a subprocess,
-    If the job execution time exceeds timeout, the subprocess is killed and return None,
-    otherwise return `JobResult` instance,
-    """
-    from mlflow.utils.process import _exec_cmd, _join_commands
+) -> _PreparedJobSubprocess:
+    from mlflow.server.jobs._job_env_setup import _get_incomplete_marker_path
+    from mlflow.utils.process import _join_commands
     from mlflow.utils.virtualenv import (
         _get_mlflow_virtualenv_root,
-        _get_uv_env_creation_command,
         _get_virtualenv_activate_cmd,
-        _get_virtualenv_extra_env_vars,
         _get_virtualenv_name,
     )
 
+    setup_commands = []
     if python_env is not None:
         if shutil.which("uv") is None:
             raise MlflowException(
@@ -210,27 +294,40 @@ def _exec_job_in_subproc(
                 "but 'uv' is not installed."
             )
 
-        # set up virtual python environment
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
         env_name = _get_virtualenv_name(python_env, None)
         env_dir = virtual_envs_root_path / env_name
         activate_cmd = _get_virtualenv_activate_cmd(env_dir)
 
-        if not env_dir.exists():
-            _logger.info(f"Creating a python virtual environment in {env_dir}.")
-            # create python environment
-            env_creation_cmd = _get_uv_env_creation_command(env_dir, python_env.python)
-            _exec_cmd(env_creation_cmd, capture_output=False)
-
-            # install dependencies
-            tmp_req_file = "requirements.txt"
-            (Path(tmpdir) / tmp_req_file).write_text("\n".join(python_env.dependencies))
-            cmd = _join_commands(activate_cmd, f"uv pip install -r {tmp_req_file}")
-            _exec_cmd(
-                cmd,
-                cwd=tmpdir,
-                extra_env=_get_virtualenv_extra_env_vars(),
-                capture_output=False,
+        if not env_dir.exists() or _get_incomplete_marker_path(env_dir).exists():
+            _logger.info(f"Creating or repairing a python virtual environment in {env_dir}.")
+            requirements_file = Path(tmpdir) / "requirements.txt"
+            requirements_file.write_text("\n".join(python_env.dependencies))
+            setup_command = [
+                sys.executable,
+                "-m",
+                _JOB_ENV_SETUP_MODULE,
+                "--env-dir",
+                str(env_dir),
+                "--python-version",
+                python_env.python,
+                "--requirements-file",
+                str(requirements_file),
+            ]
+            # Install build dependencies (e.g. pinned pip/setuptools/wheel)
+            # before the regular dependencies, mirroring the canonical MLflow
+            # environment-restore ordering.
+            if python_env.build_dependencies:
+                build_requirements_file = Path(tmpdir) / "build-requirements.txt"
+                build_requirements_file.write_text("\n".join(python_env.build_dependencies))
+                setup_command += ["--build-requirements-file", str(build_requirements_file)]
+            # Record the original parent pid so the setup subprocess can exit (and
+            # release its environment lock) if the server dies and it is reparented.
+            setup_commands.append(
+                _PreparedJobSetupCommand(
+                    command=setup_command,
+                    extra_env={MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: str(os.getpid())},
+                )
             )
         else:
             _logger.debug(f"The python environment {env_dir} already exists.")
@@ -258,12 +355,60 @@ def _exec_job_in_subproc(
         **(extra_envs or {}),
     }
 
-    if workspace:
+    if workspace is None:
+        job_env.pop(MLFLOW_WORKSPACE.name, None)
+    else:
         job_env[MLFLOW_WORKSPACE.name] = workspace
 
-    with subprocess.Popen(
-        job_cmd,
+    return _PreparedJobSubprocess(
+        command=job_cmd,
         env=job_env,
+        result_path=result_file,
+        setup_commands=tuple(setup_commands),
+    )
+
+
+def _exec_job_in_subproc(
+    function_fullname: str,
+    params: dict[str, Any],
+    python_env: _PythonEnv | None,
+    transient_error_classes: list[type[Exception]] | None,
+    timeout: float | None,
+    tmpdir: str,
+    job_store: "AbstractJobStore",
+    job_id: str,
+    job_name: str,
+    workspace: str | None,
+    extra_envs: dict[str, str] | None = None,
+) -> _SubprocessJobResult | None:
+    """
+    Executes the job function in a subprocess,
+    If the job execution time exceeds timeout, the subprocess is killed and return None,
+    otherwise return `_SubprocessJobResult` instance,
+    """
+    prepared_subprocess = _prepare_job_subprocess(
+        function_fullname=function_fullname,
+        params=params,
+        python_env=python_env,
+        transient_error_classes=transient_error_classes,
+        tmpdir=tmpdir,
+        job_id=job_id,
+        job_name=job_name,
+        workspace=workspace,
+        extra_envs=extra_envs,
+    )
+
+    for setup_command in prepared_subprocess.setup_commands:
+        _exec_cmd(
+            setup_command.command,
+            cwd=setup_command.cwd,
+            extra_env=setup_command.extra_env,
+            capture_output=False,
+        )
+
+    with subprocess.Popen(
+        prepared_subprocess.command,
+        env=prepared_subprocess.env,
     ) as popen:
         beg_time = time.time()
         while popen.poll() is None:
@@ -282,12 +427,12 @@ def _exec_job_in_subproc(
                     return None
 
         if popen.returncode == 0:
-            return JobResult.load(result_file)
+            return _SubprocessJobResult.load(prepared_subprocess.result_path)
 
-        return JobResult.from_error(
+        return _SubprocessJobResult.from_error(
             RuntimeError(
                 f"The subprocess that executes job function {function_fullname} "
-                f"exists with error code {popen.returncode}"
+                f"exited with error code {popen.returncode}"
             )
         )
 

--- a/tests/server/jobs/test_executor_registry.py
+++ b/tests/server/jobs/test_executor_registry.py
@@ -243,6 +243,10 @@ def test_get_executor_registry_lazy_init(monkeypatch):
     mod._global_registry = None
     monkeypatch.setenv("MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND", "local")
     monkeypatch.delenv("MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", raising=False)
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor.LocalJobExecutor.check_requirements",
+        lambda self: None,
+    )
 
     with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[]):
         registry = get_executor_registry()
@@ -268,6 +272,10 @@ def test_shutdown_executor_registry_is_idempotent():
 def test_validate_executor_config_succeeds(monkeypatch):
     monkeypatch.setenv("MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND", "local")
     monkeypatch.delenv("MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", raising=False)
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor.LocalJobExecutor.check_requirements",
+        lambda self: None,
+    )
 
     with mock.patch("mlflow.server.jobs.executor_registry.get_entry_points", return_value=[]):
         validate_executor_config()

--- a/tests/server/jobs/test_job_env_setup.py
+++ b/tests/server/jobs/test_job_env_setup.py
@@ -1,0 +1,130 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from mlflow.server.jobs._job_env_setup import (
+    _get_incomplete_marker_path,
+    _setup_job_environment,
+)
+from mlflow.server.jobs.utils import _prepare_job_subprocess
+from mlflow.utils.environment import _PythonEnv
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="MLflow job environment setup is not supported on Windows",
+)
+
+
+def test_setup_job_environment_replaces_incomplete_environment(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_dir = tmp_path / "env"
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    env_dir.mkdir()
+    (env_dir / "stale").touch()
+    incomplete_marker.touch()
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+    call_count = 0
+
+    def _exec_cmd(command, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        assert not (env_dir / "stale").exists()
+        assert incomplete_marker.exists()
+        if call_count == 1:
+            (env_dir / "bin").mkdir(parents=True)
+            (env_dir / "bin" / "activate").touch()
+        else:
+            (env_dir / "installed").touch()
+
+    monkeypatch.setattr("mlflow.server.jobs._job_env_setup._exec_cmd", _exec_cmd)
+
+    _setup_job_environment(env_dir, "3.11", requirements_file)
+
+    assert call_count == 2
+    assert (env_dir / "installed").exists()
+    assert not incomplete_marker.exists()
+
+
+def test_setup_job_environment_removes_partial_environment_after_failure(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_dir = tmp_path / "env"
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+    call_count = 0
+
+    def _exec_cmd(command, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            (env_dir / "bin").mkdir(parents=True)
+            (env_dir / "bin" / "activate").touch()
+        else:
+            raise RuntimeError("installation failed")
+
+    monkeypatch.setattr("mlflow.server.jobs._job_env_setup._exec_cmd", _exec_cmd)
+
+    with pytest.raises(RuntimeError, match="installation failed"):
+        _setup_job_environment(env_dir, "3.11", requirements_file)
+
+    assert not env_dir.exists()
+    assert not incomplete_marker.exists()
+
+
+def test_prepare_job_subprocess_retries_environment_marked_incomplete(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_root = tmp_path / "envs"
+    env_dir = env_root / "test-env"
+    env_dir.mkdir(parents=True)
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    incomplete_marker.touch()
+    monkeypatch.setattr("mlflow.server.jobs.utils.shutil.which", lambda command: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "mlflow.utils.virtualenv._get_mlflow_virtualenv_root",
+        lambda: str(env_root),
+    )
+    monkeypatch.setattr(
+        "mlflow.utils.virtualenv._get_virtualenv_name",
+        lambda python_env, work_dir_path: env_dir.name,
+    )
+    python_env = _PythonEnv(
+        python="3.11",
+        build_dependencies=[],
+        dependencies=["pytest<9"],
+    )
+
+    incomplete = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+        params={"x": 1, "y": 2},
+        python_env=python_env,
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-1",
+        job_name="basic_job_fun",
+        workspace=None,
+    )
+
+    assert len(incomplete.setup_commands) == 1
+    assert "mlflow.server.jobs._job_env_setup" in incomplete.setup_commands[0].command
+
+    incomplete_marker.unlink()
+    complete = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+        params={"x": 1, "y": 2},
+        python_env=python_env,
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-2",
+        job_name="basic_job_fun",
+        workspace=None,
+    )
+
+    assert complete.setup_commands == ()

--- a/tests/server/jobs/test_job_env_setup.py
+++ b/tests/server/jobs/test_job_env_setup.py
@@ -1,0 +1,162 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from mlflow.server.jobs._job_env_setup import (
+    _get_incomplete_marker_path,
+    _setup_job_environment,
+)
+from mlflow.server.jobs.utils import _prepare_job_subprocess
+from mlflow.utils.environment import _PythonEnv
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="MLflow job environment setup is not supported on Windows",
+)
+
+
+def test_setup_job_environment_replaces_incomplete_environment(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_dir = tmp_path / "env"
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    env_dir.mkdir()
+    (env_dir / "stale").touch()
+    incomplete_marker.touch()
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+    call_count = 0
+
+    def _exec_cmd(command, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        assert not (env_dir / "stale").exists()
+        assert incomplete_marker.exists()
+        if call_count == 1:
+            (env_dir / "bin").mkdir(parents=True)
+            (env_dir / "bin" / "activate").touch()
+        else:
+            (env_dir / "installed").touch()
+
+    monkeypatch.setattr("mlflow.server.jobs._job_env_setup._exec_cmd", _exec_cmd)
+
+    _setup_job_environment(env_dir, "3.11", requirements_file)
+
+    assert call_count == 2
+    assert (env_dir / "installed").exists()
+    assert not incomplete_marker.exists()
+
+
+def test_setup_job_environment_removes_partial_environment_after_failure(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_dir = tmp_path / "env"
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+    call_count = 0
+
+    def _exec_cmd(command, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            (env_dir / "bin").mkdir(parents=True)
+            (env_dir / "bin" / "activate").touch()
+        else:
+            raise RuntimeError("installation failed")
+
+    monkeypatch.setattr("mlflow.server.jobs._job_env_setup._exec_cmd", _exec_cmd)
+
+    with pytest.raises(RuntimeError, match="installation failed"):
+        _setup_job_environment(env_dir, "3.11", requirements_file)
+
+    assert not env_dir.exists()
+    assert not incomplete_marker.exists()
+
+
+def test_setup_job_environment_removes_partial_environment_when_requirements_fail_after_build_deps(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_dir = tmp_path / "env"
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+    build_requirements_file = tmp_path / "build-requirements.txt"
+    build_requirements_file.write_text("pip==24.0")
+    call_count = 0
+
+    def _exec_cmd(command, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            (env_dir / "bin").mkdir(parents=True)
+            (env_dir / "bin" / "activate").touch()
+        elif call_count == 3:
+            # Build deps (call 2) succeed; the regular deps install fails.
+            raise RuntimeError("installation failed")
+
+    monkeypatch.setattr("mlflow.server.jobs._job_env_setup._exec_cmd", _exec_cmd)
+
+    with pytest.raises(RuntimeError, match="installation failed"):
+        _setup_job_environment(env_dir, "3.11", requirements_file, build_requirements_file)
+
+    assert call_count == 3
+    assert not env_dir.exists()
+    assert not incomplete_marker.exists()
+
+
+def test_prepare_job_subprocess_retries_environment_marked_incomplete(
+    monkeypatch,
+    tmp_path: Path,
+):
+    env_root = tmp_path / "envs"
+    env_dir = env_root / "test-env"
+    env_dir.mkdir(parents=True)
+    incomplete_marker = _get_incomplete_marker_path(env_dir)
+    incomplete_marker.touch()
+    monkeypatch.setattr("mlflow.server.jobs.utils.shutil.which", lambda command: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "mlflow.utils.virtualenv._get_mlflow_virtualenv_root",
+        lambda: str(env_root),
+    )
+    monkeypatch.setattr(
+        "mlflow.utils.virtualenv._get_virtualenv_name",
+        lambda python_env, work_dir_path: env_dir.name,
+    )
+    python_env = _PythonEnv(
+        python="3.11",
+        build_dependencies=[],
+        dependencies=["pytest<9"],
+    )
+
+    incomplete = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+        params={"x": 1, "y": 2},
+        python_env=python_env,
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-1",
+        job_name="basic_job_fun",
+        workspace=None,
+    )
+
+    assert len(incomplete.setup_commands) == 1
+    assert "mlflow.server.jobs._job_env_setup" in incomplete.setup_commands[0].command
+
+    incomplete_marker.unlink()
+    complete = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+        params={"x": 1, "y": 2},
+        python_env=python_env,
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-2",
+        job_name="basic_job_fun",
+        workspace=None,
+    )
+
+    assert complete.setup_commands == ()

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -11,7 +11,7 @@ import pytest
 import mlflow.store.jobs.sqlalchemy_store
 from mlflow.entities._job import Job, JobProgress, JobScopedPermission
 from mlflow.entities._job_status import JobStatus
-from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_WORKSPACE
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_ENV_ROOT, MLFLOW_WORKSPACE
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.server.handlers import _get_job_store
@@ -34,6 +34,9 @@ from mlflow.server.jobs.utils import (
     _exec_job,
     _exec_job_in_subproc,
     _exit_when_orphaned,
+    _prepare_job_subprocess,
+    _PreparedJobSetupCommand,
+    _PreparedJobSubprocess,
     _start_huey_consumer_proc,
 )
 from mlflow.store.jobs.abstract_store import JobTerminalStateUpdateException, JobUpdateStatus
@@ -1092,6 +1095,7 @@ def check_python_env_fn():
 
 def test_job_with_python_env(monkeypatch, tmp_path):
     monkeypatch.setenv("MLFLOW_HOME", _get_mlflow_repo_home())
+    monkeypatch.setenv(MLFLOW_ENV_ROOT.name, str(tmp_path / "envs"))
 
     with _setup_job_runner(
         monkeypatch,
@@ -1813,6 +1817,75 @@ def test_exec_job_in_subproc_passes_original_parent_pid(tmp_path: Path):
     assert job_result.succeeded is True
     assert job_result.result == "3"
     assert popen.call_args.kwargs["env"][MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR] == "654"
+
+
+def test_exec_job_in_subproc_runs_prepared_setup_commands(tmp_path: Path):
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        json.dumps({"succeeded": True, "result": "3", "is_transient_error": None, "error": None})
+    )
+    setup_command = _PreparedJobSetupCommand(
+        command=["uv", "venv", "/tmp/job-env"],
+        cwd=str(tmp_path),
+        extra_env={"UV_TEST": "true"},
+    )
+    prepared_subprocess = _PreparedJobSubprocess(
+        command=["python", "-m", "mlflow.server.jobs._job_subproc_entry"],
+        env={},
+        result_path=str(result_path),
+        setup_commands=(setup_command,),
+    )
+    mock_popen = mock.MagicMock()
+    mock_popen.__enter__.return_value = mock_popen
+    mock_popen.__exit__.return_value = False
+    mock_popen.poll.return_value = 0
+    mock_popen.returncode = 0
+
+    with (
+        mock.patch(
+            "mlflow.server.jobs.utils._prepare_job_subprocess",
+            return_value=prepared_subprocess,
+        ),
+        mock.patch("mlflow.server.jobs.utils._exec_cmd") as exec_cmd,
+        mock.patch("mlflow.server.jobs.utils.subprocess.Popen", return_value=mock_popen),
+    ):
+        result = _exec_job_in_subproc(
+            function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+            params={"x": 1, "y": 2},
+            python_env=None,
+            transient_error_classes=None,
+            timeout=None,
+            tmpdir=str(tmp_path),
+            job_store=mock.Mock(),
+            job_id="job-1",
+            job_name="basic_job_fun",
+            workspace=None,
+        )
+
+    assert result.succeeded is True
+    exec_cmd.assert_called_once_with(
+        setup_command.command,
+        cwd=setup_command.cwd,
+        extra_env=setup_command.extra_env,
+        capture_output=False,
+    )
+
+
+def test_prepare_job_subprocess_clears_inherited_workspace(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(MLFLOW_WORKSPACE.name, "inherited-workspace")
+
+    prepared_subprocess = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+        params={"x": 1, "y": 2},
+        python_env=None,
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-1",
+        job_name="basic_job_fun",
+        workspace=None,
+    )
+
+    assert MLFLOW_WORKSPACE.name not in prepared_subprocess.env
 
 
 def test_subproc_entry_telemetry(tmp_path, monkeypatch):

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -11,7 +11,7 @@ import pytest
 import mlflow.store.jobs.sqlalchemy_store
 from mlflow.entities._job import Job, JobProgress, JobScopedPermission
 from mlflow.entities._job_status import JobStatus
-from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_WORKSPACE
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_ENV_ROOT, MLFLOW_WORKSPACE
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.server.handlers import _get_job_store
@@ -34,6 +34,9 @@ from mlflow.server.jobs.utils import (
     _exec_job,
     _exec_job_in_subproc,
     _exit_when_orphaned,
+    _prepare_job_subprocess,
+    _PreparedJobSetupCommand,
+    _PreparedJobSubprocess,
     _start_huey_consumer_proc,
 )
 from mlflow.store.jobs.abstract_store import JobTerminalStateUpdateException, JobUpdateStatus
@@ -1092,6 +1095,7 @@ def check_python_env_fn():
 
 def test_job_with_python_env(monkeypatch, tmp_path):
     monkeypatch.setenv("MLFLOW_HOME", _get_mlflow_repo_home())
+    monkeypatch.setenv(MLFLOW_ENV_ROOT.name, str(tmp_path / "envs"))
 
     with _setup_job_runner(
         monkeypatch,
@@ -1728,6 +1732,8 @@ def test_exit_when_orphaned_exits_when_parent_pid_changes():
         ),
         mock.patch("mlflow.server.jobs.utils.os.getppid", side_effect=[123, 123, 456]),
         mock.patch("mlflow.server.jobs.utils.time.sleep"),
+        # Neutralize the process-group kill so it cannot signal the test runner.
+        mock.patch("mlflow.server.jobs.utils.os.killpg"),
         mock.patch("mlflow.server.jobs.utils.os._exit", side_effect=SystemExit(1)) as mock_exit,
         pytest.raises(SystemExit, match="1"),
     ):
@@ -1744,12 +1750,39 @@ def test_exit_when_orphaned_exits_when_already_orphaned():
             clear=False,
         ),
         mock.patch("mlflow.server.jobs.utils.os.getppid", return_value=1),
+        # Neutralize the process-group kill so it cannot signal the test runner.
+        mock.patch("mlflow.server.jobs.utils.os.killpg"),
         mock.patch("mlflow.server.jobs.utils.os._exit", side_effect=SystemExit(1)) as mock_exit,
         pytest.raises(SystemExit, match="1"),
     ):
         _exit_when_orphaned(poll_interval=0)
 
     mock_exit.assert_called_once_with(1)
+
+
+def test_exit_when_orphaned_does_not_exit_when_server_runs_as_pid_one():
+    # When the original parent legitimately runs as PID 1 (e.g. the MLflow server
+    # as a container's init process), a healthy child also observes getppid()==1,
+    # so the watcher must not treat that as orphaning and kill the process group.
+    class _StopLoop(Exception):
+        pass
+
+    with (
+        mock.patch.dict(
+            "mlflow.server.jobs.utils.os.environ",
+            {MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: "1"},
+            clear=False,
+        ),
+        mock.patch("mlflow.server.jobs.utils.os.getppid", return_value=1),
+        mock.patch("mlflow.server.jobs.utils.time.sleep", side_effect=_StopLoop("stop loop")),
+        mock.patch("mlflow.server.jobs.utils.os.killpg") as mock_killpg,
+        mock.patch("mlflow.server.jobs.utils.os._exit") as mock_exit,
+        pytest.raises(_StopLoop, match="stop loop"),
+    ):
+        _exit_when_orphaned(poll_interval=0)
+
+    mock_exit.assert_not_called()
+    mock_killpg.assert_not_called()
 
 
 def test_exit_when_orphaned_ignores_invalid_parent_pid_env():
@@ -1761,6 +1794,8 @@ def test_exit_when_orphaned_ignores_invalid_parent_pid_env():
         ),
         mock.patch("mlflow.server.jobs.utils.os.getppid", side_effect=[123, 123, 456]),
         mock.patch("mlflow.server.jobs.utils.time.sleep"),
+        # Neutralize the process-group kill so it cannot signal the test runner.
+        mock.patch("mlflow.server.jobs.utils.os.killpg"),
         mock.patch("mlflow.server.jobs.utils.os._exit", side_effect=SystemExit(1)) as mock_exit,
         pytest.raises(SystemExit, match="1"),
     ):
@@ -1813,6 +1848,75 @@ def test_exec_job_in_subproc_passes_original_parent_pid(tmp_path: Path):
     assert job_result.succeeded is True
     assert job_result.result == "3"
     assert popen.call_args.kwargs["env"][MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR] == "654"
+
+
+def test_exec_job_in_subproc_runs_prepared_setup_commands(tmp_path: Path):
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        json.dumps({"succeeded": True, "result": "3", "is_transient_error": None, "error": None})
+    )
+    setup_command = _PreparedJobSetupCommand(
+        command=["uv", "venv", "/tmp/job-env"],
+        cwd=str(tmp_path),
+        extra_env={"UV_TEST": "true"},
+    )
+    prepared_subprocess = _PreparedJobSubprocess(
+        command=["python", "-m", "mlflow.server.jobs._job_subproc_entry"],
+        env={},
+        result_path=str(result_path),
+        setup_commands=(setup_command,),
+    )
+    mock_popen = mock.MagicMock()
+    mock_popen.__enter__.return_value = mock_popen
+    mock_popen.__exit__.return_value = False
+    mock_popen.poll.return_value = 0
+    mock_popen.returncode = 0
+
+    with (
+        mock.patch(
+            "mlflow.server.jobs.utils._prepare_job_subprocess",
+            return_value=prepared_subprocess,
+        ),
+        mock.patch("mlflow.server.jobs.utils._exec_cmd") as exec_cmd,
+        mock.patch("mlflow.server.jobs.utils.subprocess.Popen", return_value=mock_popen),
+    ):
+        result = _exec_job_in_subproc(
+            function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+            params={"x": 1, "y": 2},
+            python_env=None,
+            transient_error_classes=None,
+            timeout=None,
+            tmpdir=str(tmp_path),
+            job_store=mock.Mock(),
+            job_id="job-1",
+            job_name="basic_job_fun",
+            workspace=None,
+        )
+
+    assert result.succeeded is True
+    exec_cmd.assert_called_once_with(
+        setup_command.command,
+        cwd=setup_command.cwd,
+        extra_env=setup_command.extra_env,
+        capture_output=False,
+    )
+
+
+def test_prepare_job_subprocess_clears_inherited_workspace(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv(MLFLOW_WORKSPACE.name, "inherited-workspace")
+
+    prepared_subprocess = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_jobs.basic_job_fun",
+        params={"x": 1, "y": 2},
+        python_env=None,
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-1",
+        job_name="basic_job_fun",
+        workspace=None,
+    )
+
+    assert MLFLOW_WORKSPACE.name not in prepared_subprocess.env
 
 
 def test_subproc_entry_telemetry(tmp_path, monkeypatch):

--- a/tests/server/jobs/test_local_executor.py
+++ b/tests/server/jobs/test_local_executor.py
@@ -1,0 +1,736 @@
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_GATEWAY_URI, MLFLOW_TRACKING_URI, MLFLOW_WORKSPACE
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs import job
+from mlflow.server.jobs.executor import JobExecutionContext, JobExecutorConfig
+from mlflow.server.jobs.local_executor import LocalJobExecutor
+from mlflow.server.jobs.utils import (
+    MLFLOW_SERVER_JOB_ID_ENV_VAR,
+    MLFLOW_SERVER_JOB_NAME_ENV_VAR,
+    _PreparedJobSetupCommand,
+    _PreparedJobSubprocess,
+)
+from mlflow.utils import PYTHON_VERSION
+from mlflow.utils.environment import _PythonEnv
+
+from tests.server.jobs.helpers import wait_for_process_exit
+
+pytestmark = [
+    pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
+]
+
+
+class LocalExecutorTransientError(RuntimeError):
+    pass
+
+
+@job(name="local_executor_add", max_workers=1)
+def local_executor_add(x, y):
+    return x + y
+
+
+@job(name="local_executor_runtime_error", max_workers=1)
+def local_executor_runtime_error():
+    raise RuntimeError("boom")
+
+
+@job(
+    name="local_executor_transient_error",
+    max_workers=1,
+    transient_error_classes=[LocalExecutorTransientError],
+)
+def local_executor_transient_error():
+    raise LocalExecutorTransientError("retry me")
+
+
+@job(name="local_executor_sleep", max_workers=1)
+def local_executor_sleep(sleep_secs, pid_path):
+    Path(pid_path).write_text(str(os.getpid()))
+    time.sleep(sleep_secs)
+
+
+@job(name="local_executor_spawn_child", max_workers=1)
+def local_executor_spawn_child(sleep_secs, parent_pid_path, child_pid_path):
+    subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import os, sys, time; "
+            "from pathlib import Path; "
+            "Path(sys.argv[1]).write_text(str(os.getpid())); "
+            "time.sleep(float(sys.argv[2]))"
+        ),
+        child_pid_path,
+        str(sleep_secs),
+    ])
+    Path(parent_pid_path).write_text(str(os.getpid()))
+    time.sleep(sleep_secs)
+
+
+@job(name="local_executor_spawn_child_and_return", max_workers=1)
+def local_executor_spawn_child_and_return(sleep_secs, child_pid_path):
+    subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import os, sys, time; "
+            "from pathlib import Path; "
+            "Path(sys.argv[1]).write_text(str(os.getpid())); "
+            "time.sleep(float(sys.argv[2]))"
+        ),
+        child_pid_path,
+        str(sleep_secs),
+    ])
+
+
+@job(name="local_executor_context", max_workers=1)
+def local_executor_context():
+    return {
+        "tracking_uri": os.environ.get(MLFLOW_TRACKING_URI.name),
+        "gateway_uri": os.environ.get(MLFLOW_GATEWAY_URI.name),
+        "workspace": os.environ.get(MLFLOW_WORKSPACE.name),
+        "job_id": os.environ.get(MLFLOW_SERVER_JOB_ID_ENV_VAR),
+        "job_name": os.environ.get(MLFLOW_SERVER_JOB_NAME_ENV_VAR),
+    }
+
+
+@job(name="local_executor_os_exit", max_workers=1)
+def local_executor_os_exit(exit_code):
+    os._exit(exit_code)
+
+
+def local_executor_undecorated():
+    return None
+
+
+def _make_context(
+    job_id: str,
+    tracking_uri: str = "http://tracking.test",
+    gateway_uri: str | None = None,
+    workspace: str | None = None,
+) -> JobExecutionContext:
+    return JobExecutionContext(
+        job_id=job_id,
+        tracking_uri=tracking_uri,
+        gateway_uri=gateway_uri,
+        workspace=workspace,
+    )
+
+
+def _wait_for_file(path: Path, timeout: float = 5) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.05)
+    pytest.fail(f"{path} was not created within {timeout}s")
+
+
+@pytest.fixture
+def executor():
+    local_executor = LocalJobExecutor(JobExecutorConfig(default_timeout=60.0))
+    try:
+        yield local_executor
+    finally:
+        local_executor.stop_executor()
+
+
+def test_local_executor_submit_and_wait_succeeds(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.SUCCEEDED
+    assert result.result == "3"
+    assert result.error_message is None
+    assert executor._processes == {}
+
+
+def test_local_executor_job_exception_returns_failed(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_runtime_error",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_runtime_error",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "RuntimeError('boom')" in result.error_message
+    assert result.is_transient_error is False
+
+
+def test_local_executor_declared_transient_error_sets_flag(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_transient_error",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_transient_error",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "LocalExecutorTransientError('retry me')" in result.error_message
+    assert result.is_transient_error is True
+
+
+def test_local_executor_nonzero_exit_returns_infrastructure_failure(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_os_exit",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_os_exit",
+        params={"exit_code": 7},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "error code 7" in result.error_message
+
+
+def test_local_executor_result_protocol_failure_returns_failed(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=context,
+    )
+    with mock.patch(
+        "mlflow.server.jobs.local_executor.LegacyJobResult.load",
+        side_effect=ValueError("bad result"),
+    ):
+        result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "Failed to load the local subprocess result" in result.error_message
+
+
+def test_local_executor_timeout_kills_and_reaps_child(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "timeout.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+        timeout=0.2,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(pid)
+    assert result.status == JobStatus.TIMEOUT
+    assert job_id in result.error_message
+    assert "timed out after 0.2 seconds" in result.error_message
+    assert executor._processes == {}
+
+
+@pytest.mark.parametrize(
+    ("termination", "expected_status"),
+    [("cancel", JobStatus.CANCELED), ("timeout", JobStatus.TIMEOUT)],
+)
+def test_local_executor_termination_kills_descendant_processes(
+    executor,
+    tmp_path: Path,
+    termination: str,
+    expected_status: str,
+):
+    job_id = str(uuid4())
+    parent_pid_path = tmp_path / f"{termination}-parent.pid"
+    child_pid_path = tmp_path / f"{termination}-child.pid"
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_spawn_child",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_spawn_child",
+        params={
+            "sleep_secs": 10,
+            "parent_pid_path": str(parent_pid_path),
+            "child_pid_path": str(child_pid_path),
+        },
+        context=_make_context(job_id),
+        timeout=0.5 if termination == "timeout" else None,
+    )
+    _wait_for_file(parent_pid_path)
+    _wait_for_file(child_pid_path)
+    parent_pid = int(parent_pid_path.read_text())
+    child_pid = int(child_pid_path.read_text())
+
+    if termination == "cancel":
+        executor.cancel_job(job_id)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(parent_pid)
+    wait_for_process_exit(child_pid)
+    assert result.status == expected_status
+
+
+def test_local_executor_cancel_kills_descendant_after_job_process_exits(
+    executor,
+    tmp_path: Path,
+):
+    job_id = str(uuid4())
+    child_pid_path = tmp_path / "exited-parent-child.pid"
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_spawn_child_and_return",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_spawn_child_and_return",
+        params={"sleep_secs": 10, "child_pid_path": str(child_pid_path)},
+        context=_make_context(job_id),
+    )
+    _wait_for_file(child_pid_path)
+    child_pid = int(child_pid_path.read_text())
+    result_path = Path(executor._processes[job_id].result_path)
+    _wait_for_file(result_path)
+    time.sleep(0.1)
+
+    executor.cancel_job(job_id)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(child_pid)
+    assert result.status == JobStatus.CANCELED
+
+
+def test_local_executor_cancel_loses_race_to_completed_job(
+    monkeypatch,
+    executor,
+    tmp_path: Path,
+):
+    job_id = str(uuid4())
+    child_pid_path = tmp_path / "completed-job-child.pid"
+    result_holder = {}
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_spawn_child_and_return",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_spawn_child_and_return",
+        params={"sleep_secs": 10, "child_pid_path": str(child_pid_path)},
+        context=_make_context(job_id),
+    )
+    _wait_for_file(child_pid_path)
+    child_pid = int(child_pid_path.read_text())
+    process = executor._processes[job_id].process
+    original_wait = process.wait
+    process_reaped = threading.Event()
+    release_waiter = threading.Event()
+
+    def _wait_then_pause(*args, **kwargs):
+        returncode = original_wait(*args, **kwargs)
+        process_reaped.set()
+        release_waiter.wait(timeout=5)
+        return returncode
+
+    monkeypatch.setattr(process, "wait", _wait_then_pause)
+    wait_thread = threading.Thread(
+        target=lambda: result_holder.setdefault("result", executor.wait_for_job(job_id)),
+        name="local-executor-completion-race-waiter",
+    )
+    wait_thread.start()
+    assert process_reaped.wait(timeout=5)
+    assert process.returncode == 0
+    executor.cancel_job(job_id)
+    release_waiter.set()
+    wait_thread.join(timeout=5)
+    try:
+        os.kill(child_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    wait_for_process_exit(child_pid)
+
+    assert not wait_thread.is_alive()
+    assert result_holder["result"].status == JobStatus.SUCCEEDED
+
+
+def test_local_executor_cancel_before_wait_returns_canceled(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "cancel-before.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    executor.cancel_job(job_id)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(pid)
+    assert result.status == JobStatus.CANCELED
+    assert executor._processes == {}
+
+
+def test_local_executor_cancel_while_waiting_unblocks_waiter(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "cancel-during-wait.pid"
+    context = _make_context(job_id)
+    result_holder = {}
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    wait_thread = threading.Thread(
+        target=lambda: result_holder.setdefault("result", executor.wait_for_job(job_id)),
+        name="local-executor-waiter",
+    )
+    wait_thread.start()
+    time.sleep(0.1)
+    executor.cancel_job(job_id)
+    wait_thread.join(timeout=5)
+
+    wait_for_process_exit(pid)
+    assert result_holder["result"].status == JobStatus.CANCELED
+    assert executor._processes == {}
+
+
+def test_local_executor_rejects_duplicate_submission(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "duplicate.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+
+    with pytest.raises(MlflowException, match="already being managed"):
+        executor.submit_job(
+            job_id=job_id,
+            job_name="local_executor_sleep",
+            fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+            params={"sleep_secs": 10, "pid_path": str(pid_path)},
+            context=context,
+        )
+
+    executor.cancel_job(job_id)
+    executor.wait_for_job(job_id)
+
+
+def test_local_executor_wait_unknown_job_raises(executor):
+    with pytest.raises(MlflowException, match="Unknown job ID"):
+        executor.wait_for_job("missing-job")
+
+
+def test_local_executor_cancel_unknown_job_is_noop(executor):
+    executor.cancel_job("missing-job")
+
+
+def test_local_executor_rejects_undecorated_function_with_public_decorator_name(executor):
+    job_id = str(uuid4())
+
+    with pytest.raises(MlflowException, match=r"mlflow\.server\.jobs\.job'"):
+        executor.submit_job(
+            job_id=job_id,
+            job_name="local_executor_undecorated",
+            fn_fullname="tests.server.jobs.test_local_executor.local_executor_undecorated",
+            params={},
+            context=_make_context(job_id),
+        )
+
+    assert executor._processes == {}
+
+
+def test_local_executor_cancel_during_environment_setup(
+    monkeypatch,
+    executor,
+    tmp_path: Path,
+):
+    job_id = str(uuid4())
+    setup_pid_path = tmp_path / "setup.pid"
+    setup_child_pid_path = tmp_path / "setup-child.pid"
+    final_process_marker = tmp_path / "final-process-started"
+    result_path = tmp_path / "result.json"
+    setup_child_script = (
+        "import os, sys, time; "
+        "from pathlib import Path; "
+        "Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+    setup_script = (
+        "import os, subprocess, sys, time; "
+        "from pathlib import Path; "
+        f"subprocess.Popen([sys.executable, '-c', {setup_child_script!r}, sys.argv[2]]); "
+        "Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+
+    def _fake_prepare_job_subprocess(**kwargs):
+        return _PreparedJobSubprocess(
+            command=[
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(final_process_marker)!r}).touch()",
+            ],
+            env=os.environ.copy(),
+            result_path=str(result_path),
+            setup_commands=(
+                _PreparedJobSetupCommand(
+                    command=[
+                        sys.executable,
+                        "-c",
+                        setup_script,
+                        str(setup_pid_path),
+                        str(setup_child_pid_path),
+                    ]
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor._prepare_job_subprocess",
+        _fake_prepare_job_subprocess,
+    )
+    submit_errors = []
+
+    def _submit_job():
+        try:
+            executor.submit_job(
+                job_id=job_id,
+                job_name="local_executor_add",
+                fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+                params={"x": 1, "y": 2},
+                context=_make_context(job_id),
+            )
+        except Exception as exc:
+            submit_errors.append(exc)
+
+    submit_thread = threading.Thread(
+        target=_submit_job,
+        name="local-executor-submit-during-setup",
+    )
+    submit_thread.start()
+    _wait_for_file(setup_pid_path)
+    _wait_for_file(setup_child_pid_path)
+    setup_pid = int(setup_pid_path.read_text())
+    setup_child_pid = int(setup_child_pid_path.read_text())
+
+    executor.cancel_job(job_id)
+    submit_thread.join(timeout=5)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(setup_pid)
+    wait_for_process_exit(setup_child_pid)
+    assert not submit_thread.is_alive()
+    assert submit_errors == []
+    assert result.status == JobStatus.CANCELED
+    assert not final_process_marker.exists()
+
+
+def test_local_executor_propagates_context_env(executor):
+    job_id = str(uuid4())
+    context = _make_context(
+        job_id,
+        tracking_uri="http://tracking.example",
+        gateway_uri="http://gateway.example",
+        workspace="workspace-a",
+    )
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_context",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_context",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+    payload = json.loads(result.result)
+
+    assert result.status == JobStatus.SUCCEEDED
+    assert payload == {
+        "tracking_uri": "http://tracking.example",
+        "gateway_uri": "http://gateway.example",
+        "workspace": "workspace-a",
+        "job_id": job_id,
+        "job_name": "local_executor_context",
+    }
+
+
+def test_local_executor_context_overrides_inherited_env(monkeypatch, executor):
+    monkeypatch.setenv(MLFLOW_GATEWAY_URI.name, "http://inherited-gateway.example")
+    monkeypatch.setenv(MLFLOW_WORKSPACE.name, "inherited-workspace")
+    job_id = str(uuid4())
+    context = _make_context(job_id, tracking_uri="http://tracking.example")
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_context",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_context",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+    payload = json.loads(result.result)
+
+    assert result.status == JobStatus.SUCCEEDED
+    assert payload["tracking_uri"] == "http://tracking.example"
+    assert payload["gateway_uri"] == "http://tracking.example"
+    assert payload["workspace"] is None
+
+
+def test_local_executor_normalizes_python_env(monkeypatch, executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+    captured = {}
+    mock_process = mock.Mock()
+    mock_process.poll.return_value = 0
+
+    def _fake_prepare_job_subprocess(**kwargs):
+        captured["python_env"] = kwargs["python_env"]
+        return _PreparedJobSubprocess(
+            command=["python", "-c", "print('ok')"],
+            env={},
+            result_path="/tmp/result.json",
+        )
+
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor._prepare_job_subprocess",
+        _fake_prepare_job_subprocess,
+    )
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor.subprocess.Popen",
+        lambda *a, **k: mock_process,
+    )
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=context,
+        python_env=_PythonEnv(
+            python="3.11.9",
+            build_dependencies=["pip==24.0"],
+            dependencies=["pytest<9"],
+        ),
+    )
+
+    normalized = captured["python_env"]
+    assert normalized.python == PYTHON_VERSION
+    assert normalized.build_dependencies == ["pip==24.0"]
+    assert normalized.dependencies == ["pytest<9"]
+
+
+def test_local_executor_recover_jobs_kills_known_processes_before_requeue(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "recover.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    results = executor.recover_jobs([job_id, "missing-job"])
+
+    wait_for_process_exit(pid)
+    assert [(result.job_id, result.action) for result in results] == [
+        (job_id, "requeue"),
+        ("missing-job", "requeue"),
+    ]
+    assert executor._processes == {}
+
+
+def test_local_executor_stop_executor_kills_children_and_is_idempotent(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "stop.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    executor.stop_executor()
+    executor.stop_executor()
+
+    wait_for_process_exit(pid)
+    assert executor._processes == {}
+
+
+def test_local_executor_submit_requires_matching_context_job_id(executor):
+    with pytest.raises(MlflowException, match="Job ID mismatch"):
+        executor.submit_job(
+            job_id="job-1",
+            job_name="local_executor_add",
+            fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+            params={"x": 1, "y": 2},
+            context=_make_context("job-2"),
+        )
+
+
+def test_local_executor_check_requirements_only_rejects_windows(executor):
+    executor.check_requirements()
+
+    with mock.patch("mlflow.server.jobs.local_executor.os.name", "nt"):
+        with pytest.raises(MlflowException, match="does not support Windows"):
+            executor.check_requirements()
+
+
+def test_local_executor_remote_execution_defaults_false(executor):
+    assert executor.remote_execution is False

--- a/tests/server/jobs/test_local_executor.py
+++ b/tests/server/jobs/test_local_executor.py
@@ -1,0 +1,1301 @@
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_GATEWAY_URI, MLFLOW_TRACKING_URI, MLFLOW_WORKSPACE
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs import job
+from mlflow.server.jobs.executor import JobExecutionContext, JobExecutorConfig
+from mlflow.server.jobs.local_executor import (
+    _STDERR_TAIL_MAX_CHARS,
+    LocalJobExecutor,
+    _LocalJobProcess,
+)
+from mlflow.server.jobs.utils import (
+    MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR,
+    MLFLOW_SERVER_JOB_ID_ENV_VAR,
+    MLFLOW_SERVER_JOB_NAME_ENV_VAR,
+    _prepare_job_subprocess,
+    _PreparedJobSetupCommand,
+    _PreparedJobSubprocess,
+)
+from mlflow.utils import PYTHON_VERSION
+from mlflow.utils.environment import _PythonEnv
+
+from tests.server.jobs.helpers import wait_for_process_exit
+
+pytestmark = [
+    pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
+]
+
+# CI-safe timing allowances. Readiness/liveness polling must tolerate slow CI
+# boxes, and short job timeouts must comfortably exceed subprocess startup so
+# that readiness files are written before the deadline fires.
+_READINESS_TIMEOUT = 30.0
+_SHORT_JOB_TIMEOUT = 2.0
+
+
+class LocalExecutorTransientError(RuntimeError):
+    pass
+
+
+@job(name="local_executor_add", max_workers=1)
+def local_executor_add(x, y):
+    return x + y
+
+
+@job(name="local_executor_runtime_error", max_workers=1)
+def local_executor_runtime_error():
+    raise RuntimeError("boom")
+
+
+@job(
+    name="local_executor_transient_error",
+    max_workers=1,
+    transient_error_classes=[LocalExecutorTransientError],
+)
+def local_executor_transient_error():
+    raise LocalExecutorTransientError("retry me")
+
+
+@job(name="local_executor_sleep", max_workers=1)
+def local_executor_sleep(sleep_secs, pid_path):
+    Path(pid_path).write_text(str(os.getpid()))
+    time.sleep(sleep_secs)
+
+
+@job(name="local_executor_spawn_child", max_workers=1)
+def local_executor_spawn_child(sleep_secs, parent_pid_path, child_pid_path):
+    subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import os, sys, time; "
+            "from pathlib import Path; "
+            "Path(sys.argv[1]).write_text(str(os.getpid())); "
+            "time.sleep(float(sys.argv[2]))"
+        ),
+        child_pid_path,
+        str(sleep_secs),
+    ])
+    Path(parent_pid_path).write_text(str(os.getpid()))
+    time.sleep(sleep_secs)
+
+
+@job(name="local_executor_spawn_child_and_return", max_workers=1)
+def local_executor_spawn_child_and_return(sleep_secs, child_pid_path):
+    subprocess.Popen([
+        sys.executable,
+        "-c",
+        (
+            "import os, sys, time; "
+            "from pathlib import Path; "
+            "Path(sys.argv[1]).write_text(str(os.getpid())); "
+            "time.sleep(float(sys.argv[2]))"
+        ),
+        child_pid_path,
+        str(sleep_secs),
+    ])
+
+
+@job(name="local_executor_context", max_workers=1)
+def local_executor_context():
+    return {
+        "tracking_uri": os.environ.get(MLFLOW_TRACKING_URI.name),
+        "gateway_uri": os.environ.get(MLFLOW_GATEWAY_URI.name),
+        "workspace": os.environ.get(MLFLOW_WORKSPACE.name),
+        "job_id": os.environ.get(MLFLOW_SERVER_JOB_ID_ENV_VAR),
+        "job_name": os.environ.get(MLFLOW_SERVER_JOB_NAME_ENV_VAR),
+    }
+
+
+@job(name="local_executor_os_exit", max_workers=1)
+def local_executor_os_exit(exit_code):
+    os._exit(exit_code)
+
+
+@job(name="local_executor_stderr_crash", max_workers=1)
+def local_executor_stderr_crash():
+    sys.stderr.write("boom-on-stderr-marker\n")
+    sys.stderr.flush()
+    os._exit(3)
+
+
+@job(name="local_executor_stderr_flood", max_workers=1)
+def local_executor_stderr_flood():
+    # Emit far more stderr than the retained tail, then a unique final marker so
+    # the test can assert only the bounded tail (including that marker) survives.
+    for _ in range(2000):
+        sys.stderr.write("x" * 100 + "\n")
+    sys.stderr.write("final-stderr-marker\n")
+    sys.stderr.flush()
+    os._exit(5)
+
+
+@job(name="local_executor_stderr_detached_child", max_workers=1)
+def local_executor_stderr_detached_child(sleep_secs, child_pid_path):
+    # Spawn a detached grandchild (its own session, so a process-group kill of the
+    # job cannot reach it) that inherits the stderr PIPE and outlives this job.
+    # The pipe therefore never reaches EOF after the job exits, exercising the
+    # stderr reader's interruptible drain loop.
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os, sys, time; "
+                "from pathlib import Path; "
+                "Path(sys.argv[1]).write_text(str(os.getpid())); "
+                "time.sleep(float(sys.argv[2]))"
+            ),
+            child_pid_path,
+            str(sleep_secs),
+        ],
+        start_new_session=True,
+    )
+    sys.stderr.write("detached-child-stderr-marker\n")
+    sys.stderr.flush()
+    os._exit(4)
+
+
+def local_executor_undecorated():
+    return None
+
+
+def _make_context(
+    job_id: str,
+    tracking_uri: str = "http://tracking.test",
+    gateway_uri: str | None = None,
+    workspace: str | None = None,
+) -> JobExecutionContext:
+    return JobExecutionContext(
+        job_id=job_id,
+        tracking_uri=tracking_uri,
+        gateway_uri=gateway_uri,
+        workspace=workspace,
+    )
+
+
+def _wait_for_file(path: Path, timeout: float = _READINESS_TIMEOUT) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.05)
+    pytest.fail(f"{path} was not created within {timeout}s")
+
+
+@pytest.fixture
+def executor():
+    local_executor = LocalJobExecutor(JobExecutorConfig(default_timeout=60.0))
+    try:
+        yield local_executor
+    finally:
+        local_executor.stop_executor()
+
+
+def test_local_executor_submit_and_wait_succeeds(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.SUCCEEDED
+    assert result.result == "3"
+    assert result.error_message is None
+    assert executor._processes == {}
+
+
+def test_local_executor_job_exception_returns_failed(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_runtime_error",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_runtime_error",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "RuntimeError('boom')" in result.error_message
+    assert result.is_transient_error is False
+
+
+def test_local_executor_declared_transient_error_sets_flag(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_transient_error",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_transient_error",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "LocalExecutorTransientError('retry me')" in result.error_message
+    assert result.is_transient_error is True
+
+
+def test_local_executor_nonzero_exit_returns_infrastructure_failure(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_os_exit",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_os_exit",
+        params={"exit_code": 7},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "error code 7" in result.error_message
+
+
+def test_local_executor_result_protocol_failure_returns_failed(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=context,
+    )
+    with mock.patch(
+        "mlflow.server.jobs.local_executor._SubprocessJobResult.load",
+        side_effect=ValueError("bad result"),
+    ):
+        result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "Failed to load the local subprocess result" in result.error_message
+
+
+def test_local_executor_timeout_kills_and_reaps_child(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "timeout.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+        timeout=_SHORT_JOB_TIMEOUT,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(pid, timeout=_READINESS_TIMEOUT)
+    assert result.status == JobStatus.TIMEOUT
+    assert job_id in result.error_message
+    assert f"timed out after {_SHORT_JOB_TIMEOUT} seconds" in result.error_message
+    assert executor._processes == {}
+
+
+@pytest.mark.parametrize(
+    ("termination", "expected_status"),
+    [("cancel", JobStatus.CANCELED), ("timeout", JobStatus.TIMEOUT)],
+)
+def test_local_executor_termination_kills_descendant_processes(
+    executor,
+    tmp_path: Path,
+    termination: str,
+    expected_status: str,
+):
+    job_id = str(uuid4())
+    parent_pid_path = tmp_path / f"{termination}-parent.pid"
+    child_pid_path = tmp_path / f"{termination}-child.pid"
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_spawn_child",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_spawn_child",
+        params={
+            "sleep_secs": 10,
+            "parent_pid_path": str(parent_pid_path),
+            "child_pid_path": str(child_pid_path),
+        },
+        context=_make_context(job_id),
+        timeout=_SHORT_JOB_TIMEOUT if termination == "timeout" else None,
+    )
+    _wait_for_file(parent_pid_path)
+    _wait_for_file(child_pid_path)
+    parent_pid = int(parent_pid_path.read_text())
+    child_pid = int(child_pid_path.read_text())
+
+    if termination == "cancel":
+        executor.cancel_job(job_id)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(parent_pid, timeout=_READINESS_TIMEOUT)
+    wait_for_process_exit(child_pid, timeout=_READINESS_TIMEOUT)
+    assert result.status == expected_status
+
+
+def test_local_executor_cancel_kills_descendant_after_job_process_exits(
+    executor,
+    tmp_path: Path,
+):
+    job_id = str(uuid4())
+    child_pid_path = tmp_path / "exited-parent-child.pid"
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_spawn_child_and_return",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_spawn_child_and_return",
+        params={"sleep_secs": 10, "child_pid_path": str(child_pid_path)},
+        context=_make_context(job_id),
+    )
+    _wait_for_file(child_pid_path)
+    child_pid = int(child_pid_path.read_text())
+    result_path = Path(executor._processes[job_id].result_path)
+    _wait_for_file(result_path)
+    time.sleep(0.1)
+
+    executor.cancel_job(job_id)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(child_pid)
+    assert result.status == JobStatus.CANCELED
+
+
+def test_local_executor_cancel_loses_race_to_completed_job(
+    monkeypatch,
+    executor,
+    tmp_path: Path,
+):
+    job_id = str(uuid4())
+    child_pid_path = tmp_path / "completed-job-child.pid"
+    result_holder = {}
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_spawn_child_and_return",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_spawn_child_and_return",
+        params={"sleep_secs": 10, "child_pid_path": str(child_pid_path)},
+        context=_make_context(job_id),
+    )
+    _wait_for_file(child_pid_path)
+    child_pid = int(child_pid_path.read_text())
+    process = executor._processes[job_id].active_process
+    original_wait = process.wait
+    process_reaped = threading.Event()
+    release_waiter = threading.Event()
+
+    def _wait_then_pause(*args, **kwargs):
+        returncode = original_wait(*args, **kwargs)
+        process_reaped.set()
+        release_waiter.wait(timeout=5)
+        return returncode
+
+    monkeypatch.setattr(process, "wait", _wait_then_pause)
+    wait_thread = threading.Thread(
+        target=lambda: result_holder.setdefault("result", executor.wait_for_job(job_id)),
+        name="local-executor-completion-race-waiter",
+    )
+    wait_thread.start()
+    assert process_reaped.wait(timeout=5)
+    assert process.returncode == 0
+    executor.cancel_job(job_id)
+    release_waiter.set()
+    wait_thread.join(timeout=5)
+    try:
+        os.kill(child_pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    wait_for_process_exit(child_pid)
+
+    assert not wait_thread.is_alive()
+    assert result_holder["result"].status == JobStatus.SUCCEEDED
+
+
+def test_local_executor_cancel_before_wait_returns_canceled(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "cancel-before.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    executor.cancel_job(job_id)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(pid)
+    assert result.status == JobStatus.CANCELED
+    assert executor._processes == {}
+
+
+def test_local_executor_cancel_while_waiting_unblocks_waiter(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "cancel-during-wait.pid"
+    context = _make_context(job_id)
+    result_holder = {}
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    wait_thread = threading.Thread(
+        target=lambda: result_holder.setdefault("result", executor.wait_for_job(job_id)),
+        name="local-executor-waiter",
+    )
+    wait_thread.start()
+    time.sleep(0.1)
+    executor.cancel_job(job_id)
+    wait_thread.join(timeout=5)
+
+    wait_for_process_exit(pid)
+    assert result_holder["result"].status == JobStatus.CANCELED
+    assert executor._processes == {}
+
+
+def test_local_executor_rejects_duplicate_submission(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "duplicate.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+
+    with pytest.raises(MlflowException, match="already being managed"):
+        executor.submit_job(
+            job_id=job_id,
+            job_name="local_executor_sleep",
+            fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+            params={"sleep_secs": 10, "pid_path": str(pid_path)},
+            context=context,
+        )
+
+    executor.cancel_job(job_id)
+    executor.wait_for_job(job_id)
+
+
+def test_local_executor_wait_unknown_job_raises(executor):
+    with pytest.raises(MlflowException, match="Unknown job ID"):
+        executor.wait_for_job("missing-job")
+
+
+def test_local_executor_cancel_unknown_job_is_noop(executor):
+    executor.cancel_job("missing-job")
+
+
+def test_local_executor_rejects_undecorated_function_with_public_decorator_name(executor):
+    job_id = str(uuid4())
+
+    with pytest.raises(MlflowException, match=r"mlflow\.server\.jobs\.job'"):
+        executor.submit_job(
+            job_id=job_id,
+            job_name="local_executor_undecorated",
+            fn_fullname="tests.server.jobs.test_local_executor.local_executor_undecorated",
+            params={},
+            context=_make_context(job_id),
+        )
+
+    assert executor._processes == {}
+
+
+def test_local_executor_cancel_during_environment_setup(
+    monkeypatch,
+    executor,
+    tmp_path: Path,
+):
+    job_id = str(uuid4())
+    setup_pid_path = tmp_path / "setup.pid"
+    setup_child_pid_path = tmp_path / "setup-child.pid"
+    final_process_marker = tmp_path / "final-process-started"
+    result_path = tmp_path / "result.json"
+    setup_child_script = (
+        "import os, sys, time; "
+        "from pathlib import Path; "
+        "Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+    setup_script = (
+        "import os, subprocess, sys, time; "
+        "from pathlib import Path; "
+        f"subprocess.Popen([sys.executable, '-c', {setup_child_script!r}, sys.argv[2]]); "
+        "Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+
+    def _fake_prepare_job_subprocess(**kwargs):
+        return _PreparedJobSubprocess(
+            command=[
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(final_process_marker)!r}).touch()",
+            ],
+            env=os.environ.copy(),
+            result_path=str(result_path),
+            setup_commands=(
+                _PreparedJobSetupCommand(
+                    command=[
+                        sys.executable,
+                        "-c",
+                        setup_script,
+                        str(setup_pid_path),
+                        str(setup_child_pid_path),
+                    ]
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor._prepare_job_subprocess",
+        _fake_prepare_job_subprocess,
+    )
+    submit_errors = []
+
+    def _submit_job():
+        try:
+            executor.submit_job(
+                job_id=job_id,
+                job_name="local_executor_add",
+                fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+                params={"x": 1, "y": 2},
+                context=_make_context(job_id),
+            )
+        except Exception as exc:
+            submit_errors.append(exc)
+
+    submit_thread = threading.Thread(
+        target=_submit_job,
+        name="local-executor-submit-during-setup",
+    )
+    submit_thread.start()
+    _wait_for_file(setup_pid_path)
+    _wait_for_file(setup_child_pid_path)
+    setup_pid = int(setup_pid_path.read_text())
+    setup_child_pid = int(setup_child_pid_path.read_text())
+
+    executor.cancel_job(job_id)
+    submit_thread.join(timeout=5)
+    result = executor.wait_for_job(job_id)
+
+    wait_for_process_exit(setup_pid)
+    wait_for_process_exit(setup_child_pid)
+    assert not submit_thread.is_alive()
+    assert submit_errors == []
+    assert result.status == JobStatus.CANCELED
+    assert not final_process_marker.exists()
+
+
+def test_local_executor_propagates_context_env(executor):
+    job_id = str(uuid4())
+    context = _make_context(
+        job_id,
+        tracking_uri="http://tracking.example",
+        gateway_uri="http://gateway.example",
+        workspace="workspace-a",
+    )
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_context",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_context",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+    payload = json.loads(result.result)
+
+    assert result.status == JobStatus.SUCCEEDED
+    assert payload == {
+        "tracking_uri": "http://tracking.example",
+        "gateway_uri": "http://gateway.example",
+        "workspace": "workspace-a",
+        "job_id": job_id,
+        "job_name": "local_executor_context",
+    }
+
+
+def test_local_executor_context_overrides_inherited_env(monkeypatch, executor):
+    monkeypatch.setenv(MLFLOW_GATEWAY_URI.name, "http://inherited-gateway.example")
+    monkeypatch.setenv(MLFLOW_WORKSPACE.name, "inherited-workspace")
+    job_id = str(uuid4())
+    context = _make_context(job_id, tracking_uri="http://tracking.example")
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_context",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_context",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+    payload = json.loads(result.result)
+
+    assert result.status == JobStatus.SUCCEEDED
+    assert payload["tracking_uri"] == "http://tracking.example"
+    assert payload["gateway_uri"] == "http://tracking.example"
+    assert payload["workspace"] is None
+
+
+def test_local_executor_normalizes_python_env(monkeypatch, executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+    captured = {}
+    mock_process = mock.Mock()
+    mock_process.poll.return_value = 0
+
+    def _fake_prepare_job_subprocess(**kwargs):
+        captured["python_env"] = kwargs["python_env"]
+        return _PreparedJobSubprocess(
+            command=["python", "-c", "print('ok')"],
+            env={},
+            result_path="/tmp/result.json",
+        )
+
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor._prepare_job_subprocess",
+        _fake_prepare_job_subprocess,
+    )
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor.subprocess.Popen",
+        lambda *a, **k: mock_process,
+    )
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=context,
+        python_env=_PythonEnv(
+            python="3.11.9",
+            build_dependencies=["pip==24.0"],
+            dependencies=["pytest<9"],
+        ),
+    )
+
+    normalized = captured["python_env"]
+    assert normalized.python == PYTHON_VERSION
+    assert normalized.build_dependencies == ["pip==24.0"]
+    assert normalized.dependencies == ["pytest<9"]
+
+
+def test_local_executor_recover_jobs_kills_known_processes_before_requeue(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "recover.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    results = executor.recover_jobs([job_id, "missing-job"])
+
+    wait_for_process_exit(pid)
+    assert [(result.job_id, result.action) for result in results] == [
+        (job_id, "requeue"),
+        ("missing-job", "requeue"),
+    ]
+    assert executor._processes == {}
+
+
+def test_local_executor_stop_executor_kills_children_and_is_idempotent(executor, tmp_path: Path):
+    job_id = str(uuid4())
+    pid_path = tmp_path / "stop.pid"
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_sleep",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_sleep",
+        params={"sleep_secs": 10, "pid_path": str(pid_path)},
+        context=context,
+    )
+    _wait_for_file(pid_path)
+    pid = int(pid_path.read_text())
+
+    executor.stop_executor()
+    executor.stop_executor()
+
+    wait_for_process_exit(pid)
+    assert executor._processes == {}
+
+
+def test_local_executor_submit_requires_matching_context_job_id(executor):
+    with pytest.raises(MlflowException, match="Job ID mismatch"):
+        executor.submit_job(
+            job_id="job-1",
+            job_name="local_executor_add",
+            fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+            params={"x": 1, "y": 2},
+            context=_make_context("job-2"),
+        )
+
+
+def test_local_executor_check_requirements_only_rejects_windows(executor):
+    executor.check_requirements()
+
+    with mock.patch("mlflow.server.jobs.local_executor.os.name", "nt"):
+        with pytest.raises(MlflowException, match="does not support Windows"):
+            executor.check_requirements()
+
+
+def test_local_executor_remote_execution_defaults_false(executor):
+    assert executor.remote_execution is False
+
+
+def test_prepare_job_subprocess_installs_build_dependencies_first(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("mlflow.server.jobs.utils.shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "mlflow.utils.virtualenv._get_mlflow_virtualenv_root",
+        lambda: str(tmp_path / "venvs"),
+    )
+
+    with_build = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        python_env=_PythonEnv(
+            python=PYTHON_VERSION,
+            build_dependencies=["pip==24.0", "setuptools==69.0"],
+            dependencies=["pytest<9"],
+        ),
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-build",
+        job_name="local_executor_add",
+        workspace=None,
+    )
+
+    assert len(with_build.setup_commands) == 1
+    command = with_build.setup_commands[0].command
+    build_req_file = Path(command[command.index("--build-requirements-file") + 1])
+    req_file = Path(command[command.index("--requirements-file") + 1])
+    assert build_req_file.read_text().splitlines() == ["pip==24.0", "setuptools==69.0"]
+    assert req_file.read_text().splitlines() == ["pytest<9"]
+
+    without_build = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        python_env=_PythonEnv(
+            python=PYTHON_VERSION,
+            build_dependencies=[],
+            dependencies=["pytest<9"],
+        ),
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-nobuild",
+        job_name="local_executor_add",
+        workspace=None,
+    )
+
+    assert "--build-requirements-file" not in without_build.setup_commands[0].command
+
+
+def test_setup_job_environment_installs_build_requirements_before_requirements(
+    tmp_path: Path, monkeypatch
+):
+    from mlflow.server.jobs import _job_env_setup
+
+    env_dir = tmp_path / "venvs" / "env"
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+    build_requirements_file = tmp_path / "build-requirements.txt"
+    build_requirements_file.write_text("pip==24.0")
+
+    calls = []
+    monkeypatch.setattr(
+        _job_env_setup, "_get_uv_env_creation_command", lambda *a, **k: ["uv", "venv"]
+    )
+    monkeypatch.setattr(
+        _job_env_setup, "_exec_cmd", lambda command, **kwargs: calls.append(command)
+    )
+
+    _job_env_setup._setup_job_environment(
+        env_dir=env_dir,
+        python_version=PYTHON_VERSION,
+        requirements_file=requirements_file,
+        build_requirements_file=build_requirements_file,
+    )
+
+    # Order: create the env, install build requirements, then install requirements.
+    assert len(calls) == 3
+    assert calls[0] == ["uv", "venv"]
+    assert "build-requirements.txt" in " ".join(map(str, calls[1]))
+    # The final call installs the regular requirements, not the build requirements
+    # ("build-requirements.txt" contains "requirements.txt" as a substring, so the
+    # negative assertion is what makes this check meaningful).
+    calls_2_str = " ".join(map(str, calls[2]))
+    assert "requirements.txt" in calls_2_str
+    assert "build-requirements.txt" not in calls_2_str
+
+
+def test_setup_job_environment_skips_build_requirements_when_absent(tmp_path: Path, monkeypatch):
+    from mlflow.server.jobs import _job_env_setup
+
+    env_dir = tmp_path / "venvs" / "env"
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("pytest<9")
+
+    calls = []
+    monkeypatch.setattr(
+        _job_env_setup, "_get_uv_env_creation_command", lambda *a, **k: ["uv", "venv"]
+    )
+    monkeypatch.setattr(
+        _job_env_setup, "_exec_cmd", lambda command, **kwargs: calls.append(command)
+    )
+
+    _job_env_setup._setup_job_environment(
+        env_dir=env_dir,
+        python_version=PYTHON_VERSION,
+        requirements_file=requirements_file,
+    )
+
+    # Only env creation + a single requirements install.
+    assert len(calls) == 2
+    assert calls[0] == ["uv", "venv"]
+    assert "requirements.txt" in " ".join(map(str, calls[1]))
+
+
+def test_local_executor_nonzero_exit_surfaces_stderr_tail(executor):
+    job_id = str(uuid4())
+    context = _make_context(job_id)
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_stderr_crash",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_stderr_crash",
+        params={},
+        context=context,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "error code 3" in result.error_message
+    assert "boom-on-stderr-marker" in result.error_message
+    assert executor._processes == {}
+
+
+def test_local_executor_setup_timeout_returns_timeout(monkeypatch, executor, tmp_path: Path):
+    job_id = str(uuid4())
+    setup_pid_path = tmp_path / "setup-timeout.pid"
+    setup_child_pid_path = tmp_path / "setup-timeout-child.pid"
+    final_process_marker = tmp_path / "final-process-started"
+    result_path = tmp_path / "result.json"
+    setup_child_script = (
+        "import os, sys, time; "
+        "from pathlib import Path; "
+        "Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+    setup_script = (
+        "import os, subprocess, sys, time; "
+        "from pathlib import Path; "
+        f"subprocess.Popen([sys.executable, '-c', {setup_child_script!r}, sys.argv[2]]); "
+        "Path(sys.argv[1]).write_text(str(os.getpid())); "
+        "time.sleep(30)"
+    )
+
+    def _fake_prepare_job_subprocess(**kwargs):
+        return _PreparedJobSubprocess(
+            command=[
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(final_process_marker)!r}).touch()",
+            ],
+            env=os.environ.copy(),
+            result_path=str(result_path),
+            setup_commands=(
+                _PreparedJobSetupCommand(
+                    command=[
+                        sys.executable,
+                        "-c",
+                        setup_script,
+                        str(setup_pid_path),
+                        str(setup_child_pid_path),
+                    ]
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor._prepare_job_subprocess",
+        _fake_prepare_job_subprocess,
+    )
+
+    # submit_job blocks during setup until the hard deadline elapses, proving the
+    # timeout covers environment setup and not just job execution.
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=_make_context(job_id),
+        timeout=_SHORT_JOB_TIMEOUT,
+    )
+    result = executor.wait_for_job(job_id)
+
+    _wait_for_file(setup_pid_path)
+    _wait_for_file(setup_child_pid_path)
+    setup_pid = int(setup_pid_path.read_text())
+    setup_child_pid = int(setup_child_pid_path.read_text())
+
+    wait_for_process_exit(setup_pid, timeout=_READINESS_TIMEOUT)
+    wait_for_process_exit(setup_child_pid, timeout=_READINESS_TIMEOUT)
+    assert result.status == JobStatus.TIMEOUT
+    assert "during environment setup" in result.error_message
+    assert not final_process_marker.exists()
+    assert executor._processes == {}
+
+
+def test_local_executor_orphan_watcher_kills_group_on_parent_crash(tmp_path: Path):
+    # Simulates a server crash: a job subprocess (a process-group leader started
+    # with start_new_session) is reparented, so its orphan watcher must kill the
+    # whole process group, taking any spawned descendant with it.
+    repo_root = Path(__file__).resolve().parents[3]
+    server_script = tmp_path / "fake_server.py"
+    server_script.write_text(
+        "import sys\n"
+        "import time\n"
+        "from pathlib import Path\n"
+        "\n"
+        "from mlflow.server.jobs.executor import JobExecutionContext, JobExecutorConfig\n"
+        "from mlflow.server.jobs.local_executor import LocalJobExecutor\n"
+        "\n"
+        "job_id, parent_pid_path, child_pid_path, ready_path = sys.argv[1:5]\n"
+        "executor = LocalJobExecutor(JobExecutorConfig(default_timeout=120.0))\n"
+        "executor.submit_job(\n"
+        "    job_id=job_id,\n"
+        "    job_name='local_executor_spawn_child',\n"
+        "    fn_fullname='tests.server.jobs.test_local_executor.local_executor_spawn_child',\n"
+        "    params={\n"
+        "        'sleep_secs': 120,\n"
+        "        'parent_pid_path': parent_pid_path,\n"
+        "        'child_pid_path': child_pid_path,\n"
+        "    },\n"
+        "    context=JobExecutionContext(job_id=job_id, tracking_uri='http://tracking.test'),\n"
+        ")\n"
+        "Path(ready_path).write_text('ready')\n"
+        "time.sleep(120)\n"
+    )
+
+    job_id = str(uuid4())
+    parent_pid_path = tmp_path / "orphan-parent.pid"
+    child_pid_path = tmp_path / "orphan-child.pid"
+    ready_path = tmp_path / "server-ready"
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(repo_root), env.get("PYTHONPATH", "")]).rstrip(
+        os.pathsep
+    )
+
+    server = subprocess.Popen(
+        [
+            sys.executable,
+            str(server_script),
+            job_id,
+            str(parent_pid_path),
+            str(child_pid_path),
+            str(ready_path),
+        ],
+        env=env,
+    )
+    parent_pid = None
+    child_pid = None
+    try:
+        _wait_for_file(ready_path)
+        _wait_for_file(parent_pid_path)
+        _wait_for_file(child_pid_path)
+        parent_pid = int(parent_pid_path.read_text())
+        child_pid = int(child_pid_path.read_text())
+
+        server.kill()
+        server.wait(timeout=_READINESS_TIMEOUT)
+
+        # The orphan watcher polls parentage, so allow time for detection + killpg.
+        wait_for_process_exit(parent_pid, timeout=_READINESS_TIMEOUT)
+        wait_for_process_exit(child_pid, timeout=_READINESS_TIMEOUT)
+    finally:
+        server.kill()
+        for pid in (parent_pid, child_pid):
+            if pid is not None:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, OSError):
+                    pass
+
+
+def _make_record(**overrides) -> _LocalJobProcess:
+    fields = {
+        "active_process": None,
+        "temporary_directory": tempfile.TemporaryDirectory(),
+        "result_path": "",
+        "function_fullname": "fn",
+        "timeout": 60.0,
+        "deadline": time.monotonic() + 60.0,
+    }
+    fields.update(overrides)
+    return _LocalJobProcess(**fields)
+
+
+def test_local_executor_cancel_latches_during_setup(executor):
+    # A cancel that arrives while a setup subprocess is the active process (the
+    # job subprocess has not been launched yet) must latch. Even when the kill is
+    # reported as not delivered (e.g. the setup process already exited),
+    # cancel_requested must stay set so submit_job does not go on to launch the
+    # job the caller asked to cancel.
+    job_id = str(uuid4())
+    setup_process = mock.Mock()
+    setup_process.returncode = 0  # _kill_process reports "not delivered" for this
+    record = _make_record(active_process=setup_process, job_process_launched=False)
+    executor._processes[job_id] = record
+    try:
+        executor.cancel_job(job_id)
+        assert record.cancel_requested is True
+    finally:
+        record.temporary_directory.cleanup()
+        executor._processes.pop(job_id, None)
+
+
+def test_local_executor_cancel_rolls_back_after_job_process_completed(executor):
+    # Once the job subprocess is running, a cancel that loses the race to a job
+    # that already completed must still roll back so the completed result wins.
+    job_id = str(uuid4())
+    job_process = mock.Mock()
+    job_process.returncode = 0
+    record = _make_record(active_process=job_process, job_process_launched=True)
+    executor._processes[job_id] = record
+    try:
+        executor.cancel_job(job_id)
+        assert record.cancel_requested is False
+    finally:
+        record.temporary_directory.cleanup()
+        executor._processes.pop(job_id, None)
+
+
+def test_local_executor_deadline_elapsed_before_launch_returns_timeout(
+    monkeypatch, executor, tmp_path: Path
+):
+    # The hard deadline is checked under the lock immediately before the job
+    # subprocess is launched, so a job whose budget is consumed during setup is
+    # reported as a timeout and its subprocess is never started.
+    job_id = str(uuid4())
+    final_process_marker = tmp_path / "final-process-started"
+    result_path = tmp_path / "result.json"
+
+    def _fake_prepare_job_subprocess(**kwargs):
+        # Consume the whole timeout budget before the job subprocess is launched.
+        time.sleep(_SHORT_JOB_TIMEOUT + 0.5)
+        return _PreparedJobSubprocess(
+            command=[
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(final_process_marker)!r}).touch()",
+            ],
+            env=os.environ.copy(),
+            result_path=str(result_path),
+        )
+
+    monkeypatch.setattr(
+        "mlflow.server.jobs.local_executor._prepare_job_subprocess",
+        _fake_prepare_job_subprocess,
+    )
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_add",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        context=_make_context(job_id),
+        timeout=_SHORT_JOB_TIMEOUT,
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.TIMEOUT
+    assert "during environment setup" in result.error_message
+    assert not final_process_marker.exists()
+    assert executor._processes == {}
+
+
+def test_local_executor_bounds_captured_stderr_tail(executor):
+    # A job that floods stderr before crashing must surface only a bounded tail so
+    # the server never holds the full stderr in memory.
+    job_id = str(uuid4())
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_stderr_flood",
+        fn_fullname="tests.server.jobs.test_local_executor.local_executor_stderr_flood",
+        params={},
+        context=_make_context(job_id),
+    )
+    result = executor.wait_for_job(job_id)
+
+    assert result.status == JobStatus.FAILED
+    assert "error code 5" in result.error_message
+    # The retained tail is truncated and still ends with the final marker line.
+    assert "...(truncated)..." in result.error_message
+    assert "final-stderr-marker" in result.error_message
+    _, _, stderr_section = result.error_message.partition("Subprocess stderr (tail):\n")
+    assert stderr_section
+    assert len(stderr_section) <= _STDERR_TAIL_MAX_CHARS + len("...(truncated)...\n")
+    assert executor._processes == {}
+
+
+def test_local_executor_stderr_reader_does_not_block_on_detached_descendant(
+    executor, tmp_path: Path
+):
+    # A job may spawn a detached descendant that inherits the stderr PIPE and keeps
+    # its write end open long after the job exits. wait_for_job must still return
+    # promptly (draining the reader is bounded, not gated on that descendant's
+    # lifetime) while still surfacing the stderr the job itself emitted.
+    job_id = str(uuid4())
+    child_pid_path = tmp_path / "detached-descendant.pid"
+    descendant_sleep = 30.0
+
+    executor.submit_job(
+        job_id=job_id,
+        job_name="local_executor_stderr_detached_child",
+        fn_fullname=("tests.server.jobs.test_local_executor.local_executor_stderr_detached_child"),
+        params={"sleep_secs": descendant_sleep, "child_pid_path": str(child_pid_path)},
+        context=_make_context(job_id),
+    )
+    start = time.monotonic()
+    result = executor.wait_for_job(job_id)
+    elapsed = time.monotonic() - start
+
+    # Clean up the detached descendant regardless of assertion outcomes.
+    _wait_for_file(child_pid_path)
+    child_pid = int(child_pid_path.read_text())
+    try:
+        os.kill(child_pid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    wait_for_process_exit(child_pid, timeout=_READINESS_TIMEOUT)
+
+    assert result.status == JobStatus.FAILED
+    assert "error code 4" in result.error_message
+    assert "detached-child-stderr-marker" in result.error_message
+    # Must not stall for the descendant's whole sleep; the drain loop stops within
+    # a poll interval once the job process is reaped.
+    assert elapsed < descendant_sleep / 2
+    assert executor._processes == {}
+
+
+def test_prepare_job_subprocess_setup_carries_parent_pid_for_orphan_watch(
+    tmp_path: Path, monkeypatch
+):
+    # The setup command must record the server pid so the setup subprocess can
+    # detect being orphaned (and release its environment lock) if the server dies.
+    monkeypatch.setattr("mlflow.server.jobs.utils.shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "mlflow.utils.virtualenv._get_mlflow_virtualenv_root",
+        lambda: str(tmp_path / "venvs"),
+    )
+
+    prepared = _prepare_job_subprocess(
+        function_fullname="tests.server.jobs.test_local_executor.local_executor_add",
+        params={"x": 1, "y": 2},
+        python_env=_PythonEnv(
+            python=PYTHON_VERSION,
+            build_dependencies=[],
+            dependencies=["pytest<9"],
+        ),
+        transient_error_classes=None,
+        tmpdir=str(tmp_path),
+        job_id="job-orphan",
+        job_name="local_executor_add",
+        workspace=None,
+    )
+
+    assert len(prepared.setup_commands) == 1
+    assert prepared.setup_commands[0].extra_env == {
+        MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR: str(os.getpid())
+    }
+
+
+def _run_env_setup_main(monkeypatch, tmp_path: Path, watcher_started: threading.Event) -> None:
+    from mlflow.server.jobs import _job_env_setup
+
+    (tmp_path / "req.txt").write_text("")
+    monkeypatch.setattr(
+        _job_env_setup, "_exit_when_orphaned", lambda *a, **k: watcher_started.set()
+    )
+    monkeypatch.setattr(_job_env_setup, "_setup_job_environment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "_job_env_setup",
+            "--env-dir",
+            str(tmp_path / "env"),
+            "--python-version",
+            PYTHON_VERSION,
+            "--requirements-file",
+            str(tmp_path / "req.txt"),
+        ],
+    )
+    _job_env_setup.main()
+
+
+def test_job_env_setup_starts_orphan_watcher_when_parent_pid_set(monkeypatch, tmp_path: Path):
+    watcher_started = threading.Event()
+    monkeypatch.setenv(MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR, str(os.getpid()))
+    _run_env_setup_main(monkeypatch, tmp_path, watcher_started)
+    assert watcher_started.wait(timeout=5)
+
+
+def test_job_env_setup_skips_orphan_watcher_without_parent_pid(monkeypatch, tmp_path: Path):
+    watcher_started = threading.Event()
+    monkeypatch.delenv(MLFLOW_ORIGINAL_PARENT_PID_ENV_VAR, raising=False)
+    _run_env_setup_main(monkeypatch, tmp_path, watcher_started)
+    time.sleep(0.2)
+    assert not watcher_started.is_set()


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/rfcs/pull/2

### What changes are proposed in this pull request?

This PR implements the built-in `LocalJobExecutor` for the job executor plugin framework described in RFC 0002.

It adds local subprocess submission, terminal result handling, cancellation, timeout enforcement, and restart-time requeue behavior. The executor maintains only local process state and does not mutate the job store; framework lifecycle transitions, retries, locking, and recovery orchestration remain owned by the framework.

It also extracts the existing subprocess command and environment preparation into a shared helper used by both `LocalJobExecutor` and the current Huey path. This preserves the existing Huey execution path while allowing the new executor to reuse the established subprocess entry point and result protocol.

The production cutover from Huey to `LocalJobExecutor` is intentionally deferred to a follow-up change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added focused unit and real-subprocess tests covering successful execution,
failures, cancellation, timeouts, recovery, shutdown, and execution-context
propagation.

Manually verified the same lifecycle scenarios using real local subprocesses.
### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. By default, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
