### PR TITLE
[ui] Show remote assistant entrypoint

### DIFF
--- a/.github/ui-preview/app.yaml
+++ b/.github/ui-preview/app.yaml
@@ -8,3 +8,5 @@ env:
     value: "*"
   - name: MLFLOW_CRYPTO_KEK_PASSPHRASE
     value: "__KEK_PASSPHRASE__"
+  - name: MLFLOW_ENABLE_REMOTE_ASSISTANT
+    value: "true"

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
@@ -6,7 +6,7 @@ import { DesignSystemProvider } from '@databricks/design-system';
 import { AssistantFloatingButton } from './AssistantFloatingButton';
 
 const mockOpenPanel = jest.fn();
-let mockAssistant: { isLocalServer: boolean; isPanelOpen: boolean; openPanel: jest.Mock };
+let mockAssistant: { canUseAssistant: boolean; isLocalServer: boolean; isPanelOpen: boolean; openPanel: jest.Mock };
 let mockObstructionWidth: number;
 let mockObstructionHeight: number;
 
@@ -34,7 +34,7 @@ describe('AssistantFloatingButton', () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockOpenPanel.mockClear();
-    mockAssistant = { isLocalServer: true, isPanelOpen: false, openPanel: mockOpenPanel };
+    mockAssistant = { canUseAssistant: true, isLocalServer: true, isPanelOpen: false, openPanel: mockOpenPanel };
     mockObstructionWidth = 0;
     mockObstructionHeight = 0;
   });
@@ -64,11 +64,20 @@ describe('AssistantFloatingButton', () => {
     expect(mockOpenPanel).not.toHaveBeenCalled();
   });
 
-  test('does not auto-open or render on a remote server', () => {
+  test('does not auto-open or render when the assistant is unavailable', () => {
+    mockAssistant.canUseAssistant = false;
     mockAssistant.isLocalServer = false;
     renderFab();
     expect(mockOpenPanel).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: 'MLflow Assistant' })).not.toBeInTheDocument();
+  });
+
+  test('renders on a remote server when the assistant is available', () => {
+    mockAssistant.isLocalServer = false;
+    mockAssistant.canUseAssistant = true;
+    renderFab();
+    expect(mockOpenPanel).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'MLflow Assistant' })).toBeInTheDocument();
   });
 
   test('does not auto-open when the panel is already open', () => {

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
@@ -38,16 +38,16 @@ const useWindowWidth = (): number => {
 
 /**
  * Global floating entry point for the Assistant. Pinned bottom-right on every
- * page (local server only), mirroring the convention used by other observability
- * tools. Opens the existing Assistant side panel. Hidden while the panel is open
- * to avoid overlapping it.
+ * page where the Assistant is available, mirroring the convention used by other
+ * observability tools. Opens the existing Assistant side panel. Hidden while the
+ * panel is open to avoid overlapping it.
  *
  * On first load it opens the panel once (a one-time discovery boost), persisted so
  * it never auto-opens again.
  */
 export const AssistantFloatingButton = () => {
   const { theme } = useDesignSystemTheme();
-  const { isLocalServer, isPanelOpen, openPanel } = useAssistant();
+  const { canUseAssistant, isPanelOpen, openPanel } = useAssistant();
   const obstructionWidth = useFloatingObstructionWidth();
   const obstructionHeight = useFloatingObstructionHeight();
   const windowWidth = useWindowWidth();
@@ -64,20 +64,20 @@ export const AssistantFloatingButton = () => {
   // On first load, open the panel once to surface the assistant. Mark it done even if the
   // panel is already open (e.g. restored from a prior session) so a later reload won't force it.
   useEffect(() => {
-    if (!isLocalServer || autoOpened) {
+    if (!canUseAssistant || autoOpened) {
       return;
     }
     setAutoOpened(true);
     if (!isPanelOpen) {
       openPanel();
     }
-  }, [isLocalServer, isPanelOpen, autoOpened, setAutoOpened, openPanel]);
+  }, [canUseAssistant, isPanelOpen, autoOpened, setAutoOpened, openPanel]);
 
   // Hide only when the assistant is unavailable or already open. When a right-side
   // surface is open it doesn't hide the button — it reports the width it reserves (via
   // useRegisterFloatingObstruction) and the button shifts to its left so it stays
   // visible without overlapping. This is generic across any registering surface.
-  if (!isLocalServer || isPanelOpen) {
+  if (!canUseAssistant || isPanelOpen) {
     return null;
   }
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24582

### What changes are proposed in this pull request?

Remote assistant support can make the assistant available from non-localhost clients, but the global floating entrypoint still checked `isLocalServer` directly. This updates the floating button to use the existing `canUseAssistant` availability signal, so remote-enabled deployments show the same assistant entrypoint as local servers.

The local-only behavior is still preserved when the server reports that assistant access is unavailable.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Verification commands:

```bash
yarn prettier src/assistant/AssistantFloatingButton.tsx src/assistant/AssistantFloatingButton.test.tsx --check
yarn test --testPathPattern AssistantFloatingButton.test.tsx --runInBand
yarn type-check
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Remote-enabled MLflow Assistant deployments now show the global floating assistant entrypoint.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release