### PR TITLE
fix: Use checkfirst when creating initial tables to avoid duplicate table errors (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading an existing MLflow database from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. The root cause is that `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, so it attempts to create all tables regardless of whether they already exist. If the database already contains some of these tables (e.g., from a previous migration or an existing deployment), `create_all` raises an error for the duplicate table and aborts the upgrade.

## Fix
Modify `_initialize_tables()` to pass `checkfirst=True` to `InitialBase.metadata.create_all()`. This ensures the method only creates tables that are missing, gracefully handling the case where some tables already exist. This change is safe and does not affect the subsequent `_upgrade_db()` call, which performs the actual Alembic migrations.

The fix is minimal and directly addresses the reported issue.

Closes #19943