### PR TITLE
Fall back to nested spans for Chat Sessions turn content

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.test.tsx
@@ -34,6 +34,52 @@ const createSpan = (
   },
 });
 
+const createSpanWithId = ({
+  spanId,
+  parentSpanId,
+  name,
+  inputs,
+  outputs,
+  extraAttributes = {},
+}: {
+  spanId: string;
+  parentSpanId: string | null;
+  name: string;
+  inputs?: unknown;
+  outputs?: unknown;
+  extraAttributes?: Record<string, unknown>;
+}): ModelTraceSpanV3 => ({
+  trace_id: 'trace-1',
+  span_id: spanId,
+  trace_state: '',
+  parent_span_id: parentSpanId,
+  name,
+  start_time_unix_nano: '1000000000',
+  end_time_unix_nano: '2000000000',
+  status: { code: 'STATUS_CODE_OK' },
+  attributes: {
+    'mlflow.spanType': JSON.stringify('UNKNOWN'),
+    ...(inputs === undefined ? {} : { 'mlflow.spanInputs': JSON.stringify(inputs) }),
+    ...(outputs === undefined ? {} : { 'mlflow.spanOutputs': JSON.stringify(outputs) }),
+    ...extraAttributes,
+  },
+});
+
+const createTraceFromSpans = (spans: ModelTraceSpanV3[]): ModelTrace => ({
+  data: { spans },
+  info: {
+    trace_id: 'trace-1',
+    request_time: '2025-04-19T09:04:07.875Z',
+    state: 'OK',
+    tags: {},
+    assessments: [],
+    trace_location: {
+      type: 'MLFLOW_EXPERIMENT',
+      mlflow_experiment: { experiment_id: 'exp-1' },
+    },
+  },
+});
+
 const createTrace = (span: ModelTraceSpanV3): ModelTrace => ({
   data: { spans: [span] },
   info: {
@@ -207,5 +253,94 @@ describe('SingleChatTurnMessages', () => {
 
     expect(screen.getByText('Inputs')).toBeInTheDocument();
     expect(screen.getByText('Outputs')).toBeInTheDocument();
+  });
+
+  it('falls back to a child span when the root has no inputs or outputs', () => {
+    // OpenTelemetry GenAI instrumentation puts the messages on the LLM span,
+    // which is a child of the agent span that starts the trace.
+    const root = createSpanWithId({ spanId: 'span-root', parentSpanId: null, name: 'invoke_agent' });
+    const child = createSpanWithId({
+      spanId: 'span-chat',
+      parentSpanId: 'span-root',
+      name: 'chat',
+      inputs: [{ role: 'user', content: 'This is an example Question?' }],
+      outputs: [{ role: 'assistant', content: 'This is an example answer.' }],
+    });
+
+    render(
+      <TestWrapper>
+        <SingleChatTurnMessages trace={createTraceFromSpans([root, child])} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('This is an example Question?')).toBeInTheDocument();
+    expect(screen.getByText('This is an example answer.')).toBeInTheDocument();
+  });
+
+  it('prefers the root span over a child that also has content', () => {
+    const root = createSpanWithId({
+      spanId: 'span-root',
+      parentSpanId: null,
+      name: 'invoke_agent',
+      inputs: [{ role: 'user', content: 'root question' }],
+      outputs: [{ role: 'assistant', content: 'root answer' }],
+    });
+    const child = createSpanWithId({
+      spanId: 'span-chat',
+      parentSpanId: 'span-root',
+      name: 'chat',
+      inputs: [{ role: 'user', content: 'child question' }],
+      outputs: [{ role: 'assistant', content: 'child answer' }],
+    });
+
+    render(
+      <TestWrapper>
+        <SingleChatTurnMessages trace={createTraceFromSpans([root, child])} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('root question')).toBeInTheDocument();
+    expect(screen.queryByText('child question')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty root sections when no span in the trace has content', () => {
+    const root = createSpanWithId({ spanId: 'span-root', parentSpanId: null, name: 'invoke_agent' });
+    const child = createSpanWithId({ spanId: 'span-child', parentSpanId: 'span-root', name: 'noop' });
+
+    render(
+      <TestWrapper>
+        <SingleChatTurnMessages trace={createTraceFromSpans([root, child])} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('Inputs')).toBeInTheDocument();
+    expect(screen.getByText('Outputs')).toBeInTheDocument();
+  });
+
+  it('picks the shallowest span with content', () => {
+    const root = createSpanWithId({ spanId: 'span-root', parentSpanId: null, name: 'invoke_agent' });
+    const middle = createSpanWithId({
+      spanId: 'span-middle',
+      parentSpanId: 'span-root',
+      name: 'retrieve',
+      inputs: [{ role: 'user', content: 'shallow question' }],
+      outputs: [{ role: 'assistant', content: 'shallow answer' }],
+    });
+    const deep = createSpanWithId({
+      spanId: 'span-deep',
+      parentSpanId: 'span-middle',
+      name: 'chat',
+      inputs: [{ role: 'user', content: 'deep question' }],
+      outputs: [{ role: 'assistant', content: 'deep answer' }],
+    });
+
+    render(
+      <TestWrapper>
+        <SingleChatTurnMessages trace={createTraceFromSpans([root, middle, deep])} />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('shallow question')).toBeInTheDocument();
+    expect(screen.queryByText('deep question')).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
@@ -141,13 +141,11 @@ export const getChatTurnContent = (span: ModelTraceSpanNode): ChatTurnContent | 
  * the tree breadth-first for the shallowest span that has something to show.
  */
 export const findChatTurnContent = (rootSpan: ModelTraceSpanNode): ChatTurnContent => {
-  const queue = [rootSpan];
+  // Index-based cursor rather than shift(), which re-indexes the queue each step.
+  const queue: ModelTraceSpanNode[] = [rootSpan];
 
-  while (queue.length > 0) {
-    const span = queue.shift();
-    if (!span) {
-      break;
-    }
+  for (let cursor = 0; cursor < queue.length; cursor++) {
+    const span = queue[cursor];
 
     const content = getChatTurnContent(span);
     if (content) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
-import type { ModelTrace, ModelTraceChatMessage } from '../ModelTrace.types';
+import type { ModelTrace, ModelTraceChatMessage, ModelTraceSpanNode } from '../ModelTrace.types';
 import { parseModelTraceToTree, createListFromObject } from '../ModelTraceExplorer.utils';
 import { normalizeLangchainChatInput } from '../chat-utils/langchain';
 import { ModelTraceExplorerChatMessage } from '../right-pane/ModelTraceExplorerChatMessage';
@@ -77,6 +77,90 @@ export const rankByKeyImportance = (preferredKeys: string[]) => {
 const rankInputByImportance = rankByKeyImportance(PREFERRED_INPUT_KEYS);
 const rankOutputByImportance = rankByKeyImportance(PREFERRED_OUTPUT_KEYS);
 
+type ChatTurnContent =
+  | { type: 'messages'; messages: ModelTraceChatMessage[] }
+  | { type: 'raw'; inputList: { key: string; value: string }[]; outputList: { key: string; value: string }[] };
+
+/**
+ * For the session view, show only the last user message and the final assistant
+ * response (skip tool calls, tool results, and intermediate assistant messages).
+ */
+export const getDisplayedChatMessages = (
+  chatMessages: ModelTraceChatMessage[] | undefined,
+): ModelTraceChatMessage[] => {
+  const lastUserIdx = chatMessages?.findLastIndex((message) => message.role === 'user') ?? -1;
+  const lastAssistantMessages = chatMessages
+    ? chatMessages.slice(lastUserIdx + 1).filter((m) => m.role === 'assistant' && m.content && !m.tool_calls?.length)
+    : [];
+
+  return [
+    ...(lastUserIdx >= 0 && chatMessages ? [chatMessages[lastUserIdx]] : []),
+    ...(lastAssistantMessages.length > 0 ? [lastAssistantMessages[lastAssistantMessages.length - 1]] : []),
+  ];
+};
+
+const getRawContent = (span: ModelTraceSpanNode): Extract<ChatTurnContent, { type: 'raw' }> => ({
+  type: 'raw',
+  // Sort by importance then reverse — the component expands upwards,
+  // so the last item in the array is the one visible above the fold.
+  inputList: createListFromObject(span.inputs)
+    .filter((item) => item.value !== 'null')
+    .sort(rankInputByImportance)
+    .reverse(),
+  outputList: createListFromObject(span.outputs)
+    .filter((item) => item.value !== 'null')
+    .sort(rankOutputByImportance)
+    .reverse(),
+});
+
+/** The content a single span can contribute to a turn, or null if it has none. */
+export const getChatTurnContent = (span: ModelTraceSpanNode): ChatTurnContent | null => {
+  const displayedMessages = getDisplayedChatMessages(span.chatMessages);
+  if (displayedMessages.length > 0) {
+    return { type: 'messages', messages: displayedMessages };
+  }
+
+  const simpleChatMessages = extractSimpleChatMessages(span.inputs, span.outputs);
+  if (simpleChatMessages) {
+    return { type: 'messages', messages: simpleChatMessages };
+  }
+
+  const rawContent = getRawContent(span);
+  if (rawContent.inputList.length > 0 || rawContent.outputList.length > 0) {
+    return rawContent;
+  }
+
+  return null;
+};
+
+/**
+ * Resolve the content for a turn, preferring the root span.
+ *
+ * OpenTelemetry GenAI instrumentation puts the messages on the LLM span, which is
+ * a child of an outer agent span, so a root-only lookup renders an empty turn. Walk
+ * the tree breadth-first for the shallowest span that has something to show.
+ */
+export const findChatTurnContent = (rootSpan: ModelTraceSpanNode): ChatTurnContent => {
+  const queue = [rootSpan];
+
+  while (queue.length > 0) {
+    const span = queue.shift();
+    if (!span) {
+      break;
+    }
+
+    const content = getChatTurnContent(span);
+    if (content) {
+      return content;
+    }
+
+    queue.push(...(span.children ?? []));
+  }
+
+  // Nothing anywhere in the trace: keep rendering the root's empty sections.
+  return getRawContent(rootSpan);
+};
+
 export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
   const { theme } = useDesignSystemTheme();
 
@@ -86,22 +170,12 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
     return null;
   }
 
-  // For the session view, show only the last user message and the final assistant
-  // response (skip tool calls, tool results, and intermediate assistant messages).
-  const chatMessages = rootSpan.chatMessages;
-  const lastUserIdx = chatMessages?.findLastIndex((message) => message.role === 'user') ?? -1;
-  const lastAssistantMessages = chatMessages
-    ? chatMessages.slice(lastUserIdx + 1).filter((m) => m.role === 'assistant' && m.content && !m.tool_calls?.length)
-    : [];
-  const displayedMessages = [
-    ...(lastUserIdx >= 0 && chatMessages ? [chatMessages[lastUserIdx]] : []),
-    ...(lastAssistantMessages.length > 0 ? [lastAssistantMessages[lastAssistantMessages.length - 1]] : []),
-  ];
+  const turnContent = findChatTurnContent(rootSpan);
 
-  if (displayedMessages.length !== 0) {
+  if (turnContent.type === 'messages') {
     return (
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-        {displayedMessages?.map((message, index) => (
+        {turnContent.messages.map((message, index) => (
           <ModelTraceExplorerChatMessage
             key={index}
             message={message}
@@ -117,37 +191,7 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
     );
   }
 
-  // Fallback: try to extract a simple user/assistant pair from raw inputs/outputs
-  const simpleChatMessages = extractSimpleChatMessages(rootSpan.inputs, rootSpan.outputs);
-  if (simpleChatMessages) {
-    return (
-      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-        {simpleChatMessages.map((message, index) => (
-          <ModelTraceExplorerChatMessage
-            key={index}
-            message={message}
-            css={{
-              maxWidth: '80%',
-              alignSelf: message.role === 'user' ? 'flex-start' : 'flex-end',
-              borderWidth: 2,
-              borderRadius: theme.borders.borderRadiusMd,
-            }}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  // Sort by importance then reverse — the component expands upwards,
-  // so the last item in the array is the one visible above the fold.
-  const inputList = createListFromObject(rootSpan.inputs)
-    .filter((item) => item.value !== 'null')
-    .sort(rankInputByImportance)
-    .reverse();
-  const outputList = createListFromObject(rootSpan.outputs)
-    .filter((item) => item.value !== 'null')
-    .sort(rankOutputByImportance)
-    .reverse();
+  const { inputList, outputList } = turnContent;
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>


### PR DESCRIPTION
### Related Issues/PRs

Closes #24677

### What changes are proposed in this pull request?

The Chat Sessions view resolved each turn's content from the root span only. `SingleChatTurnMessages` called `parseModelTraceToTree(trace)` and then tried, in order, the root's `chatMessages`, then `extractSimpleChatMessages(root.inputs, root.outputs)`, then raw Inputs/Outputs sections built from `root.inputs` / `root.outputs`.

OpenTelemetry GenAI instrumentation puts the messages on the LLM span, which is a child of an outer agent span:

```
[invoke_agent]  <- root span, no gen_ai.input.messages
  └── [chat]    <- child span, carries the messages
```

`mlflow/tracing/otel/translation/genai_semconv.py` already translates `gen_ai.input.messages` and `gen_ai.output.messages` into span inputs and outputs, but it does so on the span that carries them. The data was therefore stored correctly on the child while the UI only ever looked at the root, so every turn rendered empty Inputs and Outputs sections.

This PR:

- extracts the per-span resolution into `getChatTurnContent(span)`, which returns either chat messages or the raw input/output lists, or `null` when the span has nothing;
- adds `findChatTurnContent(rootSpan)`, which tries the root and otherwise walks the span tree breadth-first for the shallowest span that has content.

Two behaviours are deliberately preserved:

- the root span still wins whenever it has content, so existing traces render exactly as before;
- when no span anywhere in the trace has content, the root's empty sections are still rendered rather than the turn collapsing to nothing.

The traversal is intentionally not keyed on `gen_ai.operation.name == "chat"`. Any nested shape where the agent span wraps the span that holds the messages benefits, which also covers LangGraph-style traces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Existing tests: the 28 tests in `SingleChatTurnMessages.test.ts`/`.test.tsx` pass unchanged against the refactor, before any new tests were added, which is what establishes that the extraction is behaviour-preserving. The full `session-view` suite is 40 passing.

New tests in `SingleChatTurnMessages.test.tsx`:

| Test | Purpose |
|---|---|
| `falls back to a child span when the root has no inputs or outputs` | the reported bug |
| `prefers the root span over a child that also has content` | guards the existing behaviour |
| `renders the empty root sections when no span in the trace has content` | guards the empty-trace rendering |
| `picks the shallowest span with content` | pins the breadth-first order |

Verified the new tests actually catch the bug: with the component reverted to the root-only lookup, exactly the two nested-span cases fail and the other 30 pass. The three guard tests pass either way by design, so the fix cannot degenerate into "stop reading the root".

Manual test: `uv run dev/run_dev_server.py`, a two-turn session whose root span carries no messages and whose `chat` child carries them, viewed at `/experiments/{id}/chat-sessions/{session_id}`.

Before: both turns show empty Inputs and Outputs, matching the report.

After: both turns show the user message and the assistant response.

One note on the reproduction. I could not get a trace ingested through the OTLP endpoint to appear in the Chat Sessions view at all on a local SQLite backend, because `session.id` does not appear to be mapped to the `mlflow.trace.session` metadata key outside the Unity Catalog processor (`mlflow/tracing/processor/uc_table.py`). I therefore built the same span tree with native tracing plus explicit session metadata, which exercises the identical UI path. That may be a second, separate gap worth confirming, since without a session the OTEL-instrumented traces would not reach this view in OSS MLflow.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1280" height="820" alt="Chat Sessions view with empty Inputs and Outputs sections" src="https://github.com/user-attachments/assets/1cf64efe-e543-4a96-8c84-aae40c856c19" /> | <img width="1280" height="820" alt="Chat Sessions view showing the user message and assistant response" src="https://github.com/user-attachments/assets/c7481d0c-a904-4f58-8728-e645c9cfa13f" /> |


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Chat Sessions view now shows the inputs and outputs of a nested LLM span when the root span has none, so turns from OpenTelemetry GenAI instrumented agents are no longer blank.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
