### PR TITLE
Surface trace-export auth failures at ERROR instead of silently dropping traces

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -29,6 +29,25 @@ from mlflow.utils.uri import is_databricks_uri
 
 _logger = logging.getLogger(__name__)
 
+# Substrings that identify an authentication or credential failure in an export
+# exception. A dropped trace from one of these is worth an ERROR, not a WARNING,
+# because the fix is a user re-auth rather than a transient retry.
+_AUTH_FAILURE_MARKERS = (
+    "token refresh",
+    "unauthorized",
+    "401",
+    "403",
+    "invalid access token",
+    "expired",
+    "could not identify databricks workspace configuration",
+    "default auth",
+)
+
+
+def _is_auth_failure(exc: Exception) -> bool:
+    """Best-effort check for an auth or credential failure in an export exception."""
+    return any(marker in str(exc).lower() for marker in _AUTH_FAILURE_MARKERS)
+
 
 class MlflowV3SpanExporter(SpanExporter):
     """
@@ -208,10 +227,22 @@ class MlflowV3SpanExporter(SpanExporter):
             else:
                 _logger.warning("No trace or trace info provided, unable to export")
         except Exception as e:
-            _logger.warning(
-                f"Failed to send trace to MLflow backend: {e}",
-                exc_info=_logger.isEnabledFor(logging.DEBUG),
-            )
+            if _is_auth_failure(e):
+                # An expired or missing credential silently drops the trace: the app
+                # keeps running, so without a loud signal the user never learns the
+                # trace was lost. Surface it at ERROR with a re-auth hint.
+                _logger.error(
+                    "Failed to send trace to MLflow backend because of an "
+                    f"authentication error, so the trace was NOT saved: {e}. "
+                    "Refresh your credentials (for example, run `databricks auth login`) "
+                    "and retry.",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
+            else:
+                _logger.warning(
+                    f"Failed to send trace to MLflow backend: {e}",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
 
         # Upload attachments in a separate try-except so trace data still lands
         # even if attachment upload fails. Runs regardless of span storage mode —

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -187,6 +187,35 @@ def test_export_catch_failure(is_async, monkeypatch):
     assert any("Failed to start trace" in msg for msg in warning_calls)
 
 
+@pytest.mark.parametrize("is_async", [True, False])
+def test_export_auth_failure_logged_as_error(is_async, monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", str(is_async))
+
+    mlflow.set_tracking_uri("databricks")
+    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.start_trace",
+            side_effect=Exception(
+                "default auth: cannot configure default credentials, token refresh"
+            ),
+        ),
+        mock.patch("mlflow.tracing.export.mlflow_v3._logger") as mock_logger,
+    ):
+        _predict("hello")
+
+        if is_async:
+            _flush_async_logging()
+
+    # An auth-class failure is logged at ERROR with a re-auth hint, not swallowed at WARNING.
+    mock_logger.error.assert_called()
+    error_msgs = [call[0][0] for call in mock_logger.error.call_args_list]
+    assert any("authentication error" in msg and "NOT saved" in msg for msg in error_msgs)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="Flaky on Windows")
 def test_async_bulk_export(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")


### PR DESCRIPTION
### Related Issues/PRs

Closes #24689

### What changes are proposed in this pull request?

When trace export to a Databricks backend fails because a credential expired or is missing, `MlflowV3SpanExporter._log_trace` caught the exception and logged it at `WARNING`, then dropped the trace. Since tracing is best-effort and the application keeps running, the user got no visible signal that traces were lost. This is easy to hit when a CLI OAuth token expires mid-session: earlier runs' traces land, later ones silently do not.

This PR distinguishes authentication/credential-class failures from generic transient ones. It adds a small `_is_auth_failure(exc)` helper that matches known auth markers (token refresh, 401/403, expired, "could not identify Databricks workspace configuration", default-auth errors), and logs those at `ERROR` with a re-auth hint, so a dropped trace from an expired credential is loud instead of silent. Other transient failures keep the existing `WARNING` behavior.

Files:
- `mlflow/tracing/export/mlflow_v3.py`: add `_is_auth_failure`, branch the except handler.
- `tests/tracing/export/test_mlflow_v3_exporter.py`: add `test_export_auth_failure_logged_as_error` (async + sync).

### How is this PR tested?

- [x] New unit/integration tests

Added `test_export_auth_failure_logged_as_error` covering both async and sync export paths, asserting an auth-class exception is logged at `ERROR` with the "NOT saved" re-auth message. Full exporter suite passes (14 passed) and `ruff check` + `ruff format` are clean on both files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

- [x] This PR can wait for the next minor release
