### PR TITLE
Cap `mcp<2` for pydantic-ai <2.0.0 cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -953,12 +953,13 @@ pydantic_ai:
     maximum: "2.16.0"
     unsupported: [">=2.0.0,<2.5.0"]
     requirements:
-      ">= 0.0.0": ["mcp"]
       # pydantic-ai < 2.0.0 does `from mcp.client.streamable_http import GetSessionIdCallback`,
       # but doesn't cap mcp, so it floats to 2.0.0 which removed `GetSessionIdCallback`,
       # breaking collection with `ImportError: cannot import name 'GetSessionIdCallback'`.
-      # pydantic-ai >= 2.0.0 uses `fastmcp` instead and no longer imports that symbol.
+      # pydantic-ai >= 2.0.0 uses `fastmcp` instead and no longer imports that symbol, so it
+      # can use an uncapped mcp.
       "< 2.0.0": ["mcp<2"]
+      ">= 2.0.0": ["mcp"]
       # pydantic-ai < 1.32.0 does `from opentelemetry._events import Event`, but doesn't
       # cap opentelemetry-api, so it floats to 1.44.0 which removed the `_events` module,
       # breaking collection with `ModuleNotFoundError: No module named 'opentelemetry._events'`.

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -954,6 +954,11 @@ pydantic_ai:
     unsupported: [">=2.0.0,<2.5.0"]
     requirements:
       ">= 0.0.0": ["mcp"]
+      # pydantic-ai < 2.0.0 does `from mcp.client.streamable_http import GetSessionIdCallback`,
+      # but doesn't cap mcp, so it floats to 2.0.0 which removed `GetSessionIdCallback`,
+      # breaking collection with `ImportError: cannot import name 'GetSessionIdCallback'`.
+      # pydantic-ai >= 2.0.0 uses `fastmcp` instead and no longer imports that symbol.
+      "< 2.0.0": ["mcp<2"]
       # pydantic-ai < 1.32.0 does `from opentelemetry._events import Event`, but doesn't
       # cap opentelemetry-api, so it floats to 1.44.0 which removed the `_events` module,
       # breaking collection with `ModuleNotFoundError: No module named 'opentelemetry._events'`.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The `pydantic_ai` cross-version tests were failing when collecting `tests/pydantic_ai/test_pydanticai_mcp_tracing.py`:

```
ImportError: cannot import name 'GetSessionIdCallback' from 'mcp.client.streamable_http'
```

**Root cause:** For pydantic-ai `< 2.0.0` (e.g. the `minimum` pin `0.4.10`), `pydantic_ai/mcp.py` does `from mcp.client.streamable_http import GetSessionIdCallback` at import time. The `requirements` block pinned `mcp` with no upper bound (`">= 0.0.0": ["mcp"]`), so it floated to the newly released `mcp==2.0.0`, which **removed** `GetSessionIdCallback`. That broke module collection.

pydantic-ai `>= 2.0.0` switched to `fastmcp` and no longer imports that symbol, so the cap is applied only to `< 2.0.0`:

```yaml
"< 2.0.0": ["mcp<2"]
```

This mirrors the existing `opentelemetry-api<1.44` cap for `< 1.32.0`.

### How is this PR tested?

- [x] Existing unit/integration tests

The pydantic_ai cross-version tests run automatically on this PR because `mlflow/ml-package-versions.yml` is changed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release