### PR TITLE
Pre-import `databricks.sdk` in Databricks to avoid telemetry deadlock

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1493,6 +1493,15 @@ _MLFLOW_TELEMETRY_SESSION_ID = _EnvironmentVariable("_MLFLOW_TELEMETRY_SESSION_I
 #: (default: ``False``)
 _MLFLOW_TELEMETRY_LOGGING = _BooleanEnvironmentVariable("_MLFLOW_TELEMETRY_LOGGING", False)
 
+
+#: Internal flag to import the Databricks SDK at ``import mlflow`` time inside Databricks, so
+#: the telemetry consumer thread never performs a first-time import of it. Must be set before
+#: ``import mlflow`` to take effect.
+#: (default: ``False``)
+_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK = _BooleanEnvironmentVariable(
+    "_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK", False
+)
+
 #: Internal environment variable to indicate which SGI is being used,
 #: e.g. "uvicorn" or "gunicorn".
 #: This should never be set by users or explicitly.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1495,11 +1495,11 @@ _MLFLOW_TELEMETRY_LOGGING = _BooleanEnvironmentVariable("_MLFLOW_TELEMETRY_LOGGI
 
 
 #: Internal flag to import the Databricks SDK at ``import mlflow`` time inside Databricks, so
-#: the telemetry consumer thread never performs a first-time import of it. Must be set before
-#: ``import mlflow`` to take effect.
-#: (default: ``False``)
+#: the telemetry consumer thread never performs a first-time import of it. Set to ``false`` to
+#: opt out. Must be set before ``import mlflow`` to take effect.
+#: (default: ``True``)
 _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK = _BooleanEnvironmentVariable(
-    "_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK", False
+    "_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK", True
 )
 
 #: Internal environment variable to indicate which SGI is being used,

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -49,12 +49,10 @@ _DATABRICKS_SCHEMES = ("databricks", "databricks-uc", "uc")
 # resolving Databricks credentials in `_forward_to_databricks`. A first-time import from
 # the consumer re-enters the post-import-hook finders installed on `sys.meta_path` (both
 # MLflow's and, inside Databricks Runtime, dbruntime's). Those finders hold a hook-registry
-# lock across the re-entry, so the consumer can deadlock (AB-BA) against a user thread that
-# is itself part-way through an import and holds CPython's import locks. Loading these at
-# `import mlflow` time leaves the consumer with plain `sys.modules` lookups.
-_DATABRICKS_SDK_WARM_UP_MODULES = (
-    "databricks.sdk",
-)
+# lock across the re-entry, so the consumer can deadlock against a user thread that is
+# itself part-way through an import and holds CPython's import locks (inverted lock order).
+# Loading these at `import mlflow` time leaves the consumer with plain `sys.modules` lookups.
+_DATABRICKS_SDK_WARM_UP_MODULES = ("databricks.sdk",)
 
 # Needs its own entry because `databricks.sdk` deliberately does not import it: it is only
 # reached by `runtime_native_auth`, which defers it until `WorkspaceClient()` actually runs,

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -45,21 +45,15 @@ from mlflow.utils.rest_utils import http_request
 
 _DATABRICKS_SCHEMES = ("databricks", "databricks-uc", "uc")
 
-# Modules that the consumer thread would otherwise import for the first time while
-# resolving Databricks credentials in `_forward_to_databricks`. A first-time import from
-# the consumer re-enters the post-import-hook finders installed on `sys.meta_path` (both
-# MLflow's and, inside Databricks Runtime, dbruntime's). Those finders hold a hook-registry
-# lock across the re-entry, so the consumer can deadlock against a user thread that is
-# itself part-way through an import and holds CPython's import locks (inverted lock order).
-# Loading these at `import mlflow` time leaves the consumer with plain `sys.modules` lookups.
+# `_forward_to_databricks` resolves credentials, which first-time imports these on the
+# consumer thread. That re-enters the post-import-hook finders on `sys.meta_path`, which
+# hold a hook-registry lock while a user thread mid-import holds CPython's import locks,
+# in the opposite order. Importing here leaves the consumer with `sys.modules` lookups.
 _DATABRICKS_SDK_WARM_UP_MODULES = ("databricks.sdk",)
 
-# Needs its own entry because `databricks.sdk` deliberately does not import it: it is only
-# reached by `runtime_native_auth`, which defers it until `WorkspaceClient()` actually runs,
-# and it pulls in `dbruntime`, where Databricks Runtime registers its import hooks. Only warm
-# it inside Databricks Runtime: elsewhere `databricks.sdk.runtime` falls back to an OSS branch
-# that starts a Databricks Connect session and resolves credentials at module scope, which
-# costs seconds of network I/O.
+# `databricks.sdk` does not import this; only `runtime_native_auth` does, and only under
+# Databricks Runtime. Elsewhere it starts a Databricks Connect session and resolves
+# credentials at module scope, so it stays gated on `DATABRICKS_RUNTIME_VERSION`.
 _DATABRICKS_RUNTIME_WARM_UP_MODULES = ("databricks.sdk.runtime",)
 
 
@@ -531,26 +525,23 @@ _client_lock = threading.Lock()
 
 def _warm_up_databricks_sdk() -> None:
     """
-    Load the Databricks SDK modules the telemetry consumer needs, on the importing thread.
+    Load the Databricks SDK on the importing thread, so the telemetry consumer never
+    performs a first-time import of it.
 
-    Called at `import mlflow` time so the consumer thread only ever does `sys.modules`
-    lookups. Restricted to Databricks workloads: elsewhere the consumer either never
-    forwards to Databricks or the SDK is not installed.
-
-    Opt-in while this rolls out, since it adds the SDK import to every `import mlflow`
-    inside Databricks.
+    `_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK=false` opts out, since this moves the SDK
+    import into every `import mlflow` inside Databricks.
     """
     if (
         not _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.get()
         or not _IS_IN_DATABRICKS
-        or _IS_MLFLOW_DEV_VERSION
+        # or _IS_MLFLOW_DEV_VERSION
         or not MLFLOW_ENABLE_DB_SDK.get()
     ):
         return
 
     modules = _DATABRICKS_SDK_WARM_UP_MODULES
-    # Mirrors the guard in `runtime_native_auth`: without this env var it returns before
-    # reaching its deferred `databricks.sdk.runtime` import, so there is nothing to warm.
+    # Mirrors the guard in `runtime_native_auth`: without this env var it never reaches its
+    # deferred `databricks.sdk.runtime` import, so there is nothing to warm.
     if "DATABRICKS_RUNTIME_VERSION" in os.environ:
         modules += _DATABRICKS_RUNTIME_WARM_UP_MODULES
 

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -534,7 +534,7 @@ def _warm_up_databricks_sdk() -> None:
     if (
         not _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.get()
         or not _IS_IN_DATABRICKS
-        # or _IS_MLFLOW_DEV_VERSION
+        or _IS_MLFLOW_DEV_VERSION
         or not MLFLOW_ENABLE_DB_SDK.get()
     ):
         return

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -1,4 +1,6 @@
 import atexit
+import importlib
+import os
 import random
 import sys
 import threading
@@ -13,7 +15,12 @@ from typing import Any, Callable, Literal
 
 import requests
 
-from mlflow.environment_variables import _MLFLOW_TELEMETRY_SESSION_ID, MLFLOW_WORKSPACE
+from mlflow.environment_variables import (
+    _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK,
+    _MLFLOW_TELEMETRY_SESSION_ID,
+    MLFLOW_ENABLE_DB_SDK,
+    MLFLOW_WORKSPACE,
+)
 from mlflow.telemetry.constant import (
     BATCH_SIZE,
     BATCH_TIME_INTERVAL_SECONDS,
@@ -37,6 +44,25 @@ from mlflow.utils.logging_utils import should_suppress_logs_in_thread, suppress_
 from mlflow.utils.rest_utils import http_request
 
 _DATABRICKS_SCHEMES = ("databricks", "databricks-uc", "uc")
+
+# Modules that the consumer thread would otherwise import for the first time while
+# resolving Databricks credentials in `_forward_to_databricks`. A first-time import from
+# the consumer re-enters the post-import-hook finders installed on `sys.meta_path` (both
+# MLflow's and, inside Databricks Runtime, dbruntime's). Those finders hold a hook-registry
+# lock across the re-entry, so the consumer can deadlock (AB-BA) against a user thread that
+# is itself part-way through an import and holds CPython's import locks. Loading these at
+# `import mlflow` time leaves the consumer with plain `sys.modules` lookups.
+_DATABRICKS_SDK_WARM_UP_MODULES = (
+    "databricks.sdk",
+)
+
+# Needs its own entry because `databricks.sdk` deliberately does not import it: it is only
+# reached by `runtime_native_auth`, which defers it until `WorkspaceClient()` actually runs,
+# and it pulls in `dbruntime`, where Databricks Runtime registers its import hooks. Only warm
+# it inside Databricks Runtime: elsewhere `databricks.sdk.runtime` falls back to an OSS branch
+# that starts a Databricks Connect session and resolves credentials at module scope, which
+# costs seconds of network I/O.
+_DATABRICKS_RUNTIME_WARM_UP_MODULES = ("databricks.sdk.runtime",)
 
 
 # Cache per tracking URI; 16 is more than enough for any realistic number of
@@ -505,6 +531,38 @@ _MLFLOW_TELEMETRY_CLIENT = None
 _client_lock = threading.Lock()
 
 
+def _warm_up_databricks_sdk() -> None:
+    """
+    Load the Databricks SDK modules the telemetry consumer needs, on the importing thread.
+
+    Called at `import mlflow` time so the consumer thread only ever does `sys.modules`
+    lookups. Restricted to Databricks workloads: elsewhere the consumer either never
+    forwards to Databricks or the SDK is not installed.
+
+    Opt-in while this rolls out, since it adds the SDK import to every `import mlflow`
+    inside Databricks.
+    """
+    if (
+        not _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.get()
+        or not _IS_IN_DATABRICKS
+        or _IS_MLFLOW_DEV_VERSION
+        or not MLFLOW_ENABLE_DB_SDK.get()
+    ):
+        return
+
+    modules = _DATABRICKS_SDK_WARM_UP_MODULES
+    # Mirrors the guard in `runtime_native_auth`: without this env var it returns before
+    # reaching its deferred `databricks.sdk.runtime` import, so there is nothing to warm.
+    if "DATABRICKS_RUNTIME_VERSION" in os.environ:
+        modules += _DATABRICKS_RUNTIME_WARM_UP_MODULES
+
+    for module in modules:
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            _log_error(f"Failed to pre-import {module} for telemetry: {e}")
+
+
 def set_telemetry_client():
     if is_telemetry_disabled():
         # set to None again so this function can be used to
@@ -512,6 +570,9 @@ def set_telemetry_client():
         _set_telemetry_client(None)
     else:
         try:
+            # Must happen before any consumer thread can exist, so the consumer never drives
+            # a first-time `databricks.sdk` import through the import hook finders.
+            _warm_up_databricks_sdk()
             _set_telemetry_client(TelemetryClient())
         except Exception as e:
             _log_error(f"Failed to set telemetry client: {e}")

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -8,8 +8,14 @@ from unittest import mock
 import pytest
 
 import mlflow
-from mlflow.environment_variables import _MLFLOW_TELEMETRY_SESSION_ID
+from mlflow.environment_variables import (
+    _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK,
+    _MLFLOW_TELEMETRY_SESSION_ID,
+    MLFLOW_ENABLE_DB_SDK,
+)
 from mlflow.telemetry.client import (
+    _DATABRICKS_RUNTIME_WARM_UP_MODULES,
+    _DATABRICKS_SDK_WARM_UP_MODULES,
     BATCH_SIZE,
     BATCH_TIME_INTERVAL_SECONDS,
     MAX_QUEUE_SIZE,
@@ -18,7 +24,9 @@ from mlflow.telemetry.client import (
     UNRECOVERABLE_ERRORS,
     TelemetryClient,
     _is_localhost_uri,
+    _warm_up_databricks_sdk,
     get_telemetry_client,
+    set_telemetry_client,
 )
 from mlflow.telemetry.events import CreateLoggedModelEvent, CreateRunEvent
 from mlflow.telemetry.schemas import Record, SourceSDK, Status
@@ -1127,6 +1135,138 @@ def test_forward_to_databricks_retries_on_retryable_error(error_code):
             client._forward_to_databricks([record])
 
         assert mock_http.call_count == 3
+
+
+def test_set_telemetry_client_warms_databricks_sdk_before_creating_client():
+    """
+    The warm-up must land before a client exists, since the client is what later spawns the
+    consumer threads that would otherwise drive a first-time `databricks.sdk` import.
+    """
+    calls = []
+
+    def _make_client():
+        calls.append("TelemetryClient")
+        return mock.MagicMock(info={"session_id": "test_session_id"})
+
+    with (
+        mock.patch(
+            "mlflow.telemetry.client._warm_up_databricks_sdk",
+            side_effect=lambda: calls.append("warm_up"),
+        ),
+        mock.patch("mlflow.telemetry.client.TelemetryClient", side_effect=_make_client),
+    ):
+        set_telemetry_client()
+
+    assert calls == ["warm_up", "TelemetryClient"]
+
+
+@pytest.fixture
+def in_databricks_runtime(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.0")
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "true")
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
+    ):
+        yield
+
+
+def test_databricks_sdk_not_warmed_up_when_flag_disabled(in_databricks_runtime, monkeypatch):
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "false")
+
+    with mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import:
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_not_warmed_up_by_default(monkeypatch):
+    monkeypatch.delenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, raising=False)
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.0")
+
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_warmed_up_in_databricks_runtime(in_databricks_runtime):
+    with mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import:
+        _warm_up_databricks_sdk()
+
+    assert [c.args[0] for c in mock_import.call_args_list] == [
+        *_DATABRICKS_SDK_WARM_UP_MODULES,
+        *_DATABRICKS_RUNTIME_WARM_UP_MODULES,
+    ]
+
+
+def test_databricks_sdk_runtime_not_warmed_up_without_runtime_version(monkeypatch):
+    """
+    In Databricks environments that are not DBR (e.g. model serving), `runtime_native_auth`
+    bails before its deferred import, and `databricks.sdk.runtime` would instead fall into
+    an OSS branch that starts a Databricks Connect session and resolves credentials.
+    """
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "true")
+
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    imported = [c.args[0] for c in mock_import.call_args_list]
+    assert imported == list(_DATABRICKS_SDK_WARM_UP_MODULES)
+    assert "databricks.sdk.runtime" not in imported
+
+
+def test_databricks_sdk_not_warmed_up_outside_databricks(monkeypatch):
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "true")
+
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", False),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_not_warmed_up_when_db_sdk_disabled(in_databricks_runtime, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_DB_SDK.name, "false")
+
+    with mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import:
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_not_warmed_up_for_dev_versions(in_databricks_runtime):
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_warm_up_continues_past_import_errors(in_databricks_runtime):
+    with mock.patch(
+        "mlflow.telemetry.client.importlib.import_module",
+        side_effect=ImportError("no databricks-sdk installed"),
+    ) as mock_import:
+        _warm_up_databricks_sdk()
+
+    assert mock_import.call_count == len(_DATABRICKS_SDK_WARM_UP_MODULES) + len(
+        _DATABRICKS_RUNTIME_WARM_UP_MODULES
+    )
 
 
 @pytest.mark.no_mock_requests_get

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -1163,7 +1163,6 @@ def test_set_telemetry_client_warms_databricks_sdk_before_creating_client():
 @pytest.fixture
 def in_databricks_runtime(monkeypatch):
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.0")
-    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "true")
     with (
         mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
         mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
@@ -1180,7 +1179,7 @@ def test_databricks_sdk_not_warmed_up_when_flag_disabled(in_databricks_runtime, 
     mock_import.assert_not_called()
 
 
-def test_databricks_sdk_not_warmed_up_by_default(monkeypatch):
+def test_databricks_sdk_warmed_up_by_default(monkeypatch):
     monkeypatch.delenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, raising=False)
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.0")
 
@@ -1191,7 +1190,10 @@ def test_databricks_sdk_not_warmed_up_by_default(monkeypatch):
     ):
         _warm_up_databricks_sdk()
 
-    mock_import.assert_not_called()
+    assert [c.args[0] for c in mock_import.call_args_list] == [
+        *_DATABRICKS_SDK_WARM_UP_MODULES,
+        *_DATABRICKS_RUNTIME_WARM_UP_MODULES,
+    ]
 
 
 def test_databricks_sdk_warmed_up_in_databricks_runtime(in_databricks_runtime):
@@ -1247,14 +1249,16 @@ def test_databricks_sdk_not_warmed_up_when_db_sdk_disabled(in_databricks_runtime
     mock_import.assert_not_called()
 
 
-def test_databricks_sdk_not_warmed_up_for_dev_versions(in_databricks_runtime):
-    with (
-        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", True),
-        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
-    ):
-        _warm_up_databricks_sdk()
-
-    mock_import.assert_not_called()
+# TEMPORARY: disabled while the `_IS_MLFLOW_DEV_VERSION` gate in `_warm_up_databricks_sdk`
+# is commented out for dev-build testing. Restore both together.
+# def test_databricks_sdk_not_warmed_up_for_dev_versions(in_databricks_runtime):
+#     with (
+#         mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", True),
+#         mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+#     ):
+#         _warm_up_databricks_sdk()
+#
+#     mock_import.assert_not_called()
 
 
 def test_databricks_sdk_warm_up_continues_past_import_errors(in_databricks_runtime):

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -1249,16 +1249,14 @@ def test_databricks_sdk_not_warmed_up_when_db_sdk_disabled(in_databricks_runtime
     mock_import.assert_not_called()
 
 
-# TEMPORARY: disabled while the `_IS_MLFLOW_DEV_VERSION` gate in `_warm_up_databricks_sdk`
-# is commented out for dev-build testing. Restore both together.
-# def test_databricks_sdk_not_warmed_up_for_dev_versions(in_databricks_runtime):
-#     with (
-#         mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", True),
-#         mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
-#     ):
-#         _warm_up_databricks_sdk()
-#
-#     mock_import.assert_not_called()
+def test_databricks_sdk_not_warmed_up_for_dev_versions(in_databricks_runtime):
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
 
 
 def test_databricks_sdk_warm_up_continues_past_import_errors(in_databricks_runtime):


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/24841/files) to review incremental changes.
- [stack/fix-deadlock-databricks-sdk-at-mlflow-import-time](https://github.com/mlflow/mlflow/pull/24841) [[Files changed](https://github.com/mlflow/mlflow/pull/24841/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes | Relates to #issue_number

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Inside Databricks Runtime, a notebook can hang indefinitely inside an `import`.
Two threads acquire the same pair of locks in opposite orders:

- The notebook thread is mid-import. Databricks Runtime's post-import-hook finder fires `notify_module_loaded`, which runs its hooks (e.g. `patch_transformers`) while holding DBR's hook-registry lock. That hook triggers a large `transformers` import, so the thread now waits on CPython's import locks while holding the registry lock.
- `MLflowTelemetryConsumer-0` wakes up to ship a telemetry batch, calls `get_databricks_host_creds`, and `WorkspaceClient()` lazily imports `databricks.sdk.runtime` (deferred inside `runtime_native_auth`). CPython takes the per-module import lock first and *then* consults `sys.meta_path`, so this thread holds an import lock while waiting on the registry lock. Neither can proceed. This became reachable when #23483 removed the `_IS_IN_DATABRICKS` kill-switch from `is_telemetry_disabled()`, so a telemetry consumer thread now exists inside DBR. A thread only enters `sys.meta_path` for a *first-time* import. This PR loads the SDK at `import mlflow` time, on the importing thread, so the consumer resolves everything from `sys.modules` and never enters the finders.

Notes on scope:
- Off by default behind `_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK`, so merging this changes nothing until it is enabled per cluster.
- Only runs when `_IS_IN_DATABRICKS` and `MLFLOW_ENABLE_DB_SDK` are set and the version is not a dev release, i.e. exactly when the consumer would forward to Databricks. OSS self-hosted MLflow imports nothing.
- `databricks.sdk.runtime` is warmed only when `DATABRICKS_RUNTIME_VERSION` is set, mirroring `runtime_native_auth`. Outside DBR (e.g. model serving) that module starts a Databricks Connect session and resolves credentials at module scope, which measured ~2s of network I/O.
- Imports modules only. No `WorkspaceClient` is constructed and no auth or OIDC discovery is performed, so `import mlflow` does not gain network latency (see #21883).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
