### PR TITLE
Fix RestoreRunModal to show actual error instead of hardcoded message

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.enzyme.test.tsx
@@ -59,10 +59,13 @@ describe('RestoreRunModal', () => {
 
     const promise = wrapper.find(ConfirmModal).prop('handleSubmit')();
     promise.finally(() => {
-      expect(mockFailRestoreRunApi).toHaveBeenCalledTimes(2);
-      expect(logErrorSpy).toHaveBeenCalled();
-      logErrorSpy.mockRestore();
-      done();
+      try {
+        expect(mockFailRestoreRunApi).toHaveBeenCalledTimes(2);
+        expect(logErrorSpy).toHaveBeenCalled();
+      } finally {
+        logErrorSpy.mockRestore();
+        done();
+      }
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.enzyme.test.tsx
@@ -10,21 +10,19 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { RestoreRunModalImpl } from './RestoreRunModal';
 import { ConfirmModal } from './ConfirmModal';
+import Utils from '../../../common/utils/Utils';
 
 describe('RestoreRunModal', () => {
   let wrapper: any;
   let minimalProps: any;
-  let mockOpenErrorModal: any;
   let mockRestoreRunApi: any;
 
   beforeEach(() => {
-    mockOpenErrorModal = jest.fn(() => Promise.resolve({}));
     mockRestoreRunApi = jest.fn(() => Promise.resolve({}));
     minimalProps = {
       isOpen: false,
       onClose: jest.fn(() => Promise.resolve({})),
       selectedRunIds: ['run1', 'run2'],
-      openErrorModal: mockOpenErrorModal,
       restoreRunApi: mockRestoreRunApi,
     };
 
@@ -47,16 +45,12 @@ describe('RestoreRunModal', () => {
 
   // eslint-disable-next-line jest/no-done-callback -- TODO(FEINF-1337)
   test('handleRenameExperiment errors correctly', (done) => {
+    const logErrorSpy = jest.spyOn(Utils, 'logErrorAndNotifyUser').mockImplementation(() => {});
     const mockFailRestoreRunApi = jest.fn(
       () =>
         new Promise((resolve, reject) => {
           window.setTimeout(() => {
-            reject(
-              new Error('Limit exceeded', {
-                // @ts-expect-error TS(2554): Object literal may only specify known properties, and 'textJson' does not exist in type 'ErrorOptions'.
-                textJson: { error_code: 'RESOURCE_LIMIT_EXCEEDED', message: 'Limit exceeded' },
-              }),
-            );
+            reject(new Error('Limit exceeded'));
           }, 1000);
         }),
     );
@@ -66,7 +60,8 @@ describe('RestoreRunModal', () => {
     const promise = wrapper.find(ConfirmModal).prop('handleSubmit')();
     promise.finally(() => {
       expect(mockFailRestoreRunApi).toHaveBeenCalledTimes(2);
-      expect(mockOpenErrorModal).toHaveBeenCalledTimes(1);
+      expect(logErrorSpy).toHaveBeenCalled();
+      logErrorSpy.mockRestore();
       done();
     });
   });

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.tsx
@@ -32,7 +32,7 @@ export class RestoreRunModalImpl extends Component<Props> {
     });
     return Promise.all(restorePromises)
       .catch((e) => {
-        Utils.logErrorAndNotifyUser(e);
+        Utils.logErrorAndNotifyUser(e?.message || e);
       })
       .then(() => {
         this.props.onSuccess?.();

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.tsx
@@ -8,14 +8,13 @@
 import React, { Component } from 'react';
 import { ConfirmModal } from './ConfirmModal';
 import { connect } from 'react-redux';
-import { openErrorModal, restoreRunApi } from '../../actions';
+import { restoreRunApi } from '../../actions';
 import Utils from '../../../common/utils/Utils';
 
 type Props = {
   isOpen: boolean;
   onClose: (...args: any[]) => any;
   selectedRunIds: string[];
-  openErrorModal: (...args: any[]) => any;
   restoreRunApi: (...args: any[]) => any;
   onSuccess?: () => void;
 };
@@ -33,11 +32,7 @@ export class RestoreRunModalImpl extends Component<Props> {
     });
     return Promise.all(restorePromises)
       .catch((e) => {
-        let errorMessage = 'While restoring an experiment run, an error occurred.';
-        if (e.textJson && e.textJson.error_code === 'RESOURCE_LIMIT_EXCEEDED') {
-          errorMessage = errorMessage + ' ' + e.textJson.message;
-        }
-        this.props.openErrorModal(errorMessage);
+        Utils.logErrorAndNotifyUser(e);
       })
       .then(() => {
         this.props.onSuccess?.();
@@ -61,7 +56,6 @@ export class RestoreRunModalImpl extends Component<Props> {
 
 const mapDispatchToProps = {
   restoreRunApi,
-  openErrorModal,
 };
 
 export default connect(null, mapDispatchToProps)(RestoreRunModalImpl);


### PR DESCRIPTION
### Related Issues/PRs

Closes #24726


### What changes are proposed in this pull request?

`RestoreRunModal` had a `.catch` block that ignored the actual error and always showed a hardcoded message — `"While restoring an experiment run, an error occurred."` — regardless of what failed. A USER-role user denied permission to restore a run saw the same generic message as any other failure, with no indication that the action was blocked due to insufficient permissions.

This replaces the hardcoded `openErrorModal` call with `Utils.logErrorAndNotifyUser(e)` so the actual error (e.g. `"You do not have permission to access this resource."` for a 403) is surfaced to the user as a toast notification. The now-unused `openErrorModal` prop and its related import are also removed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated the existing `"handleRenameExperiment errors correctly"` test in `RestoreRunModal.enzyme.test.tsx` to assert that `Utils.logErrorAndNotifyUser` is called instead of `openErrorModal`. Removed the unused `openErrorModal` mock from test props.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When restoring a run fails (e.g. due to a permission error), the UI now shows the actual error message instead of a generic hardcoded one.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
