### PR TITLE
Bump `@mlflow/claude-code` to 0.3.1

### DIFF
--- a/libs/typescript/integrations/claude-code/package.json
+++ b/libs/typescript/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlflow/claude-code",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude Code and Claude Agent SDK integration package for MLflow Tracing",
   "type": "module",
   "repository": {

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -69,7 +69,7 @@
     },
     "integrations/claude-code": {
       "name": "@mlflow/claude-code",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mlflow/core": "^0.3.0"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24416

### What changes are proposed in this pull request?

Bumps `@mlflow/claude-code` from `0.3.0` to `0.3.1` so the Claude Code cost fix (#24416) can be published to npm.

Only this package is bumped. `#24416` is the sole package-source change in `libs/typescript` since `ts/v0.3.0`; the other commits in that range touch CI scripts and `package-lock.json` only, and `@mlflow/core` has no source changes at all (`git diff ts/v0.3.0..master -- libs/typescript/core` is empty). Bumping the remaining packages would mint npm releases byte-identical to `0.3.0`.

Packages have never been published in strict lockstep: at `ts/v0.2.0` every package.json read `0.2.0`, yet `@mlflow/codex@0.2.0` and `@mlflow/vercel@0.2.0` were never published. The release workflow takes an explicit package list and version-matches only the packages selected, so a single-package release is `-f packages=claude-code -f ref=ts/v0.3.1`.

Note this differs from `bump-ts-version.ts`, which bumps `@mlflow/core` and every published integration in lockstep and rewrites each integration's `@mlflow/core` constraint to match. That script is aimed at a full SDK release; for a single-integration patch it would produce eight no-op version bumps. It would also fail CI here: the min-version gate added in #24268 (`check-min-mlflow-deps.sh`) installs each declared floor from npm, and the `^0.3.1` floor the script writes does not exist until this release is published (`npm error notarget No matching version found for @mlflow/core@0.3.1`).

`@mlflow/claude-code` therefore keeps its `@mlflow/core` floor at `^0.3.0`, which is both correct (it uses no core symbol added since `0.3.0`) and necessary (core `0.3.1` is not being published, so a `^0.3.1` floor would be unresolvable on npm).

### How is this PR tested?

- [x] Manual tests

Verified `bash libs/typescript/scripts/check-min-mlflow-deps.sh` passes, and that the version bump is the only change besides the corresponding `package-lock.json` entry.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

The fix itself is described in #24416; this PR only bumps the package version.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release