### PR TITLE
Update `actions/setup-node` to v7.0.0

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
     - run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/actions/setup-node/releases/tag/v7.0.0

### What changes are proposed in this pull request?

Bump the pinned `actions/setup-node` in `.github/actions/setup-node/action.yml` from v6.3.0 to v7.0.0 to stay current on CI actions.

v7.0.0 is largely an internals release (ESM migration, `@actions/cache` 5.1.0, new `cache-primary-key`/`cache-matched-key` outputs, removal of the dummy `NODE_AUTH_TOKEN` export). Our composite action only passes `node-version`, so no usage changes are needed.

The SHA was resolved from the upstream tag:

```
gh api repos/actions/setup-node/git/ref/tags/v7.0.0
# 820762786026740c76f36085b0efc47a31fe5020
```

### How is this PR tested?

- [x] Existing unit/integration tests

CI on this PR exercises the updated action across every workflow that uses `./.github/actions/setup-node`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)