### PR TITLE
Fix grouped line charts forcing the Y axis to include zero

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.test.tsx
@@ -5,6 +5,8 @@ import { renderWithIntl, cleanup } from '../../../../common/utils/TestUtils.reac
 import { LazyPlot } from '../../LazyPlot';
 import type { PlotParams } from 'react-plotly.js';
 import { RunsChartsLineChartXAxisType } from './RunsCharts.common';
+import { RunGroupingAggregateFunction } from '../../experiment-page/utils/experimentPage.row-types';
+import type { RunGroupParentInfo } from '../../experiment-page/utils/experimentPage.row-types';
 
 jest.mock('../../LazyPlot', () => ({
   LazyPlot: jest.fn(() => null),
@@ -49,6 +51,50 @@ describe('RunsMetricsLinePlot', () => {
     renderWithIntl(<RunsMetricsLinePlot {...defaultProps} xAxisScaleType="log" />);
     expect(getLastRenderedPlotProps().data[0]).toEqual(expect.objectContaining({ x: [1, 2, 3] }));
     expect(getLastRenderedPlotProps().data[0]).toEqual(expect.objectContaining({ y: [10, 20, 30] }));
+    cleanup();
+  });
+
+  test('it should fill the grouped run band without anchoring the Y axis to zero', () => {
+    const createMetricHistory = (values: number[]) =>
+      values.map((value, step) => ({ value, step, key: 'testMetric', timestamp: 1100 + step }));
+
+    const groupedProps: RunsMetricsLinePlotProps = {
+      ...defaultProps,
+      runsData: [
+        {
+          displayName: 'Group 1',
+          uuid: 'group-1',
+          groupParentInfo: { groupId: 'group-1', runUuids: ['run-1', 'run-2'] } as RunGroupParentInfo,
+          metricsHistory: {
+            testMetric: createMetricHistory([1.05, 1.06, 1.07]),
+          },
+          aggregatedMetricsHistory: {
+            testMetric: {
+              [RunGroupingAggregateFunction.Min]: createMetricHistory([1.0, 1.01, 1.02]),
+              [RunGroupingAggregateFunction.Max]: createMetricHistory([1.08, 1.09, 1.1]),
+              [RunGroupingAggregateFunction.Average]: createMetricHistory([1.04, 1.05, 1.06]),
+            },
+          },
+        },
+      ],
+    };
+
+    renderWithIntl(<RunsMetricsLinePlot {...groupedProps} />);
+
+    // The band trace is prepended to the chart data, see `plotDataWithBands`
+    const bandTrace = getLastRenderedPlotProps().data[0];
+
+    // `tozeroy` fills down to y=0, which forces Plotly's autorange to include zero and
+    // squashes the actual data range. `toself` closes the min/max ring instead. The ring
+    // must not be split by a null separator, otherwise `toself` fills each half on its own.
+    expect(bandTrace).toEqual(
+      expect.objectContaining({
+        fill: 'toself',
+        x: [2, 1, 0, 0, 1, 2],
+        y: [1.02, 1.01, 1.0, 1.08, 1.09, 1.1],
+      }),
+    );
+
     cleanup();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
@@ -243,10 +243,11 @@ const getBandTraceForRun = ({
     }
   }
 
-  // Place a null value in the middle to create a gap, otherwise Plotly will
-  // connect the lines and the fill will be drawn incorrectly
-  const xValues = [...xMins, null, ...xMaxes];
-  const bandValues = [...yMins, null, ...yMaxes];
+  // The reversed lower bound followed by the upper bound forms a closed ring, which
+  // "toself" fills directly. Filling to zero instead would force Plotly's autorange
+  // to include y=0 and squash the band against the top of the plot.
+  const xValues = [...xMins, ...xMaxes];
+  const bandValues = [...yMins, ...yMaxes];
 
   return {
     name: runEntry.runInfo?.runName || '',
@@ -257,7 +258,7 @@ const getBandTraceForRun = ({
     hoverlabel: undefined,
     hoverinfo: 'skip',
     line: { color: 'transparent', shape: lineShape },
-    fill: 'tozeroy',
+    fill: 'toself',
     type: 'scatter',
   } as LineChartTraceData;
 };


### PR DESCRIPTION
### Related Issues/PRs

Closes #24934

### What changes are proposed in this pull request?

When runs are grouped, `RunsMetricsLinePlot` adds one extra trace per group for the aggregated min/max band. That band is emitted as a single trace filled with `fill: 'tozeroy'`. Plotly's autorange has to include the fill target, so `autorange: yRange === undefined` always yields a Y range anchored at zero — regardless of the metric's actual range. A metric confined to `[1.00, 1.10]` gets plotted on a `[0.00, 1.18]` axis and all the variation between groups collapses into the top ~8% of the plot. The same chart ungrouped (no band trace) autoranges tightly.

The band is already a closed ring: the lower bound reversed, followed by the upper bound. So it can be filled as itself rather than to zero:

- `fill: 'tozeroy'` → `fill: 'toself'`
- dropped the `null` separator in `xValues`/`bandValues`, which only existed to stop `tozeroy` filling across the gap between the two halves of the band

`toself` closes the path from the last point back to the first, producing the same visual band without dragging the axis to zero. No extra trace is added, so `bandsData.length` — which `useRenderRunsChartTraceHighlight` uses to distinguish band traces from line traces — is unchanged.

### Reproduction

Measured with the band data this component produces for a metric confined to `[1.00, 1.10]`, rendering the trace with real `plotly.js` and reading back `_fullLayout.yaxis.range`:

| | Y autorange | share of plot height used by the data |
|---|---|---|
| Before (`tozeroy`) | `[0.0000, 1.1790]` | 8.5% |
| After (`toself`) | `[0.9923, 1.1077]` | 86.6% |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `it should fill the grouped run band without anchoring the Y axis to zero` to `RunsMetricsLinePlot.test.tsx`. It renders a grouped run entry with an `aggregatedMetricsHistory` and asserts the band trace is filled with `toself` and that the ring is not split by a `null` separator. The test fails on `master` (`fill: "tozeroy"`, `x: [2, 1, 0, null, 0, 1, 2]`) and passes with this change.

Target file:

```
$ yarn test RunsMetricsLinePlot.test.tsx

 PASS  src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.test.tsx
  RunsMetricsLinePlot
    ✓ it should properly filter negative values when using log scale on X axis (197 ms)
    ✓ it should fill the grouped run band without anchoring the Y axis to zero (4 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

Full `runs-charts` suite:

```
$ yarn test src/experiment-tracking/components/runs-charts

Test Suites: 22 passed, 22 total
Tests:       125 passed, 125 total
Time:        12.52 s
```

Lint, formatting and types:

```
$ yarn lint            # no findings
$ yarn prettier:check  # All matched files use Prettier code style!
$ yarn type-check      # exit 0
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Line charts on the experiment page no longer force the Y axis to include zero when runs are grouped, so grouped charts autorange to the data the same way ungrouped ones do.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
