### PR TITLE
Set span model from model_name / ls_model_name in LangChain autolog

### DIFF
--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -397,13 +397,19 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
 
     def _extract_and_set_model_name(self, span: LiveSpan, kwargs: dict[str, Any]):
         invocation_params = kwargs.get("invocation_params", {})
-        if model := invocation_params.get("model"):
+        metadata = kwargs.get("metadata") or {}
+        # `ls_model_name` is standardized; some providers use `model_name` instead of `model`.
+        model = (
+            metadata.get("ls_model_name")
+            or invocation_params.get("model")
+            or invocation_params.get("model_name")
+        )
+        if model:
             span.set_attribute(SpanAttributeKey.MODEL, model)
         # `ls_provider` is LangChain's standardized provider field, so prefer it. `_type` is a
         # free-form model-type label that does not reliably encode the provider; it is a
         # best-effort fallback where stripping a leading "chat-" or trailing "-chat" recovers the
         # common "chat-<provider>" and "<provider>-chat" forms but not other shapes.
-        metadata = kwargs.get("metadata") or {}
         if provider := metadata.get("ls_provider"):
             span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, provider)
         elif _type := invocation_params.get("_type"):

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -195,6 +195,43 @@ def test_chat_model():
     assert chat_model_span.outputs["choices"][0]["message"]["content"] == "generated text"
 
 
+@pytest.mark.parametrize(
+    ("invocation_params", "metadata", "expected_model"),
+    [
+        # ChatVertexAI / ChatGoogleGenerativeAI expose the model under `model_name`, not `model`,
+        # so the span (and any cost computed from it) previously lost the model entirely.
+        ({"model_name": "gemini-2.5-flash"}, {}, "gemini-2.5-flash"),
+        # LangChain's standardized `ls_model_name` (in metadata) is preferred when present.
+        (
+            {"model_name": "gemini-2.5-flash"},
+            {"ls_model_name": "gemini-2.5-flash-lite"},
+            "gemini-2.5-flash-lite",
+        ),
+        # Providers that expose `model` (e.g. ChatOpenAI) keep working.
+        ({"model": "gpt-4o-mini"}, {}, "gpt-4o-mini"),
+    ],
+)
+def test_chat_model_name_extracted(invocation_params, metadata, expected_model):
+    callback = MlflowLangchainTracer()
+    run_id = str(uuid.uuid4())
+    callback.on_chat_model_start(
+        {},
+        [[HumanMessage("test prompt")]],
+        run_id=run_id,
+        name="test_chat_model",
+        invocation_params=invocation_params,
+        metadata=metadata,
+    )
+    callback.on_llm_end(
+        LLMResult(generations=[[{"text": "generated text"}]]),
+        run_id=run_id,
+    )
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    chat_model_span = trace.data.spans[0]
+    assert chat_model_span.get_attribute(SpanAttributeKey.MODEL) == expected_model
+
+
 def test_chat_model_with_tool():
     callback = MlflowLangchainTracer()
     run_id = str(uuid.uuid4())


### PR DESCRIPTION
### Related Issues/PRs

Closes #24891

### What changes are proposed in this pull request?

`mlflow.langchain.autolog()` set a CHAT_MODEL span's model only from `invocation_params["model"]`, but several LangChain providers expose the model under **`model_name`** instead (e.g. `ChatVertexAI`, `ChatGoogleGenerativeAI`). Those spans got no `mlflow.llm.model` attribute, so `mlflow.llm.cost` (computed from the model name) was never populated even though token usage and pricing were available.

In `_extract_and_set_model_name`, prefer LangChain's standardized `ls_model_name` (from `metadata`, mirroring how `ls_provider` is already preferred for the provider just below), then fall back across `invocation_params["model"]` and `invocation_params["model_name"]`. Providers that already used `model` are unaffected.

### How is this PR tested?

- [x] New unit/integration tests

Added a parametrized `test_chat_model_name_extracted` in `tests/langchain/test_langchain_tracer.py` covering the `model_name`, `ls_model_name`, and existing `model` cases, asserting `SpanAttributeKey.MODEL` is set on the span.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
