### PR TITLE
Fix DeleteRunModal to show actual error instead of hardcoded message

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.enzyme.test.tsx
@@ -9,6 +9,7 @@ import { describe, beforeEach, jest, test, expect } from '@jest/globals';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { DeleteRunModalImpl } from './DeleteRunModal';
+import Utils from '../../../common/utils/Utils';
 
 /**
  * Return a function that can be used to mock run deletion API requests, appending deleted run IDs
@@ -45,7 +46,6 @@ describe('MyComponent', () => {
       selectedRunIds: ['runId0', 'runId1'],
       openErrorModal: jest.fn(),
       deleteRunApi: getMockDeleteRunApiFn(false, []),
-      intl: { formatMessage: jest.fn() },
       childRunIdsBySelectedParent: {},
     };
     wrapper = shallow(<DeleteRunModalImpl {...minimalProps} />);
@@ -69,14 +69,16 @@ describe('MyComponent', () => {
   });
 
   // eslint-disable-next-line jest/no-done-callback -- TODO(FEINF-1337)
-  test('should show error modal if deletion fails', (done) => {
+  test('should show error notification if deletion fails', (done) => {
+    const logErrorSpy = jest.spyOn(Utils, 'logErrorAndNotifyUser').mockImplementation(() => {});
     const deletedRunIds: any = [];
     const deleteRunApi = getMockDeleteRunApiFn(true, deletedRunIds);
     wrapper = shallow(<DeleteRunModalImpl {...{ ...minimalProps, deleteRunApi }} />);
     instance = wrapper.instance();
     instance.handleDeleteSelected().then(() => {
       expect(deletedRunIds).toEqual([]);
-      expect(minimalProps.openErrorModal).toHaveBeenCalled();
+      expect(logErrorSpy).toHaveBeenCalled();
+      logErrorSpy.mockRestore();
       done();
     });
   });

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.enzyme.test.tsx
@@ -23,7 +23,7 @@ const getMockDeleteRunApiFn = (shouldFail: any, deletedIdsList: any) => {
     return new Promise((resolve, reject) => {
       window.setTimeout(() => {
         if (shouldFail) {
-          reject();
+          reject(new Error('Delete failed: PERMISSION_DENIED'));
         } else {
           deletedIdsList.push(runId);
           // @ts-expect-error TS(2794): Expected 1 arguments, but got 0. Did you forget to... Remove this comment to see the full error message
@@ -44,7 +44,6 @@ describe('MyComponent', () => {
       isOpen: false,
       onClose: jest.fn(),
       selectedRunIds: ['runId0', 'runId1'],
-      openErrorModal: jest.fn(),
       deleteRunApi: getMockDeleteRunApiFn(false, []),
       childRunIdsBySelectedParent: {},
     };
@@ -76,10 +75,13 @@ describe('MyComponent', () => {
     wrapper = shallow(<DeleteRunModalImpl {...{ ...minimalProps, deleteRunApi }} />);
     instance = wrapper.instance();
     instance.handleDeleteSelected().then(() => {
-      expect(deletedRunIds).toEqual([]);
-      expect(logErrorSpy).toHaveBeenCalled();
-      logErrorSpy.mockRestore();
-      done();
+      try {
+        expect(deletedRunIds).toEqual([]);
+        expect(logErrorSpy).toHaveBeenCalledWith('Delete failed: PERMISSION_DENIED');
+      } finally {
+        logErrorSpy.mockRestore();
+        done();
+      }
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
@@ -9,8 +9,6 @@ import React, { Component } from 'react';
 import { deleteRunApi, openErrorModal } from '../../actions';
 import { connect } from 'react-redux';
 import Utils from '../../../common/utils/Utils';
-import type { IntlShape } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { Button, Modal } from '@databricks/design-system';
 import { EXPERIMENT_PARENT_ID_TAG } from '../experiment-page/utils/experimentPage.common-utils';
 
@@ -25,7 +23,6 @@ type Props = {
   openErrorModal: (...args: any[]) => any;
   deleteRunApi: (...args: any[]) => any;
   onSuccess?: () => void;
-  intl: IntlShape;
   childRunIdsBySelectedParent: Record<string, string[]>;
 };
 
@@ -89,12 +86,8 @@ export class DeleteRunModalImpl extends Component<Props, State> {
       deletePromises.push(this.props.deleteRunApi(runId));
     });
     return Promise.all(deletePromises)
-      .catch(() => {
-        const errorModalContent = `${this.props.intl.formatMessage({
-          defaultMessage: 'While deleting an experiment run, an error occurred.',
-          description: 'Experiment tracking > delete run modal > error message',
-        })}`;
-        this.props.openErrorModal(errorModalContent);
+      .catch((e: any) => {
+        Utils.logErrorAndNotifyUser(e);
       })
       .then(() => {
         this.props.onSuccess?.();
@@ -242,4 +235,4 @@ const mapDispatchToProps = {
   openErrorModal,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(DeleteRunModalImpl));
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteRunModalImpl);

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Component } from 'react';
-import { deleteRunApi, openErrorModal } from '../../actions';
+import { deleteRunApi } from '../../actions';
 import { connect } from 'react-redux';
 import Utils from '../../../common/utils/Utils';
 import { Button, Modal } from '@databricks/design-system';
@@ -20,7 +20,6 @@ type Props = {
   isOpen: boolean;
   onClose: (...args: any[]) => any;
   selectedRunIds: string[];
-  openErrorModal: (...args: any[]) => any;
   deleteRunApi: (...args: any[]) => any;
   onSuccess?: () => void;
   childRunIdsBySelectedParent: Record<string, string[]>;
@@ -86,11 +85,11 @@ export class DeleteRunModalImpl extends Component<Props, State> {
       deletePromises.push(this.props.deleteRunApi(runId));
     });
     return Promise.all(deletePromises)
-      .catch((e: any) => {
-        Utils.logErrorAndNotifyUser(e);
-      })
       .then(() => {
         this.props.onSuccess?.();
+      })
+      .catch((e: any) => {
+        Utils.logErrorAndNotifyUser(e?.message || e);
       })
       .finally(() => {
         this.setState({ deletingMode: null });
@@ -232,7 +231,6 @@ const mapStateToProps = (state: any, ownProps: { selectedRunIds: string[] }) => 
 
 const mapDispatchToProps = {
   deleteRunApi,
-  openErrorModal,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(DeleteRunModalImpl);

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -13187,10 +13187,6 @@
     "defaultMessage": "my-api-key",
     "description": "Placeholder for API key name input"
   },
-  "tdmVWN": {
-    "defaultMessage": "While deleting an experiment run, an error occurred.",
-    "description": "Experiment tracking > delete run modal > error message"
-  },
   "tiQptW": {
     "defaultMessage": "Learn more",
     "description": "Link to the documentation page for GenAI evaluation"


### PR DESCRIPTION
### Related Issues/PRs

Closes #24725

### What changes are proposed in this pull request?

`DeleteRunModal` had a `.catch(() => {})` block that ignored the actual error and always showed a hardcoded message — `"While deleting an experiment run, an error occurred."` — regardless of what failed. A USER-role user denied permission to delete a run saw the same generic message as any other failure, with no indication that the action was blocked due to insufficient permissions.

This replaces the hardcoded `openErrorModal` call with `Utils.logErrorAndNotifyUser(e)` so the actual error (e.g. `"You do not have permission to access this resource."` for a 403) is surfaced to the user as a toast notification. The now-unused `intl` prop and related imports are also removed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated the existing `"should show error modal if deletion fails"` test in `DeleteRunModal.enzyme.test.tsx` to assert that `Utils.logErrorAndNotifyUser` is called instead of `openErrorModal`. Removed the unused `intl` mock from test props.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When deleting a run fails (e.g. due to a permission error), the UI now shows the actual error message instead of a generic hardcoded one.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
