### PR TITLE
Harden version parsing against missing/non-PEP440 versions on Databricks Serverless (+ lint rule)

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -847,6 +847,9 @@ class Linter(ast.NodeVisitor):
         if rule := rules.PreferOsEnviron.check(node, self.resolver):
             self._check(Range.from_node(node), rule)
 
+        if rules.UnsafeVersionParse.check(node, self.resolver):
+            self._check(Range.from_node(node), rules.UnsafeVersionParse())
+
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -51,6 +51,7 @@ from clint.rules.unknown_mlflow_function import UnknownMlflowFunction
 from clint.rules.unnamed_thread import UnnamedThread
 from clint.rules.unnamed_thread_pool import UnnamedThreadPool
 from clint.rules.unparameterized_generic_type import UnparameterizedGenericType
+from clint.rules.unsafe_version_parse import UnsafeVersionParse
 from clint.rules.unused_disable_comment import UnusedDisableComment
 from clint.rules.use_gh_token import UseGhToken
 from clint.rules.use_sys_executable import UseSysExecutable
@@ -112,6 +113,7 @@ __all__ = [
     "MultiAssign",
     "UnnamedThread",
     "UnparameterizedGenericType",
+    "UnsafeVersionParse",
     "UnusedDisableComment",
     "AssignBeforeAppend",
     "UseGhToken",

--- a/dev/clint/src/clint/rules/unsafe_version_parse.py
+++ b/dev/clint/src/clint/rules/unsafe_version_parse.py
@@ -1,0 +1,67 @@
+import ast
+from typing import TYPE_CHECKING
+
+from clint.rules.base import Rule
+
+if TYPE_CHECKING:
+    from clint.resolver import Resolver
+
+
+class UnsafeVersionParse(Rule):
+    # Names/attributes that hold a raw Databricks runtime (DBR) version string. These are NOT
+    # PEP 440 (e.g. "18.x-aarch64-photon-scala2") and crash `Version(...)` with `InvalidVersion`.
+    _DBR_VERSION_NAMES = frozenset({
+        "runtime_version",
+        "dbr_version",
+        "databricks_runtime",
+        "databricks_runtime_version",
+    })
+
+    def _message(self) -> str:
+        return (
+            "Do not pass an untrusted version string directly to `packaging.version.Version(...)`. "
+            "It raises on missing/non-PEP440 input, which crashes on Databricks Serverless. "
+            "For an installed distribution's version, use "
+            "`mlflow.utils.get_installed_version(...)`. For a Databricks runtime (DBR) version "
+            "string, use `mlflow.utils.databricks_utils.parse_dbr_runtime_major_minor(...)`."
+        )
+
+    @staticmethod
+    def check(node: ast.Call, resolver: "Resolver") -> bool:
+        if not UnsafeVersionParse._is_version_call(node, resolver):
+            return False
+
+        match node.args:
+            case [arg]:
+                return UnsafeVersionParse._is_metadata_version_call(
+                    arg, resolver
+                ) or UnsafeVersionParse._is_dbr_version_name(arg)
+
+        return False
+
+    @staticmethod
+    def _is_version_call(node: ast.Call, resolver: "Resolver") -> bool:
+        if resolved := resolver.resolve(node.func):
+            return resolved == ["packaging", "version", "Version"]
+        return False
+
+    @staticmethod
+    def _is_metadata_version_call(arg: ast.expr, resolver: "Resolver") -> bool:
+        if not isinstance(arg, ast.Call):
+            return False
+        if resolved := resolver.resolve(arg.func):
+            return resolved in (
+                ["importlib", "metadata", "version"],
+                ["importlib_metadata", "version"],
+            )
+        return False
+
+    @staticmethod
+    def _is_dbr_version_name(arg: ast.expr) -> bool:
+        # Match both a bare name (`runtime_version`) and an attribute access
+        # (`udf_sandbox_info.runtime_version`).
+        if isinstance(arg, ast.Name):
+            return arg.id in UnsafeVersionParse._DBR_VERSION_NAMES
+        if isinstance(arg, ast.Attribute):
+            return arg.attr in UnsafeVersionParse._DBR_VERSION_NAMES
+        return False

--- a/dev/clint/tests/rules/test_unsafe_version_parse.py
+++ b/dev/clint/tests/rules/test_unsafe_version_parse.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import lint_file
+from clint.rules.unsafe_version_parse import UnsafeVersionParse
+
+
+def test_unsafe_version_parse(index: SymbolIndex) -> None:
+    code = """
+import importlib.metadata
+import importlib_metadata
+from packaging.version import Version
+
+Version(importlib.metadata.version("some-dist"))
+Version(importlib_metadata.version("some-dist"))
+Version(runtime_version)
+Version(dbr_version)
+Version(udf_sandbox_info.runtime_version)
+Version(info.databricks_runtime)
+"""
+    config = Config(select={UnsafeVersionParse.name})
+    violations = lint_file(Path("test.py"), code, config, index)
+    assert len(violations) == 6
+    assert all(isinstance(v.rule, UnsafeVersionParse) for v in violations)
+    assert violations[0].range.start.line == 5
+    assert violations[1].range.start.line == 6
+    assert violations[2].range.start.line == 7
+    assert violations[3].range.start.line == 8
+    assert violations[4].range.start.line == 9
+    assert violations[5].range.start.line == 10
+
+
+def test_unsafe_version_parse_no_violations(index: SymbolIndex) -> None:
+    code = """
+import importlib.metadata
+from packaging.version import Version
+
+from mlflow.utils import get_installed_version
+from mlflow.utils.databricks_utils import parse_dbr_runtime_major_minor
+
+# The safe helpers themselves are fine.
+raw = importlib.metadata.version("some-dist")
+Version(raw)
+Version(__version__)
+Version("1.2.3")
+Version(module.__version__)
+get_installed_version("some-dist")
+parse_dbr_runtime_major_minor(runtime_version)
+# A non-Version call wrapping metadata.version is not our concern.
+str(importlib.metadata.version("some-dist"))
+# An attribute unrelated to DBR runtime versions.
+Version(config.some_version)
+"""
+    config = Config(select={UnsafeVersionParse.name})
+    violations = lint_file(Path("test.py"), code, config, index)
+    assert len(violations) == 0
+
+
+def test_unsafe_version_parse_aliased_import(index: SymbolIndex) -> None:
+    code = """
+from importlib import metadata
+from packaging.version import Version
+
+Version(metadata.version("some-dist"))
+"""
+    config = Config(select={UnsafeVersionParse.name})
+    violations = lint_file(Path("test.py"), code, config, index)
+    assert len(violations) == 1
+    assert violations[0].range.start.line == 4

--- a/mlflow/agno/autolog_v2.py
+++ b/mlflow/agno/autolog_v2.py
@@ -8,10 +8,10 @@ import logging
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.trace import Tracer, TracerProvider
-from packaging.version import Version
 
 from mlflow.exceptions import MlflowException
 from mlflow.tracing.provider import _get_tracer, get_current_context
+from mlflow.utils import get_installed_version
 
 _logger = logging.getLogger(__name__)
 _agno_instrumentor = None
@@ -34,10 +34,8 @@ except ImportError:
 
 def _is_agno_v2() -> bool:
     """Check if Agno V2 (>= 2.0.0) is installed."""
-    try:
-        return Version(_meta.version("agno")).major >= 2
-    except _meta.PackageNotFoundError:
-        return False
+    version = get_installed_version("agno")
+    return version is not None and version.major >= 2
 
 
 def _bridge_parent_context(context):

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 
 from packaging.version import Version
@@ -9,6 +8,7 @@ from mlflow.telemetry.events import AutologgingEvent
 from mlflow.telemetry.track import _record_event
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracing.utils import construct_full_inputs
+from mlflow.utils import get_installed_version
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     get_autologging_config,
@@ -76,7 +76,9 @@ def autolog(
         if not any(isinstance(c, MlflowCallback) for c in dspy.settings.callbacks):
             dspy.settings.configure(callbacks=[*dspy.settings.callbacks, MlflowCallback()])
         # DSPy token tracking has an issue before 3.0.4: https://github.com/stanfordnlp/dspy/pull/8831
-        if Version(importlib.metadata.version("dspy")) >= Version("3.0.4"):
+        if (dspy_version := get_installed_version("dspy")) is not None and dspy_version >= Version(
+            "3.0.4"
+        ):
             dspy.settings.configure(track_usage=True)
 
     else:
@@ -189,10 +191,9 @@ def _patched_compile(original, self, *args, **kwargs):
     save_dspy_module_state(program, "best_model.json")
 
     # Teleprompter.get_params is introduced in dspy 2.6.15
+    dspy_version = get_installed_version("dspy")
     params = (
-        self.get_params()
-        if Version(importlib.metadata.version("dspy")) >= Version("2.6.15")
-        else {}
+        self.get_params() if dspy_version is not None and dspy_version >= Version("2.6.15") else {}
     )
     # Construct the dict of arguments passed to the compile call
     inputs = construct_full_inputs(original, self, *args, **kwargs)

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -137,9 +137,10 @@ class DspyModelWrapper(PythonModel):
     def _validate_streaming(
         self,
     ):
-        if (dspy_version := get_installed_version("dspy")) is not None and dspy_version <= Version(
-            "2.6.23"
-        ):
+        # This is a hard gate: block streaming unless we can confirm dspy >= 2.6.24. An
+        # undeterminable version (None) is not safer than an old one, so refuse it too.
+        dspy_version = get_installed_version("dspy")
+        if dspy_version is None or dspy_version <= Version("2.6.23"):
             raise MlflowException(
                 "Streaming API is only supported in dspy 2.6.24 or later. "
                 "Please upgrade your dspy version."

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import json
 from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Any
@@ -14,6 +13,7 @@ from mlflow.protos.databricks_pb2 import (
 )
 from mlflow.pyfunc import PythonModel
 from mlflow.types.schema import DataType, Schema
+from mlflow.utils import get_installed_version
 
 _INVALID_SIZE_MESSAGE = (
     "Dspy model doesn't support batch inference or empty input. Please provide a single input."
@@ -137,7 +137,9 @@ class DspyModelWrapper(PythonModel):
     def _validate_streaming(
         self,
     ):
-        if Version(importlib.metadata.version("dspy")) <= Version("2.6.23"):
+        if (dspy_version := get_installed_version("dspy")) is not None and dspy_version <= Version(
+            "2.6.23"
+        ):
             raise MlflowException(
                 "Streaming API is only supported in dspy 2.6.24 or later. "
                 "Please upgrade your dspy version."

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import importlib.metadata
 import json
 from typing import Annotated, Any, TypedDict
 from uuid import uuid4
 
 from packaging.version import Version
+
+from mlflow.utils import get_installed_version
 
 try:
     from langchain_core.messages import AnyMessage, BaseMessage, convert_to_messages
@@ -18,7 +19,8 @@ try:
     except ImportError as e:
         # If LangGraph 0.3.x is installed but langgraph_prebuilt is not,
         # show a friendlier error message
-        if Version(importlib.metadata.version("langgraph")) >= Version("0.3.0"):
+        langgraph_version = get_installed_version("langgraph")
+        if langgraph_version is not None and langgraph_version >= Version("0.3.0"):
             raise ImportError(
                 "Please install `langgraph-prebuilt>=0.1.2` to use MLflow LangGraph ChatAgent "
                 "helpers with LangGraph 0.3.x.\n"

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -1,9 +1,6 @@
-import importlib.metadata
 import json
 import logging
 from typing import Any, AsyncIterator, Iterator
-
-from packaging.version import Version
 
 import mlflow
 from mlflow.entities import SpanType
@@ -26,6 +23,7 @@ from mlflow.tracing.distributed import _get_tracing_headers_from_span
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import TraceJSONEncoder
+from mlflow.utils import get_installed_version
 from mlflow.utils.autologging_utils import autologging_integration
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 from mlflow.utils.autologging_utils.safety import safe_patch
@@ -63,7 +61,7 @@ def autolog(
         disable_openai_agent_tracer: If ``True``, disable the OpenAI Agent SDK tracer. If ``False``,
             enable the OpenAI Agent SDK tracer. Default to ``True``.
     """
-    if Version(importlib.metadata.version("openai")).major < 1:
+    if (version := get_installed_version("openai")) is not None and version.major < 1:
         raise MlflowException("OpenAI autologging is only supported for openai >= 1.0.0")
 
     # This needs to be called before doing any safe-patching (otherwise safe-patch will be no-op).

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -8,7 +8,6 @@ from string import Formatter
 from typing import Any
 
 import yaml
-from packaging.version import Version
 
 import mlflow
 from mlflow import pyfunc
@@ -24,6 +23,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import ColSpec, Schema, TensorSpec
+from mlflow.utils import get_installed_version
 from mlflow.utils.annotations import deprecated
 from mlflow.utils.databricks_utils import (
     check_databricks_secret_scope_access,
@@ -118,7 +118,8 @@ def _get_model_name(model):
     if isinstance(model, str):
         return model
 
-    if Version(_get_openai_package_version()).major < 1 and isinstance(model, openai.Model):
+    openai_version = get_installed_version("openai")
+    if openai_version is not None and openai_version.major < 1 and isinstance(model, openai.Model):
         return model.id
 
     raise mlflow.MlflowException(
@@ -306,7 +307,8 @@ def save_model(
             path="model",
         )
     """
-    if Version(_get_openai_package_version()).major < 1:
+    openai_version = get_installed_version("openai")
+    if openai_version is not None and openai_version.major < 1:
         raise MlflowException("Only openai>=1.0 is supported.")
 
     import numpy as np

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import itertools
 import logging
 import os
@@ -179,8 +178,11 @@ def _get_api_config() -> _OpenAIApiConfig:
     )
 
 
-def _get_openai_package_version():
-    return importlib.metadata.version("openai")
+def _get_openai_package_version() -> str | None:
+    # Stringified for the saved model's flavor metadata. Returns None if openai has no parseable
+    # version (e.g. vendored on Databricks Serverless), rather than crashing model logging.
+    version = get_installed_version("openai")
+    return str(version) if version is not None else None
 
 
 def _log_secrets_yaml(local_model_dir, scope):

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -1,5 +1,4 @@
 import functools
-import importlib.metadata
 import inspect
 import logging
 import typing
@@ -16,6 +15,7 @@ from mlflow.pydantic_ai.autolog import (
 )
 from mlflow.telemetry.events import AutologgingEvent
 from mlflow.telemetry.track import _record_event
+from mlflow.utils import get_installed_version
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 from mlflow.utils.autologging_utils.safety import _store_patch, _wrap_patch
 
@@ -127,10 +127,7 @@ def _has_instrumentation_capability() -> bool:
 
 
 def _get_pydantic_ai_version() -> Version | None:
-    try:
-        return Version(importlib.metadata.version("pydantic-ai"))
-    except importlib.metadata.PackageNotFoundError:
-        return None
+    return get_installed_version("pydantic-ai")
 
 
 @autologging_integration(FLAVOR_NAME)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,5 +1,4 @@
 import importlib
-import importlib.metadata
 import logging
 import os
 import secrets
@@ -58,6 +57,7 @@ from mlflow.server.workspace_helpers import (
     workspace_before_request_handler,
     workspace_teardown_request_handler,
 )
+from mlflow.utils import get_installed_version
 from mlflow.utils.os import is_windows
 from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import _exec_cmd
@@ -66,7 +66,8 @@ from mlflow.version import VERSION
 REL_STATIC_DIR = "js/build"
 
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
-IS_FLASK_V1 = Version(importlib.metadata.version("flask")) < Version("2.0")
+_flask_version = get_installed_version("flask")
+IS_FLASK_V1 = _flask_version is not None and _flask_version < Version("2.0")
 
 is_running_as_server = (
     "gunicorn" in sys.modules

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -38,15 +38,15 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
         from databricks.sdk.config import Config
 
         super().__init__(artifact_uri, tracking_uri, registry_uri)
-        supports_large_file_uploads = _sdk_supports_large_file_uploads()
+        self._supports_large_file_uploads = _sdk_supports_large_file_uploads()
         wc = WorkspaceClient(
             config=(
                 Config(enable_experimental_files_api_client=True)
-                if supports_large_file_uploads
+                if self._supports_large_file_uploads
                 else None
             )
         )
-        if supports_large_file_uploads:
+        if self._supports_large_file_uploads:
             # `Config` has a `multipart_upload_min_stream_size` parameter but the constructor
             # doesn't set it. This is a bug in databricks-sdk.
             # >>> from databricks.sdk.config import Config
@@ -78,7 +78,7 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
 
     def log_artifact(self, local_file: str, artifact_path: str | None = None) -> None:
         is_large_file = Path(local_file).stat().st_size > 5 * (1024**3)
-        if is_large_file and not _sdk_supports_large_file_uploads():
+        if is_large_file and not self._supports_large_file_uploads:
             raise MlflowException.invalid_parameter_value(
                 "The installed databricks-sdk version does not support uploading files larger "
                 "than 5GB. Please upgrade the databricks-sdk package to version >= 0.45.0."

--- a/mlflow/store/artifact/databricks_sdk_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_sdk_artifact_repo.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import logging
 import posixpath
 from concurrent.futures import Future
@@ -11,6 +10,7 @@ from mlflow.entities import FileInfo
 from mlflow.environment_variables import MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
+from mlflow.utils import get_installed_version
 
 if TYPE_CHECKING:
     from databricks.sdk.service.files import FilesAPI
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
 
 def _sdk_supports_large_file_uploads() -> bool:
     # https://github.com/databricks/databricks-sdk-py/commit/7ca3fb7e8643126b74c9f5779dc01fb20c1741fb
-    return Version(importlib.metadata.version("databricks-sdk")) >= Version("0.45.0")
+    # If the version can't be determined (e.g. databricks-sdk is vendored on Databricks
+    # Serverless and reports no metadata), assume the feature is unavailable.
+    return (version := get_installed_version("databricks-sdk")) is not None and version >= Version(
+        "0.45.0"
+    )
 
 
 _logger = logging.getLogger(__name__)
@@ -73,10 +77,11 @@ class DatabricksSdkArtifactRepository(ArtifactRepository):
         return f"{self.artifact_uri}/{artifact_path}" if artifact_path else self.artifact_uri
 
     def log_artifact(self, local_file: str, artifact_path: str | None = None) -> None:
-        if Path(local_file).stat().st_size > 5 * (1024**3) and not _sdk_supports_large_file_uploads:
+        is_large_file = Path(local_file).stat().st_size > 5 * (1024**3)
+        if is_large_file and not _sdk_supports_large_file_uploads():
             raise MlflowException.invalid_parameter_value(
-                "Databricks SDK version < 0.41.0 does not support uploading files larger than 5GB. "
-                "Please upgrade the databricks-sdk package to version >= 0.41.0."
+                "The installed databricks-sdk version does not support uploading files larger "
+                "than 5GB. Please upgrade the databricks-sdk package to version >= 0.45.0."
             )
 
         with open(local_file, "rb") as f:

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -1,5 +1,4 @@
 import datetime
-import importlib.metadata
 import os
 import posixpath
 import urllib.parse
@@ -23,6 +22,7 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartUploadMixin,
     _retry_with_new_creds,
 )
+from mlflow.utils import get_installed_version
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 
 
@@ -193,9 +193,14 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     @staticmethod
     def _validate_support_mpu():
-        if Version(importlib.metadata.version("google-cloud-storage")) < Version(
-            "2.12.0"
-        ) or Version(importlib.metadata.version("google-resumable-media")) < Version("2.6.0"):
+        gcs_version = get_installed_version("google-cloud-storage")
+        media_version = get_installed_version("google-resumable-media")
+        if (
+            gcs_version is None
+            or gcs_version < Version("2.12.0")
+            or media_version is None
+            or media_version < Version("2.6.0")
+        ):
             raise _UnsupportedMultipartUploadException()
 
     @staticmethod

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import inspect
 import logging
 import socket
@@ -7,6 +8,8 @@ from contextlib import closing
 from itertools import islice
 from sys import version_info
 
+from packaging.version import InvalidVersion, Version
+
 PYTHON_VERSION = f"{version_info.major}.{version_info.minor}.{version_info.micro}"
 
 
@@ -15,6 +18,27 @@ _logger = logging.getLogger(__name__)
 
 def get_major_minor_py_version(py_version):
     return ".".join(py_version.split(".")[:2])
+
+
+def get_installed_version(dist_name: str) -> Version | None:
+    """Return the parsed version of an installed distribution, or ``None`` if it is not installed
+    or its metadata does not expose a parseable version. Never raises.
+
+    On some environments (e.g. Databricks Serverless) ``importlib.metadata.version`` can return
+    ``None`` or raise for a vendored/missing distribution, and ``Version(None)`` raises
+    ``TypeError``. Callers comparing against a threshold should treat ``None`` as "unknown" and
+    fall back to their safe default.
+    """
+    try:
+        raw = importlib.metadata.version(dist_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    if not raw:
+        return None
+    try:
+        return Version(raw)
+    except InvalidVersion:
+        return None
 
 
 def reraise(tp, value, tb=None):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,6 +1,5 @@
 import functools
 import getpass
-import importlib.metadata
 import json
 import logging
 import os
@@ -954,15 +953,14 @@ def check_databricks_sdk_supports_scopes():
         MlflowException: If databricks-sdk version is < 0.74.0
     """
 
-    try:
-        sdk_version = importlib.metadata.version("databricks-sdk")
-    except importlib.metadata.PackageNotFoundError:
+    sdk_version = mlflow.utils.get_installed_version("databricks-sdk")
+    if sdk_version is None:
         raise MlflowException.invalid_parameter_value(
-            "databricks-sdk is not installed. "
+            "databricks-sdk is not installed or its version could not be determined. "
             "Please install with: pip install databricks-sdk>=0.74.0",
         )
 
-    if Version(sdk_version) < Version(_DATABRICKS_SDK_SCOPES_MIN_VERSION):
+    if sdk_version < Version(_DATABRICKS_SDK_SCOPES_MIN_VERSION):
         raise MlflowException.invalid_parameter_value(
             f"The 'scopes' parameter requires databricks-sdk>="
             f"{_DATABRICKS_SDK_SCOPES_MIN_VERSION}. You have version {sdk_version}. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -460,7 +460,9 @@ example-rules = [
 ]
 
 [tool.clint.per-file-ignores]
-"^(?!mlflow/).*$" = ["forbidden-set-active-model-usage"]
+# These rules guard against crashes on Databricks Serverless, which only runs `mlflow/`
+# production code (never tests), so they're scoped to `mlflow/`.
+"^(?!mlflow/).*$" = ["forbidden-set-active-model-usage", "unsafe-version-parse"]
 "^(?!mlflow/|tests/).*$" = ["unnamed-thread", "unnamed-thread-pool"]
 # Multi-assign has better readability in this example.
 "docs/docs/classic-ml/getting-started/deep-learning.mdx" = ["multi-assign"]

--- a/tests/store/artifact/test_databricks_sdk_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_sdk_artifact_repo.py
@@ -1,0 +1,32 @@
+import importlib.metadata
+from unittest import mock
+
+import pytest
+
+from mlflow.store.artifact.databricks_sdk_artifact_repo import _sdk_supports_large_file_uploads
+
+
+def test_sdk_supports_large_file_uploads_true():
+    with mock.patch("importlib.metadata.version", return_value="0.45.0") as mock_version:
+        assert _sdk_supports_large_file_uploads() is True
+        mock_version.assert_called_once_with("databricks-sdk")
+
+
+def test_sdk_supports_large_file_uploads_false_for_old_version():
+    with mock.patch("importlib.metadata.version", return_value="0.44.0"):
+        assert _sdk_supports_large_file_uploads() is False
+
+
+@pytest.mark.parametrize(
+    "side_effect_or_return",
+    [
+        {"side_effect": importlib.metadata.PackageNotFoundError("databricks-sdk")},
+        {"return_value": None},
+    ],
+)
+def test_sdk_supports_large_file_uploads_missing_version_does_not_raise(side_effect_or_return):
+    # On Databricks Serverless the vendored databricks-sdk can report no version, which previously
+    # crashed `mlflow.log_model()` with `TypeError` from `Version(None)`. It must now degrade to
+    # `False` instead.
+    with mock.patch("importlib.metadata.version", **side_effect_or_return):
+        assert _sdk_supports_large_file_uploads() is False

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,13 +1,16 @@
+import importlib.metadata
 import socket
 from unittest import mock
 
 import pytest
+from packaging.version import Version
 
 from mlflow.utils import (
     AttrDict,
     _chunk_dict,
     _get_fully_qualified_class_name,
     _truncate_dict,
+    get_installed_version,
     merge_dicts,
 )
 
@@ -225,3 +228,27 @@ def test_is_port_available_returns_false_for_bound_port():
         s.bind(("127.0.0.1", 0))
         bound_port = s.getsockname()[1]
         assert is_port_available(bound_port) is False
+
+
+def test_get_installed_version_installed():
+    assert get_installed_version("mlflow") == Version(importlib.metadata.version("mlflow"))
+
+
+def test_get_installed_version_not_installed():
+    assert get_installed_version("this-package-does-not-exist-xyz") is None
+
+
+def test_get_installed_version_package_not_found():
+    with mock.patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError("foo"),
+    ) as mock_version:
+        assert get_installed_version("foo") is None
+        mock_version.assert_called_once_with("foo")
+
+
+@pytest.mark.parametrize("raw", [None, "", "not-a-version", "18.x-aarch64-photon-scala2"])
+def test_get_installed_version_missing_or_invalid(raw):
+    with mock.patch("importlib.metadata.version", return_value=raw) as mock_version:
+        assert get_installed_version("foo") is None
+        mock_version.assert_called_once_with("foo")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24336, #24353 (DBR runtime parser this PR reuses and lint-enforces)

<!-- Internal context (Databricks): ES-2047313 -->

### What changes are proposed in this pull request?

MLflow calls `packaging.version.Version(x)` on many sites. Most are safe (they parse a package's own `__version__`, always valid PEP 440). Two categories take untrusted input straight into `Version()` and crash on Databricks Serverless:

**Class A — `Version(importlib.metadata.version("some-dist"))`.** On Serverless, `importlib.metadata.version(...)` can return `None` or raise `PackageNotFoundError` when a distribution is vendored or its metadata is missing. `Version(None)` then raises `TypeError`. This is the live incident: `_sdk_supports_large_file_uploads()` in `databricks_sdk_artifact_repo.py` crashes `mlflow.log_model()` on Serverless because `databricks-sdk` reports no version.

**Class B — `Version(<a Databricks runtime string>)`,** e.g. `Version(udf_sandbox_info.runtime_version)` where the string is `"18.x-aarch64-photon-scala2"`. The `.x` is a wildcard, not a minor — not PEP 440, so `Version()` correctly rejects it. This was already fixed for the `spark_udf` path on master (#24336 / #24353) via `parse_dbr_runtime_major_minor`; no Class B code changes remain, and this PR adds a lint rule so it can't come back.

This PR:

1. **Adds a shared safe helper** `mlflow.utils.get_installed_version(dist_name) -> Version | None` that never raises (handles `PackageNotFoundError`, `None`, and `InvalidVersion`).
2. **Routes every Class A site through it**, treating an unknown version as the safe fallback for each comparison. Converted sites:
   - `mlflow/store/artifact/databricks_sdk_artifact_repo.py` — `databricks-sdk` (the live crash)
   - `mlflow/store/artifact/gcs_artifact_repo.py` — `google-cloud-storage`, `google-resumable-media`
   - `mlflow/openai/autolog.py` — `openai`
   - `mlflow/langchain/chat_agent_langgraph.py` — `langgraph`
   - `mlflow/server/__init__.py` — `flask`
   - `mlflow/dspy/autolog.py` (x2), `mlflow/dspy/wrapper.py` — `dspy`
   - `mlflow/pydantic_ai/__init__.py` — `pydantic-ai` (existing `_get_pydantic_ai_version` now delegates to the helper, closing an `InvalidVersion` gap)
   - `mlflow/agno/autolog_v2.py` — `agno` (found by the new lint rule via its aliased `importlib.metadata as _meta` import)
   - `mlflow/utils/databricks_utils.py` — `check_databricks_sdk_supports_scopes` (same incident package; was `PackageNotFoundError`-safe but still vulnerable to `Version(None)`)
3. **Adds a `clint` lint rule** (`unsafe-version-parse`) that flags `Version(importlib.metadata.version(...))` / `Version(metadata.version(...))` and `Version(<DBR runtime attr>)` (`runtime_version`, `dbr_version`, `databricks_runtime`, ...), pointing to the two helpers. The helpers themselves don't match the flagged patterns, so no allowlist is needed.

Additional fixes in `databricks_sdk_artifact_repo.py`:

- The `>5GB` guard was **dead code**: `not _sdk_supports_large_file_uploads` referenced the function object (always truthy), so the branch never fired. It now calls the function.
- The error message referenced version `0.41.0` while the check used `0.45.0`. The message now matches the actual `0.45.0` threshold.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests: `get_installed_version` (installed / not-installed / `PackageNotFoundError` / `None` / empty / non-PEP440); `_sdk_supports_large_file_uploads` including the missing-version-does-not-raise regression; and positive/negative `clint` rule tests. Ran the affected test modules plus the full `clint` suite (273 passed), `ruff check`, and `ruff format`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a crash in `mlflow.log_model()` on Databricks Serverless caused by parsing a missing/non-PEP440 distribution version, and hardens version parsing across MLflow integrations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
