### PR TITLE
Recover stale-missing shared-view links on the Runs page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.test.tsx
@@ -216,7 +216,6 @@ describe('useSharedExperimentViewState', () => {
       // cache, so pasting the link initially can't resolve the tag. The refetch returns fresh tags
       // and the view applies — driven purely through the awaited dispatch, NOT a prop-identity change
       // (an isEqual selector would collapse an identical-tags prop, so relying on that would hang).
-      jest.spyOn(console, 'error').mockImplementation(() => {});
       jest.mocked(shouldUseCompressedExperimentViewSharedState).mockImplementation(() => true);
       const compressedState = await textCompressDeflate(testSerializedShareViewState);
       const envelopeValue = encodeSavedViewEnvelope('Freshly saved', compressedState, 1770000000000);
@@ -246,8 +245,6 @@ describe('useSharedExperimentViewState', () => {
       });
       expect(result.current.sharedStateError).toBeNull();
       expect(MlflowService.getExperiment).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line no-console -- TODO(FEINF-3587)
-      jest.mocked(console.error).mockRestore();
     });
 
     it('reports not-found without looping when the refetch itself fails', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.test.tsx
@@ -266,6 +266,10 @@ describe('useSharedExperimentViewState', () => {
       await waitFor(() => {
         expect(result.current.sharedStateError).toMatch(/does not exist/);
       });
+      // The rejection path must not apply anything (a regression calling applyParsedState here would
+      // otherwise slip through).
+      expect(updateSearchFacetsMock).not.toHaveBeenCalled();
+      expect(uiStateSetterMock).not.toHaveBeenCalled();
       expect(MlflowService.getExperiment).toHaveBeenCalledTimes(1);
       // eslint-disable-next-line no-console -- TODO(FEINF-3587)
       jest.mocked(console.error).mockRestore();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.test.tsx
@@ -13,6 +13,26 @@ import { IntlProvider } from 'react-intl';
 import { shouldUseCompressedExperimentViewSharedState } from '../../../../common/utils/FeatureUtils';
 import { textCompressDeflate } from '../../../../common/utils/StringUtils';
 import { encodeSavedViewEnvelope } from '../utils/savedViewEnvelope';
+import { MlflowService } from '../../../sdk/MlflowService';
+
+// The hook dispatches getExperimentApi to refetch when a share key isn't in the cached tags. Route
+// dispatch through a fake that mimics redux-promise-middleware: it awaits the action's payload and
+// resolves to `{ value, action }` — the exact shape the hook unwraps. Driving the payload via a
+// mocked MlflowService.getExperiment (below) exercises the REAL getExperimentApi action + response
+// transform, rather than stubbing the action to a fresh object (which would hide prop-identity bugs).
+const mockDispatch = jest.fn((action: any) => Promise.resolve(action.payload).then((value) => ({ value, action })));
+jest.mock('react-redux', () => ({
+  ...jest.requireActual<typeof import('react-redux')>('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../sdk/MlflowService', () => ({
+  ...jest.requireActual<typeof import('../../../sdk/MlflowService')>('../../../sdk/MlflowService'),
+  MlflowService: {
+    ...jest.requireActual<typeof import('../../../sdk/MlflowService')>('../../../sdk/MlflowService').MlflowService,
+    getExperiment: jest.fn(),
+  },
+}));
 
 jest.mock('../../../../common/utils/FeatureUtils', () => ({
   ...jest.requireActual<typeof import('../../../../common/utils/FeatureUtils')>(
@@ -67,6 +87,11 @@ describe('useSharedExperimentViewState', () => {
     jest.mocked(useSearchParams).mockReturnValue([new URLSearchParams(), jest.fn()]);
     jest.mocked(useNavigate).mockReturnValue(navigateMock as ReturnType<typeof useNavigate>);
     jest.mocked(useUpdateExperimentPageSearchFacets).mockReturnValue(updateSearchFacetsMock);
+    // Default: a refetch reveals no new tags, so a genuinely-missing key still resolves to not-found.
+    // Tests exercising the stale-cache recovery override this to resolve with the freshly-saved tag.
+    jest
+      .mocked(MlflowService.getExperiment)
+      .mockResolvedValue({ experiment: { experimentId: 'experiment_1', tags: [] } } as any);
   });
 
   describe.each([true, false])('when state compression flag is set to %s', (compressionEnabled) => {
@@ -161,13 +186,14 @@ describe('useSharedExperimentViewState', () => {
       });
     });
 
-    it('does not apply or clear view state when the legacy share key has no matching tag', async () => {
+    it('refetches once then reports not-found when the share key has no matching tag anywhere', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => {});
       jest
         .mocked(useSearchParams)
         .mockReturnValue([new URLSearchParams(`viewStateShareKey=${testSerializedStateHash}`), jest.fn()]);
 
-      // Bare-hash key routes to the legacy branch; the experiment has no matching tag.
+      // Cached experiment lacks the tag; the refetch (default mock) also returns no matching tag — a
+      // genuinely-missing key. The hook must refetch exactly once, then report not-found (no loop).
       const experimentWithoutTag = { experimentId: 'experiment_1', tags: [] } as unknown as ExperimentEntity;
 
       const { result } = renderHookWithIntl(() =>
@@ -175,12 +201,97 @@ describe('useSharedExperimentViewState', () => {
       );
 
       await waitFor(() => {
-        expect(updateSearchFacetsMock).not.toHaveBeenCalled();
-        expect(uiStateSetterMock).not.toHaveBeenCalled();
         expect(result.current.sharedStateError).toMatch(/does not exist/);
       });
+      expect(updateSearchFacetsMock).not.toHaveBeenCalled();
+      expect(uiStateSetterMock).not.toHaveBeenCalled();
+      expect(MlflowService.getExperiment).toHaveBeenCalledTimes(1);
+      expect(MlflowService.getExperiment).toHaveBeenCalledWith({ experiment_id: 'experiment_1' });
       // eslint-disable-next-line no-console -- TODO(FEINF-3587)
       jest.mocked(console.error).mockRestore();
+    });
+
+    it('applies the view when a refetch reveals a tag that was stale-missing (paste into an open tab)', async () => {
+      // The reported bug: a tab whose experiment loaded BEFORE the view was saved has a stale tag
+      // cache, so pasting the link initially can't resolve the tag. The refetch returns fresh tags
+      // and the view applies — driven purely through the awaited dispatch, NOT a prop-identity change
+      // (an isEqual selector would collapse an identical-tags prop, so relying on that would hang).
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest.mocked(shouldUseCompressedExperimentViewSharedState).mockImplementation(() => true);
+      const compressedState = await textCompressDeflate(testSerializedShareViewState);
+      const envelopeValue = encodeSavedViewEnvelope('Freshly saved', compressedState, 1770000000000);
+      jest.mocked(MlflowService.getExperiment).mockResolvedValue({
+        experiment: {
+          experimentId: 'experiment_1',
+          tags: [{ key: `mlflow.sharedViewState.${testSerializedStateHash}`, value: envelopeValue }],
+        },
+      } as any);
+
+      jest
+        .mocked(useSearchParams)
+        .mockReturnValue([new URLSearchParams(`viewStateShareKey=${testSerializedStateHash}`), jest.fn()]);
+
+      // The cached experiment does NOT have the tag (stale) — never rerendered with a fresh one.
+      const staleExperiment = { experimentId: 'experiment_1', tags: [] } as unknown as ExperimentEntity;
+
+      const { result } = renderHookWithIntl(() => useSharedExperimentViewState(uiStateSetterMock, staleExperiment));
+
+      const expectedFacetsState = omitBy(testFacetsState, isNil);
+      const expectedUiState = omitBy(testUIState, isNil);
+      await waitFor(() => {
+        expect(updateSearchFacetsMock).toHaveBeenCalledWith(expect.objectContaining(expectedFacetsState), {
+          replace: true,
+        });
+        expect(uiStateSetterMock).toHaveBeenCalledWith(expect.objectContaining(expectedUiState));
+      });
+      expect(result.current.sharedStateError).toBeNull();
+      expect(MlflowService.getExperiment).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line no-console -- TODO(FEINF-3587)
+      jest.mocked(console.error).mockRestore();
+    });
+
+    it('reports not-found without looping when the refetch itself fails', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      jest.mocked(MlflowService.getExperiment).mockRejectedValue(new Error('network'));
+      jest
+        .mocked(useSearchParams)
+        .mockReturnValue([new URLSearchParams(`viewStateShareKey=${testSerializedStateHash}`), jest.fn()]);
+
+      const experimentWithoutTag = { experimentId: 'experiment_1', tags: [] } as unknown as ExperimentEntity;
+
+      const { result } = renderHookWithIntl(() =>
+        useSharedExperimentViewState(uiStateSetterMock, experimentWithoutTag),
+      );
+
+      await waitFor(() => {
+        expect(result.current.sharedStateError).toMatch(/does not exist/);
+      });
+      expect(MlflowService.getExperiment).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line no-console -- TODO(FEINF-3587)
+      jest.mocked(console.error).mockRestore();
+    });
+
+    it('does not refetch when the share key tag is already present in the cached experiment', async () => {
+      // Fast path untouched: a link opened in a tab whose cache already has the tag must NOT refetch.
+      jest.mocked(shouldUseCompressedExperimentViewSharedState).mockImplementation(() => true);
+      const compressedState = await textCompressDeflate(testSerializedShareViewState);
+      const envelopeValue = encodeSavedViewEnvelope('Already cached', compressedState, 1770000000000);
+      jest
+        .mocked(useSearchParams)
+        .mockReturnValue([new URLSearchParams(`viewStateShareKey=${testSerializedStateHash}`), jest.fn()]);
+
+      const experimentWithTag = {
+        experimentId: 'experiment_1',
+        tags: [{ key: `mlflow.sharedViewState.${testSerializedStateHash}`, value: envelopeValue }],
+      } as ExperimentEntity;
+
+      const { result } = renderHookWithIntl(() => useSharedExperimentViewState(uiStateSetterMock, experimentWithTag));
+
+      await waitFor(() => {
+        expect(updateSearchFacetsMock).toHaveBeenCalled();
+      });
+      expect(result.current.sharedStateError).toBeNull();
+      expect(MlflowService.getExperiment).not.toHaveBeenCalled();
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.ts
@@ -105,6 +105,10 @@ export const useSharedExperimentViewState = (
     const hasFacetParams = EXPERIMENT_PAGE_QUERY_PARAM_KEYS.some((key) => searchParams.has(key));
     if (hasFacetParams) {
       appliedShareKeyRef.current = null;
+      // Deliberately NOT clearing refetchedShareKeyRef here: it's a once-ever-per-key latch (a stale
+      // cache is refetched at most once), whereas appliedShareKeyRef is a per-apply guard that must
+      // reset so a re-pasted bare link re-applies. Clearing it here would let a missing key refetch
+      // again on every facet-wipe cycle.
       return;
     }
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useSharedExperimentViewState.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { EXPERIMENT_PAGE_QUERY_PARAM_KEYS, useUpdateExperimentPageSearchFacets } from './useExperimentPageSearchFacets';
 import { omit, pick } from 'lodash';
@@ -12,7 +13,9 @@ import type { ExperimentPageSearchFacetsState } from '../models/ExperimentPageSe
 import { createExperimentPageSearchFacetsState } from '../models/ExperimentPageSearchFacetsState';
 import type { ExperimentEntity } from '../../../types';
 import type { KeyValueEntity } from '../../../../common/types';
+import type { ThunkDispatch } from '../../../../redux-types';
 import { useNavigate, useSearchParams } from '../../../../common/utils/RoutingUtils';
+import { getExperimentApi } from '../../../actions';
 import Utils from '../../../../common/utils/Utils';
 import {
   EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX,
@@ -42,6 +45,7 @@ export const useSharedExperimentViewState = (
 ) => {
   const [searchParams] = useSearchParams();
   const intl = useIntl();
+  const dispatch = useDispatch<ThunkDispatch>();
   const viewStateShareKey = searchParams.get(EXPERIMENT_PAGE_VIEW_STATE_SHARE_URL_PARAM_KEY);
 
   const isViewStateShared = Boolean(viewStateShareKey);
@@ -82,9 +86,14 @@ export const useSharedExperimentViewState = (
   // Cleared once facets are present (the apply landed) or the key leaves the URL.
   const appliedShareKeyRef = useRef<string | null>(null);
 
+  // Tracks the share key we've already refetched the experiment for, so a genuinely-missing key
+  // errors instead of refetching forever. See the not-found branch below.
+  const refetchedShareKeyRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!viewStateShareKey) {
       appliedShareKeyRef.current = null;
+      refetchedShareKeyRef.current = null;
       return;
     }
 
@@ -179,8 +188,7 @@ export const useSharedExperimentViewState = (
       }
     };
 
-    // If the tag exists, parse the view state from the tag value
-    if (!shareViewTag) {
+    const reportShareKeyNotFound = () => {
       setSharedSearchFacetsState(null);
       setSharedUiState(null);
       setSharedStateError(`Error loading shared view state: share key ${viewStateShareKey} does not exist`);
@@ -195,13 +203,40 @@ export const useSharedExperimentViewState = (
           },
         ),
       );
+    };
+
+    // If the tag exists, parse the view state from the tag value
+    if (!shareViewTag) {
+      // The tag may just be absent from our cached experiment.tags rather than truly missing: opening
+      // a link (paste, back/forward) in a tab whose experiment was loaded before the view was saved
+      // reads a stale cache, since a client-side nav doesn't refetch. Refetch the experiment ONCE for
+      // this key and resolve against the FRESH tags in the response — not the `experiment` prop, whose
+      // reference an isEqual selector would collapse if the tags happen to match. Only if the tag is
+      // still absent after the refetch (or it fails) do we report the key as missing.
+      if (refetchedShareKeyRef.current === viewStateShareKey) {
+        reportShareKeyNotFound();
+        return;
+      }
+      refetchedShareKeyRef.current = viewStateShareKey;
+      dispatch(getExperimentApi(experiment.experimentId))
+        .then((result) => {
+          const freshTag = (result?.value?.experiment?.tags ?? []).find(
+            ({ key }: KeyValueEntity) => key === `${EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX}${viewStateShareKey}`,
+          );
+          if (freshTag) {
+            tryParseSharedStateFromTag(freshTag);
+          } else {
+            reportShareKeyNotFound();
+          }
+        })
+        .catch(() => reportShareKeyNotFound());
       return;
     }
 
     tryParseSharedStateFromTag(shareViewTag);
     // `searchParams` is a dependency so the effect re-fires when the facet params change — in
     // particular when they get wiped while the key stays, so we re-apply instead of hanging.
-  }, [experiment, viewStateShareKey, searchParams, intl]);
+  }, [experiment, viewStateShareKey, searchParams, intl, dispatch]);
 
   useEffect(() => {
     if (!sharedSearchFacetsState || disabled) {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24746 (the sibling Traces-side fix for the same stale-tag root cause)

### What changes are proposed in this pull request?

Opening a saved shared-view link (paste, or back/forward) in a browser tab whose experiment was loaded **before** the view was saved reads a stale experiment-tag cache. Because MLflow uses hash routing, following the link is a client-side navigation that never refetches the experiment, and saving a view writes the tag to a different Redux slice than the one the Runs page reads. The result: the Runs page hard-errors with "share key does not exist" for a view that actually exists. A full page refresh recovers it.

This fixes the not-found branch in `useSharedExperimentViewState`: when the share-key tag isn't in the cached `experiment.tags`, refetch the experiment **once** for that key via `getExperimentApi` and resolve against the **fresh tags in the dispatch response** — not the `experiment` prop.

Reading from the response (rather than waiting for the prop to change) is deliberate: `useExperiments` memoizes with a lodash `isEqual` selector, so a refetch that returns identical tags would collapse the prop reference and never re-run the effect. Resolving off the response sidesteps that entirely. A genuinely-missing key or a failed refetch falls straight through to the existing "does not exist" error, and a per-key guard ensures the refetch fires at most once (no loop).

This mirrors the sibling Traces fix in #24746; on Traces the stale tag was only cosmetic (the view rides in the URL), whereas on Runs the tag gates the entire view application.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual test - ran the same test, create a new view on one of two existing window, open it in the other and ensure it renders correctly. 

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release