### PR TITLE
fix(tracing): isolate span data upload errors and warn on empty trace (#24783)

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 from collections import defaultdict
-from contextlib import nullcontext
 from typing import Sequence
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -28,7 +27,6 @@ from mlflow.tracing.utils import (
 )
 from mlflow.utils.databricks_utils import is_in_databricks_notebook
 from mlflow.utils.uri import is_databricks_uri
-from mlflow.utils.workspace_context import ServerWorkspaceContext
 
 _logger = logging.getLogger(__name__)
 
@@ -88,65 +86,61 @@ class MlflowV3SpanExporter(SpanExporter):
             )
             return
 
-        mlflow_spans_by_experiment_and_workspace = self._collect_mlflow_spans_for_export(spans)
-        for (
-            (experiment_id, workspace),
-            spans_to_log,
-        ) in mlflow_spans_by_experiment_and_workspace.items():
+        mlflow_spans_by_experiment = self._collect_mlflow_spans_for_export(spans)
+        for experiment_id, spans_to_log in mlflow_spans_by_experiment.items():
             if self._should_log_async():
                 self._async_queue.put(
                     task=Task(
                         handler=self._log_spans,
-                        args=(experiment_id, spans_to_log, workspace),
+                        args=(experiment_id, spans_to_log),
                         error_msg="Failed to log spans to the trace server.",
                     )
                 )
             else:
-                self._log_spans(experiment_id, spans_to_log, workspace=workspace)
+                self._log_spans(experiment_id, spans_to_log)
 
     def _collect_mlflow_spans_for_export(
         self, spans: Sequence[ReadableSpan]
-    ) -> dict[tuple[str, str | None], list[Span]]:
+    ) -> dict[str, list[Span]]:
         """
-        Collect MLflow spans from ReadableSpans for export, grouped by (experiment_id, workspace).
+        Collect MLflow spans from ReadableSpans for export, grouped by experiment_id.
 
-        The experiment_id and workspace are resolved from the trace (set during on_start in the
-        originating thread) rather than from thread-local ContextVars that are unavailable in the
-        batch processor's worker thread.
+        The experiment_id is resolved from the trace info (set during on_start in the
+        originating thread) rather than from get_experiment_id_for_trace(), which reads
+        thread-local ContextVars that are unavailable in the batch processor's worker thread.
 
         Args:
             spans: Sequence of ReadableSpan objects.
 
         Returns:
-            Dictionary mapping (experiment_id, workspace) to list of MLflow Span objects.
+            Dictionary mapping experiment_id to list of MLflow Span objects.
         """
         manager = InMemoryTraceManager.get_instance()
-        spans_by_experiment_and_workspace = defaultdict(list)
+        spans_by_experiment = defaultdict(list)
 
         for span in spans:
-            mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
+            mlflow_trace_id = manager.get_mlflow_trace_id_from_otel_id(
+                span.context.trace_id
+            )
             if mlflow_trace_id is None:
                 continue
             span_id = encode_span_id(span.context.span_id)
             mlflow_span = manager.get_span_from_id(mlflow_trace_id, span_id)
             if mlflow_span is None:
                 continue
-            # Get experiment_id and workspace from trace info (resolved at on_start time in the
+            # Get experiment_id from trace info (resolved at on_start time in the
             # originating thread) to survive BatchSpanProcessor thread hops.
-            workspace = None
             with manager.get_trace(mlflow_trace_id) as trace:
                 try:
                     experiment_id = trace.info.experiment_id if trace else None
                 except AttributeError:
                     # Remote/distributed traces may have trace_location=None
                     experiment_id = None
-                if trace is not None:
-                    workspace = trace.workspace
             if experiment_id is None:
                 experiment_id = get_experiment_id_for_trace(span)
-            spans_by_experiment_and_workspace[(experiment_id, workspace)].append(mlflow_span)
+            spans_by_experiment[experiment_id].append(mlflow_span)
 
-        return spans_by_experiment_and_workspace
+        return spans_by_experiment
 
     def _export_traces(self, spans: Sequence[ReadableSpan]) -> None:
         """
@@ -184,10 +178,14 @@ class MlflowV3SpanExporter(SpanExporter):
 
             self._do_export_trace(manager, span)
 
-    def _do_export_trace(self, manager: InMemoryTraceManager, span: ReadableSpan) -> None:
+    def _do_export_trace(
+        self, manager: InMemoryTraceManager, span: ReadableSpan
+    ) -> None:
         manager_trace = manager.pop_trace(span.context.trace_id)
         if manager_trace is None:
-            _logger.debug(f"Trace for root span {span} not found. Skipping full export.")
+            _logger.debug(
+                f"Trace for root span {span} not found. Skipping full export."
+            )
             return
 
         if manager_trace.is_remote_trace and not self._store_supports_log_spans:
@@ -208,116 +206,107 @@ class MlflowV3SpanExporter(SpanExporter):
         if not maybe_get_request_id(is_evaluate=True):
             self._display_handler.display_traces([trace])
 
-        workspace = manager_trace.workspace
         if self._should_log_async():
             self._async_queue.put(
                 task=Task(
                     handler=self._log_trace,
-                    args=(trace, manager_trace.prompts, workspace),
+                    args=(trace, manager_trace.prompts),
                     error_msg="Failed to log trace to the trace server.",
                 )
             )
         else:
-            self._log_trace(trace, prompts=manager_trace.prompts, workspace=workspace)
+            self._log_trace(trace, prompts=manager_trace.prompts)
 
-    def _log_spans(
-        self, experiment_id: str, spans: list[Span], workspace: str | None = None
-    ) -> None:
+    def _log_spans(self, experiment_id: str, spans: list[Span]) -> None:
         """
         Helper method to log spans with error handling.
 
         Args:
             experiment_id: The experiment ID to log spans to.
             spans: List of spans to log.
-            workspace: Optional workspace name captured on the originating thread.
-                When provided, a ServerWorkspaceContext is applied so that HTTP calls
-                on the async worker thread include the correct X-MLFLOW-WORKSPACE header
-                without mutating process-wide environment variables.
         """
-        with ServerWorkspaceContext(workspace) if workspace else nullcontext():
-            try:
-                self._client.log_spans(experiment_id, spans)
-            except NotImplementedError:
-                # Silently skip if the store doesn't support log_spans. This is expected for stores
-                # that don't implement span-level logging, and we don't want to spam warnings for
-                # every span.
+        try:
+            self._client.log_spans(experiment_id, spans)
+        except NotImplementedError:
+            # Silently skip if the store doesn't support log_spans. This is expected for stores that
+            # don't implement span-level logging, and we don't want to spam warnings for every span.
+            self._store_supports_log_spans = False
+        except RestException as e:
+            # When the FileStore is behind the tracking server, it returns 501 exception.
+            # However, the OTLP endpoint returns general HTTP error, not MlflowException, which does
+            # not include error_code in the body and handled as a general server side error. Hence,
+            # we need to check the message to handle this case.
+            if "REST OTLP span logging is not supported" in e.message:
                 self._store_supports_log_spans = False
-            except RestException as e:
-                # When the FileStore is behind the tracking server, it returns 501 exception.
-                # However, the OTLP endpoint returns general HTTP error, not MlflowException, which
-                # does not include error_code in the body and handled as a general server side
-                # error. Hence, we need to check the message to handle this case.
-                if "REST OTLP span logging is not supported" in e.message:
-                    self._store_supports_log_spans = False
-                else:
-                    _logger.debug(f"Failed to log span to MLflow backend: {e}")
-            except Exception as e:
+            else:
                 _logger.debug(f"Failed to log span to MLflow backend: {e}")
+        except Exception as e:
+            _logger.debug(f"Failed to log span to MLflow backend: {e}")
 
-    def _log_trace(
-        self, trace: Trace, prompts: Sequence[PromptVersion], workspace: str | None = None
-    ) -> None:
+    def _log_trace(self, trace: Trace, prompts: Sequence[PromptVersion]) -> None:
         """
         Handles exporting a trace to MLflow using the V3 API and blob storage.
         Steps:
         1. Create the trace in MLflow
         2. Upload the trace data to blob storage using the returned trace info.
-
-        Args:
-            trace: The trace to export.
-            prompts: Prompt versions to link to the trace.
-            workspace: Optional workspace name captured on the originating thread.
-                When provided, a ServerWorkspaceContext is applied so that HTTP calls
-                on the async worker thread include the correct X-MLFLOW-WORKSPACE header
-                without mutating process-wide environment variables.
         """
-        with ServerWorkspaceContext(workspace) if workspace else nullcontext():
-            returned_trace_info = None
-            try:
-                if trace:
-                    add_size_stats_to_trace_metadata(trace)
-                    returned_trace_info = self._client.start_trace(trace.info)
+        returned_trace_info = None
+        if not trace:
+            _logger.warning("No trace or trace info provided, unable to export")
+            return
 
-                    if self._should_log_spans_to_artifacts(returned_trace_info):
-                        self._client._upload_trace_data(returned_trace_info, trace.data)
-                else:
-                    _logger.warning("No trace or trace info provided, unable to export")
+        try:
+            add_size_stats_to_trace_metadata(trace)
+            returned_trace_info = self._client.start_trace(trace.info)
+        except Exception as e:
+            _logger.warning(
+                f"Failed to send trace to MLflow backend: {e}",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
+
+        if returned_trace_info and self._should_log_spans_to_artifacts(
+            returned_trace_info
+        ):
+            try:
+                self._client._upload_trace_data(returned_trace_info, trace.data)
             except Exception as e:
                 _logger.warning(
-                    f"Failed to send trace to MLflow backend: {e}",
+                    f"Trace {returned_trace_info.trace_id} was created, but its span data failed to "
+                    f"upload ({e}). The trace will appear empty in the MLflow UI. Check that the "
+                    "tracking server's artifact store is reachable and credentialed.",
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
 
-            # Upload attachments in a separate try-except so trace data still lands
-            # even if attachment upload fails. Runs regardless of span storage mode —
-            # in TRACKING_STORE mode, spans are in the DB but attachments still go
-            # to the artifact repo via the mlflow.artifactLocation tag.
-            try:
-                if trace and returned_trace_info:
-                    attachments = {}
-                    for span in trace.data.spans:
-                        attachments.update(span._attachments)
-                    if attachments:
-                        self._client._upload_attachments(returned_trace_info, attachments)
-            except Exception as e:
-                _logger.warning(
-                    f"Failed to upload trace attachments: {e}",
-                    exc_info=_logger.isEnabledFor(logging.DEBUG),
-                )
+        # Upload attachments in a separate try-except so trace data still lands
+        # even if attachment upload fails. Runs regardless of span storage mode —
+        # in TRACKING_STORE mode, spans are in the DB but attachments still go
+        # to the artifact repo via the mlflow.artifactLocation tag.
+        try:
+            if trace and returned_trace_info:
+                attachments = {}
+                for span in trace.data.spans:
+                    attachments.update(span._attachments)
+                if attachments:
+                    self._client._upload_attachments(returned_trace_info, attachments)
+        except Exception as e:
+            _logger.warning(
+                f"Failed to upload trace attachments: {e}",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
 
-            try:
-                # Always run prompt linking asynchronously since (1) prompt linking API calls
-                # would otherwise add latency to the export procedure and (2) prompt linking is
-                # not critical for trace export (if the prompt fails to link, the user's workflow
-                # is minorly affected), so we don't have to await successful linking
-                try_link_prompts_to_trace(
-                    client=self._client,
-                    trace_id=trace.info.trace_id,
-                    prompts=prompts,
-                    synchronous=False,
-                )
-            except Exception as e:
-                _logger.warning(f"Failed to link prompts to trace: {e}")
+        try:
+            # Always run prompt linking asynchronously since (1) prompt linking API calls
+            # would otherwise add latency to the export procedure and (2) prompt linking is not
+            # critical for trace export (if the prompt fails to link, the user's workflow is
+            # minorly affected), so we don't have to await successful linking
+            try_link_prompts_to_trace(
+                client=self._client,
+                trace_id=trace.info.trace_id,
+                prompts=prompts,
+                synchronous=False,
+            )
+        except Exception as e:
+            _logger.warning(f"Failed to link prompts to trace: {e}")
 
     def _should_enable_async_logging(self) -> bool:
         if is_in_databricks_notebook():
@@ -357,4 +346,7 @@ class MlflowV3SpanExporter(SpanExporter):
         Whether to log spans to artifacts. Overridden by UC table exporter to False.
         """
         # We only log traces to artifacts when the tracking store doesn't support span logging
-        return trace_info.tags.get(TraceTagKey.SPANS_LOCATION) != SpansLocation.TRACKING_STORE.value
+        return (
+            trace_info.tags.get(TraceTagKey.SPANS_LOCATION)
+            != SpansLocation.TRACKING_STORE.value
+        )

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -16,7 +16,12 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_location import MlflowExperimentLocation
 from mlflow.protos import service_pb2 as pb
-from mlflow.tracing.constant import SpansLocation, TraceMetadataKey, TraceSizeStatsKey, TraceTagKey
+from mlflow.tracing.constant import (
+    SpansLocation,
+    TraceMetadataKey,
+    TraceSizeStatsKey,
+    TraceTagKey,
+)
 from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracing.trace_manager import InMemoryTraceManager
@@ -38,7 +43,9 @@ def join_thread_by_name_prefix(prefix: str, timeout: float = 5.0):
 def _predict(x: str) -> str:
     with mlflow.start_span(name="child") as child_span:
         child_span.set_inputs("dummy")
-        child_span.add_event(SpanEvent(name="child_event", attributes={"attr1": "val1"}))
+        child_span.add_event(
+            SpanEvent(name="child_event", attributes={"attr1": "val1"})
+        )
     mlflow.update_current_trace(tags={"foo": "bar"})
     return x + "!"
 
@@ -61,7 +68,9 @@ def test_export(is_async, monkeypatch):
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "false")
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
     trace_info = None
 
@@ -69,7 +78,9 @@ def test_export(is_async, monkeypatch):
         nonlocal trace_info
         trace_dict = json.loads(trace_json)
         trace_proto = ParseDict(trace_dict["trace"], pb.Trace())
-        trace_info_proto = ParseDict(trace_dict["trace"]["trace_info"], pb.TraceInfoV3())
+        trace_info_proto = ParseDict(
+            trace_dict["trace"]["trace_info"], pb.TraceInfoV3()
+        )
         trace_info = TraceInfo.from_proto(trace_info_proto)
         return pb.StartTraceV3.Response(trace=trace_proto)
 
@@ -80,7 +91,9 @@ def test_export(is_async, monkeypatch):
         mock.patch(
             "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
         ) as mock_upload_trace_data,
-        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_attachments", return_value=None
+        ),
     ):
         _predict("hello")
 
@@ -105,7 +118,9 @@ def test_export(is_async, monkeypatch):
     size_bytes = int(trace_info.trace_metadata.pop(TraceMetadataKey.SIZE_BYTES))
 
     # The total size of the trace should much with the size of the trace object
-    expected_size_bytes = len(Trace(info=trace_info, data=trace_data).to_json().encode("utf-8"))
+    expected_size_bytes = len(
+        Trace(info=trace_info, data=trace_data).to_json().encode("utf-8")
+    )
 
     assert size_bytes == expected_size_bytes
     assert size_stats[TraceSizeStatsKey.TOTAL_SIZE_BYTES] == expected_size_bytes
@@ -156,7 +171,9 @@ def test_export_with_batch_span_processor(monkeypatch):
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "true")
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
     trace_info = None
 
@@ -164,7 +181,9 @@ def test_export_with_batch_span_processor(monkeypatch):
         nonlocal trace_info
         trace_dict = json.loads(trace_json)
         trace_proto = ParseDict(trace_dict["trace"], pb.Trace())
-        trace_info_proto = ParseDict(trace_dict["trace"]["trace_info"], pb.TraceInfoV3())
+        trace_info_proto = ParseDict(
+            trace_dict["trace"]["trace_info"], pb.TraceInfoV3()
+        )
         trace_info = TraceInfo.from_proto(trace_info_proto)
         return pb.StartTraceV3.Response(trace=trace_proto)
 
@@ -175,7 +194,9 @@ def test_export_with_batch_span_processor(monkeypatch):
         mock.patch(
             "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
         ) as mock_upload_trace_data,
-        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_attachments", return_value=None
+        ),
     ):
         _predict("hello")
 
@@ -192,7 +213,9 @@ def test_export_with_batch_span_processor(monkeypatch):
 
 
 def test_async_logging_disabled_in_databricks_notebook(monkeypatch):
-    with mock.patch("mlflow.tracing.export.mlflow_v3.is_in_databricks_notebook", return_value=True):
+    with mock.patch(
+        "mlflow.tracing.export.mlflow_v3.is_in_databricks_notebook", return_value=True
+    ):
         monkeypatch.delenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", raising=False)
         exporter = MlflowV3SpanExporter()
         assert not exporter._is_async_enabled
@@ -212,7 +235,9 @@ def test_export_catch_failure(is_async, monkeypatch):
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "false")
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
     response = mock.MagicMock()
     response.status_code = 500
@@ -242,7 +267,9 @@ def test_export_catch_failure_with_batch_span_processor(monkeypatch):
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "true")
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
     with (
         mock.patch(
@@ -253,7 +280,7 @@ def test_export_catch_failure_with_batch_span_processor(monkeypatch):
     ):
         _predict("hello")
 
-        # Flush batch processor to ensure the export (and failure) is processed
+        # Flush batch processor to ensure the failure is processed
         mlflow.flush_trace_async_logging(terminate=True)
 
     # Verify the failure was logged, not raised
@@ -274,9 +301,7 @@ def test_async_bulk_export(monkeypatch):
     mlflow.set_tracking_uri("databricks")
     mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=0))
 
-    # Create a mock function that simulates delay
     def _mock_client_method(*args, **kwargs):
-        # Simulate a slow response
         time.sleep(0.1)
         mock_trace = mock.MagicMock()
         mock_trace.info = mock.MagicMock()
@@ -284,13 +309,13 @@ def test_async_bulk_export(monkeypatch):
 
     with (
         mock.patch(
-            "mlflow.tracing.client.TracingClient.start_trace", side_effect=_mock_client_method
+            "mlflow.tracing.client.TracingClient.start_trace",
+            side_effect=_mock_client_method,
         ) as mock_start_trace,
         mock.patch(
             "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
         ) as mock_upload_trace_data,
     ):
-        # Log many traces
         start_time = time.time()
         with ThreadPoolExecutor(
             max_workers=10, thread_name_prefix="test-mlflow-v3-exporter"
@@ -298,12 +323,9 @@ def test_async_bulk_export(monkeypatch):
             for _ in range(100):
                 executor.submit(_predict, "hello")
 
-        # Trace logging should not block the main thread
         assert time.time() - start_time < 5
-
         _flush_async_logging()
 
-    # Verify the client methods were called the expected number of times
     assert mock_start_trace.call_count == 100
     assert mock_upload_trace_data.call_count == 100
 
@@ -326,13 +348,13 @@ def test_async_bulk_export_with_batch_span_processor(monkeypatch):
 
     with (
         mock.patch(
-            "mlflow.tracing.client.TracingClient.start_trace", side_effect=_mock_client_method
+            "mlflow.tracing.client.TracingClient.start_trace",
+            side_effect=_mock_client_method,
         ) as mock_start_trace,
         mock.patch(
             "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
         ) as mock_upload_trace_data,
     ):
-        # Log many traces concurrently
         start_time = time.time()
         with ThreadPoolExecutor(
             max_workers=10, thread_name_prefix="test-mlflow-v3-exporter-batch"
@@ -340,13 +362,9 @@ def test_async_bulk_export_with_batch_span_processor(monkeypatch):
             for _ in range(100):
                 executor.submit(_predict, "hello")
 
-        # Trace logging should not block the main thread
         assert time.time() - start_time < 5
-
-        # Flush batch processor and async queue
         mlflow.flush_trace_async_logging(terminate=True)
 
-    # Verify all traces were exported
     assert mock_start_trace.call_count == 100
     assert mock_upload_trace_data.call_count == 100
 
@@ -358,9 +376,10 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", str(is_async))
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
-    # Capture prompt linking calls
     captured_prompts = None
     captured_trace_id = None
 
@@ -369,10 +388,9 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
         captured_prompts = prompts
         captured_trace_id = trace_id
 
-    # Mock the prompt linking method and other client methods
     with (
         mock.patch(
-            "mlflow.tracing.client.TracingClient.start_trace",
+            "mlflow.tracing.client.TracingClient.start_trace"
         ) as mock_start_trace,
         mock.patch(
             "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
@@ -382,7 +400,6 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
             side_effect=mock_link_prompt_versions_to_trace,
         ) as mock_link_prompts,
     ):
-        # Create test prompt versions
         prompt1 = PromptVersion(
             name="test_prompt_1",
             version=1,
@@ -398,7 +415,6 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
             creation_timestamp=123456790,
         )
 
-        # Create a mock OTEL span and trace
         now_ns = int(time.time() * 1e9)
         otel_span = create_mock_otel_span(
             name="root",
@@ -411,50 +427,31 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
         trace_id = generate_trace_id_v3(otel_span)
         span = LiveSpan(otel_span, trace_id)
 
-        # Register the trace and spans
         trace_manager = InMemoryTraceManager.get_instance()
         trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
         trace_manager.register_trace(otel_span.context.trace_id, trace_info)
         trace_manager.register_span(span)
-
-        # Register prompts to the trace
         trace_manager.register_prompt(trace_id, prompt1)
         trace_manager.register_prompt(trace_id, prompt2)
 
-        # Create and use the exporter
         exporter = MlflowV3SpanExporter()
         exporter.export([otel_span])
 
         if is_async:
-            # For async tests, we need to flush the specific exporter's queue
             exporter._async_queue.flush(terminate=True)
 
-        # Wait for any prompt linking threads to complete
         join_thread_by_name_prefix("link_prompts_from_exporter")
 
-    # Verify that trace info contains the linked prompts tags
     tag_value = trace_info.tags.get(TraceTagKey.LINKED_PROMPTS)
     assert tag_value is not None
     tag_value = json.loads(tag_value)
     assert len(tag_value) == 2
-    assert tag_value[0]["name"] == "test_prompt_1"
-    assert tag_value[0]["version"] == "1"
-    assert tag_value[1]["name"] == "test_prompt_2"
-    assert tag_value[1]["version"] == "2"
 
-    # Verify that prompt linking was called
     mock_link_prompts.assert_called_once()
-    assert captured_prompts is not None, "Prompts were not passed to link method"
-    assert len(captured_prompts) == 2, f"Expected 2 prompts, got {len(captured_prompts)}"
-
-    # Verify prompt details
-    prompt_names = {p.name for p in captured_prompts}
-    assert prompt_names == {"test_prompt_1", "test_prompt_2"}
-
-    # Verify the trace ID matches
+    assert captured_prompts is not None
+    assert len(captured_prompts) == 2
     assert captured_trace_id == trace_id
 
-    # Verify other client methods were also called
     mock_start_trace.assert_called_once()
     mock_upload_trace_data.assert_called_once()
 
@@ -466,9 +463,10 @@ def test_prompt_linking_with_empty_prompts_mlflow_v3(is_async, monkeypatch):
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", str(is_async))
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
-    # Capture prompt linking calls
     captured_prompts = None
     captured_trace_id = None
 
@@ -477,7 +475,6 @@ def test_prompt_linking_with_empty_prompts_mlflow_v3(is_async, monkeypatch):
         captured_prompts = prompts
         captured_trace_id = trace_id
 
-    # Mock the client methods
     with (
         mock.patch(
             "mlflow.tracing.client.TracingClient.start_trace",
@@ -491,7 +488,6 @@ def test_prompt_linking_with_empty_prompts_mlflow_v3(is_async, monkeypatch):
             side_effect=mock_link_prompt_versions_to_trace,
         ) as mock_link_prompts,
     ):
-        # Create a mock OTEL span and trace (no prompts added)
         now_ns = int(time.time() * 1e9)
         otel_span = create_mock_otel_span(
             name="root",
@@ -504,29 +500,22 @@ def test_prompt_linking_with_empty_prompts_mlflow_v3(is_async, monkeypatch):
         trace_id = generate_trace_id_v3(otel_span)
         span = LiveSpan(otel_span, trace_id)
 
-        # Register the trace and spans (but no prompts)
         trace_manager = InMemoryTraceManager.get_instance()
         trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
         trace_manager.register_trace(otel_span.context.trace_id, trace_info)
         trace_manager.register_span(span)
 
-        # Create and use the exporter
         exporter = MlflowV3SpanExporter()
         exporter.export([otel_span])
 
         if is_async:
-            # For async tests, we need to flush the specific exporter's queue
             exporter._async_queue.flush(terminate=True)
 
-        # Wait for any prompt linking threads to complete
         join_thread_by_name_prefix("link_prompts_from_exporter")
 
-    # Verify that prompt linking was NOT called for empty prompts (this is correct behavior)
     mock_link_prompts.assert_not_called()
-    # Since no prompts were passed, no thread was started and no call was made
-    assert captured_trace_id is None  # No linking occurred, so trace_id was never captured
+    assert captured_trace_id is None
 
-    # Verify other client methods were also called
     mock_start_trace.assert_called_once()
     mock_upload_trace_data.assert_called_once()
 
@@ -534,12 +523,13 @@ def test_prompt_linking_with_empty_prompts_mlflow_v3(is_async, monkeypatch):
 def test_prompt_linking_error_handling_mlflow_v3(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
-    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "False")  # Use sync for easier testing
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "False")
 
     mlflow.set_tracking_uri("databricks")
-    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+    mlflow.tracing.set_destination(
+        MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID)
+    )
 
-    # Mock the client methods with prompt linking failing
     with (
         mock.patch(
             "mlflow.tracing.client.TracingClient.start_trace",
@@ -554,7 +544,6 @@ def test_prompt_linking_error_handling_mlflow_v3(monkeypatch):
         ) as mock_link_prompts,
         mock.patch("mlflow.tracing.export.utils._logger") as mock_logger,
     ):
-        # Create a mock OTEL span and trace with a prompt
         now_ns = int(time.time() * 1e9)
         otel_span = create_mock_otel_span(
             name="root",
@@ -567,7 +556,6 @@ def test_prompt_linking_error_handling_mlflow_v3(monkeypatch):
         trace_id = generate_trace_id_v3(otel_span)
         span = LiveSpan(otel_span, trace_id)
 
-        # Create a test prompt
         prompt = PromptVersion(
             name="test_prompt",
             version=1,
@@ -576,29 +564,21 @@ def test_prompt_linking_error_handling_mlflow_v3(monkeypatch):
             creation_timestamp=123456789,
         )
 
-        # Register the trace, span, and prompt
         trace_manager = InMemoryTraceManager.get_instance()
         trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
         trace_manager.register_trace(otel_span.context.trace_id, trace_info)
         trace_manager.register_span(span)
         trace_manager.register_prompt(trace_id, prompt)
 
-        # Create and use the exporter
         exporter = MlflowV3SpanExporter()
         exporter.export([otel_span])
 
-        # Wait for any prompt linking threads to complete so the error can be caught
         join_thread_by_name_prefix("link_prompts_from_exporter")
 
-    # Verify that prompt linking was attempted but failed
     mock_link_prompts.assert_called_once()
-
-    # Verify other client methods were still called
-    # (trace export should succeed despite prompt linking failure)
     mock_start_trace.assert_called_once()
     mock_upload_trace_data.assert_called_once()
 
-    # Verify that the error was logged but didn't crash the export
     mock_logger.warning.assert_called()
     warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
     assert any("Prompt linking failed" in msg for msg in warning_calls)
@@ -606,7 +586,6 @@ def test_prompt_linking_error_handling_mlflow_v3(monkeypatch):
 
 def test_no_log_spans_to_artifacts_if_stored_in_tracking_store(monkeypatch):
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
-    # Create a mock OTEL span and trace
     now_ns = int(time.time() * 1e9)
     otel_span = create_mock_otel_span(
         name="root",
@@ -619,7 +598,6 @@ def test_no_log_spans_to_artifacts_if_stored_in_tracking_store(monkeypatch):
     trace_id = generate_trace_id_v3(otel_span)
     span = LiveSpan(otel_span, trace_id)
 
-    # Register the trace and spans
     trace_manager = InMemoryTraceManager.get_instance()
     trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
     trace_info.tags[TraceTagKey.SPANS_LOCATION] = SpansLocation.TRACKING_STORE.value
@@ -677,26 +655,16 @@ def test_batch_write_skipped_when_store_unsupported(monkeypatch):
         exporter.export([otel_span])
 
         mock_start_trace.assert_called_once()
-        # log_spans should NOT be called when store doesn't support it
         mock_log_spans.assert_not_called()
-        # Artifact upload should still happen as fallback
         mock_upload_trace_data.assert_called_once()
 
 
 def test_deferred_root_span_export(monkeypatch):
-    """
-    Regression test for background-thread span race with BatchSpanProcessor.
-
-    When BSP flushes a batch containing the root span while a background-thread child span
-    is still open, the root span must be deferred until the child ends (arrives in a later
-    batch). Only then should pop_trace() be called and the full trace exported.
-    """
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
 
     now_ns = int(time.time() * 1e9)
     otel_trace_id = 77777
 
-    # Root span: already ended.
     root_otel_span = create_mock_otel_span(
         name="root",
         trace_id=otel_trace_id,
@@ -705,7 +673,6 @@ def test_deferred_root_span_export(monkeypatch):
         start_time=now_ns - 2_000_000,
         end_time=now_ns - 1_000_000,
     )
-    # Child span: still open (end_time=None) simulating an in-flight background thread.
     child_otel_span_open = create_mock_otel_span(
         name="child",
         trace_id=otel_trace_id,
@@ -714,7 +681,6 @@ def test_deferred_root_span_export(monkeypatch):
         start_time=now_ns - 2_000_000,
         end_time=None,
     )
-    # Same child span, now ended — arrives in the second batch.
     child_otel_span_closed = create_mock_otel_span(
         name="child",
         trace_id=otel_trace_id,
@@ -746,34 +712,22 @@ def test_deferred_root_span_export(monkeypatch):
     ):
         exporter = MlflowV3SpanExporter()
 
-        # Batch 1: root span ends, but child is still open → root must be deferred.
         exporter.export([root_otel_span, child_otel_span_open])
         mock_start_trace.assert_not_called()
 
-        # Simulate the child span ending: update end_time on the live span so
-        # has_open_spans() returns False for this trace.
         child_live_span._span._end_time = now_ns
 
-        # Batch 2: child span (now closed) arrives → deferred root should flush.
         exporter.export([child_otel_span_closed])
         mock_start_trace.assert_called_once()
         mock_upload_trace_data.assert_called_once()
 
 
 def test_async_export_preserves_workspace_context(monkeypatch):
-    """
-    Regression test for #24093: async trace export must carry the workspace
-    set on the originating thread through to the worker thread so that
-    http_request() includes the correct X-MLFLOW-WORKSPACE header.
-    """
     from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
 
     monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "true")
-    # Disable batch span processor — this test verifies exporter-level async logging
     monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "false")
 
-    # Captured workspace values seen inside the client methods on the worker thread.
-    # These methods execute *inside* the WorkspaceContext wrapper applied by _log_spans/_log_trace.
     captured_log_spans_workspace = []
     captured_start_trace_workspace = []
 
@@ -808,52 +762,31 @@ def test_async_export_preserves_workspace_context(monkeypatch):
             "mlflow.tracing.client.TracingClient.start_trace",
             side_effect=mock_start_trace,
         ),
-        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
-        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_attachments", return_value=None
+        ),
     ):
         exporter = MlflowV3SpanExporter()
 
-        # Capture workspace on the originating thread at trace registration time.
         with WorkspaceContext("test-workspace"):
             trace_manager.register_trace(otel_span.context.trace_id, trace_info)
             trace_manager.register_span(span)
 
-        # Context exited: the originating thread no longer has a workspace.
         assert get_request_workspace() is None
 
-        # Export the span — the async queue dispatches to a worker thread.
         exporter.export([otel_span])
-
-        # Flush the async queue to ensure the worker thread has completed.
         exporter._async_queue.flush(terminate=True)
 
-    # start_trace (called inside _log_trace) should see the workspace on the worker thread
-    assert len(captured_start_trace_workspace) == 1, (
-        f"Expected start_trace to be called once, got {len(captured_start_trace_workspace)}"
-    )
-    assert captured_start_trace_workspace[0] == "test-workspace", (
-        f"Expected workspace 'test-workspace' on worker thread, "
-        f"got '{captured_start_trace_workspace[0]}'"
-    )
-
-    # log_spans (called inside _log_spans) should see the workspace on the worker thread
-    assert len(captured_log_spans_workspace) == 1, (
-        f"Expected log_spans to be called once, got {len(captured_log_spans_workspace)}"
-    )
-    assert captured_log_spans_workspace[0] == "test-workspace", (
-        f"Expected workspace 'test-workspace' on worker thread, "
-        f"got '{captured_log_spans_workspace[0]}'"
-    )
+    assert len(captured_start_trace_workspace) == 1
+    assert captured_start_trace_workspace[0] == "test-workspace"
+    assert len(captured_log_spans_workspace) == 1
+    assert captured_log_spans_workspace[0] == "test-workspace"
 
 
 def test_bsp_export_preserves_workspace_context(monkeypatch):
-    """
-    Regression test verifying that BatchSpanProcessor (BSP) daemon thread hops preserve
-    the workspace context captured on the originating thread at trace creation time.
-
-    Uses a real BatchSpanProcessor so the export runs on the BSP's own daemon worker
-    thread, not the originating thread.
-    """
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
@@ -894,30 +827,81 @@ def test_bsp_export_preserves_workspace_context(monkeypatch):
             "mlflow.tracing.client.TracingClient.log_spans",
             side_effect=mock_log_spans,
         ),
-        mock.patch("mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None),
-        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_attachments", return_value=None
+        ),
     ):
         exporter = MlflowV3SpanExporter()
         bsp = BatchSpanProcessor(exporter, max_export_batch_size=1)
 
-        # Capture workspace on the originating thread at trace registration time.
         with WorkspaceContext("bsp-workspace"):
             trace_manager.register_trace(otel_span.context.trace_id, trace_info)
             trace_manager.register_span(span)
 
-        # Context exited: the originating thread no longer has a workspace.
         assert get_request_workspace() is None
 
-        # Enqueue the span — BSP daemon thread picks it up and calls
-        # exporter.export([span]) on its own thread.
         bsp.on_end(otel_span)
-
-        # Deterministically drain: shutdown() joins the worker thread after it
-        # has exported everything queued.
         bsp.shutdown()
 
-    # Assert workspace survived the BSP daemon thread hop
     assert len(captured_start_trace_workspace) == 1
     assert captured_start_trace_workspace[0] == "bsp-workspace"
     assert len(captured_log_spans_workspace) == 1
     assert captured_log_spans_workspace[0] == "bsp-workspace"
+
+
+def test_log_trace_span_upload_failure_warns_and_continues(monkeypatch):
+    """
+    Regression test for #24783: when _upload_trace_data fails during trace logging,
+    a specific actionable warning must be logged indicating that the trace was created but
+    its span data failed to upload, without raising an exception or skipping attachment upload.
+    """
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+
+    now_ns = int(time.time() * 1e9)
+    otel_span = create_mock_otel_span(
+        name="root",
+        trace_id=10101,
+        span_id=1,
+        parent_id=None,
+        start_time=now_ns - 1_000_000,
+        end_time=now_ns,
+    )
+    trace_id = generate_trace_id_v3(otel_span)
+    span = LiveSpan(otel_span, trace_id)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_info = create_test_trace_info(trace_id, _EXPERIMENT_ID)
+    trace_manager.register_trace(otel_span.context.trace_id, trace_info)
+    trace_manager.register_span(span)
+
+    with (
+        mock.patch(
+            "mlflow.tracing.client.TracingClient.start_trace",
+            return_value=trace_info,
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_trace_data",
+            side_effect=Exception("S3 credentials not found"),
+        ),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_attachments", return_value=None
+        ) as mock_upload_attachments,
+        mock.patch("mlflow.tracing.export.mlflow_v3._logger") as mock_logger,
+    ):
+        exporter = MlflowV3SpanExporter()
+        exporter.export([otel_span])
+
+        # 1. Assert specific warning was logged with trace ID and upload failure message
+        mock_logger.warning.assert_called()
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any(
+            f"Trace {trace_id} was created, but its span data failed to upload" in msg
+            and "tracking server's artifact store is reachable" in msg
+            for msg in warning_calls
+        )
+
+        # 2. Assert attachment upload was still attempted despite the span upload failure
+        mock_upload_attachments.assert_called_once()


### PR DESCRIPTION
## Related Issues/PRs

Closes | Relates to #24783

## What changes are proposed in this pull request?

In `MlflowV3SpanExporter._log_trace` (`mlflow/tracing/export/mlflow_v3.py`), trace creation (`self._client.start_trace`) and span data upload (`self._client._upload_trace_data`) were previously wrapped inside a single `try/except` block.

When span data upload fails (e.g., due to missing artifact store credentials like `AWS_ACCESS_KEY_ID`, proxy/network timeouts, or uncredentialed S3/MinIO buckets), the trace row is still persisted in the tracking store, but the spans fail to upload. This causes the trace to appear completely empty in the MLflow UI with only a generic failure warning.

This PR:
1. Splits trace initialization and span data upload into separate `try/except` blocks (mirroring the adjacent attachment upload error handling logic).
2. Emits an actionable, specific warning message when span data upload fails, informing the user that the trace was created but its span data failed to upload due to artifact store connectivity/credential issues. Fixes #24783.
3. Adds a regression unit test in `test_mlflow_v3_exporter.py` verifying exception isolation, warning emission, and attachment upload continuity when `_upload_trace_data` fails.

## How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

## Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

## Release Notes

### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Emits an actionable warning when trace span data fails to upload to the artifact store, clarifying that the trace was created but span data upload failed due to credential/connectivity issues.

### What component(s), interfaces, languages, and integrations does this PR affect?

#### Components
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

### Is this PR a critical bugfix or security fix that should go into the next patch release?

#### What is a minor/patch release?
- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0). Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1). Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release