### PR TITLE
Revert `$/` self-repository syntax for local actions

### DIFF
--- a/.github/actions/check-component-ids/action.yml
+++ b/.github/actions/check-component-ids/action.yml
@@ -3,6 +3,6 @@ description: "Verify that all componentIds in the MLflow UI are registered in th
 runs:
   using: "composite"
   steps:
-    - uses: $/.github/actions/setup-node
+    - uses: ./.github/actions/setup-node
     - run: node ${GITHUB_ACTION_PATH}/index.js
       shell: bash

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -176,14 +176,15 @@ deny_unpinned_actions contains msg if {
 	)
 }
 
-deny_workspace_relative_actions contains msg if {
-	actions := workspace_relative_actions(input)
+deny_self_repo_actions contains msg if {
+	actions := self_repo_actions(input)
 	count(actions) > 0
 	msg := sprintf(
 		concat("", [
-			"The following actions are referenced with the workspace-relative './' syntax: %s. ",
-			"Use the self-repository '$/' syntax instead (e.g., $/.github/actions/setup-python), ",
-			"which resolves to this repository at the commit being run without requiring a checkout.",
+			"The following actions are referenced with the self-repository '$/' syntax: %s. ",
+			"'$/' makes the runner download the whole repository tarball during 'Set up job', ",
+			"which costs ~20s per job in this repo. Use the workspace-relative './' syntax ",
+			"instead (e.g., ./.github/actions/setup-python), which resolves against the checkout.",
 		]),
 		[concat(", ", actions)],
 	)
@@ -348,9 +349,11 @@ ubuntu_slim_jobs_with_long_timeout(jobs) := {job_id |
 }
 
 is_step_unpinned(step) if {
-	# Actions in this repository ('$/' or './') have no ref to pin.
-	not startswith(step.uses, "$/")
+	# Actions in this repository ('./' or '$/') have no ref to pin. '$/' is
+	# reported by deny_self_repo_actions instead, so it is exempt here to keep
+	# a single, actionable message per offending step.
 	not startswith(step.uses, "./")
+	not startswith(step.uses, "$/")
 	not regex.match(`^[^@]+@[0-9a-f]{40}$`, step.uses)
 }
 
@@ -375,9 +378,9 @@ unpinned_actions(inp) := {step.uses |
 	is_step_unpinned(step)
 }
 
-workspace_relative_actions(inp) := {step.uses |
+self_repo_actions(inp) := {step.uses |
 	some step in all_steps(inp)
-	startswith(step.uses, "./")
+	startswith(step.uses, "$/")
 }
 
 any_job_has_repo_check(jobs) if {

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -119,7 +119,7 @@ jobs:
           git remote add base https://github.com/$BASE_REPO.git
           git fetch base $BASE_REF
           git merge base/$BASE_REF
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
       # ************************************************************************
       # pre-commit
       # ************************************************************************
@@ -149,7 +149,7 @@ jobs:
       # js
       # ************************************************************************
       - if: steps.diff.outputs.js == 'true'
-        uses: $/.github/actions/setup-node
+        uses: ./.github/actions/setup-node
       - if: steps.diff.outputs.js == 'true'
         working-directory: mlflow/server/js
         run: |

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -53,10 +53,10 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.inputs.ref }}
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
       - if: matrix.type == 'dev'
-        uses: $/.github/actions/setup-node
+        uses: ./.github/actions/setup-node
 
       - name: Build UI
         if: matrix.type == 'dev'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,9 +22,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-node
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --only-group lint

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,8 +75,8 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
       - name: Install flavors
@@ -145,13 +145,13 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: $/.github/actions/free-disk-space
+      - uses: ./.github/actions/free-disk-space
         if: matrix.free_disk_space
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
         with:
           python-version: ${{ matrix.python }}
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
         with:
           java-version: ${{ matrix.java }}
       - name: Remove constraints
@@ -189,7 +189,7 @@ jobs:
           MATRIX_INSTALL: ${{ matrix.install }}
         run: |
           eval "$MATRIX_INSTALL"
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Pre-test
         if: matrix.pre_test
         env:

--- a/.github/workflows/dev-setup.yml
+++ b/.github/workflows/dev-setup.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/free-disk-space
+      - uses: ./.github/actions/free-disk-space
         with:
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: |
           npm ci
@@ -74,9 +74,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-java
-      - uses: $/.github/actions/setup-node
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         working-directory: .
         run: |
@@ -84,7 +84,7 @@ jobs:
           uv pip install -r requirements/torch.txt
       - run: |
           npm ci
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - run: |
           npm run convert-notebooks
       - name: Set alias
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         working-directory: .
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: $/.github/actions/free-disk-space
+      - uses: ./.github/actions/free-disk-space
       - name: Check diff
         id: check-diff
         if: github.event_name == 'pull_request'
@@ -90,8 +90,8 @@ jobs:
           echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
           echo "examples_changed=$EXAMPLES_CHANGED" >> $GITHUB_OUTPUT
 
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
 
       - name: Install dependencies
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || steps.check-diff.outputs.examples_changed == 'true'

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
 
       - name: Detect flaky tests
         env:

--- a/.github/workflows/fs2db.yml
+++ b/.github/workflows/fs2db.yml
@@ -47,8 +47,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
 
       - name: Install MLflow ${{ matrix.mlflow-version }}
         env:
@@ -81,8 +81,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
 
       - name: Run fs2db pytest tests
         run: uv run pytest tests/store/fs2db

--- a/.github/workflows/gateway-benchmark.yml
+++ b/.github/workflows/gateway-benchmark.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         env:
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check componentId registry
-        uses: $/.github/actions/check-component-ids
+        uses: ./.github/actions/check-component-ids
 
   js:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: |
           yarn install --immutable

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,11 +53,11 @@ jobs:
           # To ensure `git diff` works correctly in dev/check_function_signatures.py,
           # we need to fetch enough history to include the base branch.
           fetch-depth: 300
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
       - name: Add problem matchers
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -59,8 +59,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh --skinny
@@ -85,19 +85,19 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --extra extras --extra gateway --extra mcp --extra genai
           uv pip install \
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt
-      - uses: $/.github/actions/show-versions
-      - uses: $/.github/actions/cache-hf
+      - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Import check
         run: |
           # `-I` is used to avoid importing modules from user-specific site-packages
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
+      - uses: ./.github/actions/untracked
       - name: Build
         run: |
           ./tests/db/compose.sh pull -q postgresql mysql mssql
@@ -200,10 +200,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
         with:
           java-version: 11
       - name: Install dependencies
@@ -224,10 +224,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --extra extras
@@ -235,7 +235,7 @@ jobs:
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt \
             'tensorflow<2.21'
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run tests
         run: |
           uv run --no-sync pytest \
@@ -258,18 +258,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync
           uv pip install \
             -r requirements/test-requirements.txt \
             pyspark langchain langchain-community
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}
@@ -293,17 +293,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --extra extras --extra genai
           uv pip install \
             -r requirements/test-requirements.txt \
             torch transformers pyspark langchain langchain-experimental shap lightgbm xgboost
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}
@@ -324,10 +324,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --extra genai
@@ -350,7 +350,7 @@ jobs:
           uv pip install \
             -r requirements/test-requirements.txt \
             deepeval ragas 'arize-phoenix-evals<3.0.0' 'langchain-community<0.4.2' trulens trulens-providers-litellm google-adk google-cloud-aiplatform
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run GenAI Tests (OSS)
         run: |
           # guardrails-ai is not installed (see the install step), so skip its
@@ -391,18 +391,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --extra extras --extra gateway
           uv pip install \
             -r requirements/test-requirements.txt \
             tensorflow 'pyspark[connect]'
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}
@@ -431,10 +431,10 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install python dependencies
         run: |
           uv sync --extra extras --extra genai --extra mcp
@@ -442,8 +442,8 @@ jobs:
             -r requirements/test-requirements.txt \
             pyspark datasets tensorflow torch transformers openai \
             tests/resources/mlflow-test-plugin
-      - uses: $/.github/actions/show-versions
-      - uses: $/.github/actions/cache-hf
+      - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Download Hadoop winutils for Spark
         run: |
           git clone https://github.com/cdarlint/winutils /tmp/winutils

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -58,7 +58,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           name: docs-build-${{ github.event.workflow_run.id }}
           path: ${{ env.DOCS_BUILD_DIR }}
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
       - name: Deploy to Netlify
         id: netlify_deploy
         env:

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -57,11 +57,11 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         env:
           PROTOBUF_MAJOR_VERSION: ${{ matrix.protobuf_major_version }}
@@ -74,8 +74,8 @@ jobs:
             'tensorflow<2.22.0' \
             torch transformers \
             "protobuf==$PROTOBUF_MAJOR_VERSION.*"
-      - uses: $/.github/actions/show-versions
-      - uses: $/.github/actions/cache-hf
+      - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}

--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
       - name: Check OpenTelemetry protos are up-to-date
         run: |
           ./mlflow/protos/opentelemetry/update.sh

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -52,9 +52,9 @@ jobs:
         with:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || null }}
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
       # This step dumps the current set of R dependencies and R version into files to be used
       # as a cache key when caching/restoring R dependencies.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -154,7 +154,7 @@ jobs:
           # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
           # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
           fetch-depth: 2
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
       - name: Install Claude CLI

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -60,11 +60,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
           uv sync --extra extras
@@ -72,7 +72,7 @@ jobs:
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt \
             langchain_experimental "pyarrow<18"
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-java
       - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
 
       - name: Create artifacts directory

--- a/.github/workflows/test-requirements.yml
+++ b/.github/workflows/test-requirements.yml
@@ -46,18 +46,18 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || null }}
           submodules: recursive
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dev script dependencies
         run: |
           uv pip install --system -r dev/requirements.txt
-      - uses: $/.github/actions/update-requirements
+      - uses: ./.github/actions/update-requirements
         if: github.event_name == 'schedule'
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh --skinny
-      - uses: $/.github/actions/show-versions
+      - uses: ./.github/actions/show-versions
       - name: Run tests
         run: |
           ./dev/run-python-skinny-tests.sh
@@ -80,23 +80,23 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || null }}
           submodules: recursive
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: $/.github/actions/setup-pyenv
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/setup-pyenv
+      - uses: ./.github/actions/setup-java
       - name: Install dev script dependencies
         run: |
           uv pip install --system -r dev/requirements.txt
-      - uses: $/.github/actions/update-requirements
+      - uses: ./.github/actions/update-requirements
         if: github.event_name == 'schedule'
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh --ml
           uv pip install --system '.[gateway]'
-      - uses: $/.github/actions/show-versions
-      - uses: $/.github/actions/cache-hf
+      - uses: ./.github/actions/show-versions
+      - uses: ./.github/actions/cache-hf
       - name: Run tests
         env:
           SPLITS: ${{ matrix.splits }}

--- a/.github/workflows/tracing-benchmark.yml
+++ b/.github/workflows/tracing-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: uv sync
 

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
 
       # Install mlflow-tracing SDK from the current directory
       - name: Install mlflow-tracing SDK

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -49,10 +49,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: $/.github/actions/untracked
-      - uses: $/.github/actions/setup-python # Required for running a tracking server
+      - uses: ./.github/actions/untracked
+      - uses: ./.github/actions/setup-python # Required for running a tracking server
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: $/.github/actions/setup-node
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -103,7 +103,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: $/.github/actions/setup-node
+        uses: ./.github/actions/setup-node
         with:
           node-version: 24
       - name: Install dependencies

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -41,13 +41,13 @@ jobs:
           persist-credentials: false
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
 
       - name: Install dependencies
         run: |
           source ./dev/install-common-deps.sh
 
-      - uses: $/.github/actions/setup-java
+      - uses: ./.github/actions/setup-java
 
       - name: Clone UnityCatalog at tag v0.4.1
         run: |

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -95,8 +95,8 @@ jobs:
           # guard above restricts it to OWNER/MEMBER/COLLABORATOR PRs.
           allow-unsafe-pr-checkout: true
 
-      - uses: $/.github/actions/setup-python
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-node
 
       - name: Install build tools
         run: uv pip install --system build setuptools

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -163,11 +163,11 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
           fetch-depth: 2
 
-      - uses: $/.github/actions/free-disk-space
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
 
       - name: Parse review arguments
         id: prompt

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -34,11 +34,11 @@ jobs:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
 
-      - uses: $/.github/actions/setup-node
+      - uses: ./.github/actions/setup-node
 
       - name: Fetch and transform model catalog
         run: uv run python dev/update_model_catalog.py

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token || github.token }}
-      - uses: $/.github/actions/setup-python
+      - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
       - name: Run uv lock --upgrade

--- a/.github/workflows/xtest-viz.yml
+++ b/.github/workflows/xtest-viz.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: $/.github/actions/setup-python
+        uses: ./.github/actions/setup-python
 
       - name: Generate cross-version test visualization
         env:


### PR DESCRIPTION
### Related Issues/PRs

Reverts #24770

### What changes are proposed in this pull request?

#24770 switched all 134 local action references from `./` to GitHub's new `$/` self-repository syntax. That turns out to cost ~20s per job.

To resolve a `$/` action, the runner downloads the whole repository tarball during `Set up job`, before any step runs. mlflow is large enough that this dominates the setup step. From a recent `lint` job log:

```
09:23:05.79  Download action repository 'mlflow/mlflow@9e97fa74...'
09:23:23.78  Download action repository 'actions/cache@...'   <- 18s later
```

Sampled `Set up job` durations for the `lint` job on master, before and after #24770 merged:

| before | after |
| --- | --- |
| 0s, 1s, 1s, 1s, 0s | 21s, 20s, 21s, 14s, 30s |

On a job that finishes in ~80s that is a ~25% tax, and it applies to every job in every workflow, so it multiplies across CI.

This reverts the 134 references back to `./`, which resolves against the existing checkout at no extra cost, and inverts the `policy.rego` rule so `$/` is flagged if it comes back.

Tradeoff worth stating explicitly, since it was the motivation for #24770: `./` resolves against whatever is in the workspace, so in workflows that check out something other than the executing commit, a fork's `action.yml` can run under the base repo's job. The affected workflows are `review.yml`, `ui-review.yml`, `ui-preview.yml`, and `autoformat.yml`. `ui-preview.yml` is already constrained (`contents: read`, `persist-credentials: false`, gated on `author_association`). Accepting the revert everywhere is deliberate here. If we want that property back for `review.yml` / `ui-review.yml`, which do carry app tokens, checking fork code out into a `path:` subdirectory is the cheaper fix and can be done separately.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

`conftest` (2701 tests), `regal`, `check-actions`, and the full `pre-commit` run pass. The inverted policy rule was verified to fire on synthetic workflow and composite-action files using `$/`, and to stay silent on `./`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)