### PR TITLE
fix: prevent upgrade failure when database has existing tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,11 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if _is_empty_database(engine):
+        _logger.info("Creating initial MLflow database tables...")
+        Base.metadata.create_all(engine)
+    else:
+        _logger.info("Database is not empty, skipping initial table creation and running migrations...")
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`.

The root cause is that `_all_tables_exist()` now checks workspace tables (e.g., 'secrets') that were introduced in 3.8. For existing databases that do not yet have those tables, it returns `False`, causing `_initialize_tables()` to run `InitialBase.metadata.create_all()`. However, this attempts to create all tables, including ones that already exist from prior versions, leading to conflicts on MySQL.

## Fix
We modified `_initialize_tables()` to only create tables when the database is completely empty. For non-empty databases (e.g., upgrading from an older version), we skip the `create_all` step and proceed directly to Alembic migrations, which safely apply only the missing schema changes.

This change makes the initialization idempotent and avoids errors from attempting to recreate existing tables.

Closes #19943