### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
       # Batch low-risk bumps into a single PR, and leave major bumps on their
       # own so a CI failure points at one action.
       actions-minor:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    # "/" only covers .github/workflows. The composite actions under
+    # .github/actions/*/action.yml pin their own dependencies (actions/cache,
+    # actions/setup-python, astral-sh/setup-uv, ...) and need to be listed
+    # explicitly, otherwise they drift out of sync with the workflows.
+    # Avoid a "**/*" glob here: it double-scans workflow files and opens
+    # duplicate PRs (dependabot/dependabot-core#10884).
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: weekly
+    # Match the 7-day package cooldown used for Python (exclude-newer) and
+    # JavaScript (min-release-age) dependencies.
+    cooldown:
+      default-days: 7
+    groups:
+      # Batch low-risk bumps into a single PR, and leave major bumps on their
+      # own so a CI failure points at one action.
+      actions-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds `.github/dependabot.yml` to keep GitHub Actions up to date. There is no Dependabot config today, so action pins are bumped by hand and 17 of the 20 pinned actions are currently behind, including 6 major versions (`astral-sh/setup-uv` v7 -> v9, `actions/stale` v10 -> v11, `actions/setup-python` v6 -> v7, `actions/cache` v5 -> v6, `azure/setup-helm` v4 -> v5, `actions/github-script` v8 -> v9).

Dependabot updates the SHA and the trailing `# vX.Y.Z` comment together, so it works with the existing pinning style without any reformatting.

Two config choices worth calling out:

- `directories` lists `/.github/actions/*` in addition to `/`. For the `github-actions` ecosystem, `/` only covers `.github/workflows` plus a root-level `action.yml`, so the composite actions under `.github/actions/` would otherwise be skipped. Four of them pin external actions (`cache-hf`, `setup-java`, `setup-node`, `setup-python`), and two of those pins (`actions/cache`, `astral-sh/setup-uv`) are also used directly in workflows, so a workflow-only scope would bump one copy and leave the other stale. A `**/*` glob is deliberately avoided since it double-scans workflow files and opens duplicate PRs (dependabot/dependabot-core#10884).
- `cooldown.default-days: 7` mirrors the 7-day package cooldown already applied to Python (`exclude-newer` in `pyproject.toml`) and JavaScript (`min-release-age` in `.npmrc`).

Minor and patch bumps are grouped, major bumps stay separate so a CI failure points at a single action. Groups are per-directory, so expect roughly two grouped PRs (one per scope) rather than one. `group-by: dependency-name` would consolidate a dependency across both scopes, but it produces one PR per dependency and so removes the batching entirely; the brief version skew it avoids is harmless, since a workflow step and a composite action step resolve their pins independently.

### How is this PR tested?

- [x] Manual tests

Validated against the Dependabot schema and the repo's formatter:

```console
$ uv run --with check-jsonschema check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
ok -- validation done
$ uv run pre-commit run --files .github/dependabot.yml
prettier.................................................................Passed
```

Glob expansion of `/.github/actions/*` can only be exercised once Dependabot runs on the repo.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
