### PR TITLE
fix(tracking): populate MLFLOW_EXPERIMENT_NAME in set_experiment()

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -278,9 +278,10 @@ def set_experiment(
     global _active_experiment_id
     _active_experiment_id = experiment.experiment_id
 
-    # Set 'MLFLOW_EXPERIMENT_ID' environment variable
-    # so that subprocess can inherit it.
+    # Set 'MLFLOW_EXPERIMENT_ID' and 'MLFLOW_EXPERIMENT_NAME' environment variables
+    # so that subprocesses and integrations can inherit them.
     MLFLOW_EXPERIMENT_ID.set(_active_experiment_id)
+    MLFLOW_EXPERIMENT_NAME.set(experiment.name)
     if resolved_location is not None:
         experiment.trace_location = resolved_location
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -182,6 +182,8 @@ def reset_experiment_id():
     """
     yield
     mlflow.tracking.fluent._active_experiment_id = None
+    MLFLOW_EXPERIMENT_ID.unset()
+    MLFLOW_EXPERIMENT_NAME.unset()
 
 
 @pytest.fixture(autouse=True)
@@ -284,6 +286,19 @@ def test_get_experiment_id_with_active_experiment_returns_active_experiment_id()
     assert exp_id is not None
     mlflow.set_experiment(name)
     assert _get_experiment_id() == exp_id
+
+
+def test_set_experiment_sets_environment_variables():
+    name = f"Random experiment {random.randint(1, int(1e6))}"
+    exp = mlflow.set_experiment(name)
+    assert MLFLOW_EXPERIMENT_ID.get() == exp.experiment_id
+    assert MLFLOW_EXPERIMENT_NAME.get() == name
+    assert os.environ.get(MLFLOW_EXPERIMENT_ID.name) == exp.experiment_id
+    assert os.environ.get(MLFLOW_EXPERIMENT_NAME.name) == name
+
+    # Verify Ultralytics-style callback experiment name resolution
+    resolved_exp_name = os.environ.get(MLFLOW_EXPERIMENT_NAME.name) or "runs/detect"
+    assert resolved_exp_name == name
 
 
 def test_get_experiment_id_with_no_active_experiments_returns_zero():


### PR DESCRIPTION
### What changes were proposed in this pull request?
When `mlflow.set_experiment()` is called, MLflow sets the active experiment ID and populates `MLFLOW_EXPERIMENT_ID` in `os.environ`, but previously omitted `MLFLOW_EXPERIMENT_NAME`.

Third-party integrations like Ultralytics (`ultralytics.utils.callbacks.mlflow`) inspect `os.environ.get("MLFLOW_EXPERIMENT_NAME")` to discover active experiment names. Because it was `None`, Ultralytics fell back to `trainer.args.project` (e.g. `"runs/detect"`) and forcibly invoked `mlflow.set_experiment(trainer.args.project)`, overriding the user's custom experiment name.

This PR updates `mlflow.set_experiment()` to populate both `MLFLOW_EXPERIMENT_ID` and `MLFLOW_EXPERIMENT_NAME` environment variables so that subprocesses and integrations inherit the custom experiment name as intended.

### How was this patch tested?
- Added `test_set_experiment_sets_environment_variables()` in `tests/tracking/fluent/test_fluent.py` verifying both env vars are set and that Ultralytics-style callback resolution retrieves the custom experiment name.
- Ran full test suite `tests/tracking/fluent/test_fluent.py` (86 tests passed).
