### PR TITLE
Support Vertex AI `eu`/`us` multi-region endpoints in gateway provider

### DIFF
--- a/mlflow/gateway/providers/vertex_ai.py
+++ b/mlflow/gateway/providers/vertex_ai.py
@@ -39,6 +39,28 @@ _VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
 # rather than the Google (Gemini API) type.
 _MAAS_PREFIXES = ("mistral", "codestral", "jamba")
 
+# Locations that span several regions instead of naming one. They are served from a
+# dedicated host rather than the "{location}-" prefixed regional one.
+_MULTI_REGION_LOCATIONS = frozenset({"eu", "us"})
+
+
+def _get_vertex_ai_host(location: str) -> str:
+    """Return the Vertex AI API host serving ``location``.
+
+    Vertex AI exposes three host shapes:
+
+    - global:       https://aiplatform.googleapis.com
+    - multi-region: https://aiplatform.{eu,us}.rep.googleapis.com
+    - regional:     https://{location}-aiplatform.googleapis.com
+
+    https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
+    """
+    if location == "global":
+        return "https://aiplatform.googleapis.com"
+    if location in _MULTI_REGION_LOCATIONS:
+        return f"https://aiplatform.{location}.rep.googleapis.com"
+    return f"https://{location}-aiplatform.googleapis.com"
+
 
 def _strip_function_call_ids(gemini_payload: dict[str, Any]) -> dict[str, Any]:
     """Remove ``id`` from functionCall/functionResponse parts of a Gemini request body.
@@ -105,8 +127,7 @@ class _VertexAIClaudeProvider(AnthropicProvider):
     def base_url(self) -> str:
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "global"
-        prefix = "" if location == "global" else f"{location}-"
-        host = f"https://{prefix}aiplatform.googleapis.com"
+        host = _get_vertex_ai_host(location)
         path = f"/v1/projects/{project}/locations/{location}/publishers/anthropic/models"
         return f"{host}{path}"
 
@@ -154,8 +175,7 @@ class _VertexAIMaaSProvider(OpenAICompatibleProvider):
     def _api_base(self) -> str:
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "us-central1"
-        prefix = "" if location == "global" else f"{location}-"
-        host = f"https://{prefix}aiplatform.googleapis.com"
+        host = _get_vertex_ai_host(location)
         return f"{host}/v1/projects/{project}/locations/{location}/endpoints/openapi"
 
 
@@ -249,10 +269,7 @@ class VertexAIProvider(GeminiProvider):
             return self._delegate._api_base
         project = self.vertex_config.vertex_project
         location = self.vertex_config.vertex_location or "global"
-        # Regional endpoints use a "{location}-" prefix; the global endpoint has no prefix.
-        # https://docs.cloud.google.com/vertex-ai/docs/general/googleapi-access-methods#regional-global-endpoints
-        prefix = "" if location == "global" else f"{location}-"
-        host = f"https://{prefix}aiplatform.googleapis.com"
+        host = _get_vertex_ai_host(location)
         publisher = "anthropic" if self._model_type == "claude" else "google"
         path = f"/v1/projects/{project}/locations/{location}/publishers/{publisher}/models"
         return f"{host}{path}"

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -10,7 +10,7 @@ from mlflow.environment_variables import MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS
 from mlflow.gateway.config import EndpointConfig, VertexAIConfig
 from mlflow.gateway.constants import MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS
 from mlflow.gateway.exceptions import AIGatewayException
-from mlflow.gateway.providers.vertex_ai import VertexAIProvider
+from mlflow.gateway.providers.vertex_ai import VertexAIProvider, _get_vertex_ai_host
 from mlflow.gateway.schemas import chat, completions
 
 from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse, mock_http_client
@@ -366,6 +366,70 @@ def test_anthropic_model_global_location():
     )
 
 
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        ("global", "https://aiplatform.googleapis.com"),
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+        ("europe-west1", "https://europe-west1-aiplatform.googleapis.com"),
+        ("us-central1", "https://us-central1-aiplatform.googleapis.com"),
+        ("us-east5", "https://us-east5-aiplatform.googleapis.com"),
+    ],
+)
+def test_get_vertex_ai_host(location, expected):
+    assert _get_vertex_ai_host(location) == expected
+
+
+@pytest.mark.parametrize("location", ["eu", "us"])
+def test_gemini_model_multi_region_location(location):
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "gemini-3-pro-preview",
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": location,
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        f"https://aiplatform.{location}.rep.googleapis.com"
+        f"/v1/projects/my-gcp-project/locations/{location}/publishers/google/models"
+    )
+
+
+@pytest.mark.parametrize("location", ["eu", "us"])
+def test_anthropic_model_multi_region_location(location):
+    endpoint_config = EndpointConfig(
+        name="vertex-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "vertex_ai",
+            "name": "claude-sonnet-4-5@20251101",
+            "config": {
+                "vertex_project": "my-gcp-project",
+                "vertex_location": location,
+            },
+        },
+    )
+    provider = VertexAIProvider(endpoint_config)
+    provider._cached_credentials = _mock_credentials()
+    assert provider.base_url == (
+        f"https://aiplatform.{location}.rep.googleapis.com"
+        f"/v1/projects/my-gcp-project/locations/{location}/publishers/anthropic/models"
+    )
+    assert provider.get_endpoint_url("llm/v1/chat") == (
+        f"https://aiplatform.{location}.rep.googleapis.com"
+        f"/v1/projects/my-gcp-project/locations/{location}/publishers/anthropic/models"
+        "/claude-sonnet-4-5@20251101:rawPredict"
+    )
+
+
 def _make_claude_provider() -> VertexAIProvider:
     endpoint_config = EndpointConfig(
         name="vertex-claude-endpoint",
@@ -499,6 +563,15 @@ def test_maas_model_uses_openapi_endpoint(model_name):
     assert provider._delegate._api_base == (
         "https://us-central1-aiplatform.googleapis.com"
         "/v1/projects/my-gcp-project/locations/us-central1/endpoints/openapi"
+    )
+
+
+@pytest.mark.parametrize("location", ["eu", "us"])
+def test_maas_model_multi_region_location(location):
+    provider = _make_maas_provider("meta/llama-3.1-405b-instruct-maas", location=location)
+    assert provider._delegate._api_base == (
+        f"https://aiplatform.{location}.rep.googleapis.com"
+        f"/v1/projects/my-gcp-project/locations/{location}/endpoints/openapi"
     )
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24868

### What changes are proposed in this pull request?

The Vertex AI gateway provider built every non-global host as `https://{location}-aiplatform.googleapis.com`, which is correct for single regions like `europe-west1` but wrong for the `eu` and `us` multi-region identifiers, which Vertex serves from `https://aiplatform.{location}.rep.googleapis.com` — so `vertex_location: eu` resolved to a host that does not exist and every request failed to connect. This PR extracts host selection into `_get_vertex_ai_host` and uses it at all three call sites (Gemini, Claude, and MaaS), which each previously duplicated the prefix logic; `global` and single-region behavior is unchanged. The endpoint shape matches Google's [multi-region announcement](https://cloud.google.com/blog/products/ai-machine-learning/multi-region-endpoints-for-claude-available-on-vertex-ai) and the equivalent special case in `googleapis/python-genai`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a parametrized test for `_get_vertex_ai_host` covering `global`, `eu`, `us`, `europe-west1`, `us-central1`, and `us-east5`, plus per-call-site coverage asserting Gemini, Claude, and MaaS all reach the `.rep` host for both multi-region IDs. `tests/gateway/providers/test_vertex_ai.py` passes (43 tests).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The AI Gateway's Vertex AI provider now routes `vertex_location: eu` and `vertex_location: us` to Vertex AI's multi-region endpoints instead of a non-existent hostname.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)