### PR TITLE
fix: Handle existing tables during DB initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,13 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create tables that don't already exist to avoid 'already exists' errors
+    inspector = sqlalchemy.inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    # Use Base.metadata to include all ORM-defined tables, not just initial ones
+    for table_name, table in Base.metadata.tables.items():
+        if table_name not in existing_tables:
+            table.create(engine, checkfirst=False)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` which unconditionally creates all tables defined in `InitialBase`, including `secrets`. Even though SQLAlchemy's `create_all` has `checkfirst=True` by default, it checks all tables metadata and may still try to create tables that exist in a partially migrated state, or the check is insufficient because the existing tables were created via a different metadata definition.

## Fix
Modified `_initialize_tables` to explicitly check for existing tables and only create missing ones. Instead of using `InitialBase.metadata` (which may differ from the current ORM models), we now iterate over `Base.metadata.tables` (which includes all registered models from tracking, registry, and workspace modules) and create only the tables that are not present in the database. This avoids the 'already exists' error while ensuring all required tables are created.

Closes #19943