### PR TITLE
Add per-record scorers to GenAI evaluation datasets

### DIFF
--- a/mlflow/entities/dataset_record.py
+++ b/mlflow/entities/dataset_record.py
@@ -14,6 +14,84 @@ from mlflow.protos.datasets_pb2 import DatasetRecordSource as ProtoDatasetRecord
 # Reserved key for wrapping non-dict outputs when storing in SQL database
 DATASET_RECORD_WRAPPED_OUTPUT_KEY = "mlflow_wrapped"
 
+# Reserved record tag holding the names of the scorers to run on that record alone.
+# Record tags are ``dict[str, str]``, so the names are stored comma-separated. This
+# piggybacks on tags rather than adding a dedicated field so that per-record scorers
+# need no dataset schema change.
+DATASET_RECORD_SCORERS_TAG = "mlflow.scorers"
+
+
+def encode_record_scorers(scorer_names: list[str]) -> str:
+    return ",".join(scorer_names)
+
+
+def decode_record_scorers(tag_value: str | None) -> list[str]:
+    if not tag_value:
+        return []
+    return [name for part in tag_value.split(",") if (name := part.strip())]
+
+
+def validate_record_scorer_names(scorers: Any) -> list[str]:
+    """Validate a record's ``scorers`` value and return it as a list of scorer names.
+
+    Only names are accepted. Passing a ``Scorer`` object is rejected because a persisted
+    record can only carry a reference, not a definition.
+    """
+    from mlflow.exceptions import MlflowException
+
+    if scorers is None or isinstance(scorers, float):  # float covers a NaN cell from pandas
+        return []
+
+    if isinstance(scorers, str):
+        raise MlflowException.invalid_parameter_value(
+            f"The record `scorers` field must be a list of scorer names, got the string "
+            f"{scorers!r}. Use `scorers=[{scorers!r}]`."
+        )
+
+    if not isinstance(scorers, (list, tuple)):
+        raise MlflowException.invalid_parameter_value(
+            f"The record `scorers` field must be a list of scorer names, got "
+            f"{type(scorers).__name__}."
+        )
+
+    for name in scorers:
+        if isinstance(name, str):
+            continue
+        # Scorer objects are the most likely mistake here, so name that case explicitly.
+        hint = (
+            " Pass the scorer's registered name instead, e.g. "
+            f"`scorers=[{getattr(name, 'name', 'my_scorer')!r}]`."
+            if hasattr(name, "name")
+            else ""
+        )
+        raise MlflowException.invalid_parameter_value(
+            f"The record `scorers` field must contain scorer names, got an item of type "
+            f"{type(name).__name__}.{hint}"
+        )
+
+    return list(scorers)
+
+
+def fold_record_scorers_into_tags(record_dicts: list[dict[str, Any]]) -> None:
+    """Move each record's ``scorers`` list into its ``tags`` map, in place.
+
+    Persisting via tags keeps per-record scorers off the dataset schema. Records without
+    ``scorers`` are left untouched, so a dataset that never uses the feature is unchanged.
+    """
+    for record in record_dicts:
+        if not isinstance(record, dict) or "scorers" not in record:
+            continue
+
+        scorer_names = validate_record_scorer_names(record.pop("scorers"))
+        if not scorer_names:
+            continue
+
+        tags = record.get("tags")
+        if tags is None or isinstance(tags, float):
+            tags = {}
+            record["tags"] = tags
+        tags[DATASET_RECORD_SCORERS_TAG] = encode_record_scorers(scorer_names)
+
 
 @dataclass
 class DatasetRecord(_MlflowObject):
@@ -53,6 +131,11 @@ class DatasetRecord(_MlflowObject):
                     self.source_id = self.source.source_data.get("source_id")
             if not self.source_type:
                 self.source_type = self.source.source_type.value
+
+    @property
+    def scorers(self) -> list[str]:
+        """Names of the scorers to run on this record alone, in addition to the run-level ones."""
+        return decode_record_scorers((self.tags or {}).get(DATASET_RECORD_SCORERS_TAG))
 
     def to_proto(self) -> ProtoDatasetRecord:
         proto = ProtoDatasetRecord()

--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -8,7 +8,7 @@ from mlflow.data import Dataset
 from mlflow.data.evaluation_dataset_source import EvaluationDatasetSource
 from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
 from mlflow.entities._mlflow_object import _MlflowObject
-from mlflow.entities.dataset_record import DatasetRecord
+from mlflow.entities.dataset_record import DatasetRecord, fold_record_scorers_into_tags
 from mlflow.entities.dataset_record_source import DatasetRecordSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.datasets_pb2 import Dataset as ProtoDataset
@@ -227,6 +227,10 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
                 - DataFrame with 'inputs' column and optionally 'expectations' and 'tags' columns
                 - List of Trace objects
 
+                A record may also carry a 'scorers' list naming scorers to run on that
+                record alone during evaluation. Only names are accepted, and each must
+                refer to a built-in scorer or a scorer registered to the experiment.
+
         Returns:
             Self for method chaining
 
@@ -266,6 +270,8 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             record_dicts = records
 
         self._validate_record_dicts(record_dicts)
+
+        fold_record_scorers_into_tags(record_dicts)
 
         self._infer_source_types(record_dicts)
 

--- a/mlflow/genai/datasets/evaluation_dataset.py
+++ b/mlflow/genai/datasets/evaluation_dataset.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any
 
 from mlflow.data import Dataset
 from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
+from mlflow.entities.dataset_record import fold_record_scorers_into_tags
 from mlflow.entities.evaluation_dataset import (
     EvaluationDataset as _EntityEvaluationDataset,
 )
@@ -12,6 +13,33 @@ from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
 if TYPE_CHECKING:
     import pandas as pd
     import pyspark.sql
+
+
+def _fold_scorers_for_managed_backend(
+    records: "list[dict[str, Any]] | pd.DataFrame | pyspark.sql.DataFrame",
+) -> "list[dict[str, Any]] | pd.DataFrame | pyspark.sql.DataFrame":
+    """Move a ``scorers`` column into record tags, for records bound for the managed backend.
+
+    Returns the records unchanged when no ``scorers`` are present, so datasets that don't use
+    the feature take exactly the path they did before.
+    """
+    import pandas as pd
+
+    if isinstance(records, list):
+        if not any(isinstance(r, dict) and "scorers" in r for r in records):
+            return records
+        # Copy so the caller's dicts are not mutated; the OSS arm folds in place on dicts it
+        # already owns, but here the list came straight from user code.
+        records = [dict(r) if isinstance(r, dict) else r for r in records]
+        fold_record_scorers_into_tags(records)
+        return records
+
+    if isinstance(records, pd.DataFrame) and "scorers" in records.columns:
+        record_dicts = records.to_dict("records")
+        fold_record_scorers_into_tags(record_dicts)
+        return pd.DataFrame(record_dicts)
+
+    return records
 
 
 class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
@@ -169,12 +197,21 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
         self,
         records: "list[dict[str, Any]] | pd.DataFrame | pyspark.sql.DataFrame",
     ) -> "EvaluationDataset":
-        """Merge records into the dataset."""
+        """Merge records into the dataset.
+
+        A record may carry a ``scorers`` list naming scorers to run on that record alone
+        during evaluation. Only names are accepted, and each must refer to a built-in scorer
+        or a scorer registered to the experiment.
+        """
         if self._mlflow_dataset:
             self._mlflow_dataset.merge_records(records)
             return self
 
         from mlflow.genai.datasets import _databricks_profile_env
+
+        # The managed backend has no `scorers` field, so fold the names into record tags before
+        # handing off to databricks-agents. Unrecognized keys would otherwise be dropped.
+        records = _fold_scorers_for_managed_backend(records)
 
         with _databricks_profile_env():
             dataset = self._databricks_dataset.merge_records(records)

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 def evaluate(
     data: "EvaluationDatasetTypes",
-    scorers: list[Scorer],
+    scorers: list[Scorer] | None = None,
     predict_fn: Callable[..., Any] | None = None,
     model_id: str | None = None,
 ) -> "EvaluationResult":
@@ -217,6 +217,27 @@ def evaluate(
             scorers=[Safety()],
         )
 
+    **4. Run different scorers on different rows.**
+
+    A `scorers` column names extra scorers to run on that row alone. Names must refer to
+    built-in scorers or scorers registered to the experiment. The `scorers` argument still
+    applies to every row, and may be omitted when every scorer is declared per row.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import Correctness
+
+        mlflow.genai.evaluate(
+            data=[
+                # Graded by Correctness and Safety.
+                {"inputs": {...}, "expectations": {...}, "scorers": ["safety"]},
+                # Graded by Correctness only.
+                {"inputs": {...}, "expectations": {...}},
+            ],
+            scorers=[Correctness()],
+        )
+
     Args:
         data: Dataset for the evaluation. Must be one of the following formats:
 
@@ -261,10 +282,15 @@ def evaluate(
             Optional columns:
                 - tags (optional): Column containing a dictionary of tags. The tags will be logged
                                    to the respective traces.
+                - scorers (optional): Column containing a list of scorer names to run on that
+                                      row only, in addition to the `scorers` argument. Each name
+                                      must be a built-in scorer or a scorer registered to the
+                                      experiment.
 
         scorers: A list of Scorer objects that produces evaluation scores from
             inputs, outputs, and other additional contexts. MLflow provides pre-defined
-            scorers, but you can also define custom ones.
+            scorers, but you can also define custom ones. Optional when every scorer is
+            declared per row via the `scorers` column.
 
         predict_fn: The target function to be evaluated. The specified function will be
             executed for each row in the input dataset, and outputs will be used for

--- a/mlflow/genai/evaluation/constant.py
+++ b/mlflow/genai/evaluation/constant.py
@@ -34,6 +34,7 @@ class InputDatasetColumn:
     TAGS = "tags"
     TRACE = "trace"
     SOURCE = "source"
+    SCORERS = "scorers"
 
 
 # Result Dataframe column names

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -9,6 +9,11 @@ import pandas as pd
 
 from mlflow.entities.assessment import Expectation, Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.dataset_record import (
+    DATASET_RECORD_SCORERS_TAG,
+    decode_record_scorers,
+    validate_record_scorer_names,
+)
 from mlflow.entities.dataset_record_source import DatasetRecordSource
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
@@ -93,6 +98,9 @@ class EvalItem:
     """Tags from the eval item."""
     tags: dict[str, str] | None = None
 
+    """Names of scorers to run on this item alone, in addition to the run-level scorers."""
+    scorers: list[str] = field(default_factory=list)
+
     """Trace of the model invocation."""
     trace: Trace | None = None
 
@@ -145,6 +153,17 @@ class EvalItem:
         # Extract tags column from the dataset.
         tags = row.get(InputDatasetColumn.TAGS, {})
 
+        # Per-record scorers come either from a `scorers` column (in-memory data) or from the
+        # reserved tag (records read back from a persisted dataset). The column wins so that a
+        # caller can override what the dataset persisted. Malformed tags are left for
+        # validate_tags() to report during scoring.
+        if InputDatasetColumn.SCORERS in row:
+            scorers = validate_record_scorer_names(row.get(InputDatasetColumn.SCORERS))
+        elif isinstance(tags, dict):
+            scorers = decode_record_scorers(tags.get(DATASET_RECORD_SCORERS_TAG))
+        else:
+            scorers = []
+
         # Extract source column from the dataset.
         source = row.get(InputDatasetColumn.SOURCE)
         if is_none_or_nan(source):
@@ -169,6 +188,7 @@ class EvalItem:
             outputs=outputs,
             expectations=expectations,
             tags=tags,
+            scorers=scorers,
             trace=trace,
             source=source,
         )

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -40,6 +40,7 @@ import mlflow
 from mlflow.entities import SpanType
 from mlflow.entities.assessment import Assessment, Expectation, Feedback
 from mlflow.entities.assessment_error import AssessmentError
+from mlflow.entities.dataset_record import DATASET_RECORD_SCORERS_TAG
 from mlflow.entities.trace import Trace
 from mlflow.environment_variables import (
     MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING,
@@ -78,6 +79,7 @@ from mlflow.genai.evaluation.utils import (
 )
 from mlflow.genai.scorers.aggregation import compute_aggregated_metrics
 from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.resolution import resolve_scorer_names
 from mlflow.genai.utils.trace_utils import (
     _does_store_support_trace_linking,
     batch_link_traces_to_run,
@@ -102,6 +104,39 @@ def _merge_scorer_stats_dicts(target: dict[str, ScorerStat], source: dict[str, S
         if scorer_name not in target:
             target[scorer_name] = ScorerStat()
         target[scorer_name].merge(stat)
+
+
+def _resolve_per_record_scorers(
+    eval_items: list[EvalItem],
+    run_level_scorers: list[Scorer],
+    experiment_id: str | None,
+) -> dict[str, Scorer]:
+    """Resolve the scorer names referenced by individual eval items.
+
+    Names already covered by a run-level scorer are not looked up, since that instance is
+    what the item would run anyway.
+    """
+    run_level_names = {scorer.name for scorer in run_level_scorers}
+    referenced = {name for item in eval_items for name in item.scorers} - run_level_names
+    return resolve_scorer_names(referenced, experiment_id)
+
+
+def _scorers_for_item(
+    eval_item: EvalItem,
+    run_level_scorers: list[Scorer],
+    per_record_scorers: dict[str, Scorer],
+) -> list[Scorer]:
+    """Return the scorers to run on one item: the run-level ones plus its own, de-duplicated."""
+    if not eval_item.scorers:
+        return run_level_scorers
+
+    scorers = list(run_level_scorers)
+    seen = {scorer.name for scorer in scorers}
+    for name in eval_item.scorers:
+        if name not in seen and (scorer := per_record_scorers.get(name)):
+            scorers.append(scorer)
+            seen.add(name)
+    return scorers
 
 
 def _parse_rate_limit(raw: str | None) -> tuple[float | None, bool]:
@@ -394,6 +429,7 @@ class _ScoreSubmitter:
         adaptive: bool,
         max_rps_multiplier: float,
         pool_workers: int,
+        per_record_scorers: dict[str, Scorer] | None = None,
     ):
         """
         Args:
@@ -409,10 +445,12 @@ class _ScoreSubmitter:
             adaptive: Whether the rate limiter uses AIMD to adapt to 429 signals.
             max_rps_multiplier: AIMD ceiling as a multiple of the initial rps.
             pool_workers: Number of threads in the score pool.
+            per_record_scorers: Resolved scorers referenced by individual items, keyed by name.
         """
         self._eval_items = eval_items
         self._single_turn_scorers = single_turn_scorers
         self._multi_turn_scorers = multi_turn_scorers
+        self._per_record_scorers = per_record_scorers or {}
         self._session_groups = session_groups
         self._run_id = run_id
         self._max_retries = max_retries
@@ -444,10 +482,11 @@ class _ScoreSubmitter:
     def submit(self, idx: int) -> Future:
         """Submit a score task for eval item *idx* and return the future."""
         _logger.debug(f"Predict completed for item {idx}, submitting score")
+        eval_item = self._eval_items[idx]
         future = self._pool.submit(
             self._timed_score,
-            self._eval_items[idx],
-            self._single_turn_scorers,
+            eval_item,
+            _scorers_for_item(eval_item, self._single_turn_scorers, self._per_record_scorers),
             self._run_id,
             self._limiter,
             self._max_retries,
@@ -529,6 +568,7 @@ def _run_pipeline(
     progress_bar,
     multi_turn_eval_results: dict[str, EvalResult],
     experiment_id: str | None,
+    per_record_scorers: dict[str, Scorer] | None = None,
 ) -> tuple[list[float], list[float]]:
     """Run the predict→score pipeline and multi-turn scoring.
 
@@ -538,8 +578,12 @@ def _run_pipeline(
     """
     _warmup_databricks_sdk()
 
+    per_record_scorers = per_record_scorers or {}
     predict_rps, predict_adaptive = _parse_rate_limit(MLFLOW_GENAI_EVAL_PREDICT_RATE_LIMIT.get())
-    num_scorers = len(single_turn_scorers) + len(multi_turn_scorers)
+    # Per-record scorers only run on a subset of items, so counting them here overstates the
+    # call volume. That is the safe direction: it raises the derived scorer rate ceiling rather
+    # than throttling below what the run actually needs.
+    num_scorers = len(single_turn_scorers) + len(multi_turn_scorers) + len(per_record_scorers)
     scorer_rps, scorer_adaptive = _get_scorer_rate_config(
         predict_rps, predict_adaptive, num_scorers
     )
@@ -570,12 +614,13 @@ def _run_pipeline(
         adaptive=scorer_adaptive,
         max_rps_multiplier=_AIMD_UPPER_MULTIPLIER,
         pool_workers=score_workers,
+        per_record_scorers=per_record_scorers,
     )
 
     try:
         heartbeat = (
             _Heartbeat(predictor, scorer_submitter, len(eval_items))
-            if single_turn_scorers
+            if (single_turn_scorers or per_record_scorers)
             else None
         )
 
@@ -678,7 +723,11 @@ def run(
     run_id = context.get_context().get_mlflow_run_id() if run_id is None else run_id
     experiment_id = mlflow.get_run(run_id).info.experiment_id
 
+    scorers = scorers or []
     single_turn_scorers, multi_turn_scorers = classify_scorers(scorers)
+    # Records may reference scorers by name; resolve them once here so a bad name fails before
+    # any prediction runs rather than per row inside the score pool.
+    per_record_scorers = _resolve_per_record_scorers(eval_items, scorers, experiment_id)
     session_groups = group_traces_by_session(eval_items) if multi_turn_scorers else {}
     # Every eval item goes through the score pool (even with no single-turn
     # scorers, _run_score still logs expectations and tags), so each item
@@ -714,6 +763,7 @@ def run(
             progress_bar=progress_bar,
             multi_turn_eval_results=multi_turn_eval_results,
             experiment_id=experiment_id,
+            per_record_scorers=per_record_scorers,
         )
     finally:
         predict_total = sum(predict_times)
@@ -761,12 +811,17 @@ def run(
     # Check for scorer failures and log a summary warning
     _log_scorer_failure_summary(scorer_stats)
 
-    # Aggregate metrics and log to MLflow run
-    aggregated_metrics = compute_aggregated_metrics(eval_results, scorers=scorers)
+    # Aggregate metrics and log to MLflow run. Per-record scorers are included so that their
+    # declared aggregations apply; each metric is averaged over the rows that scorer actually
+    # produced a value for, not the full row count.
+    all_scorers = [*scorers, *per_record_scorers.values()]
+    aggregated_metrics = compute_aggregated_metrics(eval_results, scorers=all_scorers)
     mlflow.log_metrics(aggregated_metrics)
 
     try:
-        emit_metric_usage_event(scorers, len(eval_items), len(session_groups), aggregated_metrics)
+        emit_metric_usage_event(
+            all_scorers, len(eval_items), len(session_groups), aggregated_metrics
+        )
     except Exception as e:
         _logger.debug(f"Failed to emit metric usage event: {e}", exc_info=True)
 
@@ -791,7 +846,7 @@ def run(
     # pass/fail for non-yes/no values. In-process only; not persisted.
     pass_criteria = {
         scorer.name: scorer.pass_if
-        for scorer in (scorers or [])
+        for scorer in all_scorers
         if getattr(scorer, "pass_if", None) is not None
     }
 
@@ -886,7 +941,9 @@ def _run_score(
     tags = eval_item.tags if not is_none_or_nan(eval_item.tags) else {}
     validate_tags(tags)
 
-    for key in tags.keys() - IMMUTABLE_TAGS:
+    # The per-record scorer tag is dataset metadata, not trace metadata; the assessments on the
+    # trace already record which scorers ran.
+    for key in tags.keys() - IMMUTABLE_TAGS - {DATASET_RECORD_SCORERS_TAG}:
         try:
             mlflow.set_trace_tag(trace_id=eval_item.trace.info.trace_id, key=key, value=tags[key])
         except Exception as e:

--- a/mlflow/genai/scorers/resolution.py
+++ b/mlflow/genai/scorers/resolution.py
@@ -1,0 +1,68 @@
+"""Resolution of scorer names to :py:class:`~mlflow.genai.scorers.base.Scorer` instances.
+
+Per-record scorers are persisted as names, so the harness needs to turn a name back into a
+runnable scorer. A name resolves against the built-in scorers first, then the scorer registry
+for the active experiment.
+"""
+
+import logging
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.base import Scorer
+
+_logger = logging.getLogger(__name__)
+
+
+def _builtin_scorers_by_name() -> dict[str, Scorer]:
+    from mlflow.genai.scorers.builtin_scorers import get_all_scorers
+
+    return {scorer.name: scorer for scorer in get_all_scorers()}
+
+
+def resolve_scorer_names(names: set[str], experiment_id: str | None = None) -> dict[str, Scorer]:
+    """Resolve scorer names to scorer instances.
+
+    Args:
+        names: Scorer names to resolve.
+        experiment_id: Experiment whose registered scorers to search. Defaults to the active
+            experiment.
+
+    Returns:
+        Mapping of name to the resolved scorer.
+
+    Raises:
+        MlflowException: If any name resolves to neither a built-in nor a registered scorer.
+    """
+    if not names:
+        return {}
+
+    resolved: dict[str, Scorer] = {}
+    builtins = _builtin_scorers_by_name()
+    unresolved: list[str] = []
+
+    for name in sorted(names):
+        if builtin := builtins.get(name):
+            resolved[name] = builtin
+            continue
+
+        try:
+            resolved[name] = _get_registered_scorer(name, experiment_id)
+        except Exception as e:
+            _logger.debug(f"Failed to resolve scorer {name!r} from the registry: {e}")
+            unresolved.append(name)
+
+    if unresolved:
+        raise MlflowException.invalid_parameter_value(
+            f"The following per-record scorers could not be resolved: {unresolved}. "
+            f"A per-record scorer must be either a built-in scorer or a scorer registered "
+            f"to the experiment. Register a custom scorer with `my_scorer.register()` before "
+            f"referencing it by name. Available built-in scorers: {sorted(builtins)}."
+        )
+
+    return resolved
+
+
+def _get_registered_scorer(name: str, experiment_id: str | None) -> Scorer:
+    from mlflow.genai.scorers.registry import get_scorer
+
+    return get_scorer(name=name, experiment_id=experiment_id)

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -23,16 +23,20 @@ _logger = logging.getLogger(__name__)
 IS_DBX_AGENTS_INSTALLED = importlib.util.find_spec("databricks.agents") is not None
 
 
-def validate_scorers(scorers: list[Any]) -> list[Scorer]:
+def validate_scorers(scorers: list[Any] | None) -> list[Scorer]:
     """
     Validate a list of specified scorers.
 
     Args:
-        scorers: A list of scorers to validate.
+        scorers: A list of scorers to validate. ``None`` is treated as an empty list, for runs
+            where every scorer is declared per record.
 
     Returns:
         A list of valid scorers.
     """
+    if scorers is None:
+        return []
+
     if not isinstance(scorers, list):
         raise MlflowException.invalid_parameter_value(
             "The `scorers` argument must be a list of scorers. If you are unsure about which "

--- a/tests/entities/test_dataset_record.py
+++ b/tests/entities/test_dataset_record.py
@@ -2,8 +2,14 @@ import json
 
 import pytest
 
-from mlflow.entities.dataset_record import DatasetRecord
+from mlflow.entities.dataset_record import (
+    DATASET_RECORD_SCORERS_TAG,
+    DatasetRecord,
+    fold_record_scorers_into_tags,
+    validate_record_scorer_names,
+)
 from mlflow.entities.dataset_record_source import DatasetRecordSource
+from mlflow.exceptions import MlflowException
 from mlflow.protos.datasets_pb2 import DatasetRecord as ProtoDatasetRecord
 from mlflow.protos.datasets_pb2 import DatasetRecordSource as ProtoDatasetRecordSource
 
@@ -463,3 +469,88 @@ def test_dataset_record_complex_inputs():
 
     assert record3.inputs == complex_data
     assert record3.expectations == record.expectations
+
+
+def _record(**kwargs) -> DatasetRecord:
+    return DatasetRecord(
+        dataset_id="dataset123",
+        dataset_record_id="rec123",
+        inputs={"question": "What is MLflow?"},
+        created_time=123456789,
+        last_update_time=123456789,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tag_value", "expected"),
+    [
+        ("safety", ["safety"]),
+        ("safety,correctness", ["safety", "correctness"]),
+        ("safety , correctness", ["safety", "correctness"]),
+        ("", []),
+        (None, []),
+    ],
+)
+def test_dataset_record_scorers_property(tag_value: str | None, expected: list[str]):
+    tags = {} if tag_value is None else {DATASET_RECORD_SCORERS_TAG: tag_value}
+    assert _record(tags=tags).scorers == expected
+
+
+def test_dataset_record_scorers_property_without_tags():
+    assert _record().scorers == []
+
+
+def test_fold_record_scorers_into_tags():
+    records = [
+        {"inputs": {"q": "a"}, "scorers": ["safety", "correctness"]},
+        {"inputs": {"q": "b"}, "tags": {"team": "search"}, "scorers": ["safety"]},
+        {"inputs": {"q": "c"}},
+    ]
+
+    fold_record_scorers_into_tags(records)
+
+    assert records == [
+        {"inputs": {"q": "a"}, "tags": {DATASET_RECORD_SCORERS_TAG: "safety,correctness"}},
+        {
+            "inputs": {"q": "b"},
+            "tags": {"team": "search", DATASET_RECORD_SCORERS_TAG: "safety"},
+        },
+        {"inputs": {"q": "c"}},
+    ]
+
+
+@pytest.mark.parametrize("empty", [[], None, float("nan")])
+def test_fold_record_scorers_into_tags_drops_empty_scorers(empty):
+    records = [{"inputs": {"q": "a"}, "scorers": empty}]
+
+    fold_record_scorers_into_tags(records)
+
+    assert records == [{"inputs": {"q": "a"}}]
+
+
+def test_fold_record_scorers_into_tags_replaces_nan_tags():
+    records = [{"inputs": {"q": "a"}, "tags": float("nan"), "scorers": ["safety"]}]
+
+    fold_record_scorers_into_tags(records)
+
+    assert records == [
+        {"inputs": {"q": "a"}, "tags": {DATASET_RECORD_SCORERS_TAG: "safety"}},
+    ]
+
+
+def test_validate_record_scorer_names_rejects_bare_string():
+    with pytest.raises(MlflowException, match=r"got the string 'safety'"):
+        validate_record_scorer_names("safety")
+
+
+def test_validate_record_scorer_names_rejects_non_list():
+    with pytest.raises(MlflowException, match=r"must be a list of scorer names, got dict"):
+        validate_record_scorer_names({"name": "safety"})
+
+
+def test_validate_record_scorer_names_rejects_scorer_object():
+    from mlflow.genai.scorers import Safety
+
+    with pytest.raises(MlflowException, match=r"Pass the scorer's registered name"):
+        validate_record_scorer_names([Safety()])

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -804,9 +804,16 @@ def test_model_from_deployment_endpoint(is_in_databricks):
         assert spans[0].outputs == _DUMMY_CHAT_RESPONSE
 
 
-def test_missing_scorers_argument():
-    with pytest.raises(TypeError, match=r"evaluate\(\) missing 1 required positional"):
-        mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}])
+def test_omitted_scorers_argument_allowed():
+    # `scorers` is optional so a dataset whose records carry their own scorers can run.
+    mock_result = EvaluationResult(run_id="test-run", metrics={}, result_df=pd.DataFrame())
+
+    with mock.patch("mlflow.genai.evaluation.base._run_harness") as mock_evaluate_oss:
+        mock_evaluate_oss.return_value = (mock_result, {})
+        result = mlflow.genai.evaluate(data=[{"inputs": {"q": "Hello"}, "outputs": "Hi"}])
+
+    assert result is mock_result
+    mock_evaluate_oss.assert_called_once()
 
 
 def test_empty_scorers_allowed():

--- a/tests/genai/evaluate/test_per_record_scorers.py
+++ b/tests/genai/evaluate/test_per_record_scorers.py
@@ -1,0 +1,267 @@
+from typing import Any
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import mlflow
+from mlflow.entities.dataset_record import DATASET_RECORD_SCORERS_TAG
+from mlflow.exceptions import MlflowException
+from mlflow.genai.datasets import create_dataset
+from mlflow.genai.evaluation.entities import EvalItem
+from mlflow.genai.evaluation.harness import _resolve_per_record_scorers, _scorers_for_item
+from mlflow.genai.scorers.base import Scorer, scorer
+
+
+@scorer
+def always_true(outputs) -> bool:
+    return True
+
+
+@scorer
+def always_false(outputs) -> bool:
+    return False
+
+
+def _values(result, scorer_name: str) -> list[Any]:
+    return result.result_df[f"{scorer_name}/value"].tolist()
+
+
+def _assessment_names_by_input(run_id: str) -> dict[str, set[str]]:
+    """Map each trace's `q` input to the set of assessment names on that trace."""
+    traces = mlflow.search_traces(run_id=run_id, return_type="list")
+    return {
+        trace.data.spans[0].inputs["q"]: {a.name for a in trace.info.assessments}
+        for trace in traces
+    }
+
+
+def _patch_resolution(scorers: list[Scorer]) -> mock._patch:
+    """Resolve per-record names to the given scorers.
+
+    Registering a @scorer function requires a Databricks tracking URI, so patching the
+    resolver is the only way to exercise a deterministic custom scorer per record.
+    """
+    return mock.patch(
+        "mlflow.genai.evaluation.harness.resolve_scorer_names",
+        return_value={s.name: s for s in scorers},
+    )
+
+
+def test_record_scorer_runs_only_on_its_own_row():
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "scorers": ["always_false"]},
+        {"inputs": {"q": "b"}, "outputs": "y"},
+    ]
+
+    with _patch_resolution([always_false]):
+        result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    assert _assessment_names_by_input(result.run_id) == {
+        "a": {"always_true", "always_false"},
+        "b": {"always_true"},
+    }
+    # The row the scorer did not run on has no value, rather than a default one.
+    values = _values(result, "always_false")
+    assert values[0] is False
+    assert pd.isna(values[1])
+
+
+def test_record_scorer_runs_with_a_real_builtin_name():
+    # End-to-end resolution against the built-in scorers, with no patching.
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "scorers": ["safety"]},
+        {"inputs": {"q": "b"}, "outputs": "y"},
+    ]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    # `safety` needs an LLM, so it may error here; what matters is that it was invoked on
+    # row "a" alone.
+    assert _assessment_names_by_input(result.run_id) == {
+        "a": {"always_true", "safety"},
+        "b": {"always_true"},
+    }
+
+
+def test_run_level_scorers_still_apply_to_every_row():
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "scorers": ["safety"]},
+        {"inputs": {"q": "b"}, "outputs": "y"},
+    ]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    assert _values(result, "always_true") == [True, True]
+
+
+def test_record_without_scorers_is_unaffected():
+    data = [{"inputs": {"q": "a"}, "outputs": "x"}]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    assert _values(result, "always_true") == [True]
+    assert "safety/value" not in result.result_df.columns
+
+
+def test_evaluate_with_only_record_scorers_and_no_run_level_list():
+    data = [{"inputs": {"q": "a"}, "outputs": "x", "scorers": ["always_true"]}]
+
+    with _patch_resolution([always_true]):
+        result = mlflow.genai.evaluate(data=data)
+
+    assert _values(result, "always_true") == [True]
+
+
+def test_duplicate_between_record_and_run_level_scorers_runs_once():
+    data = [{"inputs": {"q": "a"}, "outputs": "x", "scorers": ["always_true"]}]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    traces = mlflow.search_traces(run_id=result.run_id, return_type="list")
+    feedbacks = [a for a in traces[0].info.assessments if a.name == "always_true"]
+    assert len(feedbacks) == 1
+
+
+def test_unresolvable_record_scorer_name_raises():
+    data = [{"inputs": {"q": "a"}, "outputs": "x", "scorers": ["does_not_exist"]}]
+
+    with pytest.raises(MlflowException, match=r"could not be resolved: \['does_not_exist'\]"):
+        mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+
+def test_record_scorer_object_is_rejected():
+    data = [{"inputs": {"q": "a"}, "outputs": "x", "scorers": [always_true]}]
+
+    with pytest.raises(MlflowException, match=r"Pass the scorer's registered name"):
+        mlflow.genai.evaluate(data=data)
+
+
+def test_record_scorers_accepted_as_dataframe_column():
+    data = pd.DataFrame([
+        {"inputs": {"q": "a"}, "outputs": "x", "scorers": ["safety"]},
+        {"inputs": {"q": "b"}, "outputs": "y", "scorers": None},
+    ])
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    assert _values(result, "always_true") == [True, True]
+
+
+def test_reserved_scorers_tag_is_not_copied_to_the_trace():
+    data = [
+        {
+            "inputs": {"q": "a"},
+            "outputs": "x",
+            "tags": {"team": "search"},
+            "scorers": ["safety"],
+        }
+    ]
+
+    result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    traces = mlflow.search_traces(run_id=result.run_id, return_type="list")
+    assert traces[0].info.tags["team"] == "search"
+    assert DATASET_RECORD_SCORERS_TAG not in traces[0].info.tags
+
+
+def test_per_record_scorer_metrics_are_aggregated_over_its_own_rows():
+    # A per-record scorer's mean uses the rows it ran on, not the full row count.
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "scorers": ["always_false"]},
+        {"inputs": {"q": "b"}, "outputs": "y"},
+        {"inputs": {"q": "c"}, "outputs": "z"},
+    ]
+
+    with _patch_resolution([always_false]):
+        result = mlflow.genai.evaluate(data=data, scorers=[always_true])
+
+    # always_false ran on one row and returned False, so its mean is 0.0 rather than the
+    # 2/3 that averaging over all three rows would give.
+    assert result.metrics["always_false/mean"] == 0.0
+    assert result.metrics["always_true/mean"] == 1.0
+
+
+def test_persisted_dataset_round_trips_record_scorers():
+    dataset = create_dataset(name="per_record_scorers_ds")
+    dataset.merge_records([
+        {"inputs": {"q": "a"}, "scorers": ["safety", "correctness"]},
+        {"inputs": {"q": "b"}},
+    ])
+
+    records = {r["inputs"]["q"]: r for r in dataset.to_df().to_dict("records")}
+    assert records["a"]["tags"][DATASET_RECORD_SCORERS_TAG] == "safety,correctness"
+    assert DATASET_RECORD_SCORERS_TAG not in records["b"]["tags"]
+
+    assert EvalItem.from_dataset_row(records["a"]).scorers == ["safety", "correctness"]
+    assert EvalItem.from_dataset_row(records["b"]).scorers == []
+
+
+def test_merge_records_rejects_a_scorer_object():
+    dataset = create_dataset(name="per_record_scorers_reject_ds")
+
+    with pytest.raises(MlflowException, match=r"Pass the scorer's registered name"):
+        dataset.merge_records([{"inputs": {"q": "a"}, "scorers": [always_true]}])
+
+
+def test_eval_item_scorers_column_overrides_the_persisted_tag():
+    row = {
+        "inputs": {"q": "a"},
+        "tags": {DATASET_RECORD_SCORERS_TAG: "safety"},
+        "scorers": ["correctness"],
+    }
+
+    assert EvalItem.from_dataset_row(row).scorers == ["correctness"]
+
+
+def _eval_item(scorers=None) -> EvalItem:
+    return EvalItem(
+        request_id="req-1",
+        inputs={"q": "a"},
+        outputs="x",
+        expectations={},
+        scorers=scorers or [],
+    )
+
+
+def test_scorers_for_item_returns_run_level_list_when_record_has_none():
+    run_level = [always_true]
+
+    assert _scorers_for_item(_eval_item(), run_level, {"safety": always_false}) is run_level
+
+
+def test_scorers_for_item_appends_record_scorers():
+    resolved = _scorers_for_item(
+        _eval_item(["always_false"]), [always_true], {"always_false": always_false}
+    )
+
+    assert [s.name for s in resolved] == ["always_true", "always_false"]
+
+
+def test_scorers_for_item_deduplicates_by_name():
+    resolved = _scorers_for_item(
+        _eval_item(["always_true"]), [always_true], {"always_true": always_true}
+    )
+
+    assert [s.name for s in resolved] == ["always_true"]
+
+
+def test_scorers_for_item_skips_names_that_did_not_resolve():
+    resolved = _scorers_for_item(_eval_item(["missing"]), [always_true], {})
+
+    assert [s.name for s in resolved] == ["always_true"]
+
+
+def test_resolve_per_record_scorers_skips_run_level_names():
+    resolved = _resolve_per_record_scorers(
+        [_eval_item(["always_true"])], [always_true], experiment_id=None
+    )
+
+    # always_true is already a run-level scorer, so no registry lookup is needed for it.
+    assert resolved == {}
+
+
+def test_resolve_per_record_scorers_resolves_builtins():
+    resolved = _resolve_per_record_scorers([_eval_item(["safety"])], [], experiment_id=None)
+
+    assert set(resolved) == {"safety"}

--- a/tests/genai/scorers/test_resolution.py
+++ b/tests/genai/scorers/test_resolution.py
@@ -1,0 +1,57 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges import make_judge
+from mlflow.genai.scorers.resolution import resolve_scorer_names
+
+
+def test_resolve_scorer_names_empty():
+    assert resolve_scorer_names(set()) == {}
+
+
+def test_resolve_builtin_scorer_by_name():
+    resolved = resolve_scorer_names({"safety"})
+
+    assert set(resolved) == {"safety"}
+    assert resolved["safety"].name == "safety"
+
+
+def test_resolve_multiple_builtin_scorers():
+    resolved = resolve_scorer_names({"safety", "correctness"})
+
+    assert set(resolved) == {"safety", "correctness"}
+
+
+def test_resolve_registered_scorer(monkeypatch, tmp_path):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", f"sqlite:///{tmp_path / 'mlflow.db'}")
+    judge = make_judge(name="my_judge", instructions="Is {{ outputs }} polite?")
+    judge.register()
+
+    resolved = resolve_scorer_names({"my_judge"})
+
+    assert resolved["my_judge"].name == "my_judge"
+
+
+def test_builtin_takes_precedence_over_registry():
+    with mock.patch("mlflow.genai.scorers.resolution._get_registered_scorer") as mock_get:
+        resolved = resolve_scorer_names({"safety"})
+
+    mock_get.assert_not_called()
+    assert resolved["safety"].name == "safety"
+
+
+def test_resolve_unknown_scorer_name_raises():
+    with pytest.raises(MlflowException, match=r"could not be resolved: \['not_a_scorer'\]"):
+        resolve_scorer_names({"not_a_scorer"})
+
+
+def test_error_lists_every_unresolved_name():
+    with pytest.raises(MlflowException, match=r"could not be resolved: \['alpha', 'beta'\]"):
+        resolve_scorer_names({"beta", "alpha", "safety"})
+
+
+def test_error_suggests_registering_a_custom_scorer():
+    with pytest.raises(MlflowException, match=r"my_scorer\.register\(\)"):
+        resolve_scorer_names({"nope"})


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`mlflow.genai.evaluate()` applies one scorer list to every row of a dataset. This PR lets an individual record name additional scorers to run on that row alone, so a single run can grade different records with different scorers.

```python
mlflow.genai.evaluate(
    data=[
        # Graded by Correctness and Safety.
        {"inputs": {...}, "expectations": {...}, "scorers": ["safety"]},
        # Graded by Correctness only.
        {"inputs": {...}, "expectations": {...}},
    ],
    scorers=[Correctness()],
)
```

Design notes:

- **Names, not objects.** A record's `scorers` value is a `list[str]`, resolved at run time against the built-in scorers first and then the scorer registry for the active experiment. Resolution happens once up front, so an unknown name fails before any prediction runs rather than per row inside the score pool. Passing a `Scorer` instance is rejected with a message pointing at the registered name.
- **Persisted via tags, not a new field.** Names are stored in the record's existing `tags` map under the reserved key `mlflow.scorers` (comma-separated, since tags are `dict[str, str]`). This needs no dataset schema change. The reserved tag is not copied onto traces — it is dataset metadata, and the assessments on the trace already record which scorers ran.
- **`scorers` on `evaluate()` is now optional**, so a dataset whose records carry their own scorers can run without a run-level list. `validate_scorers(None)` returns `[]`.
- **Aggregation** includes per-record scorers, so each metric is averaged over the rows that scorer actually produced a value for rather than the full row count. A scorer covering 1 of 3 rows and returning `False` reports a mean of `0.0`, not `0.67`.
- **A record with no scorers behaves exactly as before**, and a dataset that never uses the feature takes the same code path it did previously.

Known limitation: custom `@scorer` functions cannot be registered outside a Databricks tracking URI (existing restriction in `Scorer._check_can_be_registered`, since deserialization uses `exec()`), so per-record custom scorers are unavailable in a purely local OSS session. Built-in scorers and `make_judge()` judges resolve by name anywhere.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

42 new tests across `tests/genai/evaluate/test_per_record_scorers.py`, `tests/genai/scorers/test_resolution.py`, and `tests/entities/test_dataset_record.py`, covering per-row routing, run-level union and de-duplication, resolution precedence (built-in before registry), the unresolvable-name error, rejection of scorer objects, dataset persistence round-trip, aggregation over a scorer's own rows, and the reserved tag being kept off traces.

One existing test changed: `test_missing_scorers_argument` asserted that omitting `scorers` raises `TypeError`. That is no longer true, so it became `test_omitted_scorers_argument_allowed`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

Added a usage section and the `scorers` column to the `mlflow.genai.evaluate()` docstring, and documented the field on `EvaluationDataset.merge_records()`.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [ ] No.
- [x] Yes. Please link the corresponding PR or explain how you plan to update it.

The evaluation skill's description of how scorers are applied to a dataset will need a note that scorers can be declared per record. Happy to follow up with that PR once the API here is settled.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Evaluation dataset records can now name additional scorers to run on that record alone, so one `mlflow.genai.evaluate()` run can grade different records with different scorers. The `scorers` argument is now optional.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
