### PR TITLE
fix: Only initialize tables from scratch when database is empty (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -93,7 +93,7 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     from mlflow.utils.file_utils import ExclusiveFileLock
 
     if os.name == "nt":
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
         return
 
@@ -102,7 +102,7 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
         usedforsecurity=False,
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.x to 3.8.x, running `mlflow db upgrade` can fail with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`.

## Root Cause
`_safe_initialize_tables` uses `_all_tables_exist` to decide whether to initialize tables. On an existing database (e.g., from 3.7.0), new ORM tables introduced in 3.8.x (like `secrets`) are not yet present, so `_all_tables_exist` returns `False`. This triggers `_initialize_tables`, which calls `InitialBase.metadata.create_all` and then `_upgrade_db`. The `create_all` only creates initial tables, not the new migration-only table, but then `_upgrade_db` runs the Alembic migration that also tries to create `secrets`. If a previous failed migration left the table partially created (or if the migration is idempotent but the table exists), the duplicate table error occurs.

## Fix
Instead of using `_all_tables_exist` (which checks all ORM tables), use `_is_empty_database` (which checks if only alembic tables exist) to decide whether to initialize from scratch. This ensures `_initialize_tables` is only called for truly new databases. For existing databases, normal Alembic migrations (via `mlflow db upgrade`) will create missing tables correctly.

Closes #19943