### PR TITLE
Add workflow to delete stale bot branches

### DIFF
--- a/.github/workflows/stale-branches.js
+++ b/.github/workflows/stale-branches.js
@@ -1,0 +1,126 @@
+// Deletes stale branches: no open PR, not protected, and untouched for longer
+// than the cutoff that applies to whoever authored the last commit.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Days untouched before sweeping, by last-commit author. Bots recreate their
+// branches from scratch, so a stale one is a leftover. null exempts humans,
+// whose branches may hold work that lives nowhere else.
+const STALE_DAYS = { bot: 30, human: null };
+
+// Bot-pushed and never has a PR, so it passes every other filter.
+const EXCLUDED = new Set(["gh-pages"]);
+
+const QUERY = `
+  query($owner: String!, $name: String!, $cursor: String) {
+    rateLimit { remaining resetAt }
+    repository(owner: $owner, name: $name) {
+      refs(refPrefix: "refs/heads/", first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          name
+          target {
+            ... on Commit {
+              committedDate
+              author {
+                name
+                user { login }
+              }
+            }
+          }
+          associatedPullRequests(first: 1, states: OPEN) { totalCount }
+        }
+      }
+    }
+  }
+`;
+
+// `GitActor.user` is always typed `User`, so the `__typename === "Bot"` check
+// used on timeline events fails here. The `[bot]` suffix can be on the login, or
+// only on the commit name (login `Claude` commits as `anthropic-code-agent[bot]`).
+const isBotCommit = (commit) =>
+  [commit?.author?.user?.login, commit?.author?.name].some((name) => name?.endsWith("[bot]"));
+
+const findStaleBranches = async (github, { owner, repo }, protectedBranches) => {
+  const stale = [];
+  let cursor = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const response = await github.graphql(QUERY, { owner, name: repo, cursor });
+    const { remaining, resetAt } = response.rateLimit;
+    console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+
+    const { nodes, pageInfo } = response.repository.refs;
+    hasNextPage = pageInfo.hasNextPage;
+    cursor = pageInfo.endCursor;
+
+    for (const ref of nodes) {
+      if (EXCLUDED.has(ref.name) || protectedBranches.has(ref.name)) {
+        continue;
+      }
+
+      if (ref.associatedPullRequests.totalCount > 0) {
+        continue;
+      }
+
+      const staleDays = STALE_DAYS[isBotCommit(ref.target) ? "bot" : "human"];
+      if (staleDays === null) {
+        continue;
+      }
+
+      const days = Math.floor((Date.now() - new Date(ref.target.committedDate)) / MS_PER_DAY);
+      if (days <= staleDays) {
+        continue;
+      }
+
+      stale.push({ name: ref.name, days });
+    }
+  }
+
+  return stale.sort((a, b) => b.days - a.days);
+};
+
+module.exports = async ({ context, github }) => {
+  const { owner, repo } = context.repo;
+  // Default to a dry run so an unset or unexpected value never deletes.
+  const dryRun = process.env.DRY_RUN !== "false";
+
+  // Protection here comes from rulesets, which GraphQL's `branchProtectionRule`
+  // does not report. The REST `protected` flag does.
+  const branches = await github.paginate(github.rest.repos.listBranches, {
+    owner,
+    repo,
+    per_page: 100,
+  });
+  const protectedBranches = new Set(branches.filter((b) => b.protected).map((b) => b.name));
+
+  let deleteCount = 0;
+
+  try {
+    const stale = await findStaleBranches(github, { owner, repo }, protectedBranches);
+    console.log(`Found ${stale.length} stale branches.`);
+
+    for (const { name, days } of stale) {
+      if (dryRun) {
+        console.log(`[dry run] Would delete ${name} (inactive for ${days} days)`);
+        continue;
+      }
+
+      console.log(`Deleting ${name} (inactive for ${days} days)`);
+      await github.rest.git.deleteRef({ owner, repo, ref: `heads/${name}` });
+      deleteCount++;
+    }
+
+    console.log(`Deleted ${deleteCount} stale branches.`);
+  } catch (error) {
+    if (error.status === 429 || error.message?.includes("rate limit")) {
+      console.log(`Rate limit hit after deleting ${deleteCount} branches. Exiting gracefully.`);
+      return;
+    }
+    throw error;
+  }
+};

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,76 @@
+name: Stale branches
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/stale-branches.yml
+      - .github/workflows/stale-branches.js
+  schedule:
+    # Run weekly on Monday at 00:00 UTC
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log the branches that would be deleted without deleting them"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  # Runs the PR's own copy of the script, so the token is read-only: a preview
+  # must not delete a branch, however the script is edited.
+  preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/stale-branches.js
+          sparse-checkout-cone-mode: false
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: "true"
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/stale-branches.js");
+            await script({ context, github });
+
+  # Deletes on the weekly schedule, and on a manual run with dry_run unchecked.
+  sweep:
+    if: github.event_name != 'pull_request' && github.repository == 'mlflow/mlflow'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/stale-branches.js
+          sparse-checkout-cone-mode: false
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DRY_RUN: ${{ inputs.dry_run == true }}
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/stale-branches.js");
+            await script({ context, github });


### PR DESCRIPTION
### Related Issues/PRs

None

### What changes are proposed in this pull request?

Adds a `Stale branches` workflow that deletes leftover bot branches: last commit authored by a bot, no open PR, untouched for 30 days, and not protected. Bots recreate their branches from scratch on every run, so a stale one is a leftover rather than work in progress.

Runs weekly. PRs touching it and manual dispatches run in dry-run mode, in a separate job whose token is read-only, so a preview cannot delete regardless of how the script is edited.

Three things worth a look:

- Bot detection matches the `[bot]` suffix on the commit author, not GraphQL `__typename`. `GitActor.user` is always typed `User`, so a `__typename === "Bot"` check (as used on timeline events in `stale-prs.js`) would silently match nothing forever.
- `gh-pages` is explicitly excluded. It is bot-pushed and never has a PR, so it passes every other filter.
- Protection is read from the REST `protected` flag, since this repo uses rulesets and GraphQL's `branchProtectionRule` returns `null`.

The cutoff is keyed by author kind (`{ bot: 30, human: null }`), so covering human branches later is a one-value change.

### How is this PR tested?

- [x] Manual tests

Ran the script against the live repo:

```
Found 1 stale branches.
[dry run] Would delete claude/fix-group-mode-display-issue (inactive for 162 days)
```

Also confirmed the open-PR guard is doing real work (`update-model-catalog` is bot-authored and unprotected but correctly skipped, since PR #24960 is open) and that the delete path targets the right ref. This PR's own CI run exercises the dry run.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
