### PR TITLE
fix(ui): Batch run fetching in `CompareRunPage` to avoid one request per run

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
@@ -1,7 +1,7 @@
-import { jest, describe, beforeAll, test, expect } from '@jest/globals';
+import { jest, describe, beforeAll, beforeEach, test, expect } from '@jest/globals';
 import { IntlProvider } from 'react-intl';
 import { render, screen, waitFor } from '../../common/utils/TestUtils.react18';
-import CompareRunPage from './CompareRunPage';
+import CompareRunPage, { COMPARE_RUNS_SEARCH_RUN_LIMIT } from './CompareRunPage';
 import { MockedReduxStoreProvider } from '../../common/utils/TestUtils';
 import { setupTestRouter, testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
 
@@ -34,20 +34,41 @@ describe('CompareRunPage', () => {
     runsFailure: rest.get('/ajax-api/2.0/mlflow/runs/get', (req, res, ctx) => {
       return res(ctx.status(404), ctx.json({ message: 'Run was not found' }));
     }),
+    searchRunsSuccess: rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => {
+      searchRunsRequestBodies.push(req.body as any);
+      return res(ctx.json({ runs: [] }));
+    }),
+    searchRunsFailure: rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => {
+      return res(ctx.status(404), ctx.json({ message: 'Run was not found' }));
+    }),
     artifactsSuccess: rest.get('/ajax-api/2.0/mlflow/artifacts/list', (req, res, ctx) => {
       return res(ctx.json({}));
     }),
   };
 
+  let searchRunsRequestBodies: { filter?: string; max_results?: number; run_view_type?: string }[] = [];
+  let getRunRequestCount = 0;
+
+  const countingRunsHandler = rest.get('/ajax-api/2.0/mlflow/runs/get', (req, res, ctx) => {
+    getRunRequestCount += 1;
+    return res(ctx.json({ experiments: [] }));
+  });
+
   const server = setupServer(
     // Setup handlers for the API calls
     apiHandlers.artifactsSuccess,
     apiHandlers.experimentsSuccess,
+    apiHandlers.searchRunsSuccess,
     apiHandlers.runsSuccess,
   );
 
   beforeAll(() => {
     server.listen();
+  });
+
+  beforeEach(() => {
+    searchRunsRequestBodies = [];
+    getRunRequestCount = 0;
   });
 
   const createPageUrl = ({
@@ -101,12 +122,40 @@ describe('CompareRunPage', () => {
   });
 
   test('should render error when run is not found', async () => {
-    server.resetHandlers(apiHandlers.runsFailure, apiHandlers.artifactsSuccess, apiHandlers.experimentsSuccess);
+    server.resetHandlers(apiHandlers.searchRunsFailure, apiHandlers.artifactsSuccess, apiHandlers.experimentsSuccess);
     renderTestComponent();
 
     await waitFor(() => {
       expect(screen.getByText(/Run was not found/)).toBeInTheDocument();
     });
+  });
+
+  test('should fetch all compared runs using a single search request', async () => {
+    const runUuids = Array.from({ length: 200 }, (_, index) => `run-${index}`);
+    renderTestComponent(createPageUrl({ runUuids }));
+
+    await waitFor(() => {
+      expect(searchRunsRequestBodies).toHaveLength(1);
+    });
+
+    const [requestBody] = searchRunsRequestBodies;
+    expect(requestBody.filter).toBe(`run_id IN (${runUuids.map((runUuid) => `'${runUuid}'`).join(',')})`);
+    // Without an explicit max_results the search would be truncated to the default page size
+    expect(requestBody.max_results).toBe(runUuids.length);
+    // Deleted runs should still show up in the comparison
+    expect(requestBody.run_view_type).toBe('ALL');
+    expect(getRunRequestCount).toBe(0);
+  });
+
+  test('should fall back to fetching runs individually when there are too many to search for', async () => {
+    server.resetHandlers(countingRunsHandler, apiHandlers.artifactsSuccess, apiHandlers.experimentsSuccess);
+    const runUuids = Array.from({ length: COMPARE_RUNS_SEARCH_RUN_LIMIT + 1 }, (_, index) => `run-${index}`);
+    renderTestComponent(createPageUrl({ runUuids }));
+
+    await waitFor(() => {
+      expect(getRunRequestCount).toBe(runUuids.length);
+    });
+    expect(searchRunsRequestBodies).toHaveLength(0);
   });
 
   test('should display graceful message when URL is malformed', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
@@ -35,8 +35,11 @@ describe('CompareRunPage', () => {
       return res(ctx.status(404), ctx.json({ message: 'Run was not found' }));
     }),
     searchRunsSuccess: rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => {
-      searchRunsRequestBodies.push(req.body as any);
-      return res(ctx.json({ runs: [] }));
+      const requestBody = req.body as { filter?: string };
+      searchRunsRequestBodies.push(requestBody);
+      // Echo back every run ID present in the filter so that none appear to be missing
+      const runUuids = Array.from(requestBody.filter?.matchAll(/'([^']+)'/g) ?? []).map(([, runUuid]) => runUuid);
+      return res(ctx.json({ runs: runUuids.map((runUuid) => ({ info: { run_uuid: runUuid } })) }));
     }),
     searchRunsFailure: rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) => {
       return res(ctx.status(404), ctx.json({ message: 'Run was not found' }));
@@ -121,13 +124,40 @@ describe('CompareRunPage', () => {
     });
   });
 
-  test('should render error when run is not found', async () => {
+  test('should render error when the request for runs fails', async () => {
     server.resetHandlers(apiHandlers.searchRunsFailure, apiHandlers.artifactsSuccess, apiHandlers.experimentsSuccess);
     renderTestComponent();
 
     await waitFor(() => {
       expect(screen.getByText(/Run was not found/)).toBeInTheDocument();
     });
+  });
+
+  test('should render error when a compared run is missing from the search results', async () => {
+    // Searching for a run that does not exist succeeds and omits it from the results
+    server.resetHandlers(
+      rest.post('/ajax-api/2.0/mlflow/runs/search', (req, res, ctx) =>
+        res(ctx.json({ runs: [{ info: { run_uuid: 'experiment123456789_run1' } }] })),
+      ),
+      apiHandlers.artifactsSuccess,
+      apiHandlers.experimentsSuccess,
+    );
+    renderTestComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Runs were not found: experiment123456789_run2/)).toBeInTheDocument();
+    });
+  });
+
+  test('should not request runs when there are none to compare', async () => {
+    renderTestComponent(createPageUrl({ runUuids: [] }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Comparing 0 runs from 1 experiment/i)).toBeInTheDocument();
+    });
+    // An empty `run_id IN ()` filter is rejected by the server, so no search should be made
+    expect(searchRunsRequestBodies).toHaveLength(0);
+    expect(getRunRequestCount).toBe(0);
   });
 
   test('should fetch all compared runs using a single search request', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
@@ -8,9 +8,10 @@
 import React, { Component } from 'react';
 import qs from 'qs';
 import { connect } from 'react-redux';
-import { getRunApi, getExperimentApi } from '../actions';
+import { getRunApi, getExperimentApi, searchRunsApi } from '../actions';
 import RequestStateWrapper from '../../common/components/RequestStateWrapper';
 import CompareRunView from './CompareRunView';
+import { ViewType } from '../sdk/MlflowEnums';
 import { getUUID } from '../../common/utils/ActionUtils';
 import { PageContainer } from '../../common/components/PageContainer';
 import { withRouterNext } from '../../common/utils/withRouterNext';
@@ -29,6 +30,13 @@ type CompareRunPageProps = {
   urlDecodeError?: boolean;
   dispatch: (...args: any[]) => any;
 };
+
+/**
+ * Upper bound on how many run IDs we inline into a single `run_id IN (...)` filter.
+ * Past ~4900 IDs the server fails to parse the filter expression, so anything larger
+ * falls back to fetching runs individually.
+ */
+export const COMPARE_RUNS_SEARCH_RUN_LIMIT = 1000;
 
 class CompareRunPageImpl extends Component<CompareRunPageProps> {
   requestIds: any;
@@ -54,16 +62,47 @@ class CompareRunPageImpl extends Component<CompareRunPageProps> {
     });
   }
 
-  componentDidMount() {
-    this.requestIds.push(...this.fetchExperiments());
-    this.props.runUuids.forEach((runUuid) => {
-      const requestId = getUUID();
-      this.requestIds.push(requestId);
+  /**
+   * Fetch all compared runs using a single search request instead of one request per run.
+   * The reducers for SEARCH_RUNS_API populate the same state slices that GET_RUN_API does
+   * (run infos, params, tags and latest metrics), so CompareRunView reads the data as before.
+   */
+  fetchRuns() {
+    const { runUuids, experimentIds } = this.props;
 
-      this.props.dispatch(getRunApi(runUuid, requestId)).catch((requestError: Error | ErrorWrapper) => {
+    if (runUuids.length > COMPARE_RUNS_SEARCH_RUN_LIMIT) {
+      return runUuids.map((runUuid) => {
+        const perRunRequestId = getUUID();
+        this.props.dispatch(getRunApi(runUuid, perRunRequestId)).catch((requestError: Error | ErrorWrapper) => {
+          this.setState({ requestError });
+        });
+        return perRunRequestId;
+      });
+    }
+
+    const requestId = getUUID();
+    const runIdsInQuotes = runUuids.map((runUuid) => `'${runUuid}'`);
+    this.props
+      .dispatch(
+        searchRunsApi({
+          id: requestId,
+          experimentIds,
+          filter: `run_id IN (${runIdsInQuotes.join(',')})`,
+          // Compared runs may have been deleted, so don't restrict the search to active ones
+          runViewType: ViewType.ALL,
+          // searchRunsApi defaults to a page size smaller than the number of compared runs
+          maxResults: runUuids.length,
+        }),
+      )
+      .catch((requestError: Error | ErrorWrapper) => {
         this.setState({ requestError });
       });
-    });
+    return [requestId];
+  }
+
+  componentDidMount() {
+    this.requestIds.push(...this.fetchExperiments());
+    this.requestIds.push(...this.fetchRuns());
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.tsx
@@ -70,6 +70,10 @@ class CompareRunPageImpl extends Component<CompareRunPageProps> {
   fetchRuns() {
     const { runUuids, experimentIds } = this.props;
 
+    if (runUuids.length < 1) {
+      return [];
+    }
+
     if (runUuids.length > COMPARE_RUNS_SEARCH_RUN_LIMIT) {
       return runUuids.map((runUuid) => {
         const perRunRequestId = getUUID();
@@ -94,6 +98,18 @@ class CompareRunPageImpl extends Component<CompareRunPageProps> {
           maxResults: runUuids.length,
         }),
       )
+      .then(({ value }: { value: { runs?: { info: { runUuid: string } }[] } }) => {
+        // Unlike getRunApi, searching for a run that does not exist succeeds and simply
+        // omits it from the results, so surface the missing runs as an error instead of
+        // rendering an incomplete comparison.
+        const foundRunUuids = new Set((value?.runs ?? []).map(({ info }) => info.runUuid));
+        const missingRunUuids = runUuids.filter((runUuid) => !foundRunUuids.has(runUuid));
+        if (missingRunUuids.length > 0) {
+          this.setState({
+            requestError: new Error(`Runs were not found: ${missingRunUuids.join(', ')}`),
+          });
+        }
+      })
       .catch((requestError: Error | ErrorWrapper) => {
         this.setState({ requestError });
       });


### PR DESCRIPTION
### Related Issues/PRs

Closes #21841

### What changes are proposed in this pull request?

`CompareRunPage.componentDidMount` dispatched one `getRunApi` call per run UUID, so opening the run comparison page for N runs issued N separate requests to `runs/get`. As reported in #21841, comparing more than ~100 runs makes the page very slow to load: each request adds round-trip latency and the browser queues them, so the page appears frozen.

This PR fetches all compared runs with a single `searchRunsApi` request filtered by `run_id IN (...)`:

```ts
const runIdsInQuotes = runUuids.map((runUuid) => `'${runUuid}'`);
this.props.dispatch(
  searchRunsApi({
    id: requestId,
    experimentIds,
    filter: `run_id IN (${runIdsInQuotes.join(',')})`,
    runViewType: ViewType.ALL,
    maxResults: runUuids.length,
  }),
);
```

The reducers for `SEARCH_RUNS_API` populate the same state slices that `GET_RUN_API` does — run infos, params, tags and latest metrics — so `CompareRunView` reads its data exactly as before and no other changes are needed.

A few details worth calling out for reviewers:

- `maxResults` is passed explicitly because `searchRunsPayload` otherwise defaults to `RUNS_SEARCH_MAX_RESULTS` (100), which would silently truncate larger comparisons.
- `runViewType` is `ViewType.ALL` because compared runs may have been deleted, and `getRunApi` applied no lifecycle filter.
- Comparisons above `COMPARE_RUNS_SEARCH_RUN_LIMIT` (1000 runs) keep the previous per-run behaviour. The server fails to parse a `run_id IN (...)` filter once several thousand IDs are inlined (it accepts 4900 but rejects 5000 with `INVALID_PARAMETER_VALUE`), so the fallback keeps very large comparisons correct rather than fast. The request is not split into chunks because the `runInfosByUuid` reducer resets its state on each `SEARCH_RUNS_API` response, so a second chunk would discard the first.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Two tests were added to `CompareRunPage.test.tsx`:

- `should fetch all compared runs using a single search request` renders the page with 200 runs and asserts that exactly one `runs/search` request is made, that no `runs/get` requests are made, and that the request carries the expected `filter`, `max_results` and `run_view_type`.
- `should fall back to fetching runs individually when there are too many to search for` asserts the per-run path is still used above the limit.

Both tests were confirmed to fail against the unmodified component, so they exercise the regression rather than passing vacuously. The existing `CompareRunPage` tests (including both enzyme tests) pass unchanged; the "run is not found" test now stubs the search endpoint instead of `runs/get`.

The request-count reduction was also measured directly against a local tracking server with an experiment of 200 runs (4 params and 6 metrics each): the page previously issued 200 requests to `runs/get`, and now issues 1.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The run comparison page now fetches all compared runs in a single request instead of one request per run, which significantly speeds up comparing large numbers of runs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release