### PR TITLE
Fix docstring `Args` entries that name a parameter the function does not take

### DIFF
--- a/mlflow/ag2/ag2_logger.py
+++ b/mlflow/ag2/ag2_logger.py
@@ -116,8 +116,6 @@ class MlflowAg2Logger(BaseLogger):
         Patch a function to start and end a span around its invocation.
 
         Args:
-            f: The function to patch.
-            span_name: The name of the span. If None, the function name is used.
             span_type: The type of the span. Default is SpanType.UNKNOWN.
             root_only: If True, only create a span if it is the root of the chat session.
                 When there is an existing root span for the chat session, the function will

--- a/mlflow/data/meta_dataset.py
+++ b/mlflow/data/meta_dataset.py
@@ -20,7 +20,7 @@ class MetaDataset(Dataset):
         name: name of the dataset. If not specified, a name is automatically generated.
         digest: digest (hash, fingerprint) of the dataset. If not specified, a digest is
             automatically computed.
-        schame: schema of the dataset.
+        schema: schema of the dataset.
 
     .. code-block:: python
         :caption: Create a MetaDataset

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -157,7 +157,6 @@ def _extract_predict_fn(model: Any) -> Callable[..., Any] | None:
 
     Args:
         model: A model object that has a predict method.
-        raw_model: A raw model object that has a predict method.
 
     Returns: The predict function.
     """

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -242,7 +242,7 @@ class DatabricksApp(DatabricksResource):
     where an agent queries a SQL table via either Genie or UC Functions.
 
      Args:
-         table_name (str): The name of the table used by the model
+         app_name (str): The name of the app used by the model
          on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
         with the permission of the invoker of the model in the serving endpoint. If set to
         None or False, the resource is accessed with the permissions of the creator

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -89,7 +89,7 @@ class DatabricksJobRunner:
     Helper class for running an MLflow project as a Databricks Job.
 
     Args:
-        databricks_profile: Optional Databricks CLI profile to use to fetch hostname &
+        databricks_profile_uri: Optional Databricks CLI profile to use to fetch hostname &
            authentication information when making Databricks API requests.
     """
 

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -203,8 +203,6 @@ def _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight, 
 
     Args:
         fitted_estimator: The already fitted classifier
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
 
     Returns:
         dictionary of (function name, computed value)
@@ -327,8 +325,6 @@ def _get_classifier_artifacts(fitted_estimator, prefix, X, y_true, sample_weight
 
     Args:
         fitted_estimator: The already fitted regressor
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
 
     Returns:
         List of artifacts to be logged
@@ -434,8 +430,6 @@ def _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight):
 
     Args:
         fitted_estimator: The already fitted regressor
-        fit_args: Positional arguments given to fit_func.
-        fit_kwargs: Keyword arguments given to fit_func.
 
     Returns:
         dictionary of (function name, computed value)

--- a/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
@@ -437,7 +437,7 @@ class UnityCatalogOssStore(BaseRestStore):
         Get temporary credentials for uploading model version files
 
         Args:
-            name: Registered model name.
+            model_name: Registered model name.
             version: Model version number.
 
         Returns:

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -283,9 +283,7 @@ def _upgrade_db(engine):
     we recommend taking a backup of your database before running migrations.
 
     Args:
-        url: Database URL, like sqlite:///<absolute-path-to-local-db-file>. See
-            https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls for a full list of
-            valid database URLs.
+        engine: SQLAlchemy engine connected to the database to upgrade.
     """
     # alembic adds significant import time, so we import it lazily
     from alembic import command

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2056,7 +2056,6 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         Args:
             run_id: String ID of the run
             tags: List of RunTag instances to log
-            path: current json path for error messages
         """
         if not tags:
             return

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -80,7 +80,6 @@ class MlflowV3SpanExporter(SpanExporter):
 
         Args:
             spans: Sequence of ReadableSpan objects to export.
-            manager: The trace manager instance.
         """
         if is_databricks_uri(self._client.tracking_uri):
             _logger.debug(

--- a/mlflow/utils/async_logging/async_artifacts_logging_queue.py
+++ b/mlflow/utils/async_logging/async_artifacts_logging_queue.py
@@ -25,7 +25,7 @@ class AsyncArtifactsLoggingQueue:
     worker thread. This class is used to process artifacts saving in async fashion.
 
     Args:
-        logging_func: A callable function that takes in three arguments:
+        artifact_logging_func: A callable function that takes in three arguments:
             - filename: The name of the artifact file.
             - artifact_path: The path to the artifact.
             - artifact: The artifact to be logged.

--- a/mlflow/utils/name_utils.py
+++ b/mlflow/utils/name_utils.py
@@ -7,10 +7,6 @@ _EXPERIMENT_ID_FIXED_WIDTH = 18
 def _generate_unique_integer_id():
     """Utility function for generating a random fixed-length integer
 
-    Args:
-        id_length: The target length of the string representation of the integer without
-            leading zeros
-
     Returns:
         a fixed-width integer
     """

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -570,7 +570,6 @@ def _get_pinned_requirement(req_str, version=None, module=None):
         module: The name of the top-level module provided by the package . For example,
             if `package` is 'scikit-learn', `module` should be 'sklearn'. If None, defaults
             to `package`.
-        extras: A list of extra names for the package.
 
     """
     req = Requirement(req_str)

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -84,7 +84,7 @@ def test_download_from_uri():
 def _run_download_artifact_command(args) -> pathlib.Path:
     """
     Args:
-        command: An `mlflow artifacts` command list.
+        args: An `mlflow artifacts` command list.
 
     Returns:
         Path to the downloaded artifact.


### PR DESCRIPTION
### Related Issues/PRs

Relates to no existing issue — found by reading `Args:` blocks against the signatures they sit above.

### What changes are proposed in this pull request?

Twenty `Args:` entries name a parameter the function does not take. Docstrings only; no signature, no behaviour, no test touched.

Seven are renames where the docstring kept the old name:

| Where | Documented | Actual |
|---|---|---|
| `MetaDataset` | `schame` | `schema` (typo) |
| `DatabricksApp` | `table_name` | `app_name` |
| `DatabricksJobRunner` | `databricks_profile` | `databricks_profile_uri` |
| `_get_temporary_model_version_write_credentials_oss` | `name` | `model_name` |
| `_upgrade_db` | `url` | `engine` |
| `AsyncArtifactsLoggingQueue` | `logging_func` | `artifact_logging_func` |
| `_run_download_artifact_command` | `command` | `args` |

`_upgrade_db` needed a new description as well as a new name — the old entry described a database URL string, and the argument is a SQLAlchemy engine.

The rest document a parameter that no longer exists: `f` and `span_name` in `AG2Logger._get_patch_function`, `raw_model` in `_extract_predict_fn`, `fit_args` and `fit_kwargs` in the three `mlflow/sklearn/utils.py` helpers, `path` in `SqlAlchemyStore._set_tags`, `manager` in `_export_spans_incrementally`, `extras` in `_get_pinned_requirement`, and `id_length` in `_generate_unique_integer_id`, which takes no arguments at all.

Two things I noticed but did not touch, since they are a different kind of fix and yours to judge:

- `DatabricksApp`'s summary is a verbatim copy of `DatabricksTable`'s — it still says "Defines a Databricks Unity Catalog (UC) Table". I only corrected the argument name.
- The `Steps:` prose in the three `mlflow/sklearn/utils.py` helpers still says "Extract X and y_true from fit_args and fit_kwargs", which predates the refactor that made `X` and `y_true` direct arguments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Every entry was opened and read against its signature. `ruff check` and `ruff format --check` pass on all fourteen files with the pinned `ruff==0.16.0`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
