### PR TITLE
[2/N] Add data-source binding and A2UI message/template validator

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.test.ts
@@ -242,3 +242,54 @@ describe('validateTemplate catalog allowlist', () => {
     });
   });
 });
+
+// A2UI types `updateDataModel.value` as `z.any()`, and components can read it
+// back through a `{ "path": ... }` DynamicString binding, so the data model
+// would otherwise be an unchecked route around the component-level rules.
+describe('validateTemplate data model', () => {
+  const templateWithDataModel = (value: unknown) => [
+    {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'main',
+        components: [{ id: 'root', component: 'Text', text: { path: '/heading' } }],
+      },
+    },
+    { version: 'v0.9', updateDataModel: { surfaceId: 'main', value } },
+  ];
+
+  it('accepts literal data-model values bound by path', () => {
+    const result = validateTemplate(templateWithDataModel({ heading: 'Trace summary', counts: [1, 2, 3] }));
+    expect(result).toEqual({ ok: true, messages: expect.any(Array) });
+  });
+
+  it('rejects a "#span:" deeplink smuggled into the data model', () => {
+    const result = validateTemplate(templateWithDataModel({ heading: 'See [the call](#span:span-abc-123)' }));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('"#span:" deeplink'),
+    });
+  });
+
+  it('rejects a "#span:" deeplink nested inside arrays and objects', () => {
+    const result = validateTemplate(templateWithDataModel({ rows: [{ label: 'ok' }, { label: '#span:abc' }] }));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('"#span:" deeplink'),
+    });
+  });
+
+  // Markers are never resolved in the data model, so even well-formed ones would
+  // render as raw JSON — reject them rather than persist a broken binding.
+  it.each([
+    ['a valid $source marker', { heading: { $source: 'metrics.latency' } }, '$source'],
+    ['an unknown $source marker', { heading: { $source: 'metrics.bogus' } }, '$source'],
+    ['a $spanRef marker', { heading: { $spanRef: 'root' } }, '$spanRef'],
+  ])('rejects %s in the data model', (_label, value, marker) => {
+    const result = validateTemplate(templateWithDataModel(value));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining(`"${marker}" marker`),
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { validateAndPrepareMessages, validateTemplate } from './validateA2uiMessages';
+
+// A concrete (marker-free) per-trace message stream, as `resolveTemplate`
+// produces it — the input `validateAndPrepareMessages` strict-validates before
+// the stream reaches the (catalog-unaware) renderer.
+const resolvedMessages = (components: unknown[]) => [
+  {
+    version: 'v0.9',
+    updateComponents: {
+      surfaceId: 'main',
+      components,
+    },
+  },
+];
+
+const prepare = (components: unknown[]) =>
+  validateAndPrepareMessages(resolvedMessages(components), { surfaceId: 'surface-1', catalogId: 'catalog-1' });
+
+const assessmentBoardTemplate = (childrenMarker: Record<string, unknown>) => [
+  {
+    version: 'v0.9',
+    updateComponents: {
+      surfaceId: 'main',
+      components: [
+        {
+          id: 'root',
+          component: 'AssessmentBoard',
+          title: 'Assessments',
+          children: childrenMarker,
+        },
+      ],
+    },
+  },
+];
+
+const columnTemplate = (children: unknown) => [
+  {
+    version: 'v0.9',
+    updateComponents: {
+      surfaceId: 'main',
+      components: [
+        { id: 'root', component: 'Column', children },
+        { id: 'child-a', component: 'Text', text: 'A' },
+      ],
+    },
+  },
+];
+
+// TreeView / TreeNode and DataTable were removed from the catalog, so a view
+// saved while they existed no longer validates. The closed allowlist rejects them
+// on every path, which surfaces the "rebuild it with the assistant" placeholder
+// instead of forwarding an unknown component to the renderer.
+describe('validateTemplate removed catalog primitives', () => {
+  const componentTemplate = (component: Record<string, unknown>) => [
+    { version: 'v0.9', updateComponents: { surfaceId: 'main', components: [component] } },
+  ];
+
+  it.each(['TreeView', 'TreeNode'])('rejects a stored %s template as an unknown component type', (component) => {
+    const result = validateTemplate(componentTemplate({ id: 'root', component, children: ['child-a'] }));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining(`unknown component type "${component}"`),
+    });
+  });
+
+  it('rejects a stored DataTable template as an unknown component type', () => {
+    const result = validateTemplate(
+      componentTemplate({
+        id: 'root',
+        component: 'DataTable',
+        title: 'Tool Performance',
+        columns: [{ label: 'Tool' }],
+      }),
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('unknown component type "DataTable"'),
+    });
+  });
+
+  it.each(['spanTree', 'toolRows'])('rejects the removed "%s" source', (source) => {
+    const result = validateTemplate(componentTemplate({ id: 'root', component: 'Text', text: { $source: source } }));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining(`references unknown $source "${source}"`),
+    });
+  });
+});
+
+describe('validateTemplate children source binding', () => {
+  it('accepts literal child ids on a layout container', () => {
+    const result = validateTemplate(columnTemplate(['child-a']));
+    expect(result).toEqual({ ok: true, messages: expect.any(Array) });
+  });
+
+  it('accepts a structural source on AssessmentBoard children', () => {
+    const result = validateTemplate(assessmentBoardTemplate({ $source: 'assessments' }));
+    expect(result).toEqual({ ok: true, messages: expect.any(Array) });
+  });
+
+  it('rejects a scalar source bound to children', () => {
+    const result = validateTemplate(columnTemplate({ $source: 'metrics.latency' }));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('binds a non-structural "metrics.latency" source to "children"'),
+    });
+  });
+
+  it('rejects spanField bound to children', () => {
+    const result = validateTemplate(columnTemplate({ $source: 'spanField', spanRef: 'root', field: 'outputs' }));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('binds a non-structural "spanField" source to "children"'),
+    });
+  });
+});
+
+// The validator is a CLOSED catalog allowlist. It must reject any component type
+// or prop the catalog does not define so that no injected component
+// (iframe/script/etc.) or unlisted field reaches the Console DOM via the
+// catalog-unaware A2UI renderer.
+describe('validateAndPrepareMessages catalog allowlist', () => {
+  it('accepts valid basic and custom catalog components', () => {
+    const result = prepare([
+      { id: 'root', component: 'Column', children: ['row', 'txt'], align: 'stretch' },
+      { id: 'row', component: 'Row', children: ['stat'], align: 'stretch' },
+      { id: 'stat', component: 'StatCard', value: '14', label: 'Tool calls', icon: 'wrench', weight: 1 },
+      { id: 'txt', component: 'Text', text: 'Summary', variant: 'h4', weight: 1 },
+    ]);
+    expect(result).toEqual({ ok: true, messages: expect.any(Array) });
+  });
+
+  it('rejects an unknown / injected component type', () => {
+    const result = prepare([
+      { id: 'root', component: 'Column', children: ['evil'] },
+      { id: 'evil', component: 'iframe', src: 'https://evil.example/xss' },
+    ]);
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('unknown component type "iframe"'),
+    });
+  });
+
+  it('rejects an unlisted prop on a basic component (no unknown-field passthrough)', () => {
+    const result = prepare([{ id: 'root', component: 'Text', text: 'hi', onClick: 'doEvil()' }]);
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('invalid props'),
+    });
+  });
+
+  it('rejects a raw dangerouslySetInnerHTML-style prop on a basic layout component', () => {
+    const result = prepare([
+      {
+        id: 'root',
+        component: 'Row',
+        children: ['x'],
+        dangerouslySetInnerHTML: { __html: '<img src=x onerror=alert(1)>' },
+      },
+    ]);
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('invalid props'),
+    });
+  });
+
+  it('rejects an unlisted prop on a custom component', () => {
+    const result = prepare([
+      { id: 'root', component: 'Column', children: ['stat'] },
+      { id: 'stat', component: 'StatCard', value: '1', label: 'x', bogusProp: true },
+    ]);
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('invalid props'),
+    });
+  });
+
+  it('accepts the "justify" prop on Row/Column (a renderer-supported layout prop)', () => {
+    const result = prepare([
+      { id: 'root', component: 'Column', children: ['row'], justify: 'spaceBetween' },
+      { id: 'row', component: 'Row', children: ['txt'], justify: 'center', align: 'stretch' },
+      { id: 'txt', component: 'Text', text: 'Hi' },
+    ]);
+    expect(result).toEqual({ ok: true, messages: expect.any(Array) });
+  });
+
+  // The allowlist is keyed on a null-prototype object, so a component named after
+  // an Object.prototype member is rejected (not silently accepted) and never
+  // crashes the strict per-trace validator via a truthy non-schema lookup.
+  it.each(['constructor', 'toString', 'hasOwnProperty', '__proto__', 'valueOf'])(
+    'rejects a component whose type collides with Object.prototype member "%s"',
+    (name) => {
+      const result = prepare([
+        { id: 'root', component: 'Column', children: ['evil'] },
+        { id: 'evil', component: name },
+      ]);
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining(`unknown component type "${name}"`),
+      });
+    },
+  );
+});
+
+describe('validateTemplate catalog allowlist', () => {
+  const templateWith = (components: unknown[]) => [
+    { version: 'v0.9', updateComponents: { surfaceId: 'main', components } },
+  ];
+
+  it('rejects an unknown / injected component type at save time', () => {
+    const result = validateTemplate(
+      templateWith([
+        { id: 'root', component: 'Column', children: ['evil'] },
+        { id: 'evil', component: 'script', text: 'alert(1)' },
+      ]),
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('unknown component type "script"'),
+    });
+  });
+
+  it('still accepts a basic component whose data prop holds a binding marker', () => {
+    const result = validateTemplate(
+      templateWith([{ id: 'root', component: 'Text', text: { $source: 'spanField', spanRef: 'root', field: 'name' } }]),
+    );
+    expect(result).toEqual({ ok: true, messages: expect.any(Array) });
+  });
+
+  it('rejects a component whose type collides with an Object.prototype member', () => {
+    const result = validateTemplate(
+      templateWith([
+        { id: 'root', component: 'Column', children: ['evil'] },
+        { id: 'evil', component: 'constructor' },
+      ]),
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('unknown component type "constructor"'),
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.test.ts
@@ -241,6 +241,20 @@ describe('validateTemplate catalog allowlist', () => {
       error: expect.stringContaining('unknown component type "constructor"'),
     });
   });
+
+  // A2UI marks `id` optional, so an id-less component clears the envelope schema.
+  // The per-trace validator rejects it, so accepting it at save time would persist
+  // a view that can never render.
+  it.each([
+    ['an absent id', { component: 'Text', text: 'orphan' }],
+    ['an empty id', { id: '', component: 'Text', text: 'orphan' }],
+  ])('rejects a template component with %s', (_label, orphan) => {
+    const result = validateTemplate(templateWith([{ id: 'root', component: 'Column', children: ['a'] }, orphan]));
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('missing a non-empty "id"'),
+    });
+  });
 });
 
 // A2UI types `updateDataModel.value` as `z.any()`, and components can read it

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.ts
@@ -304,6 +304,14 @@ const validateTemplateComponent = (component: Record<string, unknown>): string |
     return `Component "${id}" has an unknown component type "${componentName}". Only components defined in the custom-view catalog are allowed.`;
   }
 
+  // A2UI types `id` as optional, but an id-less component is unreferenceable and
+  // the per-trace validator rejects it — so without this guard the template saves
+  // and then fails to render forever. Fail at save time, while the agent can still
+  // repair it.
+  if (component['id'] === undefined || component['id'] === null || component['id'] === '') {
+    return `Component "${componentName}" is missing a non-empty "id".`;
+  }
+
   if ('renderIfSpan' in component && !isValidSpanRefSelector(unwrapSpanRefSelector(component['renderIfSpan']))) {
     return (
       `Component "${id}" (${componentName}) has an invalid "renderIfSpan" guard. Use a spanRef selector: ` +
@@ -519,7 +527,7 @@ export const validateTemplate = (raw: unknown): TemplateValidateResult => {
           error: `Invalid updateDataModel message: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
         };
       }
-      const dataModelError = validateTemplateDataModelValue(payload?.['value']);
+      const dataModelError = validateTemplateDataModelValue(parsed.data.updateDataModel.value);
       if (dataModelError) {
         return { ok: false, error: dataModelError };
       }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.ts
@@ -1,0 +1,485 @@
+import { z, type ZodTypeAny } from 'zod';
+import {
+  type A2uiMessage,
+  ChildListSchema,
+  CreateSurfaceMessageSchema,
+  DynamicStringSchema,
+  UpdateComponentsMessageSchema,
+  UpdateDataModelMessageSchema,
+} from '@a2ui/web_core/v0_9';
+
+import { AssessmentBoard } from '../catalog-primitives/AssessmentBoard';
+import { AssessmentCard } from '../catalog-primitives/AssessmentCard';
+import { Card } from '../catalog-primitives/Card';
+import { Icon } from '../catalog-primitives/Icon';
+import { KeyValueViewer } from '../catalog-primitives/KeyValueViewer';
+import { Markdown } from '../catalog-primitives/Markdown';
+import { StatCard } from '../catalog-primitives/StatCard';
+import {
+  SPAN_FIELD_SOURCE_NAME,
+  isKnownSource,
+  isRecord,
+  isSourceMarker,
+  isSpanRefMarker,
+  isStructuralSource,
+  isValidSpanFieldMarker,
+  isValidSpanRefSelector,
+  unwrapSpanRefSelector,
+} from '../customViewSources';
+
+// Each catalog primitive's component implementation carries its A2UI `name` and
+// Zod `schema` (via `createComponentImplementation`), so we derive the validation
+// map straight from them — the component impls are the single source of truth, so
+// the primitives don't need to export their schema definitions separately.
+const COMPONENT_SCHEMAS: Record<string, ZodTypeAny> = Object.fromEntries(
+  [StatCard, Icon, Card, Markdown, AssessmentBoard, AssessmentCard, KeyValueViewer].map(
+    (component): [string, ZodTypeAny] => [component.name, component.schema],
+  ),
+);
+
+// Prop shapes for the A2UI "basic catalog" layout primitives (Text / Row /
+// Column). Unlike the custom primitives above, these have no local
+// `ReactComponentImplementation` whose Zod schema we can reuse, so we declare
+// their allowlisted prop shapes here.
+//
+// These MUST mirror the props the A2UI basic-catalog schema (and its React
+// renderer) actually accept — NOT merely the subset documented to the model in
+// `CATALOG_REFERENCE` (buildAgentPrompt.ts). This runs `.strict()` at per-trace
+// render time, so anything the renderer legitimately supports but we omit here
+// would make a valid saved view fail to render (error placeholder). `justify`
+// on Row/Column and `weight` (the shared `CatalogComponentCommon` flex weight)
+// are renderer props even though the prompt doesn't teach all of them; the
+// custom `Text` renderer also reads `variant` / `weight`. `.strict()` still
+// blocks any prop outside this set — no unknown-field passthrough.
+const TEXT_VARIANTS = ['h1', 'h2', 'h3', 'h4', 'h5', 'caption', 'body'] as const;
+const LAYOUT_ALIGNMENTS = ['start', 'center', 'end', 'stretch'] as const;
+// Main-axis distribution enum shared by Row and Column in the basic catalog.
+const LAYOUT_JUSTIFY = ['start', 'center', 'end', 'spaceBetween', 'spaceAround', 'spaceEvenly', 'stretch'] as const;
+
+const BASIC_COMPONENT_SCHEMAS = {
+  Text: z
+    .object({
+      text: DynamicStringSchema,
+      variant: z.enum(TEXT_VARIANTS).optional(),
+      weight: z.number().optional(),
+    })
+    .strict(),
+  Row: z
+    .object({
+      children: ChildListSchema,
+      align: z.enum(LAYOUT_ALIGNMENTS).optional(),
+      justify: z.enum(LAYOUT_JUSTIFY).optional(),
+      weight: z.number().optional(),
+    })
+    .strict(),
+  Column: z
+    .object({
+      children: ChildListSchema,
+      align: z.enum(LAYOUT_ALIGNMENTS).optional(),
+      justify: z.enum(LAYOUT_JUSTIFY).optional(),
+      weight: z.number().optional(),
+    })
+    .strict(),
+} satisfies Record<string, ZodTypeAny>;
+
+// The complete, CLOSED allowlist of catalog component types (custom + basic).
+// The validator is the only gate before the A2UI renderer, which does NOT
+// re-check components against the catalog — so any component type absent from
+// this map (an injected `iframe`/`script`, a typo, an unlisted primitive) must
+// be rejected rather than forwarded to the DOM.
+//
+// Built on a NULL prototype so a component named after an `Object.prototype`
+// member (`constructor`, `toString`, `__proto__`, `hasOwnProperty`, …) can't
+// slip through: with a normal prototype, `'constructor' in schemas` is `true`
+// (bypassing the template-time allowlist) and `schemas['constructor']` resolves
+// to `Object`'s constructor — truthy but with no `.safeParse`, which would throw
+// at per-trace validation instead of cleanly rejecting.
+const CATALOG_COMPONENT_SCHEMAS: Record<string, ZodTypeAny> = Object.assign(
+  Object.create(null),
+  COMPONENT_SCHEMAS,
+  BASIC_COMPONENT_SCHEMAS,
+);
+
+// The A2UI protocol version this custom-view integration targets. Every emitted
+// message carries it, and the authoring prompt references it, so keep it single-sourced.
+export const A2UI_VERSION = 'v0.9';
+
+export type ValidateResult = { ok: true; messages: A2uiMessage[] } | { ok: false; error: string };
+
+// Pulls a message array out of whatever JSON the model returned. We accept the
+// canonical encodings: a bare array, a `{ messages: [...] }` wrapper, or a
+// single message object. Entries stay `unknown` — each caller guards them with
+// `isRecord` before use, so we never assert a shape the model hasn't proven.
+const toMessageArray = (raw: unknown): unknown[] | undefined => {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (isRecord(raw)) {
+    if (Array.isArray(raw['messages'])) {
+      return raw['messages'];
+    }
+    // A single message object (has one of the known top-level keys).
+    if ('createSurface' in raw || 'updateComponents' in raw || 'updateDataModel' in raw) {
+      return [raw];
+    }
+  }
+  return undefined;
+};
+
+// Models occasionally emit a component as `{ id, component, props: { ... } }`
+// (React-style) instead of our flat shape where every prop sits directly on the
+// object alongside `id`/`component`. Hoist a nested `props` object up so both the
+// strict per-component schema and the renderer (which consume the flat shape)
+// see the real props. Existing top-level keys win over the nested ones.
+const flattenComponentProps = (component: Record<string, unknown>): Record<string, unknown> => {
+  if (!isRecord(component['props'])) {
+    return component;
+  }
+  const { props, ...rest } = component;
+  return { ...(props as Record<string, unknown>), ...rest };
+};
+
+// Validates the props of a single component against the catalog schema.
+// `id` and `component` are stripped first since the per-component schemas (like
+// the renderer) only describe the component's own props. Resolved components
+// carry concrete trace data (markers are already resolved to literals), so every
+// prop is validated strictly against its schema, and a component type absent from
+// the catalog allowlist is rejected outright.
+const validateComponentProps = (component: Record<string, unknown>): string | undefined => {
+  const componentName = component['component'];
+  if (typeof componentName !== 'string') {
+    return 'A component is missing its string "component" type.';
+  }
+  if (component['id'] === undefined || component['id'] === null || component['id'] === '') {
+    return `Component "${componentName}" is missing a non-empty "id".`;
+  }
+  const { id: _id, component: _component, ...props } = component;
+
+  const schema = CATALOG_COMPONENT_SCHEMAS[componentName];
+  if (!schema) {
+    // Closed allowlist: an unknown/injected component type must never reach the
+    // renderer (which does not re-check the catalog), so reject it here.
+    return `Component "${String(component['id'])}" has an unknown component type "${componentName}". Only components defined in the custom-view catalog are allowed.`;
+  }
+  const result = schema.safeParse(props);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('; ');
+    return `Component "${String(component['id'])}" (${componentName}) has invalid props: ${detail}`;
+  }
+  return undefined;
+};
+
+/**
+ * Validates and normalizes an LLM-generated A2UI message stream so it can be
+ * safely handed to `MessageProcessor.processMessages` (which does NOT validate
+ * against the catalog). We:
+ *
+ *  - extract the message array from the model's JSON (array / wrapper / single),
+ *  - drop any `createSurface` / `deleteSurface` the model emitted and inject our
+ *    own `createSurface` so the surface id + catalog id are host-controlled
+ *    (the model shouldn't pick surface ids or delete surfaces),
+ *  - rewrite the `surfaceId` on every kept message to the target surface,
+ *  - validate each message envelope (Zod) and each custom component's props,
+ *  - require at least one `updateComponents` containing a `root` component.
+ */
+export const validateAndPrepareMessages = (
+  raw: unknown,
+  { surfaceId, catalogId }: { surfaceId: string; catalogId: string },
+): ValidateResult => {
+  const rawMessages = toMessageArray(raw);
+  if (!rawMessages || rawMessages.length === 0) {
+    return { ok: false, error: 'The model did not return any A2UI messages.' };
+  }
+
+  const kept: A2uiMessage[] = [
+    {
+      version: A2UI_VERSION,
+      createSurface: { surfaceId, catalogId, sendDataModel: true },
+    },
+  ];
+
+  let sawRoot = false;
+
+  for (const message of rawMessages) {
+    if (!isRecord(message)) {
+      return { ok: false, error: 'Encountered a message that is not a JSON object.' };
+    }
+
+    if ('createSurface' in message || 'deleteSurface' in message) {
+      continue;
+    }
+
+    if ('updateComponents' in message) {
+      let payload: Record<string, unknown> | undefined = isRecord(message['updateComponents'])
+        ? { ...message['updateComponents'], surfaceId }
+        : undefined;
+      // Flatten any nested `props` objects so validation and rendering both see
+      // the flat shape we expect.
+      if (payload && Array.isArray(payload['components'])) {
+        payload = {
+          ...payload,
+          components: payload['components'].map((component: unknown) =>
+            isRecord(component) ? flattenComponentProps(component) : component,
+          ),
+        };
+      }
+      const normalized = { version: A2UI_VERSION, updateComponents: payload };
+      const parsed = UpdateComponentsMessageSchema.safeParse(normalized);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: `Invalid updateComponents message: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+        };
+      }
+      const rawComponents = payload?.['components'];
+      const components = Array.isArray(rawComponents) ? rawComponents : [];
+      for (const component of components) {
+        if (!isRecord(component)) {
+          return { ok: false, error: 'A component entry is not a JSON object.' };
+        }
+        if (component['id'] === 'root') {
+          sawRoot = true;
+        }
+        const componentError = validateComponentProps(component);
+        if (componentError) {
+          return { ok: false, error: componentError };
+        }
+      }
+      kept.push(parsed.data);
+      continue;
+    }
+
+    if ('updateDataModel' in message) {
+      const payload = isRecord(message['updateDataModel']) ? { ...message['updateDataModel'], surfaceId } : undefined;
+      const normalized = { version: A2UI_VERSION, updateDataModel: payload };
+      const parsed = UpdateDataModelMessageSchema.safeParse(normalized);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: `Invalid updateDataModel message: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+        };
+      }
+      kept.push(parsed.data);
+      continue;
+    }
+
+    // Unknown / unsupported message shape - ignore it rather than fail the whole
+    // generation, since the processor would reject it anyway.
+  }
+
+  // Sanity-check our own injected createSurface against the schema too.
+  const surfaceCheck = CreateSurfaceMessageSchema.safeParse(kept[0]);
+  if (!surfaceCheck.success) {
+    return { ok: false, error: 'Failed to construct a valid createSurface message.' };
+  }
+
+  if (!sawRoot) {
+    return { ok: false, error: 'The generated UI has no "root" component to render.' };
+  }
+
+  return { ok: true, messages: kept };
+};
+
+// Placeholder surface id stamped on a stored template. The real, host-owned
+// surface id is injected later by `validateAndPrepareMessages` when the resolved
+// per-trace messages are prepared.
+const TEMPLATE_SURFACE_ID = 'main';
+
+// Validates the binding markers + narrative rules for a single template
+// component. Unlike `validateComponentProps`, this does NOT strict-check props
+// against the catalog schema, because data-bearing props hold `$source` /
+// `$spanRef` markers at template time; strict validation happens on the resolved
+// per-trace output. Returns an error string, or undefined when the component is
+// a valid template component.
+const validateTemplateComponent = (component: Record<string, unknown>): string | undefined => {
+  const componentName = typeof component['component'] === 'string' ? component['component'] : '(unknown)';
+  const id = component['id'] === undefined ? '(no id)' : String(component['id']);
+
+  // Reject an off-catalog component at save time (fail fast). Unlike the per-trace
+  // validator we can't strict-check props here — data props still hold markers —
+  // but the component TYPE is a fixed literal, so the closed allowlist applies.
+  if (!(componentName in CATALOG_COMPONENT_SCHEMAS)) {
+    return `Component "${id}" has an unknown component type "${componentName}". Only components defined in the custom-view catalog are allowed.`;
+  }
+
+  if ('renderIfSpan' in component && !isValidSpanRefSelector(unwrapSpanRefSelector(component['renderIfSpan']))) {
+    return (
+      `Component "${id}" (${componentName}) has an invalid "renderIfSpan" guard. Use a spanRef selector: ` +
+      `"root", { "type": "<SPAN_TYPE>", "nth"?: n }, or { "name": "<span name>" }.`
+    );
+  }
+
+  // The structural "assessments" source materializes into a `string[]` of
+  // generated child ids, so it only makes sense on a `children` prop
+  // (AssessmentBoard). `resolveComponent` rewrites ANY prop carrying such a
+  // marker to that child-id list, so binding one to a scalar prop (`child`,
+  // `value`) would silently produce malformed resolved
+  // A2UI at per-trace render. Conversely, a non-structural source on `children`
+  // resolves to a string/array, not child ids — reject both mismatches at save time.
+  for (const [key, propValue] of Object.entries(component)) {
+    if (key !== 'children' && isSourceMarker(propValue) && isStructuralSource(propValue.$source)) {
+      return (
+        `Component "${id}" (${componentName}) binds the structural "${propValue.$source}" source to "${key}", but ` +
+        `structural sources may only bind a "children" prop (AssessmentBoard). Use a scalar or "spanField" ` +
+        `source for data props.`
+      );
+    }
+    if (key === 'children' && isSourceMarker(propValue) && !isStructuralSource(propValue.$source)) {
+      return (
+        `Component "${id}" (${componentName}) binds a non-structural "${propValue.$source}" source to "children", but ` +
+        `only the structural "assessments" source may bind "children" (AssessmentBoard). Use ` +
+        `literal child ids for Row/Column layout, or a scalar or "spanField" source for data props.`
+      );
+    }
+  }
+
+  let error: string | undefined;
+
+  const walk = (value: unknown) => {
+    if (error) {
+      return;
+    }
+    if (isSourceMarker(value)) {
+      if (!isKnownSource(value.$source)) {
+        error = `Component "${id}" (${componentName}) references unknown $source "${value.$source}".`;
+        return;
+      }
+      if (value.$source === SPAN_FIELD_SOURCE_NAME && !isValidSpanFieldMarker(value)) {
+        error =
+          `Component "${id}" (${componentName}) has an invalid spanField marker. Provide a valid "spanRef" ` +
+          `("root" / { "type": "<SPAN_TYPE>", "nth"?: n } / { "name": "<span name>" }) and a "field" of ` +
+          `inputs|outputs|attributes|name|spanId. An optional "path" (non-empty array of string keys / number ` +
+          `indices, e.g. ["choices", 0, "message", "content"]) is allowed only on inputs|outputs|attributes.`;
+        return;
+      }
+      // Fall through to recurse into the marker's other fields so the narrative
+      // rules below apply to any nested strings too.
+    } else if (isSpanRefMarker(value)) {
+      if (!isValidSpanRefSelector(value.$spanRef)) {
+        error =
+          `Component "${id}" (${componentName}) has an invalid $spanRef selector. Use "root", ` +
+          `{ "type": "<SPAN_TYPE>", "nth"?: n }, or { "name": "<span name>" }.`;
+      }
+      return;
+    }
+    if (typeof value === 'string') {
+      // Trace-specific narrative is forbidden in a reusable view: a baked
+      // `#span:<id>` deeplink points at a span that only exists in the authoring
+      // trace, so it breaks on every other trace.
+      if (value.includes('#span:')) {
+        error =
+          `Component "${id}" (${componentName}) contains a "#span:" deeplink. Reusable views cannot embed ` +
+          `trace-specific narrative; bind a "spanField" source to select a span by role instead.`;
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+      return;
+    }
+    if (isRecord(value)) {
+      Object.values(value).forEach(walk);
+    }
+  };
+
+  walk(component);
+  return error;
+};
+
+export type TemplateValidateResult = { ok: true; messages: A2uiMessage[] } | { ok: false; error: string };
+
+/**
+ * Validates a trace-agnostic custom view TEMPLATE (authored once by the LLM with
+ * `$source` / `$spanRef` markers). Unlike `validateAndPrepareMessages`, this is
+ * marker-aware and lenient on data props: it
+ *
+ *  - extracts the message array and drops any createSurface/deleteSurface,
+ *  - normalizes the surface id to a placeholder + flattens nested props,
+ *  - validates each envelope (Zod) and each marker (known source name / valid
+ *    spanRef selector) and rejects forbidden trace-specific narrative,
+ *  - requires a `root` component,
+ *
+ * returning the marker-preserving template to persist. Per-trace rendering then
+ * runs `resolveTemplate` (to swap markers for this trace's data) followed by
+ * `validateAndPrepareMessages` (to strict-validate the resolved components).
+ */
+export const validateTemplate = (raw: unknown): TemplateValidateResult => {
+  const rawMessages = toMessageArray(raw);
+  if (!rawMessages || rawMessages.length === 0) {
+    return { ok: false, error: 'The model did not return any A2UI messages.' };
+  }
+
+  const kept: A2uiMessage[] = [];
+  let sawRoot = false;
+
+  for (const message of rawMessages) {
+    if (!isRecord(message)) {
+      return { ok: false, error: 'Encountered a message that is not a JSON object.' };
+    }
+    if ('createSurface' in message || 'deleteSurface' in message) {
+      continue;
+    }
+
+    if ('updateComponents' in message) {
+      let payload: Record<string, unknown> | undefined = isRecord(message['updateComponents'])
+        ? { ...message['updateComponents'], surfaceId: TEMPLATE_SURFACE_ID }
+        : undefined;
+      if (payload && Array.isArray(payload['components'])) {
+        payload = {
+          ...payload,
+          components: payload['components'].map((component: unknown) =>
+            isRecord(component) ? flattenComponentProps(component) : component,
+          ),
+        };
+      }
+      const normalized = { version: A2UI_VERSION, updateComponents: payload };
+      const parsed = UpdateComponentsMessageSchema.safeParse(normalized);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: `Invalid updateComponents message: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+        };
+      }
+      const rawComponents = payload?.['components'];
+      const components = Array.isArray(rawComponents) ? rawComponents : [];
+      for (const component of components) {
+        if (!isRecord(component)) {
+          return { ok: false, error: 'A component entry is not a JSON object.' };
+        }
+        if (component['id'] === 'root') {
+          sawRoot = true;
+        }
+        const componentError = validateTemplateComponent(component);
+        if (componentError) {
+          return { ok: false, error: componentError };
+        }
+      }
+      kept.push(parsed.data);
+      continue;
+    }
+
+    if ('updateDataModel' in message) {
+      const payload = isRecord(message['updateDataModel'])
+        ? { ...message['updateDataModel'], surfaceId: TEMPLATE_SURFACE_ID }
+        : undefined;
+      const normalized = { version: A2UI_VERSION, updateDataModel: payload };
+      const parsed = UpdateDataModelMessageSchema.safeParse(normalized);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: `Invalid updateDataModel message: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
+        };
+      }
+      kept.push(parsed.data);
+      continue;
+    }
+  }
+
+  if (!sawRoot) {
+    return { ok: false, error: 'The generated UI has no "root" component to render.' };
+  }
+
+  return { ok: true, messages: kept };
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/validateA2uiMessages.ts
@@ -388,6 +388,51 @@ const validateTemplateComponent = (component: Record<string, unknown>): string |
   return error;
 };
 
+// The A2UI envelope types `updateDataModel.value` as `z.any()`, so the schema
+// check above it proves nothing about the contents. A template's data model is
+// then persisted verbatim — `resolveTemplate` only swaps markers on component
+// props — yet every DynamicString prop may bind to it via `{ "path": ... }`.
+// Anything parked here therefore reaches the renderer unresolved and unchecked,
+// so apply the same trace-agnostic rules the component walk enforces.
+//
+// Markers are rejected outright (not merely validated): even a well-formed one
+// is never resolved in the data model, so it would render as raw JSON.
+const validateTemplateDataModelValue = (value: unknown): string | undefined => {
+  let error: string | undefined;
+
+  const walk = (current: unknown) => {
+    if (error) {
+      return;
+    }
+    if (isSourceMarker(current) || isSpanRefMarker(current)) {
+      const marker = isSourceMarker(current) ? '$source' : '$spanRef';
+      error =
+        `The template's data model contains a "${marker}" marker. Markers are only resolved on component ` +
+        `props, so one placed in the data model renders as raw JSON. Bind the marker to the prop that ` +
+        `displays it instead.`;
+      return;
+    }
+    if (typeof current === 'string') {
+      if (current.includes('#span:')) {
+        error =
+          `The template's data model contains a "#span:" deeplink. Reusable views cannot embed ` +
+          `trace-specific narrative; bind a "spanField" source to select a span by role instead.`;
+      }
+      return;
+    }
+    if (Array.isArray(current)) {
+      current.forEach(walk);
+      return;
+    }
+    if (isRecord(current)) {
+      Object.values(current).forEach(walk);
+    }
+  };
+
+  walk(value);
+  return error;
+};
+
 export type TemplateValidateResult = { ok: true; messages: A2uiMessage[] } | { ok: false; error: string };
 
 /**
@@ -399,6 +444,8 @@ export type TemplateValidateResult = { ok: true; messages: A2uiMessage[] } | { o
  *  - normalizes the surface id to a placeholder + flattens nested props,
  *  - validates each envelope (Zod) and each marker (known source name / valid
  *    spanRef selector) and rejects forbidden trace-specific narrative,
+ *  - walks any `updateDataModel` value for the same narrative rules, since
+ *    components can read it back through a `{ "path": ... }` binding,
  *  - requires a `root` component,
  *
  * returning the marker-preserving template to persist. Per-trace rendering then
@@ -471,6 +518,10 @@ export const validateTemplate = (raw: unknown): TemplateValidateResult => {
           ok: false,
           error: `Invalid updateDataModel message: ${parsed.error.issues.map((i) => i.message).join('; ')}`,
         };
+      }
+      const dataModelError = validateTemplateDataModelValue(payload?.['value']);
+      if (dataModelError) {
+        return { ok: false, error: dataModelError };
       }
       kept.push(parsed.data);
       continue;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.test.ts
@@ -130,6 +130,46 @@ describe('getAgentAssessments', () => {
     const result = getAgentAssessments(asInfo({}), nodeMap);
     expect(result.map((a) => a.value)).toEqual(['ground-truth', '42']);
   });
+
+  // `assessment_name` holds the issue id, so the readable `issue_name` must survive.
+  it('names issue-reference assessments after their issue name, falling back to the issue id', () => {
+    const info = asInfo({
+      trace_location: {},
+      assessments: [
+        feedback({
+          assessment_id: 'i1',
+          assessment_name: 'issue-abc-123',
+          issue: { issue_name: 'Hallucinated citation' },
+          feedback: undefined,
+          rationale: 'cited a nonexistent doc',
+        }),
+        feedback({
+          assessment_id: 'i2',
+          assessment_name: 'issue-def-456',
+          issue: { issue_name: '' },
+          feedback: undefined,
+        }),
+      ],
+    });
+    expect(getAgentAssessments(info, {})).toEqual([
+      {
+        name: 'Hallucinated citation',
+        value: undefined,
+        rationale: 'cited a nonexistent doc',
+        source: 'LLM_JUDGE',
+        spanId: undefined,
+        error: undefined,
+      },
+      {
+        name: 'issue-def-456',
+        value: undefined,
+        rationale: undefined,
+        source: 'LLM_JUDGE',
+        spanId: undefined,
+        error: undefined,
+      },
+    ]);
+  });
 });
 
 describe('collectTraceAssessments + mapToAgentAssessments', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { Assessment, ModelTrace, ModelTraceSpanNode } from '../ModelTrace.types';
+import {
+  buildAssessmentCardComponents,
+  collectTraceAssessments,
+  getAgentAssessments,
+  getAssessmentBoardItems,
+  getMetricsFromTraceInfo,
+  getSpanAttributes,
+  mapToAgentAssessments,
+} from './customViewBuilders';
+
+const makeNode = (node: Partial<ModelTraceSpanNode> & { key: string }): ModelTraceSpanNode =>
+  ({
+    title: node.key,
+    start: 0,
+    end: 0,
+    type: 'UNKNOWN',
+    events: [],
+    attributes: {},
+    assessments: [],
+    ...node,
+  }) as unknown as ModelTraceSpanNode;
+
+const asInfo = (info: Record<string, unknown>): ModelTrace['info'] => info as unknown as ModelTrace['info'];
+
+const feedback = (over: Record<string, unknown> = {}): Assessment =>
+  ({
+    assessment_id: 'a1',
+    assessment_name: 'correctness',
+    trace_id: 'trace-1',
+    source: { source_type: 'LLM_JUDGE', source_id: 'judge' },
+    create_time: '',
+    last_update_time: '',
+    feedback: { value: true },
+    ...over,
+  }) as unknown as Assessment;
+
+describe('getMetricsFromTraceInfo', () => {
+  it('derives V3 metrics (status, latency, token count) and uses the passed-in assessment count', () => {
+    const info = asInfo({
+      trace_location: {},
+      state: 'OK',
+      execution_duration: '1.23s',
+      trace_metadata: { 'mlflow.trace.tokenUsage': JSON.stringify({ total_tokens: 999 }) },
+      assessments: [feedback(), feedback({ assessment_id: 'a2' })],
+    });
+    // The count is passed in (post-merge with cached actions), not read off info.
+    expect(getMetricsFromTraceInfo(info, 3)).toEqual({
+      status: 'OK',
+      latency: '1.23s',
+      totalTokens: '999',
+      assessments: '3',
+    });
+  });
+
+  it('falls back to N/A token count when trace metadata is absent', () => {
+    const info = asInfo({ trace_location: {}, state: 'ERROR' });
+    expect(getMetricsFromTraceInfo(info, 0)).toEqual({
+      status: 'ERROR',
+      latency: 'N/A',
+      totalTokens: 'N/A',
+      assessments: '0',
+    });
+  });
+
+  it('formats legacy trace-info latency (seconds >= 1s, else ms) and reports the passed-in count', () => {
+    expect(getMetricsFromTraceInfo(asInfo({ status: 'OK', execution_time_ms: 1500 }), 2)).toEqual({
+      status: 'OK',
+      latency: '1.50s',
+      totalTokens: 'N/A',
+      assessments: '2',
+    });
+    expect(getMetricsFromTraceInfo(asInfo({ execution_time_ms: 250 }), 0).latency).toBe('250ms');
+    expect(getMetricsFromTraceInfo(asInfo({}), 0).latency).toBe('N/A');
+  });
+});
+
+describe('getAgentAssessments', () => {
+  it('collects trace- and span-level assessments, deduped by id and skipping invalid ones', () => {
+    const info = asInfo({
+      trace_location: {},
+      assessments: [feedback({ assessment_id: 'a1', feedback: { value: true }, rationale: 'looks good' })],
+    });
+    const nodeMap = {
+      s1: makeNode({
+        key: 's1',
+        assessments: [
+          // duplicate id -> ignored
+          feedback({ assessment_id: 'a1', feedback: { value: false } }),
+          // invalid -> ignored
+          feedback({ assessment_id: 'a2', valid: false }),
+          feedback({
+            assessment_id: 'a3',
+            assessment_name: 'relevance',
+            feedback: { value: 'no', error: { error_code: 'E', error_message: 'boom' } },
+            span_id: 's1',
+          }),
+        ],
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    expect(getAgentAssessments(info, nodeMap)).toEqual([
+      {
+        name: 'correctness',
+        value: true,
+        rationale: 'looks good',
+        source: 'LLM_JUDGE',
+        spanId: undefined,
+        error: undefined,
+      },
+      { name: 'relevance', value: 'no', rationale: undefined, source: 'LLM_JUDGE', spanId: 's1', error: 'boom' },
+    ]);
+  });
+
+  it('reads the value from expectation assessments (plain and serialized)', () => {
+    const nodeMap = {
+      s1: makeNode({
+        key: 's1',
+        assessments: [
+          feedback({ assessment_id: 'e1', expectation: { value: 'ground-truth' }, feedback: undefined }),
+          feedback({
+            assessment_id: 'e2',
+            expectation: { serialized_value: { value: '42', serialization_format: 'json' } },
+            feedback: undefined,
+          }),
+        ],
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    const result = getAgentAssessments(asInfo({}), nodeMap);
+    expect(result.map((a) => a.value)).toEqual(['ground-truth', '42']);
+  });
+});
+
+describe('collectTraceAssessments + mapToAgentAssessments', () => {
+  it('collectTraceAssessments returns RAW trace- and span-level assessments, deduped by id', () => {
+    const info = asInfo({
+      trace_location: {},
+      assessments: [feedback({ assessment_id: 'a1' })],
+    });
+    const nodeMap = {
+      s1: makeNode({
+        key: 's1',
+        assessments: [
+          // duplicate id -> ignored
+          feedback({ assessment_id: 'a1' }),
+          // invalid -> ignored
+          feedback({ assessment_id: 'a2', valid: false }),
+          feedback({ assessment_id: 'a3', span_id: 's1' }),
+        ],
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    const raw = collectTraceAssessments(info, nodeMap);
+    expect(raw.map((a) => a.assessment_id)).toEqual(['a1', 'a3']);
+  });
+
+  it('mapToAgentAssessments maps raw assessments, deduping ids and skipping invalid ones', () => {
+    const mapped = mapToAgentAssessments([
+      feedback({ assessment_id: 'a1', assessment_name: 'correctness', feedback: { value: true } }),
+      // an in-session addition that overlaps a base id is deduped
+      feedback({ assessment_id: 'a1', assessment_name: 'correctness', feedback: { value: false } }),
+      feedback({ assessment_id: 'a2', valid: false }),
+    ]);
+    expect(mapped).toEqual([
+      {
+        name: 'correctness',
+        value: true,
+        rationale: undefined,
+        source: 'LLM_JUDGE',
+        spanId: undefined,
+        error: undefined,
+      },
+    ]);
+  });
+});
+
+describe('getAssessmentBoardItems', () => {
+  it('derives sentiment and badge value from each assessment', () => {
+    const items = getAssessmentBoardItems([
+      { name: 'bool-true', value: true, source: 's' },
+      { name: 'bool-false', value: false, source: 's' },
+      { name: 'str-pass', value: 'pass', source: 's' },
+      { name: 'str-fail', value: 'fail', source: 's' },
+      { name: 'neutral', value: 'partial', source: 's' },
+      { name: 'errored', value: 'ignored', source: 's', error: 'kaboom' },
+      { name: 'empty', value: undefined, source: 's' },
+    ]);
+    expect(items).toEqual([
+      { name: 'bool-true', value: 'true', rationale: undefined, source: 's', sentiment: 'positive' },
+      { name: 'bool-false', value: 'false', rationale: undefined, source: 's', sentiment: 'negative' },
+      { name: 'str-pass', value: 'pass', rationale: undefined, source: 's', sentiment: 'positive' },
+      { name: 'str-fail', value: 'fail', rationale: undefined, source: 's', sentiment: 'negative' },
+      { name: 'neutral', value: 'partial', rationale: undefined, source: 's', sentiment: 'neutral' },
+      { name: 'errored', value: 'Error', rationale: 'kaboom', source: 's', sentiment: 'error' },
+      { name: 'empty', value: undefined, rationale: undefined, source: 's', sentiment: 'neutral' },
+    ]);
+  });
+});
+
+describe('getSpanAttributes', () => {
+  it('drops mlflow.* attributes and returns {} for a missing span', () => {
+    const span = makeNode({ key: 's', attributes: { 'mlflow.spanType': 'TOOL', model: 'gpt' } });
+    expect(getSpanAttributes(span)).toEqual({ model: 'gpt' });
+    expect(getSpanAttributes(undefined)).toEqual({});
+  });
+});
+
+describe('buildAssessmentCardComponents', () => {
+  it('maps board items to AssessmentCard components with only present optional fields', () => {
+    const { childIds, components } = buildAssessmentCardComponents(
+      [
+        { name: 'full', value: 'yes', rationale: 'because', source: 'judge', sentiment: 'positive' },
+        { name: 'sparse', sentiment: 'neutral' },
+      ],
+      { idPrefix: 'board' },
+    );
+    expect(childIds).toEqual(['board-card-0', 'board-card-1']);
+    expect(components[0]).toEqual({
+      id: 'board-card-0',
+      component: 'AssessmentCard',
+      name: 'full',
+      value: 'yes',
+      rationale: 'because',
+      source: 'judge',
+      sentiment: 'positive',
+    });
+    expect(components[1]).toEqual({
+      id: 'board-card-1',
+      component: 'AssessmentCard',
+      name: 'sparse',
+      sentiment: 'neutral',
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.ts
@@ -206,6 +206,12 @@ export const getSpanAttributes = (span?: ModelTraceSpanNode): Record<string, unk
 // Materializes a `{ "$source": "assessments" }` marker into one `AssessmentCard`
 // per assessment for the CURRENT trace, returning the child ids to place into
 // the host `AssessmentBoard`'s `children` and the components to append.
+//
+// The generated ids MUST stay a pure function of `idPrefix` + position: cycling
+// traces re-resolves the template onto the SAME surface, and A2UI upserts
+// components by id. A nondeterministic suffix (hash/timestamp/random) would mint
+// fresh ids every render and strand the previous cards in the surface model,
+// since nothing deletes them.
 export const buildAssessmentCardComponents = (
   items: AssessmentBoardItem[],
   { idPrefix }: { idPrefix: string },

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.ts
@@ -1,0 +1,219 @@
+import type { Assessment, ModelTrace, ModelTraceSpanNode } from '../ModelTrace.types';
+import { getTotalTokens, isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
+
+// Must match the `catalogId` declared in `catalog.json`.
+export const CUSTOM_VIEW_CATALOG_ID = 'https://mlflow.org/model-trace-explorer/custom-view/catalog.json';
+
+const formatLatencyMs = (ms: number): string => (ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${Math.round(ms)}ms`);
+
+// The metrics we can derive from `modelTraceInfo` alone. All fields are
+// display-ready strings so the custom view can bind them directly.
+export type TraceMetrics = {
+  status: string;
+  latency: string;
+  totalTokens: string;
+  assessments: string;
+};
+
+// Extracts the metrics we can derive from `modelTraceInfo` alone, normalizing
+// across the V3 and legacy/notebook trace-info shapes. `assessmentCount` is
+// passed in (not read off `info.assessments`) so the counter matches the
+// AssessmentBoard exactly: it reflects trace-level + span-level assessments AND
+// any in-session edits merged from the trace-cached-actions store, keeping the
+// counter live after a feedback submit / thumb click.
+export const getMetricsFromTraceInfo = (info: ModelTrace['info'], assessmentCount: number): TraceMetrics => {
+  if (isV3ModelTraceInfo(info)) {
+    const totalTokens = getTotalTokens(info);
+    return {
+      status: info.state ?? 'STATE_UNSPECIFIED',
+      latency: info.execution_duration ?? 'N/A',
+      totalTokens: totalTokens != null ? totalTokens.toLocaleString() : 'N/A',
+      assessments: String(assessmentCount),
+    };
+  }
+
+  // Not V3: the guard above narrowed `info` to the legacy/notebook shapes, which
+  // both expose `status` and `execution_time_ms` — no cast needed.
+  return {
+    status: info.status ?? 'UNKNOWN',
+    latency: typeof info.execution_time_ms === 'number' ? formatLatencyMs(info.execution_time_ms) : 'N/A',
+    totalTokens: 'N/A',
+    assessments: String(assessmentCount),
+  };
+};
+
+export type AssessmentSentiment = 'positive' | 'negative' | 'neutral' | 'error';
+
+export type AssessmentBoardItem = {
+  name: string;
+  value?: string;
+  rationale?: string;
+  source?: string;
+  sentiment: AssessmentSentiment;
+};
+
+export type AgentAssessment = {
+  name: string;
+  value: unknown;
+  rationale?: string;
+  source: string;
+  spanId?: string;
+  error?: string;
+};
+
+export type CustomViewData = {
+  metrics: TraceMetrics;
+  assessmentItems: AssessmentBoardItem[];
+};
+
+// Extracts the displayable value + error from any assessment variant
+// (feedback / expectation), so the agent receives real judge/feedback results.
+const getAssessmentValueAndError = (assessment: Assessment): { value: unknown; error?: string } => {
+  if ('feedback' in assessment && assessment.feedback) {
+    const err = assessment.feedback.error ?? assessment.error;
+    return {
+      value: assessment.feedback.value,
+      error: err ? (err.error_message ?? err.error_code) : undefined,
+    };
+  }
+  if ('expectation' in assessment && assessment.expectation) {
+    const expectation = assessment.expectation;
+    if ('value' in expectation) {
+      return { value: expectation.value };
+    }
+    if ('serialized_value' in expectation) {
+      return { value: expectation.serialized_value.value };
+    }
+  }
+  return { value: undefined, error: assessment.error?.error_message ?? assessment.error?.error_code };
+};
+
+// Gathers the trace's raw assessments (trace-level + span-level), deduped by id
+// and skipping invalidated ones. Kept as raw `Assessment`s (not the mapped agent
+// shape) so callers can merge in-session edits from the trace-cached-actions
+// store — keyed by assessment_id — before mapping, exactly like the assessments
+// pane. This is what keeps the custom view's counter/board live after a submit.
+export const collectTraceAssessments = (
+  info: ModelTrace['info'],
+  nodeMap: Record<string, ModelTraceSpanNode>,
+): Assessment[] => {
+  const uniqueAssessmentsById = new Map<string, Assessment>();
+  const add = (assessment: Assessment) => {
+    if (assessment.valid === false || uniqueAssessmentsById.has(assessment.assessment_id)) {
+      return;
+    }
+    uniqueAssessmentsById.set(assessment.assessment_id, assessment);
+  };
+
+  const traceAssessments = isV3ModelTraceInfo(info) ? (info.assessments ?? []) : [];
+  for (const assessment of traceAssessments) {
+    add(assessment);
+  }
+  for (const node of Object.values(nodeMap)) {
+    for (const assessment of node.assessments ?? []) {
+      add(assessment);
+    }
+  }
+  return Array.from(uniqueAssessmentsById.values());
+};
+
+// Maps raw assessments into the flat shape the agent prompt / AssessmentBoard
+// use, skipping invalidated ones and deduping by id (the input may carry cached
+// additions that overlap the base list).
+export const mapToAgentAssessments = (assessments: Assessment[]): AgentAssessment[] => {
+  const uniqueAssessmentsById = new Map<string, AgentAssessment>();
+  for (const assessment of assessments) {
+    if (assessment.valid === false || uniqueAssessmentsById.has(assessment.assessment_id)) {
+      continue;
+    }
+    const { value, error } = getAssessmentValueAndError(assessment);
+    uniqueAssessmentsById.set(assessment.assessment_id, {
+      name: assessment.assessment_name,
+      value,
+      rationale: assessment.rationale,
+      source: assessment.source?.source_type ?? 'SOURCE_TYPE_UNSPECIFIED',
+      spanId: assessment.span_id,
+      error,
+    });
+  }
+  return Array.from(uniqueAssessmentsById.values());
+};
+
+// Collects the trace's real assessments (trace-level + span-level) into the flat
+// shape the agent prompt uses. Convenience wrapper over collect + map for callers
+// that don't need to merge in-session edits.
+export const getAgentAssessments = (
+  info: ModelTrace['info'],
+  nodeMap: Record<string, ModelTraceSpanNode>,
+): AgentAssessment[] => mapToAgentAssessments(collectTraceAssessments(info, nodeMap));
+
+// Maps an assessment's raw value to a verdict polarity for coloring. Affirmative
+// values (yes/true/pass/correct) are positive (green); negatives (no/false/fail)
+// are negative (red); an error overrides everything; otherwise neutral.
+const POSITIVE_VALUES = new Set(['yes', 'true', 'pass', 'passed', 'correct', 'good', 'success']);
+const NEGATIVE_VALUES = new Set(['no', 'false', 'fail', 'failed', 'incorrect', 'bad', 'failure']);
+
+const getAssessmentSentiment = ({ value, error }: AgentAssessment): AssessmentSentiment => {
+  if (error) {
+    return 'error';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'positive' : 'negative';
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (POSITIVE_VALUES.has(normalized)) {
+      return 'positive';
+    }
+    if (NEGATIVE_VALUES.has(normalized)) {
+      return 'negative';
+    }
+  }
+  return 'neutral';
+};
+
+export const getAssessmentBoardItems = (assessments: AgentAssessment[]): AssessmentBoardItem[] =>
+  assessments.map((assessment) => {
+    const hasError = Boolean(assessment.error);
+    const hasValue = assessment.value !== undefined && assessment.value !== null;
+    return {
+      name: assessment.name,
+      value: hasError ? 'Error' : hasValue ? String(assessment.value) : undefined,
+      rationale: assessment.rationale ?? (hasError ? assessment.error : undefined),
+      source: assessment.source,
+      sentiment: getAssessmentSentiment(assessment),
+    };
+  });
+
+// Returns the span's "real" (non-`mlflow.`-prefixed) attributes, mirroring the
+// Details & Timeline Attributes tab.
+export const getSpanAttributes = (span?: ModelTraceSpanNode): Record<string, unknown> => {
+  if (!span?.attributes) {
+    return {};
+  }
+  return Object.fromEntries(Object.entries(span.attributes).filter(([key]) => !key.startsWith('mlflow.')));
+};
+
+// Materializes a `{ "$source": "assessments" }` marker into one `AssessmentCard`
+// per assessment for the CURRENT trace, returning the child ids to place into
+// the host `AssessmentBoard`'s `children` and the components to append.
+export const buildAssessmentCardComponents = (
+  items: AssessmentBoardItem[],
+  { idPrefix }: { idPrefix: string },
+): { childIds: string[]; components: Record<string, unknown>[] } => {
+  const components: Record<string, unknown>[] = [];
+  const childIds = items.map((item, index) => {
+    const id = `${idPrefix}-card-${index}`;
+    components.push({
+      id,
+      component: 'AssessmentCard',
+      name: item.name,
+      ...(item.value !== undefined ? { value: item.value } : {}),
+      ...(item.rationale !== undefined ? { rationale: item.rationale } : {}),
+      ...(item.source !== undefined ? { source: item.source } : {}),
+      sentiment: item.sentiment,
+    });
+    return id;
+  });
+  return { childIds, components };
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewBuilders.ts
@@ -66,8 +66,17 @@ export type CustomViewData = {
   assessmentItems: AssessmentBoardItem[];
 };
 
+// An issue reference stores the issue id in `assessment_name` and the readable
+// label in `issue.issue_name`, so display the latter exactly as the issues
+// section of the assessments pane does.
+const getAssessmentDisplayName = (assessment: Assessment): string =>
+  'issue' in assessment && assessment.issue
+    ? assessment.issue.issue_name || assessment.assessment_name
+    : assessment.assessment_name;
+
 // Extracts the displayable value + error from any assessment variant
 // (feedback / expectation), so the agent receives real judge/feedback results.
+// Issue references carry no verdict — their name is the whole payload.
 const getAssessmentValueAndError = (assessment: Assessment): { value: unknown; error?: string } => {
   if ('feedback' in assessment && assessment.feedback) {
     const err = assessment.feedback.error ?? assessment.error;
@@ -128,7 +137,7 @@ export const mapToAgentAssessments = (assessments: Assessment[]): AgentAssessmen
     }
     const { value, error } = getAssessmentValueAndError(assessment);
     uniqueAssessmentsById.set(assessment.assessment_id, {
-      name: assessment.assessment_name,
+      name: getAssessmentDisplayName(assessment),
       value,
       rationale: assessment.rationale,
       source: assessment.source?.source_type ?? 'SOURCE_TYPE_UNSPECIFIED',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
+import type { CustomViewData } from './customViewBuilders';
+import {
+  isKnownSource,
+  isSourceMarker,
+  isSpanRefMarker,
+  isValidSpanFieldMarker,
+  isValidSpanRefSelector,
+  resolveScalarSource,
+  resolveSpanFieldSource,
+  resolveSpanRef,
+  unwrapSpanRefSelector,
+} from './customViewSources';
+
+const makeNode = (node: Partial<ModelTraceSpanNode> & { key: string; start: number }): ModelTraceSpanNode =>
+  node as unknown as ModelTraceSpanNode;
+
+const nodeMap = {
+  root: makeNode({ key: 'root', start: 0, title: 'agent', type: ModelSpanType.AGENT }),
+  tool0: makeNode({
+    key: 'tool0',
+    start: 10,
+    parentId: 'root',
+    title: 'run_sql_query',
+    type: ModelSpanType.TOOL,
+    inputs: { q: 'select 1' },
+    outputs: { rows: 1 },
+  }),
+  tool1: makeNode({ key: 'tool1', start: 20, parentId: 'root', title: 'fetch', type: ModelSpanType.TOOL }),
+} satisfies Record<string, ModelTraceSpanNode>;
+
+const viewData: CustomViewData = {
+  metrics: { status: 'OK', latency: '275ms', totalTokens: '1,024', assessments: '3' } as CustomViewData['metrics'],
+  assessmentItems: [],
+};
+
+describe('marker guards', () => {
+  it('recognizes $source and $spanRef markers', () => {
+    expect(isSourceMarker({ $source: 'metrics.latency' })).toBe(true);
+    expect(isSourceMarker({ source: 'metrics.latency' })).toBe(false);
+    expect(isSpanRefMarker({ $spanRef: 'root' })).toBe(true);
+    expect(isSpanRefMarker({ spanRef: 'root' })).toBe(false);
+  });
+
+  it('classifies known source names across all categories', () => {
+    expect(isKnownSource('metrics.latency')).toBe(true);
+    expect(isKnownSource('assessments')).toBe(true);
+    expect(isKnownSource('spanField')).toBe(true);
+    expect(isKnownSource('nonsense')).toBe(false);
+    // Removed alongside the TreeView catalog primitive.
+    expect(isKnownSource('spanTree')).toBe(false);
+    // Removed alongside the DataTable catalog primitive (the only array source).
+    expect(isKnownSource('toolRows')).toBe(false);
+  });
+});
+
+describe('isValidSpanRefSelector', () => {
+  it('accepts root, type, name, and type+nth selectors', () => {
+    expect(isValidSpanRefSelector('root')).toBe(true);
+    expect(isValidSpanRefSelector({ type: 'TOOL' })).toBe(true);
+    expect(isValidSpanRefSelector({ name: 'run_sql_query' })).toBe(true);
+    expect(isValidSpanRefSelector({ type: 'TOOL', nth: 1 })).toBe(true);
+  });
+
+  it('rejects empty selectors, bad nth, and raw indices', () => {
+    expect(isValidSpanRefSelector({})).toBe(false);
+    expect(isValidSpanRefSelector({ type: 'TOOL', nth: '1' })).toBe(false);
+    expect(isValidSpanRefSelector(0)).toBe(false);
+    expect(isValidSpanRefSelector('first')).toBe(false);
+  });
+});
+
+describe('isValidSpanFieldMarker', () => {
+  it('accepts a valid selector + known field (bare and wrapped spanRef)', () => {
+    expect(isValidSpanFieldMarker({ spanRef: { type: 'TOOL', nth: 0 }, field: 'outputs' })).toBe(true);
+    expect(isValidSpanFieldMarker({ spanRef: { $spanRef: 'root' }, field: 'name' })).toBe(true);
+  });
+
+  it('rejects unknown fields or invalid selectors', () => {
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'cost' })).toBe(false);
+    expect(isValidSpanFieldMarker({ spanRef: {}, field: 'outputs' })).toBe(false);
+  });
+
+  it('accepts a nested path (keys + indices) on structural fields', () => {
+    expect(
+      isValidSpanFieldMarker({ spanRef: 'root', field: 'outputs', path: ['choices', 0, 'message', 'content'] }),
+    ).toBe(true);
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'inputs', path: ['query'] })).toBe(true);
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'attributes', path: ['usage', 'total_tokens'] })).toBe(
+      true,
+    );
+  });
+
+  it('rejects a path on non-structural fields or a malformed path', () => {
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'name', path: ['content'] })).toBe(false);
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'spanId', path: ['x'] })).toBe(false);
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'outputs', path: [] })).toBe(false);
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'outputs', path: 'content' })).toBe(false);
+    expect(isValidSpanFieldMarker({ spanRef: 'root', field: 'outputs', path: [{ k: 1 }] })).toBe(false);
+  });
+});
+
+describe('unwrapSpanRefSelector', () => {
+  it('unwraps the marker form and leaves bare selectors untouched', () => {
+    expect(unwrapSpanRefSelector({ $spanRef: { type: 'TOOL' } })).toEqual({ type: 'TOOL' });
+    expect(unwrapSpanRefSelector('root')).toBe('root');
+  });
+});
+
+describe('resolveScalarSource', () => {
+  it('resolves metrics.* to the current trace value', () => {
+    expect(resolveScalarSource('metrics.latency', viewData)).toBe('275ms');
+    expect(resolveScalarSource('metrics.status', viewData)).toBe('OK');
+  });
+
+  it('returns undefined for non-metric scalar names', () => {
+    expect(resolveScalarSource('assessments', viewData)).toBeUndefined();
+  });
+});
+
+describe('resolveSpanRef', () => {
+  it('resolves root to the parentless span', () => {
+    expect(resolveSpanRef('root', nodeMap)).toBe('root');
+  });
+
+  it('resolves type + nth in deterministic start order', () => {
+    expect(resolveSpanRef({ type: 'TOOL' }, nodeMap)).toBe('tool0');
+    expect(resolveSpanRef({ type: 'TOOL', nth: 1 }, nodeMap)).toBe('tool1');
+  });
+
+  it('resolves by name and returns undefined when nothing matches', () => {
+    expect(resolveSpanRef({ name: 'run_sql_query' }, nodeMap)).toBe('tool0');
+    expect(resolveSpanRef({ type: 'TOOL', nth: 5 }, nodeMap)).toBeUndefined();
+    expect(resolveSpanRef('root', {})).toBeUndefined();
+  });
+});
+
+describe('resolveSpanFieldSource', () => {
+  it('serializes the selected span field for the current trace', () => {
+    expect(resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 0 }, field: 'outputs' }, nodeMap)).toBe('{"rows":1}');
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'name' }, nodeMap)).toBe('agent');
+    expect(resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 0 }, field: 'spanId' }, nodeMap)).toBe('tool0');
+  });
+
+  it('falls back to empty/null when the span is absent in this trace', () => {
+    expect(resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 9 }, field: 'outputs' }, nodeMap)).toBe('null');
+    expect(resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 9 }, field: 'name' }, nodeMap)).toBe('');
+  });
+
+  it('extracts a nested scalar leaf as raw text (renders as prose, not JSON)', () => {
+    const nestedNodeMap = {
+      root: makeNode({
+        key: 'root',
+        start: 0,
+        title: 'agent',
+        type: ModelSpanType.LLM,
+        outputs: { choices: [{ message: { content: 'Hello world' } }] },
+        inputs: { query: 'What is the weather?' },
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    expect(
+      resolveSpanFieldSource(
+        { spanRef: 'root', field: 'outputs', path: ['choices', 0, 'message', 'content'] },
+        nestedNodeMap,
+      ),
+    ).toBe('Hello world');
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'inputs', path: ['query'] }, nestedNodeMap)).toBe(
+      'What is the weather?',
+    );
+  });
+
+  it('serializes a nested object/array leaf as JSON', () => {
+    const nestedNodeMap = {
+      root: makeNode({
+        key: 'root',
+        start: 0,
+        title: 'agent',
+        type: ModelSpanType.LLM,
+        outputs: { choices: [{ message: { content: 'hi' } }] },
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['choices', 0] }, nestedNodeMap)).toBe(
+      '{"message":{"content":"hi"}}',
+    );
+  });
+
+  it('returns empty string when a nested path is missing in this trace', () => {
+    const nestedNodeMap = {
+      root: makeNode({ key: 'root', start: 0, title: 'agent', type: ModelSpanType.LLM, outputs: { rows: 1 } }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    expect(
+      resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['missing', 'deep'] }, nestedNodeMap),
+    ).toBe('');
+    // Missing span + a path also degrades to '' rather than 'null'.
+    expect(
+      resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 9 }, field: 'outputs', path: ['content'] }, nodeMap),
+    ).toBe('');
+  });
+
+  it('preserves whole-object JSON behavior when no path is given', () => {
+    expect(resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 0 }, field: 'outputs' }, nodeMap)).toBe('{"rows":1}');
+  });
+
+  it('does not traverse the prototype chain (fails closed to empty)', () => {
+    const nestedNodeMap = {
+      root: makeNode({ key: 'root', start: 0, title: 'agent', type: ModelSpanType.LLM, outputs: { content: 'hi' } }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    // Inherited keys must NOT resolve to prototype objects/functions.
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['__proto__'] }, nestedNodeMap)).toBe('');
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['constructor'] }, nestedNodeMap)).toBe(
+      '',
+    );
+    expect(
+      resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['__proto__', 'constructor'] }, nestedNodeMap),
+    ).toBe('');
+    // A real own key alongside those still works.
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['content'] }, nestedNodeMap)).toBe('hi');
+  });
+
+  it('only indexes real in-bounds array positions', () => {
+    const nestedNodeMap = {
+      root: makeNode({
+        key: 'root',
+        start: 0,
+        title: 'agent',
+        type: ModelSpanType.LLM,
+        outputs: { items: ['a', 'b'] },
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['items', 1] }, nestedNodeMap)).toBe('b');
+    // Out-of-bounds and non-index keys (e.g. "length") degrade to ''.
+    expect(resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['items', 5] }, nestedNodeMap)).toBe('');
+    expect(
+      resolveSpanFieldSource({ spanRef: 'root', field: 'outputs', path: ['items', 'length'] }, nestedNodeMap),
+    ).toBe('');
+  });
+
+  it('does not throw when the span field is not JSON-serializable', () => {
+    const circular = { rows: 1 } satisfies Record<string, unknown>;
+    (circular as Record<string, unknown>).self = circular;
+    const cyclicNodeMap = {
+      ...nodeMap,
+      tool0: makeNode({
+        key: 'tool0',
+        start: 10,
+        parentId: 'root',
+        title: 'run_sql_query',
+        type: ModelSpanType.TOOL,
+        outputs: circular,
+      }),
+    } satisfies Record<string, ModelTraceSpanNode>;
+    expect(resolveSpanFieldSource({ spanRef: { type: 'TOOL', nth: 0 }, field: 'outputs' }, cyclicNodeMap)).toBe(
+      '"[object Object]"',
+    );
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.test.ts
@@ -68,6 +68,9 @@ describe('isValidSpanRefSelector', () => {
   it('rejects empty selectors, bad nth, and raw indices', () => {
     expect(isValidSpanRefSelector({})).toBe(false);
     expect(isValidSpanRefSelector({ type: 'TOOL', nth: '1' })).toBe(false);
+    expect(isValidSpanRefSelector({ type: 'TOOL', nth: -1 })).toBe(false);
+    expect(isValidSpanRefSelector({ type: 'TOOL', nth: 1.5 })).toBe(false);
+    expect(isValidSpanRefSelector({ type: 'TOOL', nth: Number.NaN })).toBe(false);
     expect(isValidSpanRefSelector(0)).toBe(false);
     expect(isValidSpanRefSelector('first')).toBe(false);
   });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.ts
@@ -1,0 +1,232 @@
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
+import { asString, safeJsonStringify } from './catalogPrimitiveUtils';
+import { type CustomViewData, getSpanAttributes } from './customViewBuilders';
+
+// A data-binding marker the LLM emits in place of literal data, e.g.
+// `{ "$source": "metrics.latency" }` or `{ "$source": "assessments" }`.
+export type SourceMarker = { $source: string } & Record<string, unknown>;
+
+// A span-targeting marker the LLM emits in place of a literal `spanId`, so a
+// feedback control re-targets the equivalent span in whatever trace is open.
+//  - "root"                         -> the trace's root span
+//  - { type: "TOOL", nth?: 0 }      -> the nth span of that type (default 0)
+//  - { name: "run_sql_query" }      -> the first span whose title matches
+export type SpanRefSelector = 'root' | { type?: string; name?: string; nth?: number };
+export type SpanRefMarker = { $spanRef: SpanRefSelector };
+
+// Scalar sources resolve to a single display string (StatCard value, etc.).
+export const SCALAR_SOURCE_NAMES = [
+  'metrics.status',
+  'metrics.latency',
+  'metrics.totalTokens',
+  'metrics.assessments',
+] as const;
+
+// Structural sources materialize into a set of child components (one per item)
+// whose ids are placed into the host component's `children` array.
+export const STRUCTURAL_SOURCE_NAMES = ['assessments'] as const;
+
+// A per-span field source resolves a SINGLE span (selected via a spanRef) to one
+// of its fields, re-resolved per trace. It lets a KeyValueViewer / Text bind to a
+// specific span's output/input/attributes/name/id without baking a literal — the
+// missing capability that previously forced the model to hardcode span data.
+//   { "$source": "spanField", "spanRef": { "type": "TOOL", "nth": 0 }, "field": "outputs" }
+// The structural fields (inputs/outputs/attributes) may additionally carry a
+// "path" — an array of keys/indices drilling into the field's nested JSON, e.g.
+//   { ..., "field": "outputs", "path": ["choices", 0, "message", "content"] }
+// so a single nested scalar renders as readable text instead of a JSON tree.
+export const SPAN_FIELD_SOURCE_NAME = 'spanField';
+export const SPAN_FIELD_NAMES = ['inputs', 'outputs', 'attributes', 'name', 'spanId'] as const;
+// Fields whose value is a JSON object and therefore supports a nested "path".
+export const PATHABLE_SPAN_FIELD_NAMES = ['inputs', 'outputs', 'attributes'] as const;
+
+export type ScalarSourceName = (typeof SCALAR_SOURCE_NAMES)[number];
+export type StructuralSourceName = (typeof STRUCTURAL_SOURCE_NAMES)[number];
+export type SpanFieldName = (typeof SPAN_FIELD_NAMES)[number];
+export type SpanFieldPath = (string | number)[];
+export type SpanFieldMarker = {
+  $source: 'spanField';
+  spanRef: SpanRefSelector;
+  field: SpanFieldName;
+  path?: SpanFieldPath;
+};
+
+const SCALAR_SET = new Set<string>(SCALAR_SOURCE_NAMES);
+const STRUCTURAL_SET = new Set<string>(STRUCTURAL_SOURCE_NAMES);
+const SPAN_FIELD_SET = new Set<string>(SPAN_FIELD_NAMES);
+const PATHABLE_SPAN_FIELD_SET = new Set<string>(PATHABLE_SPAN_FIELD_NAMES);
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+export const isSourceMarker = (value: unknown): value is SourceMarker =>
+  isRecord(value) && typeof value['$source'] === 'string';
+
+export const isSpanRefMarker = (value: unknown): value is SpanRefMarker => isRecord(value) && '$spanRef' in value;
+
+export const isScalarSource = (name: string): name is ScalarSourceName => SCALAR_SET.has(name);
+export const isStructuralSource = (name: string): name is StructuralSourceName => STRUCTURAL_SET.has(name);
+export const isSpanFieldSource = (name: string): boolean => name === SPAN_FIELD_SOURCE_NAME;
+export const isKnownSource = (name: string): boolean =>
+  isScalarSource(name) || isStructuralSource(name) || isSpanFieldSource(name);
+
+// A `spanField`'s "spanRef" is meant to be a BARE selector ("root" / {type,nth} /
+// {name}), but the model frequently wraps it as { "$spanRef": <selector> } (the
+// feedback-spanId marker syntax). Accept both by unwrapping the marker form.
+export const unwrapSpanRefSelector = (value: unknown): unknown => (isSpanRefMarker(value) ? value.$spanRef : value);
+
+// Validates a `$spanRef` selector against the supported grammar (used by the
+// template validator). Raw positional indices are intentionally unsupported as
+// they are fragile across traces.
+export const isValidSpanRefSelector = (selector: unknown): selector is SpanRefSelector => {
+  if (selector === 'root') {
+    return true;
+  }
+  if (!isRecord(selector)) {
+    return false;
+  }
+  const hasType = typeof selector['type'] === 'string' && selector['type'].length > 0;
+  const hasName = typeof selector['name'] === 'string' && selector['name'].length > 0;
+  if (!hasType && !hasName) {
+    return false;
+  }
+  if ('nth' in selector && typeof selector['nth'] !== 'number') {
+    return false;
+  }
+  return true;
+};
+
+// Validates an optional `spanField` "path": a non-empty array of string/number
+// segments, only meaningful on the structural fields whose value is an object.
+export const isValidSpanFieldPath = (path: unknown, field: string): boolean =>
+  PATHABLE_SPAN_FIELD_SET.has(field) &&
+  Array.isArray(path) &&
+  path.length > 0 &&
+  path.every((segment) => typeof segment === 'string' || typeof segment === 'number');
+
+// Validates a `spanField` marker: a valid spanRef selector + a known field name,
+// plus (if present) a valid nested "path" on a structural field.
+export const isValidSpanFieldMarker = (marker: Record<string, unknown>): boolean => {
+  if (!isValidSpanRefSelector(unwrapSpanRefSelector(marker['spanRef']))) {
+    return false;
+  }
+  if (typeof marker['field'] !== 'string' || !SPAN_FIELD_SET.has(marker['field'])) {
+    return false;
+  }
+  if ('path' in marker && marker['path'] !== undefined) {
+    return isValidSpanFieldPath(marker['path'], marker['field']);
+  }
+  return true;
+};
+
+// Resolves a scalar source name to the current trace's display string.
+export const resolveScalarSource = (name: string, data: CustomViewData): string | undefined => {
+  if (name.startsWith('metrics.')) {
+    const key = name.slice('metrics.'.length) as keyof CustomViewData['metrics'];
+    const value = data.metrics?.[key];
+    return value === undefined || value === null ? '' : asString(value);
+  }
+  return undefined;
+};
+
+export const resolveSpanRef = (
+  selector: SpanRefSelector,
+  nodeMap: Record<string, ModelTraceSpanNode>,
+): string | undefined => {
+  const nodes = Object.values(nodeMap);
+  if (nodes.length === 0) {
+    return undefined;
+  }
+  // Deterministic order so "nth" is stable run-to-run.
+  const ordered = [...nodes].sort((a, b) => a.start - b.start);
+
+  if (selector === 'root') {
+    const root = ordered.find((node) => !node.parentId);
+    return root ? String(root.key) : undefined;
+  }
+
+  const { type, name, nth = 0 } = selector;
+  const matches = ordered.filter((node) => {
+    const typeOk = type ? node.type === type : true;
+    const title = typeof node.title === 'string' ? node.title : asString(node.title);
+    const nameOk = name ? title === name : true;
+    return typeOk && nameOk;
+  });
+  const picked = matches[nth];
+  return picked ? String(picked.key) : undefined;
+};
+
+// Walks an array of key/index segments into a value, returning undefined as soon
+// as a segment hits a non-indexable step OR a key the container does not OWN.
+// The own-property check is deliberate: raw bracket access would let segments
+// like "__proto__"/"constructor"/"prototype" traverse the prototype chain and
+// surface inherited objects/functions, so invalid selectors must fail closed to
+// undefined (which the caller renders as '') instead of leaking runtime internals.
+const getByPath = (value: unknown, segments: SpanFieldPath): unknown => {
+  let current: unknown = value;
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') {
+      return undefined;
+    }
+    if (Array.isArray(current)) {
+      // Only real, in-bounds numeric indices into arrays (excludes "length", etc.).
+      const index = typeof segment === 'number' ? segment : Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+        return undefined;
+      }
+      current = current[index];
+    } else {
+      const key = String(segment);
+      if (!Object.prototype.hasOwnProperty.call(current, key)) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[key];
+    }
+  }
+  return current;
+};
+
+// Serializes a structural span field (inputs/outputs/attributes) for display.
+// With no path, preserves the legacy whole-object JSON string. With a path, drills
+// into the object: a scalar leaf is returned as raw text (so the renderer shows it
+// as prose), a nested object/array as JSON, and a missing path as '' so the view
+// degrades gracefully across traces whose shape differs.
+const resolveStructuralField = (base: unknown, path?: SpanFieldPath): string => {
+  if (!path || path.length === 0) {
+    return safeJsonStringify(base);
+  }
+  const resolved = getByPath(base, path);
+  if (resolved === undefined) {
+    return '';
+  }
+  return typeof resolved === 'object' && resolved !== null ? safeJsonStringify(resolved) : asString(resolved);
+};
+
+// Resolves a `spanField` marker to a display string for the CURRENT trace: finds
+// the span via its spanRef selector, then serializes the requested field.
+export const resolveSpanFieldSource = (
+  marker: Record<string, unknown>,
+  nodeMap: Record<string, ModelTraceSpanNode>,
+): string => {
+  const field = typeof marker['field'] === 'string' ? marker['field'] : '';
+  const selector = unwrapSpanRefSelector(marker['spanRef']);
+  const spanId = isValidSpanRefSelector(selector) ? resolveSpanRef(selector, nodeMap) : undefined;
+  const span = spanId ? nodeMap[spanId] : undefined;
+  // Validate the path's contents (not just Array.isArray) before use, since the
+  // marker is unvalidated template data; malformed paths fall back to no path.
+  const path = isValidSpanFieldPath(marker['path'], field) ? (marker['path'] as SpanFieldPath) : undefined;
+  switch (field) {
+    case 'inputs':
+      return resolveStructuralField(span?.inputs, path);
+    case 'outputs':
+      return resolveStructuralField(span?.outputs, path);
+    case 'attributes':
+      return resolveStructuralField(getSpanAttributes(span), path);
+    case 'name':
+      return span ? (typeof span.title === 'string' ? span.title : asString(span.title)) : '';
+    case 'spanId':
+      return spanId ?? '';
+    default:
+      return '';
+  }
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewSources.ts
@@ -90,8 +90,11 @@ export const isValidSpanRefSelector = (selector: unknown): selector is SpanRefSe
   if (!hasType && !hasName) {
     return false;
   }
-  if ('nth' in selector && typeof selector['nth'] !== 'number') {
-    return false;
+  if ('nth' in selector) {
+    const nth = selector['nth'];
+    if (typeof nth !== 'number' || !Number.isInteger(nth) || nth < 0) {
+      return false;
+    }
   }
   return true;
 };


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24792/files) to review incremental changes.
- [stack/feat/custom-view-schema-comp-imple](https://github.com/mlflow/mlflow/pull/24788) [[Files changed](https://github.com/mlflow/mlflow/pull/24788/files)] [MERGED]
  - [**stack/feat/custom-view-2-validate-a2ui-message**](https://github.com/mlflow/mlflow/pull/24792) [[Files changed](https://github.com/mlflow/mlflow/pull/24792/files)] ← _this PR_
    - [stack/feat/custom-view-3-prompt-builder-and-template-resolver](https://github.com/mlflow/mlflow/pull/24794) [[Files changed](https://github.com/mlflow/mlflow/pull/24794/files/ebdc412c3ea14ddd1d9c44dc63c4f82b22a14220..c9fab29d1504d265586d55f56ce1119419df01af)]
      - [stack/feat/custom-view-4-assistant-bridge-integration-for-non-cli-agents](https://github.com/mlflow/mlflow/pull/24796) [[Files changed](https://github.com/mlflow/mlflow/pull/24796/files/c9fab29d1504d265586d55f56ce1119419df01af..dd1fc432dfcf092235e94a5691c6132b7c557a35)]
        - [stack/feat/custom-view-5-definition-content-and-fe-wiring](https://github.com/mlflow/mlflow/pull/24798) [[Files changed](https://github.com/mlflow/mlflow/pull/24798/files/dd1fc432dfcf092235e94a5691c6132b7c557a35..71e455241ab425a28001eef425e44744c01ca67e)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

https://databricks.atlassian.net/browse/ML-68067

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

### What changes are proposed in this pull request?

This is PR 2 of the Custom View feature migration stack. It adds the data layer between a trace and the A2UI catalog, plus the security-critical validator that gates any agent-generated UI before it's rendered. Still no UI is mounted:

- custom-view/customViewBuilders.ts — derives display-ready trace metrics (status/latency/token count) and a flat AgentAssessment[]/AssessmentBoardItem[] shape from a trace's ModelTrace.info + span node map, and materializes an { "$source": "assessments" } marker into concrete AssessmentCard components.
- custom-view/customViewSources.ts — recognizes and resolves $source (scalar/structural/spanField) and $spanRef binding markers the agent emits in place of literal data, so a saved template re-renders correctly for whatever trace is currently open.
- custom-view/agent/validateA2uiMessages.ts — validateAndPrepareMessages (strict per-trace validation against the closed catalog allowlist, used right before the renderer) and validateTemplate (marker-aware validation of the trace-agnostic template at save time). Both reject any component type or prop the catalog doesn't define — this is the only gate before the catalog-unaware A2UI renderer.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
