### PR TITLE
Skip the `title` self-test on Dependabot PRs

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -21,12 +21,14 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     # Trigger conditions:
-    # - pull_request: skip fork PRs (no access to secrets)
+    # - pull_request: skip fork PRs and Dependabot PRs (neither can read secrets;
+    #   Dependabot branches live in this repo, so the fork check alone misses them)
     # - issue_comment: only maintainers can trigger via `/title` on PRs or issues
     if: >
       (
         github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.pull_request.user.login != 'dependabot[bot]'
       )
       || (
         startsWith(github.event.comment.body, '/title')


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #24901. Unblocks #24902.

### What changes are proposed in this pull request?

On `pull_request` the `title` job is a self-test, gated by a path filter on `title.yml` and `title.js`. Both `actions/checkout` and `actions/github-script` are pinned inside `title.yml`, so any Dependabot bump of either trips the filter and runs a job that cannot read `secrets.EXPERIMENTAL_ANTHROPIC_API_KEY`:

```
Error: Missing required environment variables: REPO, NUMBER, ANTHROPIC_API_KEY
```

`protect` requires every other check to pass, so those PRs are stuck, and this recurs on each release of two frequently updated actions.

The `if` already skips fork PRs with the comment "no access to secrets". Dependabot branches live in this repo rather than a fork, so that check misses them; this excludes the author explicitly.

The alternative, mirroring the key into the Dependabot secrets scope, would give lower-trust runs an Anthropic key and spend budget on every such PR. Without the secret the job can only fail, so no coverage is lost either way.

### How is this PR tested?

- [x] Manual tests

```console
$ uv run pre-commit run --files .github/workflows/title.yml
check-github-workflows...................................................Passed
conftest.................................................................Passed
```

Only the `pull_request` branch of the `if` changes; the `issue_comment` path and non-Dependabot PRs are unaffected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
