### PR TITLE
fix: prevent duplicate table creation error during db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, the `mlflow db upgrade` command fails with:
```
pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")
```
This happens because `_initialize_tables()` uses `InitialBase.metadata.create_all(engine)` without `checkfirst=True`. If a previous migration attempt partially created the 'secrets' table (or it was created by a partial upgrade), calling `create_all` again tries to recreate an already existing table.

## Fix
Added `checkfirst=True` to the `create_all()` call in `_initialize_tables()`. This tells SQLAlchemy to skip creation of tables that already exist, preventing the duplicate table error. This is a safe change because:
- The function is intended to create initial tables only if they are missing
- Subsequent migration steps handled by Alembic will manage schema changes properly
- This matches the behavior of Alembic's internal `_auto_create_tables` which already uses `checkfirst=True`

Closes #19943