### PR TITLE
[fix/CI] Align `runs.status` constraint metadata

### DIFF
--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -306,7 +306,9 @@ class SqlRun(Base):
 
     __table_args__ = (
         CheckConstraint(source_type.in_(SourceTypes), name="source_type"),
-        CheckConstraint(status.in_(RunStatusTypes), name="status"),
+        # Historical migrations generate this SQLite CHECK constraint without a stable name.
+        # Keep ORM metadata aligned with that schema so Alembic autogenerate sees no drift.
+        CheckConstraint(status.in_(RunStatusTypes)),
         CheckConstraint(
             lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
             name="runs_lifecycle_stage",


### PR DESCRIPTION
### Related Issues/PRs

[Relates to #24865 run
](https://github.com/mlflow/mlflow/actions/runs/30963663807/job/92185485281?pr=24865)

### What changes are proposed in this pull request?

This PR fixes a database CI failure introduced when the `database` test image started resolving Alembic 1.19.0.

Alembic 1.19.0 was released on August 4, 2026 and added default autogenerate detection for named `CHECK` constraints. The database CI image installs dependencies from package specs instead of the repo's `uv.lock`, so it picked up Alembic 1.19.0 while local frozen test runs were still using Alembic 1.18.5.

That stricter Alembic comparison exposed a pre-existing metadata mismatch for `runs.status`:

Actual SQLite schema generated by MLflow's fresh DB path:

```sql
CREATE TABLE "runs" (
  ...
  CONSTRAINT run_pk PRIMARY KEY (run_uuid),
  CONSTRAINT runs_lifecycle_stage CHECK (lifecycle_stage IN ('active', 'deleted')),
  CONSTRAINT source_type CHECK (source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')),
  FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
  CHECK (status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED'))
)
```

SQLAlchemy inspector reports the same thing:

```python
{'sqltext': "lifecycle_stage IN ('active', 'deleted')", 'name': 'runs_lifecycle_stage'}
{'sqltext': "source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')", 'name': 'source_type'}
{'sqltext': "status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED')", 'name': None}
```

So the database does have the `runs.status` check constraint, but it is unnamed. Current ORM metadata incorrectly claimed the same constraint had a stable name:

```python
CheckConstraint(status.in_(RunStatusTypes), name="status")
```

With Alembic 1.19.0, `compare_metadata()` saw the unnamed database constraint and the named ORM constraint as drift, then reported:

```text
add_constraint CheckConstraint(... name='status' ... table='runs')
```

This PR keeps the `runs.status` validation in ORM metadata, but removes the incorrect name so metadata matches the schema generated by MLflow's historical migration path:

```python
CheckConstraint(status.in_(RunStatusTypes))
```

A short code comment explains why this one check constraint is intentionally unnamed.

### How is this PR tested?

- [x] Existing unit/integration tests

```bash
uv run --frozen pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py::test_store_generated_schema_matches_base tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py::test_sqlalchemystore_idempotently_generates_up_to_date_schema tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py::test_running_migrations_generates_expected_schema tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py::test_db_upgrade_initializes_fresh_database tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_schema.py::test_sqlalchemy_store_detects_schema_mismatch
```

I also verified the fresh SQLite schema produced by `SqlAlchemyStore(...)` directly via `sqlite_master` and `sqlalchemy.inspect(engine).get_check_constraints("runs")`; the status check exists and has `name: None`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release