### PR TITLE
Propagate async logging failures to merged child batches in `RunBatch.complete`

### DIFF
--- a/mlflow/utils/async_logging/run_batch.py
+++ b/mlflow/utils/async_logging/run_batch.py
@@ -54,4 +54,8 @@ class RunBatch:
             self.completion_event.set()
 
         for child_batch in self.child_batches:
+            # Child batches are logged as part of this merged batch, so they share its
+            # outcome. Without this, a caller waiting on a child batch observes a successful
+            # completion for data that was never logged.
+            child_batch.exception = self._exception
             child_batch.complete()

--- a/tests/utils/test_async_logging_queue.py
+++ b/tests/utils/test_async_logging_queue.py
@@ -207,6 +207,42 @@ def test_partial_logging_failed():
         )
 
 
+def test_merged_batch_failure_reported_to_every_caller(monkeypatch):
+    # The buffering window makes the queue merge every enqueued batch into a single backend
+    # call. When that call fails, each caller must observe the failure, not just the one whose
+    # batch happened to become the merge parent.
+    monkeypatch.setenv("MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS", "2")
+
+    run_id = "test_run_id"
+    run_data = RunData(throw_exception_on_batch_number=[1])
+    with generate_async_logging_queue(run_data) as async_logging_queue:
+        async_logging_queue.activate()
+
+        run_operations = [
+            async_logging_queue.log_batch_async(
+                run_id=run_id,
+                metrics=[Metric(key=f"metric-{idx}", value=idx, timestamp=idx, step=0)],
+                tags=[],
+                params=[],
+            )
+            for idx in range(TOTAL_BATCHES)
+        ]
+        async_logging_queue.flush()
+
+        # Every enqueued batch was merged into a single backend call, and that call failed.
+        assert run_data.batch_count == 1
+
+        for run_operation in run_operations:
+            with pytest.raises(MlflowException, match="Failed to log run data"):
+                run_operation.wait()
+
+        # Each caller receives the very same exception, not just the batch that happened to
+        # become the merge parent.
+        exceptions = [f.exception() for op in run_operations for f in op._operation_futures]
+        assert len(exceptions) == TOTAL_BATCHES
+        assert all(exception is exceptions[0] for exception in exceptions)
+
+
 def test_publish_multithread_consume_single_thread():
     run_id = "test_run_id"
     run_data = RunData(throw_exception_on_batch_number=[])


### PR DESCRIPTION
### Related Issues/PRs

N/A — no existing issue. This defect was found by code inspection and reproduced locally; details and a reproduction are below.

### What changes are proposed in this pull request?

#### Problem

When `MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS` is set, a failed async batch log is reported as a **success** to every caller except one, and the affected metrics, params, and tags are silently lost.

`AsyncLoggingQueue` merges all batches enqueued within the buffering window into a single backend `log_batch` call. If that call fails, only the caller whose batch happened to become the merge parent sees the error. All other callers get a clean return from `RunOperations.wait()` for data that was never persisted.

Reproduced on `master`: five batches merged into one failing backend call, and only **1 of 5** callers observed the failure.

#### Root Cause

`_fetch_batch_from_queue` merges queued batches into one `RunBatch` — the first becomes the parent, the rest are recorded as its `child_batches`:

```python
merged_batch.add_child_batch(batch)
```

On failure, `logging_func` sets the exception on the parent only, then calls `complete()` in a `finally` block:

```python
except Exception as e:
    run_batch.exception = e
finally:
    run_batch.complete()
```

`RunBatch.complete()` fans the completion **event** out to the children, but never their **exception**:

```python
for child_batch in self.child_batches:
    child_batch.complete()
```

So `_wait_for_batch` wakes on the child's event, reads `batch.exception`, finds `None`, and returns cleanly:

```python
batch.completion_event.wait()
if batch.exception:
    raise batch.exception
```

The two halves of "this batch is finished" live in different modules. Exception assignment happens in `async_logging_queue.logging_func`, which only ever sees the merge parent. Event fan-out happens in `run_batch.complete()`, which knows about the children. Neither side owned the invariant.

#### Fix

Propagate the parent's exception to each child before signaling its completion event:

```python
for child_batch in self.child_batches:
    child_batch.exception = self._exception
    child_batch.complete()
```

Child batches are logged as part of the parent's single backend call and have no independent execution, so the parent's outcome is definitionally theirs.

Notes on correctness:

- The assignment precedes `child_batch.complete()`, so a waiter can never observe a set event with an unset exception.
- Children are only created in `_fetch_batch_from_queue` from fresh queue items and are only ever completed through their parent, so there is no pre-existing child exception to overwrite.
- This also covers the second failure path, where the worker threadpool rejects the submission and sets the exception on the parent the same way.
- On success `_exception` is `None`, so the success path is unchanged.

The change is one line plus an explanatory comment, with no reordering, no deletions, and no API change.

#### Why this was not caught

The existing `test_partial_logging_failed` calls `.wait()` immediately after each enqueue, which serializes batches so no merge ever occurs. The merged path had no failure coverage.

#### Test Plan

Added `test_merged_batch_failure_reported_to_every_caller`, which asserts all three properties of the defect:

1. `run_data.batch_count == 1` — every enqueued batch really was merged into a single backend call. This also prevents the test from passing vacuously if merging stops happening.
2. Each caller's `RunOperations.wait()` raises `MlflowException`.
3. All callers receive the *same* exception object, not just the merge parent.

#### Test Results

The new test fails on `master` with `Failed: DID NOT RAISE MlflowException` and passes with the fix.

| Suite | Result |
| --- | --- |
| `tests/utils/test_async_logging_queue.py` | 9 passed |
| `tests/utils/test_async_artifacts_logging_queue.py` | 5 passed |
| `tests/integration/async_logging/` | 4 passed |
| `tests/tracking/fluent/test_fluent.py` | 131 passed |
| `tests/tracking/test_tracking.py -k "async or batch"` | 5 passed |
| `tests/tracking/test_client.py` | 174 passed, 1 pre-existing failure unrelated to this change |

`ruff check`, `ruff format --check`, and `clint` are clean on both changed files.

The one `test_client.py` failure is `test_client_search_traces_with_large_results` (`AttributeError: 'has_calls' is not a valid assertion`), which reproduces identically on unmodified `master`.

#### Why this is not a duplicate

Searched issues and PRs for `RunBatch`, `child_batches`, `child batch exception`, `run_batch.py`, `AsyncLoggingQueue`, `log_batch_async`, `merged batch exception`, `async logging failure propagation`, and `async logging silent success` — no matches. Enumerated all open PRs touching `mlflow/utils/async_logging/`: none modify `run_batch.py`. #23432 and #11784 touch `tests/utils/test_async_logging_queue.py` but address unrelated concerns (shutdown hang and cleanups respectively); this PR only appends a new test function.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where a failed asynchronous batch log was reported as successful to callers whose batch had been merged into another batch, silently dropping the affected metrics, params, and tags.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
