### PR TITLE
[tests] Fix trace archival config test isolation

### DIFF
--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -5,6 +5,7 @@ import pytest
 
 from mlflow import MlflowClient
 from mlflow.entities.model_registry import ModelVersion
+from mlflow.environment_variables import MLFLOW_TRACE_ARCHIVAL_CONFIG
 from mlflow.store.artifact.databricks_models_artifact_repo import DatabricksModelsArtifactRepository
 from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.store.artifact.unity_catalog_models_artifact_repo import (
@@ -115,7 +116,8 @@ def test_models_artifact_repo_init_with_uc_oss_profile_inferred_from_context():
         )
 
 
-def test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_registry():
+def test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_registry(monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)
     non_databricks_uri = "non_databricks_uri"
     artifact_location = "s3://blah_bucket/"
     with (

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -44,7 +44,7 @@ from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.workspace import TraceArchivalConfig
-from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_TRACE_ARCHIVAL_CONFIG
 from mlflow.exceptions import MlflowException
 from mlflow.store.tracking.dbmodels.models import (
     SqlEntityAssociation,
@@ -396,9 +396,25 @@ def test_serving_artifacts_auto_scopes_workspace_paths(workspace_tracking_store,
     assert calls == [("mlflow-artifacts:/artifacts", "team-prefix")]
 
 
-def test_serving_artifacts_allows_pre_scoped_roots(workspace_tracking_store, monkeypatch):
+def test_serving_artifacts_allows_pre_scoped_roots(workspace_tracking_store, monkeypatch, tmp_path):
     monkeypatch.delenv("_MLFLOW_SERVER_SERVE_ARTIFACTS", raising=False)
     workspace_tracking_store.artifact_root_uri = "mlflow-artifacts:/artifacts"
+
+    archive_path = tmp_path / "archive"
+    archive_path.mkdir()
+    config_path = tmp_path / "trace-archival.yaml"
+    config_path.write_text(
+        "\n".join([
+            "trace_archival:",
+            "  enabled: true",
+            f"  location: {archive_path.as_uri()}",
+            "  retention: 30d",
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, str(config_path))
+    trace_archival_config_calls = []
 
     class PrefixedProvider:
         def __init__(self, store):
@@ -407,6 +423,15 @@ def test_serving_artifacts_allows_pre_scoped_roots(workspace_tracking_store, mon
         def resolve_artifact_root(self, artifact_root, workspace_name):
             scoped = append_to_uri_path(artifact_root, f"workspaces/{workspace_name}")
             return scoped, False
+
+        def resolve_trace_archival_config(
+            self, default_root: str, default_retention: str, workspace_name: str
+        ) -> ResolvedTraceArchivalConfig:
+            trace_archival_config_calls.append((default_root, default_retention, workspace_name))
+            return ResolvedTraceArchivalConfig(
+                config=TraceArchivalConfig(location=default_root, retention=default_retention),
+                append_workspace_prefix=True,
+            )
 
     provider = PrefixedProvider(workspace_tracking_store)
     monkeypatch.setattr(
@@ -419,6 +444,7 @@ def test_serving_artifacts_allows_pre_scoped_roots(workspace_tracking_store, mon
         exp_id = workspace_tracking_store.create_experiment("with-prefix")
         experiment = workspace_tracking_store.get_experiment(exp_id)
     assert "/workspaces/team-ready/" in experiment.artifact_location
+    assert trace_archival_config_calls == [(archive_path.as_uri(), "30d", "team-ready")]
 
 
 def test_serving_artifacts_honors_workspace_override(workspace_tracking_store, monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24714

### What changes are proposed in this pull request?

This PR fixes two tests that can fail when the process has `MLFLOW_TRACE_ARCHIVAL_CONFIG`
set. The failures are test-isolation issues: the tests mock only the behavior they used to
exercise, but `get_experiment()` and trace archival validation now touch the same provider
and artifact repository lookup paths when archival config is active.

- Adds `resolve_trace_archival_config()` to the workspace store test's `PrefixedProvider`
  mock, matching the workspace provider interface used while resolving experiment metadata.
- Clears `MLFLOW_TRACE_ARCHIVAL_CONFIG` in the models artifact repo test before it patches
  `get_artifact_repository()` to return `None`, because trace archival validation also uses
  that helper.

### How is this PR tested?

- [x] Existing unit/integration tests

```bash
uv run --no-sync pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py::test_serving_artifacts_allows_pre_scoped_roots tests/store/artifact/test_models_artifact_repo.py::test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_registry
```

```bash
tmpdir=$(mktemp -d /private/tmp/mlflow-trace-archival.XXXXXX)
mkdir -p "$tmpdir/archive"
printf 'trace_archival:\n  enabled: true\n  location: file://%s/archive\n  retention: 30d\n' "$tmpdir" > "$tmpdir/config.yaml"
MLFLOW_TRACE_ARCHIVAL_CONFIG="$tmpdir/config.yaml" uv run --no-sync pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py::test_serving_artifacts_allows_pre_scoped_roots tests/store/artifact/test_models_artifact_repo.py::test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_registry
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
