### PR TITLE
Avoid pairing external team reviewers

### DIFF
--- a/.github/workflows/team-review.js
+++ b/.github/workflows/team-review.js
@@ -9,6 +9,7 @@ const MEMBERS = [
   "mprahl",
   "HumairAK",
 ];
+const REVIEWER_BALANCE_RULES = [{ reviewers: ["mprahl", "HumairAK"], maxSelected: 1 }];
 
 async function loadStats(github, owner, repo) {
   try {
@@ -52,6 +53,35 @@ function shuffle(array) {
   return shuffled;
 }
 
+function violatesReviewerBalanceRule(reviewers) {
+  return REVIEWER_BALANCE_RULES.some((rule) => {
+    const selectedCount = rule.reviewers.filter((reviewer) => reviewers.includes(reviewer)).length;
+    return selectedCount > rule.maxSelected;
+  });
+}
+
+function balanceReviewerSelection(selectedReviewers, candidateReviewers) {
+  if (!violatesReviewerBalanceRule(selectedReviewers)) {
+    return selectedReviewers;
+  }
+
+  for (let i = selectedReviewers.length - 1; i >= 0; i--) {
+    for (const candidate of candidateReviewers) {
+      if (selectedReviewers.includes(candidate)) {
+        continue;
+      }
+
+      const replacement = [...selectedReviewers];
+      replacement[i] = candidate;
+      if (!violatesReviewerBalanceRule(replacement)) {
+        return replacement;
+      }
+    }
+  }
+
+  return selectedReviewers;
+}
+
 /**
  * Select reviewers with the lowest review counts, with random shuffling within each count tier.
  *
@@ -87,18 +117,15 @@ function selectReviewers(eligibleReviewers, stats, count = 2) {
   const sortedCounts = Object.keys(groups)
     .map(Number)
     .sort((a, b) => a - b);
-  const result = [];
+  const candidates = [];
   for (const c of sortedCounts) {
     const shuffled = shuffle(groups[c]);
     for (const reviewer of shuffled) {
-      result.push(reviewer);
-      if (result.length >= count) {
-        return result;
-      }
+      candidates.push(reviewer);
     }
   }
 
-  return result;
+  return balanceReviewerSelection(candidates.slice(0, count), candidates);
 }
 
 function updateStats(stats, selectedReviewers) {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #19428

### What changes are proposed in this pull request?

Avoid assigning `mprahl` and `HumairAK` together from the `team-review` reviewer rotation when another eligible reviewer is available. This keeps the two-reviewer assignment but prefers pairing either of them with someone else on the team.

If they are the only eligible reviewers, the workflow still assigns both instead of assigning fewer reviewers.

### How is this PR tested?

- [x] Manual tests

Manual checks:

```bash
node --check .github/workflows/team-review.js
UV_CACHE_DIR=/tmp/mlflow-team-review-uv-cache uv run --no-sync pre-commit run prettier --files .github/workflows/team-review.js
node -e 'const fs=require("fs"), vm=require("vm"); const code=fs.readFileSync(".github/workflows/team-review.js","utf8") + "\nmodule.exports._test = { selectReviewers };"; const math=Object.create(Math); math.random=()=>0; const sandbox={require, console, Math: math, module:{exports:{}}, process}; vm.runInNewContext(code, sandbox); const { selectReviewers }=sandbox.module.exports._test; const selected=selectReviewers(["mprahl","HumairAK","B-Step62"], {reviewCounts:{}}, 2); if (selected.includes("mprahl") && selected.includes("HumairAK")) { console.error(selected); process.exit(1); } const fallback=selectReviewers(["mprahl","HumairAK"], {reviewCounts:{}}, 2); if (!(fallback.includes("mprahl") && fallback.includes("HumairAK"))) { console.error(fallback); process.exit(2); } console.log(JSON.stringify({selected, fallback}));'
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
