### PR TITLE
Skip unparseable image filenames instead of dropping the run

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -991,3 +991,13 @@ test('renderNotebookSource renders plain text for dangerous workspaceUrl', () =>
   ).toEqual('iris');
   /* eslint-enable no-script-url */
 });
+
+test('logErrorAndNotifyUser logs errors it does not display to the user', () => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const error = new Error('something went wrong');
+
+  Utils.logErrorAndNotifyUser(error);
+
+  expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+  consoleErrorSpy.mockRestore();
+});

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -1012,8 +1012,10 @@ class Utils {
     } else if (e instanceof ErrorWrapper) {
       // not all error is wrapped by ErrorWrapper
       Utils.displayGlobalErrorNotification(e.renderHttpError(), duration);
-      // eslint-disable-next-line no-empty
     } else {
+      // Errors we can't render for the user still need to be traceable
+      // eslint-disable-next-line no-console
+      console.error(e);
     }
   }
 

--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.test.ts
@@ -107,7 +107,8 @@ describe('ImageReducer', () => {
     });
   });
 
-  it('should handle error and prevent state update on malformed inputs', () => {
+  it('should skip malformed inputs and keep the images that parsed', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const initialState = {};
     const action: AsyncFulfilledAction<ListImagesAction> = {
       type: 'LIST_IMAGES_API_FULFILLED',
@@ -115,6 +116,16 @@ describe('ImageReducer', () => {
         files: [
           {
             path: 'images/image1%step%0%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            path: 'images/notes.txt',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            path: 'images/image2%step%1%timestamp%1%UUID.png',
             is_dir: false,
             file_size: 123,
           },
@@ -127,7 +138,19 @@ describe('ImageReducer', () => {
       },
     };
     const newState = imagesByRunUuid(initialState, action);
-    expect(newState).toEqual({});
+    expect(newState).toEqual({
+      '123': {
+        image2: {
+          'image2%step%1%timestamp%1%UUID': {
+            filepath: 'images/image2%step%1%timestamp%1%UUID.png',
+            step: 1,
+            timestamp: 1,
+          },
+        },
+      },
+    });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    consoleErrorSpy.mockRestore();
   });
 
   it('should add image and compressed image to the state', () => {

--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
@@ -83,9 +83,16 @@ export const imagesByRunUuid = (
               if (!file.path) {
                 return acc;
               }
-              const { imageKey, step, timestamp, fileKey, extension, isCompressed } = parseImageFile(
-                file.path.slice((MLFLOW_LOGGED_IMAGE_ARTIFACTS_PATH + '/').length),
-              );
+              let parsedImageFile;
+              try {
+                parsedImageFile = parseImageFile(file.path.slice((MLFLOW_LOGGED_IMAGE_ARTIFACTS_PATH + '/').length));
+              } catch (e) {
+                // Skip files that don't follow the logged image naming convention, so that a single
+                // unparseable entry doesn't discard the images that did parse
+                Utils.logErrorAndNotifyUser(e);
+                return acc;
+              }
+              const { imageKey, step, timestamp, fileKey, extension, isCompressed } = parsedImageFile;
 
               // Double check extension of image files
               if (extension === IMAGE_FILE_EXTENSION || extension === IMAGE_COMPRESSED_FILE_EXTENSION) {


### PR DESCRIPTION
### Related Issues/PRs

Closes #24789

### What changes are proposed in this pull request?

`imagesByRunUuid` wraps the whole `files.reduce(...)` in one `try`/`catch`, so the first `ImagePathParseError` out of `parseImageFile` aborts the reduce and the catch returns the previous state. One file in `images/` that does not match the logged-image naming convention therefore discards every image for that run. It is silent because the catch calls `Utils.logErrorAndNotifyUser`, whose `else` branch was empty for anything that is neither a string nor an `ErrorWrapper`.

Two changes:

- `ImageReducer.ts`: `parseImageFile` is now called in its own `try`/`catch` inside the reduce callback. An entry that will not parse is reported and skipped with `return acc`, and the rest of the files still populate the run's images. The outer `try`/`catch` is left in place as a backstop.
- `Utils.tsx`: the empty `else` now does `console.error(e)`. Not a notification on purpose. Routing this through `displayGlobalErrorNotification` would pop a global toast on every page load because of one stray file. A console entry is enough to give the next person something to go on.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

This changes the expectation of `ImageReducer.test.ts`'s `should handle error and prevent state update on malformed inputs`, which pinned the all-or-nothing behaviour. It is replaced by `should skip malformed inputs and keep the images that parsed`, which feeds a mix of unparseable and valid entries and asserts the valid ones survive. `Utils.test.tsx` gets a test that a plain `Error` reaches `console.error`.

Verified on Linux, Node 22.14.0, with Jest. Both new tests fail on `master` and pass with this patch. Also green: `src/experiment-tracking/reducers` and `src/common/utils` (21 suites, 260 tests), the 6 test files that exercise `logErrorAndNotifyUser` (63 tests), `prettier:check`, `eslint`, and `tsc --noEmit`.

Not verified: the rendered UI. I have no browser or tracking server in this environment, so the fix is confirmed at the reducer's output state, not in the image grid itself. I also did not run the full JS test suite, so if some suite elsewhere asserts on a clean console, the new `console.error` could surface there.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where a single file in a run's `images/` artifact directory that did not match the logged-image naming convention would silently hide every logged image for that run in the UI. Unparseable entries are now skipped and logged to the console, and the remaining images render normally.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
