### PR TITLE
[UI] Show error notification when permission-denied for USER role act

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -5,11 +5,13 @@
  * annotations are already looking good, please remove this comment.
  */
 
-import { test, expect, jest } from '@jest/globals';
+import { test, expect, jest, describe, beforeEach } from '@jest/globals';
 import Utils from './Utils';
 import React from 'react';
 import { X_AXIS_RELATIVE, X_AXIS_STEP, X_AXIS_WALL } from '../../experiment-tracking/components/MetricsPlotControls';
 import { RunTag } from '../../experiment-tracking/sdk/MlflowMessages';
+import { PermissionError, UnauthorizedError } from '@databricks/web-shared/errors';
+import { ErrorWrapper } from './ErrorWrapper';
 
 test('formatMetric', () => {
   expect(Utils.formatMetric(0)).toEqual('0');
@@ -990,4 +992,42 @@ test('renderNotebookSource renders plain text for dangerous workspaceUrl', () =>
     Utils.renderNotebookSource(null, '789', 'rev1', null, '/Users/test/iris', 'javascript://evil.com', null),
   ).toEqual('iris');
   /* eslint-enable no-script-url */
+});
+
+describe('logErrorAndNotifyUser', () => {
+  let mockNotificationsApi: { error: ReturnType<typeof jest.fn> };
+
+  beforeEach(() => {
+    mockNotificationsApi = { error: jest.fn() };
+    Utils.registerNotificationsApi(mockNotificationsApi);
+  });
+
+  test('shows toast for plain string errors', () => {
+    Utils.logErrorAndNotifyUser('something went wrong');
+    expect(mockNotificationsApi.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'something went wrong' }),
+    );
+  });
+
+  test('shows toast for ErrorWrapper errors', () => {
+    const wrapper = new ErrorWrapper('{"error_code":"PERMISSION_DENIED","message":"not allowed"}', 403);
+    Utils.logErrorAndNotifyUser(wrapper);
+    expect(mockNotificationsApi.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'PERMISSION_DENIED: not allowed' }),
+    );
+  });
+
+  test('shows toast for PermissionError (PredefinedError) instead of silently dropping it', () => {
+    const error = new PermissionError({});
+    Utils.logErrorAndNotifyUser(error);
+    expect(mockNotificationsApi.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'You do not have permission to access this resource.' }),
+    );
+  });
+
+  test('shows toast for UnauthorizedError (PredefinedError)', () => {
+    const error = new UnauthorizedError({});
+    Utils.logErrorAndNotifyUser(error);
+    expect(mockNotificationsApi.error).toHaveBeenCalledWith(expect.objectContaining({ message: expect.any(String) }));
+  });
 });

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -14,6 +14,7 @@ import { ErrorCodes, SupportPageUrl } from '../constants';
 import type { IntlShape } from 'react-intl';
 import { FormattedMessage } from 'react-intl';
 import { ErrorWrapper } from './ErrorWrapper';
+import { NetworkRequestError } from '@databricks/web-shared/errors';
 import type { RunInfoEntity } from '../../experiment-tracking/types';
 import type { KeyValueEntity } from '../types';
 import { NOTE_CONTENT_TAG } from '../../experiment-tracking/utils/NoteUtils';
@@ -1012,6 +1013,8 @@ class Utils {
     } else if (e instanceof ErrorWrapper) {
       // not all error is wrapped by ErrorWrapper
       Utils.displayGlobalErrorNotification(e.renderHttpError(), duration);
+    } else if (e instanceof NetworkRequestError) {
+      Utils.displayGlobalErrorNotification(e.message, duration);
       // eslint-disable-next-line no-empty
     } else {
     }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24711

### What changes are proposed in this pull request?

`Utils.logErrorAndNotifyUser` had a silent empty `else {}` branch that swallowed `PredefinedError` instances thrown by the new `fetchAPI`/`fetchOrFail` API layer. When a `PermissionError` (HTTP 403) was returned from a mutation (e.g. delete experiment, rename run, register model), the UI showed no feedback to the user — no toast, no modal, nothing.

This adds a `NetworkRequestError` branch that calls `displayGlobalErrorNotification(e.message)`, so users with insufficient permissions now see **"You do not have permission to access this resource."** as an error toast instead of silence.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests

Added 4 unit tests to `Utils.test.tsx` covering plain string, `ErrorWrapper`, `PermissionError`, and `UnauthorizedError` inputs to `logErrorAndNotifyUser`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users who trigger a permission-denied (403) error via the new API layer now see an error notification instead of no feedback.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
