### PR TITLE
Fix: Handle Content-Encoding in gateway request body parsing

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import functools
+import gzip
 import hmac
 import importlib
 import json
@@ -19,6 +20,7 @@ import logging
 import re
 import secrets
 import threading
+import zlib
 from dataclasses import asdict, dataclass
 from http import HTTPStatus
 from typing import Any, Awaitable, Callable
@@ -4630,10 +4632,19 @@ def _get_gateway_validator(path: str) -> Callable[[str, StarletteRequest], Await
         body = None
         if path in _ROUTES_NEEDING_BODY:
             try:
-                body = await request.json()
+                # Check for Content-Encoding and decompress if needed
+                content_encoding = request.headers.get("content-encoding", "").lower().strip()
+                if content_encoding:
+                    raw_body = await request.body()
+                    decompressed_body = _decompress_gateway_body(raw_body, content_encoding)
+                    body = json.loads(decompressed_body)
+                else:
+                    body = await request.json()
                 # Cache parsed body in request.state so route handlers can reuse it
                 # (request body can only be read once in Starlette/FastAPI)
                 request.state.cached_body = body
+            except MlflowException:
+                raise
             except Exception as e:
                 raise MlflowException(f"Invalid JSON payload: {e}", error_code=BAD_REQUEST)
 
@@ -4644,6 +4655,62 @@ def _get_gateway_validator(path: str) -> Callable[[str, StarletteRequest], Await
         return _validate_gateway_use_permission(endpoint_name, username)
 
     return validator
+
+
+def _decompress_gateway_body(raw_body: bytes, content_encoding: str) -> bytes:
+    """
+    Decompress a gateway request body according to Content-Encoding.
+
+    Supported encodings:
+    - gzip
+    - deflate (RFC-compliant and raw deflate)
+    - zstd (requires the `zstandard` package)
+
+    Raises MlflowException if the payload cannot be decompressed or if the
+    encoding is not supported.
+    """
+    match content_encoding:
+        case "gzip":
+            try:
+                return gzip.decompress(raw_body)
+            except Exception:
+                raise MlflowException(
+                    "Failed to decompress gzip payload", error_code=BAD_REQUEST
+                )
+
+        case "deflate":
+            try:
+                return zlib.decompress(raw_body)
+            except Exception:
+                # Try raw DEFLATE stream (some clients send this)
+                try:
+                    return zlib.decompress(raw_body, -zlib.MAX_WBITS)
+                except Exception:
+                    raise MlflowException(
+                        "Failed to decompress deflate payload", error_code=BAD_REQUEST
+                    )
+
+        case "zstd":
+            try:
+                import zstandard
+            except ImportError:
+                raise MlflowException(
+                    "zstd decompression requires the 'zstandard' package. "
+                    "Install it with: pip install zstandard",
+                    error_code=BAD_REQUEST,
+                )
+            try:
+                decompressor = zstandard.ZstdDecompressor()
+                return decompressor.decompress(raw_body)
+            except Exception:
+                raise MlflowException(
+                    "Failed to decompress zstd payload", error_code=BAD_REQUEST
+                )
+
+        case _:
+            raise MlflowException(
+                f"Unsupported Content-Encoding: {content_encoding}", error_code=BAD_REQUEST
+            )
 
 
 def _mcp_server_suffix(path: str) -> str:

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -7,9 +7,11 @@ functionality directly into the MLflow tracking server.
 """
 
 import functools
+import gzip
 import logging
 import sys
 import time
+import zlib
 from collections.abc import AsyncIterable, Callable
 from typing import Any
 
@@ -89,6 +91,68 @@ _logger = logging.getLogger(__name__)
 gateway_router = APIRouter(prefix="/gateway", tags=["gateway"])
 
 
+def _decompress_body(raw_body: bytes, content_encoding: str) -> bytes:
+    """
+    Decompress a gateway request body according to Content-Encoding.
+
+    Supported encodings:
+    - gzip
+    - deflate (RFC-compliant and raw deflate)
+    - zstd (requires the `zstandard` package)
+
+    Raises HTTPException if the payload cannot be decompressed or if the
+    encoding is not supported.
+    """
+    match content_encoding:
+        case "gzip":
+            try:
+                return gzip.decompress(raw_body)
+            except Exception:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Failed to decompress gzip payload",
+                )
+
+        case "deflate":
+            try:
+                return zlib.decompress(raw_body)
+            except Exception:
+                # Try raw DEFLATE stream (some clients send this)
+                try:
+                    return zlib.decompress(raw_body, -zlib.MAX_WBITS)
+                except Exception:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Failed to decompress deflate payload",
+                    )
+
+        case "zstd":
+            try:
+                import zstandard
+            except ImportError:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "zstd decompression requires the 'zstandard' package. "
+                        "Install it with: pip install zstandard"
+                    ),
+                )
+            try:
+                decompressor = zstandard.ZstdDecompressor()
+                return decompressor.decompress(raw_body)
+            except Exception:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Failed to decompress zstd payload",
+                )
+
+        case _:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported Content-Encoding: {content_encoding}",
+            )
+
+
 async def _get_request_body(request: Request) -> dict[str, Any]:
     """
     Get request body, using cached version if available.
@@ -97,6 +161,9 @@ async def _get_request_body(request: Request) -> dict[str, Any]:
     validation. Since Starlette request body can only be read once, we cache
     the parsed body in request.state.cached_body for reuse by route handlers.
 
+    If the request has a Content-Encoding header (e.g., zstd, gzip, deflate),
+    the body is decompressed before JSON parsing.
+
     Args:
         request: The FastAPI Request object.
 
@@ -104,16 +171,27 @@ async def _get_request_body(request: Request) -> dict[str, Any]:
         Parsed JSON body as a dictionary.
 
     Raises:
-        HTTPException: If the request body is not valid JSON.
+        HTTPException: If the request body is not valid JSON or decompression fails.
     """
     # Check if body was already parsed by auth middleware
     cached_body = getattr(request.state, "cached_body", None)
     if isinstance(cached_body, dict):
         return cached_body
 
-    # Otherwise parse it now
+    # Check for Content-Encoding and decompress if needed
+    content_encoding = request.headers.get("content-encoding", "").lower().strip()
+
     try:
-        return await request.json()
+        if content_encoding:
+            raw_body = await request.body()
+            decompressed_body = _decompress_body(raw_body, content_encoding)
+            import json
+
+            return json.loads(decompressed_body)
+        else:
+            return await request.json()
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {e!s}")
 

--- a/tests/server/test_gateway_content_encoding.py
+++ b/tests/server/test_gateway_content_encoding.py
@@ -1,0 +1,237 @@
+"""
+Tests for Content-Encoding handling in the gateway API.
+
+This module tests the decompression of request bodies with various
+Content-Encoding values (gzip, deflate, zstd) before JSON parsing.
+"""
+
+import gzip
+import json
+import zlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from mlflow.server.gateway_api import _decompress_body, _get_request_body
+
+# Configure pytest-asyncio
+pytestmark = [pytest.mark.asyncio, pytest.mark.notrackingurimock]
+
+
+class TestDecompressBody:
+    """Tests for the _decompress_body helper function."""
+
+    def test_gzip_decompression(self):
+        """Test that gzip-encoded bodies are correctly decompressed."""
+        original = b'{"test": "data", "number": 42}'
+        compressed = gzip.compress(original)
+        result = _decompress_body(compressed, "gzip")
+        assert result == original
+
+    def test_gzip_invalid_payload(self):
+        """Test that invalid gzip payloads raise HTTPException."""
+        with pytest.raises(HTTPException, match="Failed to decompress gzip payload"):
+            _decompress_body(b"not valid gzip", "gzip")
+
+    def test_deflate_decompression(self):
+        """Test that deflate-encoded bodies are correctly decompressed."""
+        original = b'{"test": "data", "number": 42}'
+        compressed = zlib.compress(original)
+        result = _decompress_body(compressed, "deflate")
+        assert result == original
+
+    def test_deflate_raw_decompression(self):
+        """Test that raw deflate (without zlib header) bodies are decompressed."""
+        original = b'{"test": "data", "number": 42}'
+        # Raw deflate without zlib header
+        compressed = zlib.compress(original, level=9)[2:-4]
+        # Some clients send raw deflate, try both
+        try:
+            result = _decompress_body(compressed, "deflate")
+            assert result == original
+        except HTTPException:
+            # If raw deflate fails, the function should have tried both methods
+            pass
+
+    def test_deflate_invalid_payload(self):
+        """Test that invalid deflate payloads raise HTTPException."""
+        with pytest.raises(HTTPException, match="Failed to decompress deflate payload"):
+            _decompress_body(b"not valid deflate", "deflate")
+
+    def test_zstd_decompression(self):
+        """Test that zstd-encoded bodies are correctly decompressed."""
+        pytest.importorskip("zstandard")
+        import zstandard
+
+        original = b'{"test": "data", "number": 42}'
+        compressor = zstandard.ZstdCompressor()
+        compressed = compressor.compress(original)
+        result = _decompress_body(compressed, "zstd")
+        assert result == original
+
+    def test_zstd_without_package(self, monkeypatch):
+        """Test that missing zstandard package raises helpful error."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "zstandard":
+                raise ImportError("No module named 'zstandard'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
+        with pytest.raises(HTTPException, match="zstd decompression requires"):
+            _decompress_body(b"some data", "zstd")
+
+    def test_zstd_invalid_payload(self):
+        """Test that invalid zstd payloads raise HTTPException."""
+        pytest.importorskip("zstandard")
+        with pytest.raises(HTTPException, match="Failed to decompress zstd payload"):
+            _decompress_body(b"not valid zstd", "zstd")
+
+    def test_unsupported_encoding(self):
+        """Test that unsupported encodings raise HTTPException."""
+        with pytest.raises(HTTPException, match="Unsupported Content-Encoding"):
+            _decompress_body(b"some data", "br")  # brotli
+
+    def test_case_sensitivity(self):
+        """Test that encoding names are case-insensitive (handled by caller)."""
+        # The caller (_get_request_body) lowercases the encoding before passing
+        original = b'{"test": "data"}'
+        compressed = gzip.compress(original)
+        # Should work with lowercase
+        result = _decompress_body(compressed, "gzip")
+        assert result == original
+
+
+class TestGetRequestBody:
+    """Tests for the _get_request_body function with Content-Encoding."""
+
+    @pytest.fixture
+    def mock_request(self):
+        """Create a mock request object."""
+        request = MagicMock()
+        request.state = MagicMock()
+        request.state.cached_body = None
+        return request
+
+    async def test_uncompressed_json(self, mock_request):
+        """Test that uncompressed JSON is parsed correctly."""
+        body = {"test": "data", "number": 42}
+        mock_request.headers = {}
+        mock_request.json = AsyncMock(return_value=body)
+
+        result = await _get_request_body(mock_request)
+        assert result == body
+
+    async def test_cached_body_returned(self, mock_request):
+        """Test that cached body from auth middleware is returned."""
+        cached = {"cached": "data"}
+        mock_request.state.cached_body = cached
+
+        result = await _get_request_body(mock_request)
+        assert result == cached
+        # json() should not be called when cached
+        mock_request.json.assert_not_called()
+
+    async def test_gzip_encoded_json(self, mock_request):
+        """Test that gzip-encoded JSON is decompressed and parsed."""
+        body = {"test": "data", "number": 42}
+        compressed = gzip.compress(json.dumps(body).encode())
+
+        mock_request.headers = {"content-encoding": "gzip"}
+        mock_request.body = AsyncMock(return_value=compressed)
+
+        result = await _get_request_body(mock_request)
+        assert result == body
+
+    async def test_deflate_encoded_json(self, mock_request):
+        """Test that deflate-encoded JSON is decompressed and parsed."""
+        body = {"test": "data", "number": 42}
+        compressed = zlib.compress(json.dumps(body).encode())
+
+        mock_request.headers = {"content-encoding": "deflate"}
+        mock_request.body = AsyncMock(return_value=compressed)
+
+        result = await _get_request_body(mock_request)
+        assert result == body
+
+    @pytest.mark.skipif(
+        not pytest.importorskip("zstandard", reason="zstandard not installed"),
+        reason="zstandard not installed",
+    )
+    async def test_zstd_encoded_json(self, mock_request):
+        """Test that zstd-encoded JSON is decompressed and parsed."""
+        import zstandard
+
+        body = {"test": "data", "number": 42}
+        compressor = zstandard.ZstdCompressor()
+        compressed = compressor.compress(json.dumps(body).encode())
+
+        mock_request.headers = {"content-encoding": "zstd"}
+        mock_request.body = AsyncMock(return_value=compressed)
+
+        result = await _get_request_body(mock_request)
+        assert result == body
+
+    async def test_invalid_json_after_decompression(self, mock_request):
+        """Test that invalid JSON after decompression raises HTTPException."""
+        compressed = gzip.compress(b"not valid json")
+
+        mock_request.headers = {"content-encoding": "gzip"}
+        mock_request.body = AsyncMock(return_value=compressed)
+
+        with pytest.raises(HTTPException, match="Invalid JSON payload"):
+            await _get_request_body(mock_request)
+
+    async def test_invalid_gzip_raises_http_exception(self, mock_request):
+        """Test that invalid gzip data raises HTTPException with proper message."""
+        mock_request.headers = {"content-encoding": "gzip"}
+        mock_request.body = AsyncMock(return_value=b"not valid gzip")
+
+        with pytest.raises(HTTPException, match="Failed to decompress gzip payload"):
+            await _get_request_body(mock_request)
+
+    async def test_unsupported_encoding_raises_http_exception(self, mock_request):
+        """Test that unsupported encoding raises HTTPException."""
+        mock_request.headers = {"content-encoding": "br"}
+        mock_request.body = AsyncMock(return_value=b"some data")
+
+        with pytest.raises(HTTPException, match="Unsupported Content-Encoding"):
+            await _get_request_body(mock_request)
+
+    async def test_content_encoding_case_insensitive(self, mock_request):
+        """Test that Content-Encoding header is case-insensitive."""
+        body = {"test": "data"}
+        compressed = gzip.compress(json.dumps(body).encode())
+
+        # Mixed case header value
+        mock_request.headers = {"content-encoding": "GZIP"}
+        mock_request.body = AsyncMock(return_value=compressed)
+
+        result = await _get_request_body(mock_request)
+        assert result == body
+
+    async def test_content_encoding_with_whitespace(self, mock_request):
+        """Test that Content-Encoding with whitespace is handled."""
+        body = {"test": "data"}
+        compressed = gzip.compress(json.dumps(body).encode())
+
+        # Header with extra whitespace
+        mock_request.headers = {"content-encoding": "  gzip  "}
+        mock_request.body = AsyncMock(return_value=compressed)
+
+        result = await _get_request_body(mock_request)
+        assert result == body
+
+    async def test_empty_content_encoding_treated_as_none(self, mock_request):
+        """Test that empty Content-Encoding is treated as no encoding."""
+        body = {"test": "data"}
+        mock_request.headers = {"content-encoding": ""}
+        mock_request.json = AsyncMock(return_value=body)
+
+        result = await _get_request_body(mock_request)
+        assert result == body


### PR DESCRIPTION
## Related Issues/PRs

Fixes #24573

## What changes are proposed in this pull request?

Prior to this PR, the AI Gateway's request body parser (`_get_request_body`) did not handle `Content-Encoding` headers. This caused requests with compressed bodies (e.g., zstd-compressed requests from Codex CLI, which enables compression by default) to fail with `400 Invalid JSON payload` errors.

### Root cause

The gateway's `_get_request_body` function and the auth middleware's gateway validator both called `request.json()` directly without checking for `Content-Encoding`. When a client sent a compressed body (e.g., `Content-Encoding: zstd`), the raw compressed bytes were passed to the JSON parser, which failed to decode them.

### Fix

This PR adds decompression support for the following encodings before JSON parsing:
- **gzip** (standard library)
- **deflate** (standard library, supports both RFC-compliant and raw deflate)
- **zstd** (requires the optional `zstandard` package)

The fix is applied in two places:
1. `mlflow/server/gateway_api.py` - `_get_request_body()` function
2. `mlflow/server/auth/__init__.py` - gateway validator in `_get_gateway_validator()`

For zstd support, if the `zstandard` package is not installed, a helpful error message is returned suggesting installation.

## How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

A new test file `tests/server/test_gateway_content_encoding.py` is added with 21 tests covering:
- gzip, deflate, and zstd decompression
- Invalid payload handling for each encoding
- Missing `zstandard` package error handling
- Unsupported encoding error handling
- Case-insensitive encoding header handling
- Whitespace handling in encoding header
- Cached body from auth middleware
- Invalid JSON after decompression

## Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

## Release Notes

### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The AI Gateway now supports compressed request bodies with `Content-Encoding: gzip`, `deflate`, or `zstd`. This fixes compatibility with clients like Codex CLI that send compressed requests by default.

### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] area/gateway

### How should the PR be classified in the release notes?

- [ ] rn/breaking-change
- [x] rn/bug-fix
- [ ] rn/documentation
- [ ] rn/none

### Is this PR a critical bugfix or security fix?

- [ ] This is critical and needs to be in the next patch release
- [x] This can wait for the next minor release