### PR TITLE
fix: add rate limiting and retry support to automatic evaluation path

### DIFF
--- a/mlflow/genai/evaluation/rate_limiter.py
+++ b/mlflow/genai/evaluation/rate_limiter.py
@@ -16,15 +16,19 @@ _logger = logging.getLogger(__name__)
 def eval_retry_context():
     """Disable downstream 429 retries so errors bubble up to call_with_retry().
 
-    Sets flags on both the HTTP-layer retry (rest_utils) and the litellm
-    adapter so that rate-limit errors propagate to the evaluate pipeline's
-    own retry/AIMD logic.
+    Iterates the RetryAdapter registry in litellm_adapter.py and disables
+    internal retry loops for every active provider, so that rate-limit errors
+    propagate to the evaluate pipeline's own retry/AIMD logic.
     """
-    # Lazy imports to avoid circular dependency: genai.evaluation → genai.judges/utils.
-    from mlflow.genai.judges.adapters.litellm_adapter import disable_litellm_rate_limit_retries
-    from mlflow.utils.rest_utils import disable_429_retry
+    from mlflow.genai.judges.adapters.litellm_adapter import get_retry_adapters
 
-    with disable_litellm_rate_limit_retries(), disable_429_retry():
+    active_adapters = [a for a in get_retry_adapters() if a.matches()]
+    _logger.debug(
+        f"eval_retry_context: disabling retries for {[a.name for a in active_adapters]}"
+    )
+    with contextlib.ExitStack() as stack:
+        for adapter in active_adapters:
+            stack.enter_context(adapter.disable_internal_retries())
         yield
 
 

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -8,7 +8,7 @@ import threading
 from contextlib import ContextDecorator
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 import pydantic
 
@@ -59,6 +59,87 @@ def disable_litellm_rate_limit_retries() -> Iterator[None]:
 
 def is_litellm_rate_limit_retries_disabled() -> bool:
     return _DISABLE_RATE_LIMIT_RETRIES.get()
+
+
+# ---------------------------------------------------------------------------
+# RetryAdapter registry
+#
+# Each integration that has its own internal 429-retry mechanism registers a
+# RetryAdapter here. eval_retry_context() in rate_limiter.py iterates this
+# registry and disables only the adapters whose matches() returns True,
+# allowing 429s to propagate up to MLflow's own call_with_retry / AIMD logic.
+#
+# To register a new adapter:
+#   from mlflow.genai.judges.adapters.litellm_adapter import register_retry_adapter, RetryAdapter
+#   register_retry_adapter(RetryAdapter(name="myprovider", matches=..., disable_internal_retries=...))
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RetryAdapter:
+    """Descriptor for a provider that has its own internal 429-retry mechanism.
+
+    Attributes:
+        name: Human-readable identifier (used in debug logging).
+        matches: Zero-argument callable returning True when this adapter is
+            active in the current environment (e.g. package installed and the
+            active tracking URI targets that provider).
+        disable_internal_retries: Context manager that suppresses the
+            provider's own retry loop for the duration of the ``with`` block.
+    """
+
+    name: str
+    matches: Callable[[], bool]
+    disable_internal_retries: Callable[[], contextlib.AbstractContextManager]
+
+
+_RETRY_ADAPTER_REGISTRY: list[RetryAdapter] = []
+
+
+def register_retry_adapter(adapter: RetryAdapter) -> None:
+    """Register a RetryAdapter so eval_retry_context() can disable it."""
+    _RETRY_ADAPTER_REGISTRY.append(adapter)
+
+
+def get_retry_adapters() -> list[RetryAdapter]:
+    """Return the registered RetryAdapters (read-only view for callers)."""
+    return list(_RETRY_ADAPTER_REGISTRY)
+
+
+def _is_databricks_tracking_uri() -> bool:
+    try:
+        import mlflow
+
+        return mlflow.get_tracking_uri().startswith("databricks")
+    except Exception:
+        return False
+
+
+@contextlib.contextmanager
+def _disable_databricks_429_retry() -> Iterator[None]:
+    from mlflow.utils.rest_utils import disable_429_retry
+
+    with disable_429_retry():
+        yield
+
+
+# --- Built-in registrations ---
+
+register_retry_adapter(
+    RetryAdapter(
+        name="litellm",
+        matches=lambda: _is_litellm_available(),
+        disable_internal_retries=disable_litellm_rate_limit_retries,
+    )
+)
+
+register_retry_adapter(
+    RetryAdapter(
+        name="databricks-sdk",
+        matches=lambda: _is_databricks_tracking_uri(),
+        disable_internal_retries=_disable_databricks_429_retry,
+    )
+)
 
 
 # Global cache to track model capabilities across function calls

--- a/mlflow/genai/scorers/online/trace_processor.py
+++ b/mlflow/genai/scorers/online/trace_processor.py
@@ -5,7 +5,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
 from mlflow.entities import Trace
-from mlflow.environment_variables import MLFLOW_ONLINE_SCORING_MAX_WORKER_THREADS
+from mlflow.environment_variables import (
+    MLFLOW_GENAI_EVAL_MAX_RETRIES,
+    MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT,
+    MLFLOW_ONLINE_SCORING_MAX_WORKER_THREADS,
+)
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.online.constants import EXCLUDE_EVAL_RUN_TRACES_FILTER, MAX_TRACES_PER_JOB
 from mlflow.genai.scorers.online.entities import OnlineScorer
@@ -247,7 +251,22 @@ class OnlineTraceScoringProcessor:
         # Import evaluation modules lazily to avoid pulling in pandas at module load
         # time, which would break the skinny client.
         from mlflow.genai.evaluation.entities import EvalItem
-        from mlflow.genai.evaluation.harness import _compute_eval_scores, _log_assessments
+        from mlflow.genai.evaluation.harness import _log_assessments, _parse_rate_limit
+        from mlflow.genai.evaluation.harness import _compute_eval_scores
+        from mlflow.genai.evaluation.rate_limiter import RPSRateLimiter, eval_retry_context
+
+        predict_rps, adaptive = _parse_rate_limit(MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT.get())
+        rate_limiter = RPSRateLimiter(predict_rps or 10.0, adaptive=adaptive or True)
+        max_retries = MLFLOW_GENAI_EVAL_MAX_RETRIES.get()
+
+        def _score_with_rate_limiting(eval_item, scorers):
+            with eval_retry_context():
+                return _compute_eval_scores(
+                    eval_item=eval_item,
+                    scorers=scorers,
+                    rate_limiter=rate_limiter,
+                    max_retries=max_retries,
+                )
 
         with ThreadPoolExecutor(
             max_workers=MLFLOW_ONLINE_SCORING_MAX_WORKER_THREADS.get(),
@@ -260,7 +279,7 @@ class OnlineTraceScoringProcessor:
                     continue
                 eval_item = EvalItem.from_trace(task.trace)
                 future = executor.submit(
-                    _compute_eval_scores, eval_item=eval_item, scorers=task.scorers
+                    _score_with_rate_limiting, eval_item, task.scorers
                 )
                 futures[future] = task
 

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from mlflow.genai.evaluation.harness import (
     AUTO_INITIAL_RPS,
@@ -13,7 +14,10 @@ from mlflow.genai.evaluation.rate_limiter import (
     is_rate_limit_error,
 )
 from mlflow.genai.judges.adapters.litellm_adapter import (
+    RetryAdapter,
     _get_litellm_retry_policy,
+    _disable_databricks_429_retry,
+    disable_litellm_rate_limit_retries,
     is_litellm_rate_limit_retries_disabled,
 )
 from mlflow.utils.rest_utils import is_429_retry_disabled
@@ -374,12 +378,28 @@ def test_call_with_retry_reports_throttle_and_success():
 
 # ── eval_retry_context tests ──
 
+# Both built-in adapters forced active so tests don't depend on litellm
+# being installed or a Databricks tracking URI being configured.
+_BOTH_ADAPTERS_ACTIVE = [
+    RetryAdapter(
+        name="litellm",
+        matches=lambda: True,
+        disable_internal_retries=disable_litellm_rate_limit_retries,
+    ),
+    RetryAdapter(
+        name="databricks-sdk",
+        matches=lambda: True,
+        disable_internal_retries=_disable_databricks_429_retry,
+    ),
+]
+
 
 def _retry_flags_active():
     """Check that both downstream retry-suppression flags are set."""
     return is_litellm_rate_limit_retries_disabled() and is_429_retry_disabled()
 
 
+@patch("mlflow.genai.judges.adapters.litellm_adapter._RETRY_ADAPTER_REGISTRY", _BOTH_ADAPTERS_ACTIVE)
 def test_eval_retry_context_sets_and_resets():
     assert not _retry_flags_active()
 
@@ -389,6 +409,7 @@ def test_eval_retry_context_sets_and_resets():
     assert not _retry_flags_active()
 
 
+@patch("mlflow.genai.judges.adapters.litellm_adapter._RETRY_ADAPTER_REGISTRY", _BOTH_ADAPTERS_ACTIVE)
 def test_eval_retry_context_nests():
     assert not _retry_flags_active()
 


### PR DESCRIPTION
## Summary

Fixes 
Issue - #24404

Automatic evaluation (`OnlineTraceScoringProcessor._execute_scoring`) was calling
`_compute_eval_scores` with `NoOpRateLimiter()` and `max_retries=0`, causing silent
429 failures with no backpressure or retry. This PR brings it in line with programmatic
`mlflow.genai.evaluate()`, and addresses the two design points raised in the issue thread.

---

## Problem

`_compute_eval_scores` accepts `rate_limiter` and `max_retries` as optional arguments:

```python
def _compute_eval_scores(
    *,
    eval_item: EvalItem,
    scorers: list[Scorer],
    rate_limiter: RateLimiter = NoOpRateLimiter(),   # ← NoOp by default
    max_retries: int = 0,                             # ← 0 retries by default
) -> EvalResult:
```

The two call paths pass them very differently:

| Path | `rate_limiter` | `max_retries` |
|---|---|---|
| Programmatic eval (`harness.py`) | `RPSRateLimiter(adaptive=True)` | 3 (env var) |
| Automatic eval (`_execute_scoring`) | `NoOpRateLimiter()` | **0** |

On a 429 in automatic eval: `report_throttle()` is a no-op, the exception is caught by
`_log_error_assessments()`, the assessment is stored as an error, and **the trace is not
retried** — it re-enters the next Huey scheduler tick (~1 minute later) at full
concurrency with no rate limiting.

Validated experimentally on MLflow 3.12.0 with 10 traces — all 10 scorer calls fired
within **1ms** of each other with zero `acquire()` calls, zero AIMD events, zero retries:

```
12:28:44,427 [SCORER INVOKED] call #1  thread=MlflowGenAIEvalScorer_0
12:28:44,427 [SCORER INVOKED] call #2  thread=MlflowGenAIEvalScorer_0
...
12:28:44,428 [SCORER INVOKED] call #10 thread=MlflowGenAIEvalScorer_0
```

---

## Changes

### 1. `RetryAdapter` registry — `mlflow/genai/judges/adapters/litellm_adapter.py`

Introduces a small adapter registry so provider-specific retry-suppression logic lives
at the adapter layer rather than hardcoded in core evaluation code.

```python
@dataclass
class RetryAdapter:
    name: str
    matches: Callable[[], bool]                                      # is this provider active?
    disable_internal_retries: Callable[[], AbstractContextManager]   # suppress its retry loop
```

Built-in registrations:

```python
# LiteLLM — active whenever litellm is importable
register_retry_adapter(RetryAdapter(
    name="litellm",
    matches=lambda: _is_litellm_available(),
    disable_internal_retries=disable_litellm_rate_limit_retries,
))

# Databricks SDK — active only when the tracking URI targets Databricks
# (package being installed is not sufficient — it must actually be in use)
register_retry_adapter(RetryAdapter(
    name="databricks-sdk",
    matches=lambda: _is_databricks_tracking_uri(),
    disable_internal_retries=_disable_databricks_429_retry,
))
```

New providers can register themselves without touching core code:

```python
from mlflow.genai.judges.adapters.litellm_adapter import register_retry_adapter, RetryAdapter

register_retry_adapter(RetryAdapter(
    name="my-provider",
    matches=lambda: importlib.util.find_spec("myprovider") is not None,
    disable_internal_retries=my_disable_context_manager,
))
```

### 2. `eval_retry_context()` — `mlflow/genai/evaluation/rate_limiter.py`

Now iterates the registry via `ExitStack` instead of hardcoding provider names:

```python
@contextlib.contextmanager
def eval_retry_context():
    from mlflow.genai.judges.adapters.litellm_adapter import get_retry_adapters

    active_adapters = [a for a in get_retry_adapters() if a.matches()]
    with contextlib.ExitStack() as stack:
        for adapter in active_adapters:
            stack.enter_context(adapter.disable_internal_retries())
        yield
```

### 3. `_execute_scoring` — `mlflow/genai/scorers/online/trace_processor.py`

Builds a rate limiter from the existing env vars and wraps scoring with
`eval_retry_context()` **inside the worker thread** (not around `executor.submit`):

```python
# Before
future = executor.submit(
    _compute_eval_scores, eval_item=eval_item, scorers=task.scorers
    # no rate_limiter → NoOpRateLimiter(), no max_retries → 0
)

# After
predict_rps, adaptive = _parse_rate_limit(MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT.get())
rate_limiter = RPSRateLimiter(predict_rps or 10.0, adaptive=adaptive or True)
max_retries = MLFLOW_GENAI_EVAL_MAX_RETRIES.get()

def _score_with_rate_limiting(eval_item, scorers):
    with eval_retry_context():              # disables LiteLLM / Databricks internal retries
        return _compute_eval_scores(
            eval_item=eval_item,
            scorers=scorers,
            rate_limiter=rate_limiter,      # AIMD token bucket
            max_retries=max_retries,        # retry budget (default 3)
        )

future = executor.submit(_score_with_rate_limiting, eval_item, task.scorers)
```

Reuses existing env vars — no new configuration surface introduced.

---

## Experimental Validation (EXP-8)

Three configurations against 10 eval items, 429s simulated on calls 2–5:

| Configuration | `acquire()` calls | AIMD events | Retries | rps trajectory |
|---|---|---|---|---|
| Baseline (`NoOpRateLimiter`, `max_retries=0`) | 0 | 0 | 0 | flat |
| Fix 1 only (rate limiter, no `eval_retry_context`) | 14 | 1 | 4 | `10.0 → 5.0 → 6.1` |
| **Full fix** (rate limiter + `eval_retry_context`) | **14** | **1** | **4** | **`10.0 → 5.0 → 6.1`** |

Full fix log:

```
acquire() called — rps=10.0 tokens=10.00
[SCORER] call #1 → 200
acquire() called — rps=10.0 tokens=9.00
[SCORER] call #2 → 429
Rate limit hit — reducing rate from 10.0 to 5.0 rps
Rate-limited (attempt 1/4), retrying in 1s
acquire() called — rps=5.2 tokens=5.00
...
acquire() called — rps=5.8 tokens=2.84   ← AIMD recovering
```

---

## Test Changes

`test_eval_retry_context_sets_and_resets` and `test_eval_retry_context_nests` are updated
to patch `_RETRY_ADAPTER_REGISTRY` with both adapters forced active, so the tests are
independent of `litellm` being installed in the test environment.

---

## Known Limitations (follow-on)

- **Rate limiter state resets each tick**: each Huey job runs as a fresh subprocess —
  AIMD state is lost between ticks and resets to 10 RPS. A persistent shared store
  (Redis) would be needed to carry state across ticks.
- **Per-job bucket amplification**: one `RPSRateLimiter` per job means N simultaneous
  experiments = N × 10 RPS combined load. Same issue as multi-workspace programmatic
  eval; can be addressed separately.
