### PR TITLE
fix: Use Base.metadata to create all tables in _initialize_tables to prevent upgrade failures (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Fixes #19943: `mlflow db upgrade` fails with `Table 'secrets' already exists` when upgrading from 3.7.0 to 3.8.x.

**Root cause**: `_initialize_tables()` uses `InitialBase.metadata.create_all(engine)` to create initial tables. `InitialBase` is a stale snapshot of ORM models and doesn't include newer tables like `secrets`. If the database already has the initial tables but is missing newer tables, `_all_tables_exist()` returns False, triggering `_initialize_tables()`. `InitialBase.metadata.create_all()` then attempts to create already-existing tables, raising an error. Since `create_all` defaults to `checkfirst=True`, it normally skips existing tables, but the issue arises because `InitialBase` doesn't include all current tables and the call is attempted in a context where the database already has those tables.

## Fix
Change `_initialize_tables()` to use `Base.metadata.create_all(engine)` instead of `InitialBase.metadata.create_all(engine)`. `Base.metadata` is the complete, up-to-date ORM metadata for all current tables. With `checkfirst=True`, it safely creates any missing tables (including new ones like `secrets`) and skips existing tables. This prevents the 'table already exists' error and ensures new tables are created before running migrations.

This change is minimal and preserves existing behavior for fresh installations while fixing upgrades.

Closes #19943