### PR TITLE
Pass `--squash` to `gh pr merge --auto` in the `uv` workflow

### DIFF
--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -89,10 +89,10 @@ jobs:
             echo "Updating existing PR #$NUMBER on branch $BRANCH"
             git push --force origin "HEAD:$BRANCH"
             gh pr edit "$NUMBER" --body-file /tmp/pr-body.md
-            gh pr merge "$NUMBER" --auto
+            gh pr merge "$NUMBER" --auto --squash
           else
             BRANCH="uv-lock-update-$(date -u +%Y-%m-%dT%H-%M-%S)"
             git push origin "HEAD:$BRANCH"
             PR_URL=$(gh pr create --base master --head "$BRANCH" --title "$PR_TITLE" --body-file /tmp/pr-body.md --label team-review)
-            gh pr merge "$PR_URL" --auto
+            gh pr merge "$PR_URL" --auto --squash
           fi


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24852

### What changes are proposed in this pull request?

The `uv` workflow's "Create or update uv.lock PR" step failed in [this run](https://github.com/mlflow/mlflow/actions/runs/30870599555):

```
--merge, --rebase, or --squash required when not running interactively
```

`gh pr merge --auto` needs an explicit merge strategy when stdin isn't a TTY, so the step exited 1 after pushing the branch and creating the PR. The result: the run goes red, and the PR is left without auto-merge enabled (#24852 had to be fixed by hand).

This adds `--squash` to both `gh pr merge` calls (the update-existing-PR path and the create-new-PR path). Squash is the only strategy this repo allows anyway, since merge commits are disabled.

### How is this PR tested?

- [x] Existing unit/integration tests

The workflow runs on `pull_request` when `.github/workflows/uv.yml` changes, so this PR exercises the updated file. Note the PR-creation step is guarded by `if: github.event_name != 'pull_request'`, so the `gh pr merge` line itself isn't executed here. It was verified manually: `gh pr merge 24852 --auto --squash` succeeded where the bare `--auto` form failed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
