### PR TITLE
Report the underlying type hint error in the signature message

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -396,12 +396,12 @@ def _infer_signature_from_type_hints(
 
     try:
         input_schema = _infer_schema_from_list_type_hint(type_hints.input)
-    except InvalidTypeHintException:
+    except InvalidTypeHintException as e:
         raise MlflowException.invalid_parameter_value(
             "The `predict` function has unsupported type hints for the model input "
             "arguments. Update it to one of supported type hints, or remove type hints "
-            "to bypass this check. Error: {e}"
-        )
+            f"to bypass this check. Error: {e.message}"
+        ) from e
     except Exception as e:
         warnings.warn(f"Failed to infer signature from type hint: {e.message}", stacklevel=3)
         return None

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -9,6 +9,7 @@ import pytest
 from scipy.sparse import csc_matrix, csr_matrix
 
 from mlflow.exceptions import MlflowException
+from mlflow.models.signature import _infer_signature_from_type_hints, _TypeHints
 from mlflow.models.utils import PyFuncOutput, _enforce_schema
 from mlflow.types.schema import AnyType, Array, ColSpec, DataType, Map, Object, Property, Schema
 from mlflow.types.type_hints import (
@@ -507,3 +508,15 @@ def test_dict_in_pyfunc_output():
         f"dict must be in PyFuncOutput for ResponsesAgent/ChatAgent/ChatModel. "
         f"Current types: {output_types}"
     )
+
+
+def test_infer_signature_from_type_hints_reports_the_underlying_error():
+    # The generic message must carry the specific reason from the type hint check,
+    # otherwise the user is told the hint is unsupported without being told why.
+    with pytest.raises(
+        MlflowException,
+        match=r"Error: Type hint `list` doesn.t contain a collection element type",
+    ):
+        _infer_signature_from_type_hints(
+            python_model=lambda x: x, context=None, type_hints=_TypeHints(input_=list)
+        )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #none — found while reading `mlflow/models/signature.py`, no existing issue.

### What changes are proposed in this pull request?

The `InvalidTypeHintException` handler in `_infer_signature_from_type_hints` ends its message with `Error: {e}`, but the `except` clause does not bind `e` and the string is not an f-string:

```python
except InvalidTypeHintException:
    raise MlflowException.invalid_parameter_value(
        "The `predict` function has unsupported type hints for the model input "
        "arguments. Update it to one of supported type hints, or remove type hints "
        "to bypass this check. Error: {e}"
    )
```

So the placeholder reaches the caller verbatim and the specific reason is thrown away. Calling it directly today:

```
MlflowException: The `predict` function has unsupported type hints for the model input arguments.
Update it to one of supported type hints, or remove type hints to bypass this check. Error: {e}
```

The reason that is lost is the useful part. For a bare `list` hint the inner check produces "Type hint `list` doesn't contain a collection element type. Fix by adding an element type to the collection type definition, e.g. `list[str]` instead of `list`."

This binds the exception, interpolates `e.message`, and chains with `from e`. It is the only non-f-string `Error: {e}` left in the package; the other 47 or so are all f-strings already.

**Reachability, so you can judge the priority.** I could not trigger this through `log_model`. The one caller guards the call with `_signature_cannot_be_inferred_from_type_hint`, and for every hint I tried that gets past the guard and raises `InvalidTypeHintException` — bare `list`, `list[str, int]`, `list[dict[int, str]]`, `list[str | None]`, and a `list` of a Pydantic model with an `Optional` field lacking a default — an earlier validation raises first with its own good message, so the output is identical with and without this patch. The branch is reachable when `_infer_signature_from_type_hints` is called directly, which is what the new test does.

So this is a latent bug rather than a user-visible one today. If you would rather remove the handler as dead code than fix its message, that seems reasonable too and I am happy to switch.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

`test_infer_signature_from_type_hints_reports_the_underlying_error` in `tests/types/test_type_hints.py` asserts the specific reason reaches the message. Without the source change it fails with `AssertionError: Regex pattern did not match`. The full file passes (78). I put it there rather than in `tests/models/test_signature.py` because that module imports `pyspark`, which I cannot install on this machine.

`ruff check` and `ruff format --check` are clean on both files with the pinned `ruff==0.15.17`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
