### PR TITLE
Fix Vertex AI gateway `eu`/`us` multi-region endpoint routing

### DIFF
--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -79,6 +79,23 @@ def _classify_model(model_name: str) -> str:
     return "gemini"
 
 
+def _vertex_ai_host(location: str) -> str:
+    """Return the Vertex AI API host for a location.
+
+    Single-region locations (e.g. ``europe-west1``) use a ``{location}-`` prefix and
+    ``global`` uses no prefix. ``eu`` and ``us`` are multi-region identifiers, not single
+    regions, and are served from a different hostname pattern
+    (``aiplatform.{location}.rep.googleapis.com``); routing them through the ``{location}-``
+    prefix builds a host that does not resolve.
+    https://cloud.google.com/vertex-ai/generative-ai/docs/multiregion-endpoints
+    """
+    if location == "global":
+        return "https://aiplatform.googleapis.com"
+    if location in ("eu", "us"):
+        return f"https://aiplatform.{location}.rep.googleapis.com"
+    return f"https://{location}-aiplatform.googleapis.com"
+
+
 class _VertexAIClaudeProvider(AnthropicProvider):
     """AnthropicProvider adapted for Claude models hosted on Vertex AI.
 
@@ -105,8 +122,7 @@ class _VertexAIClaudeProvider(AnthropicProvider):
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "global"
-        prefix = "" if location == "global" else f"{location}-"
-        host = f"https://{prefix}aiplatform.googleapis.com"
+        host = _vertex_ai_host(location)
         path = f"/v1/projects/{project}/locations/{location}/publishers/anthropic/models"
         return f"{host}{path}"
 
@@ -154,8 +170,7 @@ class _VertexAIMaaSProvider(OpenAICompatibleProvider):
     def _api_base(self) -> str:
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "us-central1"
-        prefix = "" if location == "global" else f"{location}-"
-        host = f"https://{prefix}aiplatform.googleapis.com"
+        host = _vertex_ai_host(location)
         return f"{host}/v1/projects/{project}/locations/{location}/endpoints/openapi"
 
 
@@ -249,10 +264,7 @@ class VertexAIProvider(GeminiProvider):
             return self._delegate._api_base
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "global"
-        # Regional endpoints use a "{location}-" prefix; the global endpoint has no prefix.
-        # https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
-        prefix = "" if location == "global" else f"{location}-"
-        host = f"https://{prefix}aiplatform.googleapis.com"
+        host = _vertex_ai_host(location)
         publisher = "anthropic" if self._model_type == "claude" else "google"
         path = f"/v1/projects/{project}/locations/{location}/publishers/{publisher}/models"
         return f"{host}{path}"

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -10,7 +10,7 @@ from mlflow.environment_variables import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS
 from mlflow.gateway.exceptions import AIGatewayException
-from mlflow.gateway.providers.vertex_ai import VertexAIProvider
+from mlflow.gateway.providers.vertex_ai import VertexAIProvider, _vertex_ai_host
 from mlflow.gateway.schemas import chat, completions
 
 from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
@@ -597,3 +597,82 @@ def test_credentials_with_adc():
         headers = provider.headers
         mock_default.assert_called_once()
         assert headers == {"Authorization": "Bearer mock-access-token"}
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_host"),
+    [
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+        ("global", "https://aiplatform.googleapis.com"),
+        ("europe-west1", "https://europe-west1-aiplatform.googleapis.com"),
+        ("us-east5", "https://us-east5-aiplatform.googleapis.com"),
+    ],
+)
+def test_vertex_ai_host(location, expected_host):
+    assert _vertex_ai_host(location) == expected_host
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_host"),
+    [
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+    ],
+)
+def test_gemini_base_url_uses_multi_region_endpoint(location, expected_host):
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "gemini-2.0-flash",
+            "config": {"vertex_project": "my-gcp-project", "vertex_location": location},
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        f"{expected_host}/v1/projects/my-gcp-project/locations/{location}/publishers/google/models"
+    )
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_host"),
+    [
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+    ],
+)
+def test_claude_base_url_uses_multi_region_endpoint(location, expected_host):
+    endpoint_config = EndpointConfig(
+        name="vertex-claude-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "claude-sonnet-4-5@20251101",
+            "config": {"vertex_project": "my-gcp-project", "vertex_location": location},
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    expected_url = (
+        f"{expected_host}"
+        f"/v1/projects/my-gcp-project/locations/{location}/publishers/anthropic/models"
+    )
+    assert provider.base_url == expected_url
+    assert provider._delegate.base_url == expected_url
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_host"),
+    [
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+    ],
+)
+def test_maas_api_base_uses_multi_region_endpoint(location, expected_host):
+    provider = _make_maas_provider("meta/llama-3.1-405b-instruct-maas", location=location)
+    assert provider._delegate._api_base == (
+        f"{expected_host}/v1/projects/my-gcp-project/locations/{location}/endpoints/openapi"
+    )


### PR DESCRIPTION
### Related Issues/PRs

Closes #24868

### What changes are proposed in this pull request?

the vertex ai gateway provider does not route the `eu` and `us` multi-region endpoints correctly.

for any location that is not `global`, the provider builds the host as `https://{location}-aiplatform.googleapis.com`. that is right for single regions like `europe-west1`. but `eu` and `us` are multi-region identifiers, not single regions. vertex serves those from a different host, `https://aiplatform.{location}.rep.googleapis.com` (note the `.rep.` subdomain and no `{location}-` prefix).

so `vertex_location: eu` on a claude model resolves to `https://eu-aiplatform.googleapis.com`, which does not exist, and every request to that endpoint fails to connect.

the same prefix logic was duplicated in three places, all with the same bug:
- `_VertexAIClaudeProvider.base_url` (`mlflow/gateway/providers/vertex_ai.py` L104-111)
- `_VertexAIMaaSProvider._api_base` (same file, L153-159)
- `VertexAIProvider.base_url` (same file, L246-258)

this pr pulls the host logic into one helper, `_vertex_ai_host(location)`, and uses it at all three call sites. `eu`/`us` now go to `https://aiplatform.{location}.rep.googleapis.com`. single-region and `global` behavior is unchanged.

ref: https://cloud.google.com/vertex-ai/generative-ai/docs/multiregion-endpoints

before / after for `vertex_location: eu` on a claude model:

```
before: https://eu-aiplatform.googleapis.com/v1/projects/<p>/locations/eu/publishers/anthropic/models   (does not resolve)
after:  https://aiplatform.eu.rep.googleapis.com/v1/projects/<p>/locations/eu/publishers/anthropic/models
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

added tests in `tests/gateway/providers/test_vertex_ai.py`:
- `test_vertex_ai_host` parametrizes the helper over `eu`, `us`, `global`, `europe-west1`, `us-east5`.
- `test_gemini_base_url_uses_multi_region_endpoint`, `test_claude_base_url_uses_multi_region_endpoint`, and `test_maas_api_base_uses_multi_region_endpoint` cover all three call sites for `eu` and `us`.

proof it catches the bug: with the fix reverted, the eu case reports the old host.

```
AssertionError: WRONG HOST: 'https://eu-aiplatform.googleapis.com/.../publishers/anthropic/models'
             != 'https://aiplatform.eu.rep.googleapis.com/.../publishers/anthropic/models'
```

with the fix, the whole file passes.

```
42 passed in 3.11s
```

existing single-region and `global` tests (`test_base_url`, `test_anthropic_model_uses_anthropic_publisher`, `test_global_location_uses_global_endpoint`, ...) still pass, so no regression.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

vertex ai gateway endpoints configured with `vertex_location: eu` or `us` now route to the correct multi-region host instead of a hostname that does not resolve.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
