### PR TITLE
Add `build-docs` workflow for publishing release docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "The branch, tag or SHA to checkout from (e.g., branch-3.0)"
+        description: "Branch, tag or SHA to build from. Must contain dev/build_docs.py, i.e. be cut after it landed (e.g., branch-3.16). Cherry-pick it onto older release branches to publish their docs."
         required: true
       release_post:
         description: "Create a release post on mlflow/mlflow-website"
@@ -43,7 +43,7 @@ env:
 
 jobs:
   # Exercise both commands end-to-end on PRs that touch the script or this workflow.
-  # `--dry-run` clones the website repos and commits locally, but skips push and PR
+  # `--dry-run` commits to the website checkouts locally but skips push and PR
   # creation, so no token is required.
   test:
     if: github.event_name == 'pull_request'
@@ -96,14 +96,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
-      # Release branches are cut before this script lands on them, so run the copy
-      # from the ref this workflow was dispatched from, not the one being built.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          path: tools
-          sparse-checkout: dev/build_docs.py
-          sparse-checkout-cone-mode: false
       # `persist-credentials: true` keeps the App token in `http.extraheader` so the
       # script can push without ever handling the token itself.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -129,11 +121,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          uv run tools/dev/build_docs.py $DRY_RUN_FLAG release-post --website-dir website
+          uv run dev/build_docs.py $DRY_RUN_FLAG release-post --website-dir website
       - name: Build docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          uv run tools/dev/build_docs.py $DRY_RUN_FLAG build-docs \
+          uv run dev/build_docs.py $DRY_RUN_FLAG build-docs \
             --gtm-id GTM-N6WMTTJ \
             --website-dir legacy-website

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -55,19 +55,32 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
+      - name: Read release version
+        id: version
+        run: |
+          echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: mlflow/mlflow-website
           path: website
+      # `docs/` holds ~105 published versions; a publish touches at most three of
+      # them, so fetch only those. Every path the script writes must be listed here:
+      # entries outside the sparse set carry skip-worktree, and files written under
+      # them can be silently dropped from the commit.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: mlflow/mlflow-legacy-website
           path: legacy-website
-      - uses: ./.github/actions/free-disk-space
+          sparse-checkout: |
+            /docs/versions.json
+            /docs/latest/
+            /docs/${{ steps.version.outputs.value }}*/
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-java
-      - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-node
       - name: Test release-post
         run: |
@@ -75,6 +88,25 @@ jobs:
       - name: Test build-docs
         run: |
           uv run dev/build_docs.py --dry-run build-docs --website-dir legacy-website
+      # The sparse checkout leaves the other ~100 version directories as
+      # skip-worktree entries. Fail loudly if that ever turns into staged deletions.
+      - name: Check the commit only touches this release
+        working-directory: legacy-website
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          git show --shortstat --format= HEAD
+          paths="$(git show --name-only --format= HEAD)"
+          unexpected="$(echo "$paths" | grep -vE "^docs/(versions\.json|latest/|${VERSION}[^/]*/)" || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Commit touches paths outside this release:"
+            echo "$unexpected"
+            exit 1
+          fi
+          if ! echo "$paths" | grep -q "^docs/${VERSION}/"; then
+            echo "::error::Commit is missing docs/${VERSION}/ - the sparse checkout excluded it"
+            exit 1
+          fi
 
   run:
     if: github.event_name == 'workflow_dispatch'
@@ -96,6 +128,12 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-python
+      - name: Read release version
+        id: version
+        run: |
+          echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
       # `persist-credentials: true` keeps the App token in `http.extraheader` so the
       # script can push without ever handling the token itself.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -104,15 +142,19 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: mlflow/mlflow-website
           path: website
+      # See the `test` job for why the sparse set must cover every path written.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
           repository: mlflow/mlflow-legacy-website
           path: legacy-website
-      - uses: ./.github/actions/free-disk-space
+          sparse-checkout: |
+            /docs/versions.json
+            /docs/latest/
+            /docs/${{ steps.version.outputs.value }}*/
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-java
-      - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-node
       # Create the release post first. It's cheap, and a failure in the long docs
       # build shouldn't prevent the post from being opened.

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -78,6 +78,10 @@ jobs:
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
+      - name: Configure committer
+        run: |
+          git config --global user.name 'mlflow-app[bot]'
+          git config --global user.email 'mlflow-app[bot]@users.noreply.github.com'
       - name: Test release-post
         run: |
           uv run dev/build_docs.py --dry-run release-post --website-dir website
@@ -151,6 +155,10 @@ jobs:
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
+      - name: Configure committer
+        run: |
+          git config --global user.name 'mlflow-app[bot]'
+          git config --global user.email 'mlflow-app[bot]@users.noreply.github.com'
       # First because it's cheap, and shouldn't be lost to a docs build failure.
       - name: Create release post
         if: inputs.release_post

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,6 +1,16 @@
 name: build-docs
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - dev/build_docs.py
+      - .github/workflows/build-docs.yml
+      # `build_docs.py` mirrors the docs build steps, so re-verify it when they change
+      - .github/workflows/docs.yml
   workflow_dispatch:
     inputs:
       ref:
@@ -18,8 +28,9 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.ref }}
+  # Superseded PR pushes are safe to cancel, but a dispatched release build isn't.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}
 
@@ -31,7 +42,32 @@ env:
   DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
 
 jobs:
+  # Exercise both commands end-to-end on PRs that touch the script or this workflow.
+  # `--dry-run` clones the website repos and commits locally, but skips push and PR
+  # creation, so no token is required.
+  test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-node
+      - name: Test release-post
+        run: |
+          uv run dev/build_docs.py --dry-run release-post
+      - name: Test build-docs
+        run: |
+          uv run dev/build_docs.py --dry-run build-docs
+
   run:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -130,7 +130,8 @@ jobs:
         id: version
         run: |
           echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
-      # `persist-credentials` keeps the token in `http.extraheader`, out of the URL.
+      # `true` is required to push, and stores the token in `http.extraheader`,
+      # keeping it out of the remote URL.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,69 @@
+name: build-docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout from (e.g., branch-3.0)"
+        required: true
+      release_post:
+        description: "Create a release post on mlflow/mlflow-website"
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: "Skip push and PR creation"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: mlflow-legacy-website,mlflow-website
+          owner: mlflow
+          permission-contents: write
+          permission-pull-requests: write
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-node
+      # Create the release post first. It's cheap, and a failure in the long docs
+      # build shouldn't prevent the post from being opened.
+      - name: Create release post
+        if: inputs.release_post
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          uv run dev/build_docs.py $DRY_RUN_FLAG release-post
+      - name: Build docs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          uv run dev/build_docs.py $DRY_RUN_FLAG build-docs --gtm-id GTM-N6WMTTJ

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -86,6 +86,14 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
+      # Release branches are cut before this script lands on them, so run the copy
+      # from the ref this workflow was dispatched from, not the one being built.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: tools
+          sparse-checkout: dev/build_docs.py
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-python
@@ -97,9 +105,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          uv run dev/build_docs.py $DRY_RUN_FLAG release-post
+          uv run tools/dev/build_docs.py $DRY_RUN_FLAG release-post
       - name: Build docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          uv run dev/build_docs.py $DRY_RUN_FLAG build-docs --gtm-id GTM-N6WMTTJ
+          uv run tools/dev/build_docs.py $DRY_RUN_FLAG build-docs --gtm-id GTM-N6WMTTJ

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -130,8 +130,7 @@ jobs:
         id: version
         run: |
           echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
-      # `true` is required to push, and stores the token in `http.extraheader`,
-      # keeping it out of the remote URL.
+      # `true` is required for the script to push.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -53,7 +53,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-python
       - name: Read release version
         id: version
@@ -126,7 +125,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
-      - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-python
       - name: Read release version
         id: version

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -55,16 +55,26 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          repository: mlflow/mlflow-website
+          path: website
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          repository: mlflow/mlflow-legacy-website
+          path: legacy-website
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-node
       - name: Test release-post
         run: |
-          uv run dev/build_docs.py --dry-run release-post
+          uv run dev/build_docs.py --dry-run release-post --website-dir website
       - name: Test build-docs
         run: |
-          uv run dev/build_docs.py --dry-run build-docs
+          uv run dev/build_docs.py --dry-run build-docs --website-dir legacy-website
 
   run:
     if: github.event_name == 'workflow_dispatch'
@@ -94,6 +104,20 @@ jobs:
           path: tools
           sparse-checkout: dev/build_docs.py
           sparse-checkout-cone-mode: false
+      # `persist-credentials: true` keeps the App token in `http.extraheader` so the
+      # script can push without ever handling the token itself.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          repository: mlflow/mlflow-website
+          path: website
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          repository: mlflow/mlflow-legacy-website
+          path: legacy-website
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-python
@@ -105,9 +129,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          uv run tools/dev/build_docs.py $DRY_RUN_FLAG release-post
+          uv run tools/dev/build_docs.py $DRY_RUN_FLAG release-post --website-dir website
       - name: Build docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          uv run tools/dev/build_docs.py $DRY_RUN_FLAG build-docs --gtm-id GTM-N6WMTTJ
+          uv run tools/dev/build_docs.py $DRY_RUN_FLAG build-docs \
+            --gtm-id GTM-N6WMTTJ \
+            --website-dir legacy-website

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,7 +29,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.ref }}
-  # Superseded PR pushes are safe to cancel, but a dispatched release build isn't.
+  # Cancel superseded PR runs, never a release build.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}
@@ -42,9 +42,7 @@ env:
   DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
 
 jobs:
-  # Exercise both commands end-to-end on PRs that touch the script or this workflow.
-  # `--dry-run` commits to the website checkouts locally but skips push and PR
-  # creation, so no token is required.
+  # Both commands, end-to-end. `--dry-run` skips push and PR creation, so no token.
   test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -66,10 +64,9 @@ jobs:
           persist-credentials: false
           repository: mlflow/mlflow-website
           path: website
-      # `docs/` holds ~105 published versions; a publish touches at most three of
-      # them, so fetch only those. Every path the script writes must be listed here:
-      # entries outside the sparse set carry skip-worktree, and files written under
-      # them can be silently dropped from the commit.
+      # Fetch only the ~3 of ~105 version directories a publish writes. Anything
+      # missing here is skip-worktree, and files written under it are silently
+      # dropped from the commit.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -88,8 +85,7 @@ jobs:
       - name: Test build-docs
         run: |
           uv run dev/build_docs.py --dry-run build-docs --website-dir legacy-website
-      # The sparse checkout leaves the other ~100 version directories as
-      # skip-worktree entries. Fail loudly if that ever turns into staged deletions.
+      # The ~100 skip-worktree directories must never become staged deletions.
       - name: Check the commit only touches this release
         working-directory: legacy-website
         env:
@@ -134,8 +130,7 @@ jobs:
         id: version
         run: |
           echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
-      # `persist-credentials: true` keeps the App token in `http.extraheader` so the
-      # script can push without ever handling the token itself.
+      # `persist-credentials` keeps the token in `http.extraheader`, out of the URL.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
@@ -156,8 +151,7 @@ jobs:
           sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
-      # Create the release post first. It's cheap, and a failure in the long docs
-      # build shouldn't prevent the post from being opened.
+      # First because it's cheap, and shouldn't be lost to a docs build failure.
       - name: Create release post
         if: inputs.release_post
         env:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -93,13 +93,15 @@ jobs:
         run: |
           git show --shortstat --format= HEAD
           paths="$(git show --name-only --format= HEAD)"
-          unexpected="$(echo "$paths" | grep -vE "^docs/(versions\.json|latest/|${VERSION}[^/]*/)" || true)"
+          # Here-strings, not pipes: `grep -q` exits on the first match, and the
+          # resulting EPIPE would fail the pipeline under `pipefail`.
+          unexpected="$(grep -vE "^docs/(versions\.json|latest/|${VERSION}[^/]*/)" <<< "$paths" || true)"
           if [ -n "$unexpected" ]; then
             echo "::error::Commit touches paths outside this release:"
             echo "$unexpected"
             exit 1
           fi
-          if ! echo "$paths" | grep -q "^docs/${VERSION}/"; then
+          if ! grep -q "^docs/${VERSION}/" <<< "$paths"; then
             echo "::error::Commit is missing docs/${VERSION}/ - the sparse checkout excluded it"
             exit 1
           fi

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -1,0 +1,320 @@
+"""Build MLflow release documentation and publish to mlflow-legacy-website."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+
+class Repo:
+    def __init__(self, repo: str, root: Path, *, default_branch: str, token: str | None = None):
+        self.repo = repo
+        self.root = root
+        self.default_branch = default_branch
+        self.token = token
+
+    @classmethod
+    @contextmanager
+    def clone(
+        cls,
+        *,
+        repo: str,
+        branch: str,
+        token: str | None = None,
+    ) -> Iterator[Repo]:
+        if token:
+            url = f"https://mlflow-app[bot]:{token}@github.com/{repo}.git"
+        else:
+            url = f"https://github.com/{repo}.git"
+        cmd = ["git", "clone", "--depth", "1", "--branch", branch]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            subprocess.check_call([*cmd, url, root])
+            instance = cls(repo, root, default_branch=branch, token=token)
+            instance._configure_identity()
+            yield instance
+
+    def _configure_identity(self) -> None:
+        self.git("config", "user.name", "mlflow-app[bot]")
+        self.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
+
+    @property
+    def branch(self) -> str:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=self.root, text=True
+        )
+        return output.strip()
+
+    def git(self, *args: str) -> None:
+        subprocess.check_call(["git", *args], cwd=self.root)
+
+    def checkout_new(self, branch: str) -> None:
+        self.git("checkout", "-b", branch)
+
+    def add_all(self) -> None:
+        self.git("add", "-A")
+
+    def has_changes(self) -> bool:
+        result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=self.root)
+        return result.returncode != 0
+
+    def commit(self, message: str) -> None:
+        self.git("commit", "-m", message)
+
+    def push(self) -> None:
+        self.git("push", "origin", self.branch)
+
+    def create_pr(self, *, title: str, body: str) -> str:
+        if not self.token:
+            raise ValueError("Cannot create PR without a token")
+        env = {**os.environ, "GH_TOKEN": self.token}
+        output = subprocess.check_output(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                self.repo,
+                "--head",
+                self.branch,
+                "--base",
+                self.default_branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            text=True,
+            env=env,
+        )
+        return output.strip()
+
+
+def _read_version(repo_root: Path) -> str:
+    # `uv version` outputs "<name> <version>", e.g. "mlflow 3.11.0"
+    output = subprocess.check_output(["uv", "version"], cwd=repo_root, text=True)
+    return output.strip().split()[-1]
+
+
+def build_docs(args: argparse.Namespace) -> None:
+    mlflow_dir = Path(args.mlflow_dir).resolve()
+    release_version = _read_version(mlflow_dir)
+    print(f"Building docs for MLflow {release_version}")
+
+    subprocess.check_call(["uv", "sync", "--group", "docs", "--extra", "gateway"], cwd=mlflow_dir)
+    subprocess.check_call(["uv", "pip", "install", "-r", "requirements/torch.txt"], cwd=mlflow_dir)
+    docs_dir = mlflow_dir / "docs"
+    env = {**os.environ, "GTM_ID": args.gtm_id}
+    subprocess.check_call(["npm", "ci"], cwd=docs_dir, env=env)
+    subprocess.check_call(["npm", "run", "build-all", "--", "--use-npm"], cwd=docs_dir, env=env)
+
+    with Repo.clone(
+        repo="mlflow/mlflow-legacy-website",
+        branch="main",
+        token=args.token,
+    ) as website_repo:
+        branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
+        website_repo.checkout_new(branch_name)
+
+        version = Version(release_version)
+
+        # Clean up release candidate docs when publishing a final release
+        if not version.is_prerelease:
+            for p in (website_repo.root / "docs").iterdir():
+                if not p.is_dir():
+                    continue
+                try:
+                    v = Version(p.name)
+                except InvalidVersion:
+                    continue
+                if v.is_prerelease and v.base_version == version.base_version:
+                    shutil.rmtree(p)
+
+        # Copy built docs. `build-all.py` produces a separate build per target
+        # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
+        # so we must copy from the matching directory rather than reusing one source.
+        for dest_name in _version_targets(version, website_repo.root):
+            src = docs_dir / "build" / dest_name
+            dst = website_repo.root / "docs" / dest_name
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+
+        # Update versions.json
+        _update_versions_json(website_repo.root / "docs" / "versions.json", version)
+
+        website_repo.add_all()
+
+        if not website_repo.has_changes():
+            print("No changes to commit, skipping.")
+            return
+
+        website_repo.commit("Add docs")
+
+        if args.dry_run:
+            return
+
+        website_repo.push()
+
+        if args.token:
+            pr_url = website_repo.create_pr(
+                title=f"Add documentation for {release_version}",
+                body="",
+            )
+            print(f"Created {pr_url}")
+
+
+def _version_targets(version: Version, website_root: Path) -> list[str]:
+    json_path = website_root / "docs" / "versions.json"
+    versions_json = json.loads(json_path.read_text())
+    latest_version = max(map(Version, versions_json["versions"]))
+    targets = [str(version)]
+    if version >= latest_version:
+        targets.append("latest")
+    return targets
+
+
+def _update_versions_json(json_path: Path, release_version: Version) -> None:
+    data = json.loads(json_path.read_text())
+    versions = [Version(v) for v in data["versions"]]
+    if release_version not in versions:
+        versions.append(release_version)
+
+    # Keep only the highest version for each minor release
+    latest_by_minor: dict[tuple[int, int], Version] = {}
+    for v in versions:
+        key = (v.major, v.minor)
+        if key not in latest_by_minor or v > latest_by_minor[key]:
+            latest_by_minor[key] = v
+
+    data["versions"] = [str(v) for v in sorted(latest_by_minor.values(), reverse=True)]
+    json_path.write_text(json.dumps(data, indent=2))
+
+
+def release_post(args: argparse.Namespace) -> None:
+    mlflow_dir = Path(args.mlflow_dir).resolve()
+    release_version = _read_version(mlflow_dir)
+    print(f"Creating release post for MLflow {release_version}")
+
+    with Repo.clone(
+        repo="mlflow/mlflow-website",
+        branch="main",
+        token=args.token,
+    ) as website_repo:
+        branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
+        website_repo.checkout_new(branch_name)
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        name = f"{today}-{release_version}-release.md"
+        post_path = website_repo.root / "website" / "releases" / name
+
+        if "rc" in release_version:
+            base_version = release_version.split("rc")[0]
+            content = _RC_TEMPLATE.format(version=release_version, base_version=base_version)
+        else:
+            content = _RELEASE_TEMPLATE.format(version=release_version)
+
+        post_path.write_text(content)
+
+        website_repo.add_all()
+
+        if not website_repo.has_changes():
+            print("No changes to commit, skipping.")
+            return
+
+        website_repo.commit("Add release post")
+
+        if args.dry_run:
+            return
+
+        website_repo.push()
+
+        if args.token:
+            pr_url = website_repo.create_pr(
+                title=f"Add release post for {release_version}",
+                body="Be sure to fill in the contents",
+            )
+            print(f"Created {pr_url}")
+
+
+_RELEASE_TEMPLATE = """\
+---
+title: MLflow {version}
+slug: {version}
+authors: [mlflow-maintainers]
+---
+
+<REPLACE_ME>
+
+For a comprehensive list of changes, see the
+[release change log](https://github.com/mlflow/mlflow/releases/tag/v{version}),
+and check out the latest documentation on [mlflow.org](http://mlflow.org/).
+"""
+
+_RC_TEMPLATE = """\
+---
+title: MLflow {version}
+slug: {version}
+authors: [mlflow-maintainers]
+---
+
+MLflow {version} is a release candidate for {base_version}. To install, run the following command:
+
+```sh
+pip install mlflow=={version}
+```
+
+<!-- Major changes that need to be highlighted in the release post go here -->
+<REPLACE_ME>
+
+Please try it out and report any issues on [the issue tracker](https://github.com/mlflow/mlflow/issues).
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MLflow release documentation tools")
+    parser.add_argument(
+        "--mlflow-dir",
+        default=".",
+        help="Path to the local MLflow repository checkout",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GH_TOKEN"),
+        help="GitHub token for pushing and creating PRs (default: $GH_TOKEN)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip push and PR creation",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    docs_parser = subparsers.add_parser("build-docs", help="Build and publish MLflow documentation")
+    docs_parser.add_argument("--gtm-id", default="GTM-TEST", help="Google Tag Manager ID")
+    subparsers.add_parser("release-post", help="Create a release post")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    match args.command:
+        case "build-docs":
+            build_docs(args)
+        case "release-post":
+            release_post(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -22,22 +22,14 @@ _GIT_PUSH_TIMEOUT = 30 * 60
 class Repo:
     """A website repository checkout that this script commits and pushes to.
 
-    `actions/checkout` creates the checkout and owns its credentials, so no token
-    is handled here. `gh` picks up `$GH_TOKEN` from the environment.
+    The caller provides the checkout, its credentials and the committer identity;
+    `gh` picks up `$GH_TOKEN` from the environment.
     """
 
     def __init__(self, repo: str, root: Path, *, default_branch: str = "main"):
         self.repo = repo
         self.root = root
         self.default_branch = default_branch
-
-    @classmethod
-    def open(cls, repo: str, root: Path, *, default_branch: str = "main") -> Repo:
-        instance = cls(repo, root, default_branch=default_branch)
-        # `actions/checkout` doesn't configure a committer
-        instance.git("config", "user.name", "mlflow-app[bot]")
-        instance.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
-        return instance
 
     def git(self, *args: str, timeout: int = _GIT_TIMEOUT) -> None:
         subprocess.check_call(["git", *args], cwd=self.root, timeout=timeout)
@@ -85,7 +77,7 @@ def build_docs(args: argparse.Namespace) -> None:
     subprocess.check_call(["npm", "ci"], cwd=docs_dir, env=env)
     subprocess.check_call(["npm", "run", "build-all", "--", "--use-npm"], cwd=docs_dir, env=env)
 
-    website_repo = Repo.open("mlflow/mlflow-legacy-website", Path(args.website_dir).resolve())
+    website_repo = Repo("mlflow/mlflow-legacy-website", Path(args.website_dir).resolve())
     branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
     website_repo.git("checkout", "-q", "-b", branch_name)
 
@@ -175,7 +167,7 @@ def release_post(args: argparse.Namespace) -> None:
     release_version = _read_version(mlflow_dir)
     print(f"Creating release post for MLflow {release_version}")
 
-    website_repo = Repo.open("mlflow/mlflow-website", Path(args.website_dir).resolve())
+    website_repo = Repo("mlflow/mlflow-website", Path(args.website_dir).resolve())
     branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
     website_repo.git("checkout", "-q", "-b", branch_name)
 

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -84,7 +84,7 @@ def build_docs(args: argparse.Namespace) -> None:
 
     website_repo = Repo.open("mlflow/mlflow-legacy-website", Path(args.website_dir).resolve())
     branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
-    website_repo.git("checkout", "-b", branch_name)
+    website_repo.git("checkout", "-q", "-b", branch_name)
 
     version = Version(release_version)
 
@@ -109,7 +109,8 @@ def build_docs(args: argparse.Namespace) -> None:
         print("No changes to commit, skipping.")
         return
 
-    website_repo.git("commit", "-m", "Add docs")
+    # `-q`: a docs publish creates ~6k files, and git lists every one of them
+    website_repo.git("commit", "-q", "-m", "Add docs")
 
     if args.dry_run:
         return
@@ -173,7 +174,7 @@ def release_post(args: argparse.Namespace) -> None:
 
     website_repo = Repo.open("mlflow/mlflow-website", Path(args.website_dir).resolve())
     branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
-    website_repo.git("checkout", "-b", branch_name)
+    website_repo.git("checkout", "-q", "-b", branch_name)
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     name = f"{today}-{release_version}-release.md"
@@ -186,7 +187,7 @@ def release_post(args: argparse.Namespace) -> None:
         print("No changes to commit, skipping.")
         return
 
-    website_repo.git("commit", "-m", "Add release post")
+    website_repo.git("commit", "-q", "-m", "Add release post")
 
     if args.dry_run:
         return

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -64,9 +64,8 @@ class Repo:
 
 
 def _read_version(repo_root: Path) -> str:
-    # `uv version` outputs "<name> <version>", e.g. "mlflow 3.11.0"
-    output = subprocess.check_output(["uv", "version"], cwd=repo_root, text=True)
-    return output.strip().split()[-1]
+    output = subprocess.check_output(["uv", "version", "--short"], cwd=repo_root, text=True)
+    return output.strip()
 
 
 def build_docs(args: argparse.Namespace) -> None:

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -17,9 +17,8 @@ from packaging.version import InvalidVersion, Version
 class Repo:
     """A website repository checkout that this script commits and pushes to.
 
-    The checkout is created by `actions/checkout`, which keeps the credentials in
-    `http.extraheader` rather than in the remote URL, so no token is handled here.
-    `gh` picks up `$GH_TOKEN` from the environment.
+    `actions/checkout` creates the checkout and owns its credentials, so no token
+    is handled here. `gh` picks up `$GH_TOKEN` from the environment.
     """
 
     def __init__(self, repo: str, root: Path, *, default_branch: str = "main"):

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 from packaging.version import InvalidVersion, Version
 
+# Local git operations finish in seconds, even staging a full docs build. Pushing
+# one is the outlier, since it uploads thousands of files.
+_GIT_TIMEOUT = 5 * 60
+_GIT_PUSH_TIMEOUT = 30 * 60
+
 
 class Repo:
     """A website repository checkout that this script commits and pushes to.
@@ -34,8 +39,8 @@ class Repo:
         instance.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
         return instance
 
-    def git(self, *args: str) -> None:
-        subprocess.check_call(["git", *args], cwd=self.root)
+    def git(self, *args: str, timeout: int = _GIT_TIMEOUT) -> None:
+        subprocess.check_call(["git", *args], cwd=self.root, timeout=timeout)
 
     def has_changes(self) -> bool:
         result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=self.root)
@@ -113,7 +118,7 @@ def build_docs(args: argparse.Namespace) -> None:
     if args.dry_run:
         return
 
-    website_repo.git("push", "origin", branch_name)
+    website_repo.git("push", "origin", branch_name, timeout=_GIT_PUSH_TIMEOUT)
     pr_url = website_repo.create_pr(
         head=branch_name,
         title=f"Add documentation for {release_version}",
@@ -190,7 +195,7 @@ def release_post(args: argparse.Namespace) -> None:
     if args.dry_run:
         return
 
-    website_repo.git("push", "origin", branch_name)
+    website_repo.git("push", "origin", branch_name, timeout=_GIT_PUSH_TIMEOUT)
     pr_url = website_repo.create_pr(
         head=branch_name,
         title=f"Add release post for {release_version}",

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -42,40 +42,18 @@ class Repo:
             root = Path(tmp) / "repo"
             subprocess.check_call([*cmd, url, root])
             instance = cls(repo, root, default_branch=branch, token=token)
-            instance._configure_identity()
+            instance.git("config", "user.name", "mlflow-app[bot]")
+            instance.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
             yield instance
-
-    def _configure_identity(self) -> None:
-        self.git("config", "user.name", "mlflow-app[bot]")
-        self.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
-
-    @property
-    def branch(self) -> str:
-        output = subprocess.check_output(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=self.root, text=True
-        )
-        return output.strip()
 
     def git(self, *args: str) -> None:
         subprocess.check_call(["git", *args], cwd=self.root)
-
-    def checkout_new(self, branch: str) -> None:
-        self.git("checkout", "-b", branch)
-
-    def add_all(self) -> None:
-        self.git("add", "-A")
 
     def has_changes(self) -> bool:
         result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=self.root)
         return result.returncode != 0
 
-    def commit(self, message: str) -> None:
-        self.git("commit", "-m", message)
-
-    def push(self) -> None:
-        self.git("push", "origin", self.branch)
-
-    def create_pr(self, *, title: str, body: str) -> str:
+    def create_pr(self, *, head: str, title: str, body: str) -> str:
         if not self.token:
             raise ValueError("Cannot create PR without a token")
         env = {**os.environ, "GH_TOKEN": self.token}
@@ -87,7 +65,7 @@ class Repo:
                 "--repo",
                 self.repo,
                 "--head",
-                self.branch,
+                head,
                 "--base",
                 self.default_branch,
                 "--title",
@@ -125,7 +103,7 @@ def build_docs(args: argparse.Namespace) -> None:
         token=args.token,
     ) as website_repo:
         branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
-        website_repo.checkout_new(branch_name)
+        website_repo.git("checkout", "-b", branch_name)
 
         version = Version(release_version)
 
@@ -144,25 +122,24 @@ def build_docs(args: argparse.Namespace) -> None:
         # Update versions.json
         _update_versions_json(website_repo.root / "docs" / "versions.json", version)
 
-        website_repo.add_all()
+        website_repo.git("add", "-A")
 
         if not website_repo.has_changes():
             print("No changes to commit, skipping.")
             return
 
-        website_repo.commit("Add docs")
+        website_repo.git("commit", "-m", "Add docs")
 
         if args.dry_run:
             return
 
-        website_repo.push()
-
-        if args.token:
-            pr_url = website_repo.create_pr(
-                title=f"Add documentation for {release_version}",
-                body="",
-            )
-            print(f"Created {pr_url}")
+        website_repo.git("push", "origin", branch_name)
+        pr_url = website_repo.create_pr(
+            head=branch_name,
+            title=f"Add documentation for {release_version}",
+            body="",
+        )
+        print(f"Created {pr_url}")
 
 
 def _remove_stale_prereleases(docs_root: Path, version: Version) -> None:
@@ -219,32 +196,31 @@ def release_post(args: argparse.Namespace) -> None:
         token=args.token,
     ) as website_repo:
         branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
-        website_repo.checkout_new(branch_name)
+        website_repo.git("checkout", "-b", branch_name)
 
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         name = f"{today}-{release_version}-release.md"
         post_path = website_repo.root / "website" / "releases" / name
         post_path.write_text(_render_release_post(Version(release_version)))
 
-        website_repo.add_all()
+        website_repo.git("add", "-A")
 
         if not website_repo.has_changes():
             print("No changes to commit, skipping.")
             return
 
-        website_repo.commit("Add release post")
+        website_repo.git("commit", "-m", "Add release post")
 
         if args.dry_run:
             return
 
-        website_repo.push()
-
-        if args.token:
-            pr_url = website_repo.create_pr(
-                title=f"Add release post for {release_version}",
-                body="Be sure to fill in the contents",
-            )
-            print(f"Created {pr_url}")
+        website_repo.git("push", "origin", branch_name)
+        pr_url = website_repo.create_pr(
+            head=branch_name,
+            title=f"Add release post for {release_version}",
+            body="Be sure to fill in the contents",
+        )
+        print(f"Created {pr_url}")
 
 
 def _render_release_post(version: Version) -> str:

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -129,17 +129,7 @@ def build_docs(args: argparse.Namespace) -> None:
 
         version = Version(release_version)
 
-        # Clean up release candidate docs when publishing a final release
-        if not version.is_prerelease:
-            for p in (website_repo.root / "docs").iterdir():
-                if not p.is_dir():
-                    continue
-                try:
-                    v = Version(p.name)
-                except InvalidVersion:
-                    continue
-                if v.is_prerelease and v.base_version == version.base_version:
-                    shutil.rmtree(p)
+        _remove_stale_prereleases(website_repo.root / "docs", version)
 
         # Copy built docs. `build-all.py` produces a separate build per target
         # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
@@ -173,6 +163,22 @@ def build_docs(args: argparse.Namespace) -> None:
                 body="",
             )
             print(f"Created {pr_url}")
+
+
+def _remove_stale_prereleases(docs_root: Path, version: Version) -> None:
+    """Drop release candidate docs for `version` once the final release is published."""
+    if version.is_prerelease:
+        return
+
+    for p in docs_root.iterdir():
+        if not p.is_dir():
+            continue
+        try:
+            v = Version(p.name)
+        except InvalidVersion:
+            continue
+        if v.is_prerelease and v.base_version == version.base_version:
+            shutil.rmtree(p)
 
 
 def _version_targets(version: Version, website_root: Path) -> list[str]:
@@ -218,14 +224,7 @@ def release_post(args: argparse.Namespace) -> None:
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         name = f"{today}-{release_version}-release.md"
         post_path = website_repo.root / "website" / "releases" / name
-
-        if "rc" in release_version:
-            base_version = release_version.split("rc")[0]
-            content = _RC_TEMPLATE.format(version=release_version, base_version=base_version)
-        else:
-            content = _RELEASE_TEMPLATE.format(version=release_version)
-
-        post_path.write_text(content)
+        post_path.write_text(_render_release_post(Version(release_version)))
 
         website_repo.add_all()
 
@@ -246,6 +245,12 @@ def release_post(args: argparse.Namespace) -> None:
                 body="Be sure to fill in the contents",
             )
             print(f"Created {pr_url}")
+
+
+def _render_release_post(version: Version) -> str:
+    if version.is_prerelease:
+        return _RC_TEMPLATE.format(version=version, base_version=version.base_version)
+    return _RELEASE_TEMPLATE.format(version=version)
 
 
 _RELEASE_TEMPLATE = """\
@@ -314,6 +319,8 @@ def main() -> None:
             build_docs(args)
         case "release-post":
             release_post(args)
+        case _:
+            raise ValueError(f"Unexpected command: {args.command!r}")
 
 
 if __name__ == "__main__":

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -7,10 +7,7 @@ import json
 import os
 import shutil
 import subprocess
-import tempfile
 import uuid
-from collections.abc import Iterator
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -18,33 +15,25 @@ from packaging.version import InvalidVersion, Version
 
 
 class Repo:
-    def __init__(self, repo: str, root: Path, *, default_branch: str, token: str | None = None):
+    """A website repository checkout that this script commits and pushes to.
+
+    The checkout is created by `actions/checkout`, which keeps the credentials in
+    `http.extraheader` rather than in the remote URL, so no token is handled here.
+    `gh` picks up `$GH_TOKEN` from the environment.
+    """
+
+    def __init__(self, repo: str, root: Path, *, default_branch: str = "main"):
         self.repo = repo
         self.root = root
         self.default_branch = default_branch
-        self.token = token
 
     @classmethod
-    @contextmanager
-    def clone(
-        cls,
-        *,
-        repo: str,
-        branch: str,
-        token: str | None = None,
-    ) -> Iterator[Repo]:
-        if token:
-            url = f"https://mlflow-app[bot]:{token}@github.com/{repo}.git"
-        else:
-            url = f"https://github.com/{repo}.git"
-        cmd = ["git", "clone", "--depth", "1", "--branch", branch]
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp) / "repo"
-            subprocess.check_call([*cmd, url, root])
-            instance = cls(repo, root, default_branch=branch, token=token)
-            instance.git("config", "user.name", "mlflow-app[bot]")
-            instance.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
-            yield instance
+    def open(cls, repo: str, root: Path, *, default_branch: str = "main") -> Repo:
+        instance = cls(repo, root, default_branch=default_branch)
+        # `actions/checkout` doesn't configure a committer
+        instance.git("config", "user.name", "mlflow-app[bot]")
+        instance.git("config", "user.email", "mlflow-app[bot]@users.noreply.github.com")
+        return instance
 
     def git(self, *args: str) -> None:
         subprocess.check_call(["git", *args], cwd=self.root)
@@ -54,9 +43,6 @@ class Repo:
         return result.returncode != 0
 
     def create_pr(self, *, head: str, title: str, body: str) -> str:
-        if not self.token:
-            raise ValueError("Cannot create PR without a token")
-        env = {**os.environ, "GH_TOKEN": self.token}
         output = subprocess.check_output(
             [
                 "gh",
@@ -74,7 +60,6 @@ class Repo:
                 body,
             ],
             text=True,
-            env=env,
         )
         return output.strip()
 
@@ -97,49 +82,45 @@ def build_docs(args: argparse.Namespace) -> None:
     subprocess.check_call(["npm", "ci"], cwd=docs_dir, env=env)
     subprocess.check_call(["npm", "run", "build-all", "--", "--use-npm"], cwd=docs_dir, env=env)
 
-    with Repo.clone(
-        repo="mlflow/mlflow-legacy-website",
-        branch="main",
-        token=args.token,
-    ) as website_repo:
-        branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
-        website_repo.git("checkout", "-b", branch_name)
+    website_repo = Repo.open("mlflow/mlflow-legacy-website", Path(args.website_dir).resolve())
+    branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
+    website_repo.git("checkout", "-b", branch_name)
 
-        version = Version(release_version)
+    version = Version(release_version)
 
-        _remove_stale_prereleases(website_repo.root / "docs", version)
+    _remove_stale_prereleases(website_repo.root / "docs", version)
 
-        # Copy built docs. `build-all.py` produces a separate build per target
-        # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
-        # so we must copy from the matching directory rather than reusing one source.
-        for dest_name in _version_targets(version, website_repo.root):
-            src = docs_dir / "build" / dest_name
-            dst = website_repo.root / "docs" / dest_name
-            if dst.exists():
-                shutil.rmtree(dst)
-            shutil.copytree(src, dst)
+    # Copy built docs. `build-all.py` produces a separate build per target
+    # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
+    # so we must copy from the matching directory rather than reusing one source.
+    for dest_name in _version_targets(version, website_repo.root):
+        src = docs_dir / "build" / dest_name
+        dst = website_repo.root / "docs" / dest_name
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
 
-        # Update versions.json
-        _update_versions_json(website_repo.root / "docs" / "versions.json", version)
+    # Update versions.json
+    _update_versions_json(website_repo.root / "docs" / "versions.json", version)
 
-        website_repo.git("add", "-A")
+    website_repo.git("add", "-A")
 
-        if not website_repo.has_changes():
-            print("No changes to commit, skipping.")
-            return
+    if not website_repo.has_changes():
+        print("No changes to commit, skipping.")
+        return
 
-        website_repo.git("commit", "-m", "Add docs")
+    website_repo.git("commit", "-m", "Add docs")
 
-        if args.dry_run:
-            return
+    if args.dry_run:
+        return
 
-        website_repo.git("push", "origin", branch_name)
-        pr_url = website_repo.create_pr(
-            head=branch_name,
-            title=f"Add documentation for {release_version}",
-            body="",
-        )
-        print(f"Created {pr_url}")
+    website_repo.git("push", "origin", branch_name)
+    pr_url = website_repo.create_pr(
+        head=branch_name,
+        title=f"Add documentation for {release_version}",
+        body="",
+    )
+    print(f"Created {pr_url}")
 
 
 def _remove_stale_prereleases(docs_root: Path, version: Version) -> None:
@@ -190,37 +171,33 @@ def release_post(args: argparse.Namespace) -> None:
     release_version = _read_version(mlflow_dir)
     print(f"Creating release post for MLflow {release_version}")
 
-    with Repo.clone(
-        repo="mlflow/mlflow-website",
-        branch="main",
-        token=args.token,
-    ) as website_repo:
-        branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
-        website_repo.git("checkout", "-b", branch_name)
+    website_repo = Repo.open("mlflow/mlflow-website", Path(args.website_dir).resolve())
+    branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
+    website_repo.git("checkout", "-b", branch_name)
 
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        name = f"{today}-{release_version}-release.md"
-        post_path = website_repo.root / "website" / "releases" / name
-        post_path.write_text(_render_release_post(Version(release_version)))
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    name = f"{today}-{release_version}-release.md"
+    post_path = website_repo.root / "website" / "releases" / name
+    post_path.write_text(_render_release_post(Version(release_version)))
 
-        website_repo.git("add", "-A")
+    website_repo.git("add", "-A")
 
-        if not website_repo.has_changes():
-            print("No changes to commit, skipping.")
-            return
+    if not website_repo.has_changes():
+        print("No changes to commit, skipping.")
+        return
 
-        website_repo.git("commit", "-m", "Add release post")
+    website_repo.git("commit", "-m", "Add release post")
 
-        if args.dry_run:
-            return
+    if args.dry_run:
+        return
 
-        website_repo.git("push", "origin", branch_name)
-        pr_url = website_repo.create_pr(
-            head=branch_name,
-            title=f"Add release post for {release_version}",
-            body="Be sure to fill in the contents",
-        )
-        print(f"Created {pr_url}")
+    website_repo.git("push", "origin", branch_name)
+    pr_url = website_repo.create_pr(
+        head=branch_name,
+        title=f"Add release post for {release_version}",
+        body="Be sure to fill in the contents",
+    )
+    print(f"Created {pr_url}")
 
 
 def _render_release_post(version: Version) -> str:
@@ -271,11 +248,6 @@ def parse_args() -> argparse.Namespace:
         help="Path to the local MLflow repository checkout",
     )
     parser.add_argument(
-        "--token",
-        default=os.environ.get("GH_TOKEN"),
-        help="GitHub token for pushing and creating PRs (default: $GH_TOKEN)",
-    )
-    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Skip push and PR creation",
@@ -284,7 +256,17 @@ def parse_args() -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest="command", required=True)
     docs_parser = subparsers.add_parser("build-docs", help="Build and publish MLflow documentation")
     docs_parser.add_argument("--gtm-id", default="GTM-TEST", help="Google Tag Manager ID")
-    subparsers.add_parser("release-post", help="Create a release post")
+    docs_parser.add_argument(
+        "--website-dir",
+        required=True,
+        help="Path to a mlflow/mlflow-legacy-website checkout to publish into",
+    )
+    post_parser = subparsers.add_parser("release-post", help="Create a release post")
+    post_parser.add_argument(
+        "--website-dir",
+        required=True,
+        help="Path to a mlflow/mlflow-website checkout to publish into",
+    )
     return parser.parse_args()
 
 

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -96,6 +96,8 @@ def build_docs(args: argparse.Namespace) -> None:
     # Copy built docs. `build-all.py` produces a separate build per target
     # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
     # so we must copy from the matching directory rather than reusing one source.
+    # It names them with the raw version, which agrees with `str(Version(...))`
+    # only while releases stay PEP 440 canonical.
     for dest_name in _version_targets(version, website_repo.root):
         src = docs_dir / "build" / dest_name
         dst = website_repo.root / "docs" / dest_name

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -96,8 +96,6 @@ def build_docs(args: argparse.Namespace) -> None:
     # Copy built docs. `build-all.py` produces a separate build per target
     # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
     # so we must copy from the matching directory rather than reusing one source.
-    # It names them with the raw version, which agrees with `str(Version(...))`
-    # only while releases stay PEP 440 canonical.
     for dest_name in _version_targets(version, website_repo.root):
         src = docs_dir / "build" / dest_name
         dst = website_repo.root / "docs" / dest_name


### PR DESCRIPTION
### Related Issues/PRs

Supersedes #22314

### What changes are proposed in this pull request?

Add a `workflow_dispatch` workflow and `dev/build_docs.py` to automate building and publishing MLflow release documentation, replacing the internal doc build process.

A single dispatch takes the release ref and does both steps in one run:

- `ref` (required): branch, tag or SHA to build from (e.g. `branch-3.15`)
- `release_post` (default `true`): also open a release post PR on `mlflow/mlflow-website`
- `dry_run` (default `false`): build and commit locally, but skip push and PR creation

The docs build pushes to `mlflow/mlflow-legacy-website` and opens a PR there. The release post step runs first since it's cheap, so a failure in the hour-long docs build doesn't cost us the post.

Since a dispatch-only workflow is otherwise only exercised at release time, a `test` job runs both commands with `--dry-run` on PRs that touch `dev/build_docs.py`, this workflow, or `docs.yml` (whose build steps the script mirrors). `--dry-run` clones the website repos and commits locally but skips push and PR creation, so the job needs no token.

This is a revival of #22314, which was closed for inactivity.

### How is this PR tested?

- [x] Manual tests

Both commands were tested end-to-end in #22314, with real push and PR creation:

- `release-post`: https://github.com/mlflow/mlflow-website/pull/551
- `build-docs`: https://github.com/mlflow/mlflow-legacy-website/pull/144

The `test` job re-runs both in dry-run mode on this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)