### PR TITLE
Skip `env_pack` on ARM client images

### DIFF
--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -232,7 +232,7 @@ def _register_model(
         "arm64",
     }:
         _logger.warning(
-            "`env_pack` is not supported on ARM client images and will be ignored. "
+            "`env_pack` is not supported on the current architecture and will be ignored. "
             "The model will be registered without a packed environment."
         )
         validated_env_pack = None

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import threading
 import uuid
 import warnings
@@ -108,6 +109,8 @@ def register_model(
             in the registered model artifacts. If the string shortcut "databricks_model_serving" is
             used, then model dependencies will be installed in the current environment. This is
             useful when deploying the model to a serving environment like Databricks Model Serving.
+            On ARM client images, this parameter is ignored with a warning and the model is
+            registered without a packed environment.
 
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
@@ -224,6 +227,15 @@ def _register_model(
     # Passing in the string value is a shortcut for passing in the EnvPackConfig
     # Validate early; `_validate_env_pack` will raise on invalid inputs.
     validated_env_pack = _validate_env_pack(env_pack)
+    if validated_env_pack and os.environ.get("DATABRICKS_CPU_ARCH", "").lower() in {
+        "aarch64",
+        "arm64",
+    }:
+        _logger.warning(
+            "`env_pack` is not supported on ARM client images and will be ignored. "
+            "The model will be registered without a packed environment."
+        )
+        validated_env_pack = None
 
     # Helper to avoid parameter drift below.
     def _create_model_version(local_model_path: str | None) -> ModelVersion:

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -397,12 +397,13 @@ def test_register_model_without_env_pack_does_not_warn_on_arm(monkeypatch, caplo
         mock.patch(
             "mlflow.MlflowClient._create_model_version",
             return_value=created_model_version,
-        ),
+        ) as mock_create_version,
         caplog.at_level(logging.WARNING, logger="mlflow.tracking._model_registry.fluent"),
     ):
         register_model("s3:/some/path/to/model", "No env pack")
 
     assert ARM_ENV_PACK_WARNING not in caplog.messages
+    mock_create_version.assert_called_once()
 
 
 @pytest.mark.parametrize("cpu_arch", ["x86_64", "unknown", None])
@@ -436,12 +437,6 @@ def test_register_model_with_env_pack(tmp_path, mock_dbr_version, monkeypatch, c
         mock.patch(
             "mlflow.MlflowClient.get_model_version",
             return_value=ModelVersion("Model 1", "1", creation_timestamp=123),
-        ),
-        mock.patch("platform.machine", return_value="aarch64"),
-        mock.patch(
-            "mlflow.tracking._model_registry.fluent.machine",
-            return_value="aarch64",
-            create=True,
         ),
         caplog.at_level(logging.WARNING, logger="mlflow.tracking._model_registry.fluent"),
     ):

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -297,7 +297,7 @@ def mock_dbr_version():
 
 
 ARM_ENV_PACK_WARNING = (
-    "`env_pack` is not supported on ARM client images and will be ignored. "
+    "`env_pack` is not supported on the current architecture and will be ignored. "
     "The model will be registered without a packed environment."
 )
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -17,6 +18,7 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.tracking._model_registry.fluent import _register_model
 from mlflow.utils.databricks_utils import DatabricksRuntimeVersion
 from mlflow.utils.env_pack import EnvPackConfig
 
@@ -294,7 +296,122 @@ def mock_dbr_version():
         yield
 
 
-def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
+ARM_ENV_PACK_WARNING = (
+    "`env_pack` is not supported on ARM client images and will be ignored. "
+    "The model will be registered without a packed environment."
+)
+
+
+@pytest.mark.parametrize(
+    ("cpu_arch", "env_pack"),
+    [
+        ("AArch64", "databricks_model_serving"),
+        (
+            "arm64",
+            EnvPackConfig(name="databricks_model_serving", install_dependencies=False),
+        ),
+    ],
+)
+def test_register_model_ignores_env_pack_on_arm_client_image(
+    tmp_path, monkeypatch, caplog, cpu_arch, env_pack
+):
+    local_model_path = tmp_path / "model"
+    local_model_path.mkdir()
+    monkeypatch.setenv("DATABRICKS_CPU_ARCH", cpu_arch)
+
+    created_model_version = ModelVersion(f"Model {cpu_arch}", "1", creation_timestamp=123)
+    with (
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.pack_env_for_databricks_model_serving"
+        ) as mock_pack_env,
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.stage_model_for_databricks_model_serving"
+        ) as mock_stage_model,
+        mock.patch(
+            "mlflow.MlflowClient._create_model_version",
+            return_value=created_model_version,
+        ) as mock_create_version,
+        caplog.at_level(logging.WARNING, logger="mlflow.tracking._model_registry.fluent"),
+    ):
+        result = _register_model(
+            "s3:/some/path/to/model",
+            f"Model {cpu_arch}",
+            local_model_path=str(local_model_path),
+            env_pack=env_pack,
+        )
+
+    assert result is created_model_version
+    assert ARM_ENV_PACK_WARNING in caplog.messages
+    mock_pack_env.assert_not_called()
+    mock_stage_model.assert_not_called()
+    mock_create_version.assert_called_once_with(
+        name=f"Model {cpu_arch}",
+        source="s3:/some/path/to/model",
+        run_id=None,
+        tags=None,
+        await_creation_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+        local_model_path=str(local_model_path),
+        model_id=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("env_pack", "error_match"),
+    [
+        ("invalid", "Invalid env_pack value"),
+        (
+            EnvPackConfig(name="invalid", install_dependencies=True),
+            "Invalid EnvPackConfig.name",
+        ),
+    ],
+)
+def test_register_model_validates_env_pack_before_ignoring_it_on_arm(
+    monkeypatch, caplog, env_pack, error_match
+):
+    monkeypatch.setenv("DATABRICKS_CPU_ARCH", "aarch64")
+
+    with (
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.pack_env_for_databricks_model_serving"
+        ) as mock_pack_env,
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.stage_model_for_databricks_model_serving"
+        ) as mock_stage_model,
+        mock.patch("mlflow.MlflowClient._create_model_version") as mock_create_version,
+        caplog.at_level(logging.WARNING, logger="mlflow.tracking._model_registry.fluent"),
+        pytest.raises(MlflowException, match=error_match),
+    ):
+        register_model("s3:/some/path/to/model", "Invalid env pack", env_pack=env_pack)
+
+    assert ARM_ENV_PACK_WARNING not in caplog.messages
+    mock_pack_env.assert_not_called()
+    mock_stage_model.assert_not_called()
+    mock_create_version.assert_not_called()
+
+
+def test_register_model_without_env_pack_does_not_warn_on_arm(monkeypatch, caplog):
+    monkeypatch.setenv("DATABRICKS_CPU_ARCH", "aarch64")
+
+    created_model_version = ModelVersion("No env pack", "1", creation_timestamp=123)
+    with (
+        mock.patch(
+            "mlflow.MlflowClient._create_model_version",
+            return_value=created_model_version,
+        ),
+        caplog.at_level(logging.WARNING, logger="mlflow.tracking._model_registry.fluent"),
+    ):
+        register_model("s3:/some/path/to/model", "No env pack")
+
+    assert ARM_ENV_PACK_WARNING not in caplog.messages
+
+
+@pytest.mark.parametrize("cpu_arch", ["x86_64", "unknown", None])
+def test_register_model_with_env_pack(tmp_path, mock_dbr_version, monkeypatch, caplog, cpu_arch):
+    if cpu_arch is None:
+        monkeypatch.delenv("DATABRICKS_CPU_ARCH", raising=False)
+    else:
+        monkeypatch.setenv("DATABRICKS_CPU_ARCH", cpu_arch)
+
     # Mock download_artifacts to return a path
     mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()
@@ -320,6 +437,13 @@ def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
             "mlflow.MlflowClient.get_model_version",
             return_value=ModelVersion("Model 1", "1", creation_timestamp=123),
         ),
+        mock.patch("platform.machine", return_value="aarch64"),
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.machine",
+            return_value="aarch64",
+            create=True,
+        ),
+        caplog.at_level(logging.WARNING, logger="mlflow.tracking._model_registry.fluent"),
     ):
         # Set up the mock pack_env to yield a path
         mock_pack_env.return_value.__enter__.return_value = str(mock_artifacts_dir)
@@ -350,10 +474,13 @@ def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
             model_name="Model 1",
             model_version="1",
         )
+        assert ARM_ENV_PACK_WARNING not in caplog.messages
 
 
 @pytest.mark.parametrize("install_deps", [True, False])
-def test_register_model_with_env_pack_config(tmp_path, install_deps):
+def test_register_model_with_env_pack_config(tmp_path, install_deps, monkeypatch):
+    monkeypatch.setenv("DATABRICKS_CPU_ARCH", "x86_64")
+
     # Mock download_artifacts to return a path
     mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()
@@ -415,7 +542,9 @@ def test_register_model_with_env_pack_config(tmp_path, install_deps):
         )
 
 
-def test_register_model_with_env_pack_staging_failure(tmp_path, mock_dbr_version):
+def test_register_model_with_env_pack_staging_failure(tmp_path, mock_dbr_version, monkeypatch):
+    monkeypatch.setenv("DATABRICKS_CPU_ARCH", "x86_64")
+
     # Mock download_artifacts to return a path
     mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #15783

### What changes are proposed in this pull request?

ARM Databricks client images do not support packed environments. After validating `env_pack`, ignore valid requests when `DATABRICKS_CPU_ARCH` is `aarch64` or `arm64`, warn the caller, and continue normal model registration with the original local model path.

Packing and serving staging remain unchanged for x86, unknown, and unset architecture signals.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. On ARM Databricks client images, model registration now ignores `env_pack` with a warning and registers the model without a packed environment.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g. 1.2.0 -> 1.3.0).
- Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g. 1.2.0 -> 1.2.1).
- Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release