### PR TITLE
[BUGFIX] Fix autolog version check crash when package version is None

### DIFF
--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -77,6 +77,12 @@ def is_flavor_supported_for_associated_package_versions(flavor_name, check_max_v
             # For this case, we assume the package version is supported by MLflow.
             return True
 
+    # Some environments (e.g. Serverless) may not expose a package version, in which case
+    # the version is reported as None. Assume the package is supported rather than crashing
+    # on Version(None) below.
+    if actual_version is None:
+        return True
+
     # In Databricks, treat 'pyspark 3.x.y.dev0' as 'pyspark 3.x.y'
     if module_name == "pyspark" and is_in_databricks_runtime():
         actual_version = _strip_dev_version_suffix(actual_version)

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -732,6 +732,18 @@ def test_is_autologging_integration_supported(flavor, module_version, expected_r
 
 
 @pytest.mark.parametrize(
+    "flavor",
+    ["sklearn", "pytorch", "pyspark.ml"],
+)
+def test_is_autologging_integration_supported_when_version_is_none(flavor):
+    module_name = FLAVOR_TO_MODULE_NAME[flavor]
+    with mock.patch(module_name + ".__version__", None):
+        # A None version (e.g. Serverless environments without package metadata) must not
+        # crash; treat it as supported, matching the PackageNotFoundError fallback.
+        assert is_flavor_supported_for_associated_package_versions(flavor) is True
+
+
+@pytest.mark.parametrize(
     ("flavor", "module_version", "expected_result"),
     [
         ("pyspark.ml", "99.0.0.dev0", False),


### PR DESCRIPTION
### Related Issues/PRs

Closes #no_issue

### What changes are proposed in this pull request?

`is_flavor_supported_for_associated_package_versions` crashed with `TypeError: expected string or bytes-like object` when a package's version could not be determined — either `importlib.metadata.version()` returning `None` (e.g. on Serverless runtimes) or a module whose `__version__` attribute is `None`. The `TypeError` propagated out of `Version(None)` and broke autologging for every integration.

Fix: treat a `None` version as supported, matching the existing `PackageNotFoundError` fallback that assumes the package version is supported.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New parametrized tests cover `__version__ = None` for sklearn/pytorch/pyspark.ml flavors. Full `tests/autologging/test_autologging_utils.py` suite passes (59 tests).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed autologging crashing with TypeError when a package does not expose a version (e.g. Serverless environments).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
