### PR TITLE
fix: tighten minimum version floors for deps with known CVEs

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -364,7 +364,7 @@ def build(package_type: PackageType) -> None:
                 "gateway": gateways_requirements,
                 "genai": genai_requirements,
                 # click 8.3.0 causes MLflow MCP server to fail: https://github.com/mlflow/mlflow/issues/18747
-                "mcp": ["fastmcp<4,>=2.7.0", "click!=8.3.0"],
+                "mcp": ["fastmcp<4,>=3.2.0", "click!=8.3.0"],
                 "azure": [
                     # Required to log artifacts and models to Azure Blob Storage
                     "azure-storage-blob>=12",

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -91,7 +91,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.7.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
-  "gitpython<4,>=3.1.9",
+  "gitpython<4,>=3.1.47",
   "graphene<4",
   "gunicorn<27; platform_system != 'Windows'",
   "huey<4,>=2.5.4",
@@ -50,12 +50,12 @@ dependencies = [
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<27",
   "pandas<3",
-  "protobuf<8,>=3.12.0",
+  "protobuf<8,>=6.33.5",
   "pyarrow<25,>=4.0.0",
   "pydantic<3,>=2.0.0",
-  "python-dotenv<2,>=0.19.0",
+  "python-dotenv<2,>=1.2.2",
   "pyyaml<7,>=5.1",
-  "requests<3,>=2.17.3",
+  "requests<3,>=2.33.0",
   "scikit-learn<2",
   "scipy<2",
   "skops<1",
@@ -109,7 +109,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
-mcp = ["fastmcp<4,>=2.7.0", "click!=8.3.0"]
+mcp = ["fastmcp<4,>=3.2.0", "click!=8.3.0"]
 azure = ["azure-storage-blob>=12", "azure-identity>=1.6.1"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]


### PR DESCRIPTION
### Related Issues/PRs

Closes #23061

### What changes are proposed in this pull request?

Tighten minimum version floors for five core dependencies that have known CVEs. This prevents pip from resolving vulnerable versions when mlflow is installed alongside other packages.

| Dependency | Old | New | CVE |
|---|---|---|---|
| gitpython | <4,>=3.1.9 | <4,>=3.1.47 | GHSA-rpm5-65cw-6hj4 |
| protobuf | <8,>=3.12.0 | <8,>=6.33.5 | Multiple CVEs |
| python-dotenv | <2,>=0.19.0 | <2,>=1.2.2 | GHSA-mf9w-mj56-hr94 |
| requests | <3,>=2.17.3 | <3,>=2.33.0 | GHSA-gc5v-m9x4-r6x2 |
| fastmcp | <4,>=2.7.0 | <4,>=3.2.0 | GHSA-rww4-4w9c-7733 |

Also updated dev/pyproject.py generator.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Version constraints verified against CVE advisories
- [ ] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Raises minimum version floors so pip resolves non-vulnerable versions.

#### What component(s) does this PR affect?

- [x] area/build

#### How should the PR be classified in the release notes?

- [x] rn/bug-fix

#### Is this PR a critical security fix?

- [x] This PR is critical and needs to be in the next patch release