### PR TITLE
[1/N] Updated A2UI catalog schema and added typed primitives for custom trace views

### DIFF
--- a/.github/actions/check-component-ids/componentId-registry.js
+++ b/.github/actions/check-component-ids/componentId-registry.js
@@ -2429,6 +2429,7 @@ module.exports = {
   "shared.model-trace-explorer.cost-hovercard.input-cost.tag": "",
   "shared.model-trace-explorer.cost-hovercard.output-cost.tag": "",
   "shared.model-trace-explorer.cost-hovercard.total-cost.tag": "",
+  "shared.model-trace-explorer.custom-view.markdown.link": "",
   "shared.model-trace-explorer.expand": "",
   "shared.model-trace-explorer.expectation-array-item-tag": "",
   "shared.model-trace-explorer.expectation-learn-more-link": "",

--- a/mlflow/server/js/craco.config.js
+++ b/mlflow/server/js/craco.config.js
@@ -342,6 +342,13 @@ module.exports = function () {
           '@mlflow/mlflow/(.*)': '<rootDir>/$1',
           // mock files for recharts components
           '^recharts$': '<rootDir>/__mocks__/recharts.tsx',
+          // Jest 27's resolver doesn't understand package.json "exports" subpath
+          // maps, so @a2ui's "./v0_9"-style subpaths (which have no top-level
+          // "main"/"module" entry) can't be found without an explicit alias.
+          '^@a2ui/web_core/v0_9/basic_catalog$':
+            '<rootDir>/node_modules/@a2ui/web_core/src/v0_9/basic_catalog/index.js',
+          '^@a2ui/web_core/v0_9$': '<rootDir>/node_modules/@a2ui/web_core/src/v0_9/index.js',
+          '^@a2ui/react/v0_9$': '<rootDir>/node_modules/@a2ui/react/v0_9/index.cjs',
         };
 
         jestConfig.moduleNameMapper = moduleNameMapper;

--- a/mlflow/server/js/jest.babel.config.js
+++ b/mlflow/server/js/jest.babel.config.js
@@ -19,5 +19,8 @@ module.exports = {
         removeDefaultMessage: false,
       },
     ],
+    // babel-preset-react-app predates the ES2022 "static {}" class block syntax
+    // used by @a2ui/web_core's source (its exports map has no pre-built dist).
+    require.resolve('@babel/plugin-transform-class-static-block'),
   ],
 };

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -23,6 +23,8 @@
     "graphql-codegen:clean": "find . -path '**/__generated__/*.ts' | xargs rm"
   },
   "dependencies": {
+    "@a2ui/react": "^0.9.0",
+    "@a2ui/web_core": "^0.9.0",
     "@ag-grid-community/client-side-row-model": "^27.2.1",
     "@ag-grid-community/core": "^27.2.1",
     "@ag-grid-community/react": "^27.2.1",
@@ -103,6 +105,7 @@
     "use-sync-external-store": "^1.2.0",
     "uuid": "^13.0.0",
     "wavesurfer.js": "^7.8.8",
+    "zod": "^3.25.0",
     "zustand": "^4.5.6"
   },
   "devDependencies": {

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -9303,6 +9303,10 @@
     "defaultMessage": "Fetching traces failed",
     "description": "Error message for fetching traces failed"
   },
+  "dJbsSP": {
+    "defaultMessage": "No assessments to display.",
+    "description": "Empty state text for the custom view assessment board when it has no cards"
+  },
   "dMKo75": {
     "defaultMessage": "Search experiments",
     "description": "Placeholder text inside experiments search bar"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentBoard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentBoard.tsx
@@ -1,0 +1,98 @@
+import type { ComponentType } from 'react';
+import { useMemo } from 'react';
+
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, ChildListSchema, DynamicStringSchema } from '@a2ui/web_core/v0_9';
+import {
+  ChecklistIcon,
+  CheckCircleIcon,
+  ListBorderIcon,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { asString } from '../catalogPrimitiveUtils';
+
+const ICON_NAMES = ['checklist', 'list', 'checkCircle'] as const;
+type IconName = (typeof ICON_NAMES)[number];
+
+const ICON_BY_NAME: Record<IconName, ComponentType> = {
+  checklist: ChecklistIcon,
+  list: ListBorderIcon,
+  checkCircle: CheckCircleIcon,
+};
+
+const isIconName = (value: unknown): value is IconName =>
+  typeof value === 'string' && (ICON_NAMES as readonly string[]).includes(value);
+
+/**
+ * Schema (API) for the AssessmentBoard container. It renders an optional titled
+ * header followed by a wrapping row of child component ids - typically one
+ * AssessmentCard per assessment.
+ */
+const AssessmentBoardApi = {
+  name: 'AssessmentBoard',
+  schema: z
+    .object({
+      title: DynamicStringSchema.describe('Optional heading shown above the boxes.').optional(),
+      icon: z.enum(ICON_NAMES).describe('Optional icon shown next to the title.').optional(),
+      children: ChildListSchema.describe('The card component ids to lay out in a wrapping row.'),
+      emptyMessage: DynamicStringSchema.describe('Text shown when there are no cards.').optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+export const AssessmentBoard: ReactComponentImplementation = createComponentImplementation(
+  AssessmentBoardApi,
+  ({ props, buildChild }) => {
+    const { theme } = useDesignSystemTheme();
+
+    const childIds = useMemo(
+      () =>
+        Array.isArray(props.children) && props.children.every((child): child is string => typeof child === 'string')
+          ? props.children
+          : [],
+      [props.children],
+    );
+    const title = props.title ? asString(props.title) : undefined;
+    const IconComponent = isIconName(props.icon) ? ICON_BY_NAME[props.icon] : ChecklistIcon;
+
+    return (
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+        {title && (
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <span css={{ display: 'flex', color: theme.colors.textSecondary }}>
+              <IconComponent />
+            </span>
+            <Typography.Text bold size="lg">
+              {title}
+            </Typography.Text>
+          </div>
+        )}
+
+        {childIds.length === 0 ? (
+          <Typography.Text color="secondary">
+            {props.emptyMessage ? (
+              asString(props.emptyMessage)
+            ) : (
+              <FormattedMessage
+                defaultMessage="No assessments to display."
+                description="Empty state text for the custom view assessment board when it has no cards"
+              />
+            )}
+          </Typography.Text>
+        ) : (
+          <div css={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.md, alignItems: 'stretch' }}>
+            {childIds.map((id) => (
+              <div key={id} css={{ flex: '1 1 260px', minWidth: 260, maxWidth: 420, display: 'flex' }}>
+                {buildChild(id)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentCard.tsx
@@ -1,0 +1,128 @@
+import type { ComponentType } from 'react';
+
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, DynamicStringSchema } from '@a2ui/web_core/v0_9';
+import {
+  CheckCircleIcon,
+  DangerIcon,
+  Typography,
+  useDesignSystemTheme,
+  XCircleFillIcon,
+} from '@databricks/design-system';
+
+import { asString } from '../catalogPrimitiveUtils';
+
+const SENTIMENTS = ['positive', 'negative', 'neutral', 'error'] as const;
+type Sentiment = (typeof SENTIMENTS)[number];
+
+const isSentiment = (value: unknown): value is Sentiment =>
+  typeof value === 'string' && (SENTIMENTS as readonly string[]).includes(value);
+
+/**
+ * Schema (API) for a single assessment box.
+ */
+const AssessmentCardApi = {
+  name: 'AssessmentCard',
+  schema: z
+    .object({
+      name: DynamicStringSchema.describe('The assessment category, shown as the box header.'),
+      value: DynamicStringSchema.describe('The verdict/value, shown as a colored badge.').optional(),
+      rationale: DynamicStringSchema.describe('The explanation shown in the box body.').optional(),
+      source: DynamicStringSchema.describe('Optional source label, e.g. "LLM_JUDGE".').optional(),
+      sentiment: z
+        .enum(SENTIMENTS)
+        .describe('Verdict polarity: positive (green), negative/error (red), neutral (gray).')
+        .default('neutral')
+        .optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+export const AssessmentCard: ReactComponentImplementation = createComponentImplementation(
+  AssessmentCardApi,
+  ({ props }) => {
+    const { theme } = useDesignSystemTheme();
+
+    const sentiment: Sentiment = isSentiment(props.sentiment) ? props.sentiment : 'neutral';
+    const name = asString(props.name);
+    const value = props.value ? asString(props.value) : undefined;
+    const rationale = props.rationale ? asString(props.rationale) : undefined;
+    const source = props.source ? asString(props.source) : undefined;
+
+    const accentBySentiment: Record<Sentiment, string> = {
+      positive: theme.colors.green500,
+      negative: theme.colors.red500,
+      error: theme.colors.red500,
+      neutral: theme.colors.border,
+    };
+    const verdictIconBySentiment: Record<Sentiment, ComponentType | undefined> = {
+      positive: CheckCircleIcon,
+      negative: XCircleFillIcon,
+      error: DangerIcon,
+      neutral: undefined,
+    };
+
+    const accent = accentBySentiment[sentiment];
+    const VerdictIcon = verdictIconBySentiment[sentiment];
+
+    return (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.sm,
+          padding: theme.spacing.md,
+          width: '100%',
+          minWidth: 0,
+          boxSizing: 'border-box',
+          backgroundColor: theme.colors.backgroundPrimary,
+          border: `1px solid ${theme.colors.border}`,
+          borderLeft: `4px solid ${accent}`,
+          borderRadius: theme.borders.borderRadiusMd,
+        }}
+      >
+        <div
+          css={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: theme.spacing.sm }}
+        >
+          <Typography.Text bold size="md" css={{ minWidth: 0, overflowWrap: 'anywhere' }}>
+            {name}
+          </Typography.Text>
+          {value && (
+            <span
+              css={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: theme.spacing.xs,
+                padding: `2px ${theme.spacing.sm}px`,
+                borderRadius: theme.borders.borderRadiusMd,
+                backgroundColor: `${accent}1A`,
+                color: accent,
+                fontSize: theme.typography.fontSizeSm,
+                fontWeight: 600,
+                flexShrink: 0,
+                maxWidth: 140,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {VerdictIcon && <VerdictIcon />}
+              {value}
+            </span>
+          )}
+        </div>
+        {rationale && (
+          <Typography.Text color="secondary" css={{ overflowWrap: 'anywhere' }}>
+            {rationale}
+          </Typography.Text>
+        )}
+        {source && (
+          <Typography.Text color="secondary" size="sm" css={{ fontFamily: 'monospace' }}>
+            {source}
+          </Typography.Text>
+        )}
+      </div>
+    );
+  },
+);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentCard.tsx
@@ -33,8 +33,8 @@ const AssessmentCardApi = {
       sentiment: z
         .enum(SENTIMENTS)
         .describe('Verdict polarity: positive (green), negative/error (red), neutral (gray).')
-        .default('neutral')
-        .optional(),
+        .optional()
+        .default('neutral'),
     })
     .strict(),
 } satisfies ComponentApi;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/AssessmentCard.tsx
@@ -46,9 +46,11 @@ export const AssessmentCard: ReactComponentImplementation = createComponentImple
 
     const sentiment: Sentiment = isSentiment(props.sentiment) ? props.sentiment : 'neutral';
     const name = asString(props.name);
-    const value = props.value ? asString(props.value) : undefined;
-    const rationale = props.rationale ? asString(props.rationale) : undefined;
-    const source = props.source ? asString(props.source) : undefined;
+    // Assessment values are `string | number | boolean | null | string[]`, so a falsy-but-valid
+    // verdict (e.g. `false` or a `0` score) must still render its badge.
+    const value = props.value != null ? asString(props.value) : undefined;
+    const rationale = props.rationale != null ? asString(props.rationale) : undefined;
+    const source = props.source != null ? asString(props.source) : undefined;
 
     const accentBySentiment: Record<Sentiment, string> = {
       positive: theme.colors.green500,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Card.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Card.tsx
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, ComponentIdSchema } from '@a2ui/web_core/v0_9';
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+/**
+ * Schema (API) for our custom Card.
+ */
+const CardApi = {
+  name: 'Card',
+  schema: z
+    .object({
+      child: ComponentIdSchema.describe(
+        'The id of the single child component rendered inside the card. To show multiple elements, wrap them in a Row/Column and pass that container id.',
+      ),
+      weight: z.number().describe('Relative flex weight when placed directly inside a Row/Column.').optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+export const Card: ReactComponentImplementation = createComponentImplementation(CardApi, ({ props, buildChild }) => {
+  const { theme } = useDesignSystemTheme();
+  const weight = typeof props.weight === 'number' ? props.weight : undefined;
+
+  return (
+    <div
+      css={{
+        boxSizing: 'border-box',
+        backgroundColor: `color-mix(in srgb, ${theme.colors.backgroundSecondary} 30%, ${theme.colors.backgroundPrimary})`,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusMd,
+        padding: theme.spacing.md,
+        ...(weight !== undefined ? { flex: `${weight}`, minWidth: 0, minHeight: 0 } : {}),
+      }}
+    >
+      {typeof props.child === 'string' ? buildChild(props.child) : null}
+    </div>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Icon.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Icon.tsx
@@ -112,8 +112,10 @@ const DS_ICON_BY_NAME = {
 
 const DEFAULT_ICON: ComponentType = CircleOutlineIcon;
 
+// `name` is an unconstrained DynamicString, so an inherited key like "constructor" would resolve
+// to a non-component and crash the render. `Object.hasOwn` keeps those on the default-icon path.
 const resolveDsIcon = (name: string): ComponentType =>
-  name in DS_ICON_BY_NAME ? DS_ICON_BY_NAME[name as keyof typeof DS_ICON_BY_NAME] : DEFAULT_ICON;
+  Object.hasOwn(DS_ICON_BY_NAME, name) ? DS_ICON_BY_NAME[name as keyof typeof DS_ICON_BY_NAME] : DEFAULT_ICON;
 
 /** Sorted list of supported icon names (used by the catalog schema + prompt). */
 export const ICON_NAMES: string[] = Object.keys(DS_ICON_BY_NAME).sort();

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Icon.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Icon.tsx
@@ -1,0 +1,147 @@
+import type { ComponentType } from 'react';
+
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, DynamicStringSchema } from '@a2ui/web_core/v0_9';
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CalendarEventIcon,
+  CalendarIcon,
+  CameraIcon,
+  CheckIcon,
+  CircleOutlineIcon,
+  CloseIcon,
+  DangerIcon,
+  DownloadIcon,
+  FolderIcon,
+  GearIcon,
+  HomeIcon,
+  ImageIcon,
+  InfoIcon,
+  ListIcon,
+  LockIcon,
+  LockUnlockedIcon,
+  MailIcon,
+  MenuIcon,
+  NotificationIcon,
+  NotificationOffIcon,
+  OverflowIcon,
+  PauseIcon,
+  PencilIcon,
+  PinIcon,
+  PlayIcon,
+  PlusIcon,
+  QuestionMarkIcon,
+  RefreshIcon,
+  SearchIcon,
+  SendIcon,
+  ShareIcon,
+  StarIcon,
+  StopIcon,
+  TagIcon,
+  TrashIcon,
+  UploadIcon,
+  UserCircleIcon,
+  UserIcon,
+  VisibleIcon,
+  VisibleOffIcon,
+  WarningIcon,
+} from '@databricks/design-system';
+
+// Maps icon names to Databricks Design System icons so glyphs stay visually
+// native to the rest of MLflow.
+const DS_ICON_BY_NAME = {
+  accountCircle: UserCircleIcon,
+  add: PlusIcon,
+  arrowBack: ArrowLeftIcon,
+  arrowForward: ArrowRightIcon,
+  calendarToday: CalendarIcon,
+  camera: CameraIcon,
+  check: CheckIcon,
+  close: CloseIcon,
+  delete: TrashIcon,
+  download: DownloadIcon,
+  edit: PencilIcon,
+  event: CalendarEventIcon,
+  error: DangerIcon,
+  folder: FolderIcon,
+  help: QuestionMarkIcon,
+  home: HomeIcon,
+  info: InfoIcon,
+  locationOn: PinIcon,
+  lock: LockIcon,
+  lockOpen: LockUnlockedIcon,
+  mail: MailIcon,
+  menu: MenuIcon,
+  moreVert: OverflowIcon,
+  moreHoriz: OverflowIcon,
+  notifications: NotificationIcon,
+  notificationsOff: NotificationOffIcon,
+  pause: PauseIcon,
+  person: UserIcon,
+  photo: ImageIcon,
+  play: PlayIcon,
+  refresh: RefreshIcon,
+  search: SearchIcon,
+  send: SendIcon,
+  settings: GearIcon,
+  share: ShareIcon,
+  star: StarIcon,
+  starHalf: StarIcon,
+  starOff: StarIcon,
+  stop: StopIcon,
+  upload: UploadIcon,
+  visibility: VisibleIcon,
+  visibilityOff: VisibleOffIcon,
+  warning: WarningIcon,
+  // DS-native aliases (handy for the agent / authors).
+  calendar: CalendarIcon,
+  danger: DangerIcon,
+  gear: GearIcon,
+  image: ImageIcon,
+  list: ListIcon,
+  pencil: PencilIcon,
+  pin: PinIcon,
+  plus: PlusIcon,
+  question: QuestionMarkIcon,
+  tag: TagIcon,
+  trash: TrashIcon,
+  user: UserIcon,
+} satisfies Record<string, ComponentType>;
+
+const DEFAULT_ICON: ComponentType = CircleOutlineIcon;
+
+const resolveDsIcon = (name: string): ComponentType =>
+  name in DS_ICON_BY_NAME ? DS_ICON_BY_NAME[name as keyof typeof DS_ICON_BY_NAME] : DEFAULT_ICON;
+
+/** Sorted list of supported icon names (used by the catalog schema + prompt). */
+export const ICON_NAMES: string[] = Object.keys(DS_ICON_BY_NAME).sort();
+
+/**
+ * Schema (API) for the custom Icon component.
+ */
+const IconApi = {
+  name: 'Icon',
+  schema: z
+    .object({
+      name: DynamicStringSchema.describe(
+        'The icon to display. Resolves to a Databricks Design System icon; unknown names render a neutral default.',
+      ),
+      size: z.number().describe('Icon size in pixels (defaults to the inherited font size).').optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+export const Icon: ReactComponentImplementation = createComponentImplementation(IconApi, ({ props }) => {
+  const name = typeof props.name === 'string' ? props.name : '';
+  const IconComponent = resolveDsIcon(name);
+  const size = typeof props.size === 'number' ? props.size : undefined;
+
+  // DS icons size via font-size (they render at 1em), so set it on the wrapper.
+  return (
+    <span css={{ display: 'inline-flex', alignItems: 'center', ...(size ? { fontSize: size } : {}) }}>
+      <IconComponent />
+    </span>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/KeyValueViewer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/KeyValueViewer.tsx
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, DynamicStringSchema } from '@a2ui/web_core/v0_9';
+
+import { CodeSnippetRenderMode } from '../../ModelTrace.types';
+import { ModelTraceExplorerCodeSnippet } from '../../ModelTraceExplorerCodeSnippet';
+import { asString } from '../catalogPrimitiveUtils';
+
+const FORMATS = ['json', 'text', 'markdown'] as const;
+type Format = (typeof FORMATS)[number];
+
+const FORMAT_TO_RENDER_MODE: Record<Format, CodeSnippetRenderMode> = {
+  json: CodeSnippetRenderMode.JSON,
+  text: CodeSnippetRenderMode.TEXT,
+  markdown: CodeSnippetRenderMode.MARKDOWN,
+};
+
+const isFormat = (value: unknown): value is Format =>
+  typeof value === 'string' && (FORMATS as readonly string[]).includes(value);
+
+/**
+ * Schema (API) for the KeyValueViewer component.
+ */
+const KeyValueViewerApi = {
+  name: 'KeyValueViewer',
+  schema: z
+    .object({
+      label: DynamicStringSchema.describe('The key/label shown above the value, e.g. the attribute name.').optional(),
+      value: DynamicStringSchema.describe(
+        'JSON-encoded value to display. An object/array renders as a JSON tree; a string can be shown as text/markdown/json.',
+      ),
+      initialFormat: z
+        .enum(FORMATS)
+        .describe('Initial display format for string values (json/text/markdown).')
+        .optional(),
+      hideFormatToggle: z.boolean().describe('When true, hides the per-value format dropdown.').optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+// ModelTraceExplorerCodeSnippet expects `data` to be a valid JSON string (it
+// runs JSON.parse on it) and renders a JSON tree when it parses to a non-string.
+// `value` is a DynamicString, so at runtime it can resolve to a real object/array
+// (e.g. bound to a data-model path), not just a JSON-encoded string. Serialize
+// objects/arrays directly so they render as a tree instead of "[object Object]".
+const toJsonString = (value: unknown): string => {
+  if (typeof value === 'object' && value !== null) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      // Non-serializable (e.g. circular): keep the output valid JSON so the
+      // downstream JSON.parse doesn't throw.
+      return JSON.stringify(String(value));
+    }
+  }
+  const str = asString(value);
+  try {
+    JSON.parse(str);
+    return str;
+  } catch {
+    return JSON.stringify(str);
+  }
+};
+
+export const KeyValueViewer: ReactComponentImplementation = createComponentImplementation(
+  KeyValueViewerApi,
+  ({ props }) => {
+    const label = props.label ? asString(props.label) : '';
+    const initialRenderMode = isFormat(props.initialFormat) ? FORMAT_TO_RENDER_MODE[props.initialFormat] : undefined;
+
+    return (
+      <div css={{ flex: 1, minWidth: 0 }}>
+        <ModelTraceExplorerCodeSnippet
+          title={label}
+          data={toJsonString(props.value)}
+          initialRenderMode={initialRenderMode}
+          hideRenderModeDropdown={props.hideFormatToggle === true}
+        />
+      </div>
+    );
+  },
+);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Markdown.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Markdown.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, DynamicStringSchema } from '@a2ui/web_core/v0_9';
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+
+import { asString } from '../catalogPrimitiveUtils';
+
+import { GenAIMarkdownRenderer } from '../../../genai-markdown-renderer/GenAIMarkdownRenderer';
+import type { GenAIMarkdownRendererProps } from '../../../genai-markdown-renderer/GenAIMarkdownRenderer';
+
+/**
+ * Schema (API) for the Markdown component
+ */
+const MarkdownApi = {
+  name: 'Markdown',
+  schema: z
+    .object({
+      text: DynamicStringSchema.describe('The markdown body.'),
+      title: DynamicStringSchema.describe('Optional heading shown above the markdown.').optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+export const Markdown: ReactComponentImplementation = createComponentImplementation(MarkdownApi, ({ props }) => {
+  const { theme } = useDesignSystemTheme();
+
+  const text = props.text ? asString(props.text) : '';
+  const title = props.title ? asString(props.title) : undefined;
+
+  // Render markdown links as normal links that open in a new tab.
+  const markdownComponents = useMemo<GenAIMarkdownRendererProps['components']>(
+    () => ({
+      a: ({ href, children }: { href?: string; children?: ReactNode }) => (
+        <Typography.Link componentId="shared.model-trace-explorer.custom-view.markdown.link" href={href} openInNewTab>
+          {children}
+        </Typography.Link>
+      ),
+    }),
+    [],
+  );
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+      {title && (
+        <Typography.Text bold size="lg">
+          {title}
+        </Typography.Text>
+      )}
+      <GenAIMarkdownRenderer components={markdownComponents} compact>
+        {text}
+      </GenAIMarkdownRenderer>
+    </div>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/StatCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/StatCard.tsx
@@ -1,0 +1,117 @@
+import type { ComponentType } from 'react';
+
+import { z } from 'zod';
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { type ComponentApi, DynamicStringSchema } from '@a2ui/web_core/v0_9';
+import {
+  CheckCircleIcon,
+  ChecklistIcon,
+  ClockIcon,
+  HashIcon,
+  Typography,
+  useDesignSystemTheme,
+  WrenchIcon,
+  XCircleFillIcon,
+} from '@databricks/design-system';
+
+const ICON_NAMES = ['wrench', 'clock', 'checkCircle', 'xCircle', 'hash', 'checklist'] as const;
+type IconName = (typeof ICON_NAMES)[number];
+
+const TONES = ['info', 'success', 'warning', 'danger'] as const;
+type Tone = (typeof TONES)[number];
+
+const ICON_BY_NAME: Record<IconName, ComponentType> = {
+  wrench: WrenchIcon,
+  clock: ClockIcon,
+  checkCircle: CheckCircleIcon,
+  xCircle: XCircleFillIcon,
+  hash: HashIcon,
+  checklist: ChecklistIcon,
+};
+
+const isIconName = (value: unknown): value is IconName =>
+  typeof value === 'string' && (ICON_NAMES as readonly string[]).includes(value);
+
+const isTone = (value: unknown): value is Tone =>
+  typeof value === 'string' && (TONES as readonly string[]).includes(value);
+
+/**
+ * Schema (API) for the custom StatCard component.
+ */
+const StatCardApi = {
+  name: 'StatCard',
+  schema: z
+    .object({
+      value: DynamicStringSchema.describe('The metric value to display, e.g. "14" or "275.71ms".'),
+      label: DynamicStringSchema.describe('The caption describing the metric.'),
+      icon: z.enum(ICON_NAMES).describe('The icon to display next to the value.').optional(),
+      tone: z
+        .enum(TONES)
+        .default('info')
+        .describe('The color tone applied to the icon (info/success/warning/danger).')
+        .optional(),
+      weight: z.number().describe('Relative flex weight when placed directly inside a Row/Column.').optional(),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
+export const StatCard: ReactComponentImplementation = createComponentImplementation(StatCardApi, ({ props }) => {
+  const { theme } = useDesignSystemTheme();
+
+  const value = typeof props.value === 'string' ? props.value : String(props.value ?? '');
+  const label = typeof props.label === 'string' ? props.label : String(props.label ?? '');
+  const tone: Tone = isTone(props.tone) ? props.tone : 'info';
+  const iconName: IconName = isIconName(props.icon) ? props.icon : 'wrench';
+  const weight = typeof props.weight === 'number' ? props.weight : undefined;
+
+  const toneColor: Record<Tone, string> = {
+    info: theme.colors.blue500,
+    success: theme.colors.green500,
+    warning: theme.colors.yellow500,
+    danger: theme.colors.red500,
+  };
+
+  const iconColor = toneColor[tone];
+  const iconBgColor = `${iconColor}1A`;
+  const IconComponent = ICON_BY_NAME[iconName];
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing.sm,
+        padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+        backgroundColor: theme.colors.backgroundPrimary,
+        borderRadius: theme.borders.borderRadiusMd,
+        border: `1px solid ${theme.colors.border}`,
+        flex: weight ?? 1,
+        minWidth: 160,
+      }}
+    >
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: theme.general.iconSize,
+          height: theme.general.iconSize,
+          borderRadius: theme.borders.borderRadiusMd,
+          backgroundColor: iconBgColor,
+          color: iconColor,
+          flexShrink: 0,
+        }}
+      >
+        <IconComponent />
+      </div>
+      <div css={{ display: 'flex', flexDirection: 'column' }}>
+        <Typography.Text bold size="lg">
+          {value}
+        </Typography.Text>
+        <Typography.Text color="secondary" size="sm">
+          {label}
+        </Typography.Text>
+      </div>
+    </div>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/StatCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/StatCard.tsx
@@ -47,9 +47,9 @@ const StatCardApi = {
       icon: z.enum(ICON_NAMES).describe('The icon to display next to the value.').optional(),
       tone: z
         .enum(TONES)
-        .default('info')
         .describe('The color tone applied to the icon (info/success/warning/danger).')
-        .optional(),
+        .optional()
+        .default('info'),
       weight: z.number().describe('Relative flex weight when placed directly inside a Row/Column.').optional(),
     })
     .strict(),

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
@@ -17,6 +17,14 @@ const HEADING_STYLE = {
 
 const isHeadingVariant = (value: string): value is keyof typeof HEADING_STYLE => value in HEADING_STYLE;
 
+const HEADING_ELEMENT_LEVEL: Record<keyof typeof HEADING_STYLE, 1 | 2 | 3 | 4 | 5> = {
+  h1: 1,
+  h2: 2,
+  h3: 3,
+  h4: 4,
+  h5: 5,
+};
+
 export const Text: ReactComponentImplementation = createComponentImplementation(TextApi, ({ props }) => {
   const text = asString(props.text);
   const variant = typeof props.variant === 'string' ? props.variant : 'body';
@@ -24,11 +32,17 @@ export const Text: ReactComponentImplementation = createComponentImplementation(
   const flexStyle = weight !== undefined ? { flex: `${weight}`, minWidth: 0 } : undefined;
 
   if (isHeadingVariant(variant)) {
-    // h1–h3 map to a Title element for semantics; h4/h5 use the explicit size
-    // on a lower-emphasis Title level so the override drives the visual size.
+    // `level` only picks the Title's visual emphasis, and the explicit HEADING_STYLE size
+    // overrides it anyway, so h4/h5 can share level 3. `elementLevel` renders the heading
+    // element for the requested variant so the document outline stays accurate.
     const level = variant === 'h1' ? 1 : variant === 'h2' ? 2 : 3;
     return (
-      <Typography.Title level={level} withoutMargins css={{ ...flexStyle, ...HEADING_STYLE[variant] }}>
+      <Typography.Title
+        level={level}
+        elementLevel={HEADING_ELEMENT_LEVEL[variant]}
+        withoutMargins
+        css={{ ...flexStyle, ...HEADING_STYLE[variant] }}
+      >
         {text}
       </Typography.Title>
     );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
@@ -1,0 +1,46 @@
+import { createComponentImplementation, type ReactComponentImplementation } from '@a2ui/react/v0_9';
+import { TextApi } from '@a2ui/web_core/v0_9/basic_catalog';
+import { Typography } from '@databricks/design-system';
+
+import { asString } from '../catalogPrimitiveUtils';
+
+/**
+ * Custom Text primitive that overrides the basic catalog's Text.
+ */
+const HEADING_STYLE = {
+  h1: { fontSize: 32, lineHeight: '40px', fontWeight: 700 },
+  h2: { fontSize: 26, lineHeight: '34px', fontWeight: 700 },
+  h3: { fontSize: 22, lineHeight: '30px', fontWeight: 600 },
+  h4: { fontSize: 19, lineHeight: '26px', fontWeight: 600 },
+  h5: { fontSize: 16, lineHeight: '22px', fontWeight: 600 },
+} satisfies Record<string, { fontSize: number; lineHeight: string; fontWeight: number }>;
+
+const isHeadingVariant = (value: string): value is keyof typeof HEADING_STYLE => value in HEADING_STYLE;
+
+export const Text: ReactComponentImplementation = createComponentImplementation(TextApi, ({ props }) => {
+  const text = asString(props.text);
+  const variant = typeof props.variant === 'string' ? props.variant : 'body';
+  const weight = typeof props.weight === 'number' ? props.weight : undefined;
+  const flexStyle = weight !== undefined ? { flex: `${weight}`, minWidth: 0 } : undefined;
+
+  if (isHeadingVariant(variant)) {
+    // h1–h3 map to a Title element for semantics; h4/h5 use the explicit size
+    // on a lower-emphasis Title level so the override drives the visual size.
+    const level = variant === 'h1' ? 1 : variant === 'h2' ? 2 : 3;
+    return (
+      <Typography.Title level={level} withoutMargins css={{ ...flexStyle, ...HEADING_STYLE[variant] }}>
+        {text}
+      </Typography.Title>
+    );
+  }
+
+  if (variant === 'caption') {
+    return (
+      <Typography.Text size="sm" color="secondary" css={flexStyle}>
+        {text}
+      </Typography.Text>
+    );
+  }
+
+  return <Typography.Text css={flexStyle}>{text}</Typography.Text>;
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog-primitives/Text.tsx
@@ -15,7 +15,7 @@ const HEADING_STYLE = {
   h5: { fontSize: 16, lineHeight: '22px', fontWeight: 600 },
 } satisfies Record<string, { fontSize: number; lineHeight: string; fontWeight: number }>;
 
-const isHeadingVariant = (value: string): value is keyof typeof HEADING_STYLE => value in HEADING_STYLE;
+const isHeadingVariant = (value: string): value is keyof typeof HEADING_STYLE => Object.hasOwn(HEADING_STYLE, value);
 
 const HEADING_ELEMENT_LEVEL: Record<keyof typeof HEADING_STYLE, 1 | 2 | 3 | 4 | 5> = {
   h1: 1,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog.json
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog.json
@@ -14,37 +14,6 @@
     "Column": {
       "$ref": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json#/components/Column"
     },
-    "MediaRenderer": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "Renders trace media (image, audio, or PDF). Accepts a direct http(s):// URL, a data: URI, or an mlflow-attachment:// URI. For mlflow-attachment:// URIs the blob is fetched from the trace artifact store and rendered inline (image/audio/PDF are dispatched by content type, with a download fallback for large blobs and a click-to-expand preview for images). Audio and PDFs always arrive as mlflow-attachment:// URIs; only images can be a direct URL.",
-          "properties": {
-            "component": {
-              "const": "MediaRenderer"
-            },
-            "url": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "The media source: an http(s):// URL, a data: URI, or an mlflow-attachment:// URI."
-            },
-            "alt": {
-              "type": "string",
-              "description": "Alternative text describing the media."
-            },
-            "weight": {
-              "type": "number",
-              "description": "Relative flex weight when placed directly inside a Row/Column."
-            }
-          },
-          "required": ["component", "url"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
     "Card": {
       "type": "object",
       "allOf": [
@@ -53,7 +22,7 @@
         },
         {
           "type": "object",
-          "description": "A bordered container around a single child, themed with Databricks Design System tokens (a slightly-darker-than-white surface, border, and rounded corners) so it sits natively in the MLflow UI. To display multiple elements, wrap them in a Row/Column and pass that container's id as the child.",
+          "description": "A bordered container around a SINGLE child, themed with Databricks Design System tokens (a slightly-darker-than-white surface, border, and rounded corners) so it sits natively in the MLflow UI. To display multiple elements, wrap them in a Row/Column and pass that container's id as the child.",
           "properties": {
             "component": {
               "const": "Card"
@@ -80,7 +49,7 @@
         },
         {
           "type": "object",
-          "description": "A single Databricks Design System icon, referenced by name. Accepts the basic catalog's Material-style names (e.g. \"check\", \"close\", \"download\", \"search\", \"settings\", \"warning\", \"error\", \"info\", \"person\", \"folder\", \"star\") which are mapped to the closest DS icon, plus DS-native aliases (e.g. \"trash\", \"gear\", \"pencil\", \"tag\"). Unknown names degrade gracefully to a neutral default icon.",
+          "description": "A single Databricks Design System icon, referenced by name. Accepts the basic catalog's Material-style names (e.g. \"check\", \"close\", \"download\", \"search\", \"settings\", \"warning\", \"error\", \"info\", \"person\", \"folder\", \"star\") which are mapped to the closest DS icon, plus DS-native aliases (e.g. \"trash\", \"gear\", \"pencil\", \"tag\"). Unknown names degrade gracefully to a neutral default icon. Use sparingly: most components (StatCard/AssessmentBoard/etc.) already carry their own icon.",
           "properties": {
             "component": {
               "const": "Icon"
@@ -137,271 +106,6 @@
       ],
       "unevaluatedProperties": false
     },
-    "DataTable": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "A generic, domain-agnostic table. Callers describe the columns and supply rows whose cells are positionally aligned to the columns. An optional per-row color renders a leading indicator dot in the first cell.",
-          "properties": {
-            "component": {
-              "const": "DataTable"
-            },
-            "title": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional heading shown above the table."
-            },
-            "icon": {
-              "type": "string",
-              "description": "Optional icon shown next to the title.",
-              "enum": ["list", "wrench", "clock", "hash", "checklist"]
-            },
-            "columns": {
-              "type": "array",
-              "description": "The ordered column definitions.",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "label": {
-                    "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-                    "description": "The column header text."
-                  },
-                  "align": {
-                    "type": "string",
-                    "description": "Horizontal alignment of the column.",
-                    "enum": ["left", "center", "right"],
-                    "default": "left"
-                  }
-                },
-                "required": ["label"]
-              }
-            },
-            "rows": {
-              "type": "array",
-              "description": "The table rows.",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "color": {
-                    "type": "string",
-                    "description": "Optional CSS color for a leading indicator dot."
-                  },
-                  "cells": {
-                    "type": "array",
-                    "description": "Cell values, positionally aligned to the columns.",
-                    "items": {
-                      "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString"
-                    }
-                  }
-                },
-                "required": ["cells"]
-              }
-            },
-            "emptyMessage": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Text shown when there are no rows."
-            }
-          },
-          "required": ["component", "columns", "rows"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "TimelineChart": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "A generic Gantt-style timeline. Each row is a horizontal bar positioned by its start/end offsets (in milliseconds, relative to a common origin). The component computes the axis, scaling, and duration labels, and works for any number of rows.",
-          "properties": {
-            "component": {
-              "const": "TimelineChart"
-            },
-            "title": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional heading shown above the chart."
-            },
-            "icon": {
-              "type": "string",
-              "description": "Optional icon shown next to the title.",
-              "enum": ["clock", "list", "wrench", "hash", "checklist"]
-            },
-            "rows": {
-              "type": "array",
-              "description": "The timeline rows, in display order.",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "label": {
-                    "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-                    "description": "The row label (e.g. the span name)."
-                  },
-                  "start": {
-                    "type": "number",
-                    "description": "Start offset in milliseconds."
-                  },
-                  "end": {
-                    "type": "number",
-                    "description": "End offset in milliseconds."
-                  },
-                  "depth": {
-                    "type": "number",
-                    "description": "Indentation level for hierarchy.",
-                    "default": 0
-                  },
-                  "color": {
-                    "type": "string",
-                    "description": "Optional CSS color for the bar."
-                  }
-                },
-                "required": ["label", "start", "end"]
-              }
-            },
-            "emptyMessage": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Text shown when there are no rows."
-            }
-          },
-          "required": ["component", "rows"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "TreeView": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "A collapsible tree container. It lays out its TreeNode children (referenced by id) on the left and, when a node with panelItems is selected, shows that node's side panel (built by the host from the span's data) on the right. Selection is also driven by markdown #span:<id> deeplinks inside any markdown. Compose TreeNodes to map 1:1 to spans (with an input/output side panel) or to represent higher-level milestones whose markdown links to spans.",
-          "properties": {
-            "component": {
-              "const": "TreeView"
-            },
-            "title": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional heading shown above the tree."
-            },
-            "children": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList",
-              "description": "The root TreeNode component ids, in display order."
-            },
-            "emptyMessage": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Text shown when there are no nodes."
-            }
-          },
-          "required": ["component", "children"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "TreeNode": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "A composable tree node. Renders a row (icon + label + optional badge) and an optional set of nested child TreeNodes. Attach panelItems directives describing what the host should build in the TreeView side panel when the node is selected (the span's input/output/attributes, a markdown summary, feedback buttons).",
-          "properties": {
-            "component": {
-              "const": "TreeNode"
-            },
-            "label": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "The node label (e.g. the span name). Used when title is absent."
-            },
-            "title": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Preferred node heading; falls back to label."
-            },
-            "icon": {
-              "type": "string",
-              "description": "The span icon type."
-            },
-            "hasException": {
-              "type": "boolean",
-              "description": "Renders the icon in the danger tone with an exception marker."
-            },
-            "isRootSpan": {
-              "type": "boolean",
-              "description": "Renders the icon in the root/AI tone."
-            },
-            "badge": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional trailing tag text (e.g. an assessment count)."
-            },
-            "spanId": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional span id this node represents. Lets markdown #span:<id> deeplinks target this node and scopes the side panel + embedded feedback."
-            },
-            "panelItems": {
-              "type": "array",
-              "description": "Directives for the side panel shown when this node is selected. The host builds the actual components (KeyValueViewer / Markdown / FeedbackThumbsUpDownButtons) from the span data",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "description": "input/output/attributes -> the span field as a KeyValueViewer (the host also auto-renders any media attachments found in the field as players/thumbnails above the JSON); markdown -> a Markdown block; feedback -> thumbs up/down FeedbackThumbsUpDownButtons; rating -> a RadioGroup of options; rationale -> a free-text box paired to a rating with the same name; submit -> a button that logs all staged rating/rationale on this view.",
-                    "enum": ["input", "output", "attributes", "markdown", "feedback", "rating", "rationale", "submit"]
-                  },
-                  "text": {
-                    "type": "string",
-                    "description": "Markdown body (type: markdown). Supports [text](#span:<spanId>) deeplinks."
-                  },
-                  "title": {
-                    "type": "string",
-                    "description": "Section heading (markdown) or value label override."
-                  },
-                  "label": {
-                    "type": "string",
-                    "description": "Prompt text (feedback/rating/rationale) or button text (submit)."
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Assessment + staging name (feedback/rating/rationale). A rating and its rationale must share the same name; make it unique per span."
-                  },
-                  "options": {
-                    "type": "array",
-                    "description": "Selectable options for a rating (type: rating).",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "label": { "type": "string" },
-                        "value": { "type": "string" }
-                      },
-                      "required": ["label", "value"]
-                    }
-                  },
-                  "placeholder": {
-                    "type": "string",
-                    "description": "Placeholder for a rationale text box (type: rationale)."
-                  }
-                },
-                "required": ["type"]
-              }
-            },
-            "children": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList",
-              "description": "Nested TreeNode ids, rendered indented below this node."
-            }
-          },
-          "required": ["component"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
     "Markdown": {
       "type": "object",
       "allOf": [
@@ -410,14 +114,14 @@
         },
         {
           "type": "object",
-          "description": "Renders a markdown text block (optionally under a title). Links of the form [text](#span:<spanId>) are deeplinks: instead of navigating, they select that span's node in the TreeView. Typically built by the host inside a TreeNode side panel, but usable anywhere.",
+          "description": "Renders a markdown text block (optionally under a title).",
           "properties": {
             "component": {
               "const": "Markdown"
             },
             "text": {
               "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "The markdown body. Supports [text](#span:<spanId>) deeplinks when inside a TreeView."
+              "description": "The markdown body."
             },
             "title": {
               "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
@@ -437,7 +141,7 @@
         },
         {
           "type": "object",
-          "description": "Displays a single labeled value, with a format toggle (text/json/markdown for strings; an interactive JSON tree for objects/arrays). Use it to show one span attribute/input/output field directly.",
+          "description": "Displays a SINGLE labeled value using the Details & Timeline snippet renderer, with a format toggle (text/json/markdown for strings; an interactive JSON tree for objects/arrays). Use it to show one span attribute/input/output field directly.",
           "properties": {
             "component": {
               "const": "KeyValueViewer"
@@ -540,201 +244,41 @@
         }
       ],
       "unevaluatedProperties": false
-    },
-    "FeedbackThumbsUpDownButtons": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "An interactive thumbs up / thumbs down control. Clicking a feedback button logs an MLflow feedback assessment (boolean: thumbs up = true, thumbs down = false) for the current trace and reflects the choice via its bound value. A lightweight alternative to the full assessment input form.",
-          "properties": {
-            "component": {
-              "const": "FeedbackThumbsUpDownButtons"
-            },
-            "label": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional prompt shown next to the thumbs, e.g. \"Was this helpful?\"."
-            },
-            "name": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "The assessment name to log. Defaults to \"User feedback\"."
-            },
-            "value": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicBoolean",
-              "description": "Selected state: true = thumbs up, false = thumbs down. Bind to a /feedback/... data-model path to reflect and seed the choice."
-            },
-            "spanId": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional span id to scope the feedback to a specific span instead of the whole trace."
-            },
-            "weight": {
-              "type": "number",
-              "description": "Relative flex weight when placed directly inside a Row/Column."
-            }
-          },
-          "required": ["component"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "RadioGroup": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "An interactive single-choice control for human feedback. Selecting an option stages the choice host-side under \"name\"; it is logged as an MLflow feedback assessment (string value) only when a FeedbackSubmit button is clicked. Emit one RadioGroup per feedback dimension, each with a unique \"name\".",
-          "properties": {
-            "component": {
-              "const": "RadioGroup"
-            },
-            "label": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional prompt shown above the options, e.g. \"Who did better on Accuracy?\"."
-            },
-            "name": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "The assessment name this dimension logs (also the staging key). Required and unique per dimension; a FeedbackInputText sharing this name attaches as its rationale."
-            },
-            "options": {
-              "type": "array",
-              "description": "The selectable options, in display order.",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "label": {
-                    "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-                    "description": "The option text shown to the user."
-                  },
-                  "value": {
-                    "type": "string",
-                    "description": "The feedback value logged when this option is selected."
-                  }
-                },
-                "required": ["label", "value"]
-              }
-            },
-            "value": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Selected option value. Bind to a /feedback/... data-model path to reflect and seed the choice."
-            },
-            "spanId": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional span id to scope the feedback to a specific span instead of the whole trace."
-            },
-            "weight": {
-              "type": "number",
-              "description": "Relative flex weight when placed directly inside a Row/Column."
-            }
-          },
-          "required": ["component", "name", "options"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "FeedbackInputText": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "A feedback-scoped free-text box (not a generic input). Its text is staged host-side under \"name\" and logged only on FeedbackSubmit. \"field\" controls what the text populates: \"rationale\" (default) attaches an optional why to a RadioGroup sharing the same \"name\"; \"value\" makes a standalone free-text feedback value (no radio needed).",
-          "properties": {
-            "component": {
-              "const": "FeedbackInputText"
-            },
-            "label": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional prompt shown above the box, e.g. \"Optional rationale (why?)\"."
-            },
-            "name": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "The assessment name this text logs. Match a RadioGroup's name to attach as rationale, or use a unique name for a standalone free-text value."
-            },
-            "field": {
-              "type": "string",
-              "enum": ["value", "rationale"],
-              "description": "Whether the typed text becomes the assessment \"value\" or its \"rationale\". Defaults to \"rationale\"."
-            },
-            "placeholder": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Placeholder text shown when the box is empty."
-            },
-            "value": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Bind to a /feedback/... data-model path to reflect and seed the text."
-            },
-            "spanId": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Optional span id to scope the feedback to a specific span instead of the whole trace."
-            },
-            "weight": {
-              "type": "number",
-              "description": "Relative flex weight when placed directly inside a Row/Column."
-            }
-          },
-          "required": ["component", "name"]
-        }
-      ],
-      "unevaluatedProperties": false
-    },
-    "FeedbackSubmit": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-        },
-        {
-          "type": "object",
-          "description": "A button that submits all staged feedback (from RadioGroup / FeedbackInputText) on the view. Clicking it logs one MLflow assessment per staged dimension and clears the staged values. Emit exactly one per view when collecting multi-dimension feedback.",
-          "properties": {
-            "component": {
-              "const": "FeedbackSubmit"
-            },
-            "label": {
-              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
-              "description": "Button text. Defaults to \"Submit feedback\"."
-            },
-            "weight": {
-              "type": "number",
-              "description": "Relative flex weight when placed directly inside a Row/Column."
-            }
-          },
-          "required": ["component"]
-        }
-      ],
-      "unevaluatedProperties": false
     }
   },
   "$defs": {
     "anyComponent": {
       "oneOf": [
-        { "$ref": "#/components/Text" },
-        { "$ref": "#/components/Row" },
-        { "$ref": "#/components/Column" },
-        { "$ref": "#/components/MediaRenderer" },
-        { "$ref": "#/components/Card" },
-        { "$ref": "#/components/Icon" },
-        { "$ref": "#/components/StatCard" },
-        { "$ref": "#/components/DataTable" },
-        { "$ref": "#/components/TimelineChart" },
-        { "$ref": "#/components/TreeView" },
-        { "$ref": "#/components/TreeNode" },
-        { "$ref": "#/components/Markdown" },
-        { "$ref": "#/components/KeyValueViewer" },
-        { "$ref": "#/components/AssessmentCard" },
-        { "$ref": "#/components/AssessmentBoard" },
-        { "$ref": "#/components/FeedbackThumbsUpDownButtons" },
-        { "$ref": "#/components/RadioGroup" },
-        { "$ref": "#/components/FeedbackInputText" },
-        { "$ref": "#/components/FeedbackSubmit" }
+        {
+          "$ref": "#/components/Text"
+        },
+        {
+          "$ref": "#/components/Row"
+        },
+        {
+          "$ref": "#/components/Column"
+        },
+        {
+          "$ref": "#/components/Card"
+        },
+        {
+          "$ref": "#/components/Icon"
+        },
+        {
+          "$ref": "#/components/StatCard"
+        },
+        {
+          "$ref": "#/components/Markdown"
+        },
+        {
+          "$ref": "#/components/KeyValueViewer"
+        },
+        {
+          "$ref": "#/components/AssessmentCard"
+        },
+        {
+          "$ref": "#/components/AssessmentBoard"
+        }
       ],
       "discriminator": {
         "propertyName": "component"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog.json
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalog.json
@@ -99,6 +99,10 @@
               "description": "The color tone applied to the icon.",
               "enum": ["info", "success", "warning", "danger"],
               "default": "info"
+            },
+            "weight": {
+              "type": "number",
+              "description": "Relative flex weight when placed directly inside a Row/Column."
             }
           },
           "required": ["component", "value", "label"]

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalogPrimitiveUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalogPrimitiveUtils.ts
@@ -1,0 +1,11 @@
+/** Coerces an A2UI DynamicString prop value to a plain string for rendering. */
+export const asString = (value: unknown): string => (typeof value === 'string' ? value : String(value ?? ''));
+
+/** JSON.stringify that never throws — falls back to a JSON string for String(value). */
+export const safeJsonStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return JSON.stringify(String(value));
+  }
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalogPrimitiveUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/catalogPrimitiveUtils.ts
@@ -4,7 +4,8 @@ export const asString = (value: unknown): string => (typeof value === 'string' ?
 /** JSON.stringify that never throws — falls back to a JSON string for String(value). */
 export const safeJsonStringify = (value: unknown): string => {
   try {
-    return JSON.stringify(value ?? null);
+    // Functions and symbols serialize to `undefined`, which would break the `string` contract.
+    return JSON.stringify(value ?? null) ?? 'null';
   } catch {
     return JSON.stringify(String(value));
   }

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -5,6 +5,47 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@a2ui/markdown-it@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@a2ui/markdown-it@npm:0.0.3"
+  dependencies:
+    dompurify: "npm:^3.3.1"
+    markdown-it: "npm:^14.1.0"
+  peerDependencies:
+    "@a2ui/web_core": ^0.9.2
+  checksum: 10c0/a8dfe917d9f08bfd432668554d3369445cb3e5e43d262975a53cb405356ef7e6b3b0fa29e540c7907302b11b28871b0629e3c7d12585803ef4c55ba6f4588be3
+  languageName: node
+  linkType: hard
+
+"@a2ui/react@npm:^0.9.0":
+  version: 0.9.1
+  resolution: "@a2ui/react@npm:0.9.1"
+  dependencies:
+    "@a2ui/markdown-it": "npm:^0.0.3"
+    "@a2ui/web_core": "npm:^0.9.2"
+    clsx: "npm:^2.1.0"
+    markdown-it: "npm:^14.0.0"
+    zod: "npm:^3.23.8"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    zod: ^3.23.8
+  checksum: 10c0/e6e5715b25da1e74c48e62b273ab8d2d8695eb16ae5c4171788227c4adef80ef2553b94eab0ec41b0039594028d47e30d7dc4879fc358db867bc490e47be1293
+  languageName: node
+  linkType: hard
+
+"@a2ui/web_core@npm:^0.9.0, @a2ui/web_core@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "@a2ui/web_core@npm:0.9.2"
+  dependencies:
+    "@preact/signals-core": "npm:^1.13.0"
+    date-fns: "npm:^4.1.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/af0b0dcdca8a716ce676e518bcb5c541dbc3c79fdb43b1bcf8bea4f8a6311cafb3c8cee50e7ad3acc15aff6f46cae232ea20ca4721e36f65f2531f2e9389e468
+  languageName: node
+  linkType: hard
+
 "@aashutoshrathi/word-wrap@npm:^1.2.3":
   version: 1.2.6
   resolution: "@aashutoshrathi/word-wrap@npm:1.2.6"
@@ -4827,6 +4868,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mlflow/mlflow@workspace:."
   dependencies:
+    "@a2ui/react": "npm:^0.9.0"
+    "@a2ui/web_core": "npm:^0.9.0"
     "@ag-grid-community/client-side-row-model": "npm:^27.2.1"
     "@ag-grid-community/core": "npm:^27.2.1"
     "@ag-grid-community/react": "npm:^27.2.1"
@@ -4983,6 +5026,7 @@ __metadata:
     wavesurfer.js: "npm:^7.8.8"
     webpack: "npm:^5.69.0"
     whatwg-fetch: "npm:^3.6.17"
+    zod: "npm:^3.25.0"
     zustand: "npm:^4.5.6"
   languageName: unknown
   linkType: soft
@@ -5778,6 +5822,13 @@ __metadata:
     webpack-plugin-serve:
       optional: true
   checksum: 10c0/afe7d5d5895f2edc1f4336e57082072736a27d79389eabc6c4e1297dae08da06e01d17f1b3866ed871989e070dbc3ec14ad8a1a88a22b11c1c530db5aa67fa12
+  languageName: node
+  linkType: hard
+
+"@preact/signals-core@npm:^1.13.0":
+  version: 1.14.4
+  resolution: "@preact/signals-core@npm:1.14.4"
+  checksum: 10c0/963622e5c1c98a6946ec1ad01e9901ebacf316ab0a7e3c56c6ebaefee5b2c8ea03c3bdb8ba74120612b5f8976f5dc94693134670e372dded79db9994045aadd1
   languageName: node
   linkType: hard
 
@@ -10581,7 +10632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:*, @types/trusted-types@npm:^2.0.2":
+"@types/trusted-types@npm:*, @types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
@@ -14779,7 +14830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.0.0, clsx@npm:^2.1.1":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.0, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
@@ -16469,6 +16520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^4.1.0":
+  version: 4.4.0
+  resolution: "date-fns@npm:4.4.0"
+  checksum: 10c0/988f0a13db183f5dfc85c36bbb6847a9c135a9225888bbea4005876ec15539a8613c21a07370a4e7ea543918d5a1cafb423c528b42cdbbde5fdfddb178126b21
+  languageName: node
+  linkType: hard
+
 "date-now@npm:^0.1.4":
   version: 0.1.4
   resolution: "date-now@npm:0.1.4"
@@ -17139,6 +17197,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dompurify@npm:^3.3.1":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  languageName: node
+  linkType: hard
+
 "domutils@npm:^1.7.0":
   version: 1.7.0
   resolution: "domutils@npm:1.7.0"
@@ -17503,7 +17573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -24133,6 +24203,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
+  dependencies:
+    uc.micro: "npm:^2.0.0"
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
+  languageName: node
+  linkType: hard
+
 "listr2@npm:^4.0.5":
   version: 4.0.5
   resolution: "listr2@npm:4.0.5"
@@ -24684,6 +24763,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^14.0.0, markdown-it@npm:^14.1.0":
+  version: 14.3.0
+  resolution: "markdown-it@npm:14.3.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    entities: "npm:^4.5.0"
+    linkify-it: "npm:^5.0.2"
+    mdurl: "npm:^2.0.0"
+    punycode.js: "npm:^2.3.1"
+    uc.micro: "npm:^2.1.0"
+  bin:
+    markdown-it: bin/markdown-it.mjs
+  checksum: 10c0/b2dea908968109d6e9088ac972254bca842157d85d2e6838d0eb263cd8106e7e6a72663b138366cc98f57441d9f3f2ebfb842bf7b2f9e1c13187ebe70e0af8f9
+  languageName: node
+  linkType: hard
+
 "markdown-table@npm:^3.0.0":
   version: 3.0.3
   resolution: "markdown-table@npm:3.0.3"
@@ -24985,6 +25080,13 @@ __metadata:
   version: 1.0.1
   resolution: "mdurl@npm:1.0.1"
   checksum: 10c0/ea8534341eb002aaa532a722daef6074cd8ca66202e10a2b4cda46722c1ebdb1da92197ac300bc953d3ef1bf41cd6561ef2cc69d82d5d0237dae00d4a61a4eee
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "mdurl@npm:2.1.0"
+  checksum: 10c0/aed11a75b791d596c7104fa6a3d84680e87cd2bfdb32ecfe512e795481d40a64b21d627b325ffd58aadcd15faf7498ac06130b8f198ebec437aceeead24bd1b1
   languageName: node
   linkType: hard
 
@@ -29158,6 +29260,13 @@ __metadata:
     inherits: "npm:^2.0.3"
     pump: "npm:^2.0.0"
   checksum: 10c0/0bcabf9e3dbf2d0cc1f9b84ac80d3c75386111caf8963bfd98817a1e2192000ac0ccc804ca6ccd5b2b8430fdb71347b20fb2f014fe3d41adbacb1b502a841c45
+  languageName: node
+  linkType: hard
+
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 10c0/1d12c1c0e06127fa5db56bd7fdf698daf9a78104456a6b67326877afc21feaa821257b171539caedd2f0524027fa38e67b13dd094159c8d70b6d26d2bea4dfdb
   languageName: node
   linkType: hard
 
@@ -34728,6 +34837,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10c0/8862eddb412dda76f15db8ad1c640ccc2f47cdf8252a4a30be908d535602c8d33f9855dfcccb8b8837855c1ce1eaa563f7fa7ebe3c98fd0794351aab9b9c55fa
+  languageName: node
+  linkType: hard
+
 "uglify-js@npm:^3.1.4":
   version: 3.19.3
   resolution: "uglify-js@npm:3.19.3"
@@ -37107,12 +37223,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+  languageName: node
+  linkType: hard
+
 "zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
   peerDependencies:
     zod: ^3.25.0 || ^4.0.0
   checksum: 10c0/0ccfec48c46de1be440b719cd02044d4abb89ed0e14c13e637cd55bf29102f67ccdba373f25def0fc7130e5f15025be4d557a7edcc95d5a3811599aade689e1b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8, zod@npm:^3.25.0, zod@npm:^3.25.76":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24788/files) to review incremental changes.
- [**stack/feat/custom-view-schema-comp-imple**](https://github.com/mlflow/mlflow/pull/24788) [[Files changed](https://github.com/mlflow/mlflow/pull/24788/files)] ← _this PR_
  - [stack/feat/custom-view-2-validate-a2ui-message](https://github.com/mlflow/mlflow/pull/24792) [[Files changed](https://github.com/mlflow/mlflow/pull/24792/files/d611db7c8e4a8cfd6ad4e28dccf704424ffcf033..2b66ed55f4c3e4af7dfc1945b23c3729a7d38cfa)]
    - [stack/feat/custom-view-3-prompt-builder-and-template-resolver](https://github.com/mlflow/mlflow/pull/24794) [[Files changed](https://github.com/mlflow/mlflow/pull/24794/files/2b66ed55f4c3e4af7dfc1945b23c3729a7d38cfa..bab0da71cad31096cabc7cc15a6743882b31836b)]
      - [stack/feat/custom-view-4-assistant-bridge-integration-for-non-cli-agents](https://github.com/mlflow/mlflow/pull/24796) [[Files changed](https://github.com/mlflow/mlflow/pull/24796/files/bab0da71cad31096cabc7cc15a6743882b31836b..a0a13dddc61653ff082046c0a0fd07222597b1f3)]
        - [stack/feat/custom-view-5-definition-content-and-fe-wiring](https://github.com/mlflow/mlflow/pull/24798) [[Files changed](https://github.com/mlflow/mlflow/pull/24798/files/a0a13dddc61653ff082046c0a0fd07222597b1f3..011210b8ee6c3c97e86fa683ddbab89a7208e0af)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

Updated A2UI catalog schema and added typed primitives for custom trace views

This is PR 1 of a 5-PR stack porting the Custom View feature (an agent-authored A2UI layout in the trace explorer) from Databricks' internal implementation to OSS MLflow. This PR lands only the rendering foundation — no UI is mounted and no behavior is visible yet:

- Add @a2ui/react and @a2ui/web_core as dependencies (package.json, yarn.lock).
- Updated custom-view/catalog.json A2UI component catalog
- Add custom-view/catalogPrimitiveUtils.ts — small shared helpers for the primitive components.
- Add 8 zod-validated catalog primitive components under custom-view/catalog-primitives/: Text, Card, Icon, StatCard, Markdown, KeyValueViewer, AssessmentBoard, AssessmentCard.
- Update craco.config.js / jest.babel.config.js with the moduleNameMapper/Babel plugin fixes needed for Jest to resolve and transpile the ESM-only @a2ui packages (subpath exports + ES2022 static class blocks).

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
