### PR TITLE
Fix traces shared-view banner bleeding into non-saved-view pages (#24785)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -657,6 +657,8 @@ describe('TracesV3Logs', () => {
     const getColumnsButton = () =>
       screen.getAllByRole('button').find((el) => (el.textContent ?? '').startsWith('Columns'));
 
+    const sharedViewBannerText = /You're viewing a shared view/;
+
     // request_time + execution_duration exist as columns; the user has only request_time selected.
     const previewColumns = [
       {
@@ -697,12 +699,16 @@ describe('TracesV3Logs', () => {
     it('renders the toolbar column count from the preview, not the user’s own selection', async () => {
       // User owns 1 column (the default mock); the shared view in the URL selects 2. The toolbar
       // counter must reflect the previewed 2/2, matching the body — not the user's 1.
-      renderComponent({}, [`/?traceViewShareKey=v1&selectedColumns=${REQUEST_TIME_COLUMN_ID},execution_duration`]);
+      renderComponent({ enableSavedViews: true }, [
+        `/?traceViewShareKey=v1&selectedColumns=${REQUEST_TIME_COLUMN_ID},execution_duration`,
+      ]);
       await waitForRoutesToBeRendered();
 
       await waitFor(() => expect(getColumnsButton()).toHaveTextContent('Columns2/2'));
       // The column control is disabled during preview — editing is deferred to Override/Discard.
       expect(getColumnsButton()).toBeDisabled();
+      // The shared-view banner is shown on a page that hosts saved views.
+      expect(screen.getByText(sharedViewBannerText)).toBeInTheDocument();
     });
 
     it('shows the user’s own column count (not a preview) when no shared view is open', async () => {
@@ -718,7 +724,7 @@ describe('TracesV3Logs', () => {
       // A garbage/deleted share key has no selectedColumns/sort in the URL, so there's nothing to
       // preview. Presence of the key alone must not enter preview mode: the user keeps their own
       // column count and the control stays editable (no misleading "shared view" state).
-      renderComponent({}, ['/?traceViewShareKey=does-not-exist']);
+      renderComponent({ enableSavedViews: true }, ['/?traceViewShareKey=does-not-exist']);
       await waitForRoutesToBeRendered();
 
       await waitFor(() => expect(getColumnsButton()).toHaveTextContent('Columns1/2'));
@@ -729,7 +735,7 @@ describe('TracesV3Logs', () => {
       // buildTraceViewQuery also serializes startTime/endTime/filter, so a view that captures only a
       // time range still carries real state. previewActive must gate on the full captured param set,
       // not just columns/sort — otherwise this link would skip preview and enable the controls.
-      renderComponent({}, ['/?traceViewShareKey=v-time&startTime=2026-01-01T00:00:00.000Z']);
+      renderComponent({ enableSavedViews: true }, ['/?traceViewShareKey=v-time&startTime=2026-01-01T00:00:00.000Z']);
       await waitForRoutesToBeRendered();
 
       // In preview the column control is disabled (editing is deferred to Override/Discard), even
@@ -741,10 +747,36 @@ describe('TracesV3Logs', () => {
       // captureTraceViewState/buildTraceViewQuery treat an empty-string value as captured (present),
       // so `selectedColumns=` is a real view — every column deselected. The state check uses `!== null`
       // (not truthiness) so this still enters preview rather than silently skipping it.
-      renderComponent({}, ['/?traceViewShareKey=v-empty&selectedColumns=']);
+      renderComponent({ enableSavedViews: true }, ['/?traceViewShareKey=v-empty&selectedColumns=']);
       await waitForRoutesToBeRendered();
 
       await waitFor(() => expect(getColumnsButton()).toBeDisabled());
+    });
+
+    it('does not preview on a page that does not host saved views, even with a shared-view URL', async () => {
+      // Regression for the sessions-page bleed: TracesV3Logs is reused (e.g. by the Chat Sessions
+      // page, SelectTracesModal, gateway pages) without the saved-views feature. A traceViewShareKey
+      // in the URL — shared across tabs — must NOT put those pages into preview: no banner, and the
+      // column control stays editable showing the user's own selection. `enableSavedViews` defaults
+      // to false, so this is the default behavior for every non–Traces-tab consumer.
+      renderComponent({}, [`/?traceViewShareKey=v1&selectedColumns=${REQUEST_TIME_COLUMN_ID},execution_duration`]);
+      await waitForRoutesToBeRendered();
+
+      await waitFor(() => expect(getColumnsButton()).toHaveTextContent('Columns1/2'));
+      expect(getColumnsButton()).not.toBeDisabled();
+      expect(screen.queryByText(sharedViewBannerText)).not.toBeInTheDocument();
+    });
+
+    it('does not preview on the chat-sessions view even with a shared-view URL', async () => {
+      // The Chat Sessions page mounts TracesV3Logs with forceGroupBySession and no saved-views UI.
+      // The shared-view banner/disabled-controls must not bleed into it.
+      renderComponent({ forceGroupBySession: true }, [
+        `/?traceViewShareKey=v1&selectedColumns=${REQUEST_TIME_COLUMN_ID},execution_duration`,
+      ]);
+      await waitForRoutesToBeRendered();
+
+      expect(screen.queryByText(sharedViewBannerText)).not.toBeInTheDocument();
+      await waitFor(() => expect(getColumnsButton()).not.toBeDisabled());
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -152,6 +152,7 @@ const TracesV3LogsImpl = React.memo(
     customDefaultSelectedColumns,
     toolbarAddons,
     toolbarCornerAddons,
+    enableSavedViews = false,
     drawerWidth,
   }: {
     /**
@@ -183,6 +184,13 @@ const TracesV3LogsImpl = React.memo(
     // controls (saved views) that should sit apart from the filter/sort/column cluster. Wrapped in
     // the same live-view-state provider as addons so a "Save" placed here captures live columns/sort.
     toolbarCornerAddons?: React.ReactNode;
+    // Whether this mount hosts the saved-views feature (Views/Share menu). Only the Traces tab
+    // (TracesV3View) does. Gates the shared-view preview: the `traceViewShareKey` URL param is shared
+    // across tabs, so without this flag every other consumer of TracesV3Logs (chat sessions, select-
+    // traces modal, gateway pages, ...) would show the "you're viewing a shared view" banner and
+    // disable its column controls whenever such a key is in the URL. Defaults to false so those pages
+    // opt out by omission.
+    enableSavedViews?: boolean;
     drawerWidth?: string | number;
   }) => {
     // When viewing a single experiment, pass its ID to enable experiment-specific
@@ -320,7 +328,9 @@ const TracesV3LogsImpl = React.memo(
     // resolves to nothing. Checks the full captured param set (not just columns/sort) so a
     // time-range- or filter-only shared view still previews.
     const previewActive =
-      Boolean(searchParams.get(TRACE_SHARE_URL_PARAM_KEY)) && urlHasCapturedTraceViewState(searchParams);
+      enableSavedViews &&
+      Boolean(searchParams.get(TRACE_SHARE_URL_PARAM_KEY)) &&
+      urlHasCapturedTraceViewState(searchParams);
     // Leave preview by dropping only the share key — NOT by navigating to the bare route. Override
     // writes columns/sort via the table setters first (which, when table-state persistence is in
     // URL mode, write the selectedColumns/sort params); a bare-route navigation would clobber those

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -42,6 +42,7 @@ const TracesV3Content = ({
         endpointName={endpointName || ''}
         timeRange={timeRange}
         drawerWidth="80vw"
+        enableSavedViews
         toolbarCornerAddons={
           experimentId && <TracesV3SavedViewsButton experimentId={experimentId} savedViews={savedViews} />
         }


### PR DESCRIPTION
### Related Issues/PRs

Backport of #24785 to `branch-3.15`. Relates to #24427.

### What changes are proposed in this pull request?

Cherry-pick of #24785 (`808e161046c62c2d0a4a7b440031a70d35690331`) onto the 3.15 release branch. No changes from the master version — the cherry-pick applied cleanly.

#24427 moved the shared-view banner above the toolbar in `TracesV3Logs`. But the preview state (`previewActive`) is derived solely from the `traceViewShareKey` URL param, and that param lives in the shared URL query string — not scoped to the Traces tab. `TracesV3Logs` is reused by seven other pages that don't host the saved-views feature, so any of them showed the "You're viewing a shared view" banner and rendered their column controls disabled whenever such a key was in the URL. The Chat Sessions page is the most visible instance.

This adds an `enableSavedViews` prop (defaults to `false`) that gates `previewActive`. Only `TracesV3View` (the Traces tab) mounts the Views/Share menu, so only it sets the flag. Because everything downstream flows from `previewActive`, this suppresses the entire preview machinery (banner, disabled controls, column/sort swap) on every non-host page from a single, explicitly-named knob.

**Scope note:** the bleed fixed here is purely cosmetic — no state crosses over (Override isn't reachable on those pages, and their localStorage column keys are namespaced). There is a separate, latent state-bleed where the URL `selectedColumns` param can override a page's columns, but only when `shouldEnableTracesTableStatePersistence()` is on (currently `false` in OSS). That is not addressed here.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests in `TracesV3Logs.test.tsx` assert that with a shared-view URL present, a mount **without** `enableSavedViews` (default, and the `forceGroupBySession` chat-sessions case) shows no banner and keeps its column control editable, while a mount **with** `enableSavedViews` still previews and shows the banner.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where the traces "shared view" banner and disabled column controls could appear on pages that don't support saved views (e.g. the Chat Sessions page) when a shared-view link had been opened.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release