### PR TITLE
Remove Node 22.22.1 pin in `typescript.yml`

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -39,9 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 22.22.2 has a regression where `npm install -g` fails
-        # See: https://github.com/nodejs/node/issues/62425
-        node-version: [22.22.1, 24]
+        node-version: [22, 24]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/nodejs/node/issues/62425

### What changes are proposed in this pull request?

Remove the Node `22.22.1` pin from the `typescript.yml` matrix and go back to `[22, 24]`. The pin was added to dodge a regression in 22.22.2 where `npm install -g` fails (https://github.com/nodejs/node/issues/62425). That issue was fixed and closed on 2026-05-14, and the current 22.x release is 22.23.1, so the pin is no longer needed.

This also unblocks moving CI to npm 12 (follow-up PR), which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`.

### How is this PR tested?

- [x] Existing unit/integration tests

The `typescript.yml` workflow runs on this PR with the unpinned matrix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)