### PR TITLE
fix(prompts): log Catalog Explorer URL in `register_prompt`

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -760,11 +760,7 @@ class MlflowClient:
 
             prompt_version = registry_client.get_prompt_version(name, str(prompt_version.version))
             self._log_prompt_ui_link(name)
-            # Import here to avoid circular import
-            from mlflow.tracking.fluent import _get_experiment_id
-
-            if uc_experiment_id := _get_experiment_id():
-                self._set_prompt_registry_location_tag(name, uc_experiment_id)
+            self._set_prompt_registry_location_tag(name)
             return prompt_version
 
         # OSS approach using RegisteredModel with special tags
@@ -846,9 +842,7 @@ class MlflowClient:
 
         if experiment_id := _get_experiment_id():
             self._link_prompt_to_experiment(prompt_version, experiment_id)
-            self._set_prompt_registry_location_tag(name, experiment_id)
 
-        self._log_prompt_ui_link(name)
         return prompt_version
 
     def _log_prompt_ui_link(self, name: str) -> None:
@@ -874,17 +868,33 @@ class MlflowClient:
         except Exception:
             pass  # never break registration
 
-    def _set_prompt_registry_location_tag(self, name: str, experiment_id: str) -> None:
-        """Set mlflow.promptRegistryLocation on the active experiment for 3-part UC prompt names.
+    def _set_prompt_registry_location_tag(self, name: str) -> None:
+        """Set mlflow.promptRegistryLocation on the active experiment for UC-backed prompts.
 
-        This causes the experiment's Prompts tab to be pre-populated with prompts from the
-        catalog.schema where the prompt was registered.  Emits a warning on failure; never raises.
+        Called only from the Unity Catalog branch of register_prompt. Pre-populates the
+        experiment Prompts tab so useSearchPrompts / listRegisteredPromptsViaUC (both gated
+        on this tag) can list prompts without any manual setup by the caller.
+
+        The experiment ID and tag write are resolved inside this method so that any failure
+        (including a missing/unreachable tracking server) is swallowed and never breaks
+        registration. The tag is written via this client's tracking store, which is the same
+        store the fluent context targets when the caller uses the default MlflowClient(); in
+        the rare case of a cross-server client the write may target a different server, but
+        the failure is benign (the tag goes to the wrong server and the try/except swallows
+        the error).
         """
         try:
             parts = name.split(".")
             if len(parts) != 3:
                 return
             catalog, schema, _ = parts
+            # Import here to avoid circular import. Resolve the experiment id inside the
+            # try/except so that any lookup failure is swallowed (best-effort).
+            from mlflow.tracking.fluent import _get_experiment_id
+
+            experiment_id = _get_experiment_id()
+            if not experiment_id:
+                return
             self.set_experiment_tag(
                 experiment_id,
                 "mlflow.promptRegistryLocation",
@@ -892,8 +902,7 @@ class MlflowClient:
             )
         except Exception as e:
             _logger.warning(
-                "Failed to set mlflow.promptRegistryLocation tag on experiment %s: %s",
-                experiment_id,
+                "Failed to set mlflow.promptRegistryLocation tag: %s",
                 e,
             )
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -761,12 +761,9 @@ class MlflowClient:
             prompt_version = registry_client.get_prompt_version(name, str(prompt_version.version))
             self._log_prompt_ui_link(name)
             # Import here to avoid circular import
-            from mlflow.tracking.fluent import _get_experiment_id, active_run
+            from mlflow.tracking.fluent import _get_experiment_id
 
-            uc_experiment_id = _get_experiment_id()
-            if (ar := active_run()) and ar.info.experiment_id:
-                uc_experiment_id = ar.info.experiment_id
-            if uc_experiment_id:
+            if uc_experiment_id := _get_experiment_id():
                 self._set_prompt_registry_location_tag(name, uc_experiment_id)
             return prompt_version
 
@@ -845,14 +842,9 @@ class MlflowClient:
         prompt_version = model_version_to_prompt_version(mv, prompt_tags=prompt_tags)
 
         # Import here to avoid circular import
-        from mlflow.tracking.fluent import _get_experiment_id, active_run
+        from mlflow.tracking.fluent import _get_experiment_id
 
-        experiment_id = _get_experiment_id()
-        # Prefer the active run's experiment when one is set directly via start_run()
-        if (ar := active_run()) and ar.info.experiment_id:
-            experiment_id = ar.info.experiment_id
-
-        if experiment_id:
+        if experiment_id := _get_experiment_id():
             self._link_prompt_to_experiment(prompt_version, experiment_id)
             self._set_prompt_registry_location_tag(name, experiment_id)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -760,7 +760,6 @@ class MlflowClient:
 
             prompt_version = registry_client.get_prompt_version(name, str(prompt_version.version))
             self._log_prompt_ui_link(name)
-            self._set_prompt_registry_location_tag(name)
             return prompt_version
 
         # OSS approach using RegisteredModel with special tags
@@ -867,44 +866,6 @@ class MlflowClient:
             )
         except Exception:
             pass  # never break registration
-
-    def _set_prompt_registry_location_tag(self, name: str) -> None:
-        """Set mlflow.promptRegistryLocation on the active experiment for UC-backed prompts.
-
-        Called only from the Unity Catalog branch of register_prompt. Pre-populates the
-        experiment Prompts tab so useSearchPrompts / listRegisteredPromptsViaUC (both gated
-        on this tag) can list prompts without any manual setup by the caller.
-
-        The experiment ID and tag write are resolved inside this method so that any failure
-        (including a missing/unreachable tracking server) is swallowed and never breaks
-        registration. The tag is written via this client's tracking store, which is the same
-        store the fluent context targets when the caller uses the default MlflowClient(); in
-        the rare case of a cross-server client the write may target a different server, but
-        the failure is benign (the tag goes to the wrong server and the try/except swallows
-        the error).
-        """
-        try:
-            parts = name.split(".")
-            if len(parts) != 3:
-                return
-            catalog, schema, _ = parts
-            # Import here to avoid circular import. Resolve the experiment id inside the
-            # try/except so that any lookup failure is swallowed (best-effort).
-            from mlflow.tracking.fluent import _get_experiment_id
-
-            experiment_id = _get_experiment_id()
-            if not experiment_id:
-                return
-            self.set_experiment_tag(
-                experiment_id,
-                "mlflow.promptRegistryLocation",
-                f"{catalog}.{schema}",
-            )
-        except Exception as e:
-            _logger.warning(
-                "Failed to set mlflow.promptRegistryLocation tag: %s",
-                e,
-            )
 
     def _link_prompt_to_experiment(self, prompt_version: PromptVersion, experiment_id: str) -> None:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -134,6 +134,7 @@ from mlflow.utils.annotations import deprecated, deprecated_parameter, experimen
 from mlflow.utils.async_logging.run_operations import RunOperations
 from mlflow.utils.databricks_utils import (
     get_databricks_run_url,
+    get_workspace_id,
     get_workspace_url,
     is_in_databricks_runtime,
 )
@@ -759,7 +760,7 @@ class MlflowClient:
             )
 
             prompt_version = registry_client.get_prompt_version(name, str(prompt_version.version))
-            self._log_prompt_ui_link(name)
+            self._log_prompt_ui_link(name, prompt_version.version)
             return prompt_version
 
         # OSS approach using RegisteredModel with special tags
@@ -844,25 +845,35 @@ class MlflowClient:
 
         return prompt_version
 
-    def _log_prompt_ui_link(self, name: str) -> None:
-        """Log a Catalog Explorer URL for the registered prompt when running on Databricks.
+    def _log_prompt_ui_link(self, name: str, version: int) -> None:
+        """Log the registered prompt in the active experiment's Prompts tab.
 
         Emits an informational message only; never raises.
         """
         try:
             workspace_url = get_workspace_url()
-            if not workspace_url:
+            # Import here to avoid circular import.
+            from mlflow.tracking.fluent import _get_experiment_id
+
+            experiment_id = _get_experiment_id()
+            if not workspace_url or not experiment_id:
                 return
             parts = name.split(".")
             if len(parts) != 3:
                 return
-            catalog, schema, prompt_name = parts
+            workspace_id = get_workspace_id()
+            query = (
+                f"?o={workspace_id}&promptVersion={version}"
+                if workspace_id
+                else f"?promptVersion={version}"
+            )
             _logger.info(
-                "Prompt registered. View in Catalog Explorer: %s/explore/data/%s/%s/%s",
+                "Prompt registered. View in experiment Prompts tab: "
+                "%s/ml/experiments/%s/prompts/%s%s",
                 workspace_url.rstrip("/"),
-                catalog,
-                schema,
-                prompt_name,
+                experiment_id,
+                name,
+                query,
             )
         except Exception:
             pass  # never break registration

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -134,6 +134,7 @@ from mlflow.utils.annotations import deprecated, deprecated_parameter, experimen
 from mlflow.utils.async_logging.run_operations import RunOperations
 from mlflow.utils.databricks_utils import (
     get_databricks_run_url,
+    get_workspace_url,
     is_in_databricks_runtime,
 )
 from mlflow.utils.logging_utils import eprint
@@ -757,7 +758,17 @@ class MlflowClient:
                 model_config=model_config,
             )
 
-            return registry_client.get_prompt_version(name, str(prompt_version.version))
+            prompt_version = registry_client.get_prompt_version(name, str(prompt_version.version))
+            self._log_prompt_ui_link(name)
+            # Import here to avoid circular import
+            from mlflow.tracking.fluent import _get_experiment_id, active_run
+
+            uc_experiment_id = _get_experiment_id()
+            if (ar := active_run()) and ar.info.experiment_id:
+                uc_experiment_id = ar.info.experiment_id
+            if uc_experiment_id:
+                self._set_prompt_registry_location_tag(name, uc_experiment_id)
+            return prompt_version
 
         # OSS approach using RegisteredModel with special tags
         is_new_prompt = False
@@ -834,12 +845,65 @@ class MlflowClient:
         prompt_version = model_version_to_prompt_version(mv, prompt_tags=prompt_tags)
 
         # Import here to avoid circular import
-        from mlflow.tracking.fluent import _get_experiment_id
+        from mlflow.tracking.fluent import _get_experiment_id, active_run
 
-        if experiment_id := _get_experiment_id():
+        experiment_id = _get_experiment_id()
+        # Prefer the active run's experiment when one is set directly via start_run()
+        if (ar := active_run()) and ar.info.experiment_id:
+            experiment_id = ar.info.experiment_id
+
+        if experiment_id:
             self._link_prompt_to_experiment(prompt_version, experiment_id)
+            self._set_prompt_registry_location_tag(name, experiment_id)
 
+        self._log_prompt_ui_link(name)
         return prompt_version
+
+    def _log_prompt_ui_link(self, name: str) -> None:
+        """Log a Catalog Explorer URL for the registered prompt when running on Databricks.
+
+        Emits an informational message only; never raises.
+        """
+        try:
+            workspace_url = get_workspace_url()
+            if not workspace_url:
+                return
+            parts = name.split(".")
+            if len(parts) != 3:
+                return
+            catalog, schema, prompt_name = parts
+            _logger.info(
+                "Prompt registered. View in Catalog Explorer: %s/explore/data/%s/%s/%s",
+                workspace_url.rstrip("/"),
+                catalog,
+                schema,
+                prompt_name,
+            )
+        except Exception:
+            pass  # never break registration
+
+    def _set_prompt_registry_location_tag(self, name: str, experiment_id: str) -> None:
+        """Set mlflow.promptRegistryLocation on the active experiment for 3-part UC prompt names.
+
+        This causes the experiment's Prompts tab to be pre-populated with prompts from the
+        catalog.schema where the prompt was registered.  Emits a warning on failure; never raises.
+        """
+        try:
+            parts = name.split(".")
+            if len(parts) != 3:
+                return
+            catalog, schema, _ = parts
+            self.set_experiment_tag(
+                experiment_id,
+                "mlflow.promptRegistryLocation",
+                f"{catalog}.{schema}",
+            )
+        except Exception as e:
+            _logger.warning(
+                "Failed to set mlflow.promptRegistryLocation tag on experiment %s: %s",
+                experiment_id,
+                e,
+            )
 
     def _link_prompt_to_experiment(self, prompt_version: PromptVersion, experiment_id: str) -> None:
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -876,7 +876,7 @@ class MlflowClient:
                 query,
             )
         except Exception:
-            pass  # never break registration
+            _logger.debug("Failed to log prompt UI link", exc_info=True)
 
     def _link_prompt_to_experiment(self, prompt_version: PromptVersion, experiment_id: str) -> None:
         """

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4040,7 +4040,7 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
 
 def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri):
     """register_prompt logs the registered prompt in the active experiment's Prompts tab."""
-    fake_workspace_url = "https://my-workspace.azuredatabricks.net"
+    fake_workspace_url = "https://my-workspace.azuredatabricks.net/"
     client = MlflowClient(tracking_uri=tracking_uri)
 
     with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
@@ -4067,7 +4067,7 @@ def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri):
 
     log_info.assert_called_once_with(
         "Prompt registered. View in experiment Prompts tab: %s/ml/experiments/%s/prompts/%s%s",
-        fake_workspace_url,
+        fake_workspace_url.rstrip("/"),
         "987654",
         "catalog.schema.my_prompt",
         "?o=123456&promptVersion=1",

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import pickle
 import threading
@@ -3994,101 +3995,165 @@ def test_create_issue_with_all_fields(tmp_path: Path):
 
 
 # ─── D2/D3 tests: register_prompt UI discoverability ─────────────────────────
+#
+# D2 and D3 side-effects fire ONLY from the Unity Catalog branch of
+# register_prompt (when is_databricks_unity_catalog_uri returns True). Tests
+# mock the UC registry backend so the UC branch runs without a live Databricks
+# connection.
 
 
-def test_register_prompt_logs_ui_link_when_workspace_url_available(tracking_uri, caplog):
-    """D2: register_prompt should log an info message with a resolvable UI URL when
-    get_workspace_url() returns a workspace URL and the prompt name is a 3-part UC name."""
-    import logging
+def _make_uc_prompt_version(name: str, version: int = 1):
+    """Return a minimal PromptVersion suitable for use as a UC registry stub return value."""
+    from mlflow.entities.model_registry.prompt_version import PromptVersion
 
+    return PromptVersion(name=name, version=version, template="stub {{var}}")
+
+
+def _uc_register_prompt_patches(name: str, tracking_uri: str):
+    """Context manager stack that makes register_prompt execute the UC branch.
+
+    Patches applied:
+    - is_databricks_unity_catalog_uri -> True (so the UC branch is entered)
+    - registry_client.create_prompt -> no-op
+    - registry_client.create_prompt_version -> Mock(version=1)
+    - registry_client.get_prompt_version -> minimal PromptVersion
+    - get_workspace_url -> fake workspace URL
+    - set_experiment_tag -> tracked via a real MlflowClient method backed by tracking_uri
+    """
+    import contextlib
+
+    fake_pv = _make_uc_prompt_version(name)
+    mock_version = Mock(version=1)
+    mock_registry_client = Mock()
+    mock_registry_client.create_prompt.return_value = None
+    mock_registry_client.create_prompt_version.return_value = mock_version
+    mock_registry_client.get_prompt_version.return_value = fake_pv
+
+    @contextlib.contextmanager
+    def _stack():
+        with (
+            mock.patch(
+                "mlflow.tracking.client.is_databricks_unity_catalog_uri",
+                return_value=True,
+            ),
+            mock.patch.object(
+                MlflowClient,
+                "_get_registry_client",
+                return_value=mock_registry_client,
+            ),
+        ):
+            yield mock_registry_client
+
+    return _stack()
+
+
+def test_register_prompt_uc_branch_logs_ui_link(tracking_uri, caplog):
+    """D2 (UC branch): register_prompt emits an INFO log with the Catalog Explorer URL when
+    get_workspace_url() returns a workspace URL and the name is a 3-part UC name."""
     fake_workspace_url = "https://my-workspace.azuredatabricks.net"
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    with mock.patch(
-        "mlflow.tracking.client.get_workspace_url",
-        return_value=fake_workspace_url,
-    ):
-        with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
+    with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
+        with mock.patch(
+            "mlflow.tracking.client.get_workspace_url",
+            return_value=fake_workspace_url,
+        ):
+            with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
+                client.register_prompt(
+                    name="catalog.schema.my_prompt",
+                    template="Answer: {{question}}",
+                )
+
+    log_messages = "\n".join(caplog.messages)
+    assert fake_workspace_url in log_messages
+    assert "/explore/data/" in log_messages
+    assert "catalog" in log_messages
+    assert "schema" in log_messages
+    assert "my_prompt" in log_messages
+
+
+def test_register_prompt_uc_branch_no_ui_link_when_workspace_url_none(tracking_uri, caplog):
+    """D2 (UC branch): no UI link is logged when get_workspace_url() returns None."""
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
+        with mock.patch(
+            "mlflow.tracking.client.get_workspace_url",
+            return_value=None,
+        ):
+            with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
+                client.register_prompt(
+                    name="catalog.schema.my_prompt",
+                    template="Answer: {{question}}",
+                )
+
+    assert "/explore/data/" not in "\n".join(caplog.messages)
+
+
+def test_register_prompt_uc_branch_sets_experiment_tag(tracking_uri):
+    """D3 (UC branch): after register_prompt with a 3-part UC name and an active experiment
+    (set via set_experiment so _get_experiment_id() resolves it), the experiment tag
+    mlflow.promptRegistryLocation is set to 'catalog.schema'."""
+    experiment = mlflow.set_experiment("test_d3_uc_experiment")
+    experiment_id = experiment.experiment_id
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
+        with mock.patch(
+            "mlflow.tracking.client.get_workspace_url",
+            return_value=None,
+        ):
             client.register_prompt(
                 name="catalog.schema.my_prompt",
                 template="Answer: {{question}}",
             )
 
-    # Should have logged a line containing the workspace URL and the three path parts
-    log_messages = "\n".join(caplog.messages)
-    assert fake_workspace_url in log_messages
-    assert "catalog" in log_messages
-    assert "schema" in log_messages
-    assert "my_prompt" in log_messages
-    assert "/explore/data/" in log_messages
-
-
-def test_register_prompt_no_ui_link_logged_when_workspace_url_none(tracking_uri, caplog):
-    """D2: when get_workspace_url() returns None (non-Databricks env), no UI link is logged."""
-    import logging
-
-    client = MlflowClient(tracking_uri=tracking_uri)
-
-    with mock.patch(
-        "mlflow.tracking.client.get_workspace_url",
-        return_value=None,
-    ):
-        with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
-            client.register_prompt(
-                name="plain_prompt",
-                template="Hello {{name}}",
-            )
-
-    # No explore/data link should appear
-    log_messages = "\n".join(caplog.messages)
-    assert "/explore/data/" not in log_messages
-
-
-def test_register_prompt_sets_experiment_tag_for_uc_name(tracking_uri):
-    """D3 (OSS path): After register_prompt with a 3-part UC-style name when an experiment
-    is active via set_experiment(), the experiment tag mlflow.promptRegistryLocation is set
-    to 'catalog.schema'.  Mirrors the real scenario: user calls set_experiment() then
-    register_prompt() — _get_experiment_id() resolves the experiment without an active_run
-    fallback."""
-    import threading
-
-    # set_experiment() sets _active_experiment_id so _get_experiment_id() returns it
-    experiment = mlflow.set_experiment("test_d3_experiment")
-    experiment_id = experiment.experiment_id
-    client = MlflowClient(tracking_uri=tracking_uri)
-
-    with mock.patch(
-        "mlflow.tracking.client.get_workspace_url",
-        return_value=None,
-    ):
-        client.register_prompt(
-            name="catalog.schema.my_prompt",
-            template="Answer: {{question}}",
-        )
-
-    # Wait for any background threads from _link_prompt_to_experiment
-    for t in threading.enumerate():
-        if t.name.startswith("link_prompt_to_experiment_thread"):
-            t.join(timeout=5.0)
-
     fetched = client.get_experiment(experiment_id)
     assert fetched.tags.get("mlflow.promptRegistryLocation") == "catalog.schema"
 
 
-def test_register_prompt_no_experiment_tag_for_non_uc_name(tracking_uri):
-    """D3: For a plain (non-3-part) prompt name, no promptRegistryLocation tag should be set."""
-    experiment = mlflow.set_experiment("test_d3_plain_name")
+def test_register_prompt_uc_branch_tag_failure_does_not_break_registration(tracking_uri):
+    """D3 best-effort: if set_experiment_tag raises, register_prompt still returns a
+    PromptVersion without propagating the exception."""
+    client = MlflowClient(tracking_uri=tracking_uri)
+    mlflow.set_experiment("test_d3_best_effort")
+
+    with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
+        with mock.patch(
+            "mlflow.tracking.client.get_workspace_url",
+            return_value=None,
+        ):
+            with mock.patch.object(
+                client,
+                "set_experiment_tag",
+                side_effect=Exception("simulated tag failure"),
+            ):
+                # Must NOT raise
+                pv = client.register_prompt(
+                    name="catalog.schema.my_prompt",
+                    template="Answer: {{question}}",
+                )
+
+    from mlflow.entities.model_registry.prompt_version import PromptVersion
+
+    assert isinstance(pv, PromptVersion)
+
+
+def test_register_prompt_uc_branch_no_tag_for_non_uc_name(tracking_uri):
+    """D3: for a non-3-part UC name the promptRegistryLocation tag is not set."""
+    experiment = mlflow.set_experiment("test_d3_uc_non3part")
     experiment_id = experiment.experiment_id
     client = MlflowClient(tracking_uri=tracking_uri)
 
-    with mock.patch(
-        "mlflow.tracking.client.get_workspace_url",
-        return_value=None,
-    ):
-        client.register_prompt(
-            name="plain_prompt_name",
-            template="Hello {{name}}",
-        )
+    with _uc_register_prompt_patches("my_prompt", tracking_uri):
+        with mock.patch(
+            "mlflow.tracking.client.get_workspace_url",
+            return_value=None,
+        ):
+            client.register_prompt(
+                name="my_prompt",
+                template="Hello {{name}}",
+            )
 
     fetched = client.get_experiment(experiment_id)
     assert "mlflow.promptRegistryLocation" not in (fetched.tags or {})

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4040,7 +4040,7 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
 
 
 def test_register_prompt_uc_branch_logs_ui_link(tracking_uri, caplog):
-    """D2 (UC branch): register_prompt emits an INFO log with the Catalog Explorer URL when
+    """register_prompt emits an INFO log with the Catalog Explorer URL when
     get_workspace_url() returns a workspace URL and the name is a 3-part UC name.
     """
     fake_workspace_url = "https://my-workspace.azuredatabricks.net"

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import logging
 import os
 import pickle
 import threading
@@ -4039,7 +4038,7 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
     return _stack()
 
 
-def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri, caplog):
+def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri):
     """register_prompt logs the registered prompt in the active experiment's Prompts tab."""
     fake_workspace_url = "https://my-workspace.azuredatabricks.net"
     client = MlflowClient(tracking_uri=tracking_uri)
@@ -4059,32 +4058,51 @@ def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri, capl
                 "mlflow.tracking.fluent._get_experiment_id",
                 return_value="987654",
             ),
+            mock.patch("mlflow.tracking.client._logger.info") as log_info,
         ):
-            with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
-                client.register_prompt(
-                    name="catalog.schema.my_prompt",
-                    template="Answer: {{question}}",
-                )
+            client.register_prompt(
+                name="catalog.schema.my_prompt",
+                template="Answer: {{question}}",
+            )
 
-    log_messages = "\n".join(caplog.messages)
-    assert (
-        f"{fake_workspace_url}/ml/experiments/987654/prompts/"
-        "catalog.schema.my_prompt?o=123456&promptVersion=1"
-    ) in log_messages
+    log_info.assert_called_once_with(
+        "Prompt registered. View in experiment Prompts tab: %s/ml/experiments/%s/prompts/%s%s",
+        fake_workspace_url,
+        "987654",
+        "catalog.schema.my_prompt",
+        "?o=123456&promptVersion=1",
+    )
 
 
-def test_register_prompt_uc_branch_no_ui_link_when_workspace_url_none(tracking_uri, caplog):
+def test_register_prompt_uc_branch_no_ui_link_when_workspace_url_none(tracking_uri):
     client = MlflowClient(tracking_uri=tracking_uri)
 
     with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
-        with mock.patch(
-            "mlflow.tracking.client.get_workspace_url",
-            return_value=None,
+        with (
+            mock.patch(
+                "mlflow.tracking.client.get_workspace_url",
+                return_value=None,
+            ),
+            mock.patch("mlflow.tracking.client._logger.info") as log_info,
         ):
-            with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
-                client.register_prompt(
-                    name="catalog.schema.my_prompt",
-                    template="Answer: {{question}}",
-                )
+            client.register_prompt(
+                name="catalog.schema.my_prompt",
+                template="Answer: {{question}}",
+            )
 
-    assert "/explore/data/" not in "\n".join(caplog.messages)
+    log_info.assert_not_called()
+
+
+def test_register_prompt_ui_link_logs_debug_on_error(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with (
+        mock.patch(
+            "mlflow.tracking.client.get_workspace_url",
+            side_effect=RuntimeError("workspace lookup failed"),
+        ),
+        mock.patch("mlflow.tracking.client._logger.debug") as log_debug,
+    ):
+        client._log_prompt_ui_link("catalog.schema.my_prompt", 1)
+
+    log_debug.assert_called_once_with("Failed to log prompt UI link", exc_info=True)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3991,3 +3991,100 @@ def test_create_issue_with_all_fields(tmp_path: Path):
     assert issue.source_run_id == run.info.run_id
     assert issue.created_by == "monitoring_system"
     assert issue.created_timestamp > 0
+
+
+# ─── D2/D3 tests: register_prompt UI discoverability ─────────────────────────
+
+
+def test_register_prompt_logs_ui_link_when_workspace_url_available(tracking_uri, caplog):
+    """D2: register_prompt should log an info message with a resolvable UI URL when
+    get_workspace_url() returns a workspace URL and the prompt name is a 3-part UC name."""
+    import logging
+
+    fake_workspace_url = "https://my-workspace.azuredatabricks.net"
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with mock.patch(
+        "mlflow.tracking.client.get_workspace_url",
+        return_value=fake_workspace_url,
+    ):
+        with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
+            client.register_prompt(
+                name="catalog.schema.my_prompt",
+                template="Answer: {{question}}",
+            )
+
+    # Should have logged a line containing the workspace URL and the three path parts
+    log_messages = "\n".join(caplog.messages)
+    assert fake_workspace_url in log_messages
+    assert "catalog" in log_messages
+    assert "schema" in log_messages
+    assert "my_prompt" in log_messages
+    assert "/explore/data/" in log_messages
+
+
+def test_register_prompt_no_ui_link_logged_when_workspace_url_none(tracking_uri, caplog):
+    """D2: when get_workspace_url() returns None (non-Databricks env), no UI link is logged."""
+    import logging
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    with mock.patch(
+        "mlflow.tracking.client.get_workspace_url",
+        return_value=None,
+    ):
+        with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
+            client.register_prompt(
+                name="plain_prompt",
+                template="Hello {{name}}",
+            )
+
+    # No explore/data link should appear
+    log_messages = "\n".join(caplog.messages)
+    assert "/explore/data/" not in log_messages
+
+
+def test_register_prompt_sets_experiment_tag_for_uc_name(tracking_uri):
+    """D3 (OSS path): After register_prompt with a 3-part UC-style name inside an active
+    experiment, the experiment tag mlflow.promptRegistryLocation is set to 'catalog.schema'."""
+    import threading
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    experiment_id = client.create_experiment("test_d3_experiment")
+
+    with mock.patch(
+        "mlflow.tracking.client.get_workspace_url",
+        return_value=None,
+    ):
+        with mlflow.start_run(experiment_id=experiment_id):
+            client.register_prompt(
+                name="catalog.schema.my_prompt",
+                template="Answer: {{question}}",
+            )
+
+    # Wait for any background threads from linking
+    for t in threading.enumerate():
+        if t.name.startswith("link_prompt_to_experiment_thread"):
+            t.join(timeout=5.0)
+
+    experiment = client.get_experiment(experiment_id)
+    assert experiment.tags.get("mlflow.promptRegistryLocation") == "catalog.schema"
+
+
+def test_register_prompt_no_experiment_tag_for_non_uc_name(tracking_uri):
+    """D3: For a plain (non-3-part) prompt name, no promptRegistryLocation tag should be set."""
+    client = MlflowClient(tracking_uri=tracking_uri)
+    experiment_id = client.create_experiment("test_d3_plain_name")
+
+    with mock.patch(
+        "mlflow.tracking.client.get_workspace_url",
+        return_value=None,
+    ):
+        with mlflow.start_run(experiment_id=experiment_id):
+            client.register_prompt(
+                name="plain_prompt_name",
+                template="Hello {{name}}",
+            )
+
+    experiment = client.get_experiment(experiment_id)
+    assert "mlflow.promptRegistryLocation" not in (experiment.tags or {})

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 import os
@@ -4017,8 +4018,6 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
     - registry_client.create_prompt_version -> Mock(version=1)
     - registry_client.get_prompt_version -> minimal PromptVersion
     """
-    import contextlib
-
     fake_pv = _make_uc_prompt_version(name)
     mock_version = Mock(version=1)
     mock_registry_client = Mock()
@@ -4071,7 +4070,6 @@ def test_register_prompt_uc_branch_logs_ui_link(tracking_uri, caplog):
 
 
 def test_register_prompt_uc_branch_no_ui_link_when_workspace_url_none(tracking_uri, caplog):
-    """D2 (UC branch): no UI link is logged when get_workspace_url() returns None."""
     client = MlflowClient(tracking_uri=tracking_uri)
 
     with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3995,11 +3995,7 @@ def test_create_issue_with_all_fields(tmp_path: Path):
     assert issue.created_timestamp > 0
 
 
-# ─── D2 tests: register_prompt UI discoverability ────────────────────────────
-#
-# D2 fires ONLY from the Unity Catalog branch of register_prompt (when
-# is_databricks_unity_catalog_uri returns True). Tests mock the UC registry
-# backend so the UC branch runs without a live Databricks connection.
+# register_prompt UI discoverability tests
 
 
 def _make_uc_prompt_version(name: str, version: int = 1):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3994,12 +3994,11 @@ def test_create_issue_with_all_fields(tmp_path: Path):
     assert issue.created_timestamp > 0
 
 
-# ─── D2/D3 tests: register_prompt UI discoverability ─────────────────────────
+# ─── D2 tests: register_prompt UI discoverability ────────────────────────────
 #
-# D2 and D3 side-effects fire ONLY from the Unity Catalog branch of
-# register_prompt (when is_databricks_unity_catalog_uri returns True). Tests
-# mock the UC registry backend so the UC branch runs without a live Databricks
-# connection.
+# D2 fires ONLY from the Unity Catalog branch of register_prompt (when
+# is_databricks_unity_catalog_uri returns True). Tests mock the UC registry
+# backend so the UC branch runs without a live Databricks connection.
 
 
 def _make_uc_prompt_version(name: str, version: int = 1):
@@ -4017,8 +4016,6 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
     - registry_client.create_prompt -> no-op
     - registry_client.create_prompt_version -> Mock(version=1)
     - registry_client.get_prompt_version -> minimal PromptVersion
-    - get_workspace_url -> fake workspace URL
-    - set_experiment_tag -> tracked via a real MlflowClient method backed by tracking_uri
     """
     import contextlib
 
@@ -4049,7 +4046,8 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
 
 def test_register_prompt_uc_branch_logs_ui_link(tracking_uri, caplog):
     """D2 (UC branch): register_prompt emits an INFO log with the Catalog Explorer URL when
-    get_workspace_url() returns a workspace URL and the name is a 3-part UC name."""
+    get_workspace_url() returns a workspace URL and the name is a 3-part UC name.
+    """
     fake_workspace_url = "https://my-workspace.azuredatabricks.net"
     client = MlflowClient(tracking_uri=tracking_uri)
 
@@ -4088,72 +4086,3 @@ def test_register_prompt_uc_branch_no_ui_link_when_workspace_url_none(tracking_u
                 )
 
     assert "/explore/data/" not in "\n".join(caplog.messages)
-
-
-def test_register_prompt_uc_branch_sets_experiment_tag(tracking_uri):
-    """D3 (UC branch): after register_prompt with a 3-part UC name and an active experiment
-    (set via set_experiment so _get_experiment_id() resolves it), the experiment tag
-    mlflow.promptRegistryLocation is set to 'catalog.schema'."""
-    experiment = mlflow.set_experiment("test_d3_uc_experiment")
-    experiment_id = experiment.experiment_id
-    client = MlflowClient(tracking_uri=tracking_uri)
-
-    with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
-        with mock.patch(
-            "mlflow.tracking.client.get_workspace_url",
-            return_value=None,
-        ):
-            client.register_prompt(
-                name="catalog.schema.my_prompt",
-                template="Answer: {{question}}",
-            )
-
-    fetched = client.get_experiment(experiment_id)
-    assert fetched.tags.get("mlflow.promptRegistryLocation") == "catalog.schema"
-
-
-def test_register_prompt_uc_branch_tag_failure_does_not_break_registration(tracking_uri):
-    """D3 best-effort: if set_experiment_tag raises, register_prompt still returns a
-    PromptVersion without propagating the exception."""
-    client = MlflowClient(tracking_uri=tracking_uri)
-    mlflow.set_experiment("test_d3_best_effort")
-
-    with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
-        with mock.patch(
-            "mlflow.tracking.client.get_workspace_url",
-            return_value=None,
-        ):
-            with mock.patch.object(
-                client,
-                "set_experiment_tag",
-                side_effect=Exception("simulated tag failure"),
-            ):
-                # Must NOT raise
-                pv = client.register_prompt(
-                    name="catalog.schema.my_prompt",
-                    template="Answer: {{question}}",
-                )
-
-    from mlflow.entities.model_registry.prompt_version import PromptVersion
-
-    assert isinstance(pv, PromptVersion)
-
-
-def test_register_prompt_uc_branch_no_tag_for_non_uc_name(tracking_uri):
-    """D3: for a non-3-part UC name the promptRegistryLocation tag is not set."""
-    experiment = mlflow.set_experiment("test_d3_uc_non3part")
-    experiment_id = experiment.experiment_id
-    client = MlflowClient(tracking_uri=tracking_uri)
-
-    with _uc_register_prompt_patches("my_prompt", tracking_uri):
-        with mock.patch(
-            "mlflow.tracking.client.get_workspace_url",
-            return_value=None,
-        ):
-            client.register_prompt(
-                name="my_prompt",
-                template="Hello {{name}}",
-            )
-
-    fetched = client.get_experiment(experiment_id)
-    assert "mlflow.promptRegistryLocation" not in (fetched.tags or {})

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4045,46 +4045,50 @@ def test_register_prompt_no_ui_link_logged_when_workspace_url_none(tracking_uri,
 
 
 def test_register_prompt_sets_experiment_tag_for_uc_name(tracking_uri):
-    """D3 (OSS path): After register_prompt with a 3-part UC-style name inside an active
-    experiment, the experiment tag mlflow.promptRegistryLocation is set to 'catalog.schema'."""
+    """D3 (OSS path): After register_prompt with a 3-part UC-style name when an experiment
+    is active via set_experiment(), the experiment tag mlflow.promptRegistryLocation is set
+    to 'catalog.schema'.  Mirrors the real scenario: user calls set_experiment() then
+    register_prompt() — _get_experiment_id() resolves the experiment without an active_run
+    fallback."""
     import threading
 
+    # set_experiment() sets _active_experiment_id so _get_experiment_id() returns it
+    experiment = mlflow.set_experiment("test_d3_experiment")
+    experiment_id = experiment.experiment_id
     client = MlflowClient(tracking_uri=tracking_uri)
-    experiment_id = client.create_experiment("test_d3_experiment")
 
     with mock.patch(
         "mlflow.tracking.client.get_workspace_url",
         return_value=None,
     ):
-        with mlflow.start_run(experiment_id=experiment_id):
-            client.register_prompt(
-                name="catalog.schema.my_prompt",
-                template="Answer: {{question}}",
-            )
+        client.register_prompt(
+            name="catalog.schema.my_prompt",
+            template="Answer: {{question}}",
+        )
 
-    # Wait for any background threads from linking
+    # Wait for any background threads from _link_prompt_to_experiment
     for t in threading.enumerate():
         if t.name.startswith("link_prompt_to_experiment_thread"):
             t.join(timeout=5.0)
 
-    experiment = client.get_experiment(experiment_id)
-    assert experiment.tags.get("mlflow.promptRegistryLocation") == "catalog.schema"
+    fetched = client.get_experiment(experiment_id)
+    assert fetched.tags.get("mlflow.promptRegistryLocation") == "catalog.schema"
 
 
 def test_register_prompt_no_experiment_tag_for_non_uc_name(tracking_uri):
     """D3: For a plain (non-3-part) prompt name, no promptRegistryLocation tag should be set."""
+    experiment = mlflow.set_experiment("test_d3_plain_name")
+    experiment_id = experiment.experiment_id
     client = MlflowClient(tracking_uri=tracking_uri)
-    experiment_id = client.create_experiment("test_d3_plain_name")
 
     with mock.patch(
         "mlflow.tracking.client.get_workspace_url",
         return_value=None,
     ):
-        with mlflow.start_run(experiment_id=experiment_id):
-            client.register_prompt(
-                name="plain_prompt_name",
-                template="Hello {{name}}",
-            )
+        client.register_prompt(
+            name="plain_prompt_name",
+            template="Hello {{name}}",
+        )
 
-    experiment = client.get_experiment(experiment_id)
-    assert "mlflow.promptRegistryLocation" not in (experiment.tags or {})
+    fetched = client.get_experiment(experiment_id)
+    assert "mlflow.promptRegistryLocation" not in (fetched.tags or {})

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4039,17 +4039,26 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
     return _stack()
 
 
-def test_register_prompt_uc_branch_logs_ui_link(tracking_uri, caplog):
-    """register_prompt emits an INFO log with the Catalog Explorer URL when
-    get_workspace_url() returns a workspace URL and the name is a 3-part UC name.
-    """
+def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri, caplog):
+    """register_prompt logs the registered prompt in the active experiment's Prompts tab."""
     fake_workspace_url = "https://my-workspace.azuredatabricks.net"
     client = MlflowClient(tracking_uri=tracking_uri)
 
     with _uc_register_prompt_patches("catalog.schema.my_prompt", tracking_uri):
-        with mock.patch(
-            "mlflow.tracking.client.get_workspace_url",
-            return_value=fake_workspace_url,
+        with (
+            mock.patch(
+                "mlflow.tracking.client.get_workspace_url",
+                return_value=fake_workspace_url,
+            ),
+            mock.patch(
+                "mlflow.tracking.client.get_workspace_id",
+                return_value="123456",
+                create=True,
+            ),
+            mock.patch(
+                "mlflow.tracking.fluent._get_experiment_id",
+                return_value="987654",
+            ),
         ):
             with caplog.at_level(logging.INFO, logger="mlflow.tracking.client"):
                 client.register_prompt(
@@ -4058,11 +4067,10 @@ def test_register_prompt_uc_branch_logs_ui_link(tracking_uri, caplog):
                 )
 
     log_messages = "\n".join(caplog.messages)
-    assert fake_workspace_url in log_messages
-    assert "/explore/data/" in log_messages
-    assert "catalog" in log_messages
-    assert "schema" in log_messages
-    assert "my_prompt" in log_messages
+    assert (
+        f"{fake_workspace_url}/ml/experiments/987654/prompts/"
+        "catalog.schema.my_prompt?o=123456&promptVersion=1"
+    ) in log_messages
 
 
 def test_register_prompt_uc_branch_no_ui_link_when_workspace_url_none(tracking_uri, caplog):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -4039,7 +4039,6 @@ def _uc_register_prompt_patches(name: str, tracking_uri: str):
 
 
 def test_register_prompt_uc_branch_logs_experiment_prompt_url(tracking_uri):
-    """register_prompt logs the registered prompt in the active experiment's Prompts tab."""
     fake_workspace_url = "https://my-workspace.azuredatabricks.net/"
     client = MlflowClient(tracking_uri=tracking_uri)
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24777

### What changes are proposed in this pull request?

`MlflowClient.register_prompt()` returned only a protocol URI (`prompts:/catalog.schema.name/1`), giving users no browsable link to the registered prompt.

This PR adds a `_log_prompt_ui_link` helper that logs an INFO line with a link to the prompt in the experiment's Prompts tab (`{workspace_url}/ml/experiments/{experiment_id}/prompts/{name}?o={workspace_id}&promptVersion={version}`) after a Unity Catalog prompt is registered. The link is only built when `get_workspace_url()` returns a workspace URL, an active experiment is set, and the name is a three-part UC name; the `o={workspace_id}` query param is omitted when the workspace id is unavailable. The helper is wrapped in `try/except` (logging a DEBUG traceback on failure) so it never breaks registration.

Per maintainer discussion on #24777, the originally proposed `mlflow.promptRegistryLocation` auto-set was intentionally dropped — that tag is expected to be set explicitly per the Databricks docs.

### How is this PR tested?

- [x] New unit/integration tests

Three tests in `tests/tracking/test_client.py` covering the UC branch: the INFO link is logged (with workspace-URL trailing-slash normalization) when a workspace URL is available, nothing is logged when `get_workspace_url()` returns `None`, and a failing lookup is swallowed and logged at DEBUG rather than raising.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`register_prompt` now logs a direct Catalog Explorer URL after registering a Unity Catalog prompt, so the prompt can be opened in the UI without constructing a link manually.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
