### PR TITLE
Use the latest model of each family in `/review` and `/ui-review`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -182,15 +182,15 @@ jobs:
               "sonnet",
               "haiku",
               "claude-fable-5",
-              "claude-opus-4-7",
-              "claude-sonnet-4-6",
+              "claude-opus-5",
+              "claude-sonnet-5",
               "claude-haiku-4-5",
           ]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
           labels = {l["name"] for l in json.loads(os.environ["LABELS_JSON"])}
           big = bool(labels & {"size/M", "size/L", "size/XL"})
-          default_model = "claude-opus-4-7" if big else "claude-sonnet-4-6"
+          default_model = "claude-opus-5" if big else "claude-sonnet-5"
 
           body = sys.stdin.read().removeprefix("/review")
 

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -185,8 +185,8 @@ jobs:
               "sonnet",
               "haiku",
               "claude-fable-5",
-              "claude-opus-4-7",
-              "claude-sonnet-4-6",
+              "claude-opus-5",
+              "claude-sonnet-5",
               "claude-haiku-4-5",
           ]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
@@ -199,7 +199,7 @@ jobs:
 
           parser = argparse.ArgumentParser(add_help=False)
           # -m/--model and -e/--effort mirror the /review command.
-          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default="claude-opus-4-7")
+          parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default="claude-opus-5")
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
           args = parser.parse_args(tokens)
 


### PR DESCRIPTION
### Related Issues/PRs

None

### What changes are proposed in this pull request?

Bumps the pinned model IDs in `review.yml` and `ui-review.yml` to the current generation of each family:

| | Before | After |
|---|---|---|
| `/review`, large PRs (`size/M\|L\|XL`) | `claude-opus-4-7` | `claude-opus-5` |
| `/review`, small PRs | `claude-sonnet-4-6` | `claude-sonnet-5` |
| `/ui-review` default | `claude-opus-4-7` | `claude-opus-5` |

`claude-fable-5` and `claude-haiku-4-5` were already current and are unchanged (there is no Haiku 5). The superseded IDs are dropped from `MODEL_CHOICES` rather than kept alongside, so each list stays one entry per family.

`ui-review.yml` carries the same `MODEL_CHOICES` block and its comment says its flags mirror `/review`, so both move together to keep them from drifting apart.

Neither swap raises the bill at list price: Opus 5 is $5/$25 per MTok, the same as Opus 4.7, and Sonnet 5 is on introductory pricing at $2/$10 through 2026-08-31 versus Sonnet 4.6's $3/$15, so small-PR reviews are cheaper until then and at parity afterwards.

`EFFORT_CHOICES` and the size-based default split are untouched.

### How is this PR tested?

- [x] Manual tests

This PR is self-testing for `/review`: `review.yml` triggers on changes to its own path, so the `review` check ran under the new defaults. Its uploaded transcript confirms the model actually used, rather than just that the job was green:

```
init model:  claude-sonnet-5   (only model in the transcript)
result:      subtype=success, is_error=false
stop_reason: end_turn          (no refusal, no max_tokens)
```

Cache reads dominated input (382,931 read vs 18 fresh), so prompt caching survived the model swap.

Also confirmed no superseded IDs remain anywhere under `.github/`. The remaining repo-wide hits are gateway provider tests, demo fixtures, and `mlflow/utils/model_catalog/anthropic.json`, which is a catalog that legitimately lists older models.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
