### PR TITLE
Add scorer_ensemble primitive for combining scorer results

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1023,6 +1023,7 @@ mlflow.genai.labeling.labeling.ReviewApp
 mlflow.genai.list_scorers
 mlflow.genai.load_prompt
 mlflow.genai.make_judge
+mlflow.genai.make_scorer_ensemble
 mlflow.genai.optimize.BasePromptOptimizer
 mlflow.genai.optimize.BasePromptOptimizer.optimize
 mlflow.genai.optimize.GepaPromptOptimizer
@@ -1080,7 +1081,6 @@ mlflow.genai.review_queues.set_review_queue_item_status
 mlflow.genai.review_queues.update_review_queue
 mlflow.genai.scheduled_scorers.ScorerScheduleConfig
 mlflow.genai.scorer
-mlflow.genai.scorer_ensemble
 mlflow.genai.scorers.Completeness
 mlflow.genai.scorers.Completeness.get_input_fields
 mlflow.genai.scorers.Completeness.model_post_init
@@ -1290,6 +1290,7 @@ mlflow.genai.scorers.guardrails.ToxicLanguage.model_post_init
 mlflow.genai.scorers.guardrails.get_scorer
 mlflow.genai.scorers.list_scorers
 mlflow.genai.scorers.majority_vote
+mlflow.genai.scorers.make_scorer_ensemble
 mlflow.genai.scorers.maximum
 mlflow.genai.scorers.mean
 mlflow.genai.scorers.minimum
@@ -1396,7 +1397,6 @@ mlflow.genai.scorers.ragas.scorers.rag_metrics.NonLLMContextPrecisionWithReferen
 mlflow.genai.scorers.ragas.scorers.rag_metrics.NonLLMContextRecall
 mlflow.genai.scorers.ragas.scorers.rag_metrics.SemanticSimilarity
 mlflow.genai.scorers.scorer
-mlflow.genai.scorers.scorer_ensemble
 mlflow.genai.scorers.trulens.AnswerRelevance
 mlflow.genai.scorers.trulens.AnswerRelevance.model_post_init
 mlflow.genai.scorers.trulens.Coherence

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1080,6 +1080,7 @@ mlflow.genai.review_queues.set_review_queue_item_status
 mlflow.genai.review_queues.update_review_queue
 mlflow.genai.scheduled_scorers.ScorerScheduleConfig
 mlflow.genai.scorer
+mlflow.genai.scorer_ensemble
 mlflow.genai.scorers.Completeness
 mlflow.genai.scorers.Completeness.get_input_fields
 mlflow.genai.scorers.Completeness.model_post_init
@@ -1151,6 +1152,8 @@ mlflow.genai.scorers.ToolCallEfficiency.get_input_fields
 mlflow.genai.scorers.ToolCallEfficiency.model_post_init
 mlflow.genai.scorers.UserFrustration
 mlflow.genai.scorers.UserFrustration.model_post_init
+mlflow.genai.scorers.agg_all
+mlflow.genai.scorers.agg_any
 mlflow.genai.scorers.base.Scorer
 mlflow.genai.scorers.base.ScorerSamplingConfig
 mlflow.genai.scorers.builtin_scorers.Completeness
@@ -1286,6 +1289,10 @@ mlflow.genai.scorers.guardrails.ToxicLanguage
 mlflow.genai.scorers.guardrails.ToxicLanguage.model_post_init
 mlflow.genai.scorers.guardrails.get_scorer
 mlflow.genai.scorers.list_scorers
+mlflow.genai.scorers.majority_vote
+mlflow.genai.scorers.maximum
+mlflow.genai.scorers.mean
+mlflow.genai.scorers.minimum
 mlflow.genai.scorers.phoenix.Hallucination
 mlflow.genai.scorers.phoenix.Hallucination.model_post_init
 mlflow.genai.scorers.phoenix.QA
@@ -1389,6 +1396,7 @@ mlflow.genai.scorers.ragas.scorers.rag_metrics.NonLLMContextPrecisionWithReferen
 mlflow.genai.scorers.ragas.scorers.rag_metrics.NonLLMContextRecall
 mlflow.genai.scorers.ragas.scorers.rag_metrics.SemanticSimilarity
 mlflow.genai.scorers.scorer
+mlflow.genai.scorers.scorer_ensemble
 mlflow.genai.scorers.trulens.AnswerRelevance
 mlflow.genai.scorers.trulens.AnswerRelevance.model_post_init
 mlflow.genai.scorers.trulens.Coherence

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -74,8 +74,8 @@ from mlflow.genai.scorers import (
     delete_scorer,
     get_scorer,
     list_scorers,
+    make_scorer_ensemble,
     scorer,
-    scorer_ensemble,
 )
 from mlflow.genai.simulators import ConversationSimulator
 
@@ -86,7 +86,7 @@ __all__ = [
     "to_predict_fn",
     "Scorer",
     "scorer",
-    "scorer_ensemble",
+    "make_scorer_ensemble",
     "get_scorer",
     "list_scorers",
     "delete_scorer",

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -69,7 +69,14 @@ from mlflow.genai.prompts import (
 from mlflow.genai.scheduled_scorers import (
     ScorerScheduleConfig,
 )
-from mlflow.genai.scorers import Scorer, delete_scorer, get_scorer, list_scorers, scorer
+from mlflow.genai.scorers import (
+    Scorer,
+    delete_scorer,
+    get_scorer,
+    list_scorers,
+    scorer,
+    scorer_ensemble,
+)
 from mlflow.genai.simulators import ConversationSimulator
 
 __all__ = [
@@ -79,6 +86,7 @@ __all__ = [
     "to_predict_fn",
     "Scorer",
     "scorer",
+    "scorer_ensemble",
     "get_scorer",
     "list_scorers",
     "delete_scorer",

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -20,6 +20,7 @@ from mlflow.genai.evaluation.utils import (
     _get_eval_data_size_and_fields,
 )
 from mlflow.genai.scorers import Scorer
+from mlflow.genai.scorers.base import flatten_scorers
 from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 from mlflow.genai.simulators import ConversationSimulator
@@ -370,7 +371,9 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
 
         df = _convert_to_eval_set(data)
 
-        builtin_scorers = [scorer for scorer in scorers if isinstance(scorer, BuiltInScorer)]
+        builtin_scorers = [
+            scorer for scorer in flatten_scorers(scorers) if isinstance(scorer, BuiltInScorer)
+        ]
         valid_data_for_builtin_scorers(df, builtin_scorers, predict_fn)
 
         sample_input = df.iloc[0][InputDatasetColumn.INPUTS]

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, scorer, scorer_ensemble
+from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, make_scorer_ensemble, scorer
 from mlflow.genai.scorers.ensemble import agg_all, agg_any, majority_vote, maximum, mean, minimum
 from mlflow.genai.scorers.registry import delete_scorer, get_scorer, list_scorers
 
@@ -138,7 +138,7 @@ __all__ = [
     "UserFrustration",
     "Scorer",
     "scorer",
-    "scorer_ensemble",
+    "make_scorer_ensemble",
     "ScorerSamplingConfig",
     "agg_all",
     "agg_any",

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
-from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, scorer
+from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, scorer, scorer_ensemble
+from mlflow.genai.scorers.ensemble import agg_all, agg_any, majority_vote, maximum, mean, minimum
 from mlflow.genai.scorers.registry import delete_scorer, get_scorer, list_scorers
 
 # Metadata keys for scorer feedback
@@ -137,7 +138,14 @@ __all__ = [
     "UserFrustration",
     "Scorer",
     "scorer",
+    "scorer_ensemble",
     "ScorerSamplingConfig",
+    "agg_all",
+    "agg_any",
+    "majority_vote",
+    "maximum",
+    "mean",
+    "minimum",
     "get_all_scorers",
     "get_scorer",
     "list_scorers",

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -114,6 +114,44 @@ def _extract_scorer_value(result: Any) -> Any:
     return result
 
 
+def flatten_scorers(scorers: list[Any]) -> list[Any]:
+    """Expand ensemble scorers into their sub-scorers, recursively.
+
+    Callers that classify scorers by type -- required-column pre-validation, usage
+    telemetry -- must see through an ensemble to the scorers that actually run, otherwise
+    an ensemble wrapping built-in judges is treated as an opaque custom scorer and its
+    sub-scorers' input requirements go unchecked.
+    """
+    flattened = []
+    for scorer in scorers:
+        if getattr(scorer, "kind", None) == ScorerKind.ENSEMBLE:
+            flattened.extend(flatten_scorers(scorer._scorers))
+        else:
+            flattened.append(scorer)
+    return flattened
+
+
+def _is_feedbacks_mode(ensemble_fn: Callable[..., Any]) -> bool:
+    """Whether ``ensemble_fn`` opts into receiving full ``Feedback`` objects.
+
+    The aggregate input is passed positionally, so only the name of the first accepted
+    parameter selects the mode -- a ``feedbacks`` keyword elsewhere in the signature (e.g.
+    ``fn(values, feedbacks=None)``) must not flip it. Callables with no introspectable
+    signature (C builtins like ``max``) default to values-mode rather than raising.
+    """
+    try:
+        params = inspect.signature(ensemble_fn).parameters
+    except (ValueError, TypeError):
+        return False
+    positional = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.VAR_POSITIONAL,
+    )
+    first = next((p for p in params.values() if p.kind in positional), None)
+    return first is not None and first.name == "feedbacks"
+
+
 @dataclass
 class SerializedScorer:
     """
@@ -1141,6 +1179,17 @@ class Scorer(BaseModel):
                 copy.description = self.description
             if self.aggregations is not None:
                 copy.aggregations = self.aggregations
+        elif self.kind == ScorerKind.ENSEMBLE:
+            # Copy each sub-scorer through its own _create_copy so kind-specific handling
+            # still applies; a deepcopy of `_scorers` would recurse infinitely on a
+            # third-party sub-scorer holding an `instructor`-wrapped client.
+            copy = make_scorer_ensemble(
+                name=self.name,
+                scorers=[s._create_copy() for s in self._scorers],
+                ensemble_fn=self._ensemble_fn_name or self._ensemble_fn,
+                description=self.description,
+                aggregations=self.aggregations,
+            )
         else:
             copy = self.model_copy(deep=True)
         # Duplicate the cached dump so modifications to the copy don't affect the original
@@ -1495,6 +1544,17 @@ class EnsembleScorer(Scorer):
         except Exception as e:
             return Feedback(name=sub_scorer.name, error=e)
 
+    def _describe_failed_sub_scorers(self, sub_feedbacks: list[Feedback]) -> str:
+        # Built-in ensemble fns reject a missing value, and their generic "returned no value"
+        # message loses the underlying cause. Name the sub-scorers that failed and quote their
+        # errors so the aggregate failure stays actionable.
+        failures = [
+            f"'{fb.name}': {fb.error.error_message or fb.error.error_code}"
+            for fb in sub_feedbacks
+            if fb.error is not None
+        ]
+        return "; ".join(failures)
+
     def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Feedback]:
         # feedbacks-mode ensemble fns and the sub-feedbacks metadata both need a real
         # Feedback per sub-scorer; bare-value returns are wrapped and named after the scorer.
@@ -1543,17 +1603,9 @@ class EnsembleScorer(Scorer):
         results = [self._run_sub_scorer(s, kwargs) for s in self._scorers]
         values = [_extract_scorer_value(r) for r in results]
 
-        # Dispatch mode is chosen by the ensemble_fn's parameter name: the default (values-mode)
-        # passes the list of extracted primitive values, while a fn whose parameter is named
-        # "feedbacks" receives the full Feedback objects instead (value + rationale + source +
-        # error). Some callables (C builtins like max) expose no signature; default to
-        # values-mode rather than raising.
-        try:
-            params = inspect.signature(self._ensemble_fn).parameters
-            feedbacks_mode = "feedbacks" in params
-        except (ValueError, TypeError):
-            feedbacks_mode = False
+        feedbacks_mode = _is_feedbacks_mode(self._ensemble_fn)
         sub_feedbacks = self._normalize_to_feedbacks(results, values)
+        sub_metadata = self._build_sub_feedbacks_metadata(sub_feedbacks)
 
         if not feedbacks_mode:
             for sub_scorer, value in zip(self._scorers, values):
@@ -1565,9 +1617,18 @@ class EnsembleScorer(Scorer):
                     )
 
         agg_input = sub_feedbacks if feedbacks_mode else values
-        result = self._ensemble_fn(agg_input)
-
-        sub_metadata = self._build_sub_feedbacks_metadata(sub_feedbacks)
+        try:
+            result = self._ensemble_fn(agg_input)
+        except Exception as e:
+            # Attach the sub-scorer provenance to the failure so a crashed sub-scorer is
+            # debuggable: without this, a built-in fn's generic "returned no value" error
+            # hides both which sub-scorer failed and why.
+            failures = self._describe_failed_sub_scorers(sub_feedbacks)
+            suffix = f" Failed sub-scorers -- {failures}." if failures else ""
+            raise MlflowException.invalid_parameter_value(
+                f"Ensemble scorer '{self.name}' failed to aggregate its sub-scorer "
+                f"results: {e}{suffix}"
+            ) from e
 
         if isinstance(result, Feedback):
             if result.name == DEFAULT_FEEDBACK_NAME:
@@ -1578,6 +1639,7 @@ class EnsembleScorer(Scorer):
         return Feedback(name=self.name, value=result, metadata=sub_metadata)
 
 
+@experimental(version="3.15.0")
 def make_scorer_ensemble(
     *,
     name: str,
@@ -1586,7 +1648,8 @@ def make_scorer_ensemble(
     description: str | None = None,
     aggregations: list[_AggregationType] | None = None,
 ) -> EnsembleScorer:
-    """Create a scorer that runs several sub-scorers and aggregates their results.
+    """
+    Create a scorer that runs several sub-scorers and aggregates their results.
 
     Args:
         name: Name of the ensemble scorer (and of the emitted Feedback).
@@ -1650,9 +1713,10 @@ def make_scorer_ensemble(
             declared = getattr(s, "feedback_value_type", None)
             if declared is not None and not is_bool_feedback_type(declared):
                 raise MlflowException.invalid_parameter_value(
-                    f"Ensemble function '{fn_name}' requires boolean sub-scorer values, "
-                    f"but sub-scorer '{s.name}' declares a non-boolean feedback_value_type "
-                    f"({declared!r}). Use majority_vote for categorical scorers."
+                    f"Ensemble function '{fn_name}' requires sub-scorer values with a "
+                    f"yes/no reading, but sub-scorer '{s.name}' declares a "
+                    f"feedback_value_type of {declared!r}. Use majority_vote for other "
+                    f"categorical scorers."
                 )
 
     agg = EnsembleScorer(name=name, description=description, aggregations=aggregations)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1487,8 +1487,8 @@ class EnsembleScorer(Scorer):
                 feedback = result
             else:
                 feedback = Feedback(name=sub_scorer.name, value=value)
-            # Ensure the entry is attributable to the sub-scorer even if the returned
-            # Feedback used the default name.
+            # Defensive guard: feedbacks-mode fns may return a Feedback with the default name;
+            # always use the sub-scorer's name so every metadata entry is attributable.
             if feedback.name in (None, DEFAULT_FEEDBACK_NAME):
                 feedback.name = sub_scorer.name
             entries.append(feedback.to_dictionary())

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1474,20 +1474,18 @@ class EnsembleScorer(Scorer):
         )
         return asdict(serialized)
 
-    def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Any]:
+    def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Feedback]:
         # feedbacks-mode ensemble fns and the sub-feedbacks metadata both need a real
         # Feedback per sub-scorer; bare-value returns are wrapped and named after the scorer.
         feedbacks = []
         for sub_scorer, result, value in zip(self._scorers, results, values):
+            # Scorer.run() already renamed a default-named Feedback to the sub-scorer's name,
+            # so a returned Feedback is passed through as-is; bare-value returns are wrapped.
             fb = (
                 result
                 if isinstance(result, Feedback)
                 else Feedback(name=sub_scorer.name, value=value)
             )
-            # Defensive guard: feedbacks-mode fns may return a Feedback with the default name;
-            # always use the sub-scorer's name so every metadata entry is attributable.
-            if fb.name in (None, DEFAULT_FEEDBACK_NAME):
-                fb.name = sub_scorer.name
             feedbacks.append(fb)
         return feedbacks
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1476,19 +1476,22 @@ class EnsembleScorer(Scorer):
     def _build_sub_feedbacks_metadata(
         self, results: list[Any], values: list[Any]
     ) -> dict[str, str]:
-        # Preserve each sub-scorer's provenance (name, value, rationale, error) on the aggregate
-        # Feedback so the ensemble result stays explainable. metadata is dict[str, str], so the
-        # structured list is JSON-encoded under a single key.
+        # Preserve each sub-scorer's full Feedback (value, rationale, source, error) on the
+        # aggregate so the ensemble result stays fully explainable — including which judge/human/
+        # code produced each sub-result. metadata is dict[str, str], so the list of Feedback
+        # dicts is JSON-encoded under a single key. Bare-value sub-scorers are normalized to a
+        # Feedback named after the sub-scorer (source defaults to CODE).
         entries = []
         for sub_scorer, result, value in zip(self._scorers, results, values):
-            rationale = result.rationale if isinstance(result, Feedback) else None
-            error = str(result.error) if isinstance(result, Feedback) and result.error else None
-            entries.append({
-                "name": sub_scorer.name,
-                "value": value,
-                "rationale": rationale,
-                "error": error,
-            })
+            if isinstance(result, Feedback):
+                feedback = result
+            else:
+                feedback = Feedback(name=sub_scorer.name, value=value)
+            # Ensure the entry is attributable to the sub-scorer even if the returned
+            # Feedback used the default name.
+            if feedback.name in (None, DEFAULT_FEEDBACK_NAME):
+                feedback.name = sub_scorer.name
+            entries.append(feedback.to_dictionary())
         return {self._SUB_FEEDBACKS_METADATA_KEY: json.dumps(entries)}
 
     @property

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1480,7 +1480,7 @@ class EnsembleScorer(Scorer):
         feedbacks = []
         for sub_scorer, result, value in zip(self._scorers, results, values):
             # Scorer.run() already renamed a default-named Feedback to the sub-scorer's name,
-            # so a returned Feedback is passed through as-is; bare-value returns are wrapped.
+            # so a returned Feedback needs no rename here.
             fb = (
                 result
                 if isinstance(result, Feedback)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -570,6 +570,7 @@ class Scorer(BaseModel):
                 scorers=sub_scorers,
                 ensemble_fn=fn_name,
                 description=serialized.description,
+                aggregations=serialized.aggregations,
             )
 
         # Invalid serialized data
@@ -1473,25 +1474,29 @@ class EnsembleScorer(Scorer):
         )
         return asdict(serialized)
 
-    def _build_sub_feedbacks_metadata(
-        self, results: list[Any], values: list[Any]
-    ) -> dict[str, str]:
+    def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Any]:
+        # feedbacks-mode ensemble fns and the sub-feedbacks metadata both need a real
+        # Feedback per sub-scorer; bare-value returns are wrapped and named after the scorer.
+        feedbacks = []
+        for sub_scorer, result, value in zip(self._scorers, results, values):
+            fb = (
+                result
+                if isinstance(result, Feedback)
+                else Feedback(name=sub_scorer.name, value=value)
+            )
+            # Defensive guard: feedbacks-mode fns may return a Feedback with the default name;
+            # always use the sub-scorer's name so every metadata entry is attributable.
+            if fb.name in (None, DEFAULT_FEEDBACK_NAME):
+                fb.name = sub_scorer.name
+            feedbacks.append(fb)
+        return feedbacks
+
+    def _build_sub_feedbacks_metadata(self, sub_feedbacks: list[Any]) -> dict[str, str]:
         # Preserve each sub-scorer's full Feedback (value, rationale, source, error) on the
         # aggregate so the ensemble result stays fully explainable — including which judge/human/
         # code produced each sub-result. metadata is dict[str, str], so the list of Feedback
-        # dicts is JSON-encoded under a single key. Bare-value sub-scorers are normalized to a
-        # Feedback named after the sub-scorer (source defaults to CODE).
-        entries = []
-        for sub_scorer, result, value in zip(self._scorers, results, values):
-            if isinstance(result, Feedback):
-                feedback = result
-            else:
-                feedback = Feedback(name=sub_scorer.name, value=value)
-            # Defensive guard: feedbacks-mode fns may return a Feedback with the default name;
-            # always use the sub-scorer's name so every metadata entry is attributable.
-            if feedback.name in (None, DEFAULT_FEEDBACK_NAME):
-                feedback.name = sub_scorer.name
-            entries.append(feedback.to_dictionary())
+        # dicts is JSON-encoded under a single key.
+        entries = [fb.to_dictionary() for fb in sub_feedbacks]
         return {self._SUB_FEEDBACKS_METADATA_KEY: json.dumps(entries)}
 
     @property
@@ -1526,6 +1531,7 @@ class EnsembleScorer(Scorer):
 
         params = inspect.signature(self._ensemble_fn).parameters
         feedbacks_mode = "feedbacks" in params
+        sub_feedbacks = self._normalize_to_feedbacks(results, values)
 
         if not feedbacks_mode:
             for sub_scorer, value in zip(self._scorers, values):
@@ -1536,10 +1542,10 @@ class EnsembleScorer(Scorer):
                         f"'{sub_scorer.name}' returned {type(value).__name__}."
                     )
 
-        agg_input = results if feedbacks_mode else values
+        agg_input = sub_feedbacks if feedbacks_mode else values
         result = self._ensemble_fn(agg_input)
 
-        sub_metadata = self._build_sub_feedbacks_metadata(results, values)
+        sub_metadata = self._build_sub_feedbacks_metadata(sub_feedbacks)
 
         if isinstance(result, Feedback):
             if result.name == DEFAULT_FEEDBACK_NAME:
@@ -1556,6 +1562,7 @@ def scorer_ensemble(
     scorers: list[Scorer],
     ensemble_fn: str | Callable[..., Any],
     description: str | None = None,
+    aggregations: list[_AggregationType] | None = None,
 ) -> EnsembleScorer:
     """Create a scorer that runs several sub-scorers and aggregates their results.
 
@@ -1568,6 +1575,10 @@ def scorer_ensemble(
             ``(feedbacks) -> value|Feedback`` to receive full Feedback objects, or the
             string name of a built-in (one of ``mlflow.genai.scorers.ensemble``).
         description: Optional description.
+        aggregations: A list of aggregation functions to apply to the scorer's output
+            across rows. Each entry is either a string
+            (``"min"``, ``"max"``, ``"mean"``, ``"median"``, ``"variance"``, ``"p90"``)
+            or a callable ``(list[values]) -> float``. Defaults to ``"mean"``.
     """
     from mlflow.genai.scorers.ensemble import (
         BUILTIN_ENSEMBLES,
@@ -1616,7 +1627,7 @@ def scorer_ensemble(
                     f"({declared!r}). Use majority_vote for categorical scorers."
                 )
 
-    agg = EnsembleScorer(name=name, description=description)
+    agg = EnsembleScorer(name=name, description=description, aggregations=aggregations)
     object.__setattr__(agg, "_scorers", list(scorers))
     object.__setattr__(agg, "_ensemble_fn", fn)
     object.__setattr__(agg, "_ensemble_fn_name", fn_name)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -52,6 +52,7 @@ class ScorerKind(Enum):
     GUIDELINES = "guidelines"
     THIRD_PARTY = "third_party"
     MEMORY_AUGMENTED = "memory_augmented"
+    ENSEMBLE = "ensemble"
 
 
 _ALLOWED_SCORERS_FOR_REGISTRATION = [
@@ -61,6 +62,7 @@ _ALLOWED_SCORERS_FOR_REGISTRATION = [
     ScorerKind.GUIDELINES,
     ScorerKind.MEMORY_AUGMENTED,
     ScorerKind.THIRD_PARTY,
+    ScorerKind.ENSEMBLE,
 ]
 
 
@@ -85,6 +87,23 @@ class ScorerSamplingConfig:
 
 
 AggregationFunc = Callable[[list[float]], float]  # List of per-row value -> aggregated value
+
+
+def _extract_scorer_value(result: Any) -> Any:
+    """Reduce a sub-scorer's return to a single aggregatable value.
+
+    Failures and empty assessments (``None`` or an error ``Feedback``) become ``None``
+    so the ensemble function decides how to treat them.
+    """
+    if result is None:
+        return None
+    if isinstance(result, Feedback):
+        return None if result.error is not None else result.value
+    if isinstance(result, list):
+        raise MlflowException.invalid_parameter_value(
+            "scorer_ensemble does not support sub-scorers that return a list of Feedback objects."
+        )
+    return result
 
 
 @dataclass
@@ -122,6 +141,10 @@ class SerializedScorer:
     #   {"module": ..., "class": ..., "metric_name": ..., "model": ..., "kwargs": {...}}
     third_party_scorer_data: dict[str, Any] | None = None
 
+    # Ensemble scorer fields (for scorer_ensemble()). Shape:
+    #   {"ensemble_fn": <builtin name>, "scorers": [<serialized sub-scorer dict>, ...]}
+    ensemble_scorer_data: dict[str, Any] | None = None
+
     def __post_init__(self):
         """Validate that exactly one type of scorer fields is present."""
         has_builtin_fields = self.builtin_scorer_class is not None
@@ -129,6 +152,7 @@ class SerializedScorer:
         has_instructions_fields = self.instructions_judge_pydantic_data is not None
         has_memory_augmented_fields = self.memory_augmented_judge_data is not None
         has_third_party_fields = self.third_party_scorer_data is not None
+        has_ensemble_fields = self.ensemble_scorer_data is not None
 
         # Count how many field types are present
         field_count = sum([
@@ -137,6 +161,7 @@ class SerializedScorer:
             has_instructions_fields,
             has_memory_augmented_fields,
             has_third_party_fields,
+            has_ensemble_fields,
         ])
 
         if field_count == 0:
@@ -145,7 +170,8 @@ class SerializedScorer:
                 "(builtin_scorer_class), decorator scorer fields (call_source), "
                 "instructions judge fields (instructions_judge_pydantic_data), "
                 "memory augmented judge fields (memory_augmented_judge_data), "
-                "or third-party scorer fields (third_party_scorer_data) present"
+                "third-party scorer fields (third_party_scorer_data), "
+                "or ensemble scorer fields (ensemble_scorer_data) present"
             )
 
         if field_count > 1:
@@ -526,6 +552,25 @@ class Scorer(BaseModel):
                 scorer_instance.aggregations = serialized.aggregations
             object.__setattr__(scorer_instance, "_cached_dump", asdict(serialized))
             return scorer_instance
+
+        # Handle ensemble scorers
+        elif serialized.ensemble_scorer_data is not None:
+            from mlflow.genai.scorers.ensemble import BUILTIN_ENSEMBLES
+
+            data = serialized.ensemble_scorer_data
+            fn_name = data.get("ensemble_fn")
+            if fn_name not in BUILTIN_ENSEMBLES:
+                raise MlflowException.invalid_parameter_value(
+                    f"Ensemble scorer '{serialized.name}': unknown ensemble function "
+                    f"'{fn_name}'. Available: {sorted(BUILTIN_ENSEMBLES)}."
+                )
+            sub_scorers = [cls.model_validate(d) for d in data.get("scorers", [])]
+            return scorer_ensemble(
+                name=serialized.name,
+                scorers=sub_scorers,
+                ensemble_fn=fn_name,
+                description=serialized.description,
+            )
 
         # Invalid serialized data
         else:
@@ -1395,3 +1440,158 @@ def scorer(
         description=description,
         aggregations=aggregations,
     )
+
+
+class EnsembleScorer(Scorer):
+    _scorers: list[Scorer] = PrivateAttr(default_factory=list)
+    _ensemble_fn: Callable[..., Any] = PrivateAttr()
+    _ensemble_fn_name: str | None = PrivateAttr(default=None)
+    _is_session_level: bool = PrivateAttr(default=False)
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        from mlflow.genai.scorers.ensemble import BUILTIN_ENSEMBLES
+
+        if self._ensemble_fn_name is None:
+            raise MlflowException.invalid_parameter_value(
+                "This ensemble scorer uses a custom ensemble function and cannot be "
+                "serialized or registered. Pass one of the built-in ensemble functions "
+                f"({sorted(BUILTIN_ENSEMBLES)}) to make it serializable."
+            )
+        serialized = SerializedScorer(
+            name=self.name,
+            description=self.description,
+            aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
+            mlflow_version=mlflow.__version__,
+            serialization_version=_SERIALIZATION_VERSION,
+            ensemble_scorer_data={
+                "ensemble_fn": self._ensemble_fn_name,
+                "scorers": [s.model_dump() for s in self._scorers],
+            },
+        )
+        return asdict(serialized)
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.ENSEMBLE
+
+    @property
+    def is_session_level_scorer(self) -> bool:
+        return self._is_session_level
+
+    def __call__(
+        self,
+        *,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+        trace: Trace | None = None,
+        session: list[Trace] | None = None,
+    ) -> Feedback:
+        if self._is_session_level:
+            kwargs = {"session": session, "expectations": expectations}
+        else:
+            kwargs = {
+                "inputs": inputs,
+                "outputs": outputs,
+                "expectations": expectations,
+                "trace": trace,
+            }
+
+        results = [s.run(**kwargs) for s in self._scorers]
+        values = [_extract_scorer_value(r) for r in results]
+
+        params = inspect.signature(self._ensemble_fn).parameters
+        feedbacks_mode = "feedbacks" in params
+
+        if not feedbacks_mode:
+            for sub_scorer, value in zip(self._scorers, values):
+                if value is not None and not isinstance(value, (bool, int, float, str)):
+                    raise MlflowException.invalid_parameter_value(
+                        f"scorer_ensemble only supports sub-scorers returning bool, "
+                        f"numeric, or categorical (str) values. Sub-scorer "
+                        f"'{sub_scorer.name}' returned {type(value).__name__}."
+                    )
+
+        agg_input = results if feedbacks_mode else values
+        result = self._ensemble_fn(agg_input)
+
+        if isinstance(result, Feedback):
+            if result.name == DEFAULT_FEEDBACK_NAME:
+                result.name = self.name
+            return result
+        return Feedback(name=self.name, value=result)
+
+
+def scorer_ensemble(
+    *,
+    name: str,
+    scorers: list[Scorer],
+    ensemble_fn: str | Callable[..., Any],
+    description: str | None = None,
+) -> EnsembleScorer:
+    """Create a scorer that runs several sub-scorers and aggregates their results.
+
+    Args:
+        name: Name of the ensemble scorer (and of the emitted Feedback).
+        scorers: Sub-scorers to run. Must be homogeneous in level — all session-level
+            or all single-turn. Each must return a bool, numeric, or categorical
+            (str) value.
+        ensemble_fn: A callable ``(values) -> value|Feedback``, or a callable
+            ``(feedbacks) -> value|Feedback`` to receive full Feedback objects, or the
+            string name of a built-in (one of ``mlflow.genai.scorers.ensemble``).
+        description: Optional description.
+    """
+    from mlflow.genai.scorers.ensemble import (
+        BUILTIN_ENSEMBLES,
+        NUMERIC_ENSEMBLES,
+        is_numeric_feedback_type,
+    )
+
+    if not scorers:
+        raise MlflowException.invalid_parameter_value(
+            "scorer_ensemble requires at least one sub-scorer."
+        )
+
+    levels = {s.is_session_level_scorer for s in scorers}
+    if len(levels) > 1:
+        raise MlflowException.invalid_parameter_value(
+            "All sub-scorers passed to scorer_ensemble must be the same level: "
+            "either all session-level or all single-turn."
+        )
+    is_session_level = levels.pop()
+
+    if isinstance(ensemble_fn, str):
+        if ensemble_fn not in BUILTIN_ENSEMBLES:
+            raise MlflowException.invalid_parameter_value(
+                f"'{ensemble_fn}' is not a built-in ensemble function. "
+                f"Available: {sorted(BUILTIN_ENSEMBLES)}."
+            )
+        fn_name = ensemble_fn
+        fn = BUILTIN_ENSEMBLES[ensemble_fn]
+    else:
+        fn = ensemble_fn
+        # Record the built-in name when a built-in callable is passed directly, so the
+        # scorer stays serializable.
+        fn_name = next((n for n, f in BUILTIN_ENSEMBLES.items() if f is fn), None)
+
+    # Up-front validation: numeric built-ins reject sub-scorers that DECLARE a
+    # non-numeric feedback_value_type (e.g. a Literal["yes","no"] judge), giving a clear
+    # error before any evaluation runs. Only judges/builtin scorers declare this; decorator
+    # scorers omit it and are validated at call time by the runtime value-check.
+    if fn_name in NUMERIC_ENSEMBLES:
+        for s in scorers:
+            declared = getattr(s, "feedback_value_type", None)
+            if declared is not None and not is_numeric_feedback_type(declared):
+                raise MlflowException.invalid_parameter_value(
+                    f"Ensemble function '{fn_name}' requires numeric sub-scorer values, "
+                    f"but sub-scorer '{s.name}' declares a non-numeric feedback_value_type "
+                    f"({declared!r}). Use majority_vote for categorical scorers."
+                )
+
+    agg = EnsembleScorer(name=name, description=description)
+    object.__setattr__(agg, "_scorers", list(scorers))
+    object.__setattr__(agg, "_ensemble_fn", fn)
+    object.__setattr__(agg, "_ensemble_fn_name", fn_name)
+    object.__setattr__(agg, "_is_session_level", is_session_level)
+    return agg

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -16,8 +16,10 @@ from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.ensemble import (
+    BOOL_ENSEMBLES,
     BUILTIN_ENSEMBLES,
     NUMERIC_ENSEMBLES,
+    is_bool_feedback_type,
     is_numeric_feedback_type,
 )
 from mlflow.genai.scorers.scorer_utils import (
@@ -106,7 +108,8 @@ def _extract_scorer_value(result: Any) -> Any:
         return None if result.error is not None else result.value
     if isinstance(result, list):
         raise MlflowException.invalid_parameter_value(
-            "scorer_ensemble does not support sub-scorers that return a list of Feedback objects."
+            "make_scorer_ensemble does not support sub-scorers that return a list of Feedback "
+            "objects."
         )
     return result
 
@@ -146,7 +149,7 @@ class SerializedScorer:
     #   {"module": ..., "class": ..., "metric_name": ..., "model": ..., "kwargs": {...}}
     third_party_scorer_data: dict[str, Any] | None = None
 
-    # Ensemble scorer fields (for scorer_ensemble()). Shape:
+    # Ensemble scorer fields (for make_scorer_ensemble()). Shape:
     #   {"ensemble_fn": <builtin name>, "scorers": [<serialized sub-scorer dict>, ...]}
     ensemble_scorer_data: dict[str, Any] | None = None
 
@@ -568,7 +571,7 @@ class Scorer(BaseModel):
                     f"'{fn_name}'. Available: {sorted(BUILTIN_ENSEMBLES)}."
                 )
             sub_scorers = [cls.model_validate(d) for d in data.get("scorers", [])]
-            return scorer_ensemble(
+            return make_scorer_ensemble(
                 name=serialized.name,
                 scorers=sub_scorers,
                 ensemble_fn=fn_name,
@@ -1156,6 +1159,13 @@ class Scorer(BaseModel):
                 )
             raise MlflowException.invalid_parameter_value(error_message)
 
+        # An ensemble is only registerable if every sub-scorer is registerable too (e.g. an
+        # ensemble containing a decorator sub-scorer on a non-Databricks URI is rejected with
+        # the same rule the sub-scorer would raise on its own).
+        if self.kind == ScorerKind.ENSEMBLE:
+            for sub_scorer in self._scorers:
+                sub_scorer._check_can_be_registered(error_message)
+
         # NB: Custom (@scorer) scorers use exec() during deserialization, which poses a code
         # execution risk. Only allow registration when using Databricks tracking URI.
         # Registration itself is safe (just stores code), but we restrict it to Databricks
@@ -1475,6 +1485,16 @@ class EnsembleScorer(Scorer):
         )
         return asdict(serialized)
 
+    def _run_sub_scorer(self, sub_scorer: "Scorer", kwargs: dict[str, Any]) -> Any:
+        # Isolate sub-scorer failures: a raised exception becomes an error Feedback so one
+        # bad scorer doesn't abort the whole ensemble. Built-in ensemble fns still treat the
+        # resulting None as fatal; custom fns can tolerate it. (Sub-scorers run sequentially;
+        # parallel execution is future work.)
+        try:
+            return sub_scorer.run(**kwargs)
+        except Exception as e:
+            return Feedback(name=sub_scorer.name, error=e)
+
     def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Feedback]:
         # feedbacks-mode ensemble fns and the sub-feedbacks metadata both need a real
         # Feedback per sub-scorer; bare-value returns are wrapped and named after the scorer.
@@ -1520,18 +1540,26 @@ class EnsembleScorer(Scorer):
                 "trace": trace,
             }
 
-        results = [s.run(**kwargs) for s in self._scorers]
+        results = [self._run_sub_scorer(s, kwargs) for s in self._scorers]
         values = [_extract_scorer_value(r) for r in results]
 
-        params = inspect.signature(self._ensemble_fn).parameters
-        feedbacks_mode = "feedbacks" in params
+        # Dispatch mode is chosen by the ensemble_fn's parameter name: the default (values-mode)
+        # passes the list of extracted primitive values, while a fn whose parameter is named
+        # "feedbacks" receives the full Feedback objects instead (value + rationale + source +
+        # error). Some callables (C builtins like max) expose no signature; default to
+        # values-mode rather than raising.
+        try:
+            params = inspect.signature(self._ensemble_fn).parameters
+            feedbacks_mode = "feedbacks" in params
+        except (ValueError, TypeError):
+            feedbacks_mode = False
         sub_feedbacks = self._normalize_to_feedbacks(results, values)
 
         if not feedbacks_mode:
             for sub_scorer, value in zip(self._scorers, values):
                 if value is not None and not isinstance(value, (bool, int, float, str)):
                     raise MlflowException.invalid_parameter_value(
-                        f"scorer_ensemble only supports sub-scorers returning bool, "
+                        f"make_scorer_ensemble only supports sub-scorers returning bool, "
                         f"numeric, or categorical (str) values. Sub-scorer "
                         f"'{sub_scorer.name}' returned {type(value).__name__}."
                     )
@@ -1550,7 +1578,7 @@ class EnsembleScorer(Scorer):
         return Feedback(name=self.name, value=result, metadata=sub_metadata)
 
 
-def scorer_ensemble(
+def make_scorer_ensemble(
     *,
     name: str,
     scorers: list[Scorer],
@@ -1567,7 +1595,10 @@ def scorer_ensemble(
             (str) value.
         ensemble_fn: A callable ``(values) -> value|Feedback``, or a callable
             ``(feedbacks) -> value|Feedback`` to receive full Feedback objects, or the
-            string name of a built-in (one of ``mlflow.genai.scorers.ensemble``).
+            string name of a built-in (one of ``mlflow.genai.scorers.ensemble``). The
+            callable may return a primitive (wrapped into a Feedback named after the
+            ensemble scorer) or a ``Feedback`` directly (passed through, with its name
+            defaulted to the ensemble scorer's name when unset).
         description: Optional description.
         aggregations: A list of aggregation functions to apply to the scorer's output
             across rows. Each entry is either a string
@@ -1576,13 +1607,13 @@ def scorer_ensemble(
     """
     if not scorers:
         raise MlflowException.invalid_parameter_value(
-            "scorer_ensemble requires at least one sub-scorer."
+            "make_scorer_ensemble requires at least one sub-scorer."
         )
 
     levels = {s.is_session_level_scorer for s in scorers}
     if len(levels) > 1:
         raise MlflowException.invalid_parameter_value(
-            "All sub-scorers passed to scorer_ensemble must be the same level: "
+            "All sub-scorers passed to make_scorer_ensemble must be the same level: "
             "either all session-level or all single-turn."
         )
     is_session_level = levels.pop()
@@ -1612,6 +1643,15 @@ def scorer_ensemble(
                 raise MlflowException.invalid_parameter_value(
                     f"Ensemble function '{fn_name}' requires numeric sub-scorer values, "
                     f"but sub-scorer '{s.name}' declares a non-numeric feedback_value_type "
+                    f"({declared!r}). Use majority_vote for categorical scorers."
+                )
+    elif fn_name in BOOL_ENSEMBLES:
+        for s in scorers:
+            declared = getattr(s, "feedback_value_type", None)
+            if declared is not None and not is_bool_feedback_type(declared):
+                raise MlflowException.invalid_parameter_value(
+                    f"Ensemble function '{fn_name}' requires boolean sub-scorer values, "
+                    f"but sub-scorer '{s.name}' declares a non-boolean feedback_value_type "
                     f"({declared!r}). Use majority_vote for categorical scorers."
                 )
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1443,6 +1443,8 @@ def scorer(
 
 
 class EnsembleScorer(Scorer):
+    _SUB_FEEDBACKS_METADATA_KEY: ClassVar[str] = "mlflow.ensemble.sub_feedbacks"
+
     _scorers: list[Scorer] = PrivateAttr(default_factory=list)
     _ensemble_fn: Callable[..., Any] = PrivateAttr()
     _ensemble_fn_name: str | None = PrivateAttr(default=None)
@@ -1470,6 +1472,24 @@ class EnsembleScorer(Scorer):
             },
         )
         return asdict(serialized)
+
+    def _build_sub_feedbacks_metadata(
+        self, results: list[Any], values: list[Any]
+    ) -> dict[str, str]:
+        # Preserve each sub-scorer's provenance (name, value, rationale) on the aggregate
+        # Feedback so the ensemble result stays explainable. metadata is dict[str, str], so the
+        # structured list is JSON-encoded under a single key.
+        entries = []
+        for sub_scorer, result, value in zip(self._scorers, results, values):
+            rationale = result.rationale if isinstance(result, Feedback) else None
+            error = str(result.error) if isinstance(result, Feedback) and result.error else None
+            entries.append({
+                "name": sub_scorer.name,
+                "value": value,
+                "rationale": rationale,
+                "error": error,
+            })
+        return {self._SUB_FEEDBACKS_METADATA_KEY: json.dumps(entries)}
 
     @property
     def kind(self) -> ScorerKind:
@@ -1516,11 +1536,15 @@ class EnsembleScorer(Scorer):
         agg_input = results if feedbacks_mode else values
         result = self._ensemble_fn(agg_input)
 
+        sub_metadata = self._build_sub_feedbacks_metadata(results, values)
+
         if isinstance(result, Feedback):
             if result.name == DEFAULT_FEEDBACK_NAME:
                 result.name = self.name
+            # Merge, letting the ensemble_fn's own metadata win on key collisions.
+            result.metadata = {**sub_metadata, **(result.metadata or {})}
             return result
-        return Feedback(name=self.name, value=result)
+        return Feedback(name=self.name, value=result, metadata=sub_metadata)
 
 
 def scorer_ensemble(

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -15,6 +15,11 @@ from mlflow.entities import Assessment, Feedback
 from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.ensemble import (
+    BUILTIN_ENSEMBLES,
+    NUMERIC_ENSEMBLES,
+    is_numeric_feedback_type,
+)
 from mlflow.genai.scorers.scorer_utils import (
     DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,
     THIRD_PARTY_SCORER_ALLOWED_MODULES,
@@ -555,8 +560,6 @@ class Scorer(BaseModel):
 
         # Handle ensemble scorers
         elif serialized.ensemble_scorer_data is not None:
-            from mlflow.genai.scorers.ensemble import BUILTIN_ENSEMBLES
-
             data = serialized.ensemble_scorer_data
             fn_name = data.get("ensemble_fn")
             if fn_name not in BUILTIN_ENSEMBLES:
@@ -1452,8 +1455,6 @@ class EnsembleScorer(Scorer):
     _is_session_level: bool = PrivateAttr(default=False)
 
     def model_dump(self, **kwargs) -> dict[str, Any]:
-        from mlflow.genai.scorers.ensemble import BUILTIN_ENSEMBLES
-
         if self._ensemble_fn_name is None:
             raise MlflowException.invalid_parameter_value(
                 "This ensemble scorer uses a custom ensemble function and cannot be "
@@ -1477,17 +1478,12 @@ class EnsembleScorer(Scorer):
     def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Feedback]:
         # feedbacks-mode ensemble fns and the sub-feedbacks metadata both need a real
         # Feedback per sub-scorer; bare-value returns are wrapped and named after the scorer.
-        feedbacks = []
-        for sub_scorer, result, value in zip(self._scorers, results, values):
-            # Scorer.run() already renamed a default-named Feedback to the sub-scorer's name,
-            # so a returned Feedback needs no rename here.
-            fb = (
-                result
-                if isinstance(result, Feedback)
-                else Feedback(name=sub_scorer.name, value=value)
-            )
-            feedbacks.append(fb)
-        return feedbacks
+        # Scorer.run() already renamed a default-named Feedback to the sub-scorer's name, so a
+        # returned Feedback needs no rename here.
+        return [
+            result if isinstance(result, Feedback) else Feedback(name=sub_scorer.name, value=value)
+            for sub_scorer, result, value in zip(self._scorers, results, values)
+        ]
 
     def _build_sub_feedbacks_metadata(self, sub_feedbacks: list[Any]) -> dict[str, str]:
         # Preserve each sub-scorer's full Feedback (value, rationale, source, error) on the
@@ -1578,12 +1574,6 @@ def scorer_ensemble(
             (``"min"``, ``"max"``, ``"mean"``, ``"median"``, ``"variance"``, ``"p90"``)
             or a callable ``(list[values]) -> float``. Defaults to ``"mean"``.
     """
-    from mlflow.genai.scorers.ensemble import (
-        BUILTIN_ENSEMBLES,
-        NUMERIC_ENSEMBLES,
-        is_numeric_feedback_type,
-    )
-
     if not scorers:
         raise MlflowException.invalid_parameter_value(
             "scorer_ensemble requires at least one sub-scorer."

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1476,7 +1476,7 @@ class EnsembleScorer(Scorer):
     def _build_sub_feedbacks_metadata(
         self, results: list[Any], values: list[Any]
     ) -> dict[str, str]:
-        # Preserve each sub-scorer's provenance (name, value, rationale) on the aggregate
+        # Preserve each sub-scorer's provenance (name, value, rationale, error) on the aggregate
         # Feedback so the ensemble result stays explainable. metadata is dict[str, str], so the
         # structured list is JSON-encoded under a single key.
         entries = []

--- a/mlflow/genai/scorers/ensemble.py
+++ b/mlflow/genai/scorers/ensemble.py
@@ -1,7 +1,7 @@
-"""Built-in ensemble functions for ``scorer_ensemble``.
+"""Built-in ensemble functions for ``make_scorer_ensemble``.
 
 Each function receives the list of per-sub-scorer values and returns a single
-``Feedback``. The parameter is named ``values`` on purpose: ``scorer_ensemble``
+``Feedback``. The parameter is named ``values`` on purpose: ``make_scorer_ensemble``
 introspects the parameter name to decide whether to pass raw values or full
 ``Feedback`` objects (a parameter named ``feedbacks`` opts into the latter).
 """
@@ -14,6 +14,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.exceptions import MlflowException
 
 NUMERIC_ENSEMBLES: set[str] = {"mean", "minimum", "maximum"}
+BOOL_ENSEMBLES: set[str] = {"agg_all", "agg_any"}
 
 
 def _require_numeric(values: list[Any]) -> None:
@@ -26,6 +27,31 @@ def _require_numeric(values: list[Any]) -> None:
                 f"This ensemble function requires numeric sub-scorer values, but got a value of "
                 f"type {type(v).__name__}. Use majority_vote for categorical values."
             )
+
+
+def _require_bool(values: list[Any]) -> None:
+    # agg_all/agg_any are boolean reducers; reject non-bool values (e.g. "no"/"yes" strings,
+    # which are all truthy) rather than silently returning a misleading result.
+    for v in values:
+        if not isinstance(v, bool):
+            raise MlflowException.invalid_parameter_value(
+                f"This ensemble function requires boolean sub-scorer values, but got a value "
+                f"of type {type(v).__name__}. Use majority_vote for categorical values."
+            )
+
+
+def is_bool_feedback_type(feedback_value_type) -> bool:
+    """Whether a declared ``feedback_value_type`` denotes a boolean value.
+
+    Used to validate sub-scorers up front against boolean built-ins (agg_all/agg_any). A
+    ``Literal[...]`` is boolean only when every member is a bool. Unknown/unannotated types
+    return False (caller treats them as non-bool).
+    """
+    if feedback_value_type is bool:
+        return True
+    if get_origin(feedback_value_type) is Literal:
+        return all(isinstance(arg, bool) for arg in get_args(feedback_value_type))
+    return False
 
 
 def is_numeric_feedback_type(feedback_value_type) -> bool:
@@ -61,7 +87,10 @@ def majority_vote(values: list[Any]) -> Feedback:
     _require_complete(values)
     counts = Counter(values)
     top = max(counts.values())
-    # Deterministic tie-break: lexicographic order of the string form of the value.
+    # Deterministic tie-break: lexicographic order of the string form of each tied value.
+    # This is intended for categorical/bool values. For numerics the string ordering is NOT
+    # numeric ordering (e.g. str(10) < str(9), and False sorts before True), so majority_vote
+    # is not appropriate for continuous numerics -- use mean/minimum/maximum for those.
     winner = min((v for v, c in counts.items() if c == top), key=lambda v: str(v))
     return Feedback(
         value=winner,
@@ -92,12 +121,14 @@ def maximum(values: list[Any]) -> Feedback:
 
 def agg_all(values: list[Any]) -> Feedback:
     _require_complete(values)
+    _require_bool(values)
     result = all(values)
     return Feedback(value=result, rationale=f"all() over {len(values)} scorers = {result}")
 
 
 def agg_any(values: list[Any]) -> Feedback:
     _require_complete(values)
+    _require_bool(values)
     result = any(values)
     return Feedback(value=result, rationale=f"any() over {len(values)} scorers = {result}")
 

--- a/mlflow/genai/scorers/ensemble.py
+++ b/mlflow/genai/scorers/ensemble.py
@@ -12,9 +12,28 @@ from typing import Any, Callable, Literal, get_args, get_origin
 
 from mlflow.entities.assessment import Feedback
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
 
 NUMERIC_ENSEMBLES: set[str] = {"mean", "minimum", "maximum"}
 BOOL_ENSEMBLES: set[str] = {"agg_all", "agg_any"}
+
+
+def _coerce_to_bool(value: Any) -> bool | None:
+    """Map a sub-scorer value onto a bool, or ``None`` when it has no boolean reading.
+
+    Built-in judges return ``Literal["yes", "no"]`` rather than a bool, so the boolean
+    reducers accept the same affirmative/negative vocabulary the judges normalize to
+    (``CategoricalRating`` is a ``StrEnum``, so it compares equal to its string value).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _AFFIRMATIVE_VALUES:
+            return True
+        if normalized in _NEGATIVE_VALUES:
+            return False
+    return None
 
 
 def _require_numeric(values: list[Any]) -> None:
@@ -29,28 +48,35 @@ def _require_numeric(values: list[Any]) -> None:
             )
 
 
-def _require_bool(values: list[Any]) -> None:
-    # agg_all/agg_any are boolean reducers; reject non-bool values (e.g. "no"/"yes" strings,
-    # which are all truthy) rather than silently returning a misleading result.
-    for v in values:
-        if not isinstance(v, bool):
+def _as_bools(values: list[Any]) -> list[bool]:
+    # agg_all/agg_any are boolean reducers, so never fall back to Python truthiness: a bare
+    # `all(["no", "no"])` is True because non-empty strings are truthy. Coerce each value to
+    # an explicit bool and reject anything with no boolean reading.
+    bools = []
+    for value in values:
+        coerced = _coerce_to_bool(value)
+        if coerced is None:
             raise MlflowException.invalid_parameter_value(
-                f"This ensemble function requires boolean sub-scorer values, but got a value "
-                f"of type {type(v).__name__}. Use majority_vote for categorical values."
+                f"This ensemble function requires boolean sub-scorer values, but got "
+                f"{value!r} (type {type(value).__name__}), which has no yes/no reading. "
+                f"Use majority_vote for other categorical values."
             )
+        bools.append(coerced)
+    return bools
 
 
 def is_bool_feedback_type(feedback_value_type) -> bool:
     """Whether a declared ``feedback_value_type`` denotes a boolean value.
 
     Used to validate sub-scorers up front against boolean built-ins (agg_all/agg_any). A
-    ``Literal[...]`` is boolean only when every member is a bool. Unknown/unannotated types
-    return False (caller treats them as non-bool).
+    ``Literal[...]`` qualifies when every member has a boolean reading, which includes the
+    ``Literal["yes", "no"]`` that built-in judges declare. Unknown/unannotated types return
+    False (caller treats them as non-bool).
     """
     if feedback_value_type is bool:
         return True
     if get_origin(feedback_value_type) is Literal:
-        return all(isinstance(arg, bool) for arg in get_args(feedback_value_type))
+        return all(_coerce_to_bool(arg) is not None for arg in get_args(feedback_value_type))
     return False
 
 
@@ -121,15 +147,13 @@ def maximum(values: list[Any]) -> Feedback:
 
 def agg_all(values: list[Any]) -> Feedback:
     _require_complete(values)
-    _require_bool(values)
-    result = all(values)
+    result = all(_as_bools(values))
     return Feedback(value=result, rationale=f"all() over {len(values)} scorers = {result}")
 
 
 def agg_any(values: list[Any]) -> Feedback:
     _require_complete(values)
-    _require_bool(values)
-    result = any(values)
+    result = any(_as_bools(values))
     return Feedback(value=result, rationale=f"any() over {len(values)} scorers = {result}")
 
 

--- a/mlflow/genai/scorers/ensemble.py
+++ b/mlflow/genai/scorers/ensemble.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Literal, get_args, get_origin
 from mlflow.entities.assessment import Feedback
 from mlflow.exceptions import MlflowException
 
-# Built-ins that require numeric values (reject categorical/string inputs).
 NUMERIC_ENSEMBLES: set[str] = {"mean", "minimum", "maximum"}
 
 

--- a/mlflow/genai/scorers/ensemble.py
+++ b/mlflow/genai/scorers/ensemble.py
@@ -1,0 +1,113 @@
+"""Built-in ensemble functions for ``scorer_ensemble``.
+
+Each function receives the list of per-sub-scorer values and returns a single
+``Feedback``. The parameter is named ``values`` on purpose: ``scorer_ensemble``
+introspects the parameter name to decide whether to pass raw values or full
+``Feedback`` objects (a parameter named ``feedbacks`` opts into the latter).
+"""
+
+from collections import Counter
+from statistics import mean as _statistics_mean
+from typing import Any, Callable, Literal, get_args, get_origin
+
+from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
+
+# Built-ins that require numeric values (reject categorical/string inputs).
+NUMERIC_ENSEMBLES: set[str] = {"mean", "minimum", "maximum"}
+
+
+def _require_numeric(values: list[Any]) -> None:
+    # Numeric built-ins (mean/minimum/maximum) reject categorical/string values with a
+    # clear error rather than letting statistics/min/max raise an opaque TypeError.
+    for v in values:
+        # bool is an int subclass and is acceptable as a numeric 0/1.
+        if not isinstance(v, (bool, int, float)):
+            raise MlflowException.invalid_parameter_value(
+                f"This ensemble function requires numeric sub-scorer values, but got a value of "
+                f"type {type(v).__name__}. Use majority_vote for categorical values."
+            )
+
+
+def is_numeric_feedback_type(feedback_value_type) -> bool:
+    """Whether a declared ``feedback_value_type`` denotes a numeric value.
+
+    Used to validate sub-scorers up front against numeric built-ins. A ``Literal[...]`` is
+    numeric only when every member is an int/float. ``bool`` counts as numeric (0/1).
+    Unknown/unannotated types return False (caller treats them as categorical).
+    """
+    if feedback_value_type in (bool, int, float):
+        return True
+    if get_origin(feedback_value_type) is Literal:
+        return all(isinstance(arg, (bool, int, float)) for arg in get_args(feedback_value_type))
+    return False
+
+
+def _require_complete(values: list[Any]) -> None:
+    # Built-ins treat any failed/empty sub-scorer (surfaced as None) as fatal so a
+    # partial ensemble never silently produces a misleading aggregate.
+    if not values:
+        raise MlflowException.invalid_parameter_value(
+            "Aggregation failed: no sub-scorer values were provided."
+        )
+    if any(v is None for v in values):
+        raise MlflowException.invalid_parameter_value(
+            "Aggregation failed: at least one sub-scorer returned no value (it errored "
+            "or produced an empty assessment). Built-in aggregation functions require "
+            "every sub-scorer to return a value."
+        )
+
+
+def majority_vote(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    counts = Counter(values)
+    top = max(counts.values())
+    # Deterministic tie-break: lexicographic order of the string form of the value.
+    winner = min((v for v, c in counts.items() if c == top), key=lambda v: str(v))
+    return Feedback(
+        value=winner,
+        rationale=f"Majority vote over {len(values)} scorers: {dict(counts)}",
+    )
+
+
+def mean(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    _require_numeric(values)
+    result = _statistics_mean(values)
+    return Feedback(value=result, rationale=f"Mean over {len(values)} scorers = {result}")
+
+
+def minimum(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    _require_numeric(values)
+    result = min(values)
+    return Feedback(value=result, rationale=f"Minimum over {len(values)} scorers = {result}")
+
+
+def maximum(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    _require_numeric(values)
+    result = max(values)
+    return Feedback(value=result, rationale=f"Maximum over {len(values)} scorers = {result}")
+
+
+def agg_all(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    result = all(values)
+    return Feedback(value=result, rationale=f"all() over {len(values)} scorers = {result}")
+
+
+def agg_any(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    result = any(values)
+    return Feedback(value=result, rationale=f"any() over {len(values)} scorers = {result}")
+
+
+BUILTIN_ENSEMBLES: dict[str, Callable[[list[Any]], Feedback]] = {
+    "majority_vote": majority_vote,
+    "mean": mean,
+    "minimum": minimum,
+    "maximum": maximum,
+    "agg_all": agg_all,
+    "agg_any": agg_any,
+}

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -1,0 +1,330 @@
+from typing import Literal
+
+import pandas as pd
+import pytest
+
+import mlflow
+from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers import scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind, _extract_scorer_value, scorer_ensemble
+from mlflow.genai.scorers.builtin_scorers import Safety
+from mlflow.genai.scorers.ensemble import (
+    BUILTIN_ENSEMBLES,
+    agg_all,
+    agg_any,
+    is_numeric_feedback_type,
+    majority_vote,
+    maximum,
+    mean,
+    minimum,
+)
+
+
+def test_majority_vote_picks_most_common():
+    fb = majority_vote([True, True, False])
+    assert isinstance(fb, Feedback)
+    assert fb.value is True
+
+
+def test_majority_vote_breaks_ties_lexicographically():
+    # Tie between True and False -> lexicographic order of str(value): "False" < "True"
+    assert majority_vote([True, False]).value is False
+    assert majority_vote(["b", "a"]).value == "a"
+
+
+def test_mean_averages():
+    assert mean([1.0, 2.0, 3.0]).value == 2.0
+
+
+def test_minimum_maximum():
+    assert minimum([3, 1, 2]).value == 1
+    assert maximum([3, 1, 2]).value == 3
+
+
+def test_agg_all_and_any():
+    assert agg_all([True, True]).value is True
+    assert agg_all([True, False]).value is False
+    assert agg_any([False, False]).value is False
+    assert agg_any([False, True]).value is True
+
+
+@pytest.mark.parametrize("fn", [majority_vote, mean, minimum, maximum, agg_all, agg_any])
+def test_builtins_raise_on_none_entry(fn):
+    with pytest.raises(MlflowException, match="failed"):
+        fn([True, None])
+
+
+@pytest.mark.parametrize("fn", [majority_vote, mean, minimum, maximum, agg_all, agg_any])
+def test_builtins_raise_on_empty_input(fn):
+    with pytest.raises(MlflowException, match="failed"):
+        fn([])
+
+
+def test_builtin_registry_maps_names():
+    assert BUILTIN_ENSEMBLES["majority_vote"] is majority_vote
+    assert BUILTIN_ENSEMBLES["mean"] is mean
+    assert set(BUILTIN_ENSEMBLES) == {
+        "majority_vote",
+        "mean",
+        "minimum",
+        "maximum",
+        "agg_all",
+        "agg_any",
+    }
+
+
+def test_scorer_kind_has_ensemble():
+    assert ScorerKind.ENSEMBLE.value == "ensemble"
+
+
+def test_extract_value_from_feedback():
+    assert _extract_scorer_value(Feedback(value=0.5)) == 0.5
+
+
+def test_extract_value_from_primitive():
+    assert _extract_scorer_value(True) is True
+    assert _extract_scorer_value(3) == 3
+
+
+def test_extract_value_none_for_none_and_error():
+    assert _extract_scorer_value(None) is None
+    assert _extract_scorer_value(Feedback(error=ValueError("boom"))) is None
+
+
+def test_extract_value_rejects_feedback_list():
+    with pytest.raises(MlflowException, match="list"):
+        _extract_scorer_value([Feedback(value=1), Feedback(value=2)])
+
+
+@scorer
+def _always_true(outputs) -> bool:
+    return True
+
+
+@scorer
+def _always_false(outputs) -> bool:
+    return False
+
+
+@scorer
+def _num_len(outputs) -> int:
+    return len(outputs)
+
+
+def test_ensemble_majority_vote_end_to_end():
+    agg = scorer_ensemble(
+        name="vote",
+        scorers=[_always_true, _always_true, _always_false],
+        ensemble_fn="majority_vote",
+    )
+    fb = agg(outputs="hello")
+    assert fb.value is True
+    assert fb.name == "vote"
+
+
+def test_ensemble_dispatches_mixed_signatures():
+    # _always_true takes outputs; _num_len takes outputs too; use maximum over ints/bools.
+    agg = scorer_ensemble(name="max_agg", scorers=[_num_len], ensemble_fn="maximum")
+    assert agg(outputs="abcd").value == 4
+
+
+def test_ensemble_custom_callable_on_values():
+    def spread(values):
+        return max(values) - min(values)
+
+    agg = scorer_ensemble(name="spread", scorers=[_num_len, _num_len], ensemble_fn=spread)
+    fb = agg(outputs="abc")
+    assert fb.value == 0  # both return 3
+    assert fb.name == "spread"
+
+
+def test_ensemble_feedbacks_mode():
+    def count_feedbacks(feedbacks):
+        return len(feedbacks)
+
+    agg = scorer_ensemble(
+        name="count", scorers=[_always_true, _always_false], ensemble_fn=count_feedbacks
+    )
+    assert agg(outputs="x").value == 2
+
+
+def test_ensemble_rejects_unsupported_value_type():
+    # A scorer returning a non-str/numeric type (dict) is still rejected in values-mode.
+    @scorer
+    def _returns_dict(outputs) -> dict[str, str]:
+        return {"key": "val"}
+
+    agg = scorer_ensemble(name="bad", scorers=[_returns_dict], ensemble_fn="majority_vote")
+    with pytest.raises(MlflowException, match="_returns_dict"):
+        agg(outputs="x")
+
+
+def test_ensemble_rejects_empty_scorers():
+    with pytest.raises(MlflowException, match="at least one"):
+        scorer_ensemble(name="e", scorers=[], ensemble_fn="mean")
+
+
+def test_ensemble_rejects_unknown_builtin_name():
+    with pytest.raises(MlflowException, match="not a built-in"):
+        scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="bogus")
+
+
+def test_ensemble_session_level_derivation_and_mixing():
+    @scorer
+    def _sess(session) -> bool:
+        return len(session) > 0
+
+    session_agg = scorer_ensemble(name="s", scorers=[_sess], ensemble_fn="agg_all")
+    assert session_agg.is_session_level_scorer is True
+
+    single_agg = scorer_ensemble(name="t", scorers=[_always_true], ensemble_fn="agg_all")
+    assert single_agg.is_session_level_scorer is False
+
+    with pytest.raises(MlflowException, match="same level"):
+        scorer_ensemble(name="m", scorers=[_sess, _always_true], ensemble_fn="agg_all")
+
+
+def test_ensemble_records_builtin_name_for_callable():
+    agg = scorer_ensemble(name="v", scorers=[_always_true], ensemble_fn=majority_vote)
+    assert agg._ensemble_fn_name == "majority_vote"
+
+
+def test_ensemble_custom_callable_has_no_builtin_name():
+    agg = scorer_ensemble(name="c", scorers=[_always_true], ensemble_fn=lambda values: max(values))
+    assert agg._ensemble_fn_name is None
+
+
+# --- Serialization tests ---
+# Round-trip tests use Safety() (a builtin scorer) as the sub-scorer because decorator-backed
+# sub-scorers require a Databricks tracking URI to reconstruct (_reconstruct_decorator_scorer
+# raises outside Databricks). Safety serializes/reconstructs locally without any network call.
+
+
+def test_ensemble_serialization_produces_ensemble_scorer_data():
+    """model_dump() on an ensemble scorer must produce ensemble_scorer_data, not trip the
+    SerializedScorer mutual-exclusion validator.
+    """
+    # Safety declares Literal["yes","no"]; use majority_vote (categorical-friendly).
+    agg = scorer_ensemble(
+        name="agg_safety",
+        scorers=[Safety()],
+        ensemble_fn="majority_vote",
+    )
+    dumped = agg.model_dump()
+    assert "ensemble_scorer_data" in dumped
+    assert dumped["ensemble_scorer_data"]["ensemble_fn"] == "majority_vote"
+    assert len(dumped["ensemble_scorer_data"]["scorers"]) == 1
+
+
+def test_ensemble_serialization_round_trip():
+    """Full dump → validate round-trip using a builtin sub-scorer (Safety) to avoid the
+    OSS decorator-reconstruction block.
+    """
+    # Safety declares Literal["yes","no"]; use majority_vote (categorical-friendly).
+    agg = scorer_ensemble(
+        name="agg_safety",
+        scorers=[Safety()],
+        ensemble_fn="majority_vote",
+    )
+    dumped = agg.model_dump()
+    assert dumped["ensemble_scorer_data"]["ensemble_fn"] == "majority_vote"
+    assert len(dumped["ensemble_scorer_data"]["scorers"]) == 1
+
+    restored = Scorer.model_validate(dumped)
+    assert restored.name == "agg_safety"
+    assert restored.kind.value == "ensemble"
+    assert restored._ensemble_fn_name == "majority_vote"
+    assert len(restored._scorers) == 1
+    assert isinstance(restored._scorers[0], Safety)
+
+
+def test_ensemble_custom_callable_not_serializable():
+    agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: sum(values))
+    with pytest.raises(MlflowException, match="custom ensemble function"):
+        agg.model_dump()
+
+
+def test_public_exports():
+    import mlflow.genai
+    from mlflow.genai.scorers import (
+        agg_all,
+        agg_any,
+        majority_vote,
+        maximum,
+        mean,
+        minimum,
+        scorer_ensemble,
+    )
+
+    assert mlflow.genai.scorer_ensemble is scorer_ensemble
+    assert all(callable(fn) for fn in (majority_vote, mean, minimum, maximum, agg_all, agg_any))
+
+
+def test_ensemble_in_evaluate(is_in_databricks):
+    data = pd.DataFrame({
+        "inputs": [{"q": "a"}, {"q": "b"}],
+        "outputs": ["yes", "no"],
+    })
+    agg = scorer_ensemble(
+        name="ensemble",
+        scorers=[_always_true, _always_false],
+        ensemble_fn="agg_any",
+    )
+    result = mlflow.genai.evaluate(data=data, scorers=[agg])
+    # agg_any is order-independent, so the ensemble feedback is logged for every row
+    assert "ensemble/mean" in result.metrics
+
+
+# ---------------------------------------------------------------------------
+# Task 7: categorical/Literal values + feedback_value_type validation
+# ---------------------------------------------------------------------------
+
+
+@scorer
+def _label(outputs) -> str:
+    return outputs
+
+
+def test_ensemble_majority_vote_categorical():
+    # majority_vote now handles categorical string values.
+    agg = scorer_ensemble(name="cat", scorers=[_label, _label, _label], ensemble_fn="majority_vote")
+    assert agg(outputs="yes").value == "yes"
+
+
+def test_mean_rejects_categorical_values():
+    # mean must raise for string values at call time, not silently crash in statistics.mean.
+    agg = scorer_ensemble(name="m", scorers=[_label], ensemble_fn="mean")
+    with pytest.raises(MlflowException, match="numeric"):
+        agg(outputs="0.5")
+
+
+def test_feedbacks_mode_allows_non_numeric():
+    # feedbacks-mode bypasses the value-type check entirely; feedbacks contains raw run() results.
+    def first_value(feedbacks):
+        return feedbacks[0]
+
+    agg = scorer_ensemble(name="f", scorers=[_label], ensemble_fn=first_value)
+    assert agg(outputs="hello").value == "hello"
+
+
+def test_numeric_builtin_rejects_literal_judge_upfront():
+    # Safety declares feedback_value_type == Literal["yes","no"]; mean must reject it early.
+    with pytest.raises(MlflowException, match="numeric"):
+        scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="mean")
+
+
+def test_majority_vote_accepts_literal_judge():
+    # majority_vote is categorical-friendly; Safety() constructs fine.
+    agg = scorer_ensemble(name="ok", scorers=[Safety()], ensemble_fn="majority_vote")
+    assert agg.name == "ok"
+
+
+def test_is_numeric_feedback_type_unit_checks():
+    assert is_numeric_feedback_type(float) is True
+    assert is_numeric_feedback_type(int) is True
+    assert is_numeric_feedback_type(bool) is True
+    assert is_numeric_feedback_type(Literal[1, 2, 3]) is True
+    assert is_numeric_feedback_type(Literal["yes", "no"]) is False
+    assert is_numeric_feedback_type(str) is False
+    assert is_numeric_feedback_type(None) is False

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -15,13 +15,14 @@ from mlflow.genai.scorers.base import (
     Scorer,
     ScorerKind,
     _extract_scorer_value,
-    scorer_ensemble,
+    make_scorer_ensemble,
 )
 from mlflow.genai.scorers.builtin_scorers import Safety
 from mlflow.genai.scorers.ensemble import (
     BUILTIN_ENSEMBLES,
     agg_all,
     agg_any,
+    is_bool_feedback_type,
     is_numeric_feedback_type,
     majority_vote,
     maximum,
@@ -111,6 +112,20 @@ def test_numeric_builtins_reject_non_numeric(fn, values):
         fn(values)
 
 
+@pytest.mark.parametrize("fn", [agg_all, agg_any])
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(["yes", "no"], id="strings"),
+        pytest.param([1, 2], id="ints_not_bool"),
+        pytest.param([True, 1], id="mixed_bool_int"),
+    ],
+)
+def test_bool_builtins_reject_non_bool(fn, values):
+    with pytest.raises(MlflowException, match="boolean"):
+        fn(values)
+
+
 def test_builtin_registry_maps_names():
     assert BUILTIN_ENSEMBLES["majority_vote"] is majority_vote
     assert BUILTIN_ENSEMBLES["mean"] is mean
@@ -182,7 +197,7 @@ def _num_len(outputs) -> int:
 
 
 def test_ensemble_majority_vote_end_to_end():
-    agg = scorer_ensemble(
+    agg = make_scorer_ensemble(
         name="vote",
         scorers=[_always_true, _always_true, _always_false],
         ensemble_fn="majority_vote",
@@ -194,15 +209,39 @@ def test_ensemble_majority_vote_end_to_end():
 
 def test_ensemble_dispatches_mixed_signatures():
     # _always_true takes outputs; _num_len takes outputs too; use maximum over ints/bools.
-    agg = scorer_ensemble(name="max_agg", scorers=[_num_len], ensemble_fn="maximum")
+    agg = make_scorer_ensemble(name="max_agg", scorers=[_num_len], ensemble_fn="maximum")
     assert agg(outputs="abcd").value == 4
+
+
+def test_ensemble_fn_c_builtin_no_signature():
+    # C builtins like max expose no introspectable signature; the dispatch must not raise and
+    # should default to values-mode (max over the extracted values).
+    agg = make_scorer_ensemble(name="b", scorers=[_num_len, _num_len], ensemble_fn=max)
+    assert agg(outputs="abcd").value == 4
+
+
+def test_ensemble_resilient_to_sub_scorer_failure():
+    @scorer
+    def _boom(outputs) -> bool:
+        raise ValueError("kaboom")
+
+    def tolerant(feedbacks):
+        # One sub-scorer crashed; a feedbacks-mode fn can still produce a result.
+        return True
+
+    agg = make_scorer_ensemble(name="e", scorers=[_always_true, _boom], ensemble_fn=tolerant)
+    fb = agg(outputs="x")
+    assert fb.value is True
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    crashed = next(e for e in sub if e["assessment_name"] == "_boom")
+    assert crashed["feedback"]["error"]["error_code"] == "ValueError"
 
 
 def test_ensemble_custom_callable_on_values():
     def spread(values):
         return max(values) - min(values)
 
-    agg = scorer_ensemble(name="spread", scorers=[_num_len, _num_len], ensemble_fn=spread)
+    agg = make_scorer_ensemble(name="spread", scorers=[_num_len, _num_len], ensemble_fn=spread)
     fb = agg(outputs="abc")
     assert fb.value == 0  # both return 3
     assert fb.name == "spread"
@@ -212,31 +251,33 @@ def test_ensemble_feedbacks_mode():
     def count_feedbacks(feedbacks):
         return len(feedbacks)
 
-    agg = scorer_ensemble(
+    agg = make_scorer_ensemble(
         name="count", scorers=[_always_true, _always_false], ensemble_fn=count_feedbacks
     )
     assert agg(outputs="x").value == 2
 
 
 def test_ensemble_rejects_unsupported_value_type():
-    # A scorer returning a non-str/numeric type (dict) is still rejected in values-mode.
+    # A sub-scorer whose Feedback carries a non-str/numeric value (dict) is rejected in
+    # values-mode. The value is wrapped in a Feedback so it survives Scorer.run() validation
+    # and reaches the ensemble's own value-type guard.
     @scorer
-    def _returns_dict(outputs) -> dict[str, str]:
-        return {"key": "val"}
+    def _returns_dict(outputs) -> Feedback:
+        return Feedback(value={"key": "val"})
 
-    agg = scorer_ensemble(name="bad", scorers=[_returns_dict], ensemble_fn="majority_vote")
+    agg = make_scorer_ensemble(name="bad", scorers=[_returns_dict], ensemble_fn="majority_vote")
     with pytest.raises(MlflowException, match="_returns_dict"):
         agg(outputs="x")
 
 
 def test_ensemble_rejects_empty_scorers():
     with pytest.raises(MlflowException, match="at least one"):
-        scorer_ensemble(name="e", scorers=[], ensemble_fn="mean")
+        make_scorer_ensemble(name="e", scorers=[], ensemble_fn="mean")
 
 
 def test_ensemble_rejects_unknown_builtin_name():
     with pytest.raises(MlflowException, match="not a built-in"):
-        scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="bogus")
+        make_scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="bogus")
 
 
 def test_ensemble_session_level_derivation_and_mixing():
@@ -244,23 +285,25 @@ def test_ensemble_session_level_derivation_and_mixing():
     def _sess(session) -> bool:
         return len(session) > 0
 
-    session_agg = scorer_ensemble(name="s", scorers=[_sess], ensemble_fn="agg_all")
+    session_agg = make_scorer_ensemble(name="s", scorers=[_sess], ensemble_fn="agg_all")
     assert session_agg.is_session_level_scorer is True
 
-    single_agg = scorer_ensemble(name="t", scorers=[_always_true], ensemble_fn="agg_all")
+    single_agg = make_scorer_ensemble(name="t", scorers=[_always_true], ensemble_fn="agg_all")
     assert single_agg.is_session_level_scorer is False
 
     with pytest.raises(MlflowException, match="same level"):
-        scorer_ensemble(name="m", scorers=[_sess, _always_true], ensemble_fn="agg_all")
+        make_scorer_ensemble(name="m", scorers=[_sess, _always_true], ensemble_fn="agg_all")
 
 
 def test_ensemble_records_builtin_name_for_callable():
-    agg = scorer_ensemble(name="v", scorers=[_always_true], ensemble_fn=majority_vote)
+    agg = make_scorer_ensemble(name="v", scorers=[_always_true], ensemble_fn=majority_vote)
     assert agg._ensemble_fn_name == "majority_vote"
 
 
 def test_ensemble_custom_callable_has_no_builtin_name():
-    agg = scorer_ensemble(name="c", scorers=[_always_true], ensemble_fn=lambda values: max(values))
+    agg = make_scorer_ensemble(
+        name="c", scorers=[_always_true], ensemble_fn=lambda values: max(values)
+    )
     assert agg._ensemble_fn_name is None
 
 
@@ -277,7 +320,7 @@ def test_ensemble_serialization_produces_ensemble_scorer_data():
     SerializedScorer mutual-exclusion validator.
     """
     # Safety declares Literal["yes","no"]; use majority_vote (categorical-friendly).
-    agg = scorer_ensemble(
+    agg = make_scorer_ensemble(
         name="agg_safety",
         scorers=[Safety()],
         ensemble_fn="majority_vote",
@@ -293,7 +336,7 @@ def test_ensemble_serialization_round_trip():
     OSS decorator-reconstruction block.
     """
     # Safety declares Literal["yes","no"]; use majority_vote (categorical-friendly).
-    agg = scorer_ensemble(
+    agg = make_scorer_ensemble(
         name="agg_safety",
         scorers=[Safety()],
         ensemble_fn="majority_vote",
@@ -311,7 +354,7 @@ def test_ensemble_serialization_round_trip():
 
 
 def test_ensemble_serialization_preserves_aggregations():
-    agg = scorer_ensemble(
+    agg = make_scorer_ensemble(
         name="agg_safety",
         scorers=[Safety()],
         ensemble_fn="majority_vote",
@@ -324,13 +367,13 @@ def test_ensemble_serialization_preserves_aggregations():
 
 
 def test_ensemble_custom_callable_not_serializable():
-    agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: sum(values))
+    agg = make_scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: sum(values))
     with pytest.raises(MlflowException, match="custom ensemble function"):
         agg.model_dump()
 
 
 def test_public_exports():
-    assert mlflow.genai.scorer_ensemble is scorer_ensemble
+    assert mlflow.genai.make_scorer_ensemble is make_scorer_ensemble
     for name, fn in [
         ("majority_vote", majority_vote),
         ("mean", mean),
@@ -338,9 +381,23 @@ def test_public_exports():
         ("maximum", maximum),
         ("agg_all", agg_all),
         ("agg_any", agg_any),
-        ("scorer_ensemble", scorer_ensemble),
+        ("make_scorer_ensemble", make_scorer_ensemble),
     ]:
         assert getattr(_public_scorers, name) is fn
+
+
+def test_ensemble_check_can_be_registered_passes_for_builtin_sub_scorers():
+    # An ensemble of builtin sub-scorers is registerable: _check_can_be_registered must not raise.
+    agg = make_scorer_ensemble(name="ok", scorers=[Safety()], ensemble_fn="majority_vote")
+    agg._check_can_be_registered()
+
+
+def test_ensemble_check_can_be_registered_rejects_decorator_sub_scorer_non_databricks():
+    # A decorator sub-scorer is only registerable under a Databricks tracking URI. The ensemble
+    # must be rejected with the same rule (recursion into sub-scorers), not silently allowed.
+    agg = make_scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="Custom scorer registration"):
+        agg._check_can_be_registered()
 
 
 def test_ensemble_in_evaluate(is_in_databricks):
@@ -348,7 +405,7 @@ def test_ensemble_in_evaluate(is_in_databricks):
         "inputs": [{"q": "a"}, {"q": "b"}],
         "outputs": ["yes", "no"],
     })
-    agg = scorer_ensemble(
+    agg = make_scorer_ensemble(
         name="ensemble",
         scorers=[_always_true, _always_false],
         ensemble_fn="agg_any",
@@ -370,13 +427,15 @@ def _label(outputs) -> str:
 
 def test_ensemble_majority_vote_categorical():
     # majority_vote now handles categorical string values.
-    agg = scorer_ensemble(name="cat", scorers=[_label, _label, _label], ensemble_fn="majority_vote")
+    agg = make_scorer_ensemble(
+        name="cat", scorers=[_label, _label, _label], ensemble_fn="majority_vote"
+    )
     assert agg(outputs="yes").value == "yes"
 
 
 def test_mean_rejects_categorical_values():
     # mean must raise for string values at call time, not silently crash in statistics.mean.
-    agg = scorer_ensemble(name="m", scorers=[_label], ensemble_fn="mean")
+    agg = make_scorer_ensemble(name="m", scorers=[_label], ensemble_fn="mean")
     with pytest.raises(MlflowException, match="numeric"):
         agg(outputs="0.5")
 
@@ -386,7 +445,7 @@ def test_feedbacks_mode_allows_non_numeric():
     def first_value(feedbacks):
         return feedbacks[0].value
 
-    agg = scorer_ensemble(name="f", scorers=[_label], ensemble_fn=first_value)
+    agg = make_scorer_ensemble(name="f", scorers=[_label], ensemble_fn=first_value)
     assert agg(outputs="hello").value == "hello"
 
 
@@ -399,7 +458,7 @@ def test_ensemble_feedbacks_mode_receives_feedback_objects():
         return feedbacks[0].value
 
     # _num_len returns a bare int; must be wrapped into a Feedback in feedbacks-mode.
-    agg = scorer_ensemble(name="fb", scorers=[_num_len], ensemble_fn=inspect_fn)
+    agg = make_scorer_ensemble(name="fb", scorers=[_num_len], ensemble_fn=inspect_fn)
     fb = agg(outputs="abcd")
     assert captured["types"] == ["Feedback"]
     assert captured["names"] == ["_num_len"]
@@ -409,12 +468,12 @@ def test_ensemble_feedbacks_mode_receives_feedback_objects():
 def test_numeric_builtin_rejects_literal_judge_upfront():
     # Safety declares feedback_value_type == Literal["yes","no"]; mean must reject it early.
     with pytest.raises(MlflowException, match="numeric"):
-        scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="mean")
+        make_scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="mean")
 
 
 def test_majority_vote_accepts_literal_judge():
     # majority_vote is categorical-friendly; Safety() constructs fine.
-    agg = scorer_ensemble(name="ok", scorers=[Safety()], ensemble_fn="majority_vote")
+    agg = make_scorer_ensemble(name="ok", scorers=[Safety()], ensemble_fn="majority_vote")
     assert agg.name == "ok"
 
 
@@ -434,6 +493,37 @@ def test_is_numeric_feedback_type(feedback_type, expected):
     assert is_numeric_feedback_type(feedback_type) is expected
 
 
+@pytest.mark.parametrize(
+    ("feedback_type", "expected"),
+    [
+        pytest.param(bool, True, id="bool"),
+        pytest.param(Literal[True, False], True, id="literal_bool"),
+        pytest.param(int, False, id="int"),
+        pytest.param(float, False, id="float"),
+        pytest.param(Literal[1, 2, 3], False, id="literal_numeric"),
+        pytest.param(Literal["yes", "no"], False, id="literal_str"),
+        pytest.param(str, False, id="str"),
+        pytest.param(None, False, id="none"),
+    ],
+)
+def test_is_bool_feedback_type(feedback_type, expected):
+    assert is_bool_feedback_type(feedback_type) is expected
+
+
+def test_bool_builtin_rejects_literal_judge_upfront():
+    # Safety declares feedback_value_type == Literal["yes","no"]; agg_all must reject it early.
+    with pytest.raises(MlflowException, match="boolean"):
+        make_scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="agg_all")
+
+
+def test_agg_all_at_call_time_rejects_non_bool_values():
+    # A decorator scorer declares no feedback_value_type, so the up-front check is skipped;
+    # agg_all still rejects the non-bool string value ("yes") at call time.
+    agg = make_scorer_ensemble(name="a", scorers=[_label], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="boolean"):
+        agg(outputs="yes")
+
+
 # ---------------------------------------------------------------------------
 # Sub-scorer provenance in ensemble Feedback.metadata
 # ---------------------------------------------------------------------------
@@ -448,7 +538,7 @@ def test_ensemble_preserves_sub_feedbacks_in_metadata():
     def _no(outputs) -> Feedback:
         return Feedback(value=False, rationale="found an issue")
 
-    agg = scorer_ensemble(name="e", scorers=[_yes, _no], ensemble_fn="majority_vote")
+    agg = make_scorer_ensemble(name="e", scorers=[_yes, _no], ensemble_fn="majority_vote")
     fb = agg(outputs="x")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
     assert len(sub) == 2
@@ -468,7 +558,7 @@ def test_ensemble_metadata_captures_sub_feedback_source():
             ),
         )
 
-    agg = scorer_ensemble(name="e", scorers=[_judge], ensemble_fn="agg_all")
+    agg = make_scorer_ensemble(name="e", scorers=[_judge], ensemble_fn="agg_all")
     fb = agg(outputs="x")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
     assert sub[0]["source"]["source_type"] == "LLM_JUDGE"
@@ -476,7 +566,7 @@ def test_ensemble_metadata_captures_sub_feedback_source():
 
 
 def test_ensemble_metadata_normalizes_bare_value():
-    agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: max(values))
+    agg = make_scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: max(values))
     fb = agg(outputs="abcd")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
     assert sub[0]["assessment_name"] == "_num_len"
@@ -490,14 +580,14 @@ def test_ensemble_fn_metadata_wins_on_collision():
     def fn_with_meta(feedbacks):
         return Feedback(value=True, metadata={key: "override"})
 
-    agg = scorer_ensemble(name="m", scorers=[_always_true], ensemble_fn=fn_with_meta)
+    agg = make_scorer_ensemble(name="m", scorers=[_always_true], ensemble_fn=fn_with_meta)
     fb = agg(outputs="x")
     # The ensemble_fn's own metadata wins on key collision.
     assert fb.metadata[key] == "override"
 
 
 def test_ensemble_metadata_is_string_valued():
-    agg = scorer_ensemble(name="s", scorers=[_always_true], ensemble_fn="agg_all")
+    agg = make_scorer_ensemble(name="s", scorers=[_always_true], ensemble_fn="agg_all")
     fb = agg(outputs="x")
     for v in fb.metadata.values():
         assert isinstance(v, str)
@@ -511,7 +601,7 @@ def test_ensemble_metadata_captures_error_feedback():
     def tolerant(feedbacks):
         return True
 
-    agg = scorer_ensemble(name="e", scorers=[_errs], ensemble_fn=tolerant)
+    agg = make_scorer_ensemble(name="e", scorers=[_errs], ensemble_fn=tolerant)
     fb = agg(outputs="x")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
     assert sub[0]["assessment_name"] == "_errs"

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -4,11 +4,18 @@ from typing import Literal
 import pandas as pd
 import pytest
 
-import mlflow
+import mlflow.genai
 from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import scorer
-from mlflow.genai.scorers.base import Scorer, ScorerKind, _extract_scorer_value, scorer_ensemble
+from mlflow.genai.scorers.base import (
+    EnsembleScorer,
+    Scorer,
+    ScorerKind,
+    _extract_scorer_value,
+    scorer_ensemble,
+)
 from mlflow.genai.scorers.builtin_scorers import Safety
 from mlflow.genai.scorers.ensemble import (
     BUILTIN_ENSEMBLES,
@@ -21,45 +28,83 @@ from mlflow.genai.scorers.ensemble import (
     minimum,
 )
 
+# ---------------------------------------------------------------------------
+# Built-in ensemble function unit tests
+# ---------------------------------------------------------------------------
 
-def test_majority_vote_picks_most_common():
-    fb = majority_vote([True, True, False])
-    assert isinstance(fb, Feedback)
-    assert fb.value is True
-
-
-def test_majority_vote_breaks_ties_lexicographically():
-    # Tie between True and False -> lexicographic order of str(value): "False" < "True"
-    assert majority_vote([True, False]).value is False
-    assert majority_vote(["b", "a"]).value == "a"
+_ALL_BUILTINS = [majority_vote, mean, minimum, maximum, agg_all, agg_any]
+_NUMERIC_BUILTINS = [mean, minimum, maximum]
 
 
-def test_mean_averages():
-    assert mean([1.0, 2.0, 3.0]).value == 2.0
+@pytest.mark.parametrize(
+    ("fn", "values", "expected"),
+    [
+        # majority_vote
+        pytest.param(majority_vote, [True, True, False], True, id="majority_vote-basic"),
+        pytest.param(majority_vote, [True, False], False, id="majority_vote-tie_false_wins"),
+        pytest.param(majority_vote, ["b", "a"], "a", id="majority_vote-categorical_tie"),
+        pytest.param(majority_vote, ["x", "x", "y"], "x", id="majority_vote-categorical_majority"),
+        pytest.param(majority_vote, [True], True, id="majority_vote-single"),
+        pytest.param(majority_vote, ["only"], "only", id="majority_vote-single_categorical"),
+        # mean
+        pytest.param(mean, [1.0, 2.0, 3.0], 2.0, id="mean-basic"),
+        pytest.param(mean, [2], 2, id="mean-single"),
+        pytest.param(mean, [True, False], 0.5, id="mean-bools"),
+        pytest.param(mean, [-1.0, 1.0], 0.0, id="mean-zero"),
+        # minimum
+        pytest.param(minimum, [3, 1, 2], 1, id="minimum-basic"),
+        pytest.param(minimum, [5], 5, id="minimum-single"),
+        pytest.param(minimum, [True, False], False, id="minimum-bools"),
+        # maximum
+        pytest.param(maximum, [3, 1, 2], 3, id="maximum-basic"),
+        pytest.param(maximum, [5], 5, id="maximum-single"),
+        pytest.param(maximum, [True, False], True, id="maximum-bools"),
+        # agg_all
+        pytest.param(agg_all, [True, True], True, id="agg_all-all_true"),
+        pytest.param(agg_all, [True, False], False, id="agg_all-mixed"),
+        pytest.param(agg_all, [True], True, id="agg_all-single"),
+        # agg_any
+        pytest.param(agg_any, [False, False], False, id="agg_any-all_false"),
+        pytest.param(agg_any, [False, True], True, id="agg_any-mixed"),
+        pytest.param(agg_any, [False], False, id="agg_any-single"),
+    ],
+)
+def test_builtin_happy_path(fn, values, expected):
+    result = fn(values)
+    assert isinstance(result, Feedback)
+    assert result.value == expected
 
 
-def test_minimum_maximum():
-    assert minimum([3, 1, 2]).value == 1
-    assert maximum([3, 1, 2]).value == 3
-
-
-def test_agg_all_and_any():
-    assert agg_all([True, True]).value is True
-    assert agg_all([True, False]).value is False
-    assert agg_any([False, False]).value is False
-    assert agg_any([False, True]).value is True
-
-
-@pytest.mark.parametrize("fn", [majority_vote, mean, minimum, maximum, agg_all, agg_any])
-def test_builtins_raise_on_none_entry(fn):
+@pytest.mark.parametrize("fn", _ALL_BUILTINS)
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param([True, None], id="with_none"),
+        pytest.param([None], id="all_none"),
+    ],
+)
+def test_builtins_raise_on_none_entry(fn, values):
     with pytest.raises(MlflowException, match="failed"):
-        fn([True, None])
+        fn(values)
 
 
-@pytest.mark.parametrize("fn", [majority_vote, mean, minimum, maximum, agg_all, agg_any])
+@pytest.mark.parametrize("fn", _ALL_BUILTINS)
 def test_builtins_raise_on_empty_input(fn):
     with pytest.raises(MlflowException, match="failed"):
         fn([])
+
+
+@pytest.mark.parametrize("fn", _NUMERIC_BUILTINS)
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(["a", "b"], id="all_strings"),
+        pytest.param([1.0, "b"], id="mixed"),
+    ],
+)
+def test_numeric_builtins_reject_non_numeric(fn, values):
+    with pytest.raises(MlflowException, match="numeric"):
+        fn(values)
 
 
 def test_builtin_registry_maps_names():
@@ -75,27 +120,37 @@ def test_builtin_registry_maps_names():
     }
 
 
+# ---------------------------------------------------------------------------
+# ScorerKind and _extract_scorer_value unit tests
+# ---------------------------------------------------------------------------
+
+
 def test_scorer_kind_has_ensemble():
     assert ScorerKind.ENSEMBLE.value == "ensemble"
 
 
-def test_extract_value_from_feedback():
-    assert _extract_scorer_value(Feedback(value=0.5)) == 0.5
-
-
-def test_extract_value_from_primitive():
-    assert _extract_scorer_value(True) is True
-    assert _extract_scorer_value(3) == 3
-
-
-def test_extract_value_none_for_none_and_error():
-    assert _extract_scorer_value(None) is None
-    assert _extract_scorer_value(Feedback(error=ValueError("boom"))) is None
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(Feedback(value=0.5), 0.5, id="feedback_value"),
+        pytest.param(True, True, id="bool_primitive"),
+        pytest.param(3, 3, id="int_primitive"),
+        pytest.param(None, None, id="none_input"),
+        pytest.param(Feedback(error=ValueError("boom")), None, id="error_feedback"),
+    ],
+)
+def test_extract_scorer_value(value, expected):
+    assert _extract_scorer_value(value) == expected
 
 
 def test_extract_value_rejects_feedback_list():
     with pytest.raises(MlflowException, match="list"):
         _extract_scorer_value([Feedback(value=1), Feedback(value=2)])
+
+
+# ---------------------------------------------------------------------------
+# Module-level scorer fixtures used across integration tests
+# ---------------------------------------------------------------------------
 
 
 @scorer
@@ -111,6 +166,11 @@ def _always_false(outputs) -> bool:
 @scorer
 def _num_len(outputs) -> int:
     return len(outputs)
+
+
+# ---------------------------------------------------------------------------
+# EnsembleScorer integration tests
+# ---------------------------------------------------------------------------
 
 
 def test_ensemble_majority_vote_end_to_end():
@@ -196,7 +256,9 @@ def test_ensemble_custom_callable_has_no_builtin_name():
     assert agg._ensemble_fn_name is None
 
 
-# --- Serialization tests ---
+# ---------------------------------------------------------------------------
+# Serialization tests
+# ---------------------------------------------------------------------------
 # Round-trip tests use Safety() (a builtin scorer) as the sub-scorer because decorator-backed
 # sub-scorers require a Databricks tracking URI to reconstruct (_reconstruct_decorator_scorer
 # raises outside Databricks). Safety serializes/reconstructs locally without any network call.
@@ -260,17 +322,6 @@ def test_ensemble_custom_callable_not_serializable():
 
 
 def test_public_exports():
-    import mlflow.genai
-    from mlflow.genai.scorers import (
-        agg_all,
-        agg_any,
-        majority_vote,
-        maximum,
-        mean,
-        minimum,
-        scorer_ensemble,
-    )
-
     assert mlflow.genai.scorer_ensemble is scorer_ensemble
     assert all(callable(fn) for fn in (majority_vote, mean, minimum, maximum, agg_all, agg_any))
 
@@ -291,7 +342,7 @@ def test_ensemble_in_evaluate(is_in_databricks):
 
 
 # ---------------------------------------------------------------------------
-# Task 7: categorical/Literal values + feedback_value_type validation
+# Categorical / Literal values and feedback_value_type validation
 # ---------------------------------------------------------------------------
 
 
@@ -350,24 +401,28 @@ def test_majority_vote_accepts_literal_judge():
     assert agg.name == "ok"
 
 
-def test_is_numeric_feedback_type_unit_checks():
-    assert is_numeric_feedback_type(float) is True
-    assert is_numeric_feedback_type(int) is True
-    assert is_numeric_feedback_type(bool) is True
-    assert is_numeric_feedback_type(Literal[1, 2, 3]) is True
-    assert is_numeric_feedback_type(Literal["yes", "no"]) is False
-    assert is_numeric_feedback_type(str) is False
-    assert is_numeric_feedback_type(None) is False
+@pytest.mark.parametrize(
+    ("feedback_type", "expected"),
+    [
+        pytest.param(float, True, id="float"),
+        pytest.param(int, True, id="int"),
+        pytest.param(bool, True, id="bool"),
+        pytest.param(Literal[1, 2, 3], True, id="literal_numeric"),
+        pytest.param(Literal["yes", "no"], False, id="literal_str"),
+        pytest.param(str, False, id="str"),
+        pytest.param(None, False, id="none"),
+    ],
+)
+def test_is_numeric_feedback_type(feedback_type, expected):
+    assert is_numeric_feedback_type(feedback_type) is expected
 
 
 # ---------------------------------------------------------------------------
-# Task 10/11: sub-scorer provenance preserved in ensemble Feedback.metadata
+# Sub-scorer provenance in ensemble Feedback.metadata
 # ---------------------------------------------------------------------------
 
 
 def test_ensemble_preserves_sub_feedbacks_in_metadata():
-    from mlflow.genai.scorers.base import EnsembleScorer
-
     @scorer
     def _yes(outputs) -> Feedback:
         return Feedback(value=True, rationale="looks safe")
@@ -387,9 +442,6 @@ def test_ensemble_preserves_sub_feedbacks_in_metadata():
 
 
 def test_ensemble_metadata_captures_sub_feedback_source():
-    from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
-    from mlflow.genai.scorers.base import EnsembleScorer
-
     @scorer
     def _judge(outputs) -> Feedback:
         return Feedback(
@@ -407,8 +459,6 @@ def test_ensemble_metadata_captures_sub_feedback_source():
 
 
 def test_ensemble_metadata_normalizes_bare_value():
-    from mlflow.genai.scorers.base import EnsembleScorer
-
     agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: max(values))
     fb = agg(outputs="abcd")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
@@ -418,8 +468,6 @@ def test_ensemble_metadata_normalizes_bare_value():
 
 
 def test_ensemble_fn_metadata_wins_on_collision():
-    from mlflow.genai.scorers.base import EnsembleScorer
-
     key = EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY
 
     def fn_with_meta(feedbacks):
@@ -439,8 +487,6 @@ def test_ensemble_metadata_is_string_valued():
 
 
 def test_ensemble_metadata_captures_error_feedback():
-    from mlflow.genai.scorers.base import EnsembleScorer
-
     @scorer
     def _errs(outputs) -> Feedback:
         return Feedback(error=ValueError("boom"))

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -1,3 +1,4 @@
+import json
 from typing import Literal
 
 import pandas as pd
@@ -328,3 +329,58 @@ def test_is_numeric_feedback_type_unit_checks():
     assert is_numeric_feedback_type(Literal["yes", "no"]) is False
     assert is_numeric_feedback_type(str) is False
     assert is_numeric_feedback_type(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Task 10: sub-scorer provenance preserved in ensemble Feedback.metadata
+# ---------------------------------------------------------------------------
+
+
+def test_ensemble_preserves_sub_rationales_in_metadata():
+    from mlflow.genai.scorers.base import EnsembleScorer
+
+    @scorer
+    def _yes(outputs) -> Feedback:
+        return Feedback(value=True, rationale="looks safe")
+
+    @scorer
+    def _no(outputs) -> Feedback:
+        return Feedback(value=False, rationale="found an issue")
+
+    agg = scorer_ensemble(name="e", scorers=[_yes, _no], ensemble_fn="majority_vote")
+    fb = agg(outputs="x")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert len(sub) == 2
+    assert {e["rationale"] for e in sub} == {"looks safe", "found an issue"}
+    assert {e["name"] for e in sub} == {"_yes", "_no"}
+
+
+def test_ensemble_metadata_present_for_custom_value_fn():
+    from mlflow.genai.scorers.base import EnsembleScorer
+
+    agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: max(values))
+    fb = agg(outputs="abcd")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert len(sub) == 1
+    assert sub[0]["name"] == "_num_len"
+    assert sub[0]["value"] == 4
+
+
+def test_ensemble_fn_metadata_wins_on_collision():
+    from mlflow.genai.scorers.base import EnsembleScorer
+
+    def fn_with_meta(feedbacks):
+        return Feedback(value=True, metadata={"custom": "kept"})
+
+    agg = scorer_ensemble(name="m", scorers=[_always_true], ensemble_fn=fn_with_meta)
+    fb = agg(outputs="x")
+    assert fb.metadata["custom"] == "kept"
+    # sub-feedback provenance is still attached alongside it
+    assert EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY in fb.metadata
+
+
+def test_ensemble_metadata_is_string_valued():
+    agg = scorer_ensemble(name="s", scorers=[_always_true], ensemble_fn="agg_all")
+    fb = agg(outputs="x")
+    for v in fb.metadata.values():
+        assert isinstance(v, str)

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -1,5 +1,6 @@
 import json
 from typing import Literal
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -9,15 +10,18 @@ import mlflow.genai.scorers as _public_scorers
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges import make_judge
+from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import scorer
 from mlflow.genai.scorers.base import (
     EnsembleScorer,
     Scorer,
     ScorerKind,
     _extract_scorer_value,
+    flatten_scorers,
     make_scorer_ensemble,
 )
-from mlflow.genai.scorers.builtin_scorers import Safety
+from mlflow.genai.scorers.builtin_scorers import Correctness, Safety
 from mlflow.genai.scorers.ensemble import (
     BUILTIN_ENSEMBLES,
     agg_all,
@@ -116,14 +120,33 @@ def test_numeric_builtins_reject_non_numeric(fn, values):
 @pytest.mark.parametrize(
     "values",
     [
-        pytest.param(["yes", "no"], id="strings"),
+        pytest.param(["maybe", "no"], id="unmappable_string"),
         pytest.param([1, 2], id="ints_not_bool"),
         pytest.param([True, 1], id="mixed_bool_int"),
     ],
 )
-def test_bool_builtins_reject_non_bool(fn, values):
-    with pytest.raises(MlflowException, match="boolean"):
+def test_bool_builtins_reject_values_without_yes_no_reading(fn, values):
+    with pytest.raises(MlflowException, match="yes/no reading"):
         fn(values)
+
+
+@pytest.mark.parametrize(
+    ("fn", "values", "expected"),
+    [
+        # Built-in judges return Literal["yes","no"], not bools. Truthiness would make every
+        # non-empty string True, so "no" must read as False.
+        pytest.param(agg_all, ["yes", "no"], False, id="agg_all-yes_no"),
+        pytest.param(agg_all, ["yes", "yes"], True, id="agg_all-all_yes"),
+        pytest.param(agg_any, ["no", "no"], False, id="agg_any-all_no"),
+        pytest.param(agg_any, ["no", "yes"], True, id="agg_any-one_yes"),
+        pytest.param(agg_all, [CategoricalRating.YES, "yes"], True, id="agg_all-rating_enum"),
+        pytest.param(agg_all, ["YES", " yes "], True, id="agg_all-case_and_space"),
+        pytest.param(agg_all, ["pass", True], True, id="agg_all-affirmative-synonym"),
+    ],
+)
+def test_bool_builtins_coerce_categorical_yes_no(fn, values, expected):
+    result = fn(values)
+    assert result.value is expected
 
 
 def test_builtin_registry_maps_names():
@@ -235,6 +258,49 @@ def test_ensemble_resilient_to_sub_scorer_failure():
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
     crashed = next(e for e in sub if e["assessment_name"] == "_boom")
     assert crashed["feedback"]["error"]["error_code"] == "ValueError"
+
+
+def test_builtin_ensemble_failure_names_the_crashed_sub_scorer():
+    @scorer
+    def _boom(outputs) -> bool:
+        raise ValueError("kaboom")
+
+    # Built-in fns treat a missing sub-scorer value as fatal. The raised error must still
+    # identify which sub-scorer failed and why, rather than only "returned no value".
+    agg = make_scorer_ensemble(name="e", scorers=[_always_true, _boom], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="_boom.*kaboom"):
+        agg(outputs="x")
+
+
+@pytest.mark.parametrize(
+    ("ensemble_fn", "expects_feedbacks"),
+    [
+        pytest.param(lambda values: values, False, id="values"),
+        pytest.param(lambda feedbacks: feedbacks, True, id="feedbacks"),
+        # The aggregate input is passed positionally, so a `feedbacks` keyword that is not
+        # the first parameter must not flip the mode.
+        pytest.param(lambda values, feedbacks=None: values, False, id="feedbacks-not-first"),
+        pytest.param(lambda feedbacks, values=None: feedbacks, True, id="feedbacks-first"),
+    ],
+)
+def test_dispatch_mode_follows_first_positional_parameter(ensemble_fn, expects_feedbacks):
+    agg = make_scorer_ensemble(name="d", scorers=[_num_len], ensemble_fn=ensemble_fn)
+    received = agg(outputs="abcd").value
+    assert isinstance(received[0], Feedback) is expects_feedbacks
+
+
+def test_ensemble_create_copy_recurses_into_sub_scorers():
+    # Sub-scorers must be copied through their own _create_copy rather than deep-copied
+    # wholesale: a deepcopy recurses infinitely on a third-party sub-scorer that holds an
+    # `instructor`-wrapped client.
+    sub = Safety()
+    agg = make_scorer_ensemble(name="c", scorers=[sub], ensemble_fn="majority_vote")
+    copy = agg._create_copy()
+    assert isinstance(copy, EnsembleScorer)
+    assert copy.name == "c"
+    assert copy._ensemble_fn_name == "majority_vote"
+    assert isinstance(copy._scorers[0], Safety)
+    assert copy._scorers[0] is not sub
 
 
 def test_ensemble_custom_callable_on_values():
@@ -415,6 +481,54 @@ def test_ensemble_in_evaluate(is_in_databricks):
     assert "ensemble/mean" in result.metrics
 
 
+@pytest.mark.parametrize(
+    ("scorers", "expected_names"),
+    [
+        pytest.param([_always_true], ["_always_true"], id="plain"),
+        pytest.param(
+            [make_scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="agg_all")],
+            ["_always_true"],
+            id="ensemble",
+        ),
+        pytest.param(
+            [
+                make_scorer_ensemble(
+                    name="outer",
+                    scorers=[
+                        make_scorer_ensemble(
+                            name="inner", scorers=[_always_true], ensemble_fn="agg_all"
+                        ),
+                        _always_false,
+                    ],
+                    ensemble_fn="agg_all",
+                )
+            ],
+            ["_always_true", "_always_false"],
+            id="nested-ensemble",
+        ),
+    ],
+)
+def test_flatten_scorers_expands_ensembles(scorers, expected_names):
+    assert [s.name for s in flatten_scorers(scorers)] == expected_names
+
+
+def test_ensemble_sub_scorer_missing_columns_is_reported_upfront(is_in_databricks):
+    # Correctness requires `expectations`, which this dataset lacks. The warning must fire
+    # for a sub-scorer wrapped in an ensemble, not just a top-level built-in scorer.
+    data = pd.DataFrame({"inputs": [{"q": "a"}], "outputs": ["a"]})
+    agg = make_scorer_ensemble(
+        name="ensemble", scorers=[Correctness()], ensemble_fn="majority_vote"
+    )
+    with mock.patch("mlflow.genai.evaluation.base.valid_data_for_builtin_scorers") as mock_valid:
+        try:
+            mlflow.genai.evaluate(data=data, scorers=[agg])
+        except Exception:
+            pass
+    mock_valid.assert_called_once()
+    passed_scorers = mock_valid.call_args[0][1]
+    assert [type(s).__name__ for s in passed_scorers] == ["Correctness"]
+
+
 # ---------------------------------------------------------------------------
 # Categorical / Literal values and feedback_value_type validation
 # ---------------------------------------------------------------------------
@@ -501,7 +615,11 @@ def test_is_numeric_feedback_type(feedback_type, expected):
         pytest.param(int, False, id="int"),
         pytest.param(float, False, id="float"),
         pytest.param(Literal[1, 2, 3], False, id="literal_numeric"),
-        pytest.param(Literal["yes", "no"], False, id="literal_str"),
+        # Built-in judges declare Literal["yes","no"], which has a yes/no reading and so
+        # is usable with the boolean reducers.
+        pytest.param(Literal["yes", "no"], True, id="literal_yes_no"),
+        pytest.param(Literal["pass", "fail"], True, id="literal_pass_fail"),
+        pytest.param(Literal["great", "terrible"], False, id="literal_unmappable_str"),
         pytest.param(str, False, id="str"),
         pytest.param(None, False, id="none"),
     ],
@@ -510,18 +628,36 @@ def test_is_bool_feedback_type(feedback_type, expected):
     assert is_bool_feedback_type(feedback_type) is expected
 
 
-def test_bool_builtin_rejects_literal_judge_upfront():
-    # Safety declares feedback_value_type == Literal["yes","no"]; agg_all must reject it early.
-    with pytest.raises(MlflowException, match="boolean"):
-        make_scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="agg_all")
+def test_bool_builtin_accepts_literal_yes_no_judge():
+    # "all judges must pass" over built-in judges is the primary agg_all use case. Safety
+    # declares Literal["yes","no"], which has a yes/no reading, so it must not be rejected.
+    agg = make_scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="agg_all")
+    assert agg.name == "x"
 
 
-def test_agg_all_at_call_time_rejects_non_bool_values():
-    # A decorator scorer declares no feedback_value_type, so the up-front check is skipped;
-    # agg_all still rejects the non-bool string value ("yes") at call time.
+def test_bool_builtin_rejects_non_boolean_literal_judge_upfront():
+    judge = make_judge(
+        name="grade",
+        instructions="Grade {{ outputs }}.",
+        model="openai:/gpt-4",
+        feedback_value_type=Literal["great", "terrible"],
+    )
+    with pytest.raises(MlflowException, match="yes/no reading"):
+        make_scorer_ensemble(name="x", scorers=[judge], ensemble_fn="agg_all")
+
+
+def test_agg_all_coerces_yes_no_at_call_time():
+    # A decorator scorer declares no feedback_value_type, so the up-front check is skipped.
+    # "yes" must still read as True rather than relying on string truthiness.
     agg = make_scorer_ensemble(name="a", scorers=[_label], ensemble_fn="agg_all")
-    with pytest.raises(MlflowException, match="boolean"):
-        agg(outputs="yes")
+    assert agg(outputs="yes").value is True
+    assert agg(outputs="no").value is False
+
+
+def test_agg_all_at_call_time_rejects_values_without_yes_no_reading():
+    agg = make_scorer_ensemble(name="a", scorers=[_label], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="yes/no reading"):
+        agg(outputs="maybe")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -332,11 +332,11 @@ def test_is_numeric_feedback_type_unit_checks():
 
 
 # ---------------------------------------------------------------------------
-# Task 10: sub-scorer provenance preserved in ensemble Feedback.metadata
+# Task 10/11: sub-scorer provenance preserved in ensemble Feedback.metadata
 # ---------------------------------------------------------------------------
 
 
-def test_ensemble_preserves_sub_rationales_in_metadata():
+def test_ensemble_preserves_sub_feedbacks_in_metadata():
     from mlflow.genai.scorers.base import EnsembleScorer
 
     @scorer
@@ -351,19 +351,41 @@ def test_ensemble_preserves_sub_rationales_in_metadata():
     fb = agg(outputs="x")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
     assert len(sub) == 2
+    assert {e["assessment_name"] for e in sub} == {"_yes", "_no"}
     assert {e["rationale"] for e in sub} == {"looks safe", "found an issue"}
-    assert {e["name"] for e in sub} == {"_yes", "_no"}
+    # values live under the nested "feedback" key
+    assert {e["feedback"]["value"] for e in sub} == {True, False}
 
 
-def test_ensemble_metadata_present_for_custom_value_fn():
+def test_ensemble_metadata_captures_sub_feedback_source():
+    from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+    from mlflow.genai.scorers.base import EnsembleScorer
+
+    @scorer
+    def _judge(outputs) -> Feedback:
+        return Feedback(
+            value=True,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id="gpt-4o-mini"
+            ),
+        )
+
+    agg = scorer_ensemble(name="e", scorers=[_judge], ensemble_fn="agg_all")
+    fb = agg(outputs="x")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert sub[0]["source"]["source_type"] == "LLM_JUDGE"
+    assert sub[0]["source"]["source_id"] == "gpt-4o-mini"
+
+
+def test_ensemble_metadata_normalizes_bare_value():
     from mlflow.genai.scorers.base import EnsembleScorer
 
     agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: max(values))
     fb = agg(outputs="abcd")
     sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
-    assert len(sub) == 1
-    assert sub[0]["name"] == "_num_len"
-    assert sub[0]["value"] == 4
+    assert sub[0]["assessment_name"] == "_num_len"
+    assert sub[0]["feedback"]["value"] == 4
+    assert sub[0]["source"]["source_type"] == "CODE"
 
 
 def test_ensemble_fn_metadata_wins_on_collision():

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -240,6 +240,19 @@ def test_ensemble_serialization_round_trip():
     assert isinstance(restored._scorers[0], Safety)
 
 
+def test_ensemble_serialization_preserves_aggregations():
+    agg = scorer_ensemble(
+        name="agg_safety",
+        scorers=[Safety()],
+        ensemble_fn="majority_vote",
+        aggregations=["min", "max"],
+    )
+    dumped = agg.model_dump()
+    assert dumped["aggregations"] == ["min", "max"]
+    restored = Scorer.model_validate(dumped)
+    assert restored.aggregations == ["min", "max"]
+
+
 def test_ensemble_custom_callable_not_serializable():
     agg = scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: sum(values))
     with pytest.raises(MlflowException, match="custom ensemble function"):
@@ -301,12 +314,28 @@ def test_mean_rejects_categorical_values():
 
 
 def test_feedbacks_mode_allows_non_numeric():
-    # feedbacks-mode bypasses the value-type check entirely; feedbacks contains raw run() results.
+    # feedbacks-mode bypasses the value-type check entirely; feedbacks contains Feedback objects.
     def first_value(feedbacks):
-        return feedbacks[0]
+        return feedbacks[0].value
 
     agg = scorer_ensemble(name="f", scorers=[_label], ensemble_fn=first_value)
     assert agg(outputs="hello").value == "hello"
+
+
+def test_ensemble_feedbacks_mode_receives_feedback_objects():
+    captured = {}
+
+    def inspect_fn(feedbacks):
+        captured["types"] = [type(f).__name__ for f in feedbacks]
+        captured["names"] = [f.name for f in feedbacks]
+        return feedbacks[0].value
+
+    # _num_len returns a bare int; must be wrapped into a Feedback in feedbacks-mode.
+    agg = scorer_ensemble(name="fb", scorers=[_num_len], ensemble_fn=inspect_fn)
+    fb = agg(outputs="abcd")
+    assert captured["types"] == ["Feedback"]
+    assert captured["names"] == ["_num_len"]
+    assert fb.value == 4
 
 
 def test_numeric_builtin_rejects_literal_judge_upfront():

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import mlflow.genai
+import mlflow.genai.scorers as _public_scorers
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
@@ -72,7 +73,10 @@ _NUMERIC_BUILTINS = [mean, minimum, maximum]
 def test_builtin_happy_path(fn, values, expected):
     result = fn(values)
     assert isinstance(result, Feedback)
-    assert result.value == expected
+    if isinstance(expected, bool):
+        assert result.value is expected
+    else:
+        assert result.value == expected
 
 
 @pytest.mark.parametrize("fn", _ALL_BUILTINS)
@@ -140,7 +144,11 @@ def test_scorer_kind_has_ensemble():
     ],
 )
 def test_extract_scorer_value(value, expected):
-    assert _extract_scorer_value(value) == expected
+    result = _extract_scorer_value(value)
+    if isinstance(expected, bool):
+        assert result is expected
+    else:
+        assert result == expected
 
 
 def test_extract_value_rejects_feedback_list():
@@ -323,7 +331,16 @@ def test_ensemble_custom_callable_not_serializable():
 
 def test_public_exports():
     assert mlflow.genai.scorer_ensemble is scorer_ensemble
-    assert all(callable(fn) for fn in (majority_vote, mean, minimum, maximum, agg_all, agg_any))
+    for name, fn in [
+        ("majority_vote", majority_vote),
+        ("mean", mean),
+        ("minimum", minimum),
+        ("maximum", maximum),
+        ("agg_all", agg_all),
+        ("agg_any", agg_any),
+        ("scorer_ensemble", scorer_ensemble),
+    ]:
+        assert getattr(_public_scorers, name) is fn
 
 
 def test_ensemble_in_evaluate(is_in_databricks):

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -407,3 +407,22 @@ def test_ensemble_metadata_is_string_valued():
     fb = agg(outputs="x")
     for v in fb.metadata.values():
         assert isinstance(v, str)
+
+
+def test_ensemble_metadata_captures_error_feedback():
+    from mlflow.genai.scorers.base import EnsembleScorer
+
+    @scorer
+    def _errs(outputs) -> Feedback:
+        return Feedback(error=ValueError("boom"))
+
+    def tolerant(feedbacks):
+        return True
+
+    agg = scorer_ensemble(name="e", scorers=[_errs], ensemble_fn=tolerant)
+    fb = agg(outputs="x")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert sub[0]["assessment_name"] == "_errs"
+    # to_dictionary() puts error info under the nested "feedback.error" key
+    assert sub[0]["feedback"]["error"]["error_code"] == "ValueError"
+    assert sub[0]["feedback"]["error"]["error_message"] == "boom"

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -369,14 +369,15 @@ def test_ensemble_metadata_present_for_custom_value_fn():
 def test_ensemble_fn_metadata_wins_on_collision():
     from mlflow.genai.scorers.base import EnsembleScorer
 
+    key = EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY
+
     def fn_with_meta(feedbacks):
-        return Feedback(value=True, metadata={"custom": "kept"})
+        return Feedback(value=True, metadata={key: "override"})
 
     agg = scorer_ensemble(name="m", scorers=[_always_true], ensemble_fn=fn_with_meta)
     fb = agg(outputs="x")
-    assert fb.metadata["custom"] == "kept"
-    # sub-feedback provenance is still attached alongside it
-    assert EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY in fb.metadata
+    # The ensemble_fn's own metadata wins on key collision.
+    assert fb.metadata[key] == "override"
 
 
 def test_ensemble_metadata_is_string_valued():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

This PR adds a new `scorer_ensemble` primitive to `mlflow.genai.scorers` for combining the
results of several scorers into a single `Feedback`.

```python
from mlflow.genai.scorers import scorer_ensemble, majority_vote

ensemble = scorer_ensemble(
    name="safety_ensemble",
    scorers=[safety_a, safety_b, safety_c],
    ensemble_fn=majority_vote,  # callable, or the name of a built-in
)

mlflow.genai.evaluate(data=data, scorers=[ensemble])
```

The returned scorer runs each sub-scorer, extracts a value from each result, and combines
them into one `Feedback` via `ensemble_fn`. Highlights:

- **Six built-in ensemble functions** (in `mlflow/genai/scorers/ensemble.py`):
  `majority_vote`, `mean`, `minimum`, `maximum`, `agg_all`, `agg_any`. `ensemble_fn` accepts
  a built-in name string or any callable.
- **Value kinds:** `bool | int | float | str`. Categorical (`Literal[...]`/string) labels are
  aggregated by `majority_vote`; the numeric built-ins (`mean`/`minimum`/`maximum`) require
  numeric values and raise a clear error otherwise.
- **`feedback_value_type` validation:** when a sub-scorer declares its value type (e.g. a
  judge/built-in scorer returning `Literal["yes","no"]`), a numeric ensemble function is
  rejected up front with a clear error instead of failing mid-run.
- **`values` vs `feedbacks` mode:** the ensemble function's parameter name selects whether it
  receives the list of raw values (default) or the full list of `Feedback` objects
  (`feedbacks`). The bool/numeric/str type-check applies only in values-mode.
- **Single-turn and session-level** sub-scorers are both supported. The ensemble's level is
  derived from its sub-scorers, which must be homogeneous (mixing raises a clear error).
- **Serialization/registration:** an ensemble scorer round-trips through
  `model_dump`/`model_validate` (recursively serializing its sub-scorers) when `ensemble_fn`
  is a named built-in; a custom callable raises a clear error on serialization.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests live in `tests/genai/scorers/test_scorer_ensemble.py` and cover the built-in
functions (including tie-breaking, `None`/empty rejection), value extraction, dispatch across
mixed sub-scorer signatures, categorical vs numeric handling, `values`/`feedbacks` mode,
session-level derivation and mixing, serialization round-trip, and an end-to-end
`mlflow.genai.evaluate` run.

**Manual end-to-end test** against a live Databricks workspace: ran
`mlflow.genai.evaluate` with `scorer_ensemble(name="safety_relevance_vote",
scorers=[Safety(), RelevanceToQuery()], ensemble_fn=majority_vote)` over a 3-row dataset.
`Safety` and `RelevanceToQuery` are built-in LLM judges (`Literal["yes","no"]`) that use the
workspace judge model, so no `model=` argument was needed.

Results (individual judges logged alongside the ensemble for comparison):

- `safety/mean = 1.0`, `relevance_to_query/mean = 0.667`, `safety_relevance_vote/mean = 0.667`.
- Per-row `majority_vote` was correct, including the lexicographic tie-break for a 1–1 split
  (`"no" < "yes"`):

  | input | safety | relevance | ensemble vote |
  |---|---|---|---|
  | good on-topic answer | yes | yes | yes |
  | off-topic answer to the question | yes | no | no (tie → "no") |
  | good on-topic answer | yes | yes | yes |

- Each ensemble `Feedback` carried the sub-scorer provenance under
  `metadata["mlflow.ensemble.sub_feedbacks"]`, including each sub-`Feedback`'s value,
  rationale, and `source` (e.g. `source_type=LLM_JUDGE`, `source_id=databricks`).

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

The new public symbols (`scorer_ensemble` and the six built-in functions) carry docstrings;
API reference docs pick these up from `mlflow.genai.scorers`.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds `mlflow.genai.scorers.scorer_ensemble`, a primitive that combines several scorers into
one via a built-in or custom ensemble function (e.g. `majority_vote`, `mean`), for building
ensemble/voting scorers over bool, numeric, or categorical values.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
