### PR TITLE
fix: avoid recreate-table error on upgrade by using migrations for existing DBs (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -94,7 +94,10 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
 
     if os.name == "nt":
         if not _all_tables_exist(engine):
-            _initialize_tables(engine)
+            if _is_empty_database(engine):
+                _initialize_tables(engine)
+            else:
+                _upgrade_db(engine)
         return
 
     url_hash = hashlib.md5(
@@ -103,7 +106,10 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
         if not _all_tables_exist(engine):
-            _initialize_tables(engine)
+            if _is_empty_database(engine):
+                _initialize_tables(engine)
+            else:
+                _upgrade_db(engine)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What

When upgrading MLflow from 3.7.0 to 3.8.x, users with existing databases encounter a `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")` when running `mlflow db upgrade`. This happens because new tables (e.g., `secrets`) are added to ORM metadata in 3.8.x. The `_safe_initialize_tables` function checks if all ORM tables exist and, if any are missing, calls `_initialize_tables` which creates the initial schema using `InitialBase.metadata.create_all`. This attempts to re-create tables that already exist (e.g., `experiments`), causing the error.

## Fix

Updated `_safe_initialize_tables` (and the Windows branch) to differentiate between a completely empty database and an existing database that is missing only new tables:
- If the database is empty (no non-alembic tables), run `_initialize_tables` as before.
- If the database is not empty but is missing some ORM tables, run `_upgrade_db` directly. Alembic migrations handle creating only the new tables, avoiding the `CREATE TABLE` error.

This ensures a seamless upgrade path for existing deployments while preserving initial setup for new installations.

Closes #19943