### PR TITLE
Clarify LiteLLM is an optional extension in AI Gateway docs

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
@@ -8,7 +8,7 @@ import TabItem from "@theme/TabItem";
 
 # Model Providers
 
-MLflow AI Gateway supports many model providers natively, and even more through the optional LiteLLM integration. This page covers the major providers, their capabilities, and how to use their passthrough APIs.
+MLflow AI Gateway supports many model providers natively, without requiring any additional dependencies. For providers not listed here, you can optionally install [LiteLLM](https://docs.litellm.ai/docs/providers) to extend the gateway to use them. LiteLLM is not a dependency of MLflow AI Gateway&mdash;it is only used if you choose to install it in your environment. This page covers the major providers, their capabilities, and how to use their passthrough APIs.
 
 ## Supported Providers
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Clarifies the AI Gateway model providers documentation so it doesn't imply MLflow OSS AI Gateway *depends on* LiteLLM.

The current intro reads "MLflow AI Gateway supports many model providers natively, and even more through the optional LiteLLM integration," which some users have read as MLflow being reliant on LiteLLM. In reality, MLflow AI Gateway supports many providers natively with no extra dependency, and LiteLLM is only an optional install to extend support to additional providers.

This surfaced from a customer inquiry where the distinction between the (LiteLLM-free) Unity AI Gateway and OSS MLflow Gateway needed clarifying, and the docs wording contributed to the confusion.

Updated `docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx` to explicitly state LiteLLM is not a dependency and is only used if the user chooses to install it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Docs-only wording change; no runtime code affected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.