### PR TITLE
Skip `free-disk-space` cleanup when the runner already has headroom

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -7,6 +7,14 @@ runs:
       run: |
         echo "Disk usage before cleanup:"
         df -h /
+        # Skip the cleanup when at least 40G is already free. GitHub only guarantees
+        # 14G, so it stays in place for runners that come up with less headroom.
+        # https://github.com/actions/runner-images/issues/14492
+        avail=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+        if [ "$avail" -ge 40 ]; then
+          echo "${avail}G available, skipping cleanup"
+          exit 0
+        fi
         # Remove large pre-installed toolchains that MLflow jobs never use so that
         # disk-heavy steps (e.g. Docker image builds) have enough headroom. The
         # deletions run in parallel to save time, but we `wait` for them to finish


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/actions/runner-images/issues/14492

### What changes are proposed in this pull request?

`free-disk-space` costs ~50s (median, up to ~78s) per job, and across the 11 jobs in a `master.yml` run that is roughly 9 minutes of runner time. On our runners it is reclaiming space we already have: the deletions free ~21G on a disk that already has ~88G available.

Per the runner-images issue above, the size is a property of the VM SKU. Public repos get the 4-core SKU with a 150G disk (~88G free); private repos get the 2-core SKU with a 75G disk (~18G free). GitHub only guarantees 14G free on either tier and will not commit to keeping 150G indefinitely, so this skips the cleanup when there is already headroom rather than removing it. If we ever land on a smaller disk the cleanup runs as before.

Supersedes the earlier `background: true` approach on this branch: backgrounding still pays the I/O cost and races the setup steps precisely when disk is tight, which is the case where the cleanup actually matters.

### How is this PR tested?

- [x] Existing unit/integration tests

CI on this PR is the test: jobs should log `skipping cleanup` and still pass without hitting ENOSPC.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
