### PR TITLE
Test fork-PR access to ubuntu-latest-crowdstrike runner (do not merge)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
   # while also verifying certain dependencies are omitted.
   python-skinny:
     if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false || github.event.pull_request.user.login == 'Copilot' && github.event.pull_request.user.type == 'Bot')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-crowdstrike
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to mlflow/runners#3 and #24337.

### What changes are proposed in this pull request?

Test PR from a fork (`harupy/mlflow`) to verify whether fork-triggered `pull_request` workflows can reach the enterprise larger runner `ubuntu-latest-crowdstrike`. The in-repo PR path is confirmed working (#24337); fork PRs are the last untested path.

Do not merge.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. You can skip the rest of this section.
- [ ] Yes.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components: `area/build`

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] No.
- [ ] Yes.

<!--
🤖 Generated with [Claude Code](https://claude.com/claude-code)
-->