### PR TITLE
Fix search match navigation resetting active tab for Events/Links (#24763)

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test.tsx
@@ -275,6 +275,46 @@ describe('ModelTraceExplorer', () => {
     expect(await screen.findByText('event-level-attribute')).toBeInTheDocument();
   });
 
+  it('should keep the events tab active when jumping to the next search match (#24763)', async () => {
+    const secondEventsSpan: ModelTraceSpanV2 = {
+      ...MOCK_EVENTS_SPAN,
+      context: { span_id: 'events_span_2', trace_id: '1' },
+      parent_id: 'events_span',
+      name: 'events_span_2',
+      events: [
+        {
+          name: 'event1',
+          attributes: { 'event1-attr1': 'shared-event-marker-second-span' },
+        },
+      ],
+    };
+    const trace = {
+      data: {
+        spans: [
+          { ...MOCK_EVENTS_SPAN, events: [{ name: 'event1', attributes: { 'event1-attr1': 'shared-event-marker' } }] },
+          secondEventsSpan,
+        ],
+      },
+      info: {},
+    };
+
+    render(<TestComponent modelTrace={trace} />);
+
+    const searchBar = screen.getByPlaceholderText('Search');
+    await userEvent.type(searchBar, 'shared-event-marker');
+
+    // first match: events tab open on the first span
+    expect(await screen.findByText('shared-event-marker')).toBeInTheDocument();
+
+    // jump to the next match, which is on the second span
+    const nextButton = await screen.findByTestId('next-search-match');
+    await userEvent.click(nextButton);
+
+    // the events tab should stay active for the new span, instead of resetting to the default tab
+    expect(await screen.findByText('2 / 2')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Events/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('should default to content tab when the selected node does not have chats', async () => {
     const trace = {
       data: {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test.tsx
@@ -306,6 +306,15 @@ describe('ModelTraceExplorer', () => {
     // first match: events tab open on the first span
     expect(await screen.findByText('shared-event-marker')).toBeInTheDocument();
 
+    // Clearing search and selecting another span should apply that span's default tab.
+    // This also verifies that selecting a search match on the already-selected node
+    // does not leave a stale tab-reset bypass behind.
+    await userEvent.clear(searchBar);
+    await userEvent.click(screen.getAllByText('events_span_2')[0]);
+    expect(await screen.findByTestId('model-trace-explorer-content-tab')).toBeInTheDocument();
+
+    await userEvent.type(searchBar, 'shared-event-marker');
+
     // jump to the next match, which is on the second span
     const nextButton = await screen.findByTestId('next-search-match');
     await userEvent.click(nextButton);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
@@ -110,6 +110,7 @@ export const ModelTraceExplorerDetailView = ({
     rootNode,
     activeTab,
     setActiveTab,
+    setSelectedNodeAndTab,
     showGraph,
     setShowGraph,
     updatePaneSizeRatios,
@@ -257,7 +258,7 @@ export const ModelTraceExplorerDetailView = ({
     treeNodes: topLevelNodes,
     selectedNode,
     setSelectedNode,
-    setActiveTab,
+    setSelectedNodeAndTab,
     setExpandedKeys,
     modelTraceInfo,
   });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
@@ -36,6 +36,9 @@ export type ModelTraceExplorerViewState = {
   setActiveView: (view: 'summary' | 'detail') => void;
   selectedNode: ModelTraceSpanNode | undefined;
   setSelectedNode: (node: ModelTraceSpanNode | undefined) => void;
+  // Sets the selected node and active tab together, skipping the
+  // default-tab-on-node-change reset so the explicit tab sticks.
+  setSelectedNodeAndTab: (node: ModelTraceSpanNode | undefined, tab: ModelTraceExplorerTab) => void;
   activeTab: ModelTraceExplorerTab;
   setActiveTab: (tab: ModelTraceExplorerTab) => void;
   showGraph: boolean;
@@ -63,6 +66,7 @@ export const ModelTraceExplorerViewStateContext = createContext<ModelTraceExplor
   setActiveView: () => {},
   selectedNode: undefined,
   setSelectedNode: () => {},
+  setSelectedNodeAndTab: () => {},
   activeTab: 'content',
   setActiveTab: () => {},
   showGraph: true,
@@ -154,6 +158,17 @@ export const ModelTraceExplorerViewStateProvider = ({
   const [selectedNode, setSelectedNode] = useState<ModelTraceSpanNode | undefined>(defaultSelectedNode);
   const defaultActiveTab = getDefaultActiveTab(selectedNode);
   const [activeTab, setActiveTab] = useState<ModelTraceExplorerTab>(defaultActiveTab);
+
+  // When set, the next selectedNode-change effect skips resetting activeTab
+  // to the node's default tab, so an explicit tab set alongside the node
+  // (e.g. jumping to a search match) sticks.
+  const skipTabResetRef = useRef(false);
+
+  const setSelectedNodeAndTab = useCallback((node: ModelTraceSpanNode | undefined, tab: ModelTraceExplorerTab) => {
+    skipTabResetRef.current = true;
+    setSelectedNode(node);
+    setActiveTab(tab);
+  }, []);
   const [showGraph, setShowGraph] = useState(Boolean(rootNode));
   const [showTimelineTreeGantt, setShowTimelineTreeGantt] = useState(false);
   const [assessmentsPaneExpanded, setAssessmentsPaneExpandedInternal] = useState(() => {
@@ -202,6 +217,10 @@ export const ModelTraceExplorerViewStateProvider = ({
   }, []);
 
   useEffect(() => {
+    if (skipTabResetRef.current) {
+      skipTabResetRef.current = false;
+      return;
+    }
     const defaultActiveTab = getDefaultActiveTab(selectedNode);
     setActiveTab(defaultActiveTab);
   }, [selectedNode]);
@@ -223,6 +242,7 @@ export const ModelTraceExplorerViewStateProvider = ({
       setActiveTab,
       selectedNode,
       setSelectedNode,
+      setSelectedNodeAndTab,
       showGraph,
       setShowGraph,
       showTimelineTreeGantt,
@@ -245,6 +265,7 @@ export const ModelTraceExplorerViewStateProvider = ({
       activeTab,
       rootNode,
       selectedNode,
+      setSelectedNodeAndTab,
       showGraph,
       showTimelineTreeGantt,
       setShowTimelineTreeGantt,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerViewStateContext.tsx
@@ -159,13 +159,13 @@ export const ModelTraceExplorerViewStateProvider = ({
   const defaultActiveTab = getDefaultActiveTab(selectedNode);
   const [activeTab, setActiveTab] = useState<ModelTraceExplorerTab>(defaultActiveTab);
 
-  // When set, the next selectedNode-change effect skips resetting activeTab
-  // to the node's default tab, so an explicit tab set alongside the node
-  // (e.g. jumping to a search match) sticks.
-  const skipTabResetRef = useRef(false);
+  // Tracks the node whose tab was explicitly selected (e.g. by search navigation).
+  // Associating the bypass with a node prevents a stale bypass when React skips a
+  // selectedNode update because that node is already selected.
+  const explicitTabNodeRef = useRef<{ node: ModelTraceSpanNode | undefined } | null>(null);
 
   const setSelectedNodeAndTab = useCallback((node: ModelTraceSpanNode | undefined, tab: ModelTraceExplorerTab) => {
-    skipTabResetRef.current = true;
+    explicitTabNodeRef.current = { node };
     setSelectedNode(node);
     setActiveTab(tab);
   }, []);
@@ -217,8 +217,9 @@ export const ModelTraceExplorerViewStateProvider = ({
   }, []);
 
   useEffect(() => {
-    if (skipTabResetRef.current) {
-      skipTabResetRef.current = false;
+    const explicitTabNode = explicitTabNodeRef.current;
+    explicitTabNodeRef.current = null;
+    if (explicitTabNode?.node === selectedNode) {
       return;
     }
     const defaultActiveTab = getDefaultActiveTab(selectedNode);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useModelTraceSearch.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useModelTraceSearch.tsx
@@ -56,14 +56,14 @@ export const useModelTraceSearch = ({
   treeNodes,
   selectedNode,
   setSelectedNode,
-  setActiveTab,
+  setSelectedNodeAndTab,
   setExpandedKeys,
   modelTraceInfo,
 }: {
   treeNodes: ModelTraceSpanNode[];
   selectedNode: ModelTraceSpanNode | undefined;
   setSelectedNode: (node: ModelTraceSpanNode) => void;
-  setActiveTab: (tab: ModelTraceExplorerTab) => void;
+  setSelectedNodeAndTab: (node: ModelTraceSpanNode, tab: ModelTraceExplorerTab) => void;
   setExpandedKeys: React.Dispatch<React.SetStateAction<Set<string | number>>>;
   modelTraceInfo: ModelTrace['info'] | null;
 }): {
@@ -115,8 +115,7 @@ export const useModelTraceSearch = ({
       }
       setActiveMatchIndex(newMatchIndex);
       const match = matches[newMatchIndex];
-      setSelectedNode(match.span);
-      setActiveTab(getTabForMatch(match));
+      setSelectedNodeAndTab(match.span, getTabForMatch(match));
       // Make sure parents are expanded
       const parents = getSpanNodeParentIds(match.span, nodeMap);
       setExpandedKeys((expandedKeys) => {
@@ -124,7 +123,7 @@ export const useModelTraceSearch = ({
         return new Set([...expandedKeys, ...parents]);
       });
     },
-    [matches, setSelectedNode, setActiveTab, nodeMap, setExpandedKeys],
+    [matches, setSelectedNodeAndTab, nodeMap, setExpandedKeys],
   );
 
   const handleNextSearchMatch = useCallback(() => {
@@ -150,8 +149,7 @@ export const useModelTraceSearch = ({
       const selectedNodeKey = selectedNode?.key ?? '';
       if (!(selectedNodeKey in nodeMap)) {
         const newSpan = filteredTreeNodes[0];
-        setSelectedNode(newSpan);
-        setActiveTab(newSpan?.chatMessages ? 'chat' : 'content');
+        setSelectedNodeAndTab(newSpan, newSpan?.chatMessages ? 'chat' : 'content');
       } else {
         // another reason the tree can change is if modelTraceInfo changes.
         // (e.g. tags/assessments were updated). if this happens, we need
@@ -168,11 +166,10 @@ export const useModelTraceSearch = ({
 
     // when matches update, select the first match
     setActiveMatchIndex(0);
-    setSelectedNode(matches[0].span);
-    setActiveTab(getTabForMatch(matches[0]));
+    setSelectedNodeAndTab(matches[0].span, getTabForMatch(matches[0]));
     // don't subscribe to selectedNode to prevent infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filteredTreeNodes, matches, setSelectedNode]);
+  }, [filteredTreeNodes, matches, setSelectedNodeAndTab]);
 
   return {
     matchData: {


### PR DESCRIPTION
### Related Issues/PRs

Closes #24763

### What changes are proposed in this pull request?

Jumping to the next/previous search match on a different span selected the correct span but reset the active tab back to its default, hiding the matched content whenever the match was in the Events (or Links) tab.

Root cause: `useModelTraceSearch`'s match navigation called `setSelectedNode` and `setActiveTab` together, but a `useEffect` in `ModelTraceExplorerViewStateContext` that runs on every `selectedNode` change unconditionally reset `activeTab` back to the node's default, running after and overriding the tab the search hook had just set.

Fix: add `setSelectedNodeAndTab(node, tab)` to the view state context. It sets a ref flag that makes the node-change effect skip its one-time default-tab reset, so the tab the caller explicitly requested sticks. `useModelTraceSearch` now uses this combined setter for match navigation (next/prev match and auto-selecting the first match). Other `setSelectedNode` call sites (tree clicks, graph clicks) are untouched and keep the existing default-tab-reset behavior.

### How is this PR tested?

- [x] New unit/integration tests

Added a test in `ModelTraceExplorer.test.tsx` reproducing the bug: two spans with matching search terms in their event attributes, click "next search match", assert the Events tab stays active instead of resetting to the default tab. Full `ModelTraceExplorer.test.tsx` suite passes (13/13).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes a bug in the trace explorer UI where clicking "next match" during a search would reset the details tab away from the one showing the actual match (e.g. Events), so the user couldn't see the matched content.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - The PR will be mentioned in the "Bug fixes" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release