### PR TITLE
Refresh Assistant config when leaving settings so the provider indicator isn't stale

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -19,6 +19,7 @@ beforeAll(() => {
 const mockSendMessage = jest.fn();
 const mockCancelSession = jest.fn();
 const mockClearPendingPrompt = jest.fn();
+const mockRefreshConfig = jest.fn();
 let mockSetupComplete = true;
 let mockPendingPrompt: string | null = null;
 const EMPTY_TOKEN_USAGE: TokenUsage = {
@@ -54,9 +55,22 @@ jest.mock('./AssistantContext', () => ({
     regenerateLastMessage: jest.fn(),
     reset: jest.fn(),
     cancelSession: mockCancelSession,
-    refreshConfig: jest.fn(),
+    refreshConfig: mockRefreshConfig,
     completeSetup: jest.fn(),
   }),
+}));
+
+// Stub the setup wizard so the settings view exposes its onBack handler directly,
+// without depending on the wizard's internal steps.
+jest.mock('./setup', () => ({
+  AssistantSetupWizard: ({ onBack }: { onBack?: () => void }) =>
+    onBack ? (
+      <button type="button" onClick={onBack}>
+        Back from settings
+      </button>
+    ) : (
+      <div>Setup wizard</div>
+    ),
 }));
 
 jest.mock('./AssistantPageContext', () => ({
@@ -82,6 +96,7 @@ describe('AssistantChatPanel', () => {
     mockSendMessage.mockClear();
     mockCancelSession.mockClear();
     mockClearPendingPrompt.mockClear();
+    mockRefreshConfig.mockClear();
     mockSetupComplete = true;
     mockPendingPrompt = null;
     mockTokenUsage = EMPTY_TOKEN_USAGE;
@@ -198,6 +213,19 @@ describe('AssistantChatPanel', () => {
     await user.keyboard('{Enter}');
 
     expect(mockLogTelemetryEvent).not.toHaveBeenCalled();
+  });
+
+  test('returning from settings refreshes config so the provider indicator is not stale', async () => {
+    const user = userEvent.setup();
+    renderChatPanel();
+
+    // Opening settings alone should not refetch config.
+    await user.click(screen.getByLabelText('Settings'));
+    expect(mockRefreshConfig).not.toHaveBeenCalled();
+
+    // Going back re-reads the config, so a provider changed in settings is reflected immediately.
+    await user.click(screen.getByRole('button', { name: 'Back from settings' }));
+    expect(mockRefreshConfig).toHaveBeenCalledTimes(1);
   });
 
   test('token footer shows a compact total and an info trigger when usage is present', () => {

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -224,8 +224,10 @@ describe('AssistantChatPanel', () => {
     expect(mockRefreshConfig).not.toHaveBeenCalled();
 
     // Going back re-reads the config, so a provider changed in settings is reflected immediately.
+    // The refresh is silent so it doesn't flash the loading state over the already-open chat.
     await user.click(screen.getByRole('button', { name: 'Back from settings' }));
     expect(mockRefreshConfig).toHaveBeenCalledTimes(1);
+    expect(mockRefreshConfig).toHaveBeenCalledWith({ silent: true });
   });
 
   test('token footer shows a compact total and an info trigger when usage is present', () => {

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -776,7 +776,9 @@ export const AssistantChatPanel = () => {
   const handleBackFromSettings = useCallback(() => {
     // Re-read the config so the composer's provider indicator reflects any
     // change made in settings; without this it stays stale until a reload.
-    refreshConfig();
+    // `silent` avoids flashing the full-panel loading state over the chat,
+    // since the panel is already open during back-navigation.
+    refreshConfig({ silent: true });
     setCurrentView('chat');
   }, [refreshConfig]);
 

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -737,8 +737,16 @@ const SetupPrompt = ({ onSetup }: { onSetup: () => void }) => {
 export const AssistantChatPanel = () => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
-  const { closePanel, reset, setupComplete, isLoadingConfig, canUseAssistant, completeSetup, isLocalServer } =
-    useAssistant();
+  const {
+    closePanel,
+    reset,
+    setupComplete,
+    isLoadingConfig,
+    canUseAssistant,
+    completeSetup,
+    isLocalServer,
+    refreshConfig,
+  } = useAssistant();
   const context = useAssistantPageContext();
   const experimentId = context['experimentId'] as string | undefined;
 
@@ -766,8 +774,11 @@ export const AssistantChatPanel = () => {
   }, []);
 
   const handleBackFromSettings = useCallback(() => {
+    // Re-read the config so the composer's provider indicator reflects any
+    // change made in settings; without this it stays stale until a reload.
+    refreshConfig();
     setCurrentView('chat');
-  }, []);
+  }, [refreshConfig]);
 
   const renderContent = () => {
     // Show message when this client isn't allowed to use the Assistant

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -422,8 +422,13 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   // Setup actions
-  const refreshConfig = useCallback(async () => {
-    setIsLoadingConfig(true);
+  // `silent` refreshes config without toggling `isLoadingConfig`, so a background
+  // re-read (e.g. returning from settings while the panel is already open) doesn't
+  // flash the full-panel loading state over the chat view.
+  const refreshConfig = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
+    if (!silent) {
+      setIsLoadingConfig(true);
+    }
     try {
       const config = await getConfig();
       const { setupComplete: isComplete, selectedProvider: provider } = await resolveSetup(config);
@@ -438,7 +443,9 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       setRemoteAccessAllowed(false);
       setSelectedProvider(null);
     } finally {
-      setIsLoadingConfig(false);
+      if (!silent) {
+        setIsLoadingConfig(false);
+      }
     }
   }, []);
 

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -188,8 +188,8 @@ export interface AssistantAgentActions {
   reset: () => void;
   /** Cancel the current streaming session */
   cancelSession: () => void;
-  /** Fetch/refresh config from backend */
-  refreshConfig: () => Promise<void>;
+  /** Fetch/refresh config from backend. Pass `{ silent: true }` to skip the loading state on a background refresh. */
+  refreshConfig: (options?: { silent?: boolean }) => Promise<void>;
   /** Mark setup as complete (after wizard finishes) */
   completeSetup: () => void;
   /** Answer the pending tool-call permission prompt */


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The Assistant's provider indicator reads `selectedProvider` from `AssistantContext`, which is only refreshed by `refreshConfig()`. Leaving settings via the back button (`handleBackFromSettings`) never called it, so changing the provider in settings left the indicator stale until a page reload.

Fix: call `refreshConfig()` in `handleBackFromSettings` so the indicator updates immediately.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/c02b5796-e2d7-4d2c-b62c-8c2094612d54



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Assistant's active-provider indicator now updates immediately after changing the provider in settings, instead of staying stale until a page reload.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release