### PR TITLE
Update `uv.lock`

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,3 +7,5 @@ def test_is_release_version(monkeypatch):
 
     monkeypatch.setattr(version, "VERSION", "1.19.0.dev0")
     assert not version.is_release_version()
+
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,5 +7,3 @@ def test_is_release_version(monkeypatch):
 
     monkeypatch.setattr(version, "VERSION", "1.19.0.dev0")
     assert not version.is_release_version()
-
-

--- a/uv.lock
+++ b/uv.lock
@@ -4013,7 +4013,7 @@ wheels = [
 
 [[package]]
 name = "mlflow"
-version = "3.15.0"
+version = "3.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`branch-3.15` is failing `lint` / `lint-macos` / `check` with:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
```

#24817 bumped `version` in `pyproject.toml` to `3.15.1` but `uv.lock` still records the `mlflow` workspace member as `3.15.0`, so `uv sync --locked` rejects the lockfile and every job that installs dependencies fails.

This PR refreshes `uv.lock` via `/autoformat` (which runs the `uv-lock` pre-commit hook). The dummy commit only exists to open the PR and is reverted by the same autoformat run, so the net diff is `uv.lock` alone.

### How is this PR tested?

- [x] Existing unit/integration tests

CI on this PR is the test: `lint`, `lint-macos`, and `check` must go green.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release