### PR TITLE
Fix artifact direct download capability checks in UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
@@ -200,8 +200,9 @@ describe('ArtifactView', () => {
     let revokeObjectURLMock: jest.Mock;
     let anchor: any;
     let presignedSpy: any;
+    let proxiedPresignedSpy: any;
 
-    const getImplInstance = () => {
+    const getImplInstance = (props = {}) => {
       const rootNode = new ArtifactNode(true, undefined, undefined);
       rootNode.isLoaded = true;
       const textFile = new ArtifactNode(
@@ -214,7 +215,12 @@ describe('ArtifactView', () => {
         undefined,
       );
       rootNode.setChildren([textFile.fileInfo]);
-      wrapper = getWrapper(getMockStore(rootNode), minimalProps);
+      wrapper = getWrapper(getMockStore(rootNode), {
+        ...minimalProps,
+        artifactRootUri: 's3://bucket/0/fakeUuid/artifacts',
+        multipartDownloadsEnabled: true,
+        ...props,
+      });
       wrapper.find('NodeHeader').at(0).simulate('click');
       wrapper.update();
       // Mock the DOM download plumbing only after enzyme has mounted the component:
@@ -251,6 +257,7 @@ describe('ArtifactView', () => {
         writable: true,
       });
       presignedSpy = jest.spyOn(MlflowService, 'createPresignedDownloadUrl');
+      proxiedPresignedSpy = jest.spyOn(MlflowService, 'getMlflowArtifactsPresignedDownloadUrl');
       jest.mocked(getArtifactBlob).mockClear();
     });
 
@@ -270,6 +277,46 @@ describe('ArtifactView', () => {
       expect(presignedSpy).toHaveBeenCalledWith({ run_id: 'fakeUuid', path: 'summary.txt' });
       expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/signed');
       expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test('should navigate to the proxied artifact presigned URL when server-info enables multipart downloads', async () => {
+      proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
+
+      const implInstance = getImplInstance({ artifactRootUri: 'mlflow-artifacts:/0/fakeUuid/artifacts' });
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(proxiedPresignedSpy).toHaveBeenCalledWith('0/fakeUuid/artifacts/summary.txt');
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/proxied-signed');
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test('should use the run-scoped presigned URL for direct artifact roots when multipart downloads are disabled', async () => {
+      presignedSpy.mockResolvedValue({ presigned_url: 'https://s3.example.com/signed', file_size: 100 });
+
+      const implInstance = getImplInstance({ multipartDownloadsEnabled: false });
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(presignedSpy).toHaveBeenCalledWith({ run_id: 'fakeUuid', path: 'summary.txt' });
+      expect(proxiedPresignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/signed');
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test('should use the proxied download for proxied artifact roots when server-info disables multipart downloads', async () => {
+      presignedSpy.mockResolvedValue({ presigned_url: 'https://s3.example.com/signed', file_size: 100 });
+      proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
+
+      const implInstance = getImplInstance({
+        artifactRootUri: 'mlflow-artifacts:/0/fakeUuid/artifacts',
+        multipartDownloadsEnabled: false,
+      });
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(proxiedPresignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).not.toHaveBeenCalled();
+      expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
     });
 
     test.each([400, 404, 501, 503])(

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
@@ -26,6 +26,8 @@ import Utils from '../../common/utils/Utils';
 import { getArtifactBlob } from '../../common/utils/ArtifactUtils';
 import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
 import { MlflowService } from '../sdk/MlflowService';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { ServerInfoProvider } from '../hooks/useServerInfo';
 
 const { Text } = Typography;
 
@@ -65,6 +67,30 @@ describe('ArtifactView', () => {
         </DesignSystemProvider>
       </Provider>,
     );
+  const getWrapperWithServerInfo = (fakeStore: any, mockProps: any, multipartDownloadsEnabled: boolean) => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['serverInfo'], {
+      store_type: null,
+      workspaces_enabled: false,
+      trace_archival_enabled: false,
+      multipart_uploads_enabled: false,
+      multipart_downloads_enabled: multipartDownloadsEnabled,
+    });
+
+    return mountWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <ServerInfoProvider>
+          <Provider store={fakeStore}>
+            <DesignSystemProvider>
+              <BrowserRouter>
+                <ArtifactView {...mockProps} />
+              </BrowserRouter>
+            </DesignSystemProvider>
+          </Provider>
+        </ServerInfoProvider>
+      </QueryClientProvider>,
+    );
+  };
   beforeEach(() => {
     // TODO: remove global fetch mock by explicitly mocking all the service API calls
     jest
@@ -202,7 +228,10 @@ describe('ArtifactView', () => {
     let presignedSpy: any;
     let proxiedPresignedSpy: any;
 
-    const getImplInstance = (props = {}) => {
+    const getImplInstance = (
+      props: any = {},
+      options: { cachedMultipartDownloadsEnabled?: boolean } = {},
+    ) => {
       const rootNode = new ArtifactNode(true, undefined, undefined);
       rootNode.isLoaded = true;
       const textFile = new ArtifactNode(
@@ -215,12 +244,16 @@ describe('ArtifactView', () => {
         undefined,
       );
       rootNode.setChildren([textFile.fileInfo]);
-      wrapper = getWrapper(getMockStore(rootNode), {
+      const mockProps = {
         ...minimalProps,
         artifactRootUri: 's3://bucket/0/fakeUuid/artifacts',
         multipartDownloadsEnabled: true,
         ...props,
-      });
+      };
+      wrapper =
+        options.cachedMultipartDownloadsEnabled === undefined
+          ? getWrapper(getMockStore(rootNode), mockProps)
+          : getWrapperWithServerInfo(getMockStore(rootNode), mockProps, options.cachedMultipartDownloadsEnabled);
       wrapper.find('NodeHeader').at(0).simulate('click');
       wrapper.update();
       // Mock the DOM download plumbing only after enzyme has mounted the component:
@@ -286,6 +319,41 @@ describe('ArtifactView', () => {
       await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
 
       expect(proxiedPresignedSpy).toHaveBeenCalledWith('0/fakeUuid/artifacts/summary.txt');
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/proxied-signed');
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test('should use cached server-info when deciding proxied artifact presigned downloads', async () => {
+      proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
+
+      const implInstance = getImplInstance(
+        {
+          artifactRootUri: 'mlflow-artifacts:/0/my%20run/artifacts',
+          multipartDownloadsEnabled: undefined,
+        },
+        { cachedMultipartDownloadsEnabled: true },
+      );
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(proxiedPresignedSpy).toHaveBeenCalledWith('0/my run/artifacts/summary.txt');
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/proxied-signed');
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
+    test('should decode and preserve proxied HTTP artifact root paths before route encoding', async () => {
+      proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
+
+      const implInstance = getImplInstance({
+        artifactRootUri:
+          'https://mlflow.example.com/prefix/api/2.0/mlflow-artifacts/artifacts/0/my%20run/api/2.0/mlflow-artifacts/artifacts/artifacts',
+      });
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(proxiedPresignedSpy).toHaveBeenCalledWith(
+        '0/my run/api/2.0/mlflow-artifacts/artifacts/artifacts/summary.txt',
+      );
       expect(presignedSpy).not.toHaveBeenCalled();
       expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/proxied-signed');
       expect(getArtifactBlob).not.toHaveBeenCalled();

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
@@ -324,6 +324,20 @@ describe('ArtifactView', () => {
       expect(getArtifactBlob).not.toHaveBeenCalled();
     });
 
+    test('should ignore the authority for mlflow-artifacts URIs', async () => {
+      proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
+
+      const implInstance = getImplInstance({
+        artifactRootUri: 'mlflow-artifacts://tracking.example.com/0/fakeUuid/artifacts',
+      });
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(proxiedPresignedSpy).toHaveBeenCalledWith('0/fakeUuid/artifacts/summary.txt');
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).toHaveBeenCalledWith('https://s3.example.com/proxied-signed');
+      expect(getArtifactBlob).not.toHaveBeenCalled();
+    });
+
     test('should use cached server-info when deciding proxied artifact presigned downloads', async () => {
       proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
 
@@ -387,6 +401,22 @@ describe('ArtifactView', () => {
       expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
     });
 
+    test('should use the proxied download for HTTP proxied artifact roots when server-info disables multipart downloads', async () => {
+      presignedSpy.mockResolvedValue({ presigned_url: 'https://s3.example.com/signed', file_size: 100 });
+      proxiedPresignedSpy.mockResolvedValue({ url: 'https://s3.example.com/proxied-signed', file_size: 100 });
+
+      const implInstance = getImplInstance({
+        artifactRootUri: 'https://mlflow.example.com/api/2.0/mlflow-artifacts/artifacts/0/fakeUuid/artifacts',
+        multipartDownloadsEnabled: false,
+      });
+      await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+      expect(presignedSpy).not.toHaveBeenCalled();
+      expect(proxiedPresignedSpy).not.toHaveBeenCalled();
+      expect(assignMock).not.toHaveBeenCalled();
+      expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
+    });
+
     test.each([400, 404, 501, 503])(
       'should fall back to the proxied download when the presigned request fails with %s',
       async (status) => {
@@ -395,6 +425,20 @@ describe('ArtifactView', () => {
         const implInstance = getImplInstance();
         await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
 
+        expect(assignMock).not.toHaveBeenCalled();
+        expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
+      },
+    );
+
+    test.each([400, 404, 501, 503])(
+      'should fall back to the proxied download when the proxied presigned request fails with %s',
+      async (status) => {
+        proxiedPresignedSpy.mockRejectedValue(new ErrorWrapper('unavailable', status));
+
+        const implInstance = getImplInstance({ artifactRootUri: 'mlflow-artifacts:/0/fakeUuid/artifacts' });
+        await implInstance.onDownloadClick('fakeUuid', 'summary.txt');
+
+        expect(presignedSpy).not.toHaveBeenCalled();
         expect(assignMock).not.toHaveBeenCalled();
         expectBlobDownload('get-artifact?path=summary.txt&run_uuid=fakeUuid');
       },

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.enzyme.test.tsx
@@ -228,10 +228,7 @@ describe('ArtifactView', () => {
     let presignedSpy: any;
     let proxiedPresignedSpy: any;
 
-    const getImplInstance = (
-      props: any = {},
-      options: { cachedMultipartDownloadsEnabled?: boolean } = {},
-    ) => {
+    const getImplInstance = (props: any = {}, options: { cachedMultipartDownloadsEnabled?: boolean } = {}) => {
       const rootNode = new ArtifactNode(true, undefined, undefined);
       rootNode.isLoaded = true;
       const textFile = new ArtifactNode(

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -71,6 +71,8 @@ const PRESIGNED_DOWNLOAD_FALLBACK_STATUSES = [400, 404, 501, 503];
 const joinArtifactPaths = (rootPath: string, artifactPath: string) =>
   [rootPath.replace(/^\/+|\/+$/g, ''), artifactPath.replace(/^\/+/, '')].filter(Boolean).join('/');
 
+const getDecodedPathname = (url: URL) => decodeURIComponent(url.pathname);
+
 const getProxiedArtifactDownloadPath = (artifactRootUri?: string, artifactPath?: string) => {
   if (!artifactRootUri || !artifactPath) {
     return undefined;
@@ -78,13 +80,14 @@ const getProxiedArtifactDownloadPath = (artifactRootUri?: string, artifactPath?:
   try {
     const parsedArtifactRootUri = new URL(artifactRootUri);
     if (parsedArtifactRootUri.protocol === 'mlflow-artifacts:') {
-      return joinArtifactPaths(parsedArtifactRootUri.pathname, artifactPath);
+      return joinArtifactPaths(getDecodedPathname(parsedArtifactRootUri), artifactPath);
     }
     if (parsedArtifactRootUri.protocol === 'http:' || parsedArtifactRootUri.protocol === 'https:') {
-      const rootPath = parsedArtifactRootUri.pathname.replace(/^\/+/, '');
+      const rootPath = getDecodedPathname(parsedArtifactRootUri).replace(/^\/+/, '');
       const routeAnchor = MLFLOW_ARTIFACTS_ROUTE_ANCHORS.find((anchor) => rootPath.includes(anchor));
       if (routeAnchor) {
-        return joinArtifactPaths(rootPath.split(routeAnchor)[1] ?? '', artifactPath);
+        const routeAnchorIndex = rootPath.indexOf(routeAnchor);
+        return joinArtifactPaths(rootPath.slice(routeAnchorIndex + routeAnchor.length), artifactPath);
       }
     }
   } catch {

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.tsx
@@ -59,8 +59,54 @@ import { CopyButton } from '../../shared/building_blocks/CopyButton';
 import type { LoggedModelArtifactViewerProps } from './artifact-view-components/ArtifactViewComponents.types';
 import { MlflowService } from '../sdk/MlflowService';
 import type { KeyValueEntity } from '../../common/types';
+import { getMultipartDownloadsEnabledSync } from '../hooks/useServerInfo';
 
 const { Text } = Typography;
+const MLFLOW_ARTIFACTS_ROUTE_ANCHORS = [
+  'api/2.0/mlflow-artifacts/artifacts/',
+  'ajax-api/2.0/mlflow-artifacts/artifacts/',
+];
+const PRESIGNED_DOWNLOAD_FALLBACK_STATUSES = [400, 404, 501, 503];
+
+const joinArtifactPaths = (rootPath: string, artifactPath: string) =>
+  [rootPath.replace(/^\/+|\/+$/g, ''), artifactPath.replace(/^\/+/, '')].filter(Boolean).join('/');
+
+const getProxiedArtifactDownloadPath = (artifactRootUri?: string, artifactPath?: string) => {
+  if (!artifactRootUri || !artifactPath) {
+    return undefined;
+  }
+  try {
+    const parsedArtifactRootUri = new URL(artifactRootUri);
+    if (parsedArtifactRootUri.protocol === 'mlflow-artifacts:') {
+      return joinArtifactPaths(parsedArtifactRootUri.pathname, artifactPath);
+    }
+    if (parsedArtifactRootUri.protocol === 'http:' || parsedArtifactRootUri.protocol === 'https:') {
+      const rootPath = parsedArtifactRootUri.pathname.replace(/^\/+/, '');
+      const routeAnchor = MLFLOW_ARTIFACTS_ROUTE_ANCHORS.find((anchor) => rootPath.includes(anchor));
+      if (routeAnchor) {
+        return joinArtifactPaths(rootPath.split(routeAnchor)[1] ?? '', artifactPath);
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
+const shouldTryRunScopedPresignedDownload = (artifactRootUri?: string) => {
+  if (!artifactRootUri) {
+    return true;
+  }
+  try {
+    const { protocol } = new URL(artifactRootUri);
+    return protocol !== 'mlflow-artifacts:' && protocol !== 'http:' && protocol !== 'https:';
+  } catch {
+    return true;
+  }
+};
+
+const canFallBackFromPresignedDownloadError = (error: unknown) =>
+  error instanceof ErrorWrapper && PRESIGNED_DOWNLOAD_FALLBACK_STATUSES.includes(error.getStatus());
 
 type ArtifactViewImplProps = DesignSystemHocProps & {
   experimentId: string;
@@ -78,6 +124,7 @@ type ArtifactViewImplProps = DesignSystemHocProps & {
   intl: IntlShape;
   getCredentialsForArtifactReadApi: (...args: any[]) => any;
   entityTags?: Partial<KeyValueEntity>[];
+  multipartDownloadsEnabled?: boolean;
 
   /**
    * If true, the artifact browser will try to use all available height
@@ -252,35 +299,55 @@ export class ArtifactViewImpl extends Component<ArtifactViewImplProps, ArtifactV
     isFallbackToLoggedModelArtifacts?: boolean,
   ) {
     if (runUuid && !isFallbackToLoggedModelArtifacts) {
-      // Prefer a presigned URL minted by the tracking server: the browser then downloads
-      // directly from cloud storage via top-level navigation, so artifact bytes are
-      // neither proxied through the tracking server nor buffered in browser memory.
-      try {
-        const response = await MlflowService.createPresignedDownloadUrl({
-          run_id: runUuid,
-          path: artifactPath,
-        });
-        // A top-level navigation cannot attach request headers; if the backend requires
-        // any, use the proxied download instead.
-        if (response.presigned_url && Object.keys(response.headers ?? {}).length === 0) {
-          window.location.assign(response.presigned_url);
-          return;
+      const proxiedArtifactDownloadPath = getProxiedArtifactDownloadPath(this.props.artifactRootUri, artifactPath);
+      const multipartDownloadsEnabled = this.props.multipartDownloadsEnabled ?? getMultipartDownloadsEnabledSync();
+      if (multipartDownloadsEnabled && proxiedArtifactDownloadPath) {
+        // For proxied artifact roots, use the capability advertised by /server-info and
+        // request the presigned URL from the mlflow-artifacts service directly.
+        try {
+          const response = await MlflowService.getMlflowArtifactsPresignedDownloadUrl(proxiedArtifactDownloadPath);
+          // A top-level navigation cannot attach request headers; if the backend requires
+          // any, use the proxied download instead.
+          if (response.url && Object.keys(response.headers ?? {}).length === 0) {
+            window.location.assign(response.url);
+            return;
+          }
+        } catch (e) {
+          if (!canFallBackFromPresignedDownloadError(e)) {
+            // Fail closed on everything else — notably 403, where falling back to the
+            // proxied path would sidestep a permission denial.
+            Utils.logErrorAndNotifyUser(e);
+            return;
+          }
         }
-      } catch (e) {
-        const canFallBack =
-          e instanceof ErrorWrapper &&
+      } else if (!proxiedArtifactDownloadPath && shouldTryRunScopedPresignedDownload(this.props.artifactRootUri)) {
+        // Prefer a presigned URL minted by the tracking server: the browser then downloads
+        // directly from cloud storage via top-level navigation, so artifact bytes are
+        // neither proxied through the tracking server nor buffered in browser memory.
+        try {
+          const response = await MlflowService.createPresignedDownloadUrl({
+            run_id: runUuid,
+            path: artifactPath,
+          });
+          // A top-level navigation cannot attach request headers; if the backend requires
+          // any, use the proxied download instead.
+          if (response.presigned_url && Object.keys(response.headers ?? {}).length === 0) {
+            window.location.assign(response.presigned_url);
+            return;
+          }
+        } catch (e) {
           // 400: the server rejects presigned downloads for proxied artifact storage
           // (`mlflow-artifacts:` URIs — the default `mlflow server` configuration), where
           // the proxied download IS the correct path. 404: older server without the
           // endpoint (for a genuinely missing artifact the proxied path surfaces the same
           // error). 501: artifact repository without presigned support. 503:
           // artifacts-only server mode.
-          [400, 404, 501, 503].includes(e.getStatus());
-        if (!canFallBack) {
-          // Fail closed on everything else — notably 403, where falling back to the
-          // proxied path would sidestep a permission denial.
-          Utils.logErrorAndNotifyUser(e);
-          return;
+          if (!canFallBackFromPresignedDownloadError(e)) {
+            // Fail closed on everything else — notably 403, where falling back to the
+            // proxied path would sidestep a permission denial.
+            Utils.logErrorAndNotifyUser(e);
+            return;
+          }
         }
       }
       await this.downloadArtifactViaBlob(getArtifactLocationUrl(artifactPath, runUuid), artifactPath);

--- a/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.test.tsx
@@ -7,8 +7,10 @@ import {
   useServerInfo,
   useIsFileStore,
   useTraceArchivalEnabled,
+  useMultipartDownloadsEnabled,
   useWorkspacesEnabled,
   getWorkspacesEnabledSync,
+  getMultipartDownloadsEnabledSync,
   resetServerInfoCache,
   ServerInfoProvider,
 } from './useServerInfo';
@@ -180,6 +182,64 @@ describe('useTraceArchivalEnabled', () => {
   });
 });
 
+describe('useMultipartDownloadsEnabled', () => {
+  describe('when backend enables multipart downloads', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            store_type: 'SqlStore',
+            workspaces_enabled: false,
+            trace_archival_enabled: false,
+            multipart_uploads_enabled: false,
+            multipart_downloads_enabled: true,
+          }),
+        );
+      }),
+    );
+
+    test('should return true', async () => {
+      const { result } = renderHook(() => useMultipartDownloadsEnabled(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe(true);
+      });
+    });
+  });
+
+  describe('when backend returns an error', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(ctx.status(500));
+      }),
+    );
+
+    test('should return false', async () => {
+      const { result } = renderHook(() => useMultipartDownloadsEnabled(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe(false);
+      });
+    });
+  });
+
+  describe('when backend omits multipart download support information', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(ctx.json({ store_type: 'SqlStore', workspaces_enabled: false, trace_archival_enabled: false }));
+      }),
+    );
+
+    test('should return false for older servers', async () => {
+      const { result } = renderHook(() => useMultipartDownloadsEnabled(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).toBe(false);
+      });
+    });
+  });
+});
+
 // Helper component to test useWorkspacesEnabled
 const WorkspacesTestComponent = () => {
   const { workspacesEnabled, loading } = useWorkspacesEnabled();
@@ -189,6 +249,11 @@ const WorkspacesTestComponent = () => {
       <span data-testid="workspaces-enabled">{workspacesEnabled ? 'true' : 'false'}</span>
     </div>
   );
+};
+
+const MultipartDownloadsTestComponent = () => {
+  const multipartDownloadsEnabled = useMultipartDownloadsEnabled();
+  return <span data-testid="multipart-downloads-enabled">{multipartDownloadsEnabled ? 'true' : 'false'}</span>;
 };
 
 // Helper to create a fresh QueryClient for each test
@@ -315,6 +380,45 @@ describe('useWorkspacesEnabled and getWorkspacesEnabledSync', () => {
 
       // While still loading (fetch not complete), should return false
       expect(getWorkspacesEnabledSync()).toBe(false);
+    });
+  });
+});
+
+describe('getMultipartDownloadsEnabledSync', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+  });
+
+  afterEach(() => {
+    resetServerInfoCache();
+    queryClient.clear();
+  });
+
+  describe('when server returns multipart downloads enabled', () => {
+    setupServer(
+      rest.get('/ajax-api/3.0/mlflow/server-info', (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            store_type: 'SqlStore',
+            workspaces_enabled: false,
+            trace_archival_enabled: false,
+            multipart_uploads_enabled: false,
+            multipart_downloads_enabled: true,
+          }),
+        );
+      }),
+    );
+
+    test('should return true from the cached server-info response', async () => {
+      renderWithProviders(<MultipartDownloadsTestComponent />, queryClient);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('multipart-downloads-enabled').textContent).toBe('true');
+      });
+
+      expect(getMultipartDownloadsEnabledSync()).toBe(true);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useServerInfo.tsx
@@ -10,6 +10,8 @@ interface ServerInfoResponse {
   store_type: string | null;
   workspaces_enabled: boolean;
   trace_archival_enabled: boolean;
+  multipart_uploads_enabled: boolean;
+  multipart_downloads_enabled: boolean;
 }
 
 // Default response when the API call fails (e.g., older server without this endpoint)
@@ -17,6 +19,8 @@ const DEFAULT_RESPONSE: ServerInfoResponse = {
   store_type: '',
   workspaces_enabled: false,
   trace_archival_enabled: false,
+  multipart_uploads_enabled: false,
+  multipart_downloads_enabled: false,
 };
 
 // Module-level reference to the QueryClient for synchronous access
@@ -66,6 +70,11 @@ export function useTraceArchivalEnabled(): boolean {
   return data?.trace_archival_enabled ?? false;
 }
 
+export function useMultipartDownloadsEnabled(): boolean {
+  const { data } = useServerInfo();
+  return data?.multipart_downloads_enabled ?? false;
+}
+
 interface ServerInfoProviderProps {
   children: ReactNode;
 }
@@ -108,6 +117,11 @@ export const useWorkspacesEnabled = (): { workspacesEnabled: boolean; loading: b
 export const getWorkspacesEnabledSync = (): boolean => {
   const cachedData = queryClientRef?.getQueryData<ServerInfoResponse>([SERVER_INFO_QUERY_KEY]);
   return cachedData?.workspaces_enabled ?? false;
+};
+
+export const getMultipartDownloadsEnabledSync = (): boolean => {
+  const cachedData = queryClientRef?.getQueryData<ServerInfoResponse>([SERVER_INFO_QUERY_KEY]);
+  return cachedData?.multipart_downloads_enabled ?? false;
 };
 
 // For testing purposes - allows resetting the cached state

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
@@ -51,6 +51,8 @@ type GetCredentialsForLoggedModelArtifactReadResult = {
 
 const searchRunsPath = () => 'ajax-api/2.0/mlflow/runs/search';
 
+const encodePathForRoute = (path: string) => path.split('/').map(encodeURIComponent).join('/');
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class -- TODO(FEINF-4274)
 export class MlflowService {
   /**
@@ -105,6 +107,16 @@ export class MlflowService {
   static createPresignedDownloadUrl = (data: { run_id: string; path: string }) =>
     postJson({ relativeUrl: 'ajax-api/2.0/mlflow/artifacts/presigned-download-url', data }) as Promise<{
       presigned_url?: string;
+      headers?: Record<string, string>;
+      file_size?: number;
+    }>;
+
+  /**
+   * Create a presigned URL for downloading an artifact served through the mlflow-artifacts proxy.
+   */
+  static getMlflowArtifactsPresignedDownloadUrl = (path: string) =>
+    getJson({ relativeUrl: `ajax-api/2.0/mlflow-artifacts/presigned/${encodePathForRoute(path)}` }) as Promise<{
+      url?: string;
       headers?: Record<string, string>;
       file_size?: number;
     }>;


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24613, #24341

### What changes are proposed in this pull request?

This aligns the artifact download UI with the `/server-info` capability advertisement added in #24341. Proxied `mlflow-artifacts` roots should only use the direct presigned download path when the tracking server advertises multipart download support, while run artifacts stored directly in cloud storage should continue to use the run-scoped presigned URL path from #24613.

- Extend the cached frontend server-info shape with `multipart_uploads_enabled` and `multipart_downloads_enabled`, including a synchronous cached reader for artifact download code paths.
- Route proxied artifact roots through `/ajax-api/2.0/mlflow-artifacts/presigned/<path>` only when cached server-info reports multipart downloads are enabled.
- Keep direct cloud artifact roots on the existing run-scoped `/ajax-api/2.0/mlflow/artifacts/presigned-download-url` endpoint.
- Preserve the existing proxied blob download fallback and fail-closed behavior for permission-denied presigned responses.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Artifact repo that supports presigned URL (S3)**
Frontend checks `/server-info` and it returns multipart_download_enabled `True`.
<img width="962" height="329" alt="Screenshot 2026-07-29 at 20 36 52" src="https://github.com/user-attachments/assets/c756f4b4-2dda-4b54-8b61-2ac0bd869a65" />

Frontend uses `/presigned` endpoint when downloading the artifact.
<img width="572" height="169" alt="Screenshot 2026-07-29 at 20 40 30" src="https://github.com/user-attachments/assets/9b85c85b-c269-40b0-b75c-994a33cd525a" />

**Artifact repo that does not support presigned URL (local)**

Frontend checks `/server-info` and it returns multipart_download_enabled `False`.
<img width="549" height="139" alt="Screenshot 2026-07-29 at 21 05 12" src="https://github.com/user-attachments/assets/28322504-41fb-49d9-95c8-b96726385f0d" />

Frontend uses the normal `/get-artifact` endpoint instead (proxy).
<img width="357" height="162" alt="Screenshot 2026-07-29 at 21 09 33" src="https://github.com/user-attachments/assets/c3078307-987a-468b-b90d-86ca4340d00f" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow UI now honors the tracking server's advertised artifact download capabilities before using direct presigned downloads for proxied artifact roots, while retaining direct cloud-storage downloads for supported run artifact roots.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
