### PR TITLE
fix(openai): extend Anthropic-via-gateway cache token extraction to streaming path

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -396,10 +396,20 @@ def _process_last_chunk(
                     TokenUsageKey.TOTAL_TOKENS: usage.total_tokens,
                 }
 
-                # Extract cached tokens if available in the streaming chunk
+                # Extract cached tokens if available in the streaming chunk.
+                # Standard OpenAI path: prompt_tokens_details.cached_tokens.
                 if details := getattr(usage, "prompt_tokens_details", None):
                     if (cached := getattr(details, "cached_tokens", None)) is not None:
                         usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+                # Anthropic-via-gateway path: top-level cache_read/creation_input_tokens.
+                # Used when Anthropic models are served via an OpenAI-compatible endpoint
+                # (e.g. Databricks Foundation Model API) where prompt_tokens_details is None
+                # but cache counts appear at the top level of the usage object.
+                if TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage_dict:
+                    if (cache_read := getattr(usage, "cache_read_input_tokens", None)) is not None:
+                        usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+                if (cache_creation := getattr(usage, "cache_creation_input_tokens", None)) is not None:
+                    usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_creation
                 span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
 
         _end_span_on_success(span, inputs, output, is_responses_api)

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -12,6 +12,7 @@ from mlflow.types.chat import ChatCompletionRequest
 EMPTY_CHOICES = "EMPTY_CHOICES"
 LIST_CONTENT = "LIST_CONTENT"
 AZURE_ANNOTATIONS = "AZURE_ANNOTATIONS"
+ANTHROPIC_CACHE_STREAM = "ANTHROPIC_CACHE_STREAM"
 
 app = fastapi.FastAPI()
 
@@ -118,6 +119,31 @@ def _make_chat_stream_usage_chunk():
     }
 
 
+def _make_chat_stream_anthropic_cache_usage_chunk():
+    """Stream usage chunk with Anthropic-via-gateway top-level cache fields.
+
+    Anthropic endpoints served through an OpenAI-compatible gateway (e.g. Databricks
+    Foundation Model API) surface cache counts at the top level of the usage object
+    instead of the OpenAI-standard prompt_tokens_details.cached_tokens path.
+    """
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "claude-opus-4-8",
+        "system_fingerprint": None,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 20,
+            "total_tokens": 70,
+            "cache_read_input_tokens": 40,
+            "cache_creation_input_tokens": 5,
+            # prompt_tokens_details is absent (Anthropic-via-gateway endpoint)
+        },
+    }
+
+
 def _make_chat_stream_chunk_with_list_content(content_list, include_usage: bool = False):
     # Create a streaming chunk with list content (Databricks format).
     return {
@@ -180,6 +206,17 @@ async def chat_response_stream_with_list_content(include_usage: bool = False):
     )
 
 
+async def chat_response_stream_with_anthropic_cache():
+    """Stream that mimics an Anthropic-via-gateway endpoint.
+
+    The usage chunk carries cache_read_input_tokens and cache_creation_input_tokens at
+    the top level of the usage object (not under prompt_tokens_details.cached_tokens).
+    """
+    yield _make_chat_stream_chunk("Hello", include_usage=False)
+    yield _make_chat_stream_chunk(" world", include_usage=False)
+    yield _make_chat_stream_anthropic_cache_usage_chunk()
+
+
 @app.post("/chat/completions", response_model_exclude_unset=True)
 async def chat(payload: ChatCompletionRequest):
     if payload.stream:
@@ -201,6 +238,11 @@ async def chat(payload: ChatCompletionRequest):
                 async for d in chat_response_stream_with_list_content(
                     include_usage=(payload.stream_options or {}).get("include_usage", False)
                 )
+            )
+        elif ANTHROPIC_CACHE_STREAM == payload.messages[0].content:
+            content = (
+                f"data: {json.dumps(d)}\n\n"
+                async for d in chat_response_stream_with_anthropic_cache()
             )
         else:
             content = (

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -27,7 +27,7 @@ from mlflow.tracing.constant import (
 )
 from mlflow.version import IS_TRACING_SDK_ONLY
 
-from tests.openai.mock_openai import AZURE_ANNOTATIONS, EMPTY_CHOICES, LIST_CONTENT
+from tests.openai.mock_openai import ANTHROPIC_CACHE_STREAM, AZURE_ANNOTATIONS, EMPTY_CHOICES, LIST_CONTENT
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
 MOCK_TOOLS = [
@@ -524,6 +524,38 @@ async def test_chat_completions_streaming_with_list_content(client):
     assert isinstance(span.outputs, dict)
     assert span.outputs["choices"][0]["message"]["content"] == "Hello world"
 
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_with_anthropic_cache_tokens(client):
+    # Verify the streaming autolog path captures Anthropic-via-gateway cache fields.
+    # These arrive as top-level usage keys (cache_read_input_tokens,
+    # cache_creation_input_tokens) instead of inside prompt_tokens_details.
+    mlflow.openai.autolog()
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": ANTHROPIC_CACHE_STREAM}],
+        model="claude-opus-4-8",
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    if client._is_async:
+        async for _ in await stream:
+            pass
+    else:
+        for _ in stream:
+            pass
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        TokenUsageKey.INPUT_TOKENS: 50,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 70,
+        TokenUsageKey.CACHE_READ_INPUT_TOKENS: 40,
+        TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 5,
+    }
 
 @pytest.mark.asyncio
 async def test_completions_autolog(client):


### PR DESCRIPTION
## Summary

Closes #24615 (streaming path complement to #24618 which fixes the non-streaming path).

When Anthropic models are served through an OpenAI-compatible gateway such as
**Databricks Foundation Model API**, cache token counts arrive as top-level
`usage` fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) rather
than inside `prompt_tokens_details.cached_tokens`. The non-streaming autolog
path (`chat_schema.py`) already handles both sources. The streaming path in
`autolog.py::_process_last_chunk` only checked `prompt_tokens_details`, so
cache counts were silently dropped for streaming calls through these gateways.

**Changes:**

- `mlflow/openai/autolog.py`: after the standard `prompt_tokens_details.cached_tokens`
  check, fall back to top-level `cache_read_input_tokens` / `cache_creation_input_tokens`
  when the standard path yields nothing. Priority order:
  1. `prompt_tokens_details.cached_tokens` → `CACHE_READ_INPUT_TOKENS` (standard OpenAI)
  2. `usage.cache_read_input_tokens` → `CACHE_READ_INPUT_TOKENS` (Anthropic-via-gateway fallback)
  3. `usage.cache_creation_input_tokens` → `CACHE_CREATION_INPUT_TOKENS` (always checked)

- `tests/openai/mock_openai.py`: add `ANTHROPIC_CACHE_STREAM` sentinel, a usage chunk
  with top-level cache fields and no `prompt_tokens_details`, and a streaming generator
  that yields it.

- `tests/openai/test_openai_autolog.py`: add
  `test_chat_completions_streaming_with_anthropic_cache_tokens` which verifies that both
  `CACHE_READ_INPUT_TOKENS: 40` and `CACHE_CREATION_INPUT_TOKENS: 5` appear in the span's
  `CHAT_USAGE` attribute when only top-level cache fields are present.

## Relationship to existing PRs

PR #24618 (open) fixes `mlflow/openai/utils/chat_schema.py` — the **non-streaming**
`convert_chat_response_to_mlflow_chat_response()` path. This PR fixes the **streaming**
`autolog.py::_process_last_chunk()` path. The two PRs are independent and can be merged
in either order.

## Test plan

- [ ] New test `test_chat_completions_streaming_with_anthropic_cache_tokens` covers the
  Anthropic-via-gateway streaming path via the mock server.
- [ ] Existing `test_chat_completions_autolog_streaming_with_cached_tokens` continues to
  pass (standard `prompt_tokens_details` path is untouched).
- [ ] Manually verified with a Databricks-hosted `claude-opus-4-8` streaming call that
  `cache_read_input_tokens` and `cache_creation_input_tokens` appear in the MLflow trace.