### PR TITLE
docs: clarify Databricks profile, LangGraph autolog, runs-vs-traces, span attributes

### DIFF
--- a/docs/docs/genai/getting-started/databricks-trial/index.mdx
+++ b/docs/docs/genai/getting-started/databricks-trial/index.mdx
@@ -136,6 +136,25 @@ export DATABRICKS_OIDC_TOKEN_FILE="/path/to/token"
 export MLFLOW_TRACKING_URI="databricks"
 ```
 
+:::note[Multiple profiles in ~/.databrickscfg]
+
+`MLFLOW_TRACKING_URI=databricks` uses the `DEFAULT` profile in `~/.databrickscfg`, or the profile named by `DATABRICKS_CONFIG_PROFILE`. If you created your profile with `databricks auth login` (which names the profile after the workspace host, not `DEFAULT`), set:
+
+```bash
+export DATABRICKS_CONFIG_PROFILE=<your-profile-name>
+export MLFLOW_TRACKING_URI=databricks
+```
+
+Or pass the profile name directly:
+
+```bash
+export MLFLOW_TRACKING_URI=databricks://<your-profile-name>
+```
+
+Run `databricks auth profiles` to list profile names.
+
+:::
+
 #### Connect MLflow Session to Databricks Workspace
 
 We have set up the credentials, now we need to tell MLflow to send the data into Databricks Workspace.

--- a/docs/docs/genai/getting-started/databricks-trial/index.mdx
+++ b/docs/docs/genai/getting-started/databricks-trial/index.mdx
@@ -138,20 +138,20 @@ export MLFLOW_TRACKING_URI="databricks"
 
 :::note[Multiple profiles in ~/.databrickscfg]
 
-`MLFLOW_TRACKING_URI=databricks` uses the `DEFAULT` profile in `~/.databrickscfg`, or the profile named by `DATABRICKS_CONFIG_PROFILE`. If you created your profile with `databricks auth login` (which names the profile after the workspace host, not `DEFAULT`), set:
+When authentication resolves from `~/.databrickscfg` (rather than from environment variables, OIDC, or the Azure CLI above), `MLFLOW_TRACKING_URI=databricks` reads the `DEFAULT` profile, or the profile named by `DATABRICKS_CONFIG_PROFILE`. If you created your profile with `databricks auth login` (which names the profile after the workspace host, not `DEFAULT`), select it with either:
 
 ```bash
 export DATABRICKS_CONFIG_PROFILE=<your-profile-name>
 export MLFLOW_TRACKING_URI=databricks
 ```
 
-Or pass the profile name directly:
+Or pass the profile name in the tracking URI:
 
 ```bash
 export MLFLOW_TRACKING_URI=databricks://<your-profile-name>
 ```
 
-Run `databricks auth profiles` to list profile names.
+If you set the tracking URI in code with `mlflow.set_tracking_uri(...)` (see the next section), pass the profile there too: `mlflow.set_tracking_uri("databricks://<your-profile-name>")`. That call overwrites `MLFLOW_TRACKING_URI`, so a bare `"databricks"` would drop the profile. Run `databricks auth profiles` to list profile names.
 
 :::
 

--- a/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
@@ -11,6 +11,12 @@ import { Zap, BookOpen, Search } from "lucide-react";
 
 In addition to the [Auto Tracing](/genai/tracing/app-instrumentation/automatic) integrations, you can instrument your LLM application or AI agent by using MLflow's manual tracing APIs.
 
+:::note[Prefer autolog when your framework is supported]
+
+If your app is built on a [supported framework](/genai/tracing/integrations) (LangChain, LangGraph, OpenAI, LlamaIndex, and 40+ others), call that framework's `autolog()` once instead of decorating individual functions by hand. Autolog captures the framework's internal calls as a single connected trace. Hand-decorating each function separately produces one independent root trace per function rather than a unified trace, and misses the internal spans autolog records. Use manual tracing to add detail that autolog does not capture, or to instrument code that no integration covers.
+
+:::
+
 ## Decorator
 
 The `mlflow.trace` decorator allows you to create a span for any function. This approach provides a simple yet effective way to add tracing to your code with minimal effort:

--- a/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
+++ b/docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx
@@ -216,6 +216,12 @@ class MyClass {
 
 Alternatively, you can update the span dynamically inside the function.
 
+:::note[Use span attributes, not `mlflow.log_metric`, to attach data to a trace]
+
+`mlflow.log_metric()` writes to an **MLflow Run**, not to the current span. Calling it inside a traced function will not add that value to the trace or make it visible in the Traces tab. Use `span.set_attribute(key, value)` or `span.set_attributes({...})` to attach data to a span.
+
+:::
+
 <TabsWrapper>
 <Tabs groupId="programming-language">
 <TabItem value="python" label="Python" default>

--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -35,9 +35,9 @@ def my_function(input_data):
 
 MLflow provides automatic tracing (autolog) for 40+ popular libraries. See the complete list at [Automatic Tracing Integrations](/genai/tracing/integrations).
 
-### Q: I logged metrics and see "Traces: 0" -- what's wrong?
+### Q: My Traces tab is empty. Why don't my traces show up?
 
-`mlflow.log_metric()`, `mlflow.log_param()`, and `mlflow.start_run()` create **MLflow Runs** -- a different concept from **MLflow Traces**. Runs appear in the **Runs** tab of an experiment. Traces appear in the **Traces** tab. They are independent. Logging a metric does not create a trace, and tracing does not require a run context.
+Traces come from tracing calls, not from logging. `mlflow.log_metric()`, `mlflow.log_param()`, and `mlflow.start_run()` create **MLflow Runs**, a different concept from **MLflow Traces**. Runs appear in the **Runs** tab of an experiment. Traces appear in the **Traces** tab. They are independent. Logging a metric does not create a trace, and tracing does not require a run context.
 
 To generate a trace, use automatic tracing (e.g. `mlflow.openai.autolog()`, `mlflow.langchain.autolog()`) or manual tracing (e.g. `@mlflow.trace`, `mlflow.start_span()`). The Traces tab stays empty until one of these is called and the instrumented code runs.
 

--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -41,12 +41,12 @@ Traces come from tracing calls, not from logging. `mlflow.log_metric()`, `mlflow
 
 To generate a trace, use automatic tracing (e.g. `mlflow.openai.autolog()`, `mlflow.langchain.autolog()`) or manual tracing (e.g. `@mlflow.trace`, `mlflow.start_span()`). The Traces tab stays empty until one of these is called and the instrumented code runs.
 
-| What you called | Where it appears |
-|---|---|
-| `mlflow.log_metric()` | Runs tab |
-| `mlflow.openai.autolog()` + OpenAI call | Traces tab |
-| `mlflow.langchain.autolog()` + LangGraph invoke | Traces tab |
-| `@mlflow.trace` decorator | Traces tab |
+| What you called                                 | Where it appears |
+| ----------------------------------------------- | ---------------- |
+| `mlflow.log_metric()`                           | Runs tab         |
+| `mlflow.openai.autolog()` + OpenAI call         | Traces tab       |
+| `mlflow.langchain.autolog()` + LangGraph invoke | Traces tab       |
+| `@mlflow.trace` decorator                       | Traces tab       |
 
 ## User Interface and Jupyter Integration
 

--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -35,6 +35,19 @@ def my_function(input_data):
 
 MLflow provides automatic tracing (autolog) for 40+ popular libraries. See the complete list at [Automatic Tracing Integrations](/genai/tracing/integrations).
 
+### Q: I logged metrics and see "Traces: 0" -- what's wrong?
+
+`mlflow.log_metric()`, `mlflow.log_param()`, and `mlflow.start_run()` create **MLflow Runs** -- a different concept from **MLflow Traces**. Runs appear in the **Runs** tab of an experiment. Traces appear in the **Traces** tab. They are independent. Logging a metric does not create a trace, and tracing does not require a run context.
+
+To generate a trace, use automatic tracing (e.g. `mlflow.openai.autolog()`, `mlflow.langchain.autolog()`) or manual tracing (e.g. `@mlflow.trace`, `mlflow.start_span()`). The Traces tab stays empty until one of these is called and the instrumented code runs.
+
+| What you called | Where it appears |
+|---|---|
+| `mlflow.log_metric()` | Runs tab |
+| `mlflow.openai.autolog()` + OpenAI call | Traces tab |
+| `mlflow.langchain.autolog()` + LangGraph invoke | Traces tab |
+| `@mlflow.trace` decorator | Traces tab |
+
 ## User Interface and Jupyter Integration
 
 ### Q: Can I view traces directly in Jupyter notebooks?

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -43,6 +43,12 @@ LangGraph.js tracing is supported via the OpenTelemetry ingestion. See the [Gett
 </Tabs>
 </TabsWrapper>
 
+:::warning[Do not use `@mlflow.trace` on individual nodes as a substitute for autolog]
+
+Applying `@mlflow.trace` to each node function separately, without calling `mlflow.langchain.autolog()`, creates one independent root trace per node instead of a single unified graph trace. Call `mlflow.langchain.autolog()` once before invoking the graph. To add custom child spans inside a node, see [Adding spans within a node or a tool](#adding-spans-within-a-node-or-a-tool).
+
+:::
+
 ## Getting Started
 
 MLflow support tracing for LangGraph in both Python and TypeScript/JavaScript. Please select the appropriate tab below to get started.

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -43,12 +43,6 @@ LangGraph.js tracing is supported via the OpenTelemetry ingestion. See the [Gett
 </Tabs>
 </TabsWrapper>
 
-:::warning[Python: do not use `@mlflow.trace` on individual nodes as a substitute for autolog]
-
-In Python, applying `@mlflow.trace` to each node function separately, without calling `mlflow.langchain.autolog()`, creates one independent root trace per node instead of a single unified graph trace. Call `mlflow.langchain.autolog()` once before invoking the graph. To add custom child spans inside a node, see [Adding spans within a node or a tool](#adding-spans-within-a-node-or-a-tool). (JS/TS uses OpenTelemetry instrumentation instead, shown in the Getting Started section below.)
-
-:::
-
 ## Getting Started
 
 MLflow support tracing for LangGraph in both Python and TypeScript/JavaScript. Please select the appropriate tab below to get started.

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -43,9 +43,9 @@ LangGraph.js tracing is supported via the OpenTelemetry ingestion. See the [Gett
 </Tabs>
 </TabsWrapper>
 
-:::warning[Do not use `@mlflow.trace` on individual nodes as a substitute for autolog]
+:::warning[Python: do not use `@mlflow.trace` on individual nodes as a substitute for autolog]
 
-Applying `@mlflow.trace` to each node function separately, without calling `mlflow.langchain.autolog()`, creates one independent root trace per node instead of a single unified graph trace. Call `mlflow.langchain.autolog()` once before invoking the graph. To add custom child spans inside a node, see [Adding spans within a node or a tool](#adding-spans-within-a-node-or-a-tool).
+In Python, applying `@mlflow.trace` to each node function separately, without calling `mlflow.langchain.autolog()`, creates one independent root trace per node instead of a single unified graph trace. Call `mlflow.langchain.autolog()` once before invoking the graph. To add custom child spans inside a node, see [Adding spans within a node or a tool](#adding-spans-within-a-node-or-a-tool). (JS/TS uses OpenTelemetry instrumentation instead, shown in the Getting Started section below.)
 
 :::
 

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -88,6 +88,14 @@ def login(backend: str = "databricks", interactive: bool = True) -> None:
             input will be requested if no credentials are found, otherwise an exception will be
             raised if no credentials are found.
 
+    .. note::
+        This function connects to the ``DEFAULT`` profile in ``~/.databrickscfg`` (or the
+        profile named by the ``DATABRICKS_CONFIG_PROFILE`` environment variable). If you have
+        multiple named profiles, for example one created by ``databricks auth login`` (which
+        names the profile after the workspace host, not ``DEFAULT``), set
+        ``DATABRICKS_CONFIG_PROFILE=<name>`` before calling this function, or call
+        ``mlflow.set_tracking_uri("databricks://<name>")`` explicitly.
+
     .. code-block:: python
         :caption: Example
 

--- a/mlflow/utils/credentials.py
+++ b/mlflow/utils/credentials.py
@@ -89,12 +89,13 @@ def login(backend: str = "databricks", interactive: bool = True) -> None:
             raised if no credentials are found.
 
     .. note::
-        This function connects to the ``DEFAULT`` profile in ``~/.databrickscfg`` (or the
-        profile named by the ``DATABRICKS_CONFIG_PROFILE`` environment variable). If you have
-        multiple named profiles, for example one created by ``databricks auth login`` (which
-        names the profile after the workspace host, not ``DEFAULT``), set
-        ``DATABRICKS_CONFIG_PROFILE=<name>`` before calling this function, or call
-        ``mlflow.set_tracking_uri("databricks://<name>")`` explicitly.
+        When credentials resolve from ``~/.databrickscfg`` (rather than from environment
+        variables, OIDC, the Azure CLI, or another unified-auth source), this function uses
+        the ``DEFAULT`` profile, or the profile named by the ``DATABRICKS_CONFIG_PROFILE``
+        environment variable. If you have multiple named profiles, for example one created
+        by ``databricks auth login`` (which names the profile after the workspace host, not
+        ``DEFAULT``), set ``DATABRICKS_CONFIG_PROFILE=<name>`` before calling this function,
+        or call ``mlflow.set_tracking_uri("databricks://<name>")`` explicitly.
 
     .. code-block:: python
         :caption: Example


### PR DESCRIPTION
### Related Issues/PRs

N/A -- documentation clarifications, no linked issue.

### What changes are proposed in this pull request?

Four documentation clarifications for first-time GenAI tracing setup, each targeting a distinct point where a new user (or a coding agent) commonly goes wrong:

1. **Profile selection with `MLFLOW_TRACKING_URI=databricks`** (`docs/docs/genai/getting-started/databricks-trial/index.mdx` + `mlflow/utils/credentials.py` `login()` docstring). `MLFLOW_TRACKING_URI=databricks` reads the `DEFAULT` profile in `~/.databrickscfg`, or the profile named by `DATABRICKS_CONFIG_PROFILE`. A user who authenticated with `databricks auth login` gets a profile named after the workspace host, not `DEFAULT`, and silently connects to the wrong workspace. The note documents the two supported ways to target a named profile (`DATABRICKS_CONFIG_PROFILE=<name>` or `databricks://<name>`), which were previously only mentioned on the self-hosting backend-store reference page.

2. **LangGraph autolog vs. per-node `@mlflow.trace`** (`docs/docs/genai/tracing/integrations/listing/langgraph.mdx`). Decorating each graph node with `@mlflow.trace` instead of calling `mlflow.langchain.autolog()` produces one independent root trace per node rather than a single unified graph trace. A warning now states this at the top of the page and points to the child-span section for the correct in-node pattern.

3. **Runs vs. traces ("Traces: 0" after logging metrics)** (`docs/docs/genai/tracing/faq.mdx`). `mlflow.log_metric()` / `mlflow.log_param()` / `mlflow.start_run()` create MLflow Runs, which appear in the Runs tab, not Traces. A new FAQ entry explains the distinction and lists which API populates which tab.

4. **Span attributes vs. `mlflow.log_metric`** (`docs/docs/genai/tracing/app-instrumentation/manual-tracing.mdx`). Calling `mlflow.log_metric()` inside a traced function writes to the Run, not the active span, so the value never appears on the trace. A note directs users to `span.set_attribute` / `span.set_attributes`.

### How is this PR tested?

- [x] Existing unit/integration tests

Documentation-only change plus one docstring note. The `mlflow/utils/credentials.py` docstring edit passes `ruff check` and `ruff format`. No behavior change.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
