### PR TITLE
[GenAI] Add Databricks profile support to `make_judge`

### DIFF
--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -27,12 +27,14 @@ class DatabricksConfig(ConfigModel):
     (PAT, OAuth M2M, Azure CLI, etc.).
 
     Args:
+        profile: Databricks configuration profile name.
         host: Databricks workspace URL (e.g., "https://my-workspace.databricks.com").
         token: Databricks Personal Access Token.
         client_id: OAuth M2M client ID (Service Principal).
         client_secret: OAuth M2M client secret (Service Principal).
     """
 
+    profile: str | None = None
     host: str | None = None
     token: str | None = None
     client_id: str | None = None
@@ -71,9 +73,9 @@ class DatabricksProvider(OpenAICompatibleProvider):
     credential chain: PAT tokens, OAuth M2M (Service Principal), Azure CLI,
     Azure MSI, Google Cloud credentials, Databricks CLI profiles, etc.
 
-    When explicit credentials (host/token/client_id/client_secret) are
-    provided in the config, they are passed to the SDK. Otherwise the SDK
-    resolves credentials from environment variables, ~/.databrickscfg, etc.
+    When explicit configuration (profile/host/token/client_id/client_secret)
+    is provided, it is passed to the SDK. Otherwise the SDK resolves credentials
+    from environment variables, ~/.databrickscfg, etc.
     """
 
     DISPLAY_NAME = "Databricks"

--- a/mlflow/genai/judges/adapters/base_adapter.py
+++ b/mlflow/genai/judges/adapters/base_adapter.py
@@ -38,6 +38,8 @@ class AdapterInvocationInput:
             requests to the LLM provider will be routed through this URL.
         extra_headers: Optional dictionary of additional HTTP headers to include in
             requests to the LLM provider.
+        databricks_profile: Optional Databricks configuration profile used to authenticate
+            Databricks-backed judge model requests.
     """
 
     model_uri: str
@@ -50,6 +52,7 @@ class AdapterInvocationInput:
     inference_params: dict[str, Any] | None = None
     base_url: str | None = None
     extra_headers: dict[str, str] | None = None
+    databricks_profile: str | None = None
 
     def __post_init__(self):
         self._model_provider: str | None = None

--- a/mlflow/genai/judges/adapters/gateway_adapter.py
+++ b/mlflow/genai/judges/adapters/gateway_adapter.py
@@ -464,6 +464,7 @@ class GatewayAdapter(BaseJudgeAdapter):
             inference_params=input_params.inference_params,
             base_url=input_params.base_url,
             extra_headers=input_params.extra_headers,
+            databricks_profile=input_params.databricks_profile,
         )
 
         cleaned_response = _strip_markdown_code_blocks(output.response)
@@ -526,6 +527,7 @@ class GatewayAdapter(BaseJudgeAdapter):
         inference_params: dict[str, Any] | None = None,
         base_url: str | None = None,
         extra_headers: dict[str, str] | None = None,
+        databricks_profile: str | None = None,
     ) -> InvokeOutput:
         """Run the tool-calling loop using the provider infrastructure for HTTP calls."""
         # Lazy import: mlflow.types.llm pulls in numpy via mlflow.types.schema
@@ -534,7 +536,12 @@ class GatewayAdapter(BaseJudgeAdapter):
         # Resolve provider for config, URL, headers, and request/response transformation.
         # Each provider's get_endpoint_url() returns the full endpoint path
         # (e.g. OpenAI: .../chat/completions, Anthropic: .../messages).
-        provider_instance = _get_provider_instance(provider, model_name, base_url=base_url)
+        provider_instance = _get_provider_instance(
+            provider,
+            model_name,
+            base_url=base_url,
+            databricks_profile=databricks_profile,
+        )
         endpoint = base_url or provider_instance.get_endpoint_url("llm/v1/chat")
         headers = dict(provider_instance.headers or {})
         # Tag gateway requests so the server can attribute traffic to the judge

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -90,6 +90,7 @@ class InstructionsJudge(Judge):
     _base_url: str | None = PrivateAttr(default=None)
     _extra_headers: dict[str, str] | None = PrivateAttr(default=None)
     _include_timing_in_conversation: bool = PrivateAttr(default=False)
+    _databricks_profile: str | None = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -104,6 +105,7 @@ class InstructionsJudge(Judge):
         base_url: str | None = None,
         extra_headers: dict[str, str] | None = None,
         include_timing_in_conversation: bool = False,
+        databricks_profile: str | None = None,
         **kwargs,
     ):
         """
@@ -134,6 +136,8 @@ class InstructionsJudge(Judge):
             include_timing_in_conversation: If True, append timing information (duration and
                            slowest spans) to assistant responses in conversation. Useful for
                            latency-aware evaluation. Default is False for backward compatibility.
+            databricks_profile: Optional Databricks configuration profile used to
+                           authenticate requests for ``databricks:/...`` judge models.
             kwargs: Additional configuration parameters
         """
         aggregations = kwargs.pop("aggregations", None)
@@ -176,6 +180,7 @@ class InstructionsJudge(Judge):
         self._base_url = base_url
         self._extra_headers = extra_headers
         self._include_timing_in_conversation = include_timing_in_conversation
+        self._databricks_profile = databricks_profile
 
         # NB: We create a dummy PromptVersion here to leverage its existing template variable
         # extraction logic. This allows us to reuse the well-tested regex patterns and variable
@@ -209,6 +214,17 @@ class InstructionsJudge(Judge):
             )
 
         self._validate_model_format()
+        if databricks_profile is not None:
+            if not isinstance(databricks_profile, str) or not databricks_profile.strip():
+                raise MlflowException(
+                    "databricks_profile must be a non-empty string",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            if not self._model.startswith("databricks:/"):
+                raise MlflowException(
+                    "databricks_profile is only supported for databricks:/ judge models",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         self._validate_instructions_template()
 
     @property
@@ -646,6 +662,7 @@ class InstructionsJudge(Judge):
             inference_params=self._inference_params,
             base_url=self._base_url,
             extra_headers=self._extra_headers,
+            databricks_profile=self._databricks_profile,
         )
         # Surface the judge instructions in assessment metadata so the UI can
         # show the criterion that was evaluated alongside each result.
@@ -884,6 +901,8 @@ class InstructionsJudge(Judge):
             )
         if self._inference_params is not None:
             pydantic_data["inference_params"] = self._inference_params
+        if self._databricks_profile is not None:
+            pydantic_data["databricks_profile"] = self._databricks_profile
 
         serialized_scorer = SerializedScorer(
             name=self.name,

--- a/mlflow/genai/judges/make_judge.py
+++ b/mlflow/genai/judges/make_judge.py
@@ -120,6 +120,7 @@ def make_judge(
     base_url: str | None = None,
     extra_headers: dict[str, str] | None = None,
     include_timing_in_conversation: bool = False,
+    databricks_profile: str | None = None,
 ) -> Judge:
     """
     Create a custom MLflow judge instance.
@@ -175,6 +176,10 @@ def make_judge(
                         slowest spans) to assistant responses when evaluating conversations.
                         Useful for latency-aware evaluation. Default is False for backward
                         compatibility. Only applies when using {{ conversation }} template variable.
+        databricks_profile: Optional Databricks configuration profile used to
+                        authenticate requests for ``databricks:/...`` judge models. This allows
+                        judge inference
+                        to use a workspace that is independent from the MLflow tracking URI.
 
     Returns:
         An InstructionsJudge instance configured with the provided parameters
@@ -284,4 +289,5 @@ def make_judge(
         inference_params=inference_params,
         base_url=base_url,
         extra_headers=extra_headers,
+        databricks_profile=databricks_profile,
     )

--- a/mlflow/genai/judges/utils/invocation_utils.py
+++ b/mlflow/genai/judges/utils/invocation_utils.py
@@ -46,6 +46,7 @@ def invoke_judge_model(
     inference_params: dict[str, Any] | None = None,
     base_url: str | None = None,
     extra_headers: dict[str, str] | None = None,
+    databricks_profile: str | None = None,
 ) -> Feedback:
     """
     Invoke the judge model.
@@ -74,6 +75,8 @@ def invoke_judge_model(
             requests to the LLM provider will be routed through this URL.
         extra_headers: Optional dictionary of additional HTTP headers to include in
             requests to the LLM provider.
+        databricks_profile: Optional Databricks configuration profile used to authenticate
+            Databricks-backed judge model requests.
 
     Returns:
         Feedback object with the judge's assessment.
@@ -94,6 +97,7 @@ def invoke_judge_model(
         inference_params=inference_params,
         base_url=base_url,
         extra_headers=extra_headers,
+        databricks_profile=databricks_profile,
     )
 
     output = adapter.invoke(input_params)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -450,6 +450,7 @@ class Scorer(BaseModel):
                     model=data["model"],
                     feedback_value_type=feedback_value_type,
                     inference_params=data.get("inference_params"),
+                    databricks_profile=data.get("databricks_profile"),
                     aggregations=serialized.aggregations,
                 )
             except Exception as e:

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -317,7 +317,10 @@ class _MlflowGatewayProvider(OpenAIProvider):
 
 
 def _get_provider_instance(
-    provider: str, model: str, base_url: str | None = None
+    provider: str,
+    model: str,
+    base_url: str | None = None,
+    databricks_profile: str | None = None,
 ) -> "BaseProvider":
     """Get the provider instance for the given provider name and the model name.
 
@@ -329,6 +332,9 @@ def _get_provider_instance(
             from this URL. Used when the caller already knows the gateway URL
             (e.g. inside the gateway server process where ``MLFLOW_TRACKING_URI``
             points to the backend store, not an HTTP endpoint).
+        databricks_profile: Databricks configuration profile to use for the ``"databricks"``
+            provider. When specified, credentials are resolved from this profile
+            instead of the SDK's ambient default credential chain.
     """
     from mlflow.gateway.config import Provider
 
@@ -493,12 +499,15 @@ def _get_provider_instance(
     elif provider == Provider.DATABRICKS:
         from mlflow.gateway.providers.databricks import DatabricksConfig, DatabricksProvider
 
-        config = DatabricksConfig(
-            host=os.environ.get("DATABRICKS_HOST"),
-            token=os.environ.get("DATABRICKS_TOKEN"),
-            client_id=os.environ.get("DATABRICKS_CLIENT_ID"),
-            client_secret=os.environ.get("DATABRICKS_CLIENT_SECRET"),
-        )
+        if databricks_profile is not None:
+            config = DatabricksConfig(profile=databricks_profile)
+        else:
+            config = DatabricksConfig(
+                host=os.environ.get("DATABRICKS_HOST"),
+                token=os.environ.get("DATABRICKS_TOKEN"),
+                client_id=os.environ.get("DATABRICKS_CLIENT_ID"),
+                client_secret=os.environ.get("DATABRICKS_CLIENT_SECRET"),
+            )
         return DatabricksProvider(_get_route_config(config))
 
     elif provider == Provider.VERTEX_AI:

--- a/tests/gateway/providers/test_databricks.py
+++ b/tests/gateway/providers/test_databricks.py
@@ -108,6 +108,23 @@ def test_sdk_receives_explicit_credentials():
         )
 
 
+def test_sdk_receives_profile():
+    endpoint_config = EndpointConfig(
+        name="databricks-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "databricks",
+            "name": "databricks-dbrx-instruct",
+            "config": {"profile": "judge-workspace"},
+        },
+    )
+    provider = DatabricksProvider(endpoint_config)
+    with mock.patch("databricks.sdk.WorkspaceClient") as mock_ws:
+        mock_ws.return_value = _mock_workspace_client()
+        provider._get_workspace_client()
+        mock_ws.assert_called_once_with(profile="judge-workspace")
+
+
 def test_sdk_oauth_m2m_credentials():
     endpoint_config = EndpointConfig(
         name="databricks-endpoint",
@@ -181,6 +198,7 @@ async def test_embeddings():
 
 def test_config_all_optional():
     config = DatabricksConfig()
+    assert config.profile is None
     assert config.host is None
     assert config.token is None
     assert config.client_id is None

--- a/tests/genai/judges/adapters/test_gateway_adapter.py
+++ b/tests/genai/judges/adapters/test_gateway_adapter.py
@@ -677,6 +677,21 @@ def test_get_provider_instance_gateway_with_base_url():
     assert provider.headers == {}
 
 
+def test_get_provider_databricks_profile_takes_precedence_over_env(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://ambient-workspace.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "ambient-token")
+    provider = _get_provider_instance(
+        "databricks",
+        "judge-endpoint",
+        databricks_profile="judge-workspace",
+    )
+
+    with mock.patch("databricks.sdk.WorkspaceClient") as mock_workspace_client:
+        provider._get_workspace_client()
+
+    mock_workspace_client.assert_called_once_with(profile="judge-workspace")
+
+
 def test_get_provider_unsupported_raises():
     with pytest.raises(MlflowException, match="not supported"):
         _get_provider_instance("nonexistent-provider", "some-model")

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -127,6 +127,7 @@ def mock_invoke_judge_model(monkeypatch):
         inference_params=None,
         base_url=None,
         extra_headers=None,
+        databricks_profile=None,
     ):
         # Store call details in list format (for backward compatibility)
         calls.append((model_uri, prompt, assessment_name))
@@ -143,6 +144,7 @@ def mock_invoke_judge_model(monkeypatch):
             "inference_params": inference_params,
             "base_url": base_url,
             "extra_headers": extra_headers,
+            "databricks_profile": databricks_profile,
         })
 
         # Return appropriate Feedback based on whether trace is provided
@@ -663,6 +665,7 @@ def test_call_with_trace_supported(mock_trace, monkeypatch):
         inference_params=None,
         base_url=None,
         extra_headers=None,
+        databricks_profile=None,
     ):
         captured_args.update({
             "model_uri": model_uri,
@@ -1531,6 +1534,7 @@ def test_trace_prompt_augmentation(mock_trace, monkeypatch):
         inference_params=None,
         base_url=None,
         extra_headers=None,
+        databricks_profile=None,
     ):
         nonlocal captured_prompt
         captured_prompt = prompt
@@ -3923,6 +3927,62 @@ def test_make_judge_without_base_url_and_extra_headers():
     repr_str = repr(judge)
     assert "base_url" not in repr_str
     assert "extra_headers" not in repr_str
+
+
+def test_make_judge_with_databricks_profile(mock_invoke_judge_model):
+    judge = make_judge(
+        name="profile_judge",
+        instructions="Evaluate {{ outputs }}",
+        model="databricks:/judge-endpoint",
+        databricks_profile="judge-workspace",
+    )
+
+    judge(outputs="test output")
+
+    assert judge._databricks_profile == "judge-workspace"
+    assert mock_invoke_judge_model.captured_args["databricks_profile"] == "judge-workspace"
+
+
+@pytest.mark.parametrize("profile", ["", "   ", 123])
+def test_make_judge_databricks_profile_must_be_non_empty_string(profile):
+    with pytest.raises(MlflowException, match="databricks_profile must be a non-empty string"):
+        make_judge(
+            name="profile_judge",
+            instructions="Evaluate {{ outputs }}",
+            model="databricks:/judge-endpoint",
+            databricks_profile=profile,
+        )
+
+
+def test_make_judge_databricks_profile_requires_databricks_model():
+    with pytest.raises(
+        MlflowException,
+        match="databricks_profile is only supported for databricks:/ judge models",
+    ):
+        make_judge(
+            name="profile_judge",
+            instructions="Evaluate {{ outputs }}",
+            model="openai:/gpt-4",
+            databricks_profile="judge-workspace",
+        )
+
+
+def test_databricks_profile_preserved_after_round_trip_serialization():
+    judge = make_judge(
+        name="profile_judge",
+        instructions="Evaluate {{ outputs }}",
+        model="databricks:/judge-endpoint",
+        databricks_profile="judge-workspace",
+    )
+
+    serialized = judge.model_dump()
+    restored = Scorer.model_validate(serialized)
+    restored_from_json = Scorer.model_validate_json(json.dumps(serialized))
+
+    pydantic_data = serialized["instructions_judge_pydantic_data"]
+    assert pydantic_data["databricks_profile"] == "judge-workspace"
+    assert restored._databricks_profile == "judge-workspace"
+    assert restored_from_json._databricks_profile == "judge-workspace"
 
 
 def test_model_dump_excludes_base_url_and_extra_headers():


### PR DESCRIPTION
### Related Issues/PRs

Closes #24797

### What changes are proposed in this pull request?

- Add a `databricks_profile` argument to `mlflow.genai.make_judge()` for `databricks:/...` judge models.
- Extend `DatabricksConfig` with profile support and pass the selected profile to `WorkspaceClient`, keeping judge authentication independent from the MLflow tracking URI and ambient default credentials.
- Preserve the profile name, but no credentials, when serializing and restoring an instructions judge.
- Validate that the profile is a non-empty string and is used only with Databricks-backed judge models.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Tested with:

- `.venv/bin/pytest tests/genai/judges/adapters/test_gateway_adapter.py tests/genai/judges/test_make_judge.py -q` (260 passed)
- `.venv/bin/pytest tests/genai/judges/utils/test_invocation_utils.py tests/genai/judges/test_builtin.py tests/metrics/genai/test_model_utils.py::test_score_model_databricks -q` (79 passed, 9 skipped)
- Ruff formatting and lint, Clint, character normalization, and MLflow spelling checks on all changed files

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

The `make_judge()` API docstring documents the new argument and its multi-workspace behavior.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.genai.make_judge()` now supports selecting a named Databricks configuration profile for `databricks:/...` judge models, enabling tracking and judge inference to use different workspaces without process-wide authentication overrides.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

