### PR TITLE
fix(tracking): Enforce path boundary during object-store artifact deletion (#24821)

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -16,6 +16,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.store.artifact.artifact_repo import ArtifactRepository, MultipartUploadMixin
 from mlflow.utils.credentials import get_default_host_creds
+from mlflow.utils.file_utils import is_subpath_or_equal
 
 
 def encode_base64(data: str | bytes) -> str:
@@ -221,9 +222,10 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
 
+        dest_path = dest_path.rstrip("/") if dest_path else ""
         try:
             blobs = container_client.list_blobs(name_starts_with=dest_path)
-            blob_list = list(blobs)
+            blob_list = [b for b in blobs if is_subpath_or_equal(b.name, dest_path)]
             if not blob_list:
                 raise MlflowException(f"No such file or directory: '{dest_path}'")
 

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -23,6 +23,7 @@ from mlflow.store.artifact.artifact_repo import (
     _retry_with_new_creds,
 )
 from mlflow.utils import get_installed_version
+from mlflow.utils.file_utils import is_subpath_or_equal
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 
 
@@ -186,10 +187,12 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
 
+        dest_path = dest_path.rstrip("/") if dest_path else ""
         gcs_bucket = self._get_bucket(bucket_name)
         blobs = gcs_bucket.list_blobs(prefix=f"{dest_path}")
         for blob in blobs:
-            blob.delete()
+            if is_subpath_or_equal(blob.name, dest_path):
+                blob.delete()
 
     @staticmethod
     def _validate_support_mpu():

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -23,7 +23,7 @@ from mlflow.store.artifact.cloud_artifact_repo import (
     _validate_chunk_size_aws,
 )
 from mlflow.store.artifact.s3_artifact_repo import _get_s3_client
-from mlflow.utils.file_utils import read_chunk
+from mlflow.utils.file_utils import is_subpath_or_equal, read_chunk
 from mlflow.utils.request_utils import cloud_storage_http_request
 from mlflow.utils.rest_utils import augmented_raise_for_status
 
@@ -337,7 +337,7 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
 
     @staticmethod
     def _verify_listed_object_contains_artifact_path_prefix(listed_object_path, artifact_path):
-        if not listed_object_path.startswith(artifact_path):
+        if not is_subpath_or_equal(listed_object_path, artifact_path):
             raise MlflowException(
                 "The path of the listed S3 object does not begin with the specified"
                 f" artifact path. Artifact path: {artifact_path}. Object path:"
@@ -395,10 +395,11 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
             keys = []
             for to_delete_obj in result.get("Contents", []):
                 file_path = to_delete_obj.get("Key")
-                self._verify_listed_object_contains_artifact_path_prefix(
-                    listed_object_path=file_path, artifact_path=dest_path
-                )
-                keys.append({"Key": file_path})
+                if is_subpath_or_equal(file_path, dest_path):
+                    self._verify_listed_object_contains_artifact_path_prefix(
+                        listed_object_path=file_path, artifact_path=dest_path
+                    )
+                    keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(
                     Bucket=self.bucket,

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -34,7 +34,7 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartUploadMixin,
     PresignedUploadMixin,
 )
-from mlflow.utils.file_utils import relative_path_to_artifact_path
+from mlflow.utils.file_utils import is_subpath_or_equal, relative_path_to_artifact_path
 
 _logger = logging.getLogger(__name__)
 
@@ -503,7 +503,7 @@ class S3ArtifactRepository(
 
     @staticmethod
     def _verify_listed_object_contains_artifact_path_prefix(listed_object_path, artifact_path):
-        if not listed_object_path.startswith(artifact_path):
+        if not is_subpath_or_equal(listed_object_path, artifact_path):
             raise MlflowException(
                 "The path of the listed S3 object does not begin with the specified"
                 f" artifact path. Artifact path: {artifact_path}. Object path:"
@@ -544,10 +544,11 @@ class S3ArtifactRepository(
             keys = []
             for to_delete_obj in result.get("Contents", []):
                 file_path = to_delete_obj.get("Key")
-                self._verify_listed_object_contains_artifact_path_prefix(
-                    listed_object_path=file_path, artifact_path=dest_path
-                )
-                keys.append({"Key": file_path})
+                if is_subpath_or_equal(file_path, dest_path):
+                    self._verify_listed_object_contains_artifact_path_prefix(
+                        listed_object_path=file_path, artifact_path=dest_path
+                    )
+                    keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(
                     Bucket=bucket, Delete={"Objects": keys}, **self._bucket_owner_params

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -420,6 +420,19 @@ def get_parent_dir(path):
     return os.path.abspath(os.path.join(path, os.pardir))
 
 
+def is_subpath_or_equal(path: str, target_path: str) -> bool:
+    """
+    Check if `path` is equal to `target_path` or is a subpath (child) of `target_path`.
+    Enforces posix path boundaries ('/') to prevent matching sibling paths that share a prefix.
+    """
+    path = path.lstrip("/")
+    target_path = target_path.lstrip("/")
+    if not target_path or target_path.endswith("/"):
+        return path.startswith(target_path)
+    return path == target_path or path.startswith(target_path + "/")
+
+
+
 def relative_path_to_artifact_path(path):
     if os.path == posixpath:
         return path

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -570,3 +570,19 @@ def test_delete_artifacts_folder_with_nested_folders_and_files(mock_client):
     mock_client.get_container_client().delete_blob.assert_any_call(blob_props_1.name)
     mock_client.get_container_client().delete_blob.assert_any_call(blob_props_2.name)
     mock_client.get_container_client().delete_blob.assert_any_call(blob_props_3.name)
+
+
+def test_delete_artifacts_does_not_delete_sibling_prefix_artifacts(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, client=mock_client)
+
+    blob_foo = BlobProperties()
+    blob_foo.name = posixpath.join(TEST_ROOT_PATH, "foo/file1")
+    blob_foobar = BlobProperties()
+    blob_foobar.name = posixpath.join(TEST_ROOT_PATH, "foobar/keep")
+
+    mock_client.get_container_client().list_blobs.return_value = [blob_foo, blob_foobar]
+
+    repo.delete_artifacts("foo")
+
+    mock_client.get_container_client().delete_blob.assert_called_once_with(blob_foo.name)
+

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -546,3 +546,29 @@ def test_retryable_log_artifacts(throw, tmp_path):
             gcs_refreshed_bucket_mock.blob.assert_not_called()
             mock_gcs_client_factory.assert_not_called()
             mock_gcs_credentials_factory.assert_not_called()
+
+
+def test_delete_artifacts_does_not_delete_sibling_prefix_artifacts():
+    gcs_client_mock = mock.Mock()
+    gcs_bucket_mock = mock.Mock()
+    gcs_client_mock.bucket.return_value = gcs_bucket_mock
+
+    blob_foo = mock.Mock(name="blob_foo")
+    blob_foo.name = "root/foo/file.txt"
+
+    blob_foobar = mock.Mock(name="blob_foobar")
+    blob_foobar.name = "root/foobar/keep.txt"
+
+    gcs_bucket_mock.list_blobs.return_value = [blob_foo, blob_foobar]
+
+    repo = GCSArtifactRepository(
+        artifact_uri="gs://test_bucket/root",
+        client=gcs_client_mock,
+    )
+
+    repo.delete_artifacts("foo")
+
+    gcs_bucket_mock.list_blobs.assert_called_once_with(prefix="root/foo")
+    blob_foo.delete.assert_called_once()
+    blob_foobar.delete.assert_not_called()
+

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -325,3 +325,17 @@ def test_refresh_credentials():
             region_name="us-west-2",
             s3_endpoint_url=None,
         )
+
+
+def test_delete_artifacts_does_not_delete_sibling_prefix_artifacts(s3_artifact_root, mock_s3_bucket):
+    repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "root"))
+    s3_client = repo._get_s3_client()
+    s3_client.put_object(Bucket=mock_s3_bucket, Key="root/foo/file.txt", Body=b"FOO")
+    s3_client.put_object(Bucket=mock_s3_bucket, Key="root/foobar/keep.txt", Body=b"KEEP")
+
+    repo.delete_artifacts("foo")
+
+    artifacts = [obj.path for obj in repo.list_artifacts()]
+    assert "foo" not in artifacts
+    assert "foobar" in artifacts
+

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -358,6 +358,26 @@ def test_delete_artifacts_single_object(s3_artifact_repo, tmp_path):
     assert s3_artifact_repo.list_artifacts() == []
 
 
+def test_delete_artifacts_does_not_delete_sibling_prefix_artifacts(s3_artifact_repo, tmp_path):
+    subdir_foo = tmp_path / "foo"
+    subdir_foo.mkdir()
+    (subdir_foo / "file.txt").write_text("FOO")
+
+    subdir_foobar = tmp_path / "foobar"
+    subdir_foobar.mkdir()
+    (subdir_foobar / "keep.txt").write_text("KEEP")
+
+    s3_artifact_repo.log_artifacts(str(subdir_foo), artifact_path="foo")
+    s3_artifact_repo.log_artifacts(str(subdir_foobar), artifact_path="foobar")
+
+    s3_artifact_repo.delete_artifacts(artifact_path="foo")
+
+    artifacts = [obj.path for obj in s3_artifact_repo.list_artifacts()]
+    assert "foo" not in artifacts
+    assert "foobar" in artifacts
+
+
+
 @pytest.mark.parametrize("artifact_path", ["subdir", "subdir/"])
 def test_list_and_delete_artifacts_path(s3_artifact_repo, tmp_path, artifact_path):
     subdir = tmp_path / "subdir"

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -390,3 +390,19 @@ def test_safe_extractall_blocks_symlink_escape(tmp_path):
         with pytest.raises(MlflowException, match="would be extracted outside"):
             _safe_extractall(tar, dest)
     assert not (tmp_path.parent / "pwned.txt").exists()
+
+
+def test_is_subpath_or_equal():
+    from mlflow.utils.file_utils import is_subpath_or_equal
+
+    assert is_subpath_or_equal("root/foo/file.txt", "root/foo")
+    assert is_subpath_or_equal("root/foo", "root/foo")
+    assert is_subpath_or_equal("root/foo/bar/file.txt", "root/foo")
+    assert is_subpath_or_equal("root/foo/file.txt", "")
+    assert is_subpath_or_equal("root/foo/file.txt", "root/")
+
+    # Sibling path cases (must return False)
+    assert not is_subpath_or_equal("root/foobar/keep.txt", "root/foo")
+    assert not is_subpath_or_equal("root/foo_bar.txt", "root/foo")
+    assert not is_subpath_or_equal("root_sibling/file.txt", "root/")
+


### PR DESCRIPTION
Fixes [#24821](https://github.com/mlflow/mlflow/issues/24821). Prevent object store delete_artifacts(artifact_path) calls from deleting sibling paths that share a prefix with artifact_path (e.g. deleting "foo" accidentally removing "foobar/" or "foo_baz.txt"). Added is_subpath_or_equal path helper in mlflow.utils.file_utils and enforced path boundaries across S3, OptimizedS3, GCS, and Azure Blob artifact repositories with full unit test coverage.