### PR TITLE
Rebalance JS test CI shards from lopsided 2-way to balanced 3-way

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -52,7 +52,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        option: [--testPathPattern, --testPathIgnorePatterns]
+        # Test files are sharded across jobs by path so they run in parallel.
+        # Shards are balanced by measured runtime (not file count): the two
+        # heaviest areas each get a dedicated shard and everything else shares
+        # the third. Keep the three `args` mutually exclusive and collectively
+        # exhaustive so every test file runs exactly once.
+        shard:
+          - name: experiment-tracking-components
+            args: --testPathPattern src/experiment-tracking/components
+          - name: experiment-tracking-pages-and-shared
+            args: --testPathPattern src/experiment-tracking/pages|src/shared
+          - name: rest
+            args: --testPathIgnorePatterns src/experiment-tracking/components|src/experiment-tracking/pages|src/shared
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -83,17 +94,17 @@ jobs:
           yarn type-check
       - name: Run tests
         env:
-          MATRIX_OPTION: ${{ matrix.option }}
+          MATRIX_ARGS: ${{ matrix.shard.args }}
         # --maxWorkers=2: Jest's default (3) leaks module cache across test
         # files and peaks ~15 GB RSS on the 16 GB runner; 2 keeps peak ~13 GB.
         run: |
           "$GITHUB_WORKSPACE/dev/profile.sh" \
-            yarn test --silent --maxWorkers=2 $MATRIX_OPTION src/experiment-tracking/components
+            yarn test --silent --maxWorkers=2 $MATRIX_ARGS
       - name: Upload profile metrics
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: profile-metrics-${{ strategy.job-index }}
+          name: profile-metrics-${{ matrix.shard.name }}
           path: /tmp/profile-metrics.csv
           # TODO: Uncomment once `gh run download` supports non-zipped artifacts.
           # https://github.com/cli/cli/issues/13012


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `js` CI job sharded frontend test files across two jobs by path: one ran `src/experiment-tracking/components` and the other ran everything else via `--testPathIgnorePatterns`. That split is lopsided — the "everything else" shard does more than double the work, so CI wall-clock is pinned by the slow shard while the fast one sits idle.

This rebalances the split into **three runtime-balanced shards** keyed on measured per-file timings (not file count). The two heaviest areas each get a dedicated shard, and everything else shares the third:

| Shard | Pattern | Files |
| --- | --- | --- |
| `experiment-tracking-components` | `--testPathPattern src/experiment-tracking/components` | 213 |
| `experiment-tracking-pages-and-shared` | `--testPathPattern src/experiment-tracking/pages\|src/shared` | 211 |
| `rest` | `--testPathIgnorePatterns …components\|…pages\|src/shared` | 219 |

The three shards are mutually exclusive and collectively exhaustive — 213 + 211 + 219 = 643 files, each run exactly once (verified by simulating Jest's regex matching against the actual test-file list; zero orphaned, zero double-run).

Estimated test-step wall-clock drops from ~416s to ~247s (~1.68x). Timings were captured locally, so the absolute seconds are directional; the ~1.68x ratio is what holds across runner speeds.

Notes:
- Workers stay capped at `--maxWorkers=2`. The underlying module-cache leak (ML-20462) that forces that cap is unchanged here; raising worker count is a separate follow-up.
- This costs one extra runner per JS run (2 -> 3) and runs the one-time setup steps (install/lint/type-check/build) once more per run. A follow-up could move those out of the sharded matrix so only the test step fans out.

### How is this PR tested?

- [x] Existing unit/integration tests

The change only redistributes which test files run on which shard; the full suite still runs. Correctness of the partition (exhaustive + non-overlapping) was verified against the real file list before pushing.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release