### PR TITLE
Update NaiLaOpus large PR handling

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -50,7 +50,7 @@ jobs:
       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.comment.author_association) &&
       contains(fromJSON('["MEMBER", "COLLABORATOR", "OWNER"]'), github.event.issue.author_association)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Resolve PR number
         id: ctx
@@ -143,7 +143,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 5e5f9229e16b97822ea3349b31285370be36b4d1
+          ref: 6575d885c8c0d8840d81c5115417e5d759b262b8
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/internal/pull/71

### What changes are proposed in this pull request?

Update `/review-v2` large-PR handling so clean PRs have a clear path based on size:

- Expand `size/M` from `<=199` to `<=400` changed LoC, which lets `NaiLaOpus` auto-approve clean PRs up to 400 changed LoC because `M` is stamp-eligible.
- Pin `mlflow/internal` to `6575d885c8c0d8840d81c5115417e5d759b262b8`, which adds `team-review` when a clean `size/L` or `size/XL` PR cannot be auto-approved due to size.

This leaves the `NaiLaOpus` workflow timeout unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Internal `nailaopus` verification from https://github.com/mlflow/internal/pull/71:

```bash
uv run --project nailaopus --extra test ruff check nailaopus
uv run --project nailaopus --extra test pytest nailaopus/tests
```

Public workflow/labeler verification:

```bash
node --check .github/workflows/pr-size.js
git diff --check
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release