### PR TITLE
Fix UnauthorizedError constructor message copy-pasted from RateLimite

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.test.tsx
@@ -50,4 +50,11 @@ describe('PredefinedErrors', () => {
       expect(matchedError).toBeInstanceOf(UnknownError);
     });
   });
+
+  describe('UnauthorizedError', () => {
+    it('should have the correct message string', () => {
+      const error = new UnauthorizedError({});
+      expect(error.message).toBe('User is not authorized.');
+    });
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.tsx
+++ b/mlflow/server/js/src/shared/web-shared/errors/PredefinedErrors.tsx
@@ -244,7 +244,7 @@ export class UnauthorizedError extends NetworkRequestError {
   );
 
   constructor(details: NetworkRequestErrorDetails, cause?: CausableError) {
-    const message = 'This request exceeds the maximum queries per second limit. Please wait and try again.';
+    const message = 'User is not authorized.';
 
     super(message, details, cause);
   }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24724

### What changes are proposed in this pull request?

`UnauthorizedError` in `PredefinedErrors.tsx` had a copy-paste bug in its constructor — the `message` string was copied from `RateLimitedError` instead of being set to its own message. This caused `e.message` to return `"This request exceeds the maximum queries per second limit..."` for any `UnauthorizedError` instance instead of `"User is not authorized."`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a unit test to `PredefinedErrors.test.tsx` asserting that `new UnauthorizedError({}).message` returns `"User is not authorized."`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `UnauthorizedError.message` now correctly returns `"User is not authorized."` instead of the wrong rate-limit message string.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
