### PR TITLE
Capture Bedrock prompt caching token fields and normalize input tokens to include them

### DIFF
--- a/mlflow/bedrock/utils.py
+++ b/mlflow/bedrock/utils.py
@@ -30,6 +30,21 @@ TOTAL_TOKEN_KEYS: Sequence[str] = [
     "totalTokens",
 ]
 
+# Cache token fields reported when prompt caching is active. The variants cover the
+# Converse API (camelCase), Anthropic-native InvokeModel bodies (snake_case) and
+# Nova-native InvokeModel bodies (TokenCount suffix).
+CACHE_READ_TOKEN_KEYS: Sequence[str] = [
+    "cache_read_input_tokens",
+    "cacheReadInputTokens",
+    "cacheReadInputTokenCount",
+]
+
+CACHE_CREATION_TOKEN_KEYS: Sequence[str] = [
+    "cache_creation_input_tokens",
+    "cacheWriteInputTokens",
+    "cacheWriteInputTokenCount",
+]
+
 # Common documentation for token key mappings used by parsing functions
 _USAGE_DOCS = """The provider-specific usage dictionary. This function will attempt to
             extract token usage values using a variety of possible key names, including:
@@ -37,7 +52,11 @@ _USAGE_DOCS = """The provider-specific usage dictionary. This function will atte
                 - prompt_tokens / promptTokens: Also mapped as input token count
                 - output_tokens / outputTokens: Output token count
                 - completion_tokens / completionTokens: Also mapped as output token count
-                - total_tokens / totalTokens: Total token count (input + output)"""
+                - total_tokens / totalTokens: Total token count (input + output)
+                - cache_read_input_tokens / cacheReadInputTokens / cacheReadInputTokenCount:
+                  Tokens read from the prompt cache
+                - cache_creation_input_tokens / cacheWriteInputTokens / cacheWriteInputTokenCount:
+                  Tokens written to the prompt cache"""
 
 
 def _validate_usage_input(usage_data: Any) -> bool:
@@ -125,8 +144,24 @@ def parse_complete_token_usage_from_response(
     else:
         return None  # Incomplete usage without output tokens
 
-    # Extract or calculate total tokens
-    if (total_tokens := _extract_token_value_by_keys(usage_data, TOTAL_TOKEN_KEYS)) is not None:
+    # Extract cache token counts, present when prompt caching is active
+    cache_read = _extract_token_value_by_keys(usage_data, CACHE_READ_TOKEN_KEYS)
+    cache_creation = _extract_token_value_by_keys(usage_data, CACHE_CREATION_TOKEN_KEYS)
+    if cache_read is not None:
+        token_usage_data[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+    if cache_creation is not None:
+        token_usage_data[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_creation
+
+    if cache_total := (cache_read or 0) + (cache_creation or 0):
+        # Bedrock reports input tokens excluding tokens read from or written to the
+        # cache. Normalize input to include them, consistent with the anthropic flavor
+        # and cost_per_token(), and recompute the total rather than trusting the
+        # reported one, whose cache accounting is not documented.
+        token_usage_data[TokenUsageKey.INPUT_TOKENS] += cache_total
+        token_usage_data[TokenUsageKey.TOTAL_TOKENS] = (
+            token_usage_data[TokenUsageKey.INPUT_TOKENS] + output_tokens
+        )
+    elif (total_tokens := _extract_token_value_by_keys(usage_data, TOTAL_TOKEN_KEYS)) is not None:
         token_usage_data[TokenUsageKey.TOTAL_TOKENS] = total_tokens
     else:
         # Calculate total as input + output
@@ -162,6 +197,16 @@ def parse_partial_token_usage_from_response(usage_data: dict[str, Any]) -> dict[
     # Try to extract total token count.
     if (total_tokens := _extract_token_value_by_keys(usage_data, TOTAL_TOKEN_KEYS)) is not None:
         token_usage_data[TokenUsageKey.TOTAL_TOKENS] = total_tokens
+
+    # Capture cache token counts as is. The streaming wrappers buffer partial results
+    # and run parse_complete_token_usage_from_response over them at stream close, which
+    # is where the cache-aware input and total normalization happens exactly once.
+    if (cache_read := _extract_token_value_by_keys(usage_data, CACHE_READ_TOKEN_KEYS)) is not None:
+        token_usage_data[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cache_read
+    if (
+        cache_creation := _extract_token_value_by_keys(usage_data, CACHE_CREATION_TOKEN_KEYS)
+    ) is not None:
+        token_usage_data[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] = cache_creation
 
     # If no token usage data was found, return None. Otherwise, return the partial dictionary.
     return token_usage_data or None

--- a/tests/bedrock/test_bedrock_autolog.py
+++ b/tests/bedrock/test_bedrock_autolog.py
@@ -54,6 +54,17 @@ _ANTHROPIC_RESPONSE = {
     },
 }
 
+# Anthropic-native body with prompt caching active. input_tokens excludes cache tokens.
+_ANTHROPIC_CACHED_RESPONSE = {
+    **_ANTHROPIC_RESPONSE,
+    "usage": {
+        "input_tokens": 8,
+        "output_tokens": 12,
+        "cache_read_input_tokens": 100,
+        "cache_creation_input_tokens": 50,
+    },
+}
+
 # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jamba.html
 _AI21_JAMBA_REQUEST = {
     "messages": [{"role": "user", "content": "Hi"}],
@@ -104,6 +115,19 @@ _AMAZON_NOVA_RESPONSE = {
         "inputTokens": 8,
         "outputTokens": 12,
         "totalTokens": 20,
+    },
+}
+
+# Nova-native body with prompt caching active. Nova reports cache fields with a
+# TokenCount suffix, unlike the Converse API.
+_AMAZON_NOVA_CACHED_RESPONSE = {
+    **_AMAZON_NOVA_RESPONSE,
+    "usage": {
+        "inputTokens": 8,
+        "outputTokens": 12,
+        "totalTokens": 20,
+        "cacheReadInputTokenCount": 100,
+        "cacheWriteInputTokenCount": 0,
     },
 }
 
@@ -192,6 +216,30 @@ def _create_dummy_invoke_model_response(llm_response):
             _AMAZON_NOVA_REQUEST,
             _AMAZON_NOVA_RESPONSE,
             {"input_tokens": 8, "output_tokens": 12, "total_tokens": 20},
+        ),
+        (
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            _ANTHROPIC_REQUEST,
+            _ANTHROPIC_CACHED_RESPONSE,
+            {
+                "input_tokens": 158,
+                "output_tokens": 12,
+                "cache_read_input_tokens": 100,
+                "cache_creation_input_tokens": 50,
+                "total_tokens": 170,
+            },
+        ),
+        (
+            "us.amazon.nova-lite-v1:0",
+            _AMAZON_NOVA_REQUEST,
+            _AMAZON_NOVA_CACHED_RESPONSE,
+            {
+                "input_tokens": 108,
+                "output_tokens": 12,
+                "cache_read_input_tokens": 100,
+                "cache_creation_input_tokens": 0,
+                "total_tokens": 120,
+            },
         ),
         (
             "cohere.command-r-plus-v1:0",
@@ -456,6 +504,19 @@ _CONVERSE_RESPONSE = {
     "stopReason": "end_turn",
     "usage": {"inputTokens": 8, "outputTokens": 12},
     "metrics": {"latencyMs": 551},
+}
+
+# Converse response with prompt caching active. Per the AWS docs, inputTokens contains
+# only the non-cached input tokens.
+_CONVERSE_CACHED_RESPONSE = {
+    **_CONVERSE_RESPONSE,
+    "usage": {
+        "inputTokens": 8,
+        "outputTokens": 12,
+        "totalTokens": 20,
+        "cacheReadInputTokens": 100,
+        "cacheWriteInputTokens": 50,
+    },
 }
 
 _CONVERSE_EXPECTED_CHAT_ATTRIBUTE = [
@@ -758,6 +819,20 @@ _CONVERSE_MULTI_MODAL_EXPECTED_CHAT_ATTRIBUTE = [
             None,
             {"input_tokens": 8, "output_tokens": 2, "total_tokens": 10},
         ),
+        # 5. Conversation with prompt caching active
+        (
+            _CONVERSE_REQUEST,
+            _CONVERSE_CACHED_RESPONSE,
+            _CONVERSE_EXPECTED_CHAT_ATTRIBUTE,
+            None,
+            {
+                "input_tokens": 158,
+                "output_tokens": 12,
+                "cache_read_input_tokens": 100,
+                "cache_creation_input_tokens": 50,
+                "total_tokens": 170,
+            },
+        ),
     ],
 )
 def test_bedrock_autolog_converse(
@@ -1031,6 +1106,43 @@ TOKEN_USAGE_EDGE_CASE_DATA = [
         "usage_data": {"inputTokens": "10", "outputTokens": "5"},
         "expected_usage": None,  # Should return None since values are strings
     },
+    # 9. Prompt caching fields. Bedrock reports inputTokens excluding cache tokens, so
+    # input and total must be normalized to include them.
+    {
+        "name": "cache_token_fields",
+        "usage_data": {
+            "inputTokens": 500,
+            "outputTokens": 200,
+            "totalTokens": 700,
+            "cacheReadInputTokens": 10000,
+            "cacheWriteInputTokens": 300,
+        },
+        "expected_usage": {
+            "input_tokens": 10800,
+            "output_tokens": 200,
+            "cache_read_input_tokens": 10000,
+            "cache_creation_input_tokens": 300,
+            "total_tokens": 11000,
+        },
+    },
+    # 10. Zero cache fields keep the reported totals untouched
+    {
+        "name": "zero_cache_token_fields",
+        "usage_data": {
+            "inputTokens": 8,
+            "outputTokens": 12,
+            "totalTokens": 20,
+            "cacheReadInputTokens": 0,
+            "cacheWriteInputTokens": 0,
+        },
+        "expected_usage": {
+            "input_tokens": 8,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "total_tokens": 20,
+        },
+    },
 ]
 
 
@@ -1251,6 +1363,46 @@ STREAM_TOKEN_USAGE_EDGE_CASES = [
             {"type": "message_stop"},
         ],
         "expected_usage": {"input_tokens": 10, "output_tokens": 12, "total_tokens": 22},
+    },
+    # 7. Cache fields in message_start must survive buffering and be normalized into
+    # input exactly once at stream close
+    {
+        "name": "cache_fields_in_message_start",
+        "chunks": [
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "123",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 500,
+                        "output_tokens": 1,
+                        "cache_read_input_tokens": 10000,
+                        "cache_creation_input_tokens": 300,
+                    },
+                },
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "content_block": {"type": "text", "text": "Hello!"},
+            },
+            {
+                "type": "message_delta",
+                "delta": {},
+                "usage": {"output_tokens": 200},
+            },
+            {"type": "message_stop"},
+        ],
+        "expected_usage": {
+            "input_tokens": 10800,
+            "output_tokens": 200,
+            "cache_read_input_tokens": 10000,
+            "cache_creation_input_tokens": 300,
+            "total_tokens": 11000,
+        },
     },
 ]
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24867

### What changes are proposed in this pull request?

`mlflow.bedrock.autolog()` drops the prompt caching token fields the Bedrock APIs return, so traces for cached workloads under-report input tokens and under-compute cost (details and reproduction in the issue).

This PR adds cache token key lists to the bedrock usage parsers and normalizes the counts:

- Key variants cover the Converse API (`cacheReadInputTokens`/`cacheWriteInputTokens`), Anthropic-native InvokeModel bodies (`cache_read_input_tokens`/`cache_creation_input_tokens`) and Nova-native bodies (`cacheReadInputTokenCount`/`cacheWriteInputTokenCount`).
- Per the AWS docs, `inputTokens` excludes cache tokens, so input and total are normalized to include them, consistent with how `mlflow.anthropic` and the gateway already normalize and with what `cost_per_token()` expects. The total is recomputed rather than trusting the reported one, whose cache accounting is not documented.
- The cache fields are optional and only present when caching is enabled, so they are added to the usage dict only when found and behavior without them is unchanged.
- Normalization happens only in `parse_complete_token_usage_from_response`. The streaming wrappers buffer partial results and run the complete parser at stream close, so normalizing in both parsers would double count on the streaming paths.

All four call paths (`converse`, `converse_stream`, `invoke_model`, `invoke_model_with_response_stream`) go through these parsers, so one change covers them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New cases in `tests/bedrock/test_bedrock_autolog.py`: cache-bearing entries in the shared edge case table (exercised by the invoke_model, converse and converse_stream edge case tests), a dedicated streaming case that fails if normalization runs twice, cached Anthropic, Nova and Converse response fixtures in the main parametrizations, and a zero-value cache fields case confirming reported totals stay untouched.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Bedrock autologging now captures prompt caching token counts (`cache_read_input_tokens`, `cache_creation_input_tokens`) and normalizes input tokens to include them, so token usage and cost for cached workloads are reported correctly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fixes` - A bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release