### PR TITLE
Preserve Databricks scorer compatibility behavior

### DIFF
--- a/mlflow/genai/scorers/registry.py
+++ b/mlflow/genai/scorers/registry.py
@@ -81,7 +81,7 @@ class _DatabricksScheduledScorerConfig(_DatabricksManagedScorerPayload):
     name: str
     sample_rate: float | None = None
     filter_string: str | None = None
-    scorer_version: int = 1
+    scorer_version: int | None = None
 
     @classmethod
     def from_scorer(
@@ -681,7 +681,10 @@ class DatabricksStore(AbstractScorerStore):
                 registered_payload[field] = current_payload[field]
             else:
                 registered_payload.pop(field, None)
-        registered_payload["scorer_version"] = configs[index].scorer_version
+        if configs[index].scorer_version is not None:
+            registered_payload["scorer_version"] = configs[index].scorer_version
+        else:
+            registered_payload.pop("scorer_version", None)
         configs[index] = _DatabricksScheduledScorerConfig.model_validate(registered_payload)
         return configs
 
@@ -729,9 +732,7 @@ class DatabricksStore(AbstractScorerStore):
         experiment_id: str | None = None,
     ) -> Scorer:
         """Update scheduling fields without changing the current scorer definition."""
-        experiment_id = self._resolve_experiment_id(
-            experiment_id or (scorer._experiment_id if scorer is not None else None)
-        )
+        experiment_id = self._resolve_experiment_id(experiment_id)
         configs = self._list_current_scorer_configs(experiment_id)
         index = self._find_scorer_config_index(configs, name)
         if index is None:

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -464,6 +464,45 @@ def test_databricks_backend_missing_current_scorer_uses_oss_error_code():
 
 
 @pytest.mark.parametrize(
+    ("experiment_id", "expected_experiment_id"),
+    [("explicit_exp", "explicit_exp"), (None, "active_exp")],
+)
+def test_databricks_backend_schedule_update_uses_explicit_or_active_experiment(
+    experiment_id, expected_experiment_id
+):
+    scorer = Guidelines(name="test_scorer", guidelines=["Be helpful"], model="databricks:/judge")
+    scorer._experiment_id = "remembered_exp"
+    current_config = _DatabricksScheduledScorerConfig.model_validate(_scorer_config(scorer))
+    updated_config = current_config.model_copy(update={"sample_rate": 0.5})
+    store = DatabricksStore(tracking_uri="databricks")
+
+    with (
+        patch(
+            "mlflow.genai.scorers.registry._get_experiment_id", return_value="active_exp"
+        ) as mock_active_experiment,
+        patch.object(
+            store, "_list_current_scorer_configs", return_value=[current_config]
+        ) as mock_list,
+        patch.object(
+            store, "_patch_current_scorer_configs", return_value=[updated_config]
+        ) as mock_patch,
+    ):
+        store.update_registered_scorer(
+            name=scorer.name,
+            scorer=scorer,
+            sample_rate=0.5,
+            experiment_id=experiment_id,
+        )
+
+    mock_list.assert_called_once_with(expected_experiment_id)
+    mock_patch.assert_called_once_with(expected_experiment_id, [updated_config])
+    if experiment_id is None:
+        mock_active_experiment.assert_called_once_with()
+    else:
+        mock_active_experiment.assert_not_called()
+
+
+@pytest.mark.parametrize(
     ("operation", "kwargs", "agents_method"),
     [
         ("get_scorer", {}, "get_scheduled_scorer"),
@@ -649,7 +688,7 @@ def test_databricks_backend_current_scorer_configs_paginate():
     assert mock_http.call_args_list[1].kwargs["params"] == {"page_token": "page-2"}
 
 
-def test_databricks_backend_legacy_current_config_defaults_to_version_one():
+def test_databricks_backend_current_config_preserves_omitted_version():
     scorer = Guidelines(name="test_databricks_scorer", guidelines=["v1"], model="databricks:/judge")
     config = _scorer_config(scorer)
     config.pop("scorer_version")
@@ -663,7 +702,37 @@ def test_databricks_backend_legacy_current_config_defaults_to_version_one():
             "exp_123"
         )[0]
 
-    assert parsed_config.scorer_version == 1
+    assert parsed_config.scorer_version is None
+
+
+def test_databricks_backend_register_does_not_send_omitted_current_version():
+    scorer_v1 = Guidelines(
+        name="test_databricks_scorer", guidelines=["v1"], model="databricks:/judge"
+    )
+    scorer_v2 = Guidelines(
+        name="test_databricks_scorer", guidelines=["v2"], model="databricks:/judge"
+    )
+    current_config = _scorer_config(scorer_v1)
+    current_config.pop("scorer_version")
+    updated_config = _scorer_config(scorer_v2)
+    updated_config.pop("scorer_version")
+
+    with (
+        patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
+        patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+    ):
+        mock_http.side_effect = [
+            _scheduled_scorers_response([current_config]),
+            _scheduled_scorers_response([updated_config]),
+        ]
+
+        registered_version = DatabricksStore(tracking_uri="databricks").register_scorer(
+            "exp_123", scorer_v2
+        )
+
+    assert registered_version is None
+    submitted_config = mock_http.call_args_list[1].kwargs["json"]["scheduled_scorers"]["scorers"][0]
+    assert "scorer_version" not in submitted_config
 
 
 def test_databricks_backend_historical_scorer_scheduling_preserves_current_definition():
@@ -688,6 +757,7 @@ def test_databricks_backend_historical_scorer_scheduling_preserves_current_defin
     with (
         patch("mlflow.genai.scorers.registry.get_databricks_host_creds", return_value="creds"),
         patch("mlflow.genai.scorers.registry.http_request") as mock_http,
+        patch("mlflow.genai.scorers.registry._get_experiment_id", return_value="exp_123"),
     ):
         mock_http.side_effect = [
             _mock_response(historical_config),


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24611

### What changes are proposed in this pull request?

Preserve two existing Databricks scorer compatibility behaviors:

- Keep an omitted server-managed `scorer_version` absent instead of defaulting it to version 1. Registration PATCH requests send the current version only when the backend provided it.
- Resolve scheduling mutations from an explicit `experiment_id` or the currently active experiment, matching the previous `databricks-agents` behavior. A scorer's remembered experiment no longer takes precedence over the active experiment.

Exact scorer-version responses continue to require an explicit version.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added coverage that verifies omitted current versions remain `None` and are not added to registration PATCH payloads. Scheduling coverage verifies that explicit experiment IDs take precedence and otherwise the active experiment is used, even when the scorer remembers a different experiment.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
