### PR TITLE
fix: use `pickle` serialization in pytorch Docker flavor test to avoid pt2 cross-version failures

### DIFF
--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -331,6 +331,7 @@ def pytorch_model(model_path):
         pytorch_model=model,
         path=model_path,
         input_example=randn(1, 4).numpy(),
+        serialization_format="pickle",
     )
     return model_path
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24494

### What changes are proposed in this pull request?

The `pytorch_model` fixture in `test_build_image_and_serve[pytorch]` was failing with:

```
torch._dynamo.exc.UserError: Constraints violated (dynamic_dim)!
You marked dynamic_dim as dynamic but your code specialized it to be a constant (1).
```

The fixture saves a model via `save_model_with_latest_mlflow_version`, which pins the latest released MLflow version. The `serialization_format` default changed to `"pt2"` in #23988, and the fix for batch-size-1 inputs (use `Dim.AUTO`) landed in #24494. If the latest released version has the new default but not the `Dim.AUTO` fix, saving with a size-1 input example raises a `ConstraintViolation`.

This test covers Docker image building and serving, not pt2 export. Explicitly passing `serialization_format="pickle"` makes the fixture robust across released MLflow versions.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release