### PR TITLE
Report runner CPU count and `/mnt` alongside disk usage

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -5,8 +5,14 @@ runs:
   steps:
     - shell: bash
       run: |
-        echo "Disk usage before cleanup:"
+        # `ubuntu-latest` runners come in two root disk sizes, ~72G and ~145G.
+        # `nproc` and `/mnt` are reported alongside the disk usage to help
+        # https://github.com/actions/runner-images/issues/14492 determine whether
+        # the size tracks the runner SKU.
+        echo "Runner disk report:"
+        nproc
         df -h /
+        ls -d /mnt 2>/dev/null || echo "no /mnt"
         # Remove large pre-installed toolchains that MLflow jobs never use so that
         # disk-heavy steps (e.g. Docker image builds) have enough headroom. The
         # deletions run in parallel to save time, but we `wait` for them to finish


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/actions/runner-images/issues/14492

### What changes are proposed in this pull request?

`ubuntu-latest` runners hand out two different root disk sizes (~72G and ~145G) on identical image versions. A runner-images maintainer asked for `nproc` and `/mnt` alongside `df -h /` to confirm whether the size tracks the runner SKU (public 4 CPU vs private 2 CPU) rather than being an inconsistent rollout.

`free-disk-space` already prints `df -h /` before cleanup, so this adds the two extra data points there instead of introducing a separate step. No behavior change: the cleanup still runs unconditionally, since the documented guarantee is still 14G.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)