### PR TITLE
Fix chart drag-and-drop: add auto-scroll and fix stuck drag state on …

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
@@ -43,8 +43,18 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
 
   const draggedCardElementRef = useRef<HTMLDivElement | null>(null);
 
+  // const onStartDrag = useCallback<DraggableEventHandler>(
+  //   (_, { x, y }) => {
+  //     setIsDragging(true);
+  //     setDraggedCardUuid(uuid ?? null);
+  //     setOrigin({ x, y });
+  //   },
+  //   [setDraggedCardUuid, uuid],
+  // );
+  const dragActiveRef = useRef(false);
   const onStartDrag = useCallback<DraggableEventHandler>(
     (_, { x, y }) => {
+      dragActiveRef.current = true;
       setIsDragging(true);
       setDraggedCardUuid(uuid ?? null);
       setOrigin({ x, y });
@@ -75,7 +85,16 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
     },
     [origin],
   );
+  // const onStopDrag = useCallback(() => {
+  //   onDropChartCard();
+  //   setDraggedCardUuid(null);
+  //   if (draggedCardElementRef.current) {
+  //     draggedCardElementRef.current.style.transform = '';
+  //   }
+  //   setIsDragging(false);
+  // }, [onDropChartCard, setDraggedCardUuid, draggedCardElementRef]);
   const onStopDrag = useCallback(() => {
+    dragActiveRef.current = false;
     onDropChartCard();
     setDraggedCardUuid(null);
     if (draggedCardElementRef.current) {
@@ -86,24 +105,19 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
 
   // Force-end the drag if the mouse leaves the browser window entirely,
   // since native mouseup never fires in that case.
-  const isDispatchingRef = useRef(false);
   useEffect(() => {
     if (!isDragging) return;
 
     const forceStopDrag = () => {
-      if (isDispatchingRef.current) return; // avoid re-entrant loop from our own dispatch
-      isDispatchingRef.current = true;
-
-      // Dispatch a synthetic mouseup so DraggableCore's own document-level
-      // listener runs its native cleanup and internal state reset, instead
-      // of only patching our wrapper's state via onStopDrag.
-      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
-
-      isDispatchingRef.current = false;
-
-      // Safety net in case DraggableCore's listeners were already detached
-      // and didn't invoke onStop as part of the dispatch above.
-      onStopDrag();
+      // Defer until the current event has finished propagating.
+      // If DraggableCore's own mouseup handler already ran, it will
+      // have set dragActiveRef.current = false via onStopDrag — in
+      // that case, do nothing to avoid a duplicate reorder.
+      requestAnimationFrame(() => {
+        if (dragActiveRef.current) {
+          onStopDrag();
+        }
+      });
     };
 
     document.addEventListener('mouseleave', forceStopDrag);

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
@@ -86,10 +86,23 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
 
   // Force-end the drag if the mouse leaves the browser window entirely,
   // since native mouseup never fires in that case.
+  const isDispatchingRef = useRef(false);
   useEffect(() => {
     if (!isDragging) return;
 
     const forceStopDrag = () => {
+      if (isDispatchingRef.current) return; // avoid re-entrant loop from our own dispatch
+      isDispatchingRef.current = true;
+
+      // Dispatch a synthetic mouseup so DraggableCore's own document-level
+      // listener runs its native cleanup and internal state reset, instead
+      // of only patching our wrapper's state via onStopDrag.
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+
+      isDispatchingRef.current = false;
+
+      // Safety net in case DraggableCore's listeners were already detached
+      // and didn't invoke onStop as part of the dispatch above.
       onStopDrag();
     };
 

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
@@ -42,16 +42,8 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
   const { setDraggedCardUuid, onDropChartCard } = useRunsChartsDraggableGridActionsContext();
 
   const draggedCardElementRef = useRef<HTMLDivElement | null>(null);
-
-  // const onStartDrag = useCallback<DraggableEventHandler>(
-  //   (_, { x, y }) => {
-  //     setIsDragging(true);
-  //     setDraggedCardUuid(uuid ?? null);
-  //     setOrigin({ x, y });
-  //   },
-  //   [setDraggedCardUuid, uuid],
-  // );
   const dragActiveRef = useRef(false);
+
   const onStartDrag = useCallback<DraggableEventHandler>(
     (_, { x, y }) => {
       dragActiveRef.current = true;
@@ -61,6 +53,7 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
     },
     [setDraggedCardUuid, uuid],
   );
+
   const onDrag = useCallback(
     (e, { x, y }) => {
       if (draggedCardElementRef.current) {
@@ -85,14 +78,7 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
     },
     [origin],
   );
-  // const onStopDrag = useCallback(() => {
-  //   onDropChartCard();
-  //   setDraggedCardUuid(null);
-  //   if (draggedCardElementRef.current) {
-  //     draggedCardElementRef.current.style.transform = '';
-  //   }
-  //   setIsDragging(false);
-  // }, [onDropChartCard, setDraggedCardUuid, draggedCardElementRef]);
+
   const onStopDrag = useCallback(() => {
     dragActiveRef.current = false;
     onDropChartCard();
@@ -103,16 +89,18 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
     setIsDragging(false);
   }, [onDropChartCard, setDraggedCardUuid, draggedCardElementRef]);
 
-  // Force-end the drag if the mouse leaves the browser window entirely,
-  // since native mouseup never fires in that case.
+  // Force-end the drag if a real mouseup was swallowed before reaching
+  // DraggableCore's own document-level listener (e.g. an ancestor element
+  // like the sidebar calling stopPropagation). We intentionally do NOT key
+  // off `mouseleave`: the browser keeps delivering real mousemove/mouseup
+  // events to the document even when the cursor is outside the window, as
+  // long as the window still has focus, so DraggableCore's own drag state
+  // stays valid there and forcing a stop on mouseleave just desyncs us
+  // from it instead of fixing anything.
   useEffect(() => {
     if (!isDragging) return;
 
     const forceStopDrag = () => {
-      // Defer until the current event has finished propagating.
-      // If DraggableCore's own mouseup handler already ran, it will
-      // have set dragActiveRef.current = false via onStopDrag — in
-      // that case, do nothing to avoid a duplicate reorder.
       requestAnimationFrame(() => {
         if (dragActiveRef.current) {
           onStopDrag();
@@ -120,10 +108,8 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
       });
     };
 
-    document.addEventListener('mouseleave', forceStopDrag);
     document.addEventListener('mouseup', forceStopDrag, true);
     return () => {
-      document.removeEventListener('mouseleave', forceStopDrag);
       document.removeEventListener('mouseup', forceStopDrag, true);
     };
   }, [isDragging, onStopDrag]);

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCard.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, useCallback, useRef, useState } from 'react';
+import { forwardRef, memo, useCallback, useEffect, useRef, useState } from 'react';
 import { RunsChartsCard, type RunsChartsCardProps } from './cards/RunsChartsCard';
 import { DraggableCore, type DraggableEventHandler } from 'react-draggable';
 import { Resizable } from 'react-resizable';
@@ -14,6 +14,8 @@ import { useRunsChartsDraggableGridActionsContext } from './RunsChartsDraggableC
 import { RUNS_CHARTS_UI_Z_INDEX } from '../utils/runsCharts.const';
 
 const VIEWPORT_DEBOUNCE_MS = 150;
+const SCROLL_EDGE_THRESHOLD = 60;
+const SCROLL_SPEED = 15;
 
 interface RunsChartsDraggableCardProps extends RunsChartsCardProps {
   uuid?: string;
@@ -49,16 +51,30 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
     },
     [setDraggedCardUuid, uuid],
   );
-
   const onDrag = useCallback(
-    (_, { x, y }) => {
+    (e, { x, y }) => {
       if (draggedCardElementRef.current) {
         draggedCardElementRef.current.style.transform = `translate3d(${x - origin.x}px, ${y - origin.y}px, 0)`;
+      }
+
+      // Auto-scroll the chart area when dragging near its top/bottom edges
+      const scrollContainer = draggedCardElementRef.current?.closest<HTMLElement>(
+        '[data-testid="experiment-view-compare-runs-chart-area"]',
+      );
+
+      if (scrollContainer) {
+        const rect = scrollContainer.getBoundingClientRect();
+        const clientY = (e as MouseEvent).clientY;
+
+        if (clientY < rect.top + SCROLL_EDGE_THRESHOLD) {
+          scrollContainer.scrollBy(0, -SCROLL_SPEED);
+        } else if (clientY > rect.bottom - SCROLL_EDGE_THRESHOLD) {
+          scrollContainer.scrollBy(0, SCROLL_SPEED);
+        }
       }
     },
     [origin],
   );
-
   const onStopDrag = useCallback(() => {
     onDropChartCard();
     setDraggedCardUuid(null);
@@ -67,6 +83,23 @@ export const RunsChartsDraggableCard = memo((props: RunsChartsDraggableCardProps
     }
     setIsDragging(false);
   }, [onDropChartCard, setDraggedCardUuid, draggedCardElementRef]);
+
+  // Force-end the drag if the mouse leaves the browser window entirely,
+  // since native mouseup never fires in that case.
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const forceStopDrag = () => {
+      onStopDrag();
+    };
+
+    document.addEventListener('mouseleave', forceStopDrag);
+    document.addEventListener('mouseup', forceStopDrag, true);
+    return () => {
+      document.removeEventListener('mouseleave', forceStopDrag);
+      document.removeEventListener('mouseup', forceStopDrag, true);
+    };
+  }, [isDragging, onStopDrag]);
 
   const onResizeStartInternal = useCallback(() => {
     const rect = draggedCardElementRef.current?.getBoundingClientRect();


### PR DESCRIPTION
…mouseup outside window (#24542)

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24542

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Chart drag-and-drop cards in the Compare Runs chart grid had two related bugs:

1. Dragging a chart card near the top or bottom edge of the browser window did not auto-scroll the page, making it impossible to reorder cards when there were more charts than fit in the viewport.
2. If the mouse button was released outside the browser window, or over another UI element (e.g. the sidebar) that intercepted the `mouseup` event, the card's internal drag state never reset. This left the app thinking a drag was still in progress, causing visual glitches (a chart disappearing) the next time the mouse moved over another card, until the page was reloaded.
This PR fixes both issues in `RunsChartsDraggableCard.tsx`:

- Adds edge-proximity auto-scroll during `onDrag`, targeting the actual scrollable chart container (`[data-testid="experiment-view-compare-runs-chart-area"]`) rather than the window, since the chart grid scrolls within an inner container.
- Adds capture-phase `mouseup` and `mouseleave` listeners on `document` while a drag is active, to reliably force-end the drag and reset state even when the native drag-end event is swallowed by another element or never fires (e.g. mouse released outside the window).
### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
[mlflow.webm](https://github.com/user-attachments/assets/6621d6c6-0b4d-4f4a-9ee1-f1a43af26b9f)
### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Fixed chart drag-and-drop in the Compare Runs chart grid: dragging a chart card now auto-scrolls the page near viewport edges, and the drag no longer gets stuck if the mouse is released outside the browser window or over another UI element.
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
