### PR TITLE
fix: prevent database upgrade failure when 'secrets' table already exists (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,7 +86,10 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    # Only run upgrade if the database is not already at the latest revision
+    # to prevent errors when the 'secrets' table (or other later tables) already exist.
+    if not _db_is_at_latest_revision(engine):
+        _upgrade_db(engine)
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:


### PR DESCRIPTION
## What
After upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with:
`pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`

This occurs because `_initialize_tables()` unconditionally calls `_upgrade_db()` after creating initial tables, even if the database already has all tables up to the latest Alembic revision. The Alembic migration tries to create the `secrets` table again, causing a duplicate table error.

## Fix
Added a check `_db_is_at_latest_revision()` before running `_upgrade_db()` in `_initialize_tables()`. This ensures that if the database schema is already up-to-date (e.g., from a previous partial migration or manual table creation), the upgrade step is skipped, preventing the "Table already exists" error.

Closes #19943