### PR TITLE
Update CHANGELOG for 3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 3.15.1 (2026-08-03)
+
+MLflow 3.15.1 is a patch release that includes bug fixes and documentation updates.
+
+Bug fixes:
+
+- [Model Registry] Skip `env_pack` on ARM client images (#24762) (#24835, @qyc)
+- [Scoring / Tracking] Harden version parsing against missing/non-PEP440 versions on Databricks Serverless (+ lint rule) (#24799) (#24813, @PattaraS)
+
+Documentation updates:
+
+- [Docs] Clarify scorer versioning documentation (#24769) (#24805, @nihalmenon)
+
 ## 3.15.0 (2026-07-31)
 
 MLflow 3.15.0 includes several major features and improvements


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24762, #24799, #24769

### What changes are proposed in this pull request?

Adds the `CHANGELOG.md` entry for the MLflow 3.15.1 patch release, generated with `dev/update_changelog.py --prev-version 3.15.0 --release-version 3.15.1` and lightly hand-edited (patch-appropriate intro line; dropped the lone `rn/none` lockfile entry #24836). The 3.15.1 section is inserted above the existing 3.15.0 section.

The 3.15.1 section covers:

Bug fixes:
- [Model Registry] Skip `env_pack` on ARM client images (#24762) (backport #24835, @qyc)
- [Scoring / Tracking] Harden version parsing against missing/non-PEP440 versions on Databricks Serverless (#24799) (backport #24813, @PattaraS)

Documentation updates:
- [Docs] Clarify scorer versioning documentation (#24769) (backport #24805, @nihalmenon)

> [!IMPORTANT]
> Do not merge until the env_pack backport #24835 (of #24762) has landed on `branch-3.15`, so the changelog matches the released 3.15.1.

Supersedes #24837 (which was mistakenly branched off `branch-3.15`; this one targets `master`, where the changelog is maintained).

### How is this PR tested?

- [x] Manual tests

Generated by the changelog script; verified the rendered `CHANGELOG.md` diff is a single-file change inserting one section above 3.15.0.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release