### PR TITLE
Remove docstring entries for parameters that do not exist

### DIFF
--- a/mlflow/ag2/ag2_logger.py
+++ b/mlflow/ag2/ag2_logger.py
@@ -116,8 +116,6 @@ class MlflowAg2Logger(BaseLogger):
         Patch a function to start and end a span around its invocation.
 
         Args:
-            f: The function to patch.
-            span_name: The name of the span. If None, the function name is used.
             span_type: The type of the span. Default is SpanType.UNKNOWN.
             root_only: If True, only create a span if it is the root of the chat session.
                 When there is an existing root span for the chat session, the function will

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -357,10 +357,7 @@ def make_metric(
                             calculated by the system, make sure to specify the type hint for this
                             parameter as Dict[str, MetricValue].  Refer to the DefaultEvaluator
                             behavior section for what metrics will be returned based on the type of
-                            model (i.e. classifier or regressor).  kwargs: Includes a list of args
-                            that are used to compute the metric. These args could information coming
-                            from input data, model outputs or parameters specified in the
-                            `evaluator_config` argument of the `mlflow.evaluate` API.
+                            model (i.e. classifier or regressor).
                         kwargs: Includes a list of args that are used to compute the metric. These
                             args could be information coming from input data, model outputs,
                             other metrics, or parameters specified in the `evaluator_config`
@@ -438,10 +435,7 @@ def _make_metric(
                             calculated by the system, make sure to specify the type hint for this
                             parameter as Dict[str, MetricValue].  Refer to the DefaultEvaluator
                             behavior section for what metrics will be returned based on the type of
-                            model (i.e. classifier or regressor).  kwargs: Includes a list of args
-                            that are used to compute the metric. These args could information coming
-                            from input data, model outputs or parameters specified in the
-                            `evaluator_config` argument of the `mlflow.evaluate` API.
+                            model (i.e. classifier or regressor).
                         kwargs: Includes a list of args that are used to compute the metric. These
                             args could be information coming from input data, model outputs,
                             other metrics, or parameters specified in the `evaluator_config`

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -157,7 +157,6 @@ def _extract_predict_fn(model: Any) -> Callable[..., Any] | None:
 
     Args:
         model: A model object that has a predict method.
-        raw_model: A raw model object that has a predict method.
 
     Returns: The predict function.
     """

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -203,8 +203,6 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
 
     Args:
         fitted_estimator: The already fitted classifier
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
 
     Returns:
         dictionary of (function name, computed value)
@@ -327,8 +325,6 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
 
     Args:
         fitted_estimator: The already fitted regressor
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
 
     Returns:
         List of artifacts to be logged
@@ -434,8 +430,6 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
 
     Args:
         fitted_estimator: The already fitted regressor
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
 
     Returns:
         dictionary of (function name, computed value)

--- a/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
@@ -437,7 +437,7 @@ class UnityCatalogOssStore(BaseRestStore):
         Get temporary credentials for uploading model version files
 
         Args:
-            name: Registered model name.
+            model_name: Registered model name.
             version: Model version number.
 
         Returns:

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -283,7 +283,7 @@ def _upgrade_db(engine):
     we recommend taking a backup of your database before running migrations.
 
     Args:
-        url: Database URL, like sqlite:///<absolute-path-to-local-db-file>. See
+        engine: SQLAlchemy engine connected to the database to upgrade. See
             https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls for a full list of
             valid database URLs.
     """

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2001,7 +2001,6 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         Args:
             run_id: String ID of the run
             tags: List of RunTag instances to log
-            path: current json path for error messages
         """
         if not tags:
             return

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -79,7 +79,6 @@ class MlflowV3SpanExporter(SpanExporter):
 
         Args:
             spans: Sequence of ReadableSpan objects to export.
-            manager: The trace manager instance.
         """
         if is_databricks_uri(self._client.tracking_uri):
             _logger.debug(

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -570,7 +570,6 @@ def _get_pinned_requirement(req_str, version=None, module=None):
         module: The name of the top-level module provided by the package . For example,
             if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
             to `package`.
-        extras: A list of extra names for the package.
 
     """
     req = Requirement(req_str)


### PR DESCRIPTION
### Related Issues/PRs

N/A — no related issue. Found by auditing docstring `Args:` entries against actual function signatures.

### What changes are proposed in this pull request?

Several docstrings document parameters that their functions do not accept, left behind by earlier refactors. Sphinx renders these as real parameters, so readers are told about arguments they cannot pass.

- `_get_classifier_metrics`, `_get_classifier_artifacts` and `_get_regressor_metrics` document `fit_args` / `fit_kwargs`, but these helpers take `X`, `y_true` and `sample_weight` directly.
- `_upgrade_db` documents `url`, but the parameter is `engine`.
- `_get_temporary_model_version_write_credentials_oss` documents `name`, but the parameter is `model_name`.
- `_set_tags`, `_export_spans_incrementally`, `_get_pinned_requirement` and `_get_patch_function` each document a parameter that is not in the signature.

It also fixes the public `make_metric` (and `_make_metric`), where the `kwargs:` entry had been duplicated into the middle of the `metrics:` description, carrying a typo — "These args could information coming from". The correct wording already appears in `EvaluationMetric` in the same file, and a correct `kwargs:` entry directly follows the damaged text, so the duplicate is simply removed.

Two deliberate non-changes, to keep the diff minimal:

- `_extract_predict_fn`: only the `raw_model:` entry is removed. The "Precedence order" prose is accurate — `raw_model` is derived internally via `_extract_raw_model`, so it describes real behavior.
- Parameters that were never documented are left undocumented rather than newly described, so this stays a correction rather than a docs expansion.

Docstring-only change; no behavior is affected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Docstring-only, so there is no behavior to test. Each removal was verified by reading the function signature and body. `ruff format --check` and `ruff check` (pinned 0.15.17) both pass on all 9 files.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
