### PR TITLE
Clarify scorer versioning documentation

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/versioning.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/versioning.mdx
@@ -1,9 +1,26 @@
+---
+description: Register and version MLflow scorers, retrieve historical versions, and manage scorer version history.
+---
+
+import { APILink } from "@site/src/components/APILink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 # Registering and Versioning Scorers
 
 Scorers can be registered to MLflow experiments for version control and team collaboration.
+
+A scorer's version history is identified by its experiment and registered name. The first registration creates version 1, and registering another scorer with the same name in the same experiment creates the next version. Existing versions remain available until you delete them.
+
+## How scorer versioning works
+
+| Action                                                         | Version behavior                      |
+| -------------------------------------------------------------- | ------------------------------------- |
+| Register a name for the first time in an experiment            | Creates version 1                     |
+| Register the same name again in the same experiment            | Creates the next version              |
+| Register the same name in a different experiment               | Starts an independent version history |
+| Call `get_scorer()` without a version or call `list_scorers()` | Returns the latest version            |
+| Call `get_scorer(version=...)`                                 | Returns a specific version            |
 
 ## Supported Scorers
 
@@ -38,13 +55,14 @@ When you create a judge using the [Judge Builder UI](/genai/eval-monitor/scorers
 
 ### Prerequisite
 
-Judges are registered to an **MLflow Experiment** (not Run-level).
+Judges are registered to an **MLflow Experiment** (not Run-level). Set an active experiment or pass its ID to each scorer registry API.
 
 ```python
 import mlflow
 
 mlflow.set_tracking_uri("your-tracking-uri")
-mlflow.create_experiment("evaluation-judges")
+experiment = mlflow.set_experiment("evaluation-judges")
+experiment_id = experiment.experiment_id
 ```
 
 Define a sample template-based LLM scorer:
@@ -62,13 +80,10 @@ quality_judge = make_judge(
 
 ### Registering a Scorer
 
-To register a judge to the experiment, call the `register` method on the judge instance.
+To register a judge to the experiment, call the <APILink fn="mlflow.genai.scorers.Scorer.register">`register()`</APILink> method on the judge instance. The first registration creates version 1.
 
 ```python
-# Register the judge
-registered = quality_judge.register()
-# You can pass experiment_id to register the judge to a specific experiment
-# registered = quality_judge.register(experiment_id=experiment_id)
+registered_v1 = quality_judge.register(experiment_id=experiment_id)
 ```
 
 ### Updating a Scorer
@@ -93,20 +108,30 @@ registered_v2 = quality_judge_v2.register(experiment_id=experiment_id)
 
 ### Loading a Scorer
 
-To load a registered scorer, use the `get_scorer` function.
+Use <APILink fn="mlflow.genai.scorers.get_scorer">`get_scorer()`</APILink> without `version` to load the highest available version, or specify a version number to load that exact definition.
 
 ```python
 from mlflow.genai import get_scorer
 
-# Get the latest version
-latest_judge = get_scorer(name="response_quality")
-# or specify experiment_id to get a scorer from a specific experiment
-# latest_judge = get_scorer(name="response_quality", experiment_id=experiment_id)
+# Load the latest version
+latest_judge = get_scorer(
+    name="response_quality",
+    experiment_id=experiment_id,
+)
+
+# Load version 1
+v1_judge = get_scorer(
+    name="response_quality",
+    experiment_id=experiment_id,
+    version=1,
+)
 ```
+
+Pin a specific version for regression tests and other workflows that must remain reproducible. Load the latest version when the workflow should automatically adopt scorer updates.
 
 ### Listing Scorers
 
-The `list_scorers` function returns a list of the scorers registered in the experiment.
+Use <APILink fn="mlflow.genai.scorers.list_scorers">`list_scorers()`</APILink> to retrieve the latest version of each registered scorer.
 
 ```python
 from mlflow.genai import list_scorers
@@ -114,6 +139,28 @@ from mlflow.genai import list_scorers
 all_scorers = list_scorers(experiment_id=experiment_id)
 for scorer in all_scorers:
     print(f"Scorer: {scorer.name}, Model: {scorer.model}")
+```
+
+### Deleting Scorer Versions
+
+Use <APILink fn="mlflow.genai.scorers.delete_scorer">`delete_scorer()`</APILink> with an explicit version number to delete one version, or pass `version="all"` to delete the scorer and its complete version history.
+
+```python
+from mlflow.genai import delete_scorer
+
+# Delete only version 1.
+delete_scorer(
+    name="response_quality",
+    experiment_id=experiment_id,
+    version=1,
+)
+
+# Delete every remaining version.
+delete_scorer(
+    name="response_quality",
+    experiment_id=experiment_id,
+    version="all",
+)
 ```
 
   </TabItem>


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24596
Relates to #24611

### What changes are proposed in this pull request?

Clarify how scorer versions are created and scoped by experiment and registered name. Document how to load the latest or a specific version, what `list_scorers()` returns, and how to delete one version or the complete version history.

### How is this PR tested?

- [x] Manual tests

Look at the docs here: 
https://pr-24769--mlflow-docs-preview.netlify.app/docs/latest/genai/eval-monitor/scorers/versioning/

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Clarifies how MLflow scorer versions are created, retrieved, and deleted.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: A release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements.
  Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: A release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release.
  For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
