### PR TITLE
Surface why a workflow pin lookup failed in `check-actions`

### DIFF
--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -36,6 +36,8 @@ _VERSION_COMMENT_RE = re.compile(r"^v\d+\.\d+\.\d+(?:\.\d+)*$")
 
 _CACHE_PATH = Path(".cache/action-pins.json")
 
+_LS_REMOTE_TIMEOUT = 10
+
 
 def _load_cache() -> dict[str, bool]:
     if _CACHE_PATH.exists():
@@ -62,8 +64,11 @@ def _repo_from_action(action: str) -> str:
             raise ValueError(f"Invalid action format: {action!r}")
 
 
-def _verify_sha_tag(action: str, sha: str, tag: str, cache: dict[str, bool]) -> bool | None:
+class LookupFailed(Exception):
+    """`git ls-remote` produced no answer, so the pin is neither verified nor refuted."""
 
+
+def _verify_sha_tag(action: str, sha: str, tag: str, cache: dict[str, bool]) -> bool:
     cache_key = f"{action}@{sha}#{tag}"
     if cache_key in cache:
         return cache[cache_key]
@@ -71,20 +76,27 @@ def _verify_sha_tag(action: str, sha: str, tag: str, cache: dict[str, bool]) -> 
     repo = _repo_from_action(action)
     try:
         result = _resolve_tag(repo, sha, tag)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return None
+    except subprocess.TimeoutExpired as e:
+        reason = f"`git ls-remote` timed out after {_LS_REMOTE_TIMEOUT}s"
+        if e.stderr:
+            reason += f": {e.stderr.decode(errors='replace').strip()}"
+        raise LookupFailed(reason) from e
+    except subprocess.CalledProcessError as e:
+        raise LookupFailed(f"`git ls-remote` exited {e.returncode}: {e.stderr.strip()}") from e
 
     cache[cache_key] = result
     return result
 
 
 def _resolve_tag(repo: str, sha: str, tag: str) -> bool:
-    output = subprocess.check_output(
+    proc = subprocess.run(
         ["git", "ls-remote", "--tags", f"https://github.com/{repo}.git", tag],
+        capture_output=True,
         text=True,
-        timeout=10,
+        timeout=_LS_REMOTE_TIMEOUT,
+        check=True,
     )
-    return any(line.split()[0] == sha for line in output.splitlines() if line)
+    return any(line.split()[0] == sha for line in proc.stdout.splitlines() if line)
 
 
 def _iter_files() -> Iterator[Path]:
@@ -126,11 +138,12 @@ def _check_action(a: ActionRef, cache: dict[str, bool]) -> str | None:
             f" (expected '# vX.Y.Z', got {a.comment!r})"
         )
 
-    verified = _verify_sha_tag(a.action, a.ref, a.comment, cache)
-    if verified is None:
+    try:
+        verified = _verify_sha_tag(a.action, a.ref, a.comment, cache)
+    except LookupFailed as e:
         return (
             f"{a.prefix}\n  error: could not verify SHA against tag '{a.comment}'"
-            f" for {_repo_from_action(a.action)} (GitHub API unavailable)"
+            f" for {_repo_from_action(a.action)}\n  reason: {e}"
         )
     if not verified:
         return (


### PR DESCRIPTION
### Related Issues/PRs

Relates to the `Lint / lint` failure on master in [run 30793321241](https://github.com/mlflow/mlflow/actions/runs/30793321241/job/91621315710)

### What changes are proposed in this pull request?

`dev/check_actions.py` verifies each pinned action SHA by shelling out to `git ls-remote`. Both `TimeoutExpired` and `CalledProcessError` were caught together and collapsed into `None`, and every failure was reported as:

```
error: could not verify SHA against tag 'v7.0.0' for actions/checkout (GitHub API unavailable)
```

That message hid which failure happened and named a subsystem the check never touches. It also swallowed git's own stderr, since `check_output` does not capture it.

The lint failure linked above showed the cost: 22 identical violations, no git output anywhere in the job log, and no way to tell from CI that `git ls-remote` had simply hung. The pin itself was correct the whole time.

Now the reason travels to the report via a `LookupFailed` exception, so `_verify_sha_tag` stays a plain `bool`:

```
reason: `git ls-remote` timed out after 10s
reason: `git ls-remote` timed out after 10s: warning: redirecting
reason: `git ls-remote` exited 128: fatal: unable to access 'https://github.com/...': boom
```

`_resolve_tag` switched to `subprocess.run(capture_output=True, check=True)` so git's stderr is available at all. Note that `TimeoutExpired` reports stderr as bytes even under `text=True` and as `None` when the child wrote nothing, so that branch converts it before use.

This only improves diagnosis. The check's pass/fail behavior is unchanged.

### How is this PR tested?

- [x] Manual tests

Reproduced each failure path against the real workflow tree by injecting `TimeoutExpired` (with and without partial stderr) and `CalledProcessError` into `_resolve_tag`, confirming the reason reaches the report in each case. Also ran `pre-commit run check-actions --all-files` with `.cache/action-pins.json` deleted to confirm the passing path is unaffected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)