### PR TITLE
Wrap array-shaped trace inputs when building dataset records

### DIFF
--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -164,6 +164,10 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
 
             root_span = trace.data._get_root_span()
             inputs = root_span.inputs if root_span and root_span.inputs is not None else {}
+            if isinstance(inputs, list):
+                # Traces following the OpenTelemetry GenAI convention store the chat input as
+                # a bare array of messages, but a record's inputs must be a dict.
+                inputs = {"messages": inputs}
             outputs = root_span.outputs if root_span and root_span.outputs is not None else None
 
             expectations = {}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/utils/datasetUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/utils/datasetUtils.ts
@@ -40,11 +40,15 @@ export const extractDatasetInfoFromTraces = (traces: ModelTrace[]) => {
       }
     }
 
+    const inputs =
+      isV3ModelTraceSpan(rootSpan) || isV4ModelTraceSpan(rootSpan)
+        ? tryDeserializeAttribute(getSpanAttribute(rootSpan.attributes, 'mlflow.spanInputs') as string)
+        : rootSpan.inputs;
+
     return {
-      inputs:
-        isV3ModelTraceSpan(rootSpan) || isV4ModelTraceSpan(rootSpan)
-          ? tryDeserializeAttribute(getSpanAttribute(rootSpan.attributes, 'mlflow.spanInputs') as string)
-          : rootSpan.inputs,
+      // traces following the OpenTelemetry GenAI convention store the chat input as
+      // a bare array of messages, but a record's inputs must be an object
+      inputs: Array.isArray(inputs) ? { messages: inputs } : inputs,
       expectations,
       source: {
         source_type: 'TRACE',

--- a/tests/entities/test_evaluation_dataset.py
+++ b/tests/entities/test_evaluation_dataset.py
@@ -499,6 +499,27 @@ def test_process_trace_records_with_dict_outputs():
     assert record_dicts[0]["source"]["source_data"]["trace_id"] == "trace1"
 
 
+def test_process_trace_records_with_list_inputs():
+    dataset = EvaluationDataset(
+        dataset_id="dataset123",
+        name="test_dataset",
+        digest="digest123",
+        created_time=123456789,
+        last_update_time=123456789,
+    )
+
+    messages = [{"role": "user", "content": "What is MLflow?"}]
+    trace = create_test_trace(
+        trace_id="trace1",
+        inputs=messages,
+        outputs={"answer": "MLflow is a platform"},
+    )
+
+    record_dicts = dataset._process_trace_records([trace])
+
+    assert record_dicts[0]["inputs"] == {"messages": messages}
+
+
 def test_process_trace_records_with_string_outputs():
     dataset = EvaluationDataset(
         dataset_id="dataset123",

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -1271,6 +1271,28 @@ def test_trace_without_root_span_inputs(client, experiment):
     assert df.iloc[0]["expectations"] is None or df.iloc[0]["expectations"] == {}
 
 
+def test_trace_with_list_root_span_inputs(client, experiment):
+    messages = [{"role": "user", "content": "What is MLflow?"}]
+    with mlflow.start_run(experiment_id=experiment):
+        with mlflow.start_span(name="list_inputs_trace") as span:
+            span.set_inputs(messages)
+            span.set_outputs({"answer": "MLflow is an ML platform"})
+            trace_id = span.trace_id
+
+    trace = client.get_trace(trace_id)
+
+    dataset = create_dataset(
+        name="list_inputs_test",
+        experiment_id=experiment,
+    )
+
+    dataset.merge_records([trace])
+
+    df = dataset.to_df()
+    assert len(df) == 1
+    assert df.iloc[0]["inputs"] == {"messages": messages}
+
+
 def test_error_handling_invalid_trace_types(client, experiment):
     dataset = create_dataset(
         name="error_test",


### PR DESCRIPTION
Fixes #24709

`_process_trace_records` copies the root span's `inputs` straight into the dataset record, and
`extractDatasetInfoFromTraces` does the same on the UI side. Traces captured under the OpenTelemetry
GenAI convention store chat input as a bare array, so the record's `inputs` ends up a list. That either
blows up in `_validate_schema` with `AttributeError: 'list' object has no attribute 'keys'`, or reaches
the `MutableDict` column in the SQL store, where the resulting `ValueError` gets wrapped as
`INTERNAL_ERROR` and surfaces in the UI as a 500.

Both conversion sites now wrap a list input as `{"messages": [...]}`. Dict inputs are unchanged.
`messages` is the key the datasets UI, the reference-based judges, and the playground's "add to dataset"
flow already use for message-array inputs.

Verified on Linux / Python 3.10 against a sqlite backend:

- New unit test on the converter and a new end-to-end test that runs a trace with array inputs through
  `merge_records` into a real store and reads the record back. Both fail on master and pass with the fix.
- Reran the reproduction from the issue through the SDK: the record now stores as
  `{"messages": [{"role": "user", "parts": [...]}]}` with `source_type=TRACE`.
- `tests/entities/` (567 passed), `tests/genai/datasets/` (132 passed),
  `tests/store/tracking/sqlalchemy_store/` (2230 passed), ruff and clint clean.

Not verified: the TypeScript hunk. My environment has no node toolchain, so `yarn test`, `yarn lint`, and
`yarn type-check` did not run, and I did not click through the export-to-dataset modal. The change mirrors
the Python one on a value already typed `any`. Also unchanged: posting a record with list `inputs` straight
to the REST endpoint still returns `INTERNAL_ERROR` rather than a clean 400. That is a separate fix at the
store boundary, happy to add it here if you want it.

Thanks to @sebnow for the report and the root-cause analysis, which pointed at both conversion sites.