### PR TITLE
Pass `dtype` instead of deprecated `torch_dtype` to transformers

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -93,7 +93,11 @@ from mlflow.transformers.signature import (
     format_input_example_for_special_cases,
     infer_or_get_default_signature,
 )
-from mlflow.transformers.torch_utils import _TORCH_DTYPE_KEY, _deserialize_torch_dtype
+from mlflow.transformers.torch_utils import (
+    _TORCH_DTYPE_KEY,
+    _deserialize_torch_dtype,
+    _get_dtype_argument_key,
+)
 from mlflow.types.utils import _validate_input_dictionary_contains_only_strings_and_lists_of_strings
 from mlflow.utils import _truncate_and_ellipsize
 from mlflow.utils.annotations import deprecated
@@ -1419,12 +1423,15 @@ def _load_model(
         conf["device"] = device
         accelerate_model_conf["device"] = device
 
-    if dtype_val := kwargs.get(_TORCH_DTYPE_KEY) or flavor_config.get(FlavorKey.TORCH_DTYPE):
+    # Pop so that the `conf.update(**kwargs)` below cannot re-add the deprecated key
+    if dtype_val := kwargs.pop(_TORCH_DTYPE_KEY, None) or flavor_config.get(FlavorKey.TORCH_DTYPE):
         if isinstance(dtype_val, str):
             dtype_val = _deserialize_torch_dtype(dtype_val)
-        conf[_TORCH_DTYPE_KEY] = dtype_val
+        dtype_key = _get_dtype_argument_key()
+        conf[dtype_key] = dtype_val
+        # flavor_config is only read back by MLflow itself, so it keeps the `torch_dtype` key
         flavor_config[_TORCH_DTYPE_KEY] = dtype_val
-        accelerate_model_conf[_TORCH_DTYPE_KEY] = dtype_val
+        accelerate_model_conf[dtype_key] = dtype_val
 
     accelerate_model_conf["low_cpu_mem_usage"] = MLFLOW_HUGGINGFACE_USE_LOW_CPU_MEM_USAGE.get()
 
@@ -1622,6 +1629,10 @@ def _build_pipeline_from_model_input(model_dict: dict[str, Any], task: str | Non
     if task is None or task.startswith(_LLM_INFERENCE_TASK_PREFIX):
         default_task = _get_default_task_for_llm_inference_task(task)
         task = _get_task_for_model(model.name_or_path, default_task=default_task)
+
+    model_dict = dict(model_dict)
+    if dtype_val := model_dict.pop(_TORCH_DTYPE_KEY, None):
+        model_dict[_get_dtype_argument_key()] = dtype_val
 
     try:
         with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):

--- a/mlflow/transformers/model_io.py
+++ b/mlflow/transformers/model_io.py
@@ -12,6 +12,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_STATE
 from mlflow.transformers.flavor_config import FlavorKey, get_peft_base_model, is_peft_model
+from mlflow.transformers.torch_utils import _get_dtype_argument_key
 
 if TYPE_CHECKING:
     import transformers
@@ -323,7 +324,7 @@ def _load_model(model_name_or_path, flavor_conf, accelerate_conf, device, revisi
 
     load_kwargs["device"] = device
     if torch_dtype := flavor_conf.get(FlavorKey.TORCH_DTYPE):
-        load_kwargs[FlavorKey.TORCH_DTYPE] = torch_dtype
+        load_kwargs[_get_dtype_argument_key()] = torch_dtype
 
     if model := _try_load_model_with_device(cls, model_name_or_path, load_kwargs):
         return model

--- a/mlflow/transformers/torch_utils.py
+++ b/mlflow/transformers/torch_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from packaging.version import Version
+
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
@@ -9,6 +11,18 @@ if TYPE_CHECKING:
     import torch
 
 _TORCH_DTYPE_KEY = "torch_dtype"
+
+
+def _get_dtype_argument_key() -> str:
+    """
+    Return the dtype argument name accepted by the installed transformers version.
+    transformers 4.56.0 renamed `torch_dtype` to `dtype` and warns when the old name is used.
+    """
+    import transformers
+
+    if Version(transformers.__version__) >= Version("4.56.0"):
+        return "dtype"
+    return _TORCH_DTYPE_KEY
 
 
 def _extract_torch_dtype_if_set(pipeline) -> torch.dtype | None:

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import re
 import shutil
+import sys
 import textwrap
 from pathlib import Path
 from unittest import mock
@@ -48,6 +49,7 @@ from mlflow.transformers import (
     get_default_conda_env,
     get_default_pip_requirements,
 )
+from mlflow.transformers.torch_utils import _get_dtype_argument_key
 from mlflow.types.schema import Array, ColSpec, DataType, ParamSchema, ParamSpec, Schema
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -410,6 +412,118 @@ def test_basic_save_model_with_torch_dtype(text2text_generation_pipeline, model_
 
     loaded = mlflow.transformers.load_model(model_path, torch_dtype=torch.float32)
     assert loaded.model.dtype == torch.float32
+
+
+_EXPECTED_DTYPE_KEY = (
+    "dtype" if Version(transformers.__version__) >= Version("4.56.0") else "torch_dtype"
+)
+_UNEXPECTED_DTYPE_KEY = "torch_dtype" if _EXPECTED_DTYPE_KEY == "dtype" else "dtype"
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("4.55.4", "torch_dtype"),
+        ("4.56.0", "dtype"),
+        ("5.13.0", "dtype"),
+    ],
+)
+def test_get_dtype_argument_key(monkeypatch, version, expected):
+    # patch the sys.modules entry: it is what `import transformers` inside the helper
+    # resolves, and may differ from the module object imported by this test file
+    monkeypatch.setattr(sys.modules["transformers"], "__version__", version)
+    assert _get_dtype_argument_key() == expected
+
+
+def test_load_model_forwards_dtype_under_supported_argument_name(
+    text_classification_pipeline, model_path, monkeypatch
+):
+    from mlflow.transformers import model_io
+
+    mlflow.transformers.save_model(
+        transformers_model=text_classification_pipeline,
+        path=model_path,
+        torch_dtype=torch.float16,
+    )
+
+    captured = {}
+
+    def make_spy(original):
+        def spy(model_class, model_name_or_path, load_kwargs):
+            captured.update(load_kwargs)
+            return original(model_class, model_name_or_path, load_kwargs)
+
+        return spy
+
+    monkeypatch.setattr(
+        model_io,
+        "_try_load_model_with_accelerate",
+        make_spy(model_io._try_load_model_with_accelerate),
+    )
+    monkeypatch.setattr(
+        model_io,
+        "_try_load_model_with_device",
+        make_spy(model_io._try_load_model_with_device),
+    )
+
+    loaded = mlflow.transformers.load_model(model_path)
+
+    assert captured[_EXPECTED_DTYPE_KEY] == torch.float16
+    assert _UNEXPECTED_DTYPE_KEY not in captured
+    assert loaded.model.dtype == torch.float16
+
+
+def _spy_on_pipeline_kwargs(monkeypatch, captured):
+    # transformers swaps its module object in sys.modules during lazy init, so the module
+    # imported by this test file is not the object mlflow resolves; patch the live entry
+    live_transformers = sys.modules["transformers"]
+    original_pipeline = live_transformers.pipeline
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original_pipeline(*args, **kwargs)
+
+    monkeypatch.setattr(live_transformers, "pipeline", spy)
+
+
+def test_load_model_with_torch_dtype_override_forwards_single_dtype_argument(
+    text_classification_pipeline, model_path, monkeypatch
+):
+    mlflow.transformers.save_model(
+        transformers_model=text_classification_pipeline,
+        path=model_path,
+        torch_dtype=torch.float16,
+    )
+
+    captured = {}
+    _spy_on_pipeline_kwargs(monkeypatch, captured)
+    loaded = mlflow.transformers.load_model(model_path, torch_dtype=torch.float32)
+
+    assert captured[_EXPECTED_DTYPE_KEY] == torch.float32
+    assert _UNEXPECTED_DTYPE_KEY not in captured
+    assert loaded.model.dtype == torch.float32
+
+
+def test_save_model_with_dict_input_forwards_dtype_under_supported_argument_name(
+    text_classification_pipeline, model_path, monkeypatch
+):
+    model_dict = {
+        "model": text_classification_pipeline.model,
+        "tokenizer": text_classification_pipeline.tokenizer,
+        "torch_dtype": torch.float16,
+    }
+
+    captured = {}
+    _spy_on_pipeline_kwargs(monkeypatch, captured)
+    mlflow.transformers.save_model(
+        transformers_model=model_dict,
+        path=model_path,
+        task="text-classification",
+    )
+
+    assert captured[_EXPECTED_DTYPE_KEY] == torch.float16
+    assert _UNEXPECTED_DTYPE_KEY not in captured
+    assert model_dict["torch_dtype"] == torch.float16
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24875

### What changes are proposed in this pull request?

Pass `dtype` instead of the deprecated `torch_dtype` argument when forwarding a model's dtype to transformers. The argument name is picked from the installed transformers version: `dtype` on 4.56.0 and newer, `torch_dtype` on older versions. transformers 4.56.0 renamed the argument (huggingface/transformers#39782) and warns via `logger.warning_once` whenever the old name is used.

Note: #24929 fixes the main load path. This PR is the implementation I referenced in my comment on #24875 and also covers two paths that otherwise still emit the warning:

- the load-time override path (`mlflow.transformers.load_model(uri, torch_dtype=...)`): the user-supplied kwarg is popped so the later `conf.update(**kwargs)` cannot re-add the deprecated key alongside the new one
- the dict-input save path (`save_model(transformers_model={..., "torch_dtype": ...})`): `_build_pipeline_from_model_input` now forwards the version-appropriate key, without mutating the caller's dict

The saved-model metadata (MLmodel flavor config) and the public `save_model`/`load_model` `torch_dtype` API are unchanged, so models saved with any MLflow/transformers combination keep loading across environments.

Happy to close this in favor of #24929 or rebase on top of it. Feel free to cherry-pick anything useful.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests: a parametrized unit test for the version boundary (4.55.4 / 4.56.0 / 5.13.0), plus three integration tests that spy on the kwargs actually passed to `from_pretrained`/`pipeline` and assert that the version-appropriate key is present and the deprecated one is absent. The expectations are version-relative, so the same tests exercise both branches across the CI version matrix. The deprecation is emitted via transformers' `logger.warning_once`, which `pytest.warns` cannot capture, so the tests assert on argument names instead.

I also verified the fix manually in isolated environments with transformers 4.43.4 (minimum supported), 4.55.4, 4.56.0 and 5.14.1 (maximum supported). Before the fix, loading a saved model emits the deprecation warning in 4 out of 4 scenarios on 4.56.0 and newer. After the fix it emits none, and the dtype is still applied correctly, including the load-time override and the accelerate-disabled path.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the `torch_dtype` deprecation warning emitted by transformers >= 4.56 when loading transformers models, including load-time dtype overrides and models saved from a components dict.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release