### PR TITLE
Add `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` guard to `mlflow.statsmodels` flavor

### DIFF
--- a/mlflow/statsmodels/__init__.py
+++ b/mlflow/statsmodels/__init__.py
@@ -23,6 +23,7 @@ import yaml
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -35,6 +36,10 @@ from mlflow.utils.autologging_utils import (
     get_autologging_config,
     log_fn_args_as_params,
     safe_patch,
+)
+from mlflow.utils.databricks_utils import (
+    is_in_databricks_model_serving_environment,
+    is_in_databricks_runtime,
 )
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
@@ -305,6 +310,16 @@ def log_model(
 
 
 def _load_model(path):
+    if (
+        not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get()
+        and not is_in_databricks_runtime()
+        and not is_in_databricks_model_serving_environment()
+    ):
+        raise MlflowException(
+            "Deserializing model using pickle is disallowed, but this model is saved "
+            "in pickle format. The workaround is to set environment variable "
+            "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true'."
+        )
     import statsmodels.iolib.api as smio
 
     return smio.load_pickle(path)

--- a/tests/statsmodels/test_statsmodels_model_export.py
+++ b/tests/statsmodels/test_statsmodels_model_export.py
@@ -11,6 +11,7 @@ import yaml
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.statsmodels
 from mlflow import pyfunc
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.utils import _read_example, load_serving_example
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
@@ -144,6 +145,16 @@ def test_models_save_load(tmp_path):
 
 def test_models_log(tmp_path):
     _test_models_list(tmp_path, _test_model_log)
+
+
+@pytest.mark.parametrize("load_fn", [mlflow.statsmodels.load_model, pyfunc.load_model])
+def test_load_model_disallows_pickle_deserialization(model_path, monkeypatch, load_fn):
+    ols = ols_model()
+    mlflow.statsmodels.save_model(statsmodels_model=ols.model, path=model_path)
+
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        load_fn(model_path)
 
 
 def test_signature_and_examples_are_saved_correctly():


### PR DESCRIPTION
### Related Issues/PRs

Relates to GHSA-gqvg-gmmx-x4hm (private security advisory)

### What changes are proposed in this pull request?

The `mlflow.statsmodels` flavor's `_load_model` called statsmodels' `load_pickle` (a thin `pickle.load` wrapper) with **no guard**, so it ignored the `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` safety control that every other pickle-based flavor (`sklearn`, `pmdarima`, `pytorch`, etc.) honors. As a result, an attacker-supplied statsmodels model artifact could execute arbitrary code at load time via `mlflow.pyfunc.load_model()` / `mlflow.statsmodels.load_model()` even when an operator had explicitly set `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=False` to mitigate the CVE-2024-37052..37060 class of deserialization RCEs.

This PR adds the same guard used by the `pmdarima` sibling flavor: `_load_model` now raises `MlflowException` before deserializing when the control is disabled and the process is not running in a Databricks runtime / model-serving environment.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_load_model_disallows_pickle_deserialization`, parametrized over both `mlflow.statsmodels.load_model` and `pyfunc.load_model`, asserting that loading raises `MlflowException` when `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `mlflow.statsmodels` flavor now honors `MLFLOW_ALLOW_PICKLE_DESERIALIZATION`, closing a gap where the flavor deserialized pickled model artifacts regardless of that setting.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release