### PR TITLE
Honor UC-backed trace storage in Databricks model serving

### DIFF
--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -35,6 +35,26 @@ def pop_trace(request_id: str) -> dict[str, Any] | None:
     return _TRACE_BUFFER.pop(request_id, None)
 
 
+def maybe_add_trace_to_serving_buffer(trace: "Trace") -> None:
+    """Store a finished trace in the serving buffer so Model Serving can return it in the response.
+
+    The scoring server reads the completed trace from ``_TRACE_BUFFER`` (keyed by client request
+    ID) after ``predict()`` returns. Exporters that write spans elsewhere than the inference table
+    (e.g. the UC table exporter) call this so the endpoint can still return the trace. The buffer
+    is in-memory, so this does not duplicate the exporter's own span/trace export.
+
+    No-op outside model serving, or when the trace has no client request ID to key on.
+    """
+    from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
+
+    if not is_in_databricks_model_serving_environment():
+        return
+    if not (client_request_id := trace.info.client_request_id):
+        return
+    _TRACE_BUFFER[client_request_id] = trace.to_dict()
+    _logger.debug(f"Added {client_request_id} to TRACE_BUFFER")
+
+
 # For Inference Table, we use special TTLCache to store the finished traces
 # so that they can be retrieved by Databricks model serving. The values
 # in the buffer are not Trace dataclass, but rather a dictionary with the schema

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -208,9 +208,8 @@ class MlflowV3SpanExporter(SpanExporter):
         if not maybe_get_request_id(is_evaluate=True):
             self._display_handler.display_traces([trace])
 
-        # Make the trace available to the serving response. No-op outside model serving; the
-        # inference-table exporter has its own path and does not reach here, so the buffer is
-        # written at most once.
+        # The inference-table exporter has its own path and does not reach here, so the serving
+        # buffer is written at most once.
         from mlflow.tracing.export.inference_table import maybe_add_trace_to_serving_buffer
 
         maybe_add_trace_to_serving_buffer(trace)

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -17,6 +17,7 @@ from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import SpansLocation, TraceTagKey
 from mlflow.tracing.display import get_display_handler
 from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
+from mlflow.tracing.export.inference_table import maybe_add_trace_to_serving_buffer
 from mlflow.tracing.export.utils import try_link_prompts_to_trace
 from mlflow.tracing.fluent import _EVAL_REQUEST_ID_TO_TRACE_ID
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -210,8 +211,6 @@ class MlflowV3SpanExporter(SpanExporter):
 
         # The inference-table exporter has its own path and does not reach here, so the serving
         # buffer is written at most once.
-        from mlflow.tracing.export.inference_table import maybe_add_trace_to_serving_buffer
-
         maybe_add_trace_to_serving_buffer(trace)
 
         workspace = manager_trace.workspace

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -208,6 +208,13 @@ class MlflowV3SpanExporter(SpanExporter):
         if not maybe_get_request_id(is_evaluate=True):
             self._display_handler.display_traces([trace])
 
+        # Make the trace available to the serving response. No-op outside model serving; the
+        # inference-table exporter has its own path and does not reach here, so the buffer is
+        # written at most once.
+        from mlflow.tracing.export.inference_table import maybe_add_trace_to_serving_buffer
+
+        maybe_add_trace_to_serving_buffer(trace)
+
         workspace = manager_trace.workspace
         if self._should_log_async():
             self._async_queue.put(

--- a/mlflow/tracing/processor/uc_table.py
+++ b/mlflow/tracing/processor/uc_table.py
@@ -14,6 +14,7 @@ from mlflow.tracing.utils import (
     _bypass_attribute_guard,
     generate_trace_id_v4,
     get_mlflow_span_for_otel_span,
+    maybe_get_serving_request_id,
 )
 
 _logger = logging.getLogger(__name__)
@@ -64,8 +65,13 @@ class DatabricksUCTableSpanProcessor(BaseMlflowSpanProcessor):
         # Override the schema version to 4 for UC table
         metadata[TRACE_SCHEMA_VERSION_KEY] = "4"
 
+        # Carry the serving client request ID so the finished trace can be keyed into the serving
+        # response buffer. None outside model serving.
+        client_request_id = maybe_get_serving_request_id()
+
         trace_info = TraceInfo(
             trace_id=trace_id,
+            client_request_id=client_request_id,
             trace_location=trace_location,
             request_time=root_span.start_time // 1_000_000,  # nanosecond to millisecond
             execution_duration=None,

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -825,13 +825,14 @@ def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
             from mlflow.tracing.export.uc_table import DatabricksUCTableSpanExporter
             from mlflow.tracing.processor.uc_table import DatabricksUCTableSpanProcessor
 
-            # The serving process tracking URI is not a databricks URI, so pin the exporter to
-            # databricks for UC ingestion to reach the backend.
-            uc_tracking_uri = (
-                "databricks"
-                if is_in_databricks_model_serving_environment()
-                else mlflow.get_tracking_uri()
-            )
+            # In model serving the process tracking URI defaults to the local store, which cannot
+            # reach the backend UC ingestion needs. An explicit databricks URI is kept as-is so a
+            # configured profile (databricks://<profile>) is not discarded.
+            uc_tracking_uri = mlflow.get_tracking_uri()
+            if is_in_databricks_model_serving_environment() and not (
+                uc_tracking_uri and is_databricks_uri(uc_tracking_uri)
+            ):
+                uc_tracking_uri = "databricks"
             exporter = DatabricksUCTableSpanExporter(tracking_uri=uc_tracking_uri)
             processor = DatabricksUCTableSpanProcessor(span_exporter=exporter)
             processors.append(processor)

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -758,8 +758,19 @@ def _resolve_experiment_uc_location() -> UnityCatalog | None:
     from mlflow.tracking._tracking_service.utils import _get_store
     from mlflow.tracking.fluent import _get_experiment_id
 
+    # Model serving runs with a non-databricks tracking URI (the local store), so the experiment's
+    # UC binding lives in the Databricks backend and must be read through a databricks store rather
+    # than the process store. Elsewhere, only resolve when the active tracking URI is databricks.
+    in_serving = (
+        is_in_databricks_model_serving_environment()
+        and is_mlflow_tracing_enabled_in_model_serving()
+    )
     tracking_uri = mlflow.get_tracking_uri()
-    if not tracking_uri or not is_databricks_uri(tracking_uri):
+    if in_serving:
+        store_uri = "databricks"
+    elif tracking_uri and is_databricks_uri(tracking_uri):
+        store_uri = None
+    else:
         return None
 
     try:
@@ -767,7 +778,7 @@ def _resolve_experiment_uc_location() -> UnityCatalog | None:
         if not experiment_id:
             return None
 
-        experiment = _get_store().get_experiment(experiment_id)
+        experiment = _get_store(store_uri).get_experiment(experiment_id)
         if not experiment:
             return None
 
@@ -814,7 +825,14 @@ def _get_span_processors(disabled: bool = False) -> list[SpanProcessor]:
             from mlflow.tracing.export.uc_table import DatabricksUCTableSpanExporter
             from mlflow.tracing.processor.uc_table import DatabricksUCTableSpanProcessor
 
-            exporter = DatabricksUCTableSpanExporter(tracking_uri=mlflow.get_tracking_uri())
+            # The serving process tracking URI is not a databricks URI, so pin the exporter to
+            # databricks for UC ingestion to reach the backend.
+            uc_tracking_uri = (
+                "databricks"
+                if is_in_databricks_model_serving_environment()
+                else mlflow.get_tracking_uri()
+            )
+            exporter = DatabricksUCTableSpanExporter(tracking_uri=uc_tracking_uri)
             processor = DatabricksUCTableSpanProcessor(span_exporter=exporter)
             processors.append(processor)
             _logger.debug("Added DatabricksUCTableSpanProcessor based on trace destination")

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -480,6 +480,23 @@ def maybe_get_request_id(is_evaluate=False) -> str | None:
     return context.request_id
 
 
+def maybe_get_serving_request_id() -> str | None:
+    """Best-effort Databricks model-serving client request ID for the current request.
+
+    Reads the request ID from the prediction context, falling back to the ``X-Request-Id`` header
+    for streaming responses where no prediction context is active. Returns ``None`` when there is
+    no request ID rather than aborting, so callers can use it purely to key the serving buffer.
+    """
+    if request_id := maybe_get_request_id():
+        return request_id
+
+    from mlflow.tracing.processor.inference_table import _HEADER_REQUEST_ID_KEY, _get_flask_request
+
+    if flask_request := _get_flask_request():
+        return flask_request.headers.get(_HEADER_REQUEST_ID_KEY)
+    return None
+
+
 def maybe_get_dependencies_schemas() -> dict[str, Any] | None:
     if context := _try_get_prediction_context():
         return context.dependencies_schemas

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -486,7 +486,14 @@ def maybe_get_serving_request_id() -> str | None:
     Reads the request ID from the prediction context, falling back to the ``X-Request-Id`` header
     for streaming responses where no prediction context is active. Returns ``None`` when there is
     no request ID rather than aborting, so callers can use it purely to key the serving buffer.
+
+    Returns ``None`` outside model serving, where a client request ID has no meaning.
     """
+    from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
+
+    if not is_in_databricks_model_serving_environment():
+        return None
+
     if request_id := maybe_get_request_id():
         return request_id
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -29,7 +29,6 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.constant import (
     CostKey as CostKey,
 )
-from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
 from mlflow.version import IS_TRACING_SDK_ONLY
 
@@ -490,6 +489,8 @@ def maybe_get_serving_request_id() -> str | None:
 
     Returns ``None`` outside model serving, where a client request ID has no meaning.
     """
+    from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
+
     if not is_in_databricks_model_serving_environment():
         return None
 

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -29,6 +29,7 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.constant import (
     CostKey as CostKey,
 )
+from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
 from mlflow.version import IS_TRACING_SDK_ONLY
 
@@ -489,8 +490,6 @@ def maybe_get_serving_request_id() -> str | None:
 
     Returns ``None`` outside model serving, where a client request ID has no meaning.
     """
-    from mlflow.utils.databricks_utils import is_in_databricks_model_serving_environment
-
     if not is_in_databricks_model_serving_environment():
         return None
 

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -921,3 +921,83 @@ def test_bsp_export_preserves_workspace_context(monkeypatch):
     assert captured_start_trace_workspace[0] == "bsp-workspace"
     assert len(captured_log_spans_workspace) == 1
     assert captured_log_spans_workspace[0] == "bsp-workspace"
+
+
+# ML-67987: In model serving, the trace export path also populates the in-memory serving buffer so
+# the endpoint can return the trace in its response, without a second backend write. These tests
+# cover the shared MlflowV3SpanExporter path (inherited by the UC table exporter).
+def test_export_populates_serving_buffer_in_model_serving(monkeypatch):
+    from mlflow.tracing.export import inference_table
+
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+
+    now_ns = int(time.time() * 1e9)
+    otel_span = create_mock_otel_span(
+        name="root",
+        trace_id=54321,
+        span_id=1,
+        parent_id=None,
+        start_time=now_ns - 1_000_000,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+    trace_info.client_request_id = "req-serving-1"
+    trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+    trace_manager.register_span(span)
+
+    inference_table._TRACE_BUFFER.clear()
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.start_trace", return_value=trace_info
+        ) as mock_start_trace,
+        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
+    ):
+        exporter = MlflowV3SpanExporter()
+        exporter.export([otel_span])
+
+    # Buffer populated once, keyed by the client request ID, so the serving response can return it.
+    assert inference_table.pop_trace("req-serving-1") is not None
+    # Exactly one backend write — populating the buffer must not double-write the trace.
+    mock_start_trace.assert_called_once()
+    inference_table._TRACE_BUFFER.clear()
+
+
+def test_export_does_not_populate_serving_buffer_outside_model_serving(monkeypatch):
+    from mlflow.tracing.export import inference_table
+
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+    monkeypatch.delenv("IS_IN_DB_MODEL_SERVING_ENV", raising=False)
+
+    now_ns = int(time.time() * 1e9)
+    otel_span = create_mock_otel_span(
+        name="root",
+        trace_id=54322,
+        span_id=1,
+        parent_id=None,
+        start_time=now_ns - 1_000_000,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+    trace_info.client_request_id = "req-serving-2"
+    trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+    trace_manager.register_span(span)
+
+    inference_table._TRACE_BUFFER.clear()
+    with (
+        mock.patch("mlflow.tracing.client.TracingClient.start_trace", return_value=trace_info),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
+    ):
+        exporter = MlflowV3SpanExporter()
+        exporter.export([otel_span])
+
+    assert inference_table.pop_trace("req-serving-2") is None
+    inference_table._TRACE_BUFFER.clear()

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -923,9 +923,9 @@ def test_bsp_export_preserves_workspace_context(monkeypatch):
     assert captured_log_spans_workspace[0] == "bsp-workspace"
 
 
-# ML-67987: In model serving, the trace export path also populates the in-memory serving buffer so
-# the endpoint can return the trace in its response, without a second backend write. These tests
-# cover the shared MlflowV3SpanExporter path (inherited by the UC table exporter).
+# In model serving, the trace export path also populates the in-memory serving buffer so the
+# endpoint can return the trace in its response, without a second backend write. These tests cover
+# the shared MlflowV3SpanExporter path (inherited by the UC table exporter).
 def test_export_populates_serving_buffer_in_model_serving(monkeypatch):
     from mlflow.tracing.export import inference_table
 
@@ -960,9 +960,8 @@ def test_export_populates_serving_buffer_in_model_serving(monkeypatch):
         exporter = MlflowV3SpanExporter()
         exporter.export([otel_span])
 
-    # Buffer populated once, keyed by the client request ID, so the serving response can return it.
     assert inference_table.pop_trace("req-serving-1") is not None
-    # Exactly one backend write — populating the buffer must not double-write the trace.
+    # Populating the buffer must not double-write the trace to the backend.
     mock_start_trace.assert_called_once()
     inference_table._TRACE_BUFFER.clear()
 

--- a/tests/tracing/processor/test_uc_table_processor.py
+++ b/tests/tracing/processor/test_uc_table_processor.py
@@ -17,6 +17,7 @@ from mlflow.tracing.trace_manager import InMemoryTraceManager
 from tests.tracing.helper import (
     create_mock_otel_span,
     create_test_trace_info,
+    skip_when_testing_trace_sdk,
 )
 
 
@@ -180,8 +181,7 @@ def test_trace_metadata_and_tags(active_uc_schema_destination):
     assert trace_info.tags is not None
 
 
-# ML-67987: In model serving the UC processor captures the Databricks client request ID from the
-# prediction context so the finished trace can be returned in the serving response.
+@skip_when_testing_trace_sdk  # needs the prediction context, which pulls in pyfunc (not in the SDK)
 def test_start_trace_sets_client_request_id_in_model_serving(
     monkeypatch, active_uc_schema_destination
 ):
@@ -200,10 +200,16 @@ def test_start_trace_sets_client_request_id_in_model_serving(
     assert created_trace.info.client_request_id == "req-abc-123"
 
 
+@skip_when_testing_trace_sdk  # needs the prediction context, which pulls in pyfunc (not in the SDK)
 def test_start_trace_no_client_request_id_outside_model_serving(active_uc_schema_destination):
+    from mlflow.pyfunc.context import Context, set_prediction_context
+
     span = create_mock_otel_span(trace_id=12345, span_id=1, parent_id=None, start_time=5_000_000)
     processor = DatabricksUCTableSpanProcessor(span_exporter=mock.MagicMock())
-    processor.on_start(span)
+    # A prediction context is present but the process is not model serving, so no client request ID
+    # is captured.
+    with set_prediction_context(Context(request_id="req-abc-123")):
+        processor.on_start(span)
 
     trace_manager = InMemoryTraceManager.get_instance()
     created_trace = list(trace_manager._traces.values())[0]

--- a/tests/tracing/processor/test_uc_table_processor.py
+++ b/tests/tracing/processor/test_uc_table_processor.py
@@ -178,3 +178,33 @@ def test_trace_metadata_and_tags(active_uc_schema_destination):
     # Check that metadata and tags are present
     assert trace_info.trace_metadata is not None
     assert trace_info.tags is not None
+
+
+# ML-67987: In model serving the UC processor captures the Databricks client request ID from the
+# prediction context so the finished trace can be returned in the serving response.
+def test_start_trace_sets_client_request_id_in_model_serving(
+    monkeypatch, active_uc_schema_destination
+):
+    from mlflow.pyfunc.context import Context, set_prediction_context
+
+    monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
+    monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
+
+    span = create_mock_otel_span(trace_id=12345, span_id=1, parent_id=None, start_time=5_000_000)
+    processor = DatabricksUCTableSpanProcessor(span_exporter=mock.MagicMock())
+    with set_prediction_context(Context(request_id="req-abc-123")):
+        processor.on_start(span)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    created_trace = list(trace_manager._traces.values())[0]
+    assert created_trace.info.client_request_id == "req-abc-123"
+
+
+def test_start_trace_no_client_request_id_outside_model_serving(active_uc_schema_destination):
+    span = create_mock_otel_span(trace_id=12345, span_id=1, parent_id=None, start_time=5_000_000)
+    processor = DatabricksUCTableSpanProcessor(span_exporter=mock.MagicMock())
+    processor.on_start(span)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    created_trace = list(trace_manager._traces.values())[0]
+    assert created_trace.info.client_request_id is None

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1096,3 +1096,116 @@ def test_get_tracer_does_not_fail_when_experiment_id_resolution_fails():
 
     assert tracer is not None
     mlflow.tracing.reset()
+
+
+# In model serving the process tracking URI is the local store, so a UC-bound experiment's binding
+# is resolved through a databricks store rather than the local process store.
+def _serving_uc_experiment():
+    return _experiment(tags={MLFLOW_EXPERIMENT_DATABRICKS_TRACE_DESTINATION_PATH: "cat.sch.pfx"})
+
+
+def test_resolve_uc_location_in_serving_uses_databricks_store(
+    mock_databricks_serving_with_tracing_env,
+):
+    from mlflow.tracing.provider import _resolve_experiment_uc_location
+
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="sqlite:///mlflow.db",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _serving_uc_experiment()
+
+        result = _resolve_experiment_uc_location()
+
+        assert result == UnityCatalog("cat", "sch", table_prefix="pfx")
+        # The binding is resolved through the databricks store, not the local process store.
+        mock_store_fn.assert_called_once_with("databricks")
+
+    mlflow.tracing.reset()
+
+
+def test_serving_uc_bound_experiment_selects_uc_processor(
+    mock_databricks_serving_with_tracing_env,
+):
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="sqlite:///mlflow.db",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _serving_uc_experiment()
+
+        tracer = _get_tracer("test")
+        processors = tracer.span_processor._span_processors
+
+        assert len(processors) == 1
+        assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
+        assert isinstance(processors[0].span_exporter, DatabricksUCTableSpanExporter)
+        # The UC exporter is pinned to the databricks tracking URI so ingestion reaches the backend.
+        assert processors[0].span_exporter._client.tracking_uri == "databricks"
+
+    mlflow.tracing.reset()
+
+
+def test_serving_non_uc_experiment_retains_inference_table(
+    mock_databricks_serving_with_tracing_env,
+):
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="sqlite:///mlflow.db",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _experiment(tags={})
+
+        tracer = _get_tracer("test")
+        processors = tracer.span_processor._span_processors
+
+        assert len(processors) == 1
+        assert isinstance(processors[0], InferenceTableSpanProcessor)
+
+    mlflow.tracing.reset()
+
+
+def test_serving_tracing_destination_env_wins_over_experiment_binding(
+    mock_databricks_serving_with_tracing_env, monkeypatch
+):
+    # An explicit MLFLOW_TRACING_DESTINATION is read before the experiment-binding fallback, so it
+    # takes precedence and the experiment store is never consulted.
+    monkeypatch.setenv("MLFLOW_TRACING_DESTINATION", "envcat.envsch")
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value="databricks",
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _serving_uc_experiment()
+
+        tracer = _get_tracer("test")
+        processors = tracer.span_processor._span_processors
+
+        assert len(processors) == 1
+        assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
+        mock_store_fn.return_value.get_experiment.assert_not_called()
+        spans_table = get_active_spans_table_name()
+        assert spans_table == "envcat.envsch.mlflow_experiment_trace_otel_spans"
+
+    mlflow.tracing.reset()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1098,8 +1098,6 @@ def test_get_tracer_does_not_fail_when_experiment_id_resolution_fails():
     mlflow.tracing.reset()
 
 
-# In model serving the process tracking URI is the local store, so a UC-bound experiment's binding
-# is resolved through a databricks store rather than the local process store.
 def _serving_uc_experiment():
     return _experiment(tags={MLFLOW_EXPERIMENT_DATABRICKS_TRACE_DESTINATION_PATH: "cat.sch.pfx"})
 
@@ -1124,7 +1122,6 @@ def test_resolve_uc_location_in_serving_uses_databricks_store(
         result = _resolve_experiment_uc_location()
 
         assert result == UnityCatalog("cat", "sch", table_prefix="pfx")
-        # The binding is resolved through the databricks store, not the local process store.
         mock_store_fn.assert_called_once_with("databricks")
 
     mlflow.tracing.reset()
@@ -1151,7 +1148,6 @@ def test_serving_uc_bound_experiment_selects_uc_processor(
         assert len(processors) == 1
         assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
         assert isinstance(processors[0].span_exporter, DatabricksUCTableSpanExporter)
-        # The UC exporter is pinned to the databricks tracking URI so ingestion reaches the backend.
         assert processors[0].span_exporter._client.tracking_uri == "databricks"
 
     mlflow.tracing.reset()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1153,6 +1153,32 @@ def test_serving_uc_bound_experiment_selects_uc_processor(
     mlflow.tracing.reset()
 
 
+@pytest.mark.parametrize("tracking_uri", ["databricks", "databricks://myprofile"])
+def test_serving_keeps_explicit_databricks_tracking_uri(
+    mock_databricks_serving_with_tracing_env, tracking_uri
+):
+    # Substituting "databricks" in serving must not discard a configured profile.
+    mlflow.tracing.reset()
+
+    with (
+        mock.patch(
+            "mlflow.tracing.provider.mlflow.get_tracking_uri",
+            return_value=tracking_uri,
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="123"),
+        mock.patch("mlflow.tracking._tracking_service.utils._get_store") as mock_store_fn,
+    ):
+        mock_store_fn.return_value.get_experiment.return_value = _serving_uc_experiment()
+
+        tracer = _get_tracer("test")
+        processors = tracer.span_processor._span_processors
+
+        assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
+        assert processors[0].span_exporter._client.tracking_uri == tracking_uri
+
+    mlflow.tracing.reset()
+
+
 def test_serving_non_uc_experiment_retains_inference_table(
     mock_databricks_serving_with_tracing_env,
 ):


### PR DESCRIPTION
Databricks model serving that enables tracing with only MLFLOW_EXPERIMENT_ID used InferenceTableSpanProcessor even when the experiment was linked to a Unity Catalog table-prefix trace location, leaving the UC otel_spans table empty. The auto-resolver _resolve_experiment_uc_location() only ran when the process tracking URI was a databricks URI, but in the serving container the tracking URI defaults to the local store, so resolution never occurred.

Resolve the experiment's UC binding through a databricks-backed store when running in model serving (regardless of the process tracking URI), and pin the UC exporter's tracking URI to databricks so ingestion reaches the backend. A serving endpoint whose experiment is bound to a UC trace location now writes its trace spans to that location's otel_spans table. Endpoints whose experiment is not UC-bound are unaffected and keep writing to the inference table.

Preserve the serving response trace buffer without a duplicate backend write: the UC processor captures the client request id from the serving prediction context, and the shared trace-export path populates the in-memory serving buffer (an in-memory insert, not a second backend write). The inference-table exporter has its own path, so there is no double population.

Add regression coverage for serving + UC-bound experiment (UC processor selected, buffer populated, single backend write), serving + non-UC experiment (unchanged, inference table retained), and MLFLOW_TRACING_DESTINATION precedence.

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
