### PR TITLE
fix(tracing): isolate span data upload errors and warn on empty trace (#24783)

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -119,7 +119,9 @@ class MlflowV3SpanExporter(SpanExporter):
         spans_by_experiment = defaultdict(list)
 
         for span in spans:
-            mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
+            mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(
+                span.context.trace_id
+            )
             if mlflow_trace_id is None:
                 continue
             span_id = encode_span_id(span.context.span_id)
@@ -176,10 +178,14 @@ class MlflowV3SpanExporter(SpanExporter):
 
             self._do_export_trace(manager, span)
 
-    def _do_export_trace(self, manager: InMemoryTraceManager, span: ReadableSpan) -> None:
+    def _do_export_trace(
+        self, manager: InMemoryTraceManager, span: ReadableSpan
+    ) -> None:
         manager_trace = manager.pop_trace(span.context.trace_id)
         if manager_trace is None:
-            _logger.debug(f"Trace for root span {span} not found. Skipping full export.")
+            _logger.debug(
+                f"Trace for root span {span} not found. Skipping full export."
+            )
             return
 
         if manager_trace.is_remote_trace and not self._store_supports_log_spans:
@@ -245,20 +251,31 @@ class MlflowV3SpanExporter(SpanExporter):
         2. Upload the trace data to blob storage using the returned trace info.
         """
         returned_trace_info = None
-        try:
-            if trace:
-                add_size_stats_to_trace_metadata(trace)
-                returned_trace_info = self._client.start_trace(trace.info)
+        if not trace:
+            _logger.warning("No trace or trace info provided, unable to export")
+            return
 
-                if self._should_log_spans_to_artifacts(returned_trace_info):
-                    self._client._upload_trace_data(returned_trace_info, trace.data)
-            else:
-                _logger.warning("No trace or trace info provided, unable to export")
+        try:
+            add_size_stats_to_trace_metadata(trace)
+            returned_trace_info = self._client.start_trace(trace.info)
         except Exception as e:
             _logger.warning(
                 f"Failed to send trace to MLflow backend: {e}",
                 exc_info=_logger.isEnabledFor(logging.DEBUG),
             )
+
+        if returned_trace_info and self._should_log_spans_to_artifacts(
+            returned_trace_info
+        ):
+            try:
+                self._client._upload_trace_data(returned_trace_info, trace.data)
+            except Exception as e:
+                _logger.warning(
+                    f"Trace {returned_trace_info.trace_id} was created, but its span data failed to "
+                    f"upload ({e}). The trace will appear empty in the MLflow UI. Check that the "
+                    "tracking server's artifact store is reachable and credentialed.",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
 
         # Upload attachments in a separate try-except so trace data still lands
         # even if attachment upload fails. Runs regardless of span storage mode —
@@ -307,8 +324,8 @@ class MlflowV3SpanExporter(SpanExporter):
         return MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
 
     def _should_log_async(self) -> bool:
-        # During evaluate, the eval harness relies on the generated trace objects,
-        # so we should not log traces asynchronously.
+        # During evaluate or assertion tests, the harness relies on the generated
+        # trace objects being immediately available, so log synchronously.
         if maybe_get_request_id(is_evaluate=True):
             return False
 
@@ -329,4 +346,7 @@ class MlflowV3SpanExporter(SpanExporter):
         Whether to log spans to artifacts. Overridden by UC table exporter to False.
         """
         # We only log traces to artifacts when the tracking store doesn't support span logging
-        return trace_info.tags.get(TraceTagKey.SPANS_LOCATION) != SpansLocation.TRACKING_STORE.value
+        return (
+            trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+            != SpansLocation.TRACKING_STORE.value
+        )


### PR DESCRIPTION
## Related Issues/PRs

Fixes #24783

## What changes are proposed in this pull request?

In `MlflowV3SpanExporter._log_trace` (`mlflow/tracing/export/mlflow_v3.py`), trace creation (`self._client.start_trace`) and span data upload (`self._client._upload_trace_data`) were previously wrapped inside a single `try/except` block.

When span data upload fails (e.g., due to missing artifact store credentials like `AWS_ACCESS_KEY_ID`, proxy/network timeouts, or uncredentialed S3/MinIO buckets), the trace row is still persisted in the tracking store, but the spans fail to upload. This causes the trace to appear completely empty in the MLflow UI with only a generic failure warning.

This PR:
1. Splits trace initialization and span data upload into separate `try/except` blocks (mirroring the adjacent attachment upload error handling logic).
2. Emits an actionable, specific warning message when span data upload fails, informing the user that the trace was created but its span data failed to upload due to artifact store connectivity/credential issues. Fixes #24783.

## How is this PR tested?

- [ ] Existing unit tests
- [x] Code formatting and linting validated via `ruff format --isolated` and `ruff check --isolated`.
- [x] Verified that exceptions thrown during `_upload_trace_data` are caught independently without suppressing trace creation or affecting attachment uploads.

## Does this PR require documentation update?

- [ ] Yes
- [x] No

## Does this PR require updating the MLflow Skills repository?

- [ ] Yes
- [x] No

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Emits an actionable warning when trace span data fails to upload to the artifact store, clarifying that the trace was created but span data upload failed due to credential/connectivity issues.

### What component(s), interfaces, languages, and integrations does this PR affect?
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and CI infrastructure
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: LLM evaluation modules and tools
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the UI
- [ ] `area/models`: MLmodel format, flavor instances, and dependencies
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe UI
- [ ] `area/projects`: MLproject format, Project running concepts
- [ ] `area/scoring`: MLflow Model server, standard batch scoring commands
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/gateway`: AI Gateway service, APIs, and clients
- [ ] `area/stretchy-models`: Flex model support
- [x] `area/tracing`: MLflow Tracing features
- [ ] `area/uiux`: Front-end user interface

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR title in the git log
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix
- [ ] `rn/documentation` - A user-facing documentation update

### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] Yes
- [x] No