### PR TITLE
Grant workspace users `CAN_USE` on UI preview apps

### DIFF
--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -11,7 +11,7 @@ Deploy a live preview of the MLflow UI as a [Databricks App](https://docs.databr
 
 ## Access
 
-Preview apps are only accessible to users with access to the Databricks workspace.
+Preview apps are only accessible to core maintainers with workspace access.
 
 ## API access
 

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -11,7 +11,7 @@ Deploy a live preview of the MLflow UI as a [Databricks App](https://docs.databr
 
 ## Access
 
-Preview apps are only accessible to core maintainers with workspace access.
+Preview apps are only accessible to users with access to the Databricks workspace.
 
 ## API access
 

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -213,6 +213,25 @@ jobs:
           URL=$(databricks apps get "$APP_NAME" -o json | jq -r '.url')
           echo "url=$URL" >> $GITHUB_OUTPUT
 
+      - name: Grant preview access
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          APP_NAME: ${{ github.event_name == 'push' && 'mlflow-ui-preview-dev' || format('mlflow-ui-preview-pr-{0}', github.event.pull_request.number) }}
+        run: |
+          # An app is only reachable by its creator (this service principal) and
+          # workspace admins by default, so non-admin maintainers get a 403 on the
+          # preview URL. Grant CAN_USE to everyone with workspace access.
+          # `update-permissions` is additive and idempotent, so running it on every
+          # deploy also backfills apps created before this step existed.
+          databricks apps update-permissions "$APP_NAME" --json '{
+            "access_control_list": [
+              {"group_name": "users", "permission_level": "CAN_USE"}
+            ]
+          }'
+
       - name: Configure app environment
         env:
           APP_URL: ${{ steps.app.outputs.url }}
@@ -309,7 +328,7 @@ jobs:
           | **Run** | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} |
 
           > [!NOTE]
-          > This preview is only accessible to core maintainers with workspace access.
+          > This preview is only accessible to users with Databricks workspace access.
           > The preview updates automatically when new commits are pushed."
 
           # Find existing comment

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -328,7 +328,7 @@ jobs:
           | **Run** | ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} |
 
           > [!NOTE]
-          > This preview is only accessible to users with Databricks workspace access.
+          > This preview is only accessible to core maintainers with workspace access.
           > The preview updates automatically when new commits are pushed."
 
           # Find existing comment


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24704

### What changes are proposed in this pull request?

UI preview apps are unreachable for anyone who isn't a workspace admin.

A Databricks app is only accessible to its creator and to workspace admins by default. Since the previews are created by the CI service principal, the ACL ends up as just `oss-mlflow-ui-preview` (`CAN_MANAGE`) plus the `admins` group (`CAN_MANAGE`, inherited from `/apps`). Non-admin maintainers hit a 403 on the preview URL.

This adds a `Grant preview access` step that gives the `users` group `CAN_USE` on the app. It runs on every deploy rather than only at creation, since `update-permissions` is additive and idempotent, so it also backfills apps created before this step existed.

### How is this PR tested?

- [x] Manual tests

Verified against the integration testing workspace as the actual CI service principal (`oss-mlflow-ui-preview`):

- Confirmed the pre-existing ACL was the service principal plus inherited `admins` only, with no other principals.
- Ran the exact command from the new step and confirmed the resulting ACL gained `users` -> `CAN_USE`.
- Ran it twice to confirm idempotency, which is what makes the every-deploy placement safe.
- Backfilled the currently live preview apps (`mlflow-ui-preview-dev` and the apps for PRs #24582, #24584, #24685, #24704) so they are usable without waiting for a redeploy.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)