### PR TITLE
[BUGFIX] Fix dangling alias when deleting model version with string version

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1258,6 +1258,10 @@ class SqlAlchemyStore(AbstractStore):
             sql_model_version = self._get_sql_model_version(session, name, version)
             sql_registered_model = sql_model_version.registered_model
             sql_registered_model.last_updated_time = updated_time
+            # `version` may arrive as a string (e.g. from the REST API, where the proto
+            # field is a string), while `alias.version` is an integer column, so cast
+            # before comparing to avoid leaving a dangling alias behind.
+            version = _validate_model_version(version)
             aliases = sql_registered_model.registered_model_aliases
             for alias in aliases:
                 if alias.version == version:

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -1840,6 +1840,21 @@ def test_delete_model_version_deletes_alias(store):
         store.get_model_version_by_alias(model_name, "test_alias")
 
 
+def test_delete_model_version_deletes_alias_with_string_version(store):
+    model_name = "DeleteModelVersionDeletesAliasStr_TestMod"
+    _setup_and_test_aliases(store, model_name)
+    # The REST API serializes version as a string in the proto request, so
+    # the store must handle string versions when cleaning up aliases.
+    store.delete_model_version(model_name, "2")
+    model = store.get_registered_model(model_name)
+    assert model.aliases == {}
+    with pytest.raises(
+        MlflowException,
+        match=r"Registered model alias test_alias not found.",
+    ):
+        store.get_model_version_by_alias(model_name, "test_alias")
+
+
 def test_delete_model_deletes_alias(store):
     model_name = "DeleteModelDeletesAlias_TestMod"
     _setup_and_test_aliases(store, model_name)


### PR DESCRIPTION
### Related Issues/PRs

Closes #no_issue

### What changes are proposed in this pull request?

Deleting a model version that had a registered model alias left a dangling alias in the `registered_model_aliases` table. The REST API serializes `version` as a string in the proto request, but `delete_model_version` compared it against the integer `alias.version` column with Python's type-sensitive `==`, which never matched. The alias survived the deletion, and `get_model_version_by_alias` then failed with a misleading `Model Version ... not found` error instead of the expected `Registered model alias ... not found`.

Fix: cast `version` with `_validate_model_version` before the comparison, consistent with `_get_sql_model_version`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Manual: end-to-end with a real SQLite `SqlAlchemyStore` + `_delete_model_version` handler — before the fix the alias row remained after deletion; after the fix it is removed. Full `tests/store/model_registry/test_sqlalchemy_store.py` suite passes (218 tests, workspace-enabled and disabled).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed deleting a model version via the REST API leaving a dangling registered model alias behind.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
