### PR TITLE
Warn specifically when trace data upload fails, leaving an empty trace

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -277,14 +277,33 @@ class MlflowV3SpanExporter(SpanExporter):
                 if trace:
                     add_size_stats_to_trace_metadata(trace)
                     returned_trace_info = self._client.start_trace(trace.info)
-
-                    if self._should_log_spans_to_artifacts(returned_trace_info):
-                        self._client._upload_trace_data(returned_trace_info, trace.data)
                 else:
                     _logger.warning("No trace or trace info provided, unable to export")
             except Exception as e:
                 _logger.warning(
                     f"Failed to send trace to MLflow backend: {e}",
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
+                )
+
+            # Upload the trace *data* (spans) in a separate try/except from trace creation above.
+            # The trace row is already created, so if the data upload fails (e.g. missing
+            # artifact-store credentials or a proxy blocking the blob store) the trace still
+            # exists but renders EMPTY in the UI. Surface a specific, actionable warning rather
+            # than the generic "Failed to send trace" message so the empty-trace cause is
+            # discoverable. Mirrors the separate try/except used for attachment upload below.
+            try:
+                if (
+                    trace
+                    and returned_trace_info
+                    and self._should_log_spans_to_artifacts(returned_trace_info)
+                ):
+                    self._client._upload_trace_data(returned_trace_info, trace.data)
+            except Exception as e:
+                _logger.warning(
+                    f"Trace {trace.info.trace_id} was created but its span data failed to upload, "
+                    "so it will appear empty in the MLflow UI. Verify the tracking server's "
+                    "artifact store is reachable and credentialed (e.g. AWS_ACCESS_KEY_ID / "
+                    f"MLFLOW_S3_ENDPOINT_URL, and proxy/NO_PROXY settings): {e}",
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
 

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import threading
 import time
@@ -921,3 +922,39 @@ def test_bsp_export_preserves_workspace_context(monkeypatch):
     assert captured_start_trace_workspace[0] == "bsp-workspace"
     assert len(captured_log_spans_workspace) == 1
     assert captured_log_spans_workspace[0] == "bsp-workspace"
+
+
+def test_export_warns_specifically_when_trace_data_upload_fails(monkeypatch, caplog):
+    # start_trace succeeds (the trace row is created) but the span-data upload fails, e.g. the
+    # artifact store's credentials are missing or a proxy blocks it. The trace then renders EMPTY
+    # in the UI, so the exporter should log a specific, actionable warning rather than the generic
+    # "Failed to send trace to MLflow backend" message that conflates the two failure modes.
+    monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dummy-token")
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "false")
+    monkeypatch.setenv("MLFLOW_USE_BATCH_SPAN_PROCESSOR", "false")
+
+    mlflow.set_tracking_uri("databricks")
+    mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=_EXPERIMENT_ID))
+
+    def mock_response(credentials, path, method, trace_json, *args, **kwargs):
+        trace_dict = json.loads(trace_json)
+        trace_proto = ParseDict(trace_dict["trace"], pb.Trace())
+        return pb.StartTraceV3.Response(trace=trace_proto)
+
+    with (
+        mock.patch("mlflow.store.tracking.rest_store.call_endpoint", side_effect=mock_response),
+        mock.patch(
+            "mlflow.tracing.client.TracingClient._upload_trace_data",
+            side_effect=RuntimeError("Unable to locate credentials"),
+        ),
+        mock.patch("mlflow.tracing.client.TracingClient._upload_attachments", return_value=None),
+        caplog.at_level(logging.WARNING),
+    ):
+        _predict("hello")
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "will appear empty in the MLflow UI" in messages
+    assert "Unable to locate credentials" in messages
+    # the trace row was created successfully, so the generic "failed to send" warning must not fire
+    assert "Failed to send trace to MLflow backend" not in messages


### PR DESCRIPTION
### Related Issues/PRs

Closes #24783

### What changes are proposed in this pull request?

In `MlflowV3SpanExporter._log_trace` (`mlflow/tracing/export/mlflow_v3.py`), trace-row creation (`self._client.start_trace`) and span-data upload (`self._client._upload_trace_data`) were wrapped in a **single** `try/except`.

When the trace row is created but the span-data upload fails — missing artifact-store credentials (`AWS_ACCESS_KEY_ID` / `MLFLOW_S3_ENDPOINT_URL`), a proxy blocking the blob store, or an uncredentialed S3/MinIO bucket — the trace is persisted in the tracking store but its spans never upload. The trace then renders **completely empty** in the UI, while the only log line is the generic `Failed to send trace to MLflow backend`, which conflates two very different failure modes and gives no hint about the empty trace.

This PR splits the span-data upload into its **own** `try/except`, mirroring the separate attachment-upload block directly below it, and emits a specific, actionable warning that names the symptom (trace created but appears empty) and the likely cause (artifact-store reachability / credentials, and proxy / `NO_PROXY` settings). The successful path is unchanged; this is observability-only (`+22 / -3` in the exporter).

### How is this PR tested?

- [x] New unit/integration tests

New test `test_export_warns_specifically_when_trace_data_upload_fails` in `tests/tracing/export/test_mlflow_v3_exporter.py`: `start_trace` succeeds but `_upload_trace_data` raises `NoCredentialsError`; it asserts the new warning fires (`"will appear empty in the MLflow UI"`, `"Unable to locate credentials"`) and that the generic `"Failed to send trace to MLflow backend"` warning does **not** fire, since the trace row was created successfully.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
