### PR TITLE
Fix Kubernetes auth token extraction for `kubernetes-client` 36+

### DIFF
--- a/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py
+++ b/mlflow/tracking/request_auth/kubernetes_request_auth_provider.py
@@ -155,6 +155,71 @@ def _get_kubeconfig_cache_key() -> str:
     return f"{kubeconfig_path}:{context_name}"
 
 
+def _normalize_bearer_token(value: str | None) -> str | None:
+    """Return a raw token string, stripping an optional ``Bearer `` prefix.
+
+    Non-bearer schemes such as ``Basic ...`` are rejected: values that contain
+    whitespace are only accepted when they use a ``Bearer `` prefix. Otherwise
+    they would later be re-emitted as ``Bearer Basic ...``.
+    """
+    if not isinstance(value, str):
+        return None
+    token = value.strip()
+    if not token:
+        return None
+    if token.lower().startswith("bearer "):
+        token = token[7:].strip()
+        return token or None
+    # Reject other auth schemes (e.g. "Basic ...") and malformed values.
+    if any(ch.isspace() for ch in token):
+        return None
+    return token
+
+
+def _extract_token_from_api_client(api_client) -> str | None:
+    """Extract a bearer token from a Kubernetes ``ApiClient``.
+
+    Token storage differs across kubernetes-client versions and auth flows:
+    - Some flows put the resolved token in ``default_headers``.
+    - kubernetes-client <36 stores it under ``configuration.api_key["authorization"]``.
+    - kubernetes-client 36+ stores it under ``configuration.api_key["BearerToken"]``.
+    - ``configuration.auth_settings()`` is the canonical resolution path and
+      works across these layouts.
+    """
+    # 1) Try default_headers first (where some auth flows put the resolved token)
+    auth = api_client.default_headers.get("Authorization") or api_client.default_headers.get(
+        "authorization"
+    )
+    if token := _normalize_bearer_token(auth if isinstance(auth, str) else None):
+        return token
+
+    # 2) Fallback: configuration.api_key (key name varies by kubernetes-client version)
+    api_key = getattr(api_client.configuration, "api_key", None) or {}
+    for key in ("authorization", "BearerToken", "Authorization"):
+        if token := _normalize_bearer_token(api_key.get(key)):
+            return token
+
+    # 3) Fallback: auth_settings() — works for kubernetes-client 36+ and exec plugins
+    try:
+        auth_settings = api_client.configuration.auth_settings()
+    except Exception as e:
+        _logger.debug("Could not read kubernetes auth_settings: %s", e)
+        return None
+
+    if not isinstance(auth_settings, dict):
+        return None
+
+    for setting in auth_settings.values():
+        if not isinstance(setting, dict):
+            continue
+        if str(setting.get("key", "")).lower() != "authorization":
+            continue
+        if token := _normalize_bearer_token(setting.get("value")):
+            return token
+
+    return None
+
+
 def _get_token_from_kubeconfig_uncached() -> str | None:
     from kubernetes import client, config
     from kubernetes.config.config_exception import ConfigException
@@ -166,26 +231,9 @@ def _get_token_from_kubeconfig_uncached() -> str | None:
         return None
 
     with client.ApiClient() as api_client:
-        token = None
-
-        # 1) Try default_headers first (where most auth flows put the resolved token)
-        auth = api_client.default_headers.get("Authorization") or api_client.default_headers.get(
-            "authorization"
-        )
-        if isinstance(auth, str) and auth.lower().startswith("bearer "):
-            token = auth[7:].strip()
-
-        # 2) Fallback: configuration.api_key (some versions/auth flows store it here)
-        if not token:
-            api_key = api_client.configuration.api_key.get("authorization")
-            if isinstance(api_key, str):
-                token = api_key.strip()
-                if token.lower().startswith("bearer "):
-                    token = token[7:].strip()
-
+        token = _extract_token_from_api_client(api_client)
         if not token:
             return None
-
         return f"Bearer {token}"
 
 

--- a/tests/tracking/request_auth/test_kubernetes_request_auth_provider.py
+++ b/tests/tracking/request_auth/test_kubernetes_request_auth_provider.py
@@ -139,27 +139,62 @@ def test_get_namespace_source_priority(tmp_path, sa_namespace, kubeconfig_namesp
 
 
 @pytest.mark.parametrize(
-    ("default_headers", "api_key", "expected"),
+    ("default_headers", "api_key", "auth_settings", "expected"),
     [
-        ({"Authorization": "Bearer tok"}, {}, "Bearer tok"),
-        ({"authorization": "Bearer lower"}, {}, "Bearer lower"),
-        ({}, {"authorization": "raw-tok"}, "Bearer raw-tok"),
-        ({}, {"authorization": "Bearer prefixed"}, "Bearer prefixed"),
-        ({}, {}, None),
+        ({"Authorization": "Bearer tok"}, {}, None, "Bearer tok"),
+        ({"authorization": "Bearer lower"}, {}, None, "Bearer lower"),
+        ({}, {"authorization": "raw-tok"}, None, "Bearer raw-tok"),
+        ({}, {"authorization": "Bearer prefixed"}, None, "Bearer prefixed"),
+        # kubernetes-client 36+ stores the token under BearerToken instead of authorization
+        ({}, {"BearerToken": "Bearer k8s36-tok"}, None, "Bearer k8s36-tok"),
+        ({}, {"BearerToken": "k8s36-raw"}, None, "Bearer k8s36-raw"),
+        (
+            {},
+            {},
+            {
+                "BearerToken": {
+                    "type": "api_key",
+                    "in": "header",
+                    "key": "authorization",
+                    "value": "Bearer from-auth-settings",
+                }
+            },
+            "Bearer from-auth-settings",
+        ),
+        # Non-bearer Authorization schemes must not be treated as tokens.
+        ({"Authorization": "Basic abc"}, {}, {}, None),
+        (
+            {"Authorization": "Basic abc"},
+            {"BearerToken": "fallback-tok"},
+            None,
+            "Bearer fallback-tok",
+        ),
+        ({}, {"authorization": "raw with spaces"}, {}, None),
+        ({}, {}, {}, None),
     ],
     ids=[
         "default-header-bearer",
         "lowercase-header",
         "api-key-fallback",
         "api-key-strips-bearer",
+        "api-key-bearertoken-key",
+        "api-key-bearertoken-raw",
+        "auth-settings-fallback",
+        "rejects-basic-auth-header",
+        "skips-basic-auth-then-api-key",
+        "rejects-raw-token-with-whitespace",
         "no-token",
     ],
 )
-def test_token_from_kubeconfig_extraction(default_headers, api_key, expected):
+def test_token_from_kubeconfig_extraction(default_headers, api_key, auth_settings, expected):
     mock_api_client = mock.MagicMock()
     mock_api_client.__enter__.return_value = mock_api_client
     mock_api_client.default_headers = default_headers
     mock_api_client.configuration.api_key = api_key
+    if auth_settings is None:
+        mock_api_client.configuration.auth_settings.side_effect = Exception("unused")
+    else:
+        mock_api_client.configuration.auth_settings.return_value = auth_settings
     with (
         mock.patch("kubernetes.config.load_kube_config"),
         mock.patch("kubernetes.client.ApiClient", return_value=mock_api_client),


### PR DESCRIPTION
### Related Issues/PRs

Relates to kubernetes-client 36+ kubeconfig token layout change (no tracking issue).

### What changes are proposed in this pull request?

`MLFLOW_TRACKING_AUTH=kubernetes` / `kubernetes-namespaced` failed to resolve kubeconfig credentials with `kubernetes-client` 36+ (for example OpenShift `oc login` tokens used outside a pod).

`kubernetes-client` <36 stores the bearer token under `configuration.api_key["authorization"]`, while 36+ stores it under `configuration.api_key["BearerToken"]`. The provider only checked the older key (plus `default_headers`), so token extraction returned `None` and raised `Could not determine Kubernetes credentials`.

This change:
- Normalizes optional `Bearer ` prefixes via `_normalize_bearer_token`
- Extracts tokens via `_extract_token_from_api_client`, checking `default_headers`, `api_key` key variants (`authorization`, `BearerToken`, `Authorization`), then `configuration.auth_settings()`
- Extends unit coverage for the 36+ `BearerToken` and `auth_settings()` paths

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual verification: with a live OpenShift kubeconfig and `kubernetes==36.0.3`, `_get_token()` now returns the kubeconfig bearer token and `KubernetesAuth(enable_workspaces=True)` successfully sets `Authorization` / workspace headers. Focused suite: `uv run pytest tests/tracking/request_auth/test_kubernetes_request_auth_provider.py` (38 passed).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix `MLFLOW_TRACKING_AUTH=kubernetes` / `kubernetes-namespaced` credential discovery for `kubernetes-client` 36+, so kubeconfig bearer tokens (including OpenShift tokens) are found again.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release