### PR TITLE
docs: Document direct artifact downloads via presigned URLs

### DIFF
--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -255,7 +255,9 @@ You can configure the following environment variables:
 
 ## Presigned URLs for direct artifact downloads \{#presigned-download-urls}
 
-Presigned URL downloads require **MLflow >= 3.15.0**.
+:::note[MLflow 3.15.0 Required]
+Presigned URL downloads require MLflow 3.15.0 or later.
+:::
 
 When run artifacts are stored directly on supported storage (for example, an `s3://` artifact location as in
 [non-proxied artifact access](/self-hosting/architecture/tracking-server#tracking-server-no-proxy)), the MLflow UI

--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -252,3 +252,35 @@ You can configure the following environment variables:
   when logging artifacts (Default: 500 MB)
 - `MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE` - Specifies the chunk size in bytes to use when performing multipart upload
   (Default: 100 MB)
+
+## Presigned URLs for direct artifact downloads \{#presigned-download-urls}
+
+Presigned URL downloads require **MLflow >= 3.15.0**.
+
+When run artifacts are stored directly on supported storage (for example, an `s3://` artifact location as in
+[non-proxied artifact access](/self-hosting/architecture/tracking-server#tracking-server-no-proxy)), the MLflow UI
+downloads artifacts directly from the storage instead of streaming them through the Tracking Server.
+
+Under the hood, when you download an artifact from the artifact viewer, the UI requests a short-lived presigned URL
+from the Tracking Server and navigates the browser to it, letting the storage serve the artifact data.
+None of the data will pass through the Tracking Server. The URL is generated with a `Content-Disposition: attachment`
+response header so that browsers save the artifact as a file instead of rendering it.
+
+If the artifacts are not stored directly on supported storage (for example, with
+[proxied artifact access](/self-hosting/architecture/tracking-server#tracking-server-artifact-store), the default
+configuration), the UI falls back to downloading the artifact through the Tracking Server.
+
+MLflow supports presigned URL downloads for the following storage:
+
+- Amazon S3
+
+You can configure the following environment variable:
+
+- `MLFLOW_PRESIGNED_DOWNLOAD_URL_TTL_SECONDS` - Specifies how long a generated presigned URL remains valid, in
+  seconds (Default: 300)
+
+:::note
+The browser must have network access to the storage endpoint for the direct download to succeed. In deployments
+where end users cannot reach the storage directly, use proxied artifact access so that downloads flow through the
+Tracking Server. Also note that anyone holding a presigned URL can fetch the artifact until the URL expires.
+:::

--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -292,6 +292,15 @@ The MLflow client caches artifact location information on a per-run basis.
 It is therefore not recommended to alter a run's artifact location before it has terminated.
 :::
 
+:::note
+With proxied artifact access, artifact downloads from the MLflow UI also stream through the tracking server.
+Since MLflow 3.15.0, when run artifacts are instead stored directly on supported storage (currently Amazon S3,
+as with [non-proxied artifact access](#tracking-server-no-proxy)), the MLflow UI downloads artifacts directly
+from the storage via presigned URLs, bypassing the tracking server. See
+[Presigned URLs for direct artifact downloads](/self-hosting/architecture/artifact-store#presigned-download-urls)
+for details.
+:::
+
 #### Use tracking server w/o proxying artifacts access \{#tracking-server-no-proxy}
 
 In some cases, you may want to directly access remote storage without proxying through the tracking server.

--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -542,6 +542,13 @@ But reject sources like:
 
 When uploading or downloading large artifacts through the tracking server with the artifact proxy enabled, the server may take a long time to process the request. If it exceeds the timeout limit, the server will terminate the request, resulting in a request failure on the client side.
 
+:::note
+Since MLflow 3.15.0, the MLflow UI downloads artifacts directly from supported storage (e.g., Amazon S3) via
+presigned URLs instead of streaming them through the tracking server, which avoids these timeouts for UI downloads.
+See [Presigned URLs for direct artifact downloads](/self-hosting/architecture/artifact-store#presigned-download-urls)
+for details.
+:::
+
 Example client code:
 
 ```python

--- a/docs/docs/self-hosting/architecture/tracking-server.mdx
+++ b/docs/docs/self-hosting/architecture/tracking-server.mdx
@@ -543,9 +543,9 @@ But reject sources like:
 When uploading or downloading large artifacts through the tracking server with the artifact proxy enabled, the server may take a long time to process the request. If it exceeds the timeout limit, the server will terminate the request, resulting in a request failure on the client side.
 
 :::note
-Since MLflow 3.15.0, the MLflow UI downloads artifacts directly from supported storage (e.g., Amazon S3) via
-presigned URLs instead of streaming them through the tracking server, which avoids these timeouts for UI downloads.
-See [Presigned URLs for direct artifact downloads](/self-hosting/architecture/artifact-store#presigned-download-urls)
+Since MLflow 3.15.0, when run artifacts are stored directly on supported storage (currently Amazon S3), the MLflow UI
+downloads them via presigned URLs instead of streaming them through the tracking server, avoiding these timeouts for
+UI downloads. See [Presigned URLs for direct artifact downloads](/self-hosting/architecture/artifact-store#presigned-download-urls)
 for details.
 :::
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24311. Documentation follow-up for #24435 (server endpoint) and #24613 (UI), as requested by @B-Step62 in the review of #24613.

### What changes are proposed in this pull request?

Adds user-facing documentation for downloading artifacts directly from cloud storage via presigned URLs (shipped in #24435 and #24613, MLflow >= 3.15.0):

- `docs/docs/self-hosting/architecture/artifact-store.mdx`: new "Presigned URLs for direct artifact downloads" section, mirroring the structure of the existing "Multipart upload for proxied artifact access" section. Covers when the feature activates (direct `s3://` artifact locations), supported storage, the automatic fallback to proxied downloads, the `MLFLOW_PRESIGNED_DOWNLOAD_URL_TTL_SECONDS` environment variable, and a note that the browser needs network access to the storage endpoint.
- `docs/docs/self-hosting/architecture/tracking-server.mdx`: a note in "Handling timeout when uploading/downloading large artifacts" pointing to the new section, since presigned downloads bypass the tracking server for UI downloads on supported storage.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Docs-only change: `npm run eslint` (0 warnings) and `npm run prettier:check` pass locally; all cross-link anchors verified to exist.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - `docs/docs/self-hosting/architecture/artifact-store.mdx`
  - `docs/docs/self-hosting/architecture/tracking-server.mdx`

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes


#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
