### PR TITLE
Support haystack 3.x in haystack autologging

### DIFF
--- a/mlflow/haystack/autolog.py
+++ b/mlflow/haystack/autolog.py
@@ -19,6 +19,7 @@ from opentelemetry.trace import (
 
 from mlflow.entities import LiveSpan, SpanType
 from mlflow.entities.span import create_mlflow_span
+from mlflow.exceptions import MlflowException
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.provider import _get_tracer
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -42,8 +43,6 @@ def _get_opentelemetry_tracer_class():
             # In haystack < 3, `OpenTelemetryTracer` ships in the core package
             from haystack.tracing import OpenTelemetryTracer
         except ImportError as e:
-            from mlflow.exceptions import MlflowException
-
             raise MlflowException(
                 "MLflow haystack autologging requires the `opentelemetry-haystack` package "
                 "when using haystack >= 3. Please run `pip install opentelemetry-haystack`."

--- a/mlflow/haystack/autolog.py
+++ b/mlflow/haystack/autolog.py
@@ -3,7 +3,7 @@ import logging
 import threading
 from typing import Any
 
-from haystack.tracing import OpenTelemetryTracer, enable_tracing
+from haystack.tracing import enable_tracing
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
@@ -34,6 +34,23 @@ from mlflow.tracing.utils import (
 _logger = logging.getLogger(__name__)
 
 
+def _get_opentelemetry_tracer_class():
+    try:
+        from haystack_integrations.tracing.opentelemetry import OpenTelemetryTracer
+    except ImportError:
+        try:
+            # In haystack < 3, `OpenTelemetryTracer` ships in the core package
+            from haystack.tracing import OpenTelemetryTracer
+        except ImportError as e:
+            from mlflow.exceptions import MlflowException
+
+            raise MlflowException(
+                "MLflow haystack autologging requires the `opentelemetry-haystack` package "
+                "when using haystack >= 3. Please run `pip install opentelemetry-haystack`."
+            ) from e
+    return OpenTelemetryTracer
+
+
 def setup_haystack_tracing():
     from haystack import tracing as hs_tracing
 
@@ -53,7 +70,7 @@ def setup_haystack_tracing():
             provider.add_span_processor(hs_processor)
 
     tracer = trace.get_tracer(__name__)
-    enable_tracing(OpenTelemetryTracer(tracer))
+    enable_tracing(_get_opentelemetry_tracer_class()(tracer))
 
 
 def _infer_span_type_from_haystack(

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -1004,8 +1004,10 @@ haystack:
       uv pip install --system git+https://github.com/deepset-ai/haystack
   autologging:
     minimum: "2.4.0"
-    maximum: "2.31.0"
+    maximum: "3.0.0"
     requirements:
+      # `OpenTelemetryTracer` moved out of the core package in haystack 3.0
+      ">= 3.0.0": ["opentelemetry-haystack"]
     run: pytest tests/haystack
     test_tracing_sdk: true
     test_every_n_versions: 10

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -420,7 +420,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "2.4.0",
-            "maximum": "2.31.0"
+            "maximum": "3.0.0"
         }
     },
     "sentence_transformers": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,8 +230,9 @@ docs = [
   "Flask-WTF<2",
   "polars>=1",
   "openai",
-  # TODO: Support haystack 3.x (`OpenTelemetryTracer` moved to `opentelemetry-haystack`)
-  "haystack-ai<3",
+  "haystack-ai",
+  # Required for haystack >= 3 (`OpenTelemetryTracer` moved out of the core package)
+  "opentelemetry-haystack",
   "deepeval",
   "ragas",
   "instructor",

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -25,8 +25,9 @@ polars>=1
 # required for the genai evaluation example
 openai
 # required for the haystack
-# TODO: Support haystack 3.x (`OpenTelemetryTracer` moved to `opentelemetry-haystack`)
-haystack-ai<3
+haystack-ai
+# required for haystack >= 3 (`OpenTelemetryTracer` moved out of the core package)
+opentelemetry-haystack
 # required for deepeval scorer documentation
 deepeval
 # required for ragas scorer documentation

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -95,5 +95,6 @@ agno
 # Required by mlflow.strands
 strands-agents
 # Required by mlflow.haystack
-# TODO: Support haystack 3.x (`OpenTelemetryTracer` moved to `opentelemetry-haystack`)
-haystack-ai<3
+haystack-ai
+# Required for haystack >= 3 (`OpenTelemetryTracer` moved out of the core package)
+opentelemetry-haystack

--- a/tests/haystack/test_haystack_tracing.py
+++ b/tests/haystack/test_haystack_tracing.py
@@ -10,6 +10,8 @@ from haystack.document_stores.in_memory import InMemoryDocumentStore
 import mlflow
 from mlflow.entities import SpanType
 from mlflow.environment_variables import MLFLOW_USE_DEFAULT_TRACER_PROVIDER
+from mlflow.exceptions import MlflowException
+from mlflow.haystack.autolog import _get_opentelemetry_tracer_class
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.version import IS_TRACING_SDK_ONLY
 
@@ -216,9 +218,6 @@ def test_haystack_autolog_shared_provider_no_recursion(monkeypatch):
 
 
 def test_get_opentelemetry_tracer_class_error_when_unavailable(monkeypatch):
-    from mlflow.exceptions import MlflowException
-    from mlflow.haystack.autolog import _get_opentelemetry_tracer_class
-
     # Simulate an environment where neither `opentelemetry-haystack` (haystack >= 3) nor the
     # in-core `OpenTelemetryTracer` (haystack < 3) is available
     monkeypatch.setitem(sys.modules, "haystack_integrations.tracing.opentelemetry", None)

--- a/tests/haystack/test_haystack_tracing.py
+++ b/tests/haystack/test_haystack_tracing.py
@@ -1,5 +1,7 @@
+import sys
 from unittest.mock import patch
 
+import pytest
 from haystack import Document, Pipeline, component
 from haystack.components.rankers import LostInTheMiddleRanker
 from haystack.components.retrievers import InMemoryBM25Retriever
@@ -211,3 +213,16 @@ def test_haystack_autolog_shared_provider_no_recursion(monkeypatch):
     assert spans[0].span_type == SpanType.CHAIN
     assert spans[0].inputs == {"adder": {"a": 1, "b": 2}}
     assert spans[0].outputs == {"adder": {"sum": 3}}
+
+
+def test_get_opentelemetry_tracer_class_error_when_unavailable(monkeypatch):
+    from mlflow.exceptions import MlflowException
+    from mlflow.haystack.autolog import _get_opentelemetry_tracer_class
+
+    # Simulate an environment where neither `opentelemetry-haystack` (haystack >= 3) nor the
+    # in-core `OpenTelemetryTracer` (haystack < 3) is available
+    monkeypatch.setitem(sys.modules, "haystack_integrations.tracing.opentelemetry", None)
+    monkeypatch.delattr("haystack.tracing.OpenTelemetryTracer", raising=False)
+
+    with pytest.raises(MlflowException, match="pip install opentelemetry-haystack"):
+        _get_opentelemetry_tracer_class()

--- a/uv.lock
+++ b/uv.lock
@@ -4237,6 +4237,7 @@ docs = [
     { name = "nbconvert" },
     { name = "nbformat" },
     { name = "openai" },
+    { name = "opentelemetry-haystack" },
     { name = "plotly" },
     { name = "polars" },
     { name = "pyspark" },
@@ -4422,13 +4423,14 @@ docs = [
     { name = "datasets" },
     { name = "deepeval" },
     { name = "flask-wtf", specifier = "<2" },
-    { name = "haystack-ai", specifier = "<3" },
+    { name = "haystack-ai" },
     { name = "instructor" },
     { name = "keras" },
     { name = "langchain-community", specifier = ">=0.3.0" },
     { name = "nbconvert" },
     { name = "nbformat" },
     { name = "openai" },
+    { name = "opentelemetry-haystack" },
     { name = "plotly" },
     { name = "polars", specifier = ">=1" },
     { name = "pyspark" },
@@ -5274,6 +5276,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-haystack"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "haystack-ai" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/7f/4ed8ca4e56b077ec6a52e7dc9bf62317c47bf0bc0f71de8f786bc58cd95c/opentelemetry_haystack-1.0.0.tar.gz", hash = "sha256:e09ec8edd48c28cc20a1fb6234fd733740bef3a44155c9fb3cd51f31eae23ddd", size = 10967, upload-time = "2026-06-23T13:06:52.375Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/77/6c1140542dae1689f93ffc922b571fd0f08a12a50450157445d4e0c0643a/opentelemetry_haystack-1.0.0-py3-none-any.whl", hash = "sha256:e507c4499b27ca93f8f74aff35d8a6fbfe5832f43182a659bfc789bcfffb20a9", size = 9948, upload-time = "2026-06-23T13:06:51.263Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2537,7 +2537,7 @@ name = "gunicorn"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
@@ -2588,12 +2588,11 @@ wheels = [
 
 [[package]]
 name = "haystack-ai"
-version = "2.31.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "filetype" },
-    { name = "haystack-experimental" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "jsonschema" },
@@ -2614,21 +2613,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/92/0fcbe75e0e9e2884e0f346d35ad59650804c116c562e7f0862d229d80394/haystack_ai-2.31.0.tar.gz", hash = "sha256:e9fc0ae5d651bd2d92b54f08cd77ed501dbbdbaf0c7abc1d4392ebe2f01d3332", size = 510990, upload-time = "2026-07-08T11:34:38.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/f5b82c7bd90345abfff69a76445ee63e9b42f362303946a97bfd5cf49e08/haystack_ai-3.0.0.tar.gz", hash = "sha256:c948a337e7a53d9bc47f3c08c2ad5e52ca6bd44956ad6d9e3512209a056493b4", size = 469683, upload-time = "2026-07-20T12:07:00.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d3/4ad026476f10bcc4922046f29ad9c1018369c1fda305089a412de5fc1fc3/haystack_ai-2.31.0-py3-none-any.whl", hash = "sha256:f4387e691152778370d7b1dbcc12ef0f04fb5be4b01d6993719849a1c5dcdb3f", size = 734435, upload-time = "2026-07-08T11:34:37.203Z" },
-]
-
-[[package]]
-name = "haystack-experimental"
-version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "haystack-ai" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/a3/02eb86716f4856072feb852555f2d23855bb20c993264dcf4e83dfe87a8a/haystack_experimental-0.19.0.tar.gz", hash = "sha256:194f9074f9184a20d2f4efa7b5082dd33118bc886f87937d13e33616cd549067", size = 45328, upload-time = "2026-02-05T08:31:33.862Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/c4/6719e1b03b72ab31729b556a47fe3df1ab7fa233b1d01182f0c5ddadfda6/haystack_experimental-0.19.0-py3-none-any.whl", hash = "sha256:ebe1691a4b8d06f934bad792ff95fb4b6858a2ae08f08519e9cf35b7b439b4bd", size = 63150, upload-time = "2026-02-05T08:31:34.683Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3f/fa387315618f0c2dcac7178b781476363b7b9edbb0e02c23eb5a60a2392d/haystack_ai-3.0.0-py3-none-any.whl", hash = "sha256:523718f200b27e11c8e33acf29fc8608c2f9951a0877eedf11bf838d06abff05", size = 656076, upload-time = "2026-07-20T12:06:58.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24743

### What changes are proposed in this pull request?

Support haystack 3.x in `mlflow.haystack` autologging and remove the `haystack-ai<3` pin added in #24743.

haystack 3.0 moved `OpenTelemetryTracer` out of the core package into the `opentelemetry-haystack` integration package, which broke `import mlflow.haystack` (and the docs build) under 3.x. This PR:

- Resolves the tracer class lazily: `haystack_integrations.tracing.opentelemetry` (haystack >= 3) first, falling back to the in-core `haystack.tracing.OpenTelemetryTracer` (haystack < 3), with a clear `pip install opentelemetry-haystack` error when neither is available. haystack 2.x users are unaffected.
- Removes the `haystack-ai<3` pins and adds `opentelemetry-haystack` to the docs/test requirements.
- Bumps the tested maximum to 3.0.0 in `ml-package-versions.yml`, installing `opentelemetry-haystack` for haystack >= 3.

`tests/haystack` passes locally against both `haystack-ai==2.31.0` and `haystack-ai==3.0.0` (the only failure, `test_token_usage_parsed_for_llm_component`, is a pre-existing floating-point cost assertion that also fails on master).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow haystack autologging now supports haystack 3.x (requires the `opentelemetry-haystack` package on haystack >= 3).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)