### PR TITLE
Fix `torch_dtype` deprecation warning on transformers model load

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -94,6 +94,7 @@ from mlflow.transformers.signature import (
     infer_or_get_default_signature,
 )
 from mlflow.transformers.torch_utils import (
+    _DTYPE_KEY,
     _TORCH_DTYPE_KEY,
     _deserialize_torch_dtype,
     _get_torch_dtype_kwarg_name,
@@ -1423,7 +1424,13 @@ def _load_model(
         conf["device"] = device
         accelerate_model_conf["device"] = device
 
-    if dtype_val := kwargs.get(_TORCH_DTYPE_KEY) or flavor_config.get(FlavorKey.TORCH_DTYPE):
+    if dtype_val := (
+        # Accept either the legacy `torch_dtype` kwarg or the `dtype` name used by newer
+        # transformers versions, falling back to the value recorded in the flavor config.
+        kwargs.get(_TORCH_DTYPE_KEY)
+        or kwargs.get(_DTYPE_KEY)
+        or flavor_config.get(FlavorKey.TORCH_DTYPE)
+    ):
         if isinstance(dtype_val, str):
             dtype_val = _deserialize_torch_dtype(dtype_val)
         # Newer transformers versions (>= 4.56.0) renamed the `torch_dtype` kwarg to `dtype` and

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -93,7 +93,11 @@ from mlflow.transformers.signature import (
     format_input_example_for_special_cases,
     infer_or_get_default_signature,
 )
-from mlflow.transformers.torch_utils import _TORCH_DTYPE_KEY, _deserialize_torch_dtype
+from mlflow.transformers.torch_utils import (
+    _TORCH_DTYPE_KEY,
+    _deserialize_torch_dtype,
+    _get_torch_dtype_kwarg_name,
+)
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils import _truncate_and_ellipsize
 from mlflow.utils.annotations import deprecated
@@ -1422,9 +1426,14 @@ def _load_model(
     if dtype_val := kwargs.get(_TORCH_DTYPE_KEY) or flavor_config.get(FlavorKey.TORCH_DTYPE):
         if isinstance(dtype_val, str):
             dtype_val = _deserialize_torch_dtype(dtype_val)
-        conf[_TORCH_DTYPE_KEY] = dtype_val
-        flavor_config[_TORCH_DTYPE_KEY] = dtype_val
-        accelerate_model_conf[_TORCH_DTYPE_KEY] = dtype_val
+        # Newer transformers versions (>= 4.56.0) renamed the `torch_dtype` kwarg to `dtype` and
+        # warn when the old name is passed, so forward using the name the installed version expects.
+        dtype_kwarg = _get_torch_dtype_kwarg_name()
+        conf[dtype_kwarg] = dtype_val
+        accelerate_model_conf[dtype_kwarg] = dtype_val
+        # `flavor_config` is keyed by `torch_dtype` and consumed by the model loading path, which
+        # applies the version-appropriate kwarg name itself.
+        flavor_config[FlavorKey.TORCH_DTYPE] = dtype_val
 
     accelerate_model_conf["low_cpu_mem_usage"] = MLFLOW_HUGGINGFACE_USE_LOW_CPU_MEM_USAGE.get()
 

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -12,6 +12,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_STATE
 from mlflow.transformers.flavor_config import FlavorKey, get_peft_base_model, is_peft_model
+from mlflow.transformers.torch_utils import _get_torch_dtype_kwarg_name
 
 if TYPE_CHECKING:
     import transformers
@@ -323,7 +324,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
 
     load_kwargs["device"] = device
     if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
-        load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
+        load_kwargs[_get_torch_dtype_kwarg_name()] = torch_dtype
 
     if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
         return model

--- a/mlflow/transformers/torch_utils.py
+++ b/mlflow/transformers/torch_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from packaging.version import Version
+
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
@@ -9,6 +11,28 @@ if TYPE_CHECKING:
     import torch
 
 _TORCH_DTYPE_KEY = "torch_dtype"
+# transformers 4.56.0 renamed the `torch_dtype` kwarg of `from_pretrained`/`pipeline` to `dtype`
+# and emits a deprecation warning whenever the old name is used.
+_DTYPE_KEY = "dtype"
+_DTYPE_KWARG_MIN_TRANSFORMERS_VERSION = "4.56.0"
+
+
+def _get_torch_dtype_kwarg_name() -> str:
+    """
+    Return the keyword argument name that the installed transformers version expects for
+    specifying the model's torch dtype when calling ``from_pretrained``/``pipeline``.
+
+    transformers 4.56.0 renamed ``torch_dtype`` to ``dtype`` and warns when the old name is
+    passed, so newer versions receive ``dtype`` while older ones keep ``torch_dtype``.
+    """
+    try:
+        import transformers
+    except ImportError:
+        return _TORCH_DTYPE_KEY
+
+    if Version(transformers.__version__) >= Version(_DTYPE_KWARG_MIN_TRANSFORMERS_VERSION):
+        return _DTYPE_KEY
+    return _TORCH_DTYPE_KEY
 
 
 def _extract_torch_dtype_if_set(pipeline) -> torch.dtype | None:

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -75,6 +75,8 @@ def test_flavor_config_torch_dtype_overridden_when_specified(small_qa_pipeline):
     ],
 )
 def test_get_torch_dtype_kwarg_name(version, expected):
+    # `_get_torch_dtype_kwarg_name` imports transformers lazily, so patch the attribute on the
+    # transformers module object itself (there is no module-level binding to scope the patch to).
     with mock.patch("transformers.__version__", version):
         assert _get_torch_dtype_kwarg_name() == expected
 

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from mlflow.exceptions import MlflowException
@@ -6,6 +8,7 @@ from mlflow.transformers.flavor_config import (
     build_flavor_config,
     update_flavor_conf_to_persist_pretrained_model,
 )
+from mlflow.transformers.torch_utils import _get_torch_dtype_kwarg_name
 from mlflow.utils.huggingface_utils import is_valid_hf_repo_id
 
 from tests.transformers.helper import IS_NEW_FEATURE_EXTRACTION_API, IS_TRANSFORMERS_V5_OR_LATER
@@ -61,6 +64,19 @@ def test_flavor_config_torch_dtype_overridden_when_specified(small_qa_pipeline):
 
     conf = build_flavor_config(small_qa_pipeline, torch_dtype=torch.float16, save_pretrained=False)
     assert conf["torch_dtype"] == "torch.float16"
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("4.55.0", "torch_dtype"),
+        ("4.56.0", "dtype"),
+        ("5.13.0", "dtype"),
+    ],
+)
+def test_get_torch_dtype_kwarg_name(version, expected):
+    with mock.patch("transformers.__version__", version):
+        assert _get_torch_dtype_kwarg_name() == expected
 
 
 def test_flavor_config_component_multi_modal(multi_modal_pipeline):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -2,6 +2,7 @@ import base64
 import gc
 import importlib.util
 import json
+import logging
 import math
 import os
 import pathlib
@@ -410,6 +411,35 @@ def test_basic_save_model_with_torch_dtype(text2text_generation_pipeline, model_
 
     loaded = mlflow.transformers.load_model(model_path, torch_dtype=torch.float32)
     assert loaded.model.dtype == torch.float32
+
+
+def test_load_model_does_not_emit_torch_dtype_deprecation_warning(
+    text_classification_pipeline, model_path
+):
+    mlflow.transformers.save_model(
+        transformers_model=text_classification_pipeline,
+        path=model_path,
+    )
+
+    # transformers >= 4.56.0 warns via `logger.warning_once` when the deprecated `torch_dtype`
+    # kwarg is passed to `from_pretrained`/`pipeline`, so capture the transformers logger output.
+    messages = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    handler = _CaptureHandler()
+    transformers_logger = logging.getLogger("transformers")
+    transformers_logger.addHandler(handler)
+    try:
+        loaded = mlflow.transformers.load_model(model_path)
+    finally:
+        transformers_logger.removeHandler(handler)
+
+    assert not any("torch_dtype` is deprecated" in msg for msg in messages)
+    # The recorded dtype is still applied on load.
+    assert loaded.model.dtype == text_classification_pipeline.model.dtype
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -421,6 +421,12 @@ def test_load_model_does_not_emit_torch_dtype_deprecation_warning(
         path=model_path,
     )
 
+    # The pipeline's dtype is recorded into the flavor config on save even without an explicit
+    # `torch_dtype` argument, so the load path always forwards it and would warn on newer
+    # transformers versions. Assert it was recorded so the renamed-kwarg path is exercised.
+    flavor_conf = Model.load(model_path).flavors[mlflow.transformers.FLAVOR_NAME]
+    assert flavor_conf["torch_dtype"] == str(text_classification_pipeline.model.dtype)
+
     # transformers >= 4.56.0 warns via `logger.warning_once` when the deprecated `torch_dtype`
     # kwarg is passed to `from_pretrained`/`pipeline`, so capture the transformers logger output.
     messages = []


### PR DESCRIPTION
### Related Issues/PRs

Closes #24875

### What changes are proposed in this pull request?

`transformers` 4.56.0 renamed the `torch_dtype` kwarg of `from_pretrained`/`pipeline` to `dtype` and emits `` `torch_dtype` is deprecated! Use `dtype` instead! `` whenever the old name is passed.

Because `_extract_torch_dtype_if_set` records the underlying model's `.dtype` into the flavor config on essentially every log (any real PyTorch model exposes `.dtype`, not just when the user explicitly passes `torch_dtype`), the load path forwarded that value as `torch_dtype=` into `from_pretrained`/`pipeline`. As a result the deprecation warning fired on nearly every load of any transformers-flavor model logged with a recent transformers version.

This PR adds `_get_torch_dtype_kwarg_name()` in `mlflow/transformers/torch_utils.py`, which returns `dtype` for transformers `>= 4.56.0` and `torch_dtype` for older supported versions, and uses it on the model load paths in `model_io.py` and `__init__.py` (both the pipeline construction `conf` and the accelerate config). The `flavor_config` entry stays keyed under `torch_dtype`, since the load path reads it there and applies the version-appropriate kwarg name itself.

I used explicit version detection rather than the "try `dtype=`, fall back to `torch_dtype=` on `TypeError`" approach suggested in the issue: `from_pretrained`/`pipeline` both accept `**kwargs`, so an unknown kwarg is silently swallowed rather than raising `TypeError`, which would make a try/except fallback unreliable.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added:
- `test_get_torch_dtype_kwarg_name` — parametrized over transformers 4.55.0 / 4.56.0 / 5.13.0.
- `test_load_model_does_not_emit_torch_dtype_deprecation_warning` — asserts no deprecation warning is emitted on load and the recorded dtype is still applied.

Manually verified against the issue's repro:
- transformers 5.13.0: warning gone, `dtype` (`torch.float32`) still applied.
- transformers 4.55.0: still loads via `torch_dtype=`, no warning, dtype applied.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Loading a transformers-flavor model no longer emits a `` `torch_dtype` is deprecated! Use `dtype` instead! `` warning from transformers on recent (>= 4.56.0) versions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.