### PR TITLE
Add `?pr=` to NaiLaOpus run URLs for quick switch back to the PR

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -79,12 +79,14 @@ jobs:
           COMMENT_ID: ${{ github.event.comment.id }}
           SERVER_URL: ${{ github.server_url }}
           RUN_ID: ${{ github.run_id }}
+          PR: ${{ steps.ctx.outputs.pr }}
         # Mirrors review.yml's pattern: append a run-URL link to the trigger
         # comment instead of leaving a separate reaction artifact on the PR.
         # The maintainer who typed `/review-v2` sees a clickable "🚀 running"
-        # link to follow the job in real time.
+        # link to follow the job in real time. `?pr=` makes the run page
+        # render a back-link to the PR.
         run: |
-          run_url="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
+          run_url="$SERVER_URL/$REPO/actions/runs/$RUN_ID?pr=$PR"
           orig=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body)
           body=$(printf '%s\n\n---\n\n🚀 [NaiLaOpus running...](%s)' "$orig" "$run_url")
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$body" || true
@@ -216,7 +218,7 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          run_url="$SERVER_URL/$REPO/actions/runs/$RUN_ID"
+          run_url="$SERVER_URL/$REPO/actions/runs/$RUN_ID?pr=$PR"
           # printf with a single-quoted format string keeps backticks literal
           # (no command substitution) and avoids the multi-line YAML quoting
           # bug where embedded backticks broke shell parsing. The leading ❌


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Append `?pr=<PR number>` to the run URLs NaiLaOpus posts (the "🚀 NaiLaOpus running..." link on the trigger comment and the "run logs" link in the failure comment). With this query parameter, the Actions run page renders a back-link to the PR, so you can quickly switch back after checking the run. `review.yml` and `ui-review.yml` already use this pattern.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)