### PR TITLE
Add completion buffer to online trace scoring scheduler

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1564,6 +1564,17 @@ MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS = _EnvironmentVa
     "MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS", int, 5 * 60
 )
 
+#: Default buffer time in seconds subtracted from the current time when computing the trace
+#: scoring scan window's upper bound. Traces that started within this buffer are excluded from
+#: the current scan and picked up on a later pass, giving still-running traces time to reach a
+#: terminal status before the checkpoint advances past their start timestamp. Without this
+#: buffer, a trace that is still IN_PROGRESS when its start-time window is scanned is silently
+#: skipped forever, since the scheduler's checkpoint only ever moves forward.
+#: (default: ``120`` (2 minutes))
+MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS = _EnvironmentVariable(
+    "MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS", int, 2 * 60
+)
+
 
 #: Specifies the maximum number of completion iterations allowed when invoking
 #: judge models. This prevents infinite loops in case of complex traces or

--- a/mlflow/genai/scorers/online/trace_checkpointer.py
+++ b/mlflow/genai/scorers/online/trace_checkpointer.py
@@ -6,6 +6,9 @@ import time
 from dataclasses import asdict, dataclass
 
 from mlflow.entities.experiment_tag import ExperimentTag
+from mlflow.environment_variables import (
+    MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS,
+)
 from mlflow.genai.scorers.online.constants import MAX_LOOKBACK_MS
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.utils.mlflow_tags import MLFLOW_LATEST_ONLINE_SCORING_TRACE_CHECKPOINT
@@ -75,11 +78,23 @@ class OnlineTraceCheckpointManager:
         failing traces. If the checkpoint is older than MAX_LOOKBACK_MS, uses
         current_time - MAX_LOOKBACK_MS instead to skip over old problematic traces.
 
+        Also subtracts a completion buffer from the current time when computing the
+        window's upper bound, mirroring the buffer used by
+        OnlineSessionCheckpointManager. Traces are indexed by start time
+        (trace.timestamp_ms), so a trace that starts near the end of a scan window can
+        still be IN_PROGRESS when that window is scanned. Since the checkpoint only
+        ever moves forward, advancing it past such a trace's start timestamp would
+        cause that trace to be silently skipped forever, even after it finishes. The
+        buffer excludes recently-started traces from the current scan so they are
+        picked up on a later pass once they have had time to reach a terminal status.
+
         Returns:
             OnlineTraceScoringTimeWindow with min and max trace timestamps.
             min_trace_timestamp_ms is the checkpoint if it exists and is within the
             lookback period, otherwise now - MAX_LOOKBACK_MS.
-            max_trace_timestamp_ms is the current time.
+            max_trace_timestamp_ms is the current time minus the trace completion
+            buffer, clamped to min_trace_timestamp_ms so the window is never
+            inverted and the checkpoint never moves backward.
         """
         current_time_ms = int(time.time() * 1000)
         checkpoint = self.get_checkpoint()
@@ -92,7 +107,17 @@ class OnlineTraceCheckpointManager:
         else:
             min_trace_timestamp_ms = min_lookback_time_ms
 
+        buffer_seconds = max(0, MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get())
+        # Clamp to min_trace_timestamp_ms so the window is never inverted. Without the
+        # clamp, a checkpoint more recent than (now - buffer), e.g. one written by a
+        # version of this scheduler without the buffer, would produce a window whose
+        # upper bound precedes the checkpoint; persisting that upper bound would move
+        # the checkpoint backward and re-score already-processed traces.
+        max_trace_timestamp_ms = max(
+            min_trace_timestamp_ms, current_time_ms - buffer_seconds * 1000
+        )
+
         return OnlineTraceScoringTimeWindow(
             min_trace_timestamp_ms=min_trace_timestamp_ms,
-            max_trace_timestamp_ms=current_time_ms,
+            max_trace_timestamp_ms=max_trace_timestamp_ms,
         )

--- a/tests/genai/scorers/online/test_trace_checkpointer.py
+++ b/tests/genai/scorers/online/test_trace_checkpointer.py
@@ -3,6 +3,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from mlflow.environment_variables import (
+    MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS,
+)
 from mlflow.genai.scorers.online.constants import MAX_LOOKBACK_MS
 from mlflow.genai.scorers.online.trace_checkpointer import (
     OnlineTraceCheckpointManager,
@@ -84,13 +87,15 @@ def test_calculate_time_window_no_checkpoint(checkpoint_manager, mock_store, mon
     result = checkpoint_manager.calculate_time_window()
 
     expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    default_buffer_ms = MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get() * 1000
+    expected_max = (fixed_time * 1000) - default_buffer_ms
     assert result.min_trace_timestamp_ms == expected_min
-    assert result.max_trace_timestamp_ms == fixed_time * 1000
+    assert result.max_trace_timestamp_ms == expected_max
 
 
 def test_calculate_time_window_recent_checkpoint(checkpoint_manager, mock_store, monkeypatch):
     fixed_time = 1000000
-    recent_checkpoint_time = (fixed_time * 1000) - 60000  # 1 minute ago
+    recent_checkpoint_time = (fixed_time * 1000) - 300000  # 5 minutes ago, older than the buffer
     experiment = MagicMock()
     checkpoint_json = f'{{"timestamp_ms": {recent_checkpoint_time}}}'
     experiment.tags = {MLFLOW_LATEST_ONLINE_SCORING_TRACE_CHECKPOINT: checkpoint_json}
@@ -99,8 +104,10 @@ def test_calculate_time_window_recent_checkpoint(checkpoint_manager, mock_store,
 
     result = checkpoint_manager.calculate_time_window()
 
+    default_buffer_ms = MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get() * 1000
+    expected_max = (fixed_time * 1000) - default_buffer_ms
     assert result.min_trace_timestamp_ms == recent_checkpoint_time
-    assert result.max_trace_timestamp_ms == fixed_time * 1000
+    assert result.max_trace_timestamp_ms == expected_max
 
 
 def test_calculate_time_window_old_checkpoint(checkpoint_manager, mock_store, monkeypatch):
@@ -118,5 +125,97 @@ def test_calculate_time_window_old_checkpoint(checkpoint_manager, mock_store, mo
     result = checkpoint_manager.calculate_time_window()
 
     expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    default_buffer_ms = MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS.get() * 1000
+    expected_max = (fixed_time * 1000) - default_buffer_ms
     assert result.min_trace_timestamp_ms == expected_min
-    assert result.max_trace_timestamp_ms == fixed_time * 1000
+    assert result.max_trace_timestamp_ms == expected_max
+
+
+def test_calculate_time_window_with_custom_buffer(checkpoint_manager, mock_store, monkeypatch):
+    # Empty tags simulates no existing checkpoint
+    experiment = MagicMock()
+    experiment.tags = {}
+    mock_store.get_experiment.return_value = experiment
+    fixed_time = 1000000
+    custom_buffer_seconds = 30
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+    monkeypatch.setenv(
+        "MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS",
+        str(custom_buffer_seconds),
+    )
+
+    result = checkpoint_manager.calculate_time_window()
+
+    expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    expected_max = (fixed_time * 1000) - (custom_buffer_seconds * 1000)
+    assert result.min_trace_timestamp_ms == expected_min
+    assert result.max_trace_timestamp_ms == expected_max
+
+
+def test_calculate_time_window_with_negative_buffer_defaults_to_zero(
+    checkpoint_manager, mock_store, monkeypatch
+):
+    # Empty tags simulates no existing checkpoint
+    experiment = MagicMock()
+    experiment.tags = {}
+    mock_store.get_experiment.return_value = experiment
+    fixed_time = 1000000
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+    monkeypatch.setenv("MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS", "-100")
+
+    result = checkpoint_manager.calculate_time_window()
+
+    expected_min = (fixed_time * 1000) - MAX_LOOKBACK_MS
+    expected_max = fixed_time * 1000  # buffer is 0, so max = current_time
+    assert result.min_trace_timestamp_ms == expected_min
+    assert result.max_trace_timestamp_ms == expected_max
+
+
+def test_calculate_time_window_trace_still_in_progress_is_excluded_until_buffer_elapses(
+    checkpoint_manager, mock_store, monkeypatch
+):
+    """
+    Regression test for the race condition in issue #21870: a trace that starts near
+    the end of a scan window and is still IN_PROGRESS when that window is scanned
+    must not fall outside the window on the very next scan, since the scheduler's
+    checkpoint only ever moves forward and never revisits a skipped window.
+    """
+    experiment = MagicMock()
+    experiment.tags = {}
+    mock_store.get_experiment.return_value = experiment
+    fixed_time = 1000000
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+
+    # A trace that started 10 seconds before "now" and has not finished yet.
+    trace_start_ms = (fixed_time * 1000) - 10_000
+
+    result = checkpoint_manager.calculate_time_window()
+
+    # With the default 2-minute buffer, the window's upper bound sits well before the
+    # trace's start time, so this still-running trace is correctly excluded from the
+    # current scan rather than being silently skipped once it completes.
+    assert trace_start_ms > result.max_trace_timestamp_ms
+
+
+def test_calculate_time_window_checkpoint_within_buffer_does_not_invert_window(
+    checkpoint_manager, mock_store, monkeypatch
+):
+    """
+    A checkpoint more recent than (now - buffer), e.g. one written before the buffer
+    was introduced, must not produce an inverted window. The upper bound is clamped
+    to the checkpoint so persisting it never moves the checkpoint backward, which
+    would re-score already-processed traces.
+    """
+    fixed_time = 1000000
+    checkpoint_time = (fixed_time * 1000) - 60000  # 1 minute ago, within the 2-minute buffer
+    experiment = MagicMock()
+    checkpoint_json = f'{{"timestamp_ms": {checkpoint_time}}}'
+    experiment.tags = {MLFLOW_LATEST_ONLINE_SCORING_TRACE_CHECKPOINT: checkpoint_json}
+    mock_store.get_experiment.return_value = experiment
+    monkeypatch.setattr(time, "time", lambda: fixed_time)
+
+    result = checkpoint_manager.calculate_time_window()
+
+    assert result.min_trace_timestamp_ms == checkpoint_time
+    assert result.max_trace_timestamp_ms == checkpoint_time
+    assert result.min_trace_timestamp_ms <= result.max_trace_timestamp_ms


### PR DESCRIPTION
Fixes a race condition where traces that started near the end of a scan window and were still IN_PROGRESS when that window was scanned would be silently skipped forever, since the scheduler's checkpoint only moves forward. Mirrors the completion buffer pattern already used by OnlineSessionCheckpointManager for session-level scoring.

Fixes #21870

### Related Issues/PRs

Closes #21870

### What changes are proposed in this pull request?

Adds a configurable completion buffer to `OnlineTraceCheckpointManager.calculate_time_window()`, mirroring the buffer already used by `OnlineSessionCheckpointManager` for session-level scoring. The buffer subtracts a fixed number of seconds from the current time when computing the scan window's upper bound, so traces that started very recently are excluded from the current scan and picked up on a later pass once they've had time to complete.

The scheduler indexes traces by start time (`trace.timestamp_ms`) but previously advanced its checkpoint to the window's end regardless of whether any traces were found. A trace that starts near the end of a window and is still `IN_PROGRESS` when that window is scanned gets excluded by status-filtering scorers, and once the checkpoint moves past that trace's start timestamp, the trace is never re-scanned, even after it reaches a terminal status. This applies the same buffer pattern already in place for session-level scoring (`MLFLOW_ONLINE_SCORING_DEFAULT_SESSION_COMPLETION_BUFFER_SECONDS`) to the trace-level path.

The window's upper bound is clamped to its lower bound so that a checkpoint written by a pre-buffer version of the scheduler (which set the checkpoint to the window end, i.e. ~now) cannot produce an inverted window or move the checkpoint backward on upgrade, which would otherwise re-score already-processed traces.

**Tradeoffs:** this adds up to `MLFLOW_ONLINE_SCORING_DEFAULT_TRACE_COMPLETION_BUFFER_SECONDS` (default 2 minutes) of latency to when a trace becomes eligible for scoring, and traces that run longer than the buffer can still be missed. The default is conservative and configurable; open to feedback on whether a different default makes more sense.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Updated the three existing `calculate_time_window` tests in `test_trace_checkpointer.py` to account for the new default buffer, and added four new tests: custom buffer value, negative-buffer-defaults-to-zero, a regression test asserting a trace that started shortly before "now" falls outside the scan window under the default buffer, and a test covering the upgrade-safety clamp.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a bug where traces whose execution time exceeded the online scoring scheduler's scan interval could be permanently skipped by automatic evaluation, even after completing successfully.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release