### PR TITLE
Enforce a path boundary when deleting object-store artifacts

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -86,6 +86,20 @@ def _retry_with_new_creds(try_func, creds_func, orig_creds=None):
         return try_func(new_creds)
 
 
+def _is_object_within_path(object_path: str, dest_path: str) -> bool:
+    """
+    Whether an object listed by an object store belongs to ``dest_path``.
+
+    Object stores match prefixes as raw strings, so listing ``foo`` also returns objects under
+    sibling paths such as ``foobar/``. Enforce a ``/`` boundary to exclude them, while still
+    matching ``dest_path`` itself so that deleting a single object keeps working.
+    """
+    dest_path = dest_path.rstrip("/")
+    if not dest_path:
+        return True
+    return object_path == dest_path or object_path.startswith(dest_path + "/")
+
+
 def _sanitize_path_component_for_windows(component: str) -> str:
     """
     Sanitize a path component by replacing Windows-invalid characters with underscores.

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -14,7 +14,11 @@ from mlflow.entities.multipart_upload import (
 from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
-from mlflow.store.artifact.artifact_repo import ArtifactRepository, MultipartUploadMixin
+from mlflow.store.artifact.artifact_repo import (
+    ArtifactRepository,
+    MultipartUploadMixin,
+    _is_object_within_path,
+)
 from mlflow.utils.credentials import get_default_host_creds
 
 
@@ -223,7 +227,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
         try:
             blobs = container_client.list_blobs(name_starts_with=dest_path)
-            blob_list = list(blobs)
+            blob_list = [b for b in blobs if _is_object_within_path(b.name, dest_path)]
             if not blob_list:
                 raise MlflowException(f"No such file or directory: '{dest_path}'")
 

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -20,6 +20,7 @@ from mlflow.exceptions import _UnsupportedMultipartUploadException
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
     MultipartUploadMixin,
+    _is_object_within_path,
     _retry_with_new_creds,
 )
 from mlflow.utils import get_installed_version
@@ -189,6 +190,8 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         gcs_bucket = self._get_bucket(bucket_name)
         blobs = gcs_bucket.list_blobs(prefix=f"{dest_path}")
         for blob in blobs:
+            if not _is_object_within_path(blob.name, dest_path):
+                continue
             blob.delete()
 
     @staticmethod

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -15,7 +15,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialInfo
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.store.artifact.artifact_repo import _retry_with_new_creds
+from mlflow.store.artifact.artifact_repo import _is_object_within_path, _retry_with_new_creds
 from mlflow.store.artifact.cloud_artifact_repo import (
     CloudArtifactRepository,
     _complete_futures,
@@ -395,9 +395,8 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
             keys = []
             for to_delete_obj in result.get("Contents", []):
                 file_path = to_delete_obj.get("Key")
-                self._verify_listed_object_contains_artifact_path_prefix(
-                    listed_object_path=file_path, artifact_path=dest_path
-                )
+                if not _is_object_within_path(file_path, dest_path):
+                    continue
                 keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -33,6 +33,7 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartDownloadMixin,
     MultipartUploadMixin,
     PresignedUploadMixin,
+    _is_object_within_path,
 )
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 
@@ -544,9 +545,8 @@ class S3ArtifactRepository(
             keys = []
             for to_delete_obj in result.get("Contents", []):
                 file_path = to_delete_obj.get("Key")
-                self._verify_listed_object_contains_artifact_path_prefix(
-                    listed_object_path=file_path, artifact_path=dest_path
-                )
+                if not _is_object_within_path(file_path, dest_path):
+                    continue
                 keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -506,6 +506,20 @@ def test_delete_artifacts_directory(mock_client):
     mock_client.get_container_client().delete_blob.assert_any_call(blob_props_2.name)
 
 
+def test_delete_artifacts_leaves_sibling_paths_sharing_a_prefix(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, client=mock_client)
+
+    blob_props = BlobProperties()
+    blob_props.name = posixpath.join(TEST_ROOT_PATH, "foo/file")
+    sibling_blob_props = BlobProperties()
+    sibling_blob_props.name = posixpath.join(TEST_ROOT_PATH, "foobar/keep")
+    mock_client.get_container_client().list_blobs.return_value = [blob_props, sibling_blob_props]
+
+    repo.delete_artifacts("foo")
+
+    mock_client.get_container_client().delete_blob.assert_called_once_with(blob_props.name)
+
+
 def test_delete_artifacts_nonexistent_path(mock_client):
     repo = AzureBlobArtifactRepository(TEST_URI, client=mock_client)
 

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -295,8 +295,8 @@ def test_download_artifacts_downloads_expected_content(mock_client, tmp_path):
 
 
 def test_delete_artifacts(mock_client):
-    experiment_root_path = "/experiment_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + experiment_root_path, client=mock_client)
+    experiment_root_path = "experiment_id"
+    repo = GCSArtifactRepository(f"gs://test_bucket/{experiment_root_path}", client=mock_client)
 
     def delete_file():
         del obj_mock.name
@@ -304,7 +304,7 @@ def test_delete_artifacts(mock_client):
         return obj_mock
 
     obj_mock = mock.Mock()
-    run_id_path = experiment_root_path + "run_id/"
+    run_id_path = experiment_root_path + "/run_id/"
     file_path = "file"
     attrs = {"name": run_id_path + file_path, "size": 1, "delete.side_effect": delete_file}
     obj_mock.configure_mock(**attrs)
@@ -341,6 +341,26 @@ def test_delete_artifacts(mock_client):
     repo.delete_artifacts()
     artifact_file_names = [obj.path for obj in repo.list_artifacts()]
     assert not artifact_file_names
+
+
+def test_delete_artifacts_leaves_sibling_paths_sharing_a_prefix(mock_client):
+    repo = GCSArtifactRepository("gs://test_bucket/experiment_id", client=mock_client)
+
+    target = mock.Mock()
+    target.configure_mock(name="experiment_id/foo/file")
+    sibling = mock.Mock()
+    sibling.configure_mock(name="experiment_id/foobar/keep")
+
+    mock_method_chain(
+        mock_client,
+        ["bucket", "list_blobs"],
+        return_value=[target, sibling],
+    )
+
+    repo.delete_artifacts("foo")
+
+    target.delete.assert_called_once()
+    sibling.delete.assert_not_called()
 
 
 def test_gcs_mpu_arguments():

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -358,6 +358,20 @@ def test_delete_artifacts_single_object(s3_artifact_repo, tmp_path):
     assert s3_artifact_repo.list_artifacts() == []
 
 
+def test_delete_artifacts_leaves_sibling_paths_sharing_a_prefix(s3_artifact_repo, tmp_path):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    (subdir / "a.txt").write_text("A")
+
+    s3_artifact_repo.log_artifacts(str(subdir), "foo")
+    s3_artifact_repo.log_artifacts(str(subdir), "foobar")
+
+    s3_artifact_repo.delete_artifacts(artifact_path="foo")
+
+    assert s3_artifact_repo.list_artifacts("foo") == []
+    assert [obj.path for obj in s3_artifact_repo.list_artifacts("foobar")] == ["foobar/a.txt"]
+
+
 @pytest.mark.parametrize("artifact_path", ["subdir", "subdir/"])
 def test_list_and_delete_artifacts_path(s3_artifact_repo, tmp_path, artifact_path):
     subdir = tmp_path / "subdir"


### PR DESCRIPTION
Fixes #24821

`delete_artifacts` in the S3, optimized S3, GCS, and Azure Blob repos lists objects with the raw path prefix and deletes every key returned. Object stores match prefixes as raw strings, so `delete_artifacts("foo")` also matched and deleted everything under sibling paths like `foobar/`.

Added `_is_object_within_path` in `mlflow/store/artifact/artifact_repo.py`, which accepts an object only if it equals `dest_path` or starts with `dest_path + "/"`. All four `delete_artifacts` implementations now filter their listing through it. The equality case keeps single-object deletion working. In the two S3 repos this replaces the `_verify_listed_object_contains_artifact_path_prefix` call in the delete path, which the stricter check subsumes; that method is unchanged and still used by `list_artifacts`.

Tests: added `test_delete_artifacts_leaves_sibling_paths_sharing_a_prefix` to the S3, GCS, and Azure Blob test files. The S3 one runs against moto for both `S3ArtifactRepository` and `OptimizedS3ArtifactRepository` through the existing parametrized fixture. All four fail on master and pass with this change.

One pre-existing test needed a fix. `test_gcs_artifact_repo.py::test_delete_artifacts` used a repo root of `gs://test_bucket/experiment_id/` with a mock blob named `/experiment_id/run_id/file`. `list_blobs(prefix="experiment_id/")` can never return that name; the leading slash was only cancelling an off-by-one in `list_artifacts` for roots with a trailing slash. The old delete path never checked the prefix so it passed. I changed the root to `experiment_id` and the blob name to `experiment_id/run_id/file`. The `list_artifacts` off-by-one itself is a separate bug and is not touched here.

Verified on Linux, Python 3.10, with moto 4.2.14. No live S3, GCS, or Azure account was used. GCS and Azure Blob are covered by mocks only, matching how those repos are already tested here.

Thanks to @yangbaechu for the report and the minimal reproducer.