### PR TITLE
docs: credential-expiry trace-drop cause in tracing FAQ, experiment_id in quickstart

### DIFF
--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -293,6 +293,8 @@ mlflow.set_experiment("my-tracing-experiment")
 mlflow.openai.autolog()  # Call before using OpenAI
 ```
 
+**Expired or missing credentials**: If your tracking URI points to a remote server that requires authentication, an expired or missing credential causes trace export to fail. Because tracing is best-effort, your application keeps running and the failed traces are dropped. Auth failures are logged at `ERROR`, so check your logs, verify your credentials are current, and refresh them if needed (for example, re-run your auth login). This is easy to hit when a short-lived token expires partway through a long session: earlier traces land and later ones do not.
+
 ## Multi-threading and Concurrency
 
 ### Q: My trace is split into multiple traces when doing multi-threading. How can I combine them into a single trace?

--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -293,7 +293,7 @@ mlflow.set_experiment("my-tracing-experiment")
 mlflow.openai.autolog()  # Call before using OpenAI
 ```
 
-**Expired or missing credentials**: If your tracking URI points to a remote server that requires authentication, an expired or missing credential causes trace export to fail. Because tracing is best-effort, your application keeps running and the failed traces are dropped. Auth failures are logged at `ERROR`, so check your logs, verify your credentials are current, and refresh them if needed (for example, re-run your auth login). This is easy to hit when a short-lived token expires partway through a long session: earlier traces land and later ones do not.
+**Expired or missing credentials**: If your tracking URI points to a remote server that requires authentication, an expired or missing credential causes trace export to fail. Because tracing is best-effort, your application keeps running and the failed traces are dropped. The failure is written to your application logs, so check them for auth errors, verify your credentials are current, and refresh them if needed (for example, re-run your auth login). This is easy to hit when a short-lived token expires partway through a long session: earlier traces land and later ones do not.
 
 ## Multi-threading and Concurrency
 

--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -84,7 +84,10 @@ from openai import OpenAI
 mlflow.set_tracking_uri("http://localhost:5000")
 
 # Specify the experiment you just created for your LLM application or AI agent.
+# You can pass the experiment name, or attach to an existing experiment by its
+# numeric ID with the experiment_id keyword (a numeric ID passed as the name will fail):
 mlflow.set_experiment("My Application")
+# mlflow.set_experiment(experiment_id="1234567890123456")
 
 # Enable automatic tracing for all OpenAI API calls.
 mlflow.openai.autolog()

--- a/docs/docs/genai/tracing/quickstart/index.mdx
+++ b/docs/docs/genai/tracing/quickstart/index.mdx
@@ -84,8 +84,9 @@ from openai import OpenAI
 mlflow.set_tracking_uri("http://localhost:5000")
 
 # Specify the experiment you just created for your LLM application or AI agent.
-# You can pass the experiment name, or attach to an existing experiment by its
-# numeric ID with the experiment_id keyword (a numeric ID passed as the name will fail):
+# The positional argument is the experiment name. To attach to an existing
+# experiment by its numeric ID, pass it with the experiment_id keyword (a numeric
+# value passed positionally is treated as a name, not an ID):
 mlflow.set_experiment("My Application")
 # mlflow.set_experiment(experiment_id="1234567890123456")
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24689

### What changes are proposed in this pull request?

Two small tracing-docs additions surfaced by a user study:

1. **Tracing FAQ** (`docs/docs/genai/tracing/faq.mdx`): the "My traces are not appearing" answer now lists expired or missing credentials as a cause. An auth failure drops traces best-effort while the application keeps running, so a short-lived token that expires mid-session silently loses later traces. Points the reader at the ERROR-level log and a credential refresh. (Companion to the exporter fix in #24691.)

2. **Tracing quickstart** (`docs/docs/genai/tracing/quickstart/index.mdx`): show `mlflow.set_experiment(experiment_id="...")` for attaching to an existing experiment by numeric ID, and note that a numeric ID passed as the positional name fails.

### How is this PR tested?

- [x] Manual tests

Docs-only change (two MDX files, five added lines). Rendered locally.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

- [x] This PR can wait for the next minor release
