### PR TITLE
Add 13 new models to Databricks AI Gateway model catalog

### DIFF
--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -40,6 +40,28 @@
       },
       "last_updated_at": "2026-06-12"
     },
+    "databricks-claude-fable-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 10.00002,
+        "output_per_million_tokens": 50.00003,
+        "cache_write_per_million_tokens": 12.5,
+        "cache_read_per_million_tokens": 1.00002
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
     "databricks-claude-haiku-4-5": {
       "mode": "chat",
       "context_window": {
@@ -59,6 +81,28 @@
         "response_schema": false
       },
       "last_updated_at": "2026-06-12"
+    },
+    "databricks-claude-opus-4-8": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 5.00003,
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
     },
     "databricks-claude-opus-4": {
       "mode": "chat",
@@ -312,6 +356,50 @@
       },
       "last_updated_at": "2026-05-20"
     },
+    "databricks-claude-opus-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 5.00003,
+        "output_per_million_tokens": 25.00001,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
+    "databricks-claude-sonnet-5": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 2.99999,
+        "output_per_million_tokens": 15.00002,
+        "cache_write_per_million_tokens": 3.74999,
+        "cache_read_per_million_tokens": 0.3
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
     "databricks-gemini-2-5-flash": {
       "mode": "chat",
       "context_window": {
@@ -351,6 +439,26 @@
         "response_schema": false
       },
       "last_updated_at": "2026-06-12"
+    },
+    "databricks-gemini-3-1-flash-image": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535,
+        "max_tokens": 65535
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.5,
+        "output_per_million_tokens": 3.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
     },
     "databricks-gemini-3-1-flash-lite": {
       "mode": "chat",
@@ -396,6 +504,28 @@
       },
       "last_updated_at": "2026-05-20"
     },
+    "databricks-gemini-3-5-flash-lite": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535,
+        "max_tokens": 65535
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.37502,
+        "output_per_million_tokens": 3.12502,
+        "cache_write_per_million_tokens": 0.37502,
+        "cache_read_per_million_tokens": 0.0375
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
     "databricks-gemini-3-5-flash": {
       "mode": "chat",
       "context_window": {
@@ -440,6 +570,28 @@
       },
       "last_updated_at": "2026-05-20"
     },
+    "databricks-gemini-3-6-flash": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65535,
+        "max_tokens": 65535
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.87502,
+        "output_per_million_tokens": 9.37502,
+        "cache_write_per_million_tokens": 1.87502,
+        "cache_read_per_million_tokens": 0.1875
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
     "databricks-gemini-3-pro": {
       "mode": "chat",
       "context_window": {
@@ -461,6 +613,26 @@
         "response_schema": false
       },
       "last_updated_at": "2026-05-20"
+    },
+    "databricks-gemini-3-pro-image": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1048576,
+        "max_output": 65536,
+        "max_tokens": 65536
+      },
+      "pricing": {
+        "input_per_million_tokens": 2.0,
+        "output_per_million_tokens": 12.0
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
     },
     "databricks-gemma-3-12b": {
       "mode": "chat",
@@ -742,6 +914,72 @@
       },
       "last_updated_at": "2026-05-20"
     },
+    "databricks-gpt-5-6-luna": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.19999,
+        "output_per_million_tokens": 1.19999,
+        "cache_write_per_million_tokens": 0.24999,
+        "cache_read_per_million_tokens": 0.02
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
+    "databricks-gpt-5-6-sol": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 5.00003,
+        "output_per_million_tokens": 30.00003,
+        "cache_write_per_million_tokens": 6.25004,
+        "cache_read_per_million_tokens": 0.5
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
+    "databricks-gpt-5-6-terra": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1050000,
+        "max_output": 128000,
+        "max_tokens": 128000
+      },
+      "pricing": {
+        "input_per_million_tokens": 2.0,
+        "output_per_million_tokens": 12.00003,
+        "cache_write_per_million_tokens": 2.5,
+        "cache_read_per_million_tokens": 0.2
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
     "databricks-gpt-5-mini": {
       "mode": "chat",
       "context_window": {
@@ -1020,6 +1258,46 @@
         "response_schema": false
       },
       "last_updated_at": "2026-04-24"
+    },
+    "databricks-glm-5-2": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 131072,
+        "max_tokens": 131072
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.39999,
+        "output_per_million_tokens": 4.39998
+      },
+      "capabilities": {
+        "function_calling": false,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
+    },
+    "databricks-inkling": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 1000000,
+        "max_output": 131072,
+        "max_tokens": 131072
+      },
+      "pricing": {
+        "input_per_million_tokens": 1.87502,
+        "output_per_million_tokens": 4.68002
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": true,
+        "reasoning": true,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-05"
     },
     "databricks-qwen3-embedding-0-6b": {
       "mode": "embedding",

--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -97,7 +97,7 @@
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
+        "vision": true,
         "reasoning": true,
         "prompt_caching": true,
         "response_schema": false
@@ -386,14 +386,14 @@
         "max_tokens": 128000
       },
       "pricing": {
-        "input_per_million_tokens": 2.99999,
-        "output_per_million_tokens": 15.00002,
-        "cache_write_per_million_tokens": 3.74999,
-        "cache_read_per_million_tokens": 0.3
+        "input_per_million_tokens": 2.0,
+        "output_per_million_tokens": 10.0,
+        "cache_write_per_million_tokens": 2.5,
+        "cache_read_per_million_tokens": 0.2
       },
       "capabilities": {
         "function_calling": true,
-        "vision": false,
+        "vision": true,
         "reasoning": true,
         "prompt_caching": true,
         "response_schema": false

--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -1267,8 +1267,8 @@
         "max_tokens": 131072
       },
       "pricing": {
-        "input_per_million_tokens": 1.39999,
-        "output_per_million_tokens": 4.39998
+        "input_per_million_tokens": 1.4,
+        "output_per_million_tokens": 4.4
       },
       "capabilities": {
         "function_calling": false,


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds 13 new models to `mlflow/utils/model_catalog/databricks.json` based on the current [Databricks Foundation Models overview](https://docs.databricks.com/aws/en/machine-learning/model-serving/foundation-model-overview) and [supported models page](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models).

New models added:

**Anthropic Claude:**
- `databricks-claude-fable-5` — $10/$50 per 1M tokens, 1M context, 128k output, prompt caching
- `databricks-claude-opus-5` — $5/$25 per 1M tokens, 1M context, 128k output, prompt caching
- `databricks-claude-opus-4-8` — $5/$25 per 1M tokens, 1M context, 128k output, prompt caching
- `databricks-claude-sonnet-5` — $3/$15 per 1M tokens, 1M context, 128k output, prompt caching

**OpenAI GPT 5.6 family:**
- `databricks-gpt-5-6-sol` — $5/$30 per 1M tokens, 1.05M context, prompt caching
- `databricks-gpt-5-6-terra` — $2/$12 per 1M tokens, 1.05M context, prompt caching
- `databricks-gpt-5-6-luna` — $0.20/$1.20 per 1M tokens, 1.05M context, prompt caching

**Google Gemini:**
- `databricks-gemini-3-6-flash` — $1.875/$9.375 per 1M tokens, 1M context, prompt caching
- `databricks-gemini-3-5-flash-lite` — $0.375/$3.125 per 1M tokens, 1M context, prompt caching
- `databricks-gemini-3-1-flash-image` — $0.50/$3.00 per 1M tokens, vision support
- `databricks-gemini-3-pro-image` — $2.00/$12.00 per 1M tokens, vision + reasoning support

**Other:**
- `databricks-glm-5-2` (Zhipu GLM 5.2) — $1.40/$4.40 per 1M tokens, 1M context, reasoning
- `databricks-inkling` (Thinking Machines Lab) — $1.875/$4.68 per 1M tokens, 1M context, multimodal (vision/audio)

Pricing is derived from Databricks' [Proprietary Foundation Model Serving pricing page](https://www.databricks.com/product/pricing/proprietary-foundation-model-serving) (DBU rates × $0.07/DBU), cross-referenced with provider-published list prices from Anthropic, Google, and OpenAI. Third-party pricing sources were used for `glm-5-2` and `inkling` where Databricks does not publish a separate DBU row.

### How is this PR tested?

- [x] Manual tests — verified JSON is valid and all 65 model entries parse correctly

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added 13 new Databricks-hosted foundation models to the model catalog, including Claude Fable 5, Claude Opus 5, Claude Sonnet 5, GPT-5.6 family (Sol/Terra/Luna), Gemini 3.6 Flash, Gemini image models, GLM-5.2, and Inkling.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release