### PR TITLE
[4/N] Add client-tool pause/resume for `render_custom_view` in Assistant

### DIFF
--- a/mlflow/assistant/providers/base.py
+++ b/mlflow/assistant/providers/base.py
@@ -66,6 +66,17 @@ class AssistantProvider(ABC):
         """Whether this provider can serve requests from remote clients."""
         return False
 
+    @property
+    def supports_client_tools(self) -> bool:
+        """Whether this provider can pause a turn on a CLIENT-executed tool call (see
+        ``tool_executor.CLIENT_TOOLS``) and resume it once the client posts a result,
+        e.g. rendering an agent-authored UI spec in the browser. CLI-based providers
+        (Claude Code, Codex) have no such mid-stream channel without MCP plumbing, so
+        features that need this fall back to a convention (e.g. a fenced code block)
+        for those providers instead.
+        """
+        return False
+
     @abstractmethod
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
         """

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -28,6 +28,7 @@ from mlflow.assistant.providers.base import (
 )
 from mlflow.assistant.providers.prompts import ASSISTANT_SYSTEM_PROMPT
 from mlflow.assistant.providers.tool_executor import (
+    CLIENT_TOOLS,
     build_tools_schema,
     execute_tool,
     static_permission_error,
@@ -288,6 +289,12 @@ class OpenAICompatibleProvider(AssistantProvider):
     def allows_remote_access(self) -> bool:
         return self._allows_remote_access
 
+    @property
+    def supports_client_tools(self) -> bool:
+        # Schema-based providers: the tool loop below pauses on a CLIENT_TOOLS call
+        # and resumes on the next stream once a result is posted (see astream()).
+        return True
+
     def is_available(self) -> bool:
         return True
 
@@ -421,17 +428,22 @@ class OpenAICompatibleProvider(AssistantProvider):
             messages.append({"role": "system", "content": sys_content})
 
         tool_decisions = (context or {}).get("tool_decisions") or {}
+        # tool_call_id -> {"content": str, "is_error": bool}, delivered by the client
+        # after it executed a CLIENT_TOOLS call (e.g. render_custom_view).
+        client_tool_results = (context or {}).get("client_tool_results") or {}
         # A history whose last assistant turn carries tool_calls without results is
-        # a turn paused at a permission prompt. We resume it (applying the decisions
-        # in `tool_decisions`) ONLY when a decision was actually delivered. Deriving
-        # this from history alone is unsafe: if the user cancels at the prompt (a
-        # no-op for this provider, so the unresolved tool_calls stay in history) and
-        # then sends a new message, we must start a fresh turn — not silently
-        # re-resume the abandoned calls and drop their message.
+        # a turn paused at a permission prompt or a client-executed tool call. We
+        # resume it (applying `tool_decisions`/`client_tool_results`) ONLY when one was
+        # actually delivered. Deriving this from history alone is unsafe: if the user
+        # cancels at the prompt (a no-op for this provider, so the unresolved
+        # tool_calls stay in history) and then sends a new message, we must start a
+        # fresh turn — not silently re-resume the abandoned calls and drop their message.
         tool_calls_awaiting_decision = _pending_tool_calls(messages)
         # TODO (joshuawong-db) This should be refactored into a helper function when
         # more providers support tool calls as it has a close coupling with api.py logic.
-        is_resuming = bool(tool_decisions) and bool(tool_calls_awaiting_decision)
+        is_resuming = bool(tool_decisions or client_tool_results) and bool(
+            tool_calls_awaiting_decision
+        )
         if not is_resuming:
             # Close out any orphaned tool_calls (e.g. cancelled at a prompt) before
             # the new user message: OpenAI requires a result for every tool_call, so
@@ -619,6 +631,48 @@ class OpenAICompatibleProvider(AssistantProvider):
                             )
                         except json.JSONDecodeError:
                             tool_input = {}
+
+                        if tool_name in CLIENT_TOOLS:
+                            # Client-executed tool: never runs server-side and never goes
+                            # through the permission gate below. First time this call is
+                            # seen, surface it and pause the turn for the client to render
+                            # (via a client_tool_call event) and report a result on resume.
+                            client_result = client_tool_results.get(tc["id"])
+                            if client_result is None:
+                                yield Event.from_message(
+                                    Message(
+                                        role="assistant",
+                                        content=[
+                                            ToolUseBlock(
+                                                id=tc["id"], name=tool_name, input=tool_input
+                                            )
+                                        ],
+                                    )
+                                )
+                                yield Event.from_client_tool_call(tc["id"], tool_name, tool_input)
+                                paused = True
+                                break
+
+                            content = client_result.get("content", "")
+                            is_error = bool(client_result.get("is_error"))
+                            yield Event.from_message(
+                                Message(
+                                    role="user",
+                                    content=[
+                                        ToolResultBlock(
+                                            tool_use_id=tc["id"],
+                                            content=content,
+                                            is_error=is_error,
+                                        )
+                                    ],
+                                )
+                            )
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc["id"],
+                                "content": content,
+                            })
+                            continue
 
                         # Permission gating. With full access (config) tools run without
                         # prompting. Otherwise we prompt only for a call that BOTH has a session

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -13,6 +13,12 @@ _FILE_TOOLS = {"Read", "Write", "Edit"}
 # Restricted mode only permits MLflow CLI and Python; anything else needs Full Access.
 _ALLOWED_BASH_COMMANDS = {"mlflow", "python3", "python"}
 
+RENDER_CUSTOM_VIEW_TOOL_NAME = "render_custom_view"
+# Tools executed on the CLIENT (browser), not the server: the assistant loop pauses the turn and
+# waits for a client-submitted result instead of routing the call through execute_tool/the static
+# permission gate. See openai_compatible.py's tool loop.
+CLIENT_TOOLS = {RENDER_CUSTOM_VIEW_TOOL_NAME}
+
 
 def _is_path_within(path: Path, root: Path) -> bool:
     try:
@@ -266,6 +272,35 @@ def build_tools_schema() -> list[dict[str, Any]]:
                         },
                     },
                     "required": ["file_path", "old_string", "new_string"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": RENDER_CUSTOM_VIEW_TOOL_NAME,
+                "description": (
+                    "Render a custom trace view in the UI: a reusable, trace-agnostic layout of "
+                    "cards, stat tiles, key-value viewers, and assessment boards, built from the "
+                    "current trace's data. Call this once you've designed the layout; the client "
+                    "renders it and reports back whether it applied successfully."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Short display title for the view.",
+                        },
+                        "messages": {
+                            "type": "array",
+                            "description": (
+                                "A2UI message list describing the view's component tree."
+                            ),
+                            "items": {"type": "object"},
+                        },
+                    },
+                    "required": ["title", "messages"],
                 },
             },
         },

--- a/mlflow/assistant/types.py
+++ b/mlflow/assistant/types.py
@@ -58,6 +58,7 @@ class EventType(str, Enum):
     ERROR = "error"
     INTERRUPTED = "interrupted"
     PERMISSION_REQUEST = "permission_request"
+    CLIENT_TOOL_CALL = "client_tool_call"
 
     def __str__(self):
         return self.value
@@ -107,5 +108,18 @@ class Event(BaseModel):
     ) -> "Event":
         return cls(
             type=EventType.PERMISSION_REQUEST,
+            data={"request_id": request_id, "tool_name": tool_name, "tool_input": tool_input},
+        )
+
+    @classmethod
+    def from_client_tool_call(
+        cls, request_id: str, tool_name: str, tool_input: dict[str, Any]
+    ) -> "Event":
+        """A tool call the CLIENT (not the server) must execute, e.g. rendering an
+        agent-authored UI spec in the browser. Ends the turn the same way a
+        permission request does: the client posts the result to resume.
+        """
+        return cls(
+            type=EventType.CLIENT_TOOL_CALL,
             data={"request_id": request_id, "tool_name": tool_name, "tool_input": tool_input},
         )

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -193,6 +193,9 @@ class ProviderInfo(BaseModel):
     requires_api_key: bool
     has_api_key: bool
     allows_remote_access: bool
+    # Whether this provider can pause a turn on a CLIENT-executed tool call and
+    # resume it once the client posts a result. See AssistantProvider.supports_client_tools.
+    supports_client_tools: bool = False
     model_options: list[str] = Field(default_factory=list)
 
 
@@ -202,6 +205,7 @@ class ResolvedProviderInfo(BaseModel):
     auto_selected: bool
     requires_api_key: bool
     has_api_key: bool
+    supports_client_tools: bool = False
     model_provider: str | None = None
     model_options: list[str] = Field(default_factory=list)
     provider_model: str | None = None
@@ -224,6 +228,12 @@ class SessionPatchResponse(BaseModel):
 class PermissionDecision(BaseModel):
     request_id: str  # the paused tool_call's id
     decision: Literal["allow", "deny"]
+
+
+class ClientToolResult(BaseModel):
+    request_id: str  # the paused tool_call's id
+    content: str
+    is_error: bool = False
 
 
 def _store_gateway_api_key(name: str, provider_data: dict[str, Any]) -> str | None:
@@ -282,6 +292,7 @@ def _resolved_provider_info(
         auto_selected=auto_selected,
         requires_api_key=False,
         has_api_key=False,
+        supports_client_tools=provider.supports_client_tools,
     )
     if provider.name == MlflowGatewayProvider.GATEWAY_PROVIDER_NAME:
         if vendor := _gateway_vendor_from_managed_endpoint(model):
@@ -376,26 +387,31 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    # A turn is driven by either a pending user message (a new turn) or pending
-    # tool-call decisions (resuming a turn paused at a permission prompt). Both
-    # are consumed here so the stream is replay-safe.
+    # A turn is driven by a pending user message (a new turn) or pending tool-call
+    # decisions/results (resuming a turn paused at a permission prompt or a
+    # client-executed tool call). All are consumed here so the stream is replay-safe.
     pending_message = session.clear_pending_message()
     tool_decisions = session.pending_tool_decisions
     session.pending_tool_decisions = {}
-    if not pending_message and not tool_decisions:
+    client_tool_results = session.pending_client_tool_results
+    session.pending_client_tool_results = {}
+    if not pending_message and not tool_decisions and not client_tool_results:
         raise HTTPException(status_code=400, detail="No pending message to process")
     SessionManager.save(session_id, session)
 
     prompt = pending_message.content if pending_message else ""
-    # On resume the decision rides in the context; the provider detects the
+    # On resume the decision/result rides in the context; the provider detects the
     # pending tool_calls in history and applies it instead of starting a turn.
-    # A new message supersedes a pending decision: if both are present (e.g. a
-    # resume stream never consumed the decision and the user typed again),
-    # forwarding the stale tool_decisions would make the provider resume the
-    # abandoned turn and silently drop the new message. Prefer the message.
+    # A new message supersedes pending decisions/results: if both are present (e.g. a
+    # resume stream never consumed them and the user typed again), forwarding the
+    # stale state would make the provider resume the abandoned turn and silently
+    # drop the new message. Prefer the message.
     context = dict(session.context)
-    if tool_decisions and not pending_message:
-        context["tool_decisions"] = tool_decisions
+    if not pending_message:
+        if tool_decisions:
+            context["tool_decisions"] = tool_decisions
+        if client_tool_results:
+            context["client_tool_results"] = client_tool_results
 
     # Extract the MLflow server URL from the request for the assistant to use.
     # This assumes the assistant is accessing the same MLflow server that serves this API.
@@ -464,8 +480,9 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
     if request.status == "cancelled":
         # Terminate any associated subprocess. The OpenAI-compatible provider
         # holds no in-process state to release (the turn ends at each prompt).
-        # Drop any tool permissions so later stream doesn't see stale decisions.
+        # Drop any tool permissions/results so later stream doesn't see stale state.
         session.pending_tool_decisions = {}
+        session.pending_client_tool_results = {}
         SessionManager.save(session_id, session)
         terminated = terminate_session_process(session_id)
         msg = "Session cancelled and process terminated" if terminated else "Session cancelled"
@@ -495,6 +512,37 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
         raise HTTPException(status_code=404, detail="Session not found")
 
     session.pending_tool_decisions = {request.request_id: request.decision}
+    SessionManager.save(session_id, session)
+
+    return MessageResponse(
+        session_id=session_id,
+        stream_url=f"/ajax-api/3.0/mlflow/assistant/sessions/{session_id}/stream",
+    )
+
+
+@assistant_router.post("/sessions/{session_id}/tool-result")
+@_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
+async def resolve_client_tool_result(
+    session_id: str, request: ClientToolResult
+) -> MessageResponse:
+    """Deliver a client-executed tool's result and resume the paused turn on a new stream.
+
+    Mirrors `resolve_permission`: the result is stored on the session and consumed
+    by the next stream, which splices it in as the tool's result message and
+    continues the loop.
+    """
+    try:
+        SessionManager.validate_session_id(session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    session = SessionManager.load(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    session.pending_client_tool_results = {
+        request.request_id: {"content": request.content, "is_error": request.is_error}
+    }
     SessionManager.save(session_id, session)
 
     return MessageResponse(
@@ -541,6 +589,7 @@ async def get_providers() -> ProvidersResponse:
             requires_api_key=False,
             has_api_key=False,
             allows_remote_access=provider.allows_remote_access,
+            supports_client_tools=provider.supports_client_tools,
             model_options=[],
         )
         for provider in providers

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -522,9 +522,7 @@ async def resolve_permission(session_id: str, request: PermissionDecision) -> Me
 
 @assistant_router.post("/sessions/{session_id}/tool-result")
 @_remote_access_policy(_RemoteAccessPolicy.ONLY_SAFE_PROVIDER)
-async def resolve_client_tool_result(
-    session_id: str, request: ClientToolResult
-) -> MessageResponse:
+async def resolve_client_tool_result(session_id: str, request: ClientToolResult) -> MessageResponse:
     """Deliver a client-executed tool's result and resume the paused turn on a new stream.
 
     Mirrors `resolve_permission`: the result is stored on the session and consumed

--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -25,6 +25,11 @@ class Session:
     # turn paused at a permission prompt can resume. Set by the resume endpoint,
     # consumed (and cleared) by the stream.
     pending_tool_decisions: dict[str, Literal["allow", "deny"]] = field(default_factory=dict)
+    # tool_call_id -> {"content": str, "is_error": bool}: the result of a CLIENT
+    # -executed tool call (e.g. render_custom_view), awaiting the next stream so a
+    # turn paused at a client_tool_call can resume. Set by the tool-result
+    # endpoint, consumed (and cleared) by the stream.
+    pending_client_tool_results: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     def add_message(self, role: str, content: str) -> None:
         """Add a message to the session history.
@@ -75,6 +80,7 @@ class Session:
             "provider_session_id": self.provider_session_id,
             "working_dir": self.working_dir.as_posix() if self.working_dir else None,
             "pending_tool_decisions": self.pending_tool_decisions,
+            "pending_client_tool_results": self.pending_client_tool_results,
         }
 
     @classmethod
@@ -98,6 +104,7 @@ class Session:
             provider_session_id=data.get("provider_session_id"),
             working_dir=Path(data.get("working_dir")) if data.get("working_dir") else None,
             pending_tool_decisions=data.get("pending_tool_decisions") or {},
+            pending_client_tool_results=data.get("pending_client_tool_results") or {},
         )
 
 

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -284,6 +284,7 @@ describe('AssistantChatPanel', () => {
       model_options: ['gpt-5.5', 'gpt-5-mini'],
       requires_api_key: true,
       has_api_key: false,
+      supports_client_tools: true,
     };
     mockNeedsApiKey = true;
     const user = userEvent.setup();
@@ -310,6 +311,7 @@ describe('AssistantChatPanel', () => {
       model_options: ['gpt-5.5', 'gpt-5-mini'],
       requires_api_key: true,
       has_api_key: false,
+      supports_client_tools: true,
     };
     mockError = 'OpenAI requires an API key.';
     mockErrorCode = 'api_key_missing';

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -17,6 +17,7 @@ import {
 } from './AssistantContext';
 import * as AssistantService from './AssistantService';
 import type { SendMessageStreamCallbacks } from './AssistantService';
+import { registerClientToolHandler } from './clientToolHandlers';
 import type { AssistantPart, ChatMessage, ProviderInfo, ResolvedProviderInfo } from './types';
 
 const EMPTY_TOKEN_USAGE = { promptTokens: 0, completionTokens: 0, totalTokens: 0, cacheReadTokens: 0, costUsd: null };
@@ -37,6 +38,7 @@ const resolvedProvider = (overrides: Partial<ResolvedProviderInfo> = {}): Resolv
   auto_selected: true,
   requires_api_key: false,
   has_api_key: false,
+  supports_client_tools: false,
   ...overrides,
 });
 
@@ -48,6 +50,7 @@ const providerInfo = (overrides: Partial<ProviderInfo> & { name: string }): Prov
   requires_api_key: false,
   has_api_key: false,
   allows_remote_access: false,
+  supports_client_tools: false,
   model_options: [],
   ...overrides,
 });
@@ -59,6 +62,7 @@ jest.mock('./AssistantService', () => ({
   getProviders: jest.fn(),
   updateConfig: jest.fn(() => Promise.resolve({})),
   cancelSession: jest.fn(),
+  submitClientToolResult: jest.fn(),
 }));
 
 jest.mock('./AssistantPageContext', () => ({
@@ -69,6 +73,7 @@ const mockSendMessageStream = jest.mocked(AssistantService.sendMessageStream);
 const mockGetConfig = jest.mocked(AssistantService.getConfig);
 const mockGetProviders = jest.mocked(AssistantService.getProviders);
 const mockUpdateConfig = jest.mocked(AssistantService.updateConfig);
+const mockSubmitClientToolResult = jest.mocked(AssistantService.submitClientToolResult);
 const originalLocation = window.location;
 
 // A fake EventSource — the real one is created inside sendMessageStream, which we mock,
@@ -93,6 +98,10 @@ beforeEach(() => {
   mockGetConfig.mockResolvedValue({ providers: {}, projects: {} });
   mockGetProviders.mockResolvedValue({ providers: [], resolved: null });
   mockSendMessageStream.mockImplementation(async (_req, callbacks) => {
+    capturedCallbacks = callbacks;
+    return { eventSource: fakeEventSource as unknown as EventSource };
+  });
+  mockSubmitClientToolResult.mockImplementation(async (_sessionId, _requestId, _content, _isError, callbacks) => {
     capturedCallbacks = callbacks;
     return { eventSource: fakeEventSource as unknown as EventSource };
   });
@@ -644,6 +653,119 @@ describe('AssistantContext — a new message supersedes a pending permission pro
     });
 
     expect(result.current.pendingPermission).toBeNull();
+  });
+});
+
+describe('AssistantContext — client_tool_call auto-resume', () => {
+  const pauseAtClientTool = (overrides: Partial<{ toolName: string; toolInput: Record<string, unknown> }> = {}) => {
+    capturedCallbacks?.onClientToolCall?.({
+      sessionId: 'session-1',
+      requestId: 'req-1',
+      toolName: overrides.toolName ?? 'render_custom_view',
+      toolInput: overrides.toolInput ?? { title: 'Trace Summary', messages: [] },
+    });
+  };
+
+  it('runs the registered handler and submits its result to resume the stream', async () => {
+    const handler = jest.fn(async (toolInput: Record<string, any>) => ({
+      content: `applied: ${toolInput['title']}`,
+      isError: false,
+    }));
+    const unregister = registerClientToolHandler('render_custom_view', handler);
+
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+    await act(async () => {
+      pauseAtClientTool();
+    });
+
+    expect(handler).toHaveBeenCalledWith({ title: 'Trace Summary', messages: [] });
+    await waitFor(() =>
+      expect(mockSubmitClientToolResult).toHaveBeenCalledWith(
+        'session-1',
+        'req-1',
+        'applied: Trace Summary',
+        false,
+        expect.anything(),
+      ),
+    );
+    expect(result.current.pendingClientToolCall).toBeNull();
+
+    unregister();
+  });
+
+  it('submits an error result when no handler is registered for the tool name', async () => {
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+    await act(async () => {
+      pauseAtClientTool({ toolName: 'unregistered_tool' });
+    });
+
+    await waitFor(() =>
+      expect(mockSubmitClientToolResult).toHaveBeenCalledWith(
+        'session-1',
+        'req-1',
+        'No handler is registered for client tool "unregistered_tool".',
+        true,
+        expect.anything(),
+      ),
+    );
+  });
+
+  it('submits an error result when the registered handler rejects', async () => {
+    const unregister = registerClientToolHandler('render_custom_view', async () => {
+      throw new Error('failed to apply spec');
+    });
+
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+    await act(async () => {
+      pauseAtClientTool();
+    });
+
+    await waitFor(() =>
+      expect(mockSubmitClientToolResult).toHaveBeenCalledWith(
+        'session-1',
+        'req-1',
+        'failed to apply spec',
+        true,
+        expect.anything(),
+      ),
+    );
+
+    unregister();
+  });
+
+  it('clears pendingClientToolCall when a new message supersedes the paused turn', async () => {
+    const unregister = registerClientToolHandler(
+      'render_custom_view',
+      // Never resolves, so the effect stays pending and doesn't clear pendingClientToolCall itself.
+      () => new Promise(() => {}),
+    );
+
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-1');
+      pauseAtClientTool();
+    });
+    expect(result.current.pendingClientToolCall).not.toBeNull();
+
+    await act(async () => {
+      result.current.sendMessage('never mind, what is 2+2');
+    });
+
+    expect(result.current.pendingClientToolCall).toBeNull();
+
+    unregister();
   });
 });
 

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -11,6 +11,7 @@ import {
   type AssistantPart,
   type ChatMessage,
   type PermissionRequest,
+  type PendingClientToolCall,
   type AssistantProviderSelection,
   type ProviderInfo,
   type ProvidersResponse,
@@ -25,10 +26,12 @@ import {
   getConfig,
   getProviders,
   resumeStream,
+  submitClientToolResult as submitClientToolResultApi,
   updateConfig,
   type SendMessageStreamCallbacks,
   type SendMessageStreamResult,
 } from './AssistantService';
+import { getClientToolHandler } from './clientToolHandlers';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { useAssistantPageContextActions } from './AssistantPageContext';
 import { GATEWAY_PROVIDER_ID } from './constants';
@@ -150,6 +153,8 @@ const activeProviderFromSelection = (
       auto_selected: false,
       requires_api_key: selection.requiresApiKey ?? false,
       has_api_key: selection.hasApiKey ?? true,
+      // The gateway is always backed by OpenAICompatibleProvider server-side.
+      supports_client_tools: true,
       model_provider: selection.gatewayVendor,
       provider_model: selection.providerModel ?? null,
       model_options: selection.modelOptions ?? [],
@@ -163,6 +168,7 @@ const activeProviderFromSelection = (
     auto_selected: false,
     requires_api_key: provider?.requires_api_key ?? false,
     has_api_key: provider?.has_api_key ?? false,
+    supports_client_tools: provider?.supports_client_tools ?? false,
     model_options: provider?.model_options ?? [],
   };
 };
@@ -279,6 +285,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   const [currentStatus, setCurrentStatus] = useState<string | null>(null);
   const [activeTools, setActiveTools] = useState<ToolUseInfo[]>([]);
   const [pendingPermission, setPendingPermission] = useState<PermissionRequest | null>(null);
+  const [pendingClientToolCall, setPendingClientToolCall] = useState<PendingClientToolCall | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>(() => normalizeTokenUsage(persistedChat.tokenUsage));
 
@@ -412,6 +419,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setCurrentStatus(null);
     setActiveTools([]);
     setPendingPermission(null);
+    setPendingClientToolCall(null);
   }, [closeStreamingMessage]);
 
   const handleStatus = useCallback((status: string) => {
@@ -479,6 +487,10 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   const handlePermissionRequest = useCallback((request: PermissionRequest) => {
     setPendingPermission(request);
+  }, []);
+
+  const handleClientToolCall = useCallback((request: PendingClientToolCall) => {
+    setPendingClientToolCall(request);
   }, []);
 
   // Setup actions
@@ -609,6 +621,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       eventSourceRef.current = null;
       setActiveTools([]);
       setPendingPermission(null);
+      setPendingClientToolCall(null);
       closeStreamingMessage({ reason: TurnEndReason.Failed, error: errorMsg });
     },
     [closeStreamingMessage],
@@ -619,6 +632,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setCurrentStatus(null);
     setActiveTools([]);
     setPendingPermission(null);
+    setPendingClientToolCall(null);
     eventSourceRef.current = null;
     if (rafPendingRef.current !== null) {
       cancelAnimationFrame(rafPendingRef.current);
@@ -642,6 +656,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       onInterrupted: interruptStreamingTurn,
       onUsage: handleUsage,
       onPermissionRequest: handlePermissionRequest,
+      onClientToolCall: handleClientToolCall,
     }),
     [
       writeStreamedText,
@@ -654,6 +669,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       interruptStreamingTurn,
       handleUsage,
       handlePermissionRequest,
+      handleClientToolCall,
     ],
   );
 
@@ -700,6 +716,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setPersistedChat({ messages: [], tokenUsage: EMPTY_TOKEN_USAGE });
     openTextBufferRef.current = '';
     setPendingPermission(null);
+    setPendingClientToolCall(null);
   }, [setPersistedChat]);
 
   // Begin a new in-flight send: stamp a fresh token in closure,
@@ -733,6 +750,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       // here drops the stale Allow/Deny so it can't resume the abandoned turn; the
       // backend closes the orphaned tool call out as cancelled.
       setPendingPermission(null);
+      setPendingClientToolCall(null);
 
       // Add user message if prompt provided
       if (prompt) {
@@ -828,6 +846,67 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     [pendingPermission, beginRequest, attachStreamIfCurrent, streamCallbacks, failStreamingTurn],
   );
 
+  const submitClientToolResult = useCallback(
+    (content: string, isError = false) => {
+      if (!pendingClientToolCall) {
+        return;
+      }
+      // Target the request's originating session, not the current one, so a
+      // session change while the call was pending can't resolve the wrong turn.
+      const { sessionId: requestSessionId, requestId } = pendingClientToolCall;
+      setPendingClientToolCall(null);
+      setError(null);
+      setErrorCode(null);
+      setIsStreaming(true);
+
+      // The paused assistant placeholder keeps streaming — no new message; the
+      // resume stream continues accumulating into it until done.
+      const isCurrent = beginRequest();
+      submitClientToolResultApi(requestSessionId, requestId, content, isError, withGuard(isCurrent, streamCallbacks))
+        .then((result) => {
+          attachStreamIfCurrent(isCurrent, result);
+        })
+        .catch((err) => {
+          if (isCurrent()) {
+            failStreamingTurn(err instanceof Error ? err.message : 'Failed to resume');
+          }
+        });
+    },
+    [pendingClientToolCall, beginRequest, attachStreamIfCurrent, streamCallbacks, failStreamingTurn],
+  );
+
+  // A client_tool_call needs no user interaction (unlike a permission prompt):
+  // look up the feature-registered handler for the tool name (see
+  // clientToolHandlers.ts), run it, and report the result to resume the stream.
+  // No registered handler (e.g. the owning feature isn't mounted) reports an
+  // error so the paused turn doesn't hang forever.
+  useEffect(() => {
+    if (!pendingClientToolCall) {
+      return;
+    }
+    let cancelled = false;
+    const { toolName, toolInput } = pendingClientToolCall;
+    const handler = getClientToolHandler(toolName);
+    if (!handler) {
+      submitClientToolResult(`No handler is registered for client tool "${toolName}".`, true);
+      return;
+    }
+    handler(toolInput)
+      .then((result) => {
+        if (!cancelled) {
+          submitClientToolResult(result.content, result.isError);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          submitClientToolResult(err instanceof Error ? err.message : 'Client tool execution failed', true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingClientToolCall, submitClientToolResult]);
+
   const handleSendMessage = useCallback(
     async (message: string) => {
       if (!sessionId) {
@@ -841,6 +920,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       setErrorCode(null);
       setIsStreaming(true);
       setPendingPermission(null);
+      setPendingClientToolCall(null);
 
       // Add user message
       setMessages((prev) => [
@@ -936,6 +1016,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setCurrentStatus(null);
     setActiveTools([]);
     setPendingPermission(null);
+    setPendingClientToolCall(null);
   }, [sessionId, isStreaming, closeStreamingMessage]);
 
   const regenerateLastMessage = useCallback(async () => {
@@ -1040,6 +1121,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     needsApiKey,
     pendingPrompt,
     pendingPermission,
+    pendingClientToolCall,
     canUseAssistant,
     tokenUsage,
     // Actions
@@ -1055,6 +1137,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     refreshConfig,
     completeSetup,
     respondToPermission,
+    submitClientToolResult,
   };
 
   return <AssistantReactContext.Provider value={value}>{children}</AssistantReactContext.Provider>;
@@ -1079,6 +1162,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   needsApiKey: false,
   pendingPrompt: null,
   pendingPermission: null,
+  pendingClientToolCall: null,
   canUseAssistant: false,
   tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cacheReadTokens: 0, costUsd: null },
   openPanel: () => {},
@@ -1093,6 +1177,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   refreshConfig: () => Promise.resolve(),
   completeSetup: () => {},
   respondToPermission: () => {},
+  submitClientToolResult: () => {},
 };
 
 /**

--- a/mlflow/server/js/src/assistant/AssistantPageContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantPageContext.test.tsx
@@ -6,6 +6,7 @@ import {
   useAssistantPageContext,
   useAssistantPageContextActions,
 } from './AssistantPageContext';
+import { registerAssistantContextProvider } from './contextProviders';
 
 afterEach(() => {
   cleanup();
@@ -162,6 +163,37 @@ describe('useRegisterAssistantContext', () => {
     expect(ctx.current).not.toHaveProperty('selectedScorerName');
 
     unmount();
+  });
+});
+
+describe('useAssistantPageContextActions — getContext', () => {
+  it('merges reactively-registered context with pull-based dynamic providers', () => {
+    const { unmount } = renderHook(() => {
+      useRegisterAssistantContext('traceId', 'trace-123');
+    });
+    const unregister = registerAssistantContextProvider('customTraceView', () => ({ guide: 'authoring guide' }));
+
+    const { getContext } = renderHook(() => useAssistantPageContextActions()).result.current;
+    expect(getContext()).toMatchObject({
+      traceId: 'trace-123',
+      customTraceView: { guide: 'authoring guide' },
+    });
+
+    unregister();
+    expect(getContext()).not.toHaveProperty('customTraceView');
+    unmount();
+  });
+
+  it('a dynamic provider does not leak into the reactive store (only getContext sees it)', () => {
+    const unregister = registerAssistantContextProvider('dynamicKey', () => 'value');
+
+    const { result: ctx } = renderHook(() => useAssistantPageContext());
+    expect(ctx.current).not.toHaveProperty('dynamicKey');
+
+    const { getContext } = renderHook(() => useAssistantPageContextActions()).result.current;
+    expect(getContext()).toMatchObject({ dynamicKey: 'value' });
+
+    unregister();
   });
 });
 

--- a/mlflow/server/js/src/assistant/AssistantPageContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantPageContext.tsx
@@ -3,6 +3,7 @@ import { create } from '@databricks/web-shared/zustand';
 import { usePageTitle, useParams, useSearchParams } from '../common/utils/RoutingUtils';
 import type { RowSelectionState } from '@tanstack/react-table';
 
+import { collectDynamicAssistantContext } from './contextProviders';
 import type { AssistantContextKey, KnownAssistantContext } from './types';
 
 type AssistantPageContextData = Record<string, unknown>;
@@ -37,7 +38,10 @@ const useAssistantPageContextStore = create<AssistantPageContextStore>((set, get
       }
       return { context: newContext };
     }),
-  getContext: () => ({ ...get().context }),
+  // Merges in pull-based providers (see `contextProviders.ts`) on every read, so
+  // callers (e.g. `handleSendMessage`) always see the latest value without those
+  // providers having to push updates into this store's React state.
+  getContext: () => ({ ...get().context, ...collectDynamicAssistantContext() }),
 }));
 
 /**

--- a/mlflow/server/js/src/assistant/AssistantProviderPicker.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantProviderPicker.test.tsx
@@ -25,6 +25,7 @@ const providerInfo = (overrides: Partial<ProviderInfo> & { name: string; display
   requires_api_key: false,
   has_api_key: false,
   allows_remote_access: false,
+  supports_client_tools: false,
   model_options: [],
   ...overrides,
 });
@@ -35,6 +36,7 @@ const resolvedProvider = (overrides: Partial<ResolvedProviderInfo> = {}): Resolv
   auto_selected: true,
   requires_api_key: false,
   has_api_key: false,
+  supports_client_tools: false,
   ...overrides,
 });
 

--- a/mlflow/server/js/src/assistant/AssistantService.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantService.test.tsx
@@ -1,6 +1,6 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { fetchAPI } from '@mlflow/mlflow/src/common/utils/FetchUtils';
-import { resumeStream, sendMessageStream, processContentBlocks } from './AssistantService';
+import { resumeStream, sendMessageStream, submitClientToolResult, processContentBlocks } from './AssistantService';
 import type { ToolUseInfo, ToolResultInfo } from './types';
 
 // jest.mock is hoisted above imports by babel-jest, so the mock still applies.
@@ -59,6 +59,43 @@ describe('AssistantService permissions', () => {
   });
 });
 
+describe('AssistantService client tool results', () => {
+  beforeEach(() => {
+    mockedFetchAPI.mockClear();
+    FakeEventSource.instances = [];
+    (global as any).EventSource = FakeEventSource;
+  });
+
+  test('submitClientToolResult POSTs the result then opens a fresh stream', async () => {
+    const result = await submitClientToolResult('sess-1', 'req-1', 'view rendered', false, {
+      onMessage: jest.fn(),
+      onError: jest.fn(),
+      onDone: jest.fn(),
+    });
+    expect(mockedFetchAPI).toHaveBeenCalledWith('ajax-api/3.0/mlflow/assistant/sessions/sess-1/tool-result', {
+      method: 'POST',
+      body: JSON.stringify({ request_id: 'req-1', content: 'view rendered', is_error: false }),
+    });
+    expect(result.eventSource).toBeDefined();
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  test('submitClientToolResult surfaces a friendly error and returns no stream when the POST fails', async () => {
+    mockedFetchAPI.mockRejectedValueOnce(new Error('network down'));
+    const onError = jest.fn();
+
+    const result = await submitClientToolResult('sess-1', 'req-1', 'boom', true, {
+      onMessage: jest.fn(),
+      onError,
+      onDone: jest.fn(),
+    });
+
+    expect(onError).toHaveBeenCalledWith('Failed to send the client tool result. Please try again.');
+    expect(result.eventSource).toBeNull();
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+});
+
 describe('sendMessageStream permission_request event', () => {
   beforeEach(() => {
     FakeEventSource.instances = [];
@@ -91,6 +128,37 @@ describe('sendMessageStream permission_request event', () => {
       toolInput: { command: 'ls' },
     });
     // The turn ends at the prompt: the stream is closed, the decision arrives via resumeStream.
+    expect(es.readyState).toBe(FakeEventSource.CLOSED);
+  });
+
+  test('a client_tool_call SSE event invokes onClientToolCall and closes the stream', async () => {
+    const onClientToolCall = jest.fn();
+    await sendMessageStream(
+      { message: 'build me a view' },
+      {
+        onMessage: jest.fn(),
+        onError: jest.fn(),
+        onDone: jest.fn(),
+        onClientToolCall,
+      },
+    );
+
+    const es = FakeEventSource.instances[0];
+    expect(es).toBeDefined();
+    es.emit('client_tool_call', {
+      request_id: 'req-1',
+      tool_name: 'render_custom_view',
+      tool_input: { title: 'Trace Summary', messages: [] },
+    });
+
+    expect(onClientToolCall).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      requestId: 'req-1',
+      toolName: 'render_custom_view',
+      toolInput: { title: 'Trace Summary', messages: [] },
+    });
+    // Like a permission_request, the turn ends here: the client executes the tool and
+    // resumes via submitClientToolResult.
     expect(es.readyState).toBe(FakeEventSource.CLOSED);
   });
 });

--- a/mlflow/server/js/src/assistant/AssistantService.ts
+++ b/mlflow/server/js/src/assistant/AssistantService.ts
@@ -11,6 +11,7 @@ import type {
   HealthCheckResult,
   InstallSkillsResponse,
   PermissionRequest,
+  PendingClientToolCall,
   ProvidersResponse,
 } from './types';
 import { fetchAPI, getAjaxUrl, getDefaultHeaders } from '@mlflow/mlflow/src/common/utils/FetchUtils';
@@ -127,6 +128,7 @@ export interface SendMessageStreamCallbacks {
   onToolResult?: (result: ToolResultInfo) => void;
   onInterrupted?: () => void;
   onPermissionRequest?: (request: PermissionRequest) => void;
+  onClientToolCall?: (request: PendingClientToolCall) => void;
   onUsage?: (usage: {
     prompt_tokens: number;
     completion_tokens: number;
@@ -149,8 +151,18 @@ const attachStreamListeners = (
   sessionId: string,
   callbacks: SendMessageStreamCallbacks,
 ): void => {
-  const { onMessage, onError, onDone, onStatus, onToolUse, onToolResult, onInterrupted, onPermissionRequest, onUsage } =
-    callbacks;
+  const {
+    onMessage,
+    onError,
+    onDone,
+    onStatus,
+    onToolUse,
+    onToolResult,
+    onInterrupted,
+    onPermissionRequest,
+    onClientToolCall,
+    onUsage,
+  } = callbacks;
 
   // Listen for 'message' events (contains assistant's response)
   // Backend sends: {"message": {"role": "assistant", "content": "..."}}
@@ -206,6 +218,25 @@ const attachStreamListeners = (
       });
     } catch (err) {
       onError('Failed to read a tool permission request from the assistant.');
+    }
+    eventSource.close();
+  });
+
+  // A 'client_tool_call' also ENDS the turn: the tool must be executed by the
+  // client (e.g. rendering an agent-authored UI spec), not the server. We
+  // surface it and close the stream; the result is delivered via
+  // submitClientToolResult, which opens a fresh stream to continue.
+  eventSource.addEventListener('client_tool_call', (event) => {
+    try {
+      const data = JSON.parse((event as MessageEvent).data);
+      onClientToolCall?.({
+        sessionId,
+        requestId: data.request_id,
+        toolName: data.tool_name,
+        toolInput: data.tool_input ?? {},
+      });
+    } catch (err) {
+      onError('Failed to read a client tool call from the assistant.');
     }
     eventSource.close();
   });
@@ -312,6 +343,33 @@ export const resumeStream = async (
     });
   } catch (error) {
     callbacks.onError('Failed to send your permission decision. Please try again.');
+    return { eventSource: null };
+  }
+
+  const eventSource = createEventSource(sessionId);
+  attachStreamListeners(eventSource, sessionId, callbacks);
+  return { eventSource };
+};
+
+/**
+ * Resume a turn paused at a client_tool_call: POST the client-executed
+ * result, then open a fresh stream that continues from where the turn left
+ * off. Mirrors resumeStream's permission-prompt flow.
+ */
+export const submitClientToolResult = async (
+  sessionId: string,
+  requestId: string,
+  content: string,
+  isError: boolean,
+  callbacks: SendMessageStreamCallbacks,
+): Promise<SendMessageStreamResult> => {
+  try {
+    await fetchAPI(getAjaxUrl(`${API_BASE}/sessions/${sessionId}/tool-result`), {
+      method: 'POST',
+      body: JSON.stringify({ request_id: requestId, content, is_error: isError }),
+    });
+  } catch (error) {
+    callbacks.onError('Failed to send the client tool result. Please try again.');
     return { eventSource: null };
   }
 

--- a/mlflow/server/js/src/assistant/clientToolHandlers.ts
+++ b/mlflow/server/js/src/assistant/clientToolHandlers.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-level registry of handlers for CLIENT-executed assistant tool calls
+ * (e.g. `render_custom_view`), decoupling the generic Assistant context from
+ * feature-specific code (e.g. the Custom View host, which pulls in the
+ * ESM-only `@a2ui` renderer and should not be part of the Assistant's
+ * static module graph). A feature registers a handler for the tool name(s)
+ * it owns; `AssistantContext` looks the handler up by name when a
+ * `client_tool_call` event arrives, invokes it, and reports the result back
+ * to resume the stream.
+ */
+
+export interface ClientToolResult {
+  content: string;
+  isError?: boolean;
+}
+
+export type ClientToolHandler = (toolInput: Record<string, any>) => Promise<ClientToolResult>;
+
+const handlers = new Map<string, ClientToolHandler>();
+
+/** Register a handler for a client tool name. Returns an unregister function. */
+export const registerClientToolHandler = (toolName: string, handler: ClientToolHandler): (() => void) => {
+  handlers.set(toolName, handler);
+  return () => {
+    if (handlers.get(toolName) === handler) {
+      handlers.delete(toolName);
+    }
+  };
+};
+
+export const getClientToolHandler = (toolName: string): ClientToolHandler | undefined => handlers.get(toolName);

--- a/mlflow/server/js/src/assistant/contextProviders.test.ts
+++ b/mlflow/server/js/src/assistant/contextProviders.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from '@jest/globals';
+import { collectDynamicAssistantContext, registerAssistantContextProvider } from './contextProviders';
+
+describe('contextProviders', () => {
+  test('collects values from registered providers', () => {
+    const unregister = registerAssistantContextProvider('foo', () => ({ bar: 'baz' }));
+    expect(collectDynamicAssistantContext()).toEqual({ foo: { bar: 'baz' } });
+    unregister();
+  });
+
+  test('omits a key whose provider returns null or undefined', () => {
+    const unregisterNull = registerAssistantContextProvider('nullKey', () => null);
+    const unregisterUndefined = registerAssistantContextProvider('undefinedKey', () => undefined);
+    const result = collectDynamicAssistantContext();
+    expect(result).not.toHaveProperty('nullKey');
+    expect(result).not.toHaveProperty('undefinedKey');
+    unregisterNull();
+    unregisterUndefined();
+  });
+
+  test('a later registration for the same key overwrites the earlier one', () => {
+    const unregisterFirst = registerAssistantContextProvider('key', () => 'first');
+    const unregisterSecond = registerAssistantContextProvider('key', () => 'second');
+    expect(collectDynamicAssistantContext()).toEqual({ key: 'second' });
+    unregisterSecond();
+    unregisterFirst();
+  });
+
+  test('unregister is a no-op once superseded by a newer registration for the same key', () => {
+    const unregisterFirst = registerAssistantContextProvider('key', () => 'first');
+    const unregisterSecond = registerAssistantContextProvider('key', () => 'second');
+    // Unregistering the stale (superseded) provider must not clear the current one.
+    unregisterFirst();
+    expect(collectDynamicAssistantContext()).toEqual({ key: 'second' });
+    unregisterSecond();
+  });
+
+  test('unregister removes the key entirely', () => {
+    const unregister = registerAssistantContextProvider('temp', () => 'value');
+    expect(collectDynamicAssistantContext()).toEqual({ temp: 'value' });
+    unregister();
+    expect(collectDynamicAssistantContext()).not.toHaveProperty('temp');
+  });
+
+  test('providers are invoked lazily on every collection, not cached', () => {
+    let count = 0;
+    const unregister = registerAssistantContextProvider('counter', () => ++count);
+    expect(collectDynamicAssistantContext()).toEqual({ counter: 1 });
+    expect(collectDynamicAssistantContext()).toEqual({ counter: 2 });
+    unregister();
+  });
+});

--- a/mlflow/server/js/src/assistant/contextProviders.ts
+++ b/mlflow/server/js/src/assistant/contextProviders.ts
@@ -1,0 +1,40 @@
+/**
+ * Module-level registry of PULL-based context providers, decoupling the generic
+ * Assistant page-context store from feature-specific code (e.g. the Custom View
+ * host, which pulls in the ESM-only `@a2ui` renderer and should not be part of
+ * the Assistant's static module graph).
+ *
+ * Unlike `useRegisterAssistantContext` (which pushes a value into React state
+ * whenever it changes), a provider here is a plain function invoked lazily, at
+ * the moment a turn's context is assembled (see `getPageContext` in
+ * `AssistantContext.tsx`). This suits context that is expensive/unnecessary to
+ * keep reactively in sync (e.g. a large per-trace data snapshot) and context
+ * whose value depends on state resolved only at send time (e.g. which output
+ * convention to use, based on the provider about to serve the turn).
+ */
+
+export type AssistantContextProvider = () => unknown;
+
+const providers = new Map<string, AssistantContextProvider>();
+
+/** Register a pull-based context provider for a key. Returns an unregister function. */
+export const registerAssistantContextProvider = (key: string, provider: AssistantContextProvider): (() => void) => {
+  providers.set(key, provider);
+  return () => {
+    if (providers.get(key) === provider) {
+      providers.delete(key);
+    }
+  };
+};
+
+/** Invokes every registered provider and returns the non-null/undefined results, keyed. */
+export const collectDynamicAssistantContext = (): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const [key, provider] of providers) {
+    const value = provider();
+    if (value !== null && value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
+};

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -77,6 +77,19 @@ export interface PermissionRequest {
 }
 
 /**
+ * A tool call the CLIENT (not the server) must execute — e.g. rendering an
+ * agent-authored UI spec in the browser — surfaced so a registered handler
+ * (see `clientToolHandlers.ts`) can run it and report a result back.
+ */
+export interface PendingClientToolCall {
+  /** The session that produced this call, so the result targets the right session */
+  sessionId: string;
+  requestId: string;
+  toolName: string;
+  toolInput: Record<string, any>;
+}
+
+/**
  * Known context keys for the assistant.
  * Type-safe registration for common context values.
  */
@@ -107,6 +120,19 @@ export interface KnownAssistantContext {
 
   // Scorers/Judges
   selectedScorerName?: string;
+
+  /**
+   * Custom View (trace explorer "Custom View" tab) authoring context: the A2UI
+   * guide, the current trace's data snapshot, and the active view's template, if
+   * any. Populated via a pull-based provider (see `contextProviders.ts`) rather
+   * than pushed reactively, since the ESM-only `@a2ui` types it references must
+   * not be imported here. See `ExperimentCustomViewProvider.tsx`.
+   */
+  customTraceView?: {
+    guide: string;
+    traceSample: Record<string, unknown>;
+    currentTemplate?: unknown[];
+  };
 }
 
 /** All known context keys */
@@ -122,6 +148,13 @@ export interface ProviderInfo {
   requires_api_key: boolean;
   has_api_key: boolean;
   allows_remote_access: boolean;
+  /**
+   * Whether this provider can pause a turn on a CLIENT-executed tool call (see
+   * `clientToolHandlers.ts`) and resume it once the client posts a result. False for
+   * CLI-based providers (Claude Code, Codex), which have no such mid-stream channel
+   * without MCP plumbing.
+   */
+  supports_client_tools: boolean;
   /** Curated model options for simple assistant controls; empty when provider decides. */
   model_options: string[];
 }
@@ -133,6 +166,8 @@ export interface ResolvedProviderInfo {
   auto_selected: boolean;
   requires_api_key: boolean;
   has_api_key: boolean;
+  /** See `ProviderInfo.supports_client_tools`. */
+  supports_client_tools: boolean;
   /** LLM provider behind a gateway endpoint (e.g. 'openai'); null/absent otherwise. */
   model_provider?: string | null;
   /** Curated vendor model choices when resolved to an assistant-managed Gateway endpoint. */
@@ -226,6 +261,8 @@ export interface AssistantAgentState {
   pendingPrompt: string | null;
   /** A tool call awaiting the user's Yes/No decision, or null */
   pendingPermission: PermissionRequest | null;
+  /** A tool call awaiting client-side execution (e.g. rendering a UI spec), or null */
+  pendingClientToolCall: PendingClientToolCall | null;
   /** Whether the Assistant can be used from this client, considering server-side remote-access settings */
   canUseAssistant: boolean;
   /** Cumulative token usage for the session (best-effort; only some providers report it) */
@@ -257,6 +294,8 @@ export interface AssistantAgentActions {
   completeSetup: () => void;
   /** Answer the pending tool-call permission prompt */
   respondToPermission: (allow: boolean) => void;
+  /** Report the result of the pending client-executed tool call and resume the stream */
+  submitClientToolResult: (content: string, isError?: boolean) => void;
 }
 
 export type AssistantAgentContextType = AssistantAgentState & AssistantAgentActions;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.test.tsx
@@ -2,10 +2,7 @@ import { describe, test, expect, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
-import {
-  CustomViewAssistantConnectorProvider,
-  useCustomViewAssistantConnector,
-} from './CustomViewAssistantConnector';
+import { CustomViewAssistantConnectorProvider, useCustomViewAssistantConnector } from './CustomViewAssistantConnector';
 
 describe('useCustomViewAssistantConnector', () => {
   test('returns an empty connector (no-op defaults) outside any provider', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.test.tsx
@@ -1,0 +1,46 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import {
+  CustomViewAssistantConnectorProvider,
+  useCustomViewAssistantConnector,
+} from './CustomViewAssistantConnector';
+
+describe('useCustomViewAssistantConnector', () => {
+  test('returns an empty connector (no-op defaults) outside any provider', () => {
+    const { result } = renderHook(() => useCustomViewAssistantConnector());
+    expect(result.current).toEqual({});
+    expect(result.current.openAssistant).toBeUndefined();
+    expect(result.current.isStreaming).toBeUndefined();
+  });
+
+  test('exposes the injected connector inside CustomViewAssistantConnectorProvider', () => {
+    const openAssistant = jest.fn();
+    const connector = { openAssistant, isStreaming: true };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CustomViewAssistantConnectorProvider connector={connector}>{children}</CustomViewAssistantConnectorProvider>
+    );
+
+    const { result } = renderHook(() => useCustomViewAssistantConnector(), { wrapper });
+
+    expect(result.current).toBe(connector);
+    expect(result.current.isStreaming).toBe(true);
+    result.current.openAssistant?.('build a view');
+    expect(openAssistant).toHaveBeenCalledWith('build a view');
+  });
+
+  test('a nested provider overrides the outer connector for its subtree', () => {
+    const outer = { openAssistant: jest.fn(), isStreaming: false };
+    const inner = { openAssistant: jest.fn(), isStreaming: true };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CustomViewAssistantConnectorProvider connector={outer}>
+        <CustomViewAssistantConnectorProvider connector={inner}>{children}</CustomViewAssistantConnectorProvider>
+      </CustomViewAssistantConnectorProvider>
+    );
+
+    const { result } = renderHook(() => useCustomViewAssistantConnector(), { wrapper });
+
+    expect(result.current).toBe(inner);
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+
+/** Options for opening the assistant chat panel. */
+export type OpenCustomViewAssistantOptions = {
+  // Start a FRESH assistant session (thread) before opening. Set only when
+  // building a brand-new custom view; edits reuse the current session so the
+  // conversation continues.
+  newSession?: boolean;
+};
+
+/**
+ * Connects the Custom View to the host application's agent (MLflow Assistant).
+ * The host app provides a way to open the assistant chat panel (optionally
+ * seeded with a prompt) and reports whether the assistant is currently
+ * streaming.
+ */
+export type CustomViewAssistantConnector = {
+  openAssistant?: (prompt?: string, options?: OpenCustomViewAssistantOptions) => void;
+  isStreaming?: boolean;
+};
+
+const CustomViewAssistantConnectorContext = createContext<CustomViewAssistantConnector>({});
+
+export const CustomViewAssistantConnectorProvider = ({
+  connector,
+  children,
+}: {
+  connector: CustomViewAssistantConnector;
+  children: ReactNode;
+}): JSX.Element => (
+  <CustomViewAssistantConnectorContext.Provider value={connector}>
+    {children}
+  </CustomViewAssistantConnectorContext.Provider>
+);
+
+export const useCustomViewAssistantConnector = (): CustomViewAssistantConnector =>
+  useContext(CustomViewAssistantConnectorContext);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  registerCustomViewAuthoringContext,
+  getCustomViewAuthoringContext,
+  latchDispatchedCustomViewApplyTarget,
+  getDispatchedCustomViewApplyTarget,
+  type CustomViewAuthoringContext,
+} from './customViewAuthoringContext';
+
+const makeContext = (overrides: Partial<CustomViewAuthoringContext> = {}): CustomViewAuthoringContext => ({
+  guide: 'guide text',
+  traceSample: { metrics: { status: 'OK' } },
+  ...overrides,
+});
+
+describe('customViewAuthoringContext', () => {
+  test('returns null when nothing is registered', () => {
+    expect(getCustomViewAuthoringContext()).toBeNull();
+  });
+
+  test('registers and reads back the context', () => {
+    const context = makeContext();
+    const unregister = registerCustomViewAuthoringContext(context);
+    expect(getCustomViewAuthoringContext()).toBe(context);
+    unregister();
+  });
+
+  test('unregister clears the context', () => {
+    const unregister = registerCustomViewAuthoringContext(makeContext());
+    unregister();
+    expect(getCustomViewAuthoringContext()).toBeNull();
+  });
+
+  test('a later registration overwrites the earlier one (last-writer-wins)', () => {
+    const first = makeContext({ guide: 'first' });
+    const second = makeContext({ guide: 'second' });
+    const unregisterFirst = registerCustomViewAuthoringContext(first);
+    const unregisterSecond = registerCustomViewAuthoringContext(second);
+
+    expect(getCustomViewAuthoringContext()).toBe(second);
+
+    unregisterSecond();
+    unregisterFirst();
+  });
+
+  test('unregistering a superseded registration is a no-op (does not clear the current one)', () => {
+    const first = makeContext({ guide: 'first' });
+    const second = makeContext({ guide: 'second' });
+    const unregisterFirst = registerCustomViewAuthoringContext(first);
+    const unregisterSecond = registerCustomViewAuthoringContext(second);
+
+    unregisterFirst();
+    expect(getCustomViewAuthoringContext()).toBe(second);
+
+    unregisterSecond();
+    expect(getCustomViewAuthoringContext()).toBeNull();
+  });
+});
+
+describe('latchDispatchedCustomViewApplyTarget / getDispatchedCustomViewApplyTarget', () => {
+  test('returns undefined before any turn has latched a target', () => {
+    latchDispatchedCustomViewApplyTarget(undefined);
+    expect(getDispatchedCustomViewApplyTarget()).toBeUndefined();
+  });
+
+  test('latches the target passed on the most recent prompt-assembly call', () => {
+    const target = { id: 'view-1', name: 'My view', instruction: 'show text', createdAtMs: 1 };
+    latchDispatchedCustomViewApplyTarget(target);
+    expect(getDispatchedCustomViewApplyTarget()).toBe(target);
+  });
+
+  test('a later latch overwrites the earlier one, including clearing it with undefined', () => {
+    const first = { id: 'view-1', name: 'First', instruction: '', createdAtMs: 1 };
+    latchDispatchedCustomViewApplyTarget(first);
+    expect(getDispatchedCustomViewApplyTarget()).toBe(first);
+
+    const second = { id: 'view-2', name: 'Second', instruction: '', createdAtMs: 2 };
+    latchDispatchedCustomViewApplyTarget(second);
+    expect(getDispatchedCustomViewApplyTarget()).toBe(second);
+
+    latchDispatchedCustomViewApplyTarget(undefined);
+    expect(getDispatchedCustomViewApplyTarget()).toBeUndefined();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.ts
@@ -1,0 +1,60 @@
+/**
+ * Module-level store for the Custom View authoring context (the A2UI guide + the
+ * current trace's data snapshot + the active view's template). The Custom View
+ * host lives deep inside the trace drawer (web-shared), while the assistant's
+ * page context is assembled at a higher level; rather than thread per-trace
+ * state up through every layer, the host registers the current authoring
+ * context here and the assistant's context plugin reads it when building the
+ * agent prompt. Last-writer-wins (a single Custom View tab is open at a time).
+ */
+import type { A2uiMessage } from '@a2ui/web_core/v0_9';
+
+import type { CustomViewApplyTarget } from '../customViewDefinition';
+
+export type CustomViewAuthoringContext = {
+  guide: string;
+  currentTemplate?: A2uiMessage[];
+  traceSample: Record<string, unknown>;
+  // The view `currentTemplate` was taken from. Published alongside the template
+  // (never derived separately) so the two can never describe different views.
+  applyTarget?: CustomViewApplyTarget;
+};
+
+let currentContext: CustomViewAuthoringContext | null = null;
+
+// The view whose template was handed to the agent on the most recent turn. See
+// `latchDispatchedCustomViewApplyTarget` for why this, and not the live
+// selection, decides where a spec lands.
+let dispatchedApplyTarget: CustomViewApplyTarget | undefined;
+
+export const registerCustomViewAuthoringContext = (context: CustomViewAuthoringContext): (() => void) => {
+  currentContext = context;
+  return () => {
+    if (currentContext === context) {
+      currentContext = null;
+    }
+  };
+};
+
+export const getCustomViewAuthoringContext = (): CustomViewAuthoringContext | null => currentContext;
+
+/**
+ * Records which view the agent is authoring against for the turn whose prompt is
+ * being assembled right now. Call this wherever the authoring context is read
+ * into a prompt, passing that same context's `applyTarget` (including
+ * `undefined`, which clears a previous turn's latch).
+ *
+ * The agent edits the template it was given, so the view that template came from
+ * is the view its `render_custom_view` reply belongs to — even though the reply
+ * only arrives seconds later, by which time the user may have selected a
+ * different view. Latching at prompt-assembly time is what makes a mid-flight
+ * view switch apply the edit in the background to the right view instead of
+ * overwriting whatever became active. Each turn overwrites the previous latch,
+ * so it is never consumed/cleared on apply: a turn that calls the tool more than
+ * once keeps the same target throughout.
+ */
+export const latchDispatchedCustomViewApplyTarget = (target: CustomViewApplyTarget | undefined): void => {
+  dispatchedApplyTarget = target;
+};
+
+export const getDispatchedCustomViewApplyTarget = (): CustomViewApplyTarget | undefined => dispatchedApplyTarget;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.ts
@@ -52,6 +52,14 @@ export const getCustomViewAuthoringContext = (): CustomViewAuthoringContext | nu
  * overwriting whatever became active. Each turn overwrites the previous latch,
  * so it is never consumed/cleared on apply: a turn that calls the tool more than
  * once keeps the same target throughout.
+ *
+ * The latch's lifetime is tied to the TURN, not the host's mount. A trace
+ * modal closed and reopened mid-turn is a tolerated flow (see
+ * `waitForCustomViewSpecApplier`), so clearing on unregister would leave that
+ * spec having lost its target, falling through to the live selection — the
+ * exact overwrite-the-wrong-view failure this latch exists to prevent.
+ * Passing `undefined` is for a context with no active view (an empty-state
+ * build), not for the absence of a host.
  */
 export const latchDispatchedCustomViewApplyTarget = (target: CustomViewApplyTarget | undefined): void => {
   dispatchedApplyTarget = target;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewSpecApplier.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewSpecApplier.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+  registerCustomViewSpecApplier,
+  getCustomViewSpecApplier,
+  getCurrentApplierSessionId,
+  waitForCustomViewSpecApplier,
+  type CustomViewSpecApplier,
+} from './customViewSpecApplier';
+
+const makeApplier = (): CustomViewSpecApplier => jest.fn(async () => ({ ok: true as const }));
+
+describe('registerCustomViewSpecApplier / getCustomViewSpecApplier', () => {
+  test('returns null when nothing is registered', () => {
+    expect(getCustomViewSpecApplier()).toBeNull();
+    expect(getCurrentApplierSessionId()).toBeUndefined();
+  });
+
+  test('registers and reads back the applier and its session id', () => {
+    const applier = makeApplier();
+    const unregister = registerCustomViewSpecApplier('sess-1', applier);
+    expect(getCustomViewSpecApplier()).toBe(applier);
+    expect(getCurrentApplierSessionId()).toBe('sess-1');
+    unregister();
+  });
+
+  test('unregister clears the slot', () => {
+    const unregister = registerCustomViewSpecApplier('sess-1', makeApplier());
+    unregister();
+    expect(getCustomViewSpecApplier()).toBeNull();
+    expect(getCurrentApplierSessionId()).toBeUndefined();
+  });
+
+  test('a later registration overwrites the earlier one (last-writer-wins)', () => {
+    const first = makeApplier();
+    const second = makeApplier();
+    const unregisterFirst = registerCustomViewSpecApplier('sess-1', first);
+    const unregisterSecond = registerCustomViewSpecApplier('sess-2', second);
+
+    expect(getCustomViewSpecApplier()).toBe(second);
+    expect(getCurrentApplierSessionId()).toBe('sess-2');
+
+    unregisterFirst();
+    expect(getCustomViewSpecApplier()).toBe(second);
+
+    unregisterSecond();
+    expect(getCustomViewSpecApplier()).toBeNull();
+  });
+});
+
+describe('waitForCustomViewSpecApplier', () => {
+  test('resolves immediately when a matching host is already registered', async () => {
+    const applier = makeApplier();
+    const unregister = registerCustomViewSpecApplier('sess-1', applier);
+
+    await expect(waitForCustomViewSpecApplier('sess-1')).resolves.toBe(applier);
+
+    unregister();
+  });
+
+  test('resolves immediately with the current applier when no session is expected', async () => {
+    const applier = makeApplier();
+    const unregister = registerCustomViewSpecApplier('sess-1', applier);
+
+    await expect(waitForCustomViewSpecApplier(undefined)).resolves.toBe(applier);
+
+    unregister();
+  });
+
+  test('a registration for a DIFFERENT session does not satisfy an active wait', async () => {
+    jest.useFakeTimers();
+    const promise = waitForCustomViewSpecApplier('sess-expected', 3000);
+
+    // A different host mounts mid-wait; it must not resolve the waiter.
+    const wrongApplier = makeApplier();
+    const unregisterWrong = registerCustomViewSpecApplier('sess-other', wrongApplier);
+
+    jest.advanceTimersByTime(3000);
+    await expect(promise).resolves.toBeNull();
+
+    unregisterWrong();
+    jest.useRealTimers();
+  });
+
+  test('a registration for the EXPECTED session resolves the pending wait', async () => {
+    const promise = waitForCustomViewSpecApplier('sess-expected', 3000);
+
+    const applier = makeApplier();
+    const unregister = registerCustomViewSpecApplier('sess-expected', applier);
+
+    await expect(promise).resolves.toBe(applier);
+
+    unregister();
+  });
+
+  test('any next registration resolves the wait when no session was expected', async () => {
+    const promise = waitForCustomViewSpecApplier(undefined, 3000);
+
+    const applier = makeApplier();
+    const unregister = registerCustomViewSpecApplier('sess-new', applier);
+
+    await expect(promise).resolves.toBe(applier);
+
+    unregister();
+  });
+
+  test('resolves to null after the timeout when no matching host ever registers', async () => {
+    jest.useFakeTimers();
+    const promise = waitForCustomViewSpecApplier('sess-expected', 1000);
+
+    jest.advanceTimersByTime(1000);
+
+    await expect(promise).resolves.toBeNull();
+    jest.useRealTimers();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewSpecApplier.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewSpecApplier.ts
@@ -1,0 +1,102 @@
+/**
+ * Bridge between the Custom View host (which owns the live A2UI surface) and the
+ * `render_custom_view` assistant tool. The host is rendered deep inside the
+ * trace drawer, while the tool executes inside the assistant runtime; rather
+ * than thread a callback through every layer, the host registers an applier on
+ * mount and the tool looks it up at execute time.
+ */
+
+export type RenderCustomViewSpec = {
+  title?: string;
+  messages: unknown;
+};
+
+export type CustomViewApplyResult = { ok: true } | { ok: false; error: string };
+
+export type CustomViewSpecApplier = (spec: RenderCustomViewSpec) => Promise<CustomViewApplyResult>;
+
+// The slot is keyed by a per-host `sessionId` so a pending tool call can be
+// bound to the host that was active when it started. Registration is
+// last-writer-wins (a single Custom View tab is active at a time).
+type Registration = { sessionId: string; applier: CustomViewSpecApplier };
+
+let current: Registration | null = null;
+
+// Waiters ride out the brief window where the active host has unmounted
+// (clearing the slot) and is about to re-register — e.g. while the trace modal
+// is closed and reopened — so a tool call that lands mid-remount doesn't
+// spuriously report "tab not open". Each waiter records the session it is
+// waiting for so a DIFFERENT host registering can't satisfy it (which would
+// render the spec into the wrong trace explorer).
+type Waiter = { expectedSessionId?: string; resolve: (applier: CustomViewSpecApplier | null) => void };
+const applierWaiters = new Set<Waiter>();
+
+const matchesSession = (registration: Registration | null, expectedSessionId?: string): boolean =>
+  registration !== null && (expectedSessionId === undefined || registration.sessionId === expectedSessionId);
+
+/** Returns an unregister function; registration is last-writer-wins. */
+export const registerCustomViewSpecApplier = (sessionId: string, applier: CustomViewSpecApplier): (() => void) => {
+  const registration: Registration = { sessionId, applier };
+  current = registration;
+  for (const waiter of Array.from(applierWaiters)) {
+    if (waiter.expectedSessionId === undefined || waiter.expectedSessionId === sessionId) {
+      applierWaiters.delete(waiter);
+      waiter.resolve(applier);
+    }
+  }
+  return () => {
+    if (current === registration) {
+      current = null;
+    }
+  };
+};
+
+export const getCustomViewSpecApplier = (): CustomViewSpecApplier | null => current?.applier ?? null;
+
+// The session id of the currently-registered host, captured by the tool at
+// execute start so its wait can be scoped to that same host.
+export const getCurrentApplierSessionId = (): string | undefined => current?.sessionId;
+
+/**
+ * Resolves with the registered applier, waiting up to `timeoutMs` for one to
+ * appear if the slot is momentarily empty (host remounting).
+ *
+ * When `expectedSessionId` is provided, only that host satisfies the wait — a
+ * different host registering during the window is ignored, so an in-flight
+ * tool call never resumes against the wrong trace explorer. When it is
+ * omitted (no host was registered at execute start), any next registration
+ * resolves it, preserving the reopen-from-closed behavior.
+ */
+export const waitForCustomViewSpecApplier = (
+  expectedSessionId?: string,
+  timeoutMs = 3000,
+): Promise<CustomViewSpecApplier | null> => {
+  const registration = current;
+  if (matchesSession(registration, expectedSessionId) && registration !== null) {
+    return Promise.resolve(registration.applier);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const waiter: Waiter = {
+      expectedSessionId,
+      resolve: (applier: CustomViewSpecApplier | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        applierWaiters.delete(waiter);
+        resolve(applier);
+      },
+    };
+    const timer = setTimeout(() => {
+      const activeRegistration = current;
+      waiter.resolve(
+        matchesSession(activeRegistration, expectedSessionId) && activeRegistration !== null
+          ? activeRegistration.applier
+          : null,
+      );
+    }, timeoutMs);
+    applierWaiters.add(waiter);
+  });
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
@@ -1,0 +1,172 @@
+import { describe, test, expect, jest, afterEach } from '@jest/globals';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import type { AgentTraceData } from '../agent/buildAgentPrompt';
+import type { CustomView } from '../customViewDefinition';
+import { CustomViewAssistantConnectorProvider } from './CustomViewAssistantConnector';
+import { getCustomViewAuthoringContext } from './customViewAuthoringContext';
+import { getCustomViewSpecApplier, type RenderCustomViewSpec } from './customViewSpecApplier';
+import { useCustomViewAssistantBridge } from './useCustomViewAssistantBridge';
+
+const traceData = (): AgentTraceData => ({ metrics: { status: 'OK' } });
+
+const activeView = (overrides: Partial<CustomView> = {}): CustomView => ({
+  id: 'view-1',
+  name: 'My view',
+  label: 'My view',
+  instruction: 'show text',
+  template: [],
+  createdAtMs: 1,
+  ...overrides,
+});
+
+const wrapperWithConnector = (connector: { openAssistant?: (prompt?: string) => void; isStreaming?: boolean }) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <CustomViewAssistantConnectorProvider connector={connector}>{children}</CustomViewAssistantConnectorProvider>;
+  };
+
+// A no-op onSpec, correctly typed, for tests that don't assert on it being called.
+const noopOnSpec = (_spec: RenderCustomViewSpec): Promise<void> => Promise.resolve();
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useCustomViewAssistantBridge', () => {
+  test('publishes the authoring context (guide + trace sample + template + applyTarget) while enabled', () => {
+    const view = activeView({ template: [{ version: 'v0.9' } as any] });
+    const { unmount } = renderHook(() =>
+      useCustomViewAssistantBridge({ data: traceData(), activeView: view, onSpec: noopOnSpec }),
+    );
+
+    const context = getCustomViewAuthoringContext();
+    expect(context).not.toBeNull();
+    expect(context?.guide).toContain('CUSTOM TRACE VIEW AUTHORING MODE');
+    expect(context?.currentTemplate).toBe(view.template);
+    expect(context?.applyTarget).toMatchObject({ id: 'view-1', name: 'My view' });
+    expect(context?.traceSample).toMatchObject({ metrics: { status: 'OK' } });
+
+    unmount();
+    // Unmounting clears the registration so a stale context isn't read by a later turn.
+    expect(getCustomViewAuthoringContext()).toBeNull();
+  });
+
+  test('does not publish context or register an applier when disabled', () => {
+    const { unmount } = renderHook(() =>
+      useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec: noopOnSpec, enabled: false }),
+    );
+
+    expect(getCustomViewAuthoringContext()).toBeNull();
+    expect(getCustomViewSpecApplier()).toBeNull();
+
+    unmount();
+  });
+
+  test('omits applyTarget/currentTemplate when there is no active view yet', () => {
+    const { unmount } = renderHook(() => useCustomViewAssistantBridge({ data: traceData(), onSpec: noopOnSpec }));
+
+    const context = getCustomViewAuthoringContext();
+    expect(context?.currentTemplate).toBeUndefined();
+    expect(context?.applyTarget).toBeUndefined();
+
+    unmount();
+  });
+
+  test('registers an applier that calls onSpec and reports ok on success', async () => {
+    const onSpec = jest.fn(async (_spec: RenderCustomViewSpec) => {});
+    const { unmount } = renderHook(() =>
+      useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec }),
+    );
+
+    const applier = getCustomViewSpecApplier();
+    expect(applier).not.toBeNull();
+
+    const spec: RenderCustomViewSpec = { title: 'Trace Summary', messages: [] };
+    const result = await applier?.(spec);
+
+    expect(onSpec).toHaveBeenCalledWith(spec);
+    expect(result).toEqual({ ok: true });
+
+    unmount();
+  });
+
+  test('a failing onSpec surfaces a structured error and sets applyError', async () => {
+    const onSpec = jest.fn(async () => {
+      throw new Error('invalid template');
+    });
+    const { result, unmount } = renderHook(() =>
+      useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec }),
+    );
+
+    const applier = getCustomViewSpecApplier();
+    let applyResult;
+    await act(async () => {
+      applyResult = await applier?.({ title: 't', messages: [] });
+    });
+
+    expect(applyResult).toEqual({ ok: false, error: 'invalid template' });
+    expect(result.current.applyError).toBe('invalid template');
+
+    unmount();
+  });
+
+  test('clearApplyError resets a leftover error', async () => {
+    const onSpec = jest.fn(async () => {
+      throw new Error('boom');
+    });
+    const { result, unmount } = renderHook(() =>
+      useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec }),
+    );
+
+    const applier = getCustomViewSpecApplier();
+    await act(async () => {
+      await applier?.({ title: 't', messages: [] });
+    });
+    expect(result.current.applyError).toBe('boom');
+
+    act(() => {
+      result.current.clearApplyError();
+    });
+    expect(result.current.applyError).toBeUndefined();
+
+    unmount();
+  });
+
+  test('exposes the connector openAssistant/isStreaming when enabled', () => {
+    const openAssistant = jest.fn();
+    const wrapper = wrapperWithConnector({ openAssistant, isStreaming: true });
+    const { result, unmount } = renderHook(
+      () => useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec: noopOnSpec }),
+      { wrapper },
+    );
+
+    expect(result.current.isAvailable).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+    result.current.openAssistant?.('hi');
+    expect(openAssistant).toHaveBeenCalledWith('hi');
+
+    unmount();
+  });
+
+  test('isAvailable is false and isStreaming/openAssistant are suppressed when disabled', () => {
+    const openAssistant = jest.fn();
+    const wrapper = wrapperWithConnector({ openAssistant, isStreaming: true });
+    const { result, unmount } = renderHook(
+      () =>
+        useCustomViewAssistantBridge({
+          data: traceData(),
+          activeView: activeView(),
+          onSpec: noopOnSpec,
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.openAssistant).toBeUndefined();
+    expect(result.current.isStreaming).toBe(false);
+
+    unmount();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
@@ -23,7 +23,9 @@ const activeView = (overrides: Partial<CustomView> = {}): CustomView => ({
 
 const wrapperWithConnector = (connector: { openAssistant?: (prompt?: string) => void; isStreaming?: boolean }) =>
   function Wrapper({ children }: { children: ReactNode }) {
-    return <CustomViewAssistantConnectorProvider connector={connector}>{children}</CustomViewAssistantConnectorProvider>;
+    return (
+      <CustomViewAssistantConnectorProvider connector={connector}>{children}</CustomViewAssistantConnectorProvider>
+    );
   };
 
 // A no-op onSpec, correctly typed, for tests that don't assert on it being called.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { buildAgentDataSnapshot, buildCustomViewAuthoringGuide, type AgentTraceData } from '../agent/buildAgentPrompt';
+import { toCustomViewApplyTarget, type CustomView } from '../customViewDefinition';
+import { useCustomViewAssistantConnector, type OpenCustomViewAssistantOptions } from './CustomViewAssistantConnector';
+import { registerCustomViewAuthoringContext } from './customViewAuthoringContext';
+import { registerCustomViewSpecApplier, type RenderCustomViewSpec } from './customViewSpecApplier';
+
+// The static authoring guide is computed once — it has no per-trace state.
+const AUTHORING_GUIDE = buildCustomViewAuthoringGuide();
+
+export type CustomViewAssistantBridge = {
+  isAvailable: boolean;
+  openAssistant?: (prompt?: string, options?: OpenCustomViewAssistantOptions) => void;
+  isStreaming: boolean;
+  applyError?: string;
+  // Clears a leftover apply error, e.g. when the user retries a build so the
+  // building skeleton isn't immediately suppressed by the previous failure.
+  clearApplyError: () => void;
+};
+
+/**
+ * Bridges the Custom View host to the host application's agent (MLflow
+ * Assistant). It:
+ *
+ * 1. publishes the current authoring context (guide + this trace's snapshot +
+ *    the active view's template) to a module-level store so the assistant's
+ *    context plugin can include it in the agent prompt;
+ * 2. registers an applier so the `render_custom_view` tool can hand the
+ *    agent-produced spec back to this host's `onSpec` (validate + render).
+ *    CLI-based providers (Claude Code, Codex) have no mid-stream client-tool
+ *    channel without MCP plumbing and are not supported yet — a fenced-block
+ *    convention for those is tracked as a follow-up;
+ * 3. exposes the connector's chat opener + streaming state.
+ *
+ * The agent itself (tool/skill registration, panel opening) is wired at a
+ * higher layer that web-shared cannot import; this hook only depends on the
+ * injected connector and the two module-level registries.
+ */
+export const useCustomViewAssistantBridge = ({
+  data,
+  activeView,
+  onSpec,
+  enabled = true,
+}: {
+  data: AgentTraceData;
+  // The view being authored. Both the template the agent edits and the target a
+  // resulting spec applies to are derived from this single object, so they can
+  // never disagree about which view a turn is about.
+  activeView?: CustomView;
+  onSpec: (spec: RenderCustomViewSpec) => Promise<void> | void;
+  enabled?: boolean;
+}): CustomViewAssistantBridge => {
+  const connector = useCustomViewAssistantConnector();
+  const [applyError, setApplyError] = useState<string | undefined>(undefined);
+
+  // A stable id for this host instance. The render_custom_view tool captures the
+  // session that is active when it starts and scopes its wait to it, so a
+  // different Custom View host mounting mid-call can't receive this host's spec.
+  const sessionIdRef = useRef(`cv-session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`);
+
+  // The snapshot is recomputed only when the trace data changes; the applier
+  // reads the latest onSpec via a ref so registration stays stable.
+  const traceSample = useMemo(() => buildAgentDataSnapshot(data), [data]);
+
+  const onSpecRef = useRef(onSpec);
+  useEffect(() => {
+    onSpecRef.current = onSpec;
+  }, [onSpec]);
+
+  // Publish the authoring context for the assistant's context plugin to read.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    return registerCustomViewAuthoringContext({
+      guide: AUTHORING_GUIDE,
+      currentTemplate: activeView?.template,
+      traceSample,
+      applyTarget: activeView ? toCustomViewApplyTarget(activeView) : undefined,
+    });
+  }, [activeView, enabled, traceSample]);
+
+  // Register the applier the render_custom_view tool calls. Wraps onSpec so a
+  // thrown validation/render error becomes a structured failure the agent can
+  // read and the user can see.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    return registerCustomViewSpecApplier(sessionIdRef.current, async (spec) => {
+      try {
+        await onSpecRef.current(spec);
+        setApplyError(undefined);
+        return { ok: true };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to render the custom view.';
+        setApplyError(message);
+        return { ok: false, error: message };
+      }
+    });
+  }, [enabled]);
+
+  const openAssistant = useMemo(() => {
+    if (!enabled) {
+      return undefined;
+    }
+    return connector.openAssistant;
+  }, [connector, enabled]);
+
+  const clearApplyError = useCallback(() => setApplyError(undefined), []);
+
+  return {
+    isAvailable: Boolean(openAssistant),
+    openAssistant,
+    isStreaming: enabled && Boolean(connector.isStreaming),
+    applyError: enabled ? applyError : undefined,
+    clearApplyError,
+  };
+};

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -78,6 +78,12 @@ def test_is_available(which_return, expected):
         assert provider.is_available() is expected
 
 
+def test_supports_client_tools_is_false():
+    # A CLI-based provider has no mid-stream client-tool channel without MCP
+    # plumbing, so it inherits the base class's default of False.
+    assert ClaudeCodeProvider().supports_client_tools is False
+
+
 def test_check_connection_runs_auth_verification_prompt():
     completed = subprocess.CompletedProcess(
         args=["claude", "-p", "hi", "--max-turns", "1", "--output-format", "json"],

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -65,6 +65,12 @@ def test_is_available(which_return, expected):
         assert provider.is_available() is expected
 
 
+def test_supports_client_tools_is_false():
+    # A CLI-based provider has no mid-stream client-tool channel without MCP
+    # plumbing, so it inherits the base class's default of False.
+    assert CodexProvider().supports_client_tools is False
+
+
 def test_provider_name():
     assert CodexProvider().name == "codex"
 

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -14,7 +14,10 @@ from mlflow.assistant.providers.openai_compatible import (
     _strip_think_blocks,
     _trim_session,
 )
-from mlflow.assistant.providers.tool_executor import static_permission_error
+from mlflow.assistant.providers.tool_executor import (
+    RENDER_CUSTOM_VIEW_TOOL_NAME,
+    static_permission_error,
+)
 from mlflow.assistant.types import EventType
 from mlflow.tracing.constant import CostKey, TokenUsageKey
 
@@ -111,6 +114,12 @@ def config_file(tmp_path):
     with patch("mlflow.assistant.config.CONFIG_PATH", cfg):
         yield cfg
     clear_config_cache()
+
+
+def test_supports_client_tools_is_true(provider):
+    # Schema-based providers pause on a CLIENT_TOOLS call and resume on the next
+    # stream once a result is posted (see the pause/resume tests below).
+    assert provider.supports_client_tools is True
 
 
 # ---------------------------------------------------------------------------
@@ -698,6 +707,28 @@ def _tool_call_turns():
     return [turn1, turn2]
 
 
+def _client_tool_call_turns():
+    turn1 = [
+        _sse(
+            _delta(
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": RENDER_CUSTOM_VIEW_TOOL_NAME,
+                            "arguments": '{"title": "Trace Summary", "messages": []}',
+                        },
+                    }
+                ]
+            )
+        ),
+        b"data: [DONE]\n",
+    ]
+    turn2 = [_sse(_delta(content="Done")), b"data: [DONE]\n"]
+    return [turn1, turn2]
+
+
 def _done_session_id(events) -> str:
     for e in reversed(events):
         if e.type == EventType.DONE:
@@ -918,6 +949,165 @@ async def test_astream_fresh_message_after_abandoned_tool_call(provider):
         for m in final
     )
     assert any(m.get("role") == "user" and m.get("content") == "what is 2+2" for m in final)
+
+
+@pytest.mark.asyncio
+async def test_astream_pauses_at_client_tool_call_without_prompting(provider):
+    # A CLIENT_TOOLS call (e.g. render_custom_view) never goes through execute_tool or the
+    # static permission gate — it always pauses for the client to execute, even though this
+    # provider is NOT full-access and has no static allowlist entry for the tool name.
+    session, _calls = _make_aiohttp_session([_client_tool_call_turns()[0]])
+    with (
+        patch(
+            "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+            return_value=session,
+        ),
+        patch(
+            "mlflow.assistant.providers.openai_compatible.execute_tool",
+            AsyncMock(return_value=("should not run", False)),
+        ) as mock_tool,
+    ):
+        events = [
+            e
+            async for e in provider.astream(
+                "build me a view", "http://localhost:5000", mlflow_session_id=_SESSION_ID
+            )
+        ]
+
+    mock_tool.assert_not_awaited()
+    assert not any(e.type == EventType.PERMISSION_REQUEST for e in events)
+    client_calls = [e for e in events if e.type == EventType.CLIENT_TOOL_CALL]
+    assert len(client_calls) == 1
+    assert client_calls[0].data["request_id"] == "call_1"
+    assert client_calls[0].data["tool_name"] == RENDER_CUSTOM_VIEW_TOOL_NAME
+    assert client_calls[0].data["tool_input"] == {"title": "Trace Summary", "messages": []}
+    # The tool-use block is surfaced before the pause, same as a permission prompt.
+    tool_use_messages = [
+        e
+        for e in events
+        if e.type == EventType.MESSAGE
+        and isinstance(e.data["message"]["content"], list)
+        and e.data["message"]["content"][0].get("name") == RENDER_CUSTOM_VIEW_TOOL_NAME
+    ]
+    assert len(tool_use_messages) == 1
+    assert events[-1].type == EventType.DONE
+
+    history = json.loads(_done_session_id(events))
+    assert history[-1]["role"] == "assistant"
+    assert history[-1].get("tool_calls")
+    assert not any(m.get("role") == "tool" for m in history)
+
+
+@pytest.mark.asyncio
+async def test_astream_resume_with_client_tool_result_continues(provider):
+    # Pause to capture the persisted history.
+    s1, _ = _make_aiohttp_session([_client_tool_call_turns()[0]])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=s1,
+    ):
+        ev1 = [
+            e
+            async for e in provider.astream(
+                "build me a view", "http://localhost:5000", mlflow_session_id=_SESSION_ID
+            )
+        ]
+    history = _done_session_id(ev1)
+
+    # Resume with the client-reported result: the tool result is spliced in and the
+    # loop continues to a normal model turn — no re-prompting, no server execution.
+    s2, _ = _make_aiohttp_session([_client_tool_call_turns()[1]])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=s2,
+    ):
+        ev2 = [
+            e
+            async for e in provider.astream(
+                "",
+                "http://localhost:5000",
+                mlflow_session_id=_SESSION_ID,
+                session_id=history,
+                context={
+                    "client_tool_results": {
+                        "call_1": {"content": "Applied successfully.", "is_error": False}
+                    }
+                },
+            )
+        ]
+
+    assert not any(
+        e.type in (EventType.PERMISSION_REQUEST, EventType.CLIENT_TOOL_CALL) for e in ev2
+    )
+    tool_results = [
+        e
+        for e in ev2
+        if e.type == EventType.MESSAGE
+        and isinstance(e.data["message"]["content"], list)
+        and e.data["message"]["content"][0].get("content") == "Applied successfully."
+    ]
+    assert len(tool_results) == 1
+    assert any(
+        e.type == EventType.STREAM_EVENT and e.data["event"]["delta"]["text"] == "Done" for e in ev2
+    )
+
+    final = json.loads(_done_session_id(ev2))
+    assert any(
+        m.get("role") == "tool"
+        and m.get("tool_call_id") == "call_1"
+        and m.get("content") == "Applied successfully."
+        for m in final
+    )
+
+
+@pytest.mark.asyncio
+async def test_astream_resume_with_client_tool_error_result_continues(provider):
+    s1, _ = _make_aiohttp_session([_client_tool_call_turns()[0]])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=s1,
+    ):
+        ev1 = [
+            e
+            async for e in provider.astream(
+                "build me a view", "http://localhost:5000", mlflow_session_id=_SESSION_ID
+            )
+        ]
+    history = _done_session_id(ev1)
+
+    s2, _ = _make_aiohttp_session([_client_tool_call_turns()[1]])
+    with patch(
+        "mlflow.assistant.providers.openai_compatible.aiohttp.ClientSession",
+        return_value=s2,
+    ):
+        ev2 = [
+            e
+            async for e in provider.astream(
+                "",
+                "http://localhost:5000",
+                mlflow_session_id=_SESSION_ID,
+                session_id=history,
+                context={
+                    "client_tool_results": {
+                        "call_1": {"content": "Failed to render: invalid spec.", "is_error": True}
+                    }
+                },
+            )
+        ]
+
+    error_results = [
+        e
+        for e in ev2
+        if e.type == EventType.MESSAGE
+        and isinstance(e.data["message"]["content"], list)
+        and e.data["message"]["content"][0].get("content") == "Failed to render: invalid spec."
+    ]
+    assert len(error_results) == 1
+    assert error_results[0].data["message"]["content"][0]["is_error"] is True
+    final = json.loads(_done_session_id(ev2))
+    assert any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_1" for m in final
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -1105,9 +1105,7 @@ async def test_astream_resume_with_client_tool_error_result_continues(provider):
     assert len(error_results) == 1
     assert error_results[0].data["message"]["content"][0]["is_error"] is True
     final = json.loads(_done_session_id(ev2))
-    assert any(
-        m.get("role") == "tool" and m.get("tool_call_id") == "call_1" for m in final
-    )
+    assert any(m.get("role") == "tool" and m.get("tool_call_id") == "call_1" for m in final)
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/test_types.py
+++ b/tests/assistant/test_types.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from mlflow.assistant.types import Event, EventType
@@ -16,3 +18,28 @@ def test_from_exception_never_yields_empty_error(exc, expected):
     event = Event.from_exception(exc)
     assert event.type == EventType.ERROR
     assert event.data["error"] == expected
+
+
+def test_from_client_tool_call_carries_request_id_tool_name_and_input():
+    event = Event.from_client_tool_call(
+        "req-1", "render_custom_view", {"title": "Trace Summary", "messages": []}
+    )
+    assert event.type == EventType.CLIENT_TOOL_CALL
+    assert event.data == {
+        "request_id": "req-1",
+        "tool_name": "render_custom_view",
+        "tool_input": {"title": "Trace Summary", "messages": []},
+    }
+
+
+def test_client_tool_call_event_serializes_to_a_valid_sse_frame():
+    event = Event.from_client_tool_call("req-1", "render_custom_view", {"title": "t"})
+    sse = event.to_sse_event()
+    assert sse.startswith(f"event: {EventType.CLIENT_TOOL_CALL}\n")
+    data_line = next(line for line in sse.splitlines() if line.startswith("data:"))
+    payload = json.loads(data_line.removeprefix("data:").strip())
+    assert payload == {
+        "request_id": "req-1",
+        "tool_name": "render_custom_view",
+        "tool_input": {"title": "t"},
+    }

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -301,6 +301,7 @@ def test_get_providers_auto_resolves_available_default(client):
             "requires_api_key": False,
             "has_api_key": False,
             "allows_remote_access": False,
+            "supports_client_tools": False,
             "model_options": [],
         }
     ]
@@ -310,6 +311,7 @@ def test_get_providers_auto_resolves_available_default(client):
         "auto_selected": True,
         "requires_api_key": False,
         "has_api_key": False,
+        "supports_client_tools": False,
         "model_provider": None,
         "model_options": [],
         "provider_model": None,
@@ -346,6 +348,7 @@ def test_get_providers_resolves_selected_managed_gateway_endpoint():
         "auto_selected": False,
         "requires_api_key": False,
         "has_api_key": True,
+        "supports_client_tools": True,
         "model_provider": "openai",
         "model_options": ["gpt-5.5"],
         "provider_model": "gpt-5.5",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24796/files) to review incremental changes.
- [stack/feat/custom-view-schema-comp-imple](https://github.com/mlflow/mlflow/pull/24788) [[Files changed](https://github.com/mlflow/mlflow/pull/24788/files)] [MERGED]
  - [stack/feat/custom-view-2-validate-a2ui-message](https://github.com/mlflow/mlflow/pull/24792) [[Files changed](https://github.com/mlflow/mlflow/pull/24792/files)] [MERGED]
    - [stack/feat/custom-view-3-prompt-builder-and-template-resolver](https://github.com/mlflow/mlflow/pull/24794) [[Files changed](https://github.com/mlflow/mlflow/pull/24794/files)] [MERGED]
      - [**stack/feat/custom-view-4-assistant-bridge-integration-for-non-cli-agents**](https://github.com/mlflow/mlflow/pull/24796) [[Files changed](https://github.com/mlflow/mlflow/pull/24796/files)] ← _this PR_
        - [stack/feat/custom-view-5-definition-content-and-fe-wiring](https://github.com/mlflow/mlflow/pull/24798) [[Files changed](https://github.com/mlflow/mlflow/pull/24798/files/06c346974cddf8dc30ce643a8ebfb9330a138454..c98b7a67197304722d0a694320e08d89f19e0e52)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

PR 4 of the Custom View stack. It adds a **client-tool pause/resume** mechanism to the MLflow Assistant, so a schema-based provider can call a tool that the *browser* executes, plus the Custom View ↔ Assistant bridge modules built on it. Nothing is mounted yet — a later PR wires the bridge into the Custom View host and `ExperimentCustomViewProvider`.

The flow mirrors the existing permission-prompt pause/resume: the turn ends on a `client_tool_call` SSE event, the client executes the tool and POSTs the result, and a fresh stream resumes the turn from where it stopped. This lets the agent call `render_custom_view` and have the browser render the spec and report back, without the tool ever running server-side or passing through the static permission gate.

**Backend — the pause/resume channel**

- `mlflow/assistant/types.py` — new `EventType.CLIENT_TOOL_CALL` and `Event.from_client_tool_call`.
- `mlflow/assistant/providers/base.py` — new `AssistantProvider.supports_client_tools` property, defaulting to `False`.
- `mlflow/assistant/providers/tool_executor.py` — declares the `CLIENT_TOOLS` set and the `render_custom_view` tool schema (`title` + `messages`). Tools in this set never execute server-side and never reach the permission gate.
- `mlflow/assistant/providers/openai_compatible.py` — opts in, and its tool loop now pauses on a `CLIENT_TOOLS` call (emitting the `ToolUseBlock` followed by a `client_tool_call` event) and, on resume, splices the client's result back in as that call's tool result. `is_resuming` triggers on delivered `client_tool_results` as well as `tool_decisions`.
- `mlflow/server/assistant/session.py` — `Session.pending_client_tool_results`, persisted through `to_dict`/`from_dict`.
- `mlflow/server/assistant/api.py` — new `POST /sessions/{session_id}/tool-result` endpoint mirroring `resolve_permission`. The stream consumes and clears pending results so it stays replay-safe, cancelling a session drops them, and a new user message still supersedes a pending resume rather than reviving an abandoned turn. `supports_client_tools` is surfaced on `ProviderInfo`/`ResolvedProviderInfo`.

**Frontend — resolving the call without user interaction**

- `AssistantService.ts` — a `client_tool_call` listener that ends the stream, and `submitClientToolResult()`, which POSTs the result and opens the continuation stream.
- `AssistantContext.tsx` — tracks `pendingClientToolCall` and, unlike a permission prompt, resolves it automatically: an effect looks up the registered handler, runs it, and submits the outcome. A missing handler or a rejected handler reports an error result, so a paused turn can never hang. The pending call is cleared on reset, cancel, error, and when a new message supersedes the turn.
- `clientToolHandlers.ts` (new) — module-level registry mapping a tool name to its handler.
- `contextProviders.ts` (new) — module-level registry of *pull-based* context providers, invoked lazily by `AssistantPageContext.getContext()` as a turn's context is assembled. This suits values that are too large or too dynamic to push reactively, such as a per-trace data snapshot.

Both registries exist so the generic Assistant never imports feature code — specifically the Custom View host, which pulls in the ESM-only `@a2ui` renderer that must stay out of the Assistant's static module graph.

**Custom View ↔ Assistant bridge** (new `custom-view/assistant/`)

- `customViewAuthoringContext.ts` — module store publishing the authoring guide, the current trace's snapshot, the active view's template, and its apply target. `latchDispatchedCustomViewApplyTarget` records which view the agent was handed at prompt-assembly time, so if the user switches views mid-turn the edit still lands on the view the agent actually edited.
- `customViewSpecApplier.ts` — registry for the applier that renders a returned spec, keyed by a per-host session id. `waitForCustomViewSpecApplier` rides out a brief host remount (e.g. the trace modal reopening) instead of reporting "tab not open", and the session scoping stops an in-flight call resolving against a different trace explorer.
- `CustomViewAssistantConnector.tsx` — React context through which the host app injects `openAssistant` and `isStreaming`.
- `useCustomViewAssistantBridge.ts` — the hook tying these together: publishes the authoring context, registers the applier (turning a thrown validation/render error into a structured failure the agent can read), and exposes the chat opener plus streaming/apply-error state.

**Scope**

CLI-based providers (Claude Code, Codex) keep `supports_client_tools = False` and are unaffected — they have no mid-stream client-tool channel without MCP plumbing. A fenced-block convention for those is tracked separately as follow-up work.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

