### PR TITLE
Peel annotated tags in `check-actions` SHA verification

### DIFF
--- a/dev/check_actions.py
+++ b/dev/check_actions.py
@@ -89,8 +89,18 @@ def _verify_sha_tag(action: str, sha: str, tag: str, cache: dict[str, bool]) -> 
 
 
 def _resolve_tag(repo: str, sha: str, tag: str) -> bool:
+    # An annotated tag's ref points at the tag object, not the commit that `uses:` pins.
+    # The peeled ref 'refs/tags/<tag>^{}' holds that commit, but `ls-remote` only emits
+    # it when a pattern matches it, so ask for both (lightweight tags match the first).
     proc = subprocess.run(
-        ["git", "ls-remote", "--tags", f"https://github.com/{repo}.git", tag],
+        [
+            "git",
+            "ls-remote",
+            "--tags",
+            f"https://github.com/{repo}.git",
+            tag,
+            f"{tag}^{{}}",
+        ],
         capture_output=True,
         text=True,
         timeout=_LS_REMOTE_TIMEOUT,


### PR DESCRIPTION
### Related Issues/PRs

Surfaced by the Dependabot PRs from #24901 (e.g. #24904).

### What changes are proposed in this pull request?

`check-actions` rejects a correctly pinned action when the version tag is annotated:

```
.github/workflows/protect.yml:41: 'uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0'
  error: SHA '3a2844b7e9c422d3c10d287c895573f7108da1b3' does not match tag 'v9.0.0' for actions/github-script
```

`_resolve_tag` runs `git ls-remote --tags <repo> <tag>`. For an annotated tag that ref points at the tag object, while `uses:` pins the commit, which lives on the peeled ref `refs/tags/<tag>^{}`. The pattern argument filters the peeled ref out, so the commit is never seen:

```console
$ git ls-remote --tags https://github.com/actions/github-script.git v9.0.0
d746ffe35508b1917358783b479e04febd2b8f71	refs/tags/v9.0.0

$ git ls-remote --tags https://github.com/actions/github-script.git v9.0.0 'v9.0.0^{}'
d746ffe35508b1917358783b479e04febd2b8f71	refs/tags/v9.0.0
3a2844b7e9c422d3c10d287c895573f7108da1b3	refs/tags/v9.0.0^{}
```

This is not specific to Dependabot: `actions/github-script` v8.0.0 is a lightweight tag (its ref is the commit, so the check passes today) and v9.0.0 is annotated, so any action that switches tag style trips it. Passing the peeled pattern as well fixes annotated tags and leaves lightweight tags matching on the first ref.

### How is this PR tested?

- [x] Manual tests

Both tag styles verify, and a wrong SHA is still rejected:

```console
$ PASS  v9.0.0 3a2844b7 -> True  (expected True)   [annotated -> peeled commit]
$ PASS  v8.0.0 ed597411 -> True  (expected True)   [lightweight]
$ PASS  v9.0.0 ed597411 -> False (expected False)  [wrong sha still rejected]
```

The check also still passes against the current tree:

```console
$ uv run --frozen --only-group lint dev/check_actions.py
$ echo $?
0
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release