### PR TITLE
fix(db): skip table creation if database already has tables to prevent MySQL duplicate table error (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,9 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if _is_empty_database(engine):
+        _logger.info("Creating initial MLflow database tables...")
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails on MySQL with error: `(1050, "Table 'secrets' already exists")`. This happens because `_initialize_tables` unconditionally calls `InitialBase.metadata.create_all(engine)` even when the database already contains tables, which causes MySQL to raise an error for tables that already exist.

## Fix
Modified `_initialize_tables` to check if the database is actually empty (only contains alembic_ tables) before running `create_all`. If the database already has user tables, we skip `create_all` and directly run `_upgrade_db` to apply pending migrations. This matches the intended behavior: fresh databases get initial tables created, existing databases only get upgraded via Alembic.

Closes #19943