### PR TITLE
docs: troubleshoot $0 trace cost for unknown model names

### DIFF
--- a/docs/docs/genai/tracing/token-usage-cost/index.mdx
+++ b/docs/docs/genai/tracing/token-usage-cost/index.mdx
@@ -221,6 +221,10 @@ Token usage and cost tracking is supported for most MLflow tracing integrations.
 
 :::tip
 Some providers or models may not return token usage information. In these cases, the `token_usage` and `cost` fields will be `None`.
+
+Cost can also appear as $0.00 even when token counts are tracked correctly. This happens when the model name recorded on the span has no matching entry in LiteLLM's price table. Databricks serving-endpoint names (for example, `databricks-claude-opus-4-8`) are one such case: LiteLLM cannot infer the provider from the bare endpoint name, so it returns no price.
+
+In either case, you can [set the token and cost attributes directly on the span](#manually-setting-token-and-cost-information).
 :::
 
 ### Manually Setting Token and Cost Information


### PR DESCRIPTION
### Related Issues/PRs

Supersedes #24648 (opened from a fork we could not push to). Relates to #24620.

### What changes are proposed in this pull request?

Explains why cost can show \$0.00 on a trace even when token counts are tracked correctly.

Root cause: MLflow computes cost by looking up the model name in LiteLLM's price table. When the model name on the span has no entry in that table, LiteLLM returns no price and cost renders as \$0.00. Databricks serving-endpoint names (for example, `databricks-claude-opus-4-8`) are not in LiteLLM's table by default, so users of Databricks-hosted models are commonly affected.

Rather than adding a new admonition near the top of the page (which would have placed three admonitions in a row), this rolls the explanation into the existing tip that sits directly above the **Manually Setting Token and Cost Information** section — connecting the \$0.00 symptom to the manual cost-override guidance that already lives right below it.

### How is this PR tested?

- [x] Manual tests

Docs-only change.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds a troubleshooting note to the token-usage/cost page: cost shows \$0.00 when the model name on the span is not in LiteLLM's price table (common for Databricks serving-endpoint names). Points to the existing manual cost-override section as the fix.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Co-authored with @adamgurary (original author of #24648).