### PR TITLE
fix(`autolog.py`): extend Anthropic-via-gateway cache token extraction to streaming path

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -396,10 +396,20 @@ def _process_last_chunk(
                     TokenUsageKey.TOTAL_TOKENS: usage.total_tokens,
                 }
 
-                # Extract cached tokens if available in the streaming chunk
+                # Extract cached tokens if available in the streaming chunk.
+                # Standard OpenAI path: prompt_tokens_details.cached_tokens.
                 if details := getattr(usage, "prompt_tokens_details", None):
                     if (cached := getattr(details, "cached_tokens", None)) is not None:
                         usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached
+                # Anthropic-via-gateway path: top-level cache_read/creation_input_tokens.
+                # Used when Anthropic models are served via an OpenAI-compatible endpoint
+                # (e.g. Databricks Foundation Model API) where prompt_tokens_details is None
+                # but cache counts appear at the top level of the usage object.
+                if TokenUsageKey.CACHE_READ_INPUT_TOKENS not in usage_dict:
+                    if (cache_read := getattr(usage, "cache_read_input_tokens", None)) is not None:
+                        usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+                if (cache_creation := getattr(usage, "cache_creation_input_tokens", None)) is not None:
+                    usage_dict[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_creation
                 span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
 
         _end_span_on_success(span, inputs, output, is_responses_api)

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -12,6 +12,7 @@ from mlflow.types.chat import ChatCompletionRequest
 EMPTY_CHOICES = "EMPTY_CHOICES"
 LIST_CONTENT = "LIST_CONTENT"
 AZURE_ANNOTATIONS = "AZURE_ANNOTATIONS"
+ANTHROPIC_CACHE_STREAM = "ANTHROPIC_CACHE_STREAM"
 
 app = fastapi.FastAPI()
 
@@ -118,6 +119,31 @@ def _make_chat_stream_usage_chunk():
     }
 
 
+def _make_chat_stream_anthropic_cache_usage_chunk():
+    """Stream usage chunk with Anthropic-via-gateway top-level cache fields.
+
+    Anthropic endpoints served through an OpenAI-compatible gateway (e.g. Databricks
+    Foundation Model API) surface cache counts at the top level of the usage object
+    instead of the OpenAI-standard prompt_tokens_details.cached_tokens path.
+    """
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "claude-opus-4-8",
+        "system_fingerprint": None,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 20,
+            "total_tokens": 70,
+            "cache_read_input_tokens": 40,
+            "cache_creation_input_tokens": 5,
+            # prompt_tokens_details is absent (Anthropic-via-gateway endpoint)
+        },
+    }
+
+
 def _make_chat_stream_chunk_with_list_content(content_list, include_usage: bool = False):
     # Create a streaming chunk with list content (Databricks format).
     return {
@@ -180,6 +206,17 @@ async def chat_response_stream_with_list_content(include_usage: bool = False):
     )
 
 
+async def chat_response_stream_with_anthropic_cache():
+    """Stream that mimics an Anthropic-via-gateway endpoint.
+
+    The usage chunk carries cache_read_input_tokens and cache_creation_input_tokens at
+    the top level of the usage object (not under prompt_tokens_details.cached_tokens).
+    """
+    yield _make_chat_stream_chunk("Hello", include_usage=False)
+    yield _make_chat_stream_chunk(" world", include_usage=False)
+    yield _make_chat_stream_anthropic_cache_usage_chunk()
+
+
 @app.post("/chat/completions", response_model_exclude_unset=True)
 async def chat(payload: ChatCompletionRequest):
     if payload.stream:
@@ -201,6 +238,11 @@ async def chat(payload: ChatCompletionRequest):
                 async for d in chat_response_stream_with_list_content(
                     include_usage=(payload.stream_options or {}).get("include_usage", False)
                 )
+            )
+        elif ANTHROPIC_CACHE_STREAM == payload.messages[0].content:
+            content = (
+                f"data: {json.dumps(d)}\n\n"
+                async for d in chat_response_stream_with_anthropic_cache()
             )
         else:
             content = (

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -557,6 +557,7 @@ async def test_chat_completions_streaming_with_anthropic_cache_tokens(client):
         TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 5,
     }
 
+
 @pytest.mark.asyncio
 async def test_completions_autolog(client):
     mlflow.openai.autolog()

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -27,7 +27,7 @@ from mlflow.tracing.constant import (
 )
 from mlflow.version import IS_TRACING_SDK_ONLY
 
-from tests.openai.mock_openai import AZURE_ANNOTATIONS, EMPTY_CHOICES, LIST_CONTENT
+from tests.openai.mock_openai import ANTHROPIC_CACHE_STREAM, AZURE_ANNOTATIONS, EMPTY_CHOICES, LIST_CONTENT
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
 MOCK_TOOLS = [
@@ -524,6 +524,38 @@ async def test_chat_completions_streaming_with_list_content(client):
     assert isinstance(span.outputs, dict)
     assert span.outputs["choices"][0]["message"]["content"] == "Hello world"
 
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_with_anthropic_cache_tokens(client):
+    # Verify the streaming autolog path captures Anthropic-via-gateway cache fields.
+    # These arrive as top-level usage keys (cache_read_input_tokens,
+    # cache_creation_input_tokens) instead of inside prompt_tokens_details.
+    mlflow.openai.autolog()
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": ANTHROPIC_CACHE_STREAM}],
+        model="claude-opus-4-8",
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    if client._is_async:
+        async for _ in await stream:
+            pass
+    else:
+        for _ in stream:
+            pass
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        TokenUsageKey.INPUT_TOKENS: 50,
+        TokenUsageKey.OUTPUT_TOKENS: 20,
+        TokenUsageKey.TOTAL_TOKENS: 70,
+        TokenUsageKey.CACHE_READ_INPUT_TOKENS: 40,
+        TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 5,
+    }
 
 @pytest.mark.asyncio
 async def test_completions_autolog(client):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24615

### What changes are proposed in this pull request?

MLflow's `openai.autolog()` extracts token usage from the final streaming chunk in `_process_last_chunk()`. The existing code handles the standard OpenAI path (`prompt_tokens_details.cached_tokens`) but not the Anthropic-via-gateway path.

When Anthropic models are served through an OpenAI-compatible endpoint (e.g. Databricks Foundation Model API), cache counts arrive as top-level keys on the usage object (`cache_read_input_tokens`, `cache_creation_input_tokens`) — `prompt_tokens_details` is absent. This means streaming autolog spans silently drop cache token counts for all Anthropic-via-gateway calls.

The non-streaming path in `chat_schema.py` (PR #24618) already handles both paths. This PR extends the same dual-path logic to the streaming path:

1. Standard OpenAI path (unchanged): reads `prompt_tokens_details.cached_tokens` → `CACHE_READ_INPUT_TOKENS`
2. Anthropic-via-gateway fallback (new): when the standard path did not populate `CACHE_READ_INPUT_TOKENS`, reads top-level `cache_read_input_tokens`; reads `cache_creation_input_tokens` unconditionally

**Files changed:**

| File | Change |
|------|--------|
| `mlflow/openai/autolog.py` | Extend `_process_last_chunk` with Anthropic-via-gateway fallback (+10 lines) |
| `tests/openai/mock_openai.py` | Add `ANTHROPIC_CACHE_STREAM` sentinel + usage chunk factory + async generator |
| `tests/openai/test_openai_autolog.py` | Add `test_chat_completions_streaming_with_anthropic_cache_tokens` |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New test `test_chat_completions_streaming_with_anthropic_cache_tokens` sends a streaming request whose usage chunk carries top-level `cache_read_input_tokens=40` and `cache_creation_input_tokens=5` (no `prompt_tokens_details`). Asserts the resulting span's `CHAT_USAGE` attribute contains both `CACHE_READ_INPUT_TOKENS` and `CACHE_CREATION_INPUT_TOKENS` with the correct values.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Streaming `openai.autolog()` now captures `cache_read_input_tokens` and `cache_creation_input_tokens` in span usage metadata when Anthropic models are served through an OpenAI-compatible gateway (e.g. Databricks Foundation Model API). Previously these cache fields were silently dropped from streaming traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release