### PR TITLE
Fix trace archival config test isolation for the stage URI test in `test_models_artifact_repo.py`

### DIFF
--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -140,7 +140,8 @@ def test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_reg
         )
 
 
-def test_models_artifact_repo_init_with_stage_uri_and_not_using_databricks_registry():
+def test_models_artifact_repo_init_with_stage_uri_and_not_using_databricks_registry(monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)
     model_uri = "models:/MyModel/Staging"
     artifact_location = "s3://blah_bucket/"
     model_version_detailed = ModelVersion(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24717

### What changes are proposed in this pull request?

Applies the same `MLFLOW_TRACE_ARCHIVAL_CONFIG` guard #24717 added to
`test_models_artifact_repo_init_with_version_uri_and_not_using_databricks_registry`
to its sibling `..._with_stage_uri_...`, which patches `get_artifact_repository()` to
return `None` the exact same way but was missed.

When the env var leaks into that test from an earlier one on the same xdist worker,
`ModelsArtifactRepository(model_uri)` -> `MlflowClient` -> `SqlAlchemyStore.get_experiment()`
-> `get_trace_archival_server_config()` re-validates the archival config (its cache TTL is 5s,
so this fires whenever the TTL happens to lapse mid-test). Validation calls the patched
`get_artifact_repository()`, gets `None`, and trips:

```
mlflow/utils/validation.py:240: in _validate_trace_archival_repository_support
    type(artifact_repo).delete_artifacts is ArtifactRepository.delete_artifacts
E   AttributeError: type object 'NoneType' has no attribute 'delete_artifacts'
```

Recent CI hits, all on unrelated branches:

| Date (UTC) | Branch | Job |
| --- | --- | --- |
| 2026-08-04 12:46 | `support-haystack-3` | [python (2)](https://github.com/mlflow/mlflow/actions/runs/30910606406/job/91996219762) |
| 2026-08-04 09:15 | `fix/assistant-windows-subprocess-loop` | [python (4)](https://github.com/mlflow/mlflow/actions/runs/30895548398/job/91947529170) |
| 2026-08-04 06:52 | `build-docs-workflow-dispatch` | [python (2)](https://github.com/mlflow/mlflow/actions/runs/30885548850/job/91915907254) |

This is a per-test band-aid, consistent with #24717. The general fix is to stop the env var
leaking in the first place (or clear it in an autouse fixture), since any test that patches
`get_artifact_repository` is exposed. Happy to follow up with that separately.

### How is this PR tested?

- [x] Existing unit/integration tests

```bash
uv run pytest tests/store/artifact/test_models_artifact_repo.py
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release