### PR TITLE
Group Dependabot major bumps by dependency name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,22 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      # Batch low-risk bumps into a single PR, and leave major bumps on their
-      # own so a CI failure points at one action.
+      # Batch low-risk bumps into a single PR. Grouped updates already span both
+      # directories, so an action pinned in each moves in one commit.
       actions-minor:
         patterns:
           - "*"
         update-types:
           - minor
           - patch
+      # Majors stay one-per-action so a CI failure points at a single bump, but
+      # they still have to be grouped: an ungrouped update opens a separate PR
+      # per directory, and `check-actions` rejects an action pinned to two
+      # versions, so neither half can pass on its own. `group-by` keeps every
+      # copy of one action in the same PR.
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - major
+        group-by: dependency-name


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #24901. Supersedes #24906 and #24907, which cannot merge as-is.

### What changes are proposed in this pull request?

Ungrouped updates open a separate PR per directory. `actions/cache` is pinned in both `.github/workflows` and `.github/actions/cache-hf`, so its v6 bump arrived as two PRs, each moving only one copy:

```
check-actions: the following violations were found:

actions/cache is pinned to multiple versions:
  .github/actions/cache-hf/action.yml:6: '- uses: actions/cache@cdf6c1f... # v5.0.3'
  .github/workflows/lint.yml:72:         'uses: actions/cache@55cc834... # v6.1.0'
```

`check-actions` rejects an action pinned to two versions, so neither half passes CI on its own and neither can merge. This will repeat for every major bump of `actions/cache`, `astral-sh/setup-uv`, and anything else pinned in more than one place.

Majors now sit in their own group with `group-by: dependency-name`, so every copy of one action moves in a single PR while separate actions stay in separate PRs, keeping a CI failure attributable to one bump. The minor/patch group already spanned both directories (#24902 covered 11 updates across 2 directories), which is why only majors were affected.

Note that `group-by` is missing from the vendored SchemaStore `dependabot.json`, which sets `additionalProperties: false`, so `check-jsonschema --builtin-schema vendor.dependabot` rejects it. The schema is stale rather than the option being invalid: it is [documented](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) and used in production configs such as [LadybirdBrowser/ladybird](https://github.com/LadybirdBrowser/ladybird/blob/master/.github/dependabot.yml) and [TomHennen/wrangle](https://github.com/TomHennen/wrangle/blob/main/.github/dependabot.yml). Nothing in CI validates this file against that schema.

Once this lands, #24906 and #24907 should be closed so Dependabot recreates the `actions/cache` bump as a single PR.

### How is this PR tested?

- [x] Manual tests

```console
$ uv run pre-commit run --files .github/dependabot.yml
prettier.................................................................Passed
$ uv run python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"
```

Grouping behavior can only be confirmed once Dependabot next runs on the default branch.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release