### PR TITLE
Exempt Dependabot PRs from the release-note label check

### DIFF
--- a/.github/workflows/release-note.js
+++ b/.github/workflows/release-note.js
@@ -20,14 +20,22 @@ function isReleaseNoteLabel(name) {
   return name.startsWith("rn/");
 }
 
+// Bots that open pull requests without filling in the PR template, so they can
+// never select a release-note category and must not be blocked on one.
+const AUTOMATION_BOTS = ["mlflow-app[bot]", "dependabot[bot]"];
+
+function isAutomationBot(login) {
+  return AUTOMATION_BOTS.includes(login);
+}
+
 async function validateLabeled({ core, context, github }) {
   const { user, html_url: pr_url } = context.payload.pull_request;
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
 
-  // Skip validation on pull requests created by the automation bot
-  if (user.login === "mlflow-app[bot]") {
-    console.log("This pull request was created by the automation bot, skipping");
+  // Skip validation on pull requests created by an automation bot
+  if (isAutomationBot(user.login)) {
+    console.log(`This pull request was created by ${user.login}, skipping`);
     return;
   }
 
@@ -81,8 +89,8 @@ async function postMerge({ context, github }) {
   const { owner, repo } = context.repo;
   const { number: issue_number } = context.issue;
 
-  if (user.login === "mlflow-app[bot]") {
-    console.log("This PR was created by the automation bot, skipping");
+  if (isAutomationBot(user.login)) {
+    console.log(`This PR was created by ${user.login}, skipping`);
     return;
   }
 


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #24901.

### What changes are proposed in this pull request?

`validate-labeled` fails on every Dependabot PR, because Dependabot does not use the PR template and so can never select a release-note category. It gates `protect`, which is required on `master`, so the PRs are stuck until a maintainer hand-applies an `rn/*` label.

`mlflow-app[bot]` is already exempt for the same reason. This moves that check into a shared `AUTOMATION_BOTS` list and adds `dependabot[bot]`, keeping the two call sites in sync.

### How is this PR tested?

- [x] Manual tests

```console
$ gh api repos/mlflow/mlflow/pulls/24903 --jq '.user.login'
dependabot[bot]
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
