### PR TITLE
Avoid re-enabling externally-disabled loggers in `_configure_mlflow_loggers`

### DIFF
--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -160,30 +160,22 @@ class SensitiveQueryParamFilter(logging.Filter):
         return True
 
 
-class MlflowLoggingHandler(logging.StreamHandler):
-    """
-    Stream handler owned by MLflow. Subclassed rather than using a plain
-    `StreamHandler` so that repeat calls to `_configure_mlflow_loggers` can
-    identify and replace MLflow's own handler instead of stacking duplicates.
-    """
-
-
 def _configure_mlflow_loggers(root_module_name):
     """
-    Configure the loggers MLflow owns, without touching any other logger.
+    Configure the loggers MLflow owns, leaving every other logger untouched.
 
     This deliberately avoids `logging.config.dictConfig`. Even with
-    `disable_existing_loggers=False`, `dictConfig` mutates every pre-existing
-    logger: it force-sets `.disabled = False` (re-enabling loggers the host
-    application had deliberately silenced) and resets the level, handlers, and
-    propagate flag of any descendant of a configured logger. See CPython
-    bpo-44607.
+    `disable_existing_loggers=False`, `dictConfig` mutates loggers it was never
+    asked to configure: it force-sets `.disabled = False` on unrelated loggers
+    (re-enabling ones the host application had deliberately silenced) and resets
+    the level, handlers, and propagate flag of any descendant of a configured
+    logger. See CPython bpo-44607.
     """
     log_level = get_mlflow_log_level()
     # For alembic, use WARNING minimum to reduce noise, but respect higher levels
     alembic_level = log_level if log_level in ("WARNING", "ERROR", "CRITICAL") else "WARNING"
 
-    handler = MlflowLoggingHandler(stream=MLFLOW_LOGGING_STREAM)
+    handler = logging.StreamHandler(stream=MLFLOW_LOGGING_STREAM)
     handler.setFormatter(MlflowFormatter(fmt=LOGGING_LINE_FORMAT, datefmt=LOGGING_DATETIME_FORMAT))
     handler.addFilter(SuppressLogFilter())
 
@@ -194,9 +186,10 @@ def _configure_mlflow_loggers(root_module_name):
         ("huey", alembic_level),
     ):
         logger = logging.getLogger(name)
-        # `addHandler` only de-duplicates by identity, so a handler from an
-        # earlier call must be removed explicitly to keep this idempotent.
-        for stale in [h for h in logger.handlers if isinstance(h, MlflowLoggingHandler)]:
+        # Replace handlers on these four loggers rather than appending, matching
+        # what `dictConfig` did. This also keeps repeat calls idempotent, since
+        # `addHandler` only de-duplicates by object identity.
+        for stale in logger.handlers[:]:
             logger.removeHandler(stale)
         logger.addHandler(handler)
         logger.setLevel(level)

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -187,11 +187,8 @@ def _configure_mlflow_loggers(root_module_name):
     ):
         logger = logging.getLogger(name)
         # Replace handlers on these four loggers rather than appending, matching
-        # what `dictConfig` did. This also keeps repeat calls idempotent, since
-        # `addHandler` only de-duplicates by object identity.
-        for stale in logger.handlers[:]:
-            logger.removeHandler(stale)
-        logger.addHandler(handler)
+        # what `dictConfig` did. Direct assignment keeps repeat calls idempotent.
+        logger.handlers = [handler]
         logger.setLevel(level)
         logger.propagate = False
 

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import logging.config
 import re
 import sys
 
@@ -161,57 +160,47 @@ class SensitiveQueryParamFilter(logging.Filter):
         return True
 
 
+class MlflowLoggingHandler(logging.StreamHandler):
+    """
+    Stream handler owned by MLflow. Subclassed rather than using a plain
+    `StreamHandler` so that repeat calls to `_configure_mlflow_loggers` can
+    identify and replace MLflow's own handler instead of stacking duplicates.
+    """
+
+
 def _configure_mlflow_loggers(root_module_name):
-    log_level = (MLFLOW_LOGGING_LEVEL.get() or "INFO").upper()
+    """
+    Configure the loggers MLflow owns, without touching any other logger.
+
+    This deliberately avoids `logging.config.dictConfig`. Even with
+    `disable_existing_loggers=False`, `dictConfig` mutates every pre-existing
+    logger: it force-sets `.disabled = False` (re-enabling loggers the host
+    application had deliberately silenced) and resets the level, handlers, and
+    propagate flag of any descendant of a configured logger. See CPython
+    bpo-44607.
+    """
+    log_level = get_mlflow_log_level()
     # For alembic, use WARNING minimum to reduce noise, but respect higher levels
     alembic_level = log_level if log_level in ("WARNING", "ERROR", "CRITICAL") else "WARNING"
 
-    logging.config.dictConfig({
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "mlflow_formatter": {
-                "()": MlflowFormatter,
-                "format": LOGGING_LINE_FORMAT,
-                "datefmt": LOGGING_DATETIME_FORMAT,
-            },
-        },
-        "handlers": {
-            "mlflow_handler": {
-                "formatter": "mlflow_formatter",
-                "class": "logging.StreamHandler",
-                "stream": MLFLOW_LOGGING_STREAM,
-                "filters": ["suppress_in_thread"],
-            },
-        },
-        "loggers": {
-            root_module_name: {
-                "handlers": ["mlflow_handler"],
-                "level": get_mlflow_log_level(),
-                "propagate": False,
-            },
-            "sqlalchemy.engine": {
-                "handlers": ["mlflow_handler"],
-                "level": "WARN",
-                "propagate": False,
-            },
-            "alembic": {
-                "handlers": ["mlflow_handler"],
-                "level": alembic_level,
-                "propagate": False,
-            },
-            "huey": {
-                "handlers": ["mlflow_handler"],
-                "level": alembic_level,
-                "propagate": False,
-            },
-        },
-        "filters": {
-            "suppress_in_thread": {
-                "()": SuppressLogFilter,
-            }
-        },
-    })
+    handler = MlflowLoggingHandler(stream=MLFLOW_LOGGING_STREAM)
+    handler.setFormatter(MlflowFormatter(fmt=LOGGING_LINE_FORMAT, datefmt=LOGGING_DATETIME_FORMAT))
+    handler.addFilter(SuppressLogFilter())
+
+    for name, level in (
+        (root_module_name, log_level),
+        ("sqlalchemy.engine", "WARNING"),
+        ("alembic", alembic_level),
+        ("huey", alembic_level),
+    ):
+        logger = logging.getLogger(name)
+        # `addHandler` only de-duplicates by identity, so a handler from an
+        # earlier call must be removed explicitly to keep this idempotent.
+        for stale in [h for h in logger.handlers if isinstance(h, MlflowLoggingHandler)]:
+            logger.removeHandler(stale)
+        logger.addHandler(handler)
+        logger.setLevel(level)
+        logger.propagate = False
 
 
 def _install_sensitive_query_param_filter() -> None:

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -12,7 +12,9 @@ import mlflow
 from mlflow.utils import logging_utils
 from mlflow.utils.logging_utils import (
     LOGGING_LINE_FORMAT,
+    MlflowLoggingHandler,
     SensitiveQueryParamFilter,
+    _configure_mlflow_loggers,
     _redact_sensitive_query_params,
     eprint,
     suppress_logs,
@@ -285,3 +287,65 @@ assert actual_format == {actual_format!r}, actual_format
             "MLFLOW_CONFIGURE_LOGGING": configure_logging,
         },
     )
+
+
+def test_import_mlflow_preserves_disabled_loggers() -> None:
+    """
+    Importing mlflow must not re-enable loggers the host application disabled.
+    The Databricks notebook kernel disables `pyspark.sql.connect.logging` at
+    startup; re-enabling it dumps raw gRPC tracebacks into cell output.
+    """
+    code = """
+import logging
+
+connect_logger = logging.getLogger("pyspark.sql.connect.logging")
+connect_logger.disabled = True
+unrelated_logger = logging.getLogger("some.third.party")
+unrelated_logger.disabled = True
+
+import mlflow
+
+assert connect_logger.disabled, "mlflow re-enabled pyspark.sql.connect.logging"
+assert unrelated_logger.disabled, "mlflow re-enabled some.third.party"
+"""
+    subprocess.check_call([sys.executable, "-c", code], env=os.environ.copy())
+
+
+def test_import_mlflow_preserves_existing_child_logger_config() -> None:
+    """
+    Descendants of the loggers mlflow configures (`mlflow`, `sqlalchemy.engine`,
+    `alembic`, `huey`) must keep any level, handlers, and propagate flag that
+    were set before the import.
+    """
+    code = """
+import logging
+
+CHILDREN = ("mlflow.tracking.fluent", "sqlalchemy.engine.Engine")
+handler = logging.NullHandler()
+for name in CHILDREN:
+    child = logging.getLogger(name)
+    child.setLevel(logging.ERROR)
+    child.addHandler(handler)
+    child.propagate = False
+
+import mlflow
+
+for name in CHILDREN:
+    child = logging.getLogger(name)
+    assert child.level == logging.ERROR, (name, child.level)
+    assert child.handlers == [handler], (name, child.handlers)
+    assert not child.propagate, name
+"""
+    subprocess.check_call([sys.executable, "-c", code], env=os.environ.copy())
+
+
+def test_configure_mlflow_loggers_is_idempotent() -> None:
+    configured_loggers = ["mlflow", "sqlalchemy.engine", "alembic", "huey"]
+
+    for _ in range(3):
+        _configure_mlflow_loggers("mlflow")
+        for name in configured_loggers:
+            handlers = [
+                h for h in logging.getLogger(name).handlers if isinstance(h, MlflowLoggingHandler)
+            ]
+            assert len(handlers) == 1, (name, handlers)

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -288,13 +288,31 @@ assert actual_format == {actual_format!r}, actual_format
     )
 
 
+def _logging_configured_env() -> dict[str, str]:
+    """
+    Subprocess environment guaranteeing `_configure_mlflow_loggers` runs on import,
+    so the regression tests below cannot pass vacuously. The deprecated alias takes
+    precedence over `MLFLOW_CONFIGURE_LOGGING`, so it has to be cleared as well.
+    """
+    env = os.environ.copy()
+    env.pop("MLFLOW_LOGGING_CONFIGURE_LOGGING", None)
+    env["MLFLOW_CONFIGURE_LOGGING"] = "1"
+    return env
+
+
+# Guards against a vacuous pass if the import ever stops configuring logging.
+_ASSERT_LOGGING_CONFIGURED = """
+assert logging.getLogger("mlflow").handlers, "mlflow did not configure logging"
+"""
+
+
 def test_import_mlflow_preserves_disabled_loggers() -> None:
     """
     Importing mlflow must not re-enable loggers the host application disabled.
     The Databricks notebook kernel disables `pyspark.sql.connect.logging` at
     startup; re-enabling it dumps raw gRPC tracebacks into cell output.
     """
-    code = """
+    code = f"""
 import logging
 
 connect_logger = logging.getLogger("pyspark.sql.connect.logging")
@@ -303,11 +321,11 @@ unrelated_logger = logging.getLogger("some.third.party")
 unrelated_logger.disabled = True
 
 import mlflow
-
+{_ASSERT_LOGGING_CONFIGURED}
 assert connect_logger.disabled, "mlflow re-enabled pyspark.sql.connect.logging"
 assert unrelated_logger.disabled, "mlflow re-enabled some.third.party"
 """
-    subprocess.check_call([sys.executable, "-c", code], env=os.environ.copy())
+    subprocess.check_call([sys.executable, "-c", code], env=_logging_configured_env())
 
 
 def test_import_mlflow_preserves_existing_child_logger_config() -> None:
@@ -316,7 +334,7 @@ def test_import_mlflow_preserves_existing_child_logger_config() -> None:
     `alembic`, `huey`) must keep any level, handlers, and propagate flag that
     were set before the import.
     """
-    code = """
+    code = f"""
 import logging
 
 CHILDREN = ("mlflow.tracking.fluent", "sqlalchemy.engine.Engine")
@@ -328,14 +346,14 @@ for name in CHILDREN:
     child.propagate = False
 
 import mlflow
-
+{_ASSERT_LOGGING_CONFIGURED}
 for name in CHILDREN:
     child = logging.getLogger(name)
     assert child.level == logging.ERROR, (name, child.level)
     assert child.handlers == [handler], (name, child.handlers)
     assert not child.propagate, name
 """
-    subprocess.check_call([sys.executable, "-c", code], env=os.environ.copy())
+    subprocess.check_call([sys.executable, "-c", code], env=_logging_configured_env())
 
 
 def test_configure_mlflow_loggers_is_idempotent() -> None:

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -12,7 +12,6 @@ import mlflow
 from mlflow.utils import logging_utils
 from mlflow.utils.logging_utils import (
     LOGGING_LINE_FORMAT,
-    MlflowLoggingHandler,
     SensitiveQueryParamFilter,
     _configure_mlflow_loggers,
     _redact_sensitive_query_params,
@@ -345,7 +344,21 @@ def test_configure_mlflow_loggers_is_idempotent() -> None:
     for _ in range(3):
         _configure_mlflow_loggers("mlflow")
         for name in configured_loggers:
-            handlers = [
-                h for h in logging.getLogger(name).handlers if isinstance(h, MlflowLoggingHandler)
-            ]
+            handlers = logging.getLogger(name).handlers
             assert len(handlers) == 1, (name, handlers)
+
+
+def test_configure_mlflow_loggers_replaces_existing_handlers() -> None:
+    """
+    Handlers already attached to the loggers MLflow configures are replaced, not
+    appended to. Appending would emit every record twice, once through MLflow's
+    handler and once through the pre-existing one.
+    """
+    logger = logging.getLogger("alembic")
+    pre_existing = logging.StreamHandler(StringIO())
+    logger.addHandler(pre_existing)
+
+    _configure_mlflow_loggers("mlflow")
+
+    assert pre_existing not in logger.handlers
+    assert len(logger.handlers) == 1


### PR DESCRIPTION
### Related Issues/PRs

Relates to #16032

### What changes are proposed in this pull request?

`_configure_mlflow_loggers` configures MLflow's loggers with `logging.config.dictConfig`. Even with `disable_existing_loggers` set to `False`, `dictConfig` mutates loggers it was never asked to configure. From CPython's `logging/config.py`:

```python
def _handle_existing_loggers(existing, child_loggers, disable_existing):
    root = logging.root
    for log in existing:
        logger = root.manager.loggerDict[log]
        if log in child_loggers:
            if not isinstance(logger, logging.PlaceHolder):
                logger.setLevel(logging.NOTSET)
                logger.handlers = []
                logger.propagate = True
        else:
            logger.disabled = disable_existing  # unconditional assignment
```

That last line is an assignment, not a "leave it alone". So `disable_existing_loggers: False` does not mean "do not touch existing loggers", it means "force every existing logger to enabled" (bpo-44607). Separately, descendants of a configured logger have their level, handlers and propagate flag reset.

Reproduction on `master`:

```python
import logging

logging.getLogger("my.noisy.logger").disabled = True

import mlflow

print(logging.getLogger("my.noisy.logger").disabled)  # False -- re-enabled by mlflow
```

The practical impact is in notebook environments whose kernel disables `pyspark.sql.connect` logging at startup. `import mlflow` silently re-enables it, so a failing Spark query dumps a full "GRPC Error received" traceback into the cell output instead of the concise error message. Any logger an application deliberately disabled before importing MLflow is affected, not only PySpark's.

This PR configures the four loggers MLflow owns (`mlflow`, `sqlalchemy.engine`, `alembic`, `huey`) directly and leaves every other logger untouched. The resulting configuration is unchanged: the same shared handler wrapping `MLFLOW_LOGGING_STREAM`, the same `MlflowFormatter`, the same `SuppressLogFilter`, the same levels, and `propagate=False`.

One subtlety worth calling out for review: `dictConfig` cleared handlers before adding, so repeated configuration never duplicated them. `Logger.addHandler` only de-duplicates by object identity, so the new code removes any previously installed MLflow handler first. Without that, a second call (`tests/__init__.py` makes one) would stack handlers and duplicate every log line.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Three tests added to `tests/utils/test_logging_utils.py`:

- `test_import_mlflow_preserves_disabled_loggers` -- a logger disabled before the import stays disabled.
- `test_import_mlflow_preserves_existing_child_logger_config` -- a pre-configured descendant keeps its level, handlers and propagate flag.
- `test_configure_mlflow_loggers_is_idempotent` -- repeat calls leave exactly one handler per configured logger.

Before behavour:

<img width="1027" height="370" alt="Screenshot 2026-08-07 at 3 12 30 PM" src="https://github.com/user-attachments/assets/531ae928-a532-47d7-a05b-446078e65464" />

After changes (installed modified version of mlflow with the new changes in the DB notebook - no longer re-enables `pyspark.sql.connect` logger):

<img width="988" height="283" alt="Screenshot 2026-08-07 at 3 12 44 PM" src="https://github.com/user-attachments/assets/7b81918e-b727-43dc-9230-6c4e89e28b63" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Importing MLflow no longer re-enables loggers that the host application had disabled, and no longer resets the configuration of pre-existing loggers under `mlflow`, `sqlalchemy.engine`, `alembic` or `huey`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release