### PR TITLE
Refresh traces saved-view on load across multiple windows

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -713,5 +713,28 @@ describe('TracesV3Logs', () => {
       // Outside preview the control is editable.
       expect(getColumnsButton()).not.toBeDisabled();
     });
+
+    it('does not enter preview for a bare share key carrying no view state', async () => {
+      // A garbage/deleted share key has no selectedColumns/sort in the URL, so there's nothing to
+      // preview. Presence of the key alone must not enter preview mode: the user keeps their own
+      // column count and the control stays editable (no misleading "shared view" state).
+      renderComponent({}, ['/?traceViewShareKey=does-not-exist']);
+      await waitForRoutesToBeRendered();
+
+      await waitFor(() => expect(getColumnsButton()).toHaveTextContent('Columns1/2'));
+      expect(getColumnsButton()).not.toBeDisabled();
+    });
+
+    it('enters preview for a share link carrying only a time range (no columns or sort)', async () => {
+      // buildTraceViewQuery also serializes startTime/endTime/filter, so a view that captures only a
+      // time range still carries real state. previewActive must gate on the full captured param set,
+      // not just columns/sort — otherwise this link would skip preview and enable the controls.
+      renderComponent({}, ['/?traceViewShareKey=v-time&startTime=2026-01-01T00:00:00.000Z']);
+      await waitForRoutesToBeRendered();
+
+      // In preview the column control is disabled (editing is deferred to Override/Discard), even
+      // though the link carried no columns of its own — the user's own columns show, read-only.
+      await waitFor(() => expect(getColumnsButton()).toBeDisabled());
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -736,5 +736,15 @@ describe('TracesV3Logs', () => {
       // though the link carried no columns of its own — the user's own columns show, read-only.
       await waitFor(() => expect(getColumnsButton()).toBeDisabled());
     });
+
+    it('enters preview for a share link with an empty selectedColumns value (all columns deselected)', async () => {
+      // captureTraceViewState/buildTraceViewQuery treat an empty-string value as captured (present),
+      // so `selectedColumns=` is a real view — every column deselected. The state check uses `!== null`
+      // (not truthiness) so this still enters preview rather than silently skipping it.
+      renderComponent({}, ['/?traceViewShareKey=v-empty&selectedColumns=']);
+      await waitForRoutesToBeRendered();
+
+      await waitFor(() => expect(getColumnsButton()).toBeDisabled());
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -73,6 +73,7 @@ import {
   TRACE_SHARE_URL_PARAM_KEY,
   TraceLiveViewStateProvider,
   TracePreviewActionsProvider,
+  urlHasCapturedTraceViewState,
 } from './TracesV3SavedViews';
 import { useSavedViewPreview } from './traceSavedViewPreview';
 import { useDeleteTracesMutation } from '../../../evaluations/hooks/useDeleteTraces';
@@ -310,9 +311,16 @@ const TracesV3LogsImpl = React.memo(
     // columns/sort ride in the URL), render the view's columns/sort in the table WITHOUT writing to
     // the user's persisted state. Only an explicit "Override my view" adopts the preview; "Discard"
     // drops the share params and returns to the user's own state.
-    const previewActive = Boolean(searchParams.get(TRACE_SHARE_URL_PARAM_KEY));
     const rawPreviewColumns = searchParams.get('selectedColumns') ?? undefined;
     const rawPreviewSort = searchParams.get('sort') ?? undefined;
+    // Require actual view state to preview, not just the key's presence: a genuine share link always
+    // carries some captured state (columns, sort, time range, filter, ...) — see buildTraceViewQuery
+    // — whereas a bare or garbage share key carries none. Gating on the state avoids showing the
+    // "you're viewing a shared view" banner (and disabling the column controls) for a key that
+    // resolves to nothing. Checks the full captured param set (not just columns/sort) so a
+    // time-range- or filter-only shared view still previews.
+    const previewActive =
+      Boolean(searchParams.get(TRACE_SHARE_URL_PARAM_KEY)) && urlHasCapturedTraceViewState(searchParams);
     // Leave preview by dropping only the share key — NOT by navigating to the bare route. Override
     // writes columns/sort via the table setters first (which, when table-state persistence is in
     // URL mode, write the selectedColumns/sort params); a bare-route navigation would clobber those

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.test.tsx
@@ -318,3 +318,133 @@ describe('TracesV3SavedViewsButton', () => {
     expect(discard).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('useTraceSavedViews stale-tag refetch on active share key', () => {
+  // Renders just the hook at a URL carrying the given share key, so we can assert its refetch
+  // behavior without the button UI. `useGetExperimentQuery`/`refetch` are mocked at module scope.
+  const HookProbe = ({ experimentId }: { experimentId: string }) => {
+    useTraceSavedViews({ experimentId });
+    return null;
+  };
+
+  const renderHookAt = (shareKey?: string) =>
+    render(
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <MockedReduxStoreProvider>
+            <HookProbe experimentId="exp-1" />
+          </MockedReduxStoreProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+      {
+        wrapper: ({ children }) => (
+          <TestRouter
+            routes={[testRoute(<>{children}</>, '/')]}
+            history={history}
+            initialEntries={[shareKey ? `/?traceViewShareKey=${shareKey}` : '/']}
+          />
+        ),
+      },
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('refetches once when the active share key is not in the cached views (stale tag cache)', async () => {
+    // The cached experiment has v1/v2 but the pasted link references a just-saved view absent here.
+    mockExperiment(savedViewTags);
+
+    renderHookAt('freshly-saved-id');
+
+    await waitFor(() => expect(stableRefetch).toHaveBeenCalledTimes(1));
+  });
+
+  test('does not refetch again while the key stays missing after a tags update (anti-loop guard)', async () => {
+    mockExperiment(savedViewTags);
+
+    const { rerender } = renderHookAt('freshly-saved-id');
+    await waitFor(() => expect(stableRefetch).toHaveBeenCalledTimes(1));
+
+    // Simulate the refetch resolving with a NEW tags array that still lacks the key (e.g. a genuinely
+    // deleted view): views changes identity → the effect re-runs → the per-key guard must hold and
+    // NOT fire a second refetch, or a missing key would loop forever.
+    mockExperiment([...savedViewTags]);
+    rerender(
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <MockedReduxStoreProvider>
+            <HookProbe experimentId="exp-1" />
+          </MockedReduxStoreProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+    );
+
+    // Assert via waitFor so a second refetch firing on a later tick would push the count past 1 and
+    // fail this (a synchronous expect could pass before an async re-fire lands).
+    await waitFor(() => expect(stableRefetch).toHaveBeenCalledTimes(1));
+  });
+
+  test('does not refetch when the active share key is already in the cached views', async () => {
+    mockExperiment(savedViewTags);
+
+    // render() flushes the mount effect under act, and the effect calls refetch() synchronously, so a
+    // stray refetch would already be recorded here — no timing anchor needed.
+    renderHookAt('v1');
+
+    expect(stableRefetch).not.toHaveBeenCalled();
+  });
+
+  test('does not refetch when there is no active share key', async () => {
+    mockExperiment(savedViewTags);
+
+    renderHookAt();
+
+    expect(stableRefetch).not.toHaveBeenCalled();
+  });
+
+  test('the trigger label catches up to the view name once the refetch reveals the tag', async () => {
+    // Stale cache: the active share key's view isn't in the tags yet, so the trigger shows the
+    // generic "Views" and a refetch fires.
+    mockExperiment(savedViewTags);
+
+    const { rerender } = render(
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <MockedReduxStoreProvider>
+            <SavedViewsButtonHarness experimentId="exp-1" />
+          </MockedReduxStoreProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+      {
+        wrapper: ({ children }) => (
+          <TestRouter
+            routes={[testRoute(<>{children}</>, '/')]}
+            history={history}
+            initialEntries={['/?traceViewShareKey=v3']}
+          />
+        ),
+      },
+    );
+
+    expect(screen.getByTestId('trace-saved-views-trigger')).toHaveTextContent('Views');
+    await waitFor(() => expect(stableRefetch).toHaveBeenCalledTimes(1));
+
+    // Refetch resolves with the freshly-saved view now present → the trigger shows its name.
+    mockExperiment([
+      ...savedViewTags,
+      { key: 'mlflow.traceViewState.v3', value: encodeSavedViewEnvelope('P95 spikes', 'x', 3000) },
+    ]);
+    rerender(
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <MockedReduxStoreProvider>
+            <SavedViewsButtonHarness experimentId="exp-1" />
+          </MockedReduxStoreProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('trace-saved-views-trigger')).toHaveTextContent('P95 spikes'));
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import type { EvaluationsOverviewTableSort } from '@databricks/web-shared/genai-traces-table';
@@ -60,6 +60,13 @@ export const MAX_SAVED_VIEWS = 40;
 // filter); searchQuery / isGroupedBySession are in-memory in TracesV3Logs and not yet captured.
 const SINGLE_VALUE_KEYS = ['selectedColumns', 'sort', 'viewState', 'startTimeLabel', 'startTime', 'endTime'] as const;
 const MULTI_VALUE_KEYS = ['filter'] as const;
+
+// Whether the URL carries any serialized view state (columns, sort, time range, filter, ...). A
+// genuine share link built by buildTraceViewQuery always includes at least one of these; a bare or
+// garbage share key has none. Derived from the same key lists as the capture/build path so the two
+// can't drift — callers use this to decide whether a share key is actually previewing a view.
+export const urlHasCapturedTraceViewState = (params: URLSearchParams): boolean =>
+  SINGLE_VALUE_KEYS.some((key) => params.get(key)) || MULTI_VALUE_KEYS.some((key) => params.getAll(key).length > 0);
 
 type CapturedTraceViewState = {
   single: Partial<Record<(typeof SINGLE_VALUE_KEYS)[number], string>>;
@@ -339,6 +346,25 @@ export const useTraceSavedViews = ({ experimentId }: { experimentId: string }) =
   );
 
   const activeShareKey = searchParams.get(TRACE_SHARE_URL_PARAM_KEY);
+
+  // Opening a saved-view link (paste, back/forward) in a tab whose experiment was loaded before the
+  // view was saved reads a stale Apollo tag cache: a client-side nav doesn't refetch. The view itself
+  // still applies (its columns/sort ride in the URL), but the Views button/list — which derive from
+  // `views` (the tags) — wouldn't reflect it. When the active share key isn't in our list, refetch the
+  // experiment ONCE for that key so the list/label catch up. Guarded per-key so a genuinely-missing
+  // view doesn't refetch on a loop.
+  const refetchedShareKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeShareKey) {
+      refetchedShareKeyRef.current = null;
+      return;
+    }
+    const isKnown = views.some((view) => view.id === activeShareKey);
+    if (!isKnown && refetchedShareKeyRef.current !== activeShareKey) {
+      refetchedShareKeyRef.current = activeShareKey;
+      refetch();
+    }
+  }, [activeShareKey, views, refetch]);
 
   return { views, canModify, atCap, saveView, deleteView, openView, buildShareUrl, activeShareKey };
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
@@ -65,8 +65,11 @@ const MULTI_VALUE_KEYS = ['filter'] as const;
 // genuine share link built by buildTraceViewQuery always includes at least one of these; a bare or
 // garbage share key has none. Derived from the same key lists as the capture/build path so the two
 // can't drift — callers use this to decide whether a share key is actually previewing a view.
+// Presence is `!== null`, not truthiness, to match captureTraceViewState: an empty-string value
+// (e.g. `selectedColumns=` when every column is deselected) is a captured value, not "absent".
 export const urlHasCapturedTraceViewState = (params: URLSearchParams): boolean =>
-  SINGLE_VALUE_KEYS.some((key) => params.get(key)) || MULTI_VALUE_KEYS.some((key) => params.getAll(key).length > 0);
+  SINGLE_VALUE_KEYS.some((key) => params.get(key) !== null) ||
+  MULTI_VALUE_KEYS.some((key) => params.getAll(key).length > 0);
 
 type CapturedTraceViewState = {
   single: Partial<Record<(typeof SINGLE_VALUE_KEYS)[number], string>>;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/traceSavedViewPreview.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/traceSavedViewPreview.test.tsx
@@ -148,4 +148,21 @@ describe('useSavedViewPreview', () => {
     expect(args.exitPreview).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
+
+  it('override on a view with no columns/sort in the URL exits cleanly (no error)', () => {
+    const errorSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
+    const infoSpy = jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
+    // A time-range- or filter-only shared view carries neither param, so nothing decodes. Unlike the
+    // unresolvable case above, there is nothing to adopt — Override must NOT error; it just exits.
+    const args = { ...baseArgs(), rawColumns: undefined, rawSort: undefined };
+    const { result } = renderHook(() => useSavedViewPreview(args), { wrapper });
+    act(() => result.current.override());
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(args.setSelectedColumns).not.toHaveBeenCalled();
+    expect(args.setTableSort).not.toHaveBeenCalled();
+    expect(args.exitPreview).toHaveBeenCalledTimes(1);
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/traceSavedViewPreview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/traceSavedViewPreview.tsx
@@ -101,10 +101,13 @@ export const useSavedViewPreview = ({
   const override = useCallback(() => {
     const previousColumns = ownColumns;
     const previousSort = ownSort;
-    // Nothing decoded (e.g. Override clicked before allColumns finished loading, or a view saved
-    // against an incompatible schema): don't silently exit preview claiming success — tell the user
-    // and stay in preview so they can retry once columns resolve.
-    if (!columns && !sort) {
+    // The URL carried non-empty column/sort state but neither decoded (e.g. Override clicked before
+    // allColumns finished loading, or a view saved against an incompatible schema): don't silently
+    // exit preview claiming success — tell the user and stay in preview so they can retry. When the
+    // link intentionally has no columns/sort (a time-range- or filter-only view, or an all-columns-
+    // deselected view whose empty `selectedColumns` decodes to nothing), there is nothing to adopt,
+    // so fall through and let Override simply exit preview rather than erroring.
+    if ((Boolean(rawColumns) || Boolean(rawSort)) && !columns && !sort) {
       Utils.displayGlobalErrorNotification(
         intl.formatMessage({
           defaultMessage: 'This view could not be applied. Try again in a moment.',
@@ -143,7 +146,19 @@ export const useSavedViewPreview = ({
       </span>,
       5,
     );
-  }, [columns, sort, ownColumns, ownSort, setSelectedColumns, setTableSort, exitPreview, theme.spacing.sm, intl]);
+  }, [
+    columns,
+    sort,
+    rawColumns,
+    rawSort,
+    ownColumns,
+    ownSort,
+    setSelectedColumns,
+    setTableSort,
+    exitPreview,
+    theme.spacing.sm,
+    intl,
+  ]);
 
   // Drop the preview without writing anything; the user's own state resurfaces untouched.
   const discard = useCallback(() => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24427

### What changes are proposed in this pull request?

Opening a saved-view link via client-side navigation (paste, back/forward) into a window whose experiment loaded *before* the view was saved reads a stale tag cache, so the "Views" control doesn't reflect the view. (The view itself still applies — its state rides in the URL.) Refresh works, but since this is low-risk, adding it first

- **Traces** (`useTraceSavedViews`): when the active share key isn't in the cached `views`, refetch the experiment once (guarded per key so a genuinely-missing view can't loop) so the Views button/list catch up.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Created a view on one window, copied it into another existing window as it rendered correctly

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release