### PR TITLE
Pin `ag2<1` to unbreak the `flavors` CI job

### DIFF
--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -73,6 +73,8 @@ anthropic
 # Required by mlflow.ag2
 # ag2 1.0.0 is a rewrite that renames the top-level module from `autogen` to `ag2` and
 # drops `runtime_logging`, which mlflow.ag2 autologging is built on.
+# TODO: Consider migrating to ag2 1.x, which emits OpenTelemetry spans natively via
+# `ag2.middleware.builtin.TelemetryMiddleware`, and remove this pin.
 ag2<1
 # Required by mlflow.dspy
 # In dspy 2.6.9, `dspy.__name__` is not 'dspy', but 'dspy.__metadata__',

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -71,10 +71,8 @@ sentence-transformers
 # Required by mlflow.anthropic
 anthropic
 # Required by mlflow.ag2
-# ag2 1.0.0 is a rewrite that renames the top-level module from `autogen` to `ag2` and
-# drops `runtime_logging`, which mlflow.ag2 autologging is built on.
-# TODO: Consider migrating to ag2 1.x, which emits OpenTelemetry spans natively via
-# `ag2.middleware.builtin.TelemetryMiddleware`, and remove this pin.
+# TODO: Consider migrating to ag2 1.x, which renames the `autogen` module to `ag2` and drops
+# `runtime_logging`, and remove this pin.
 ag2<1
 # Required by mlflow.dspy
 # In dspy 2.6.9, `dspy.__name__` is not 'dspy', but 'dspy.__metadata__',

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -71,7 +71,9 @@ sentence-transformers
 # Required by mlflow.anthropic
 anthropic
 # Required by mlflow.ag2
-ag2
+# ag2 1.0.0 is a rewrite that renames the top-level module from `autogen` to `ag2` and
+# drops `runtime_logging`, which mlflow.ag2 autologging is built on.
+ag2<1
 # Required by mlflow.dspy
 # In dspy 2.6.9, `dspy.__name__` is not 'dspy', but 'dspy.__metadata__',
 # which causes auto-logging tests to fail.


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/actions/runs/30789177222/job/91608955356

### What changes are proposed in this pull request?

`ag2` was unpinned in `requirements/extra-ml-requirements.txt`. ag2 1.0.0 was released a few hours ago and is a rewrite: the top-level module is renamed from `autogen` to `ag2`, and `runtime_logging` (which `mlflow.ag2` autologging is built on) is gone. As a result `tests/tracking/fluent/test_fluent_autolog.py` fails at import with `ModuleNotFoundError: No module named 'autogen'`, which aborts collection and fails the entire `flavors` job on every PR.

```
tests/tracking/fluent/test_fluent_autolog.py:9: in <module>
    import autogen
E   ModuleNotFoundError: No module named 'autogen'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

This pins `ag2<1` to restore CI. Supporting ag2 1.x requires porting the flavor off `runtime_logging` and is left for a follow-up. `mlflow/ml-package-versions.yml` already caps the cross-version matrix at `0.14.0`, so no change is needed there.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)