### PR TITLE
Validate `max_results` for bulk metric history

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2154,7 +2154,21 @@ def get_metric_history_bulk_handler():
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    max_results = int(request.args.get("max_results", MAX_HISTORY_RESULTS))
+    raw_max_results = request.args.get("max_results", MAX_HISTORY_RESULTS)
+    try:
+        max_results = int(raw_max_results)
+    except (TypeError, ValueError):
+        raise MlflowException(
+            f"Invalid value {raw_max_results!r} for parameter 'max_results' supplied. "
+            "It must be a positive integer.",
+            error_code=INVALID_PARAMETER_VALUE,
+        ) from None
+    if max_results <= 0:
+        raise MlflowException(
+            f"Invalid value {max_results} for parameter 'max_results' supplied. "
+            "It must be a positive integer.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
     max_results = min(max_results, MAX_HISTORY_RESULTS)
 
     store = _get_tracking_store()

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -1052,6 +1052,13 @@ def test_get_metric_history_bulk_rejects_invalid_requests(mlflow_client):
         "GetMetricHistoryBulk request must specify a metric_key",
     )
 
+    for max_results in [0, -1, "invalid", "1.5", ""]:
+        response_invalid_max_results = requests.get(
+            f"{mlflow_client.tracking_uri}/ajax-api/2.0/mlflow/metrics/get-history-bulk",
+            params={"run_id": ["123"], "metric_key": "key", "max_results": max_results},
+        )
+        assert_response(response_invalid_max_results, "It must be a positive integer")
+
 
 def test_get_metric_history_bulk_returns_expected_metrics_in_expected_order(
     mlflow_client,


### PR DESCRIPTION
### Related Issues/PRs

None.

### What changes are proposed in this pull request?

Reject non-integer and non-positive `max_results` values in the bulk metric history endpoint with `INVALID_PARAMETER_VALUE`. The existing 25,000-result upper clamp remains unchanged.

Previously, negative values could reach the tracking store and bypass the intended query limit on SQLite. Malformed values raised an uncaught `ValueError` instead of returning a client error.

The endpoint test now covers zero, negative, empty, fractional, and non-numeric values.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```text
uv run --no-default-groups --group pytest pytest tests/tracking/test_rest_tracking.py -q -k 'get_metric_history_bulk and not interval'
uvx --from ruff==0.15.17 ruff check mlflow/server/handlers.py tests/tracking/test_rest_tracking.py
uvx --from ruff==0.15.17 ruff format --check mlflow/server/handlers.py tests/tracking/test_rest_tracking.py
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The bulk metric history endpoint now rejects invalid `max_results` values with `INVALID_PARAMETER_VALUE` instead of allowing negative limits or returning an internal server error.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
