### PR TITLE
docs: fix nonexistent `--artifacts-store-uri` flag in remote server tutorial

### DIFF
--- a/docs/docs/classic-ml/tracking/tutorials/remote-server/index.mdx
+++ b/docs/docs/classic-ml/tracking/tutorials/remote-server/index.mdx
@@ -158,7 +158,7 @@ You can find the instructions for how to configure credentials for other storage
 
 #### Launch the tracking server
 
-To specify the backend store and artifact store, you can use the `--backend-store-uri` and `--artifacts-store-uri` options respectively.
+To specify the backend store and artifact store, you can use the `--backend-store-uri` and `--artifacts-destination` options respectively.
 
 ```bash
 mlflow server \


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A — standalone documentation fix (no related issue).

### What changes are proposed in this pull request?

The remote-server tracking tutorial (`docs/docs/classic-ml/tracking/tutorials/remote-server/index.mdx`) says the artifact store is configured with `--artifacts-store-uri`, but that option does not exist. `mlflow server` registers `--artifacts-destination` (`cli_args.ARTIFACTS_DESTINATION`, applied to the `server` command in `mlflow/cli/__init__.py`; env var `MLFLOW_ARTIFACTS_DESTINATION`). A repo-wide search shows `--artifacts-store-uri` appears only in this one doc file, so `mlflow server --artifacts-store-uri ...` fails with `Error: No such option: --artifacts-store-uri`. The runnable command a few lines below in the same tutorial already uses the correct `--artifacts-destination`. This corrects the prose to match.

### How is this PR tested?

- [x] Manual tests

Verified `--artifacts-store-uri` exists nowhere in the codebase (repo-wide search returns only this doc file) and that `--artifacts-destination` is the registered option on the `server` command.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
