### PR TITLE
Pin `opentelemetry-api<1.44` for pydantic-ai < 1.0.0 cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -965,6 +965,11 @@ pydantic_ai:
     maximum: "1.107.0"
     requirements:
       ">= 0.0.0": ["mcp"]
+      # pydantic-ai < 1.0.0 does `from opentelemetry._events import Event`, but doesn't
+      # cap opentelemetry-api, so it floats to 1.44.0 which removed the `_events` module,
+      # breaking collection with `ModuleNotFoundError: No module named 'opentelemetry._events'`.
+      # pydantic-ai >= 1.0.0 either caps the api itself or switched to `opentelemetry._logs`.
+      "< 1.0.0": ["opentelemetry-api<1.44"]
     run: pytest tests/pydantic_ai
     test_tracing_sdk: true
     test_every_n_versions: 10


### PR DESCRIPTION
### Related Issues/PRs

Relates to the failing `pydantic_ai` cross-version test jobs.

### What changes are proposed in this pull request?

The `pydantic_ai` cross-version test matrix has been failing on the `autologging / 0.2.19`, `autologging / 0.5.1`, and `tracing-sdk` jobs with a collection-time error:

```
ModuleNotFoundError: No module named 'opentelemetry._events'
```

**Root cause:** `pydantic-ai < 1.0.0` does `from opentelemetry._events import Event` in `messages.py`, but these versions do **not** cap `opentelemetry-api`. On 2026-07-16, `opentelemetry-api==1.44.0` [removed the `opentelemetry._events` module](https://github.com/open-telemetry/opentelemetry-python/pull/5293) (the Events API, deprecated since 1.39.0). Since the old `pydantic-ai` versions let the api float, they resolve to the now-broken 1.44.0 and fail at import.

Versions `>= 1.0.0` are unaffected: `1.6.0`–`1.26.0` cap `opentelemetry-api` themselves (resolving to 1.42.1), and `>= 1.36.0` switched to `from opentelemetry._logs import LogRecord`. The `tracing-sdk` job reuses the install command of the minimum version (`0.2.19`), so it hits the same wall.

This PR scopes an `opentelemetry-api<1.44` pin to the affected range (`< 1.0.0`), which pulls the api back to 1.43.0 (still ships `_events`). This mirrors the existing precedent for the mistralai matrix (#23667).

### How is this PR tested?

- [x] Existing unit/integration tests

Reproduced the failure locally with `pydantic-ai==0.2.19` + `mcp` (otel-api floats to 1.44.0 → 3 collection errors). With the pin, otel-api resolves to 1.43.0 and the tests collect and pass (24 passed / 4 skipped in the tracing files, 2 passed in the mcp file). Also confirmed the `< 1.0.0` specifier only matches 0.2.19/0.5.1 and passes the matrix generator's unused-specifier validation.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.