### PR TITLE
[BUGFIX] Fix `search_experiments` 400 when `max_results` is omitted

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2512,9 +2512,23 @@ def _search_experiments():
         },
     )
 
+    # NB: An unset proto2 int field reads as 0 (never None), so passing
+    # `request_message.max_results` through directly would treat requests without
+    # `max_results` as `max_results=0` and reject them. Use HasField to fall back to the
+    # documented server-side default, and reject explicit non-positive page sizes.
+    max_results = (
+        request_message.max_results if request_message.HasField("max_results") else None
+    )
+    if max_results is not None and max_results <= 0:
+        raise MlflowException(
+            f"Invalid value {max_results} for parameter 'max_results' supplied. "
+            "It must be a positive integer.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
     experiment_entities = _get_tracking_store().search_experiments(
         view_type=request_message.view_type,
-        max_results=request_message.max_results,
+        max_results=max_results or SEARCH_MAX_RESULTS_DEFAULT,
         order_by=request_message.order_by,
         filter_string=request_message.filter,
         page_token=request_message.page_token or None,

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -263,7 +263,7 @@ from mlflow.store.model_registry import (
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
 from mlflow.store.model_registry.rest_store import RestStore as ModelRegistryRestStore
-from mlflow.store.tracking import MAX_RESULTS_QUERY_TRACE_METRICS
+from mlflow.store.tracking import MAX_RESULTS_QUERY_TRACE_METRICS, SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.databricks_rest_store import DatabricksTracingRestStore
 from mlflow.telemetry.schemas import Record, Status
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
@@ -3022,6 +3022,42 @@ def test_search_experiments_empty_page_token(mock_get_request_message, mock_trac
     call_kwargs = mock_tracking_store.search_experiments.call_args.kwargs
     assert call_kwargs.get("page_token") is None
     assert call_kwargs.get("max_results") == 10
+
+
+def test_search_experiments_without_max_results_uses_default(
+    mock_get_request_message, mock_tracking_store
+):
+    # Regression test: an unset proto2 `max_results` reads as 0, which previously became
+    # an explicit `max_results=0` store call that was rejected as a non-positive page size,
+    # making requests without `max_results` fail with INVALID_PARAMETER_VALUE.
+    search_experiments_proto = SearchExperiments()
+    assert search_experiments_proto.max_results == 0
+
+    mock_get_request_message.return_value = search_experiments_proto
+    mock_tracking_store.search_experiments.return_value = PagedList([], None)
+
+    _search_experiments()
+
+    # The store must receive the documented server-side default instead of 0
+    mock_tracking_store.search_experiments.assert_called_once()
+    call_kwargs = mock_tracking_store.search_experiments.call_args.kwargs
+    assert call_kwargs.get("max_results") == SEARCH_MAX_RESULTS_DEFAULT
+
+
+@pytest.mark.parametrize("max_results", [0, -5])
+def test_search_experiments_rejects_non_positive_max_results(
+    mock_get_request_message, mock_tracking_store, max_results
+):
+    search_experiments_proto = SearchExperiments()
+    search_experiments_proto.max_results = max_results
+
+    mock_get_request_message.return_value = search_experiments_proto
+    mock_tracking_store.search_experiments.return_value = PagedList([], None)
+
+    response = _search_experiments()
+    assert response.status_code == 400
+    assert "max_results" in response.get_data(as_text=True)
+    mock_tracking_store.search_experiments.assert_not_called()
 
 
 def test_search_registered_models_empty_page_token(


### PR DESCRIPTION
### Related Issues/PRs

Closes #no_issue

### What changes are proposed in this pull request?

When a client calls `search_experiments` without specifying `max_results`, the server returned a 400 error. An unset proto2 int field reads as 0 (never None), so passing `request_message.max_results` straight through treated the absence of `max_results` as `max_results=0` and rejected the request.

Fix: use `HasField` to fall back to the documented server-side default (1000) when `max_results` is omitted, and only reject explicit non-positive page sizes.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual: end-to-end with curl + Python client — request without `max_results` now succeeds, explicit `0` still rejected with 400.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `search_experiments` returning 400 when `max_results` is omitted; it now uses the documented default of 1000.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
