### PR TITLE
Add visual editor for structured output JSON schema in prompt creation modal

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ResponseFormatSchemaBuilder.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ResponseFormatSchemaBuilder.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEventGlobal, { PointerEventsCheckLevel } from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { ResponseFormatSchemaBuilder } from './ResponseFormatSchemaBuilder';
+
+// SimpleSelect renders as a radix combobox, which fails jsdom's pointer-events
+// check when clicked; disable it, matching the convention used for other
+// radix-based SimpleSelect interactions in this repo.
+const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+const singleFieldSchema = JSON.stringify({
+  type: 'object',
+  properties: { status: { type: 'string' } },
+  required: [],
+});
+
+const twoFieldSchema = JSON.stringify({
+  type: 'object',
+  properties: { name: { type: 'string' }, age: { type: 'integer' } },
+  required: [],
+});
+
+const enumFieldSchema = JSON.stringify({
+  type: 'object',
+  properties: { priority: { type: 'string', enum: ['low', 'medium', 'high'] } },
+  required: [],
+});
+
+const emptyEnumFieldSchema = JSON.stringify({
+  type: 'object',
+  properties: { priority: { type: 'string', enum: [] } },
+  required: [],
+});
+
+describe('ResponseFormatSchemaBuilder', () => {
+  const renderComponent = (props: { schemaText: string; onSchemaChange: (next: string) => void }) => {
+    return render(
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <ResponseFormatSchemaBuilder {...props} />
+        </DesignSystemProvider>
+      </IntlProvider>,
+    );
+  };
+
+  it('renders fields parsed from the given schemaText', () => {
+    renderComponent({ schemaText: singleFieldSchema, onSchemaChange: jest.fn<(next: string) => void>() });
+    expect(screen.getByDisplayValue('status')).toBeInTheDocument();
+  });
+
+  it('adds an empty property row when "Add property" is clicked', async () => {
+    const onSchemaChange = jest.fn<(next: string) => void>();
+    renderComponent({ schemaText: '', onSchemaChange });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add property' }));
+
+    expect(screen.getAllByPlaceholderText('Property')).toHaveLength(1);
+    expect(onSchemaChange).toHaveBeenCalledTimes(1);
+    const emitted = JSON.parse(onSchemaChange.mock.calls[0][0]);
+    expect(emitted.properties).toEqual({});
+  });
+
+  it('removes a property and emits a schema without it when its delete button is clicked', async () => {
+    const onSchemaChange = jest.fn<(next: string) => void>();
+    renderComponent({ schemaText: twoFieldSchema, onSchemaChange });
+
+    const nameInputs = screen.getAllByRole('textbox');
+    expect(nameInputs.map((input) => (input as HTMLInputElement).value)).toEqual(['name', 'age']);
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'Remove property' });
+    await userEvent.click(deleteButtons[1]); // remove "age"
+
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    const emitted = JSON.parse(onSchemaChange.mock.calls[onSchemaChange.mock.calls.length - 1][0]);
+    expect(emitted.properties).toEqual({ name: { type: 'string' } });
+  });
+
+  it('shows the enum value controls only when the type is switched to enum', async () => {
+    renderComponent({ schemaText: singleFieldSchema, onSchemaChange: jest.fn<(next: string) => void>() });
+
+    expect(screen.queryByRole('button', { name: 'Add enum value' })).not.toBeInTheDocument();
+
+    const trigger = document.querySelector<HTMLElement>(
+      '[data-component-id="mlflow.prompts.create.response_format.property_type"]',
+    );
+    if (!trigger) throw new Error('Property type SimpleSelect trigger not found');
+    await userEvent.click(trigger);
+    await userEvent.click(await screen.findByRole('option', { name: 'enum' }));
+
+    expect(screen.getByRole('button', { name: 'Add enum value' })).toBeInTheDocument();
+
+    await userEvent.click(trigger);
+    await userEvent.click(await screen.findByRole('option', { name: 'string' }));
+
+    expect(screen.queryByRole('button', { name: 'Add enum value' })).not.toBeInTheDocument();
+  });
+
+  it('renders existing enum values as individual, editable rows', () => {
+    renderComponent({ schemaText: enumFieldSchema, onSchemaChange: jest.fn<(next: string) => void>() });
+
+    expect(screen.getByDisplayValue('low')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('medium')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('high')).toBeInTheDocument();
+  });
+
+  it('adds and populates a new enum value row', async () => {
+    const onSchemaChange = jest.fn<(next: string) => void>();
+    renderComponent({ schemaText: emptyEnumFieldSchema, onSchemaChange });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add enum value' }));
+    await userEvent.type(screen.getByPlaceholderText('Allowed value'), 'low');
+
+    const emitted = JSON.parse(onSchemaChange.mock.calls[onSchemaChange.mock.calls.length - 1][0]);
+    expect(emitted.properties.priority.enum).toEqual(['low']);
+  });
+
+  it('removes a single enum value without affecting the others', async () => {
+    const onSchemaChange = jest.fn<(next: string) => void>();
+    renderComponent({ schemaText: enumFieldSchema, onSchemaChange });
+
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove enum value' });
+    await userEvent.click(removeButtons[1]); // remove "medium"
+
+    expect(screen.getByDisplayValue('low')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('medium')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('high')).toBeInTheDocument();
+
+    const emitted = JSON.parse(onSchemaChange.mock.calls[onSchemaChange.mock.calls.length - 1][0]);
+    expect(emitted.properties.priority.enum).toEqual(['low', 'high']);
+  });
+
+  it('emits an array schema when the array toggle is switched on', async () => {
+    const onSchemaChange = jest.fn<(next: string) => void>();
+    renderComponent({ schemaText: singleFieldSchema, onSchemaChange });
+
+    // Row order is [array toggle, required toggle]
+    const [arraySwitch] = screen.getAllByRole('switch');
+    await userEvent.click(arraySwitch);
+
+    const emitted = JSON.parse(onSchemaChange.mock.calls[onSchemaChange.mock.calls.length - 1][0]);
+    expect(emitted.properties.status).toEqual({ type: 'array', items: { type: 'string' } });
+  });
+
+  it('emits a schema with the field in `required` when the required toggle is switched on', async () => {
+    const onSchemaChange = jest.fn<(next: string) => void>();
+    renderComponent({ schemaText: singleFieldSchema, onSchemaChange });
+
+    // Row order is [array toggle, required toggle]
+    const [, requiredSwitch] = screen.getAllByRole('switch');
+    await userEvent.click(requiredSwitch);
+
+    const emitted = JSON.parse(onSchemaChange.mock.calls[onSchemaChange.mock.calls.length - 1][0]);
+    expect(emitted.required).toEqual(['status']);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ResponseFormatSchemaBuilder.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ResponseFormatSchemaBuilder.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import {
+  Button,
+  Input,
+  PlusIcon,
+  SimpleSelect,
+  SimpleSelectOption,
+  TrashIcon,
+  Switch,
+  Tooltip,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { jsonSchemaToProperties, nextSchemaPropertyId, propertiesToJsonSchema } from '../utils';
+import type { SchemaProperty } from '../types';
+
+const TYPE_OPTIONS: SchemaProperty['type'][] = ['string', 'number', 'integer', 'boolean', 'enum'];
+
+interface Props {
+  schemaText: string;
+  onSchemaChange: (next: string) => void;
+}
+
+/**
+ * Visual (field-by-field) editor for the structured output JSON schema, shown as an
+ * alternative to the raw JSON textarea in the prompt creation modal.
+ */
+export const ResponseFormatSchemaBuilder = ({ schemaText, onSchemaChange }: Props) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  // Parsed once on mount; `schemaText` is only re-read when switching back into this mode
+  const [properties, setProperties] = useState<SchemaProperty[]>(() => jsonSchemaToProperties(schemaText));
+
+  const emit = (next: SchemaProperty[]) => {
+    setProperties(next);
+    onSchemaChange(propertiesToJsonSchema(next));
+  };
+
+  const updateProperty = (id: string, patch: Partial<SchemaProperty>) =>
+    emit(properties.map((p) => (p.id === id ? { ...p, ...patch } : p)));
+
+  const removeProperty = (id: string) => emit(properties.filter((p) => p.id !== id));
+
+  const addProperty = () =>
+    emit([
+      ...properties,
+      { id: nextSchemaPropertyId(), name: '', type: 'string', isArray: false, required: false, enumValues: [] },
+    ]);
+
+  const updateEnumValue = (prop: SchemaProperty, index: number, value: string) =>
+    updateProperty(prop.id, {
+      enumValues: prop.enumValues.map((v, i) => (i === index ? value : v)),
+    });
+
+  const removeEnumValue = (prop: SchemaProperty, index: number) =>
+    updateProperty(prop.id, { enumValues: prop.enumValues.filter((_, i) => i !== index) });
+
+  const addEnumValue = (prop: SchemaProperty) => updateProperty(prop.id, { enumValues: [...prop.enumValues, ''] });
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+      {properties.map((prop) => (
+        <div key={prop.id} css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+            <Input
+              componentId="mlflow.prompts.create.response_format.property_name"
+              css={{ flex: 2 }}
+              value={prop.name}
+              placeholder={intl.formatMessage({ defaultMessage: 'Property', description: 'Schema property name input' })}
+              onChange={(e) => updateProperty(prop.id, { name: e.target.value })}
+            />
+            <div css={{ flex: 1 }}>
+              <SimpleSelect
+                id={`mlflow.prompts.create.response_format.property_type.${prop.id}`}
+                componentId="mlflow.prompts.create.response_format.property_type"
+                value={prop.type}
+                onChange={(e) => updateProperty(prop.id, { type: e.target.value as SchemaProperty['type'] })}
+              >
+                {TYPE_OPTIONS.map((t) => (
+                  <SimpleSelectOption key={t} value={t}>
+                    {t}
+                  </SimpleSelectOption>
+                ))}
+              </SimpleSelect>
+            </div>
+            {/* Tooltip wraps a <span> since Switch isn't guaranteed to forward hover/focus handlers */}
+            <Tooltip
+              componentId="mlflow.prompts.create.response_format.property_is_array_tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Allow multiple values',
+                description: 'Tooltip for the array toggle in the visual JSON schema editor',
+              })}
+            >
+              <span>
+                <Switch
+                  componentId="mlflow.prompts.create.response_format.property_is_array"
+                  checked={prop.isArray}
+                  onChange={(checked) => updateProperty(prop.id, { isArray: checked })}
+                  label="[ ]"
+                />
+              </span>
+            </Tooltip>
+            <Tooltip
+              componentId="mlflow.prompts.create.response_format.property_required_tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Required field',
+                description: 'Tooltip for the required toggle in the visual JSON schema editor',
+              })}
+            >
+              <span>
+                <Switch
+                  componentId="mlflow.prompts.create.response_format.property_required"
+                  checked={prop.required}
+                  onChange={(checked) => updateProperty(prop.id, { required: checked })}
+                  label="*"
+                />
+              </span>
+            </Tooltip>
+            <Button
+              componentId="mlflow.prompts.create.response_format.remove_property"
+              icon={<TrashIcon />}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Remove property',
+                description: 'Button to remove a property row in the visual JSON schema editor',
+              })}
+              onClick={() => removeProperty(prop.id)}
+            />
+          </div>
+          {/* Enum values are edited as individual rows (not a comma-separated field) so that
+              values containing commas can be entered */}
+          {prop.type === 'enum' && (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                gap: theme.spacing.xs,
+                marginLeft: theme.spacing.lg,
+                maxWidth: 320,
+                width: '100%',
+              }}
+            >
+              {prop.enumValues.map((value, index) => (
+                // Keyed by index: enum values have no identity of their own, and lists are short enough
+                // that the rare focus jump on mid-list delete beats threading ids through the conversion.
+                <div key={index} css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+                  <Input
+                    componentId="mlflow.prompts.create.response_format.property_enum_value"
+                    value={value}
+                    placeholder={intl.formatMessage({
+                      defaultMessage: 'Allowed value',
+                      description: 'Placeholder for a single enum value input in the visual JSON schema editor',
+                    })}
+                    onChange={(e) => updateEnumValue(prop, index, e.target.value)}
+                  />
+                  <Button
+                    componentId="mlflow.prompts.create.response_format.remove_enum_value"
+                    icon={<TrashIcon />}
+                    aria-label={intl.formatMessage({
+                      defaultMessage: 'Remove enum value',
+                      description: 'Button to remove a single enum value in the visual JSON schema editor',
+                    })}
+                    onClick={() => removeEnumValue(prop, index)}
+                  />
+                </div>
+              ))}
+              <Button
+                componentId="mlflow.prompts.create.response_format.add_enum_value"
+                icon={<PlusIcon />}
+                onClick={() => addEnumValue(prop)}
+              >
+                <FormattedMessage
+                  defaultMessage="Add enum value"
+                  description="Button to add a new enum value in the visual JSON schema editor"
+                />
+              </Button>
+            </div>
+          )}
+        </div>
+      ))}
+      <Button componentId="mlflow.prompts.create.response_format.add_property" icon={<PlusIcon />} onClick={addProperty}>
+        <FormattedMessage defaultMessage="Add property" description="Button to add a schema property in the visual JSON schema editor" />
+      </Button>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -11,7 +11,7 @@ import {
   SegmentedControlButton,
 } from '@databricks/design-system';
 import { useState } from 'react';
-import { useForm, Controller, FormProvider } from 'react-hook-form';
+import { useForm, useWatch, Controller, FormProvider } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import type { ChatPromptMessage, PromptModelConfigFormData, RegisteredPrompt, RegisteredPromptVersion } from '../types';
 import { useCreateRegisteredPromptMutation } from './useCreateRegisteredPromptMutation';
@@ -30,6 +30,7 @@ import {
 } from '../utils';
 import { ChatMessageCreator } from '../components/ChatMessageCreator';
 import { ModelConfigForm } from '../components/ModelConfigForm';
+import { ResponseFormatSchemaBuilder } from '../components/ResponseFormatSchemaBuilder';
 
 export enum CreatePromptModalMode {
   CreatePrompt = 'CreatePrompt',
@@ -51,6 +52,8 @@ export const useCreatePromptModal = ({
 }) => {
   const [open, setOpen] = useState(false);
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
+  const [schemaEditorMode, setSchemaEditorMode] = useState<'code' | 'visual'>('code');
+  const [visualEditorBlocked, setVisualEditorBlocked] = useState(false);
   const intl = useIntl();
 
   const form = useForm<{
@@ -90,6 +93,21 @@ export const useCreatePromptModal = ({
       ? watchedChatMessages.length === 0 || watchedChatMessages.some((m) => !m.content || !m.content.trim())
       : !watchedDraftValue?.trim();
   const isSubmitDisabled = (isCreatingNewPrompt && !watchedDraftName?.trim()) || isPromptContentEmpty;
+
+  const handleSchemaModeChange = (nextMode: 'code' | 'visual') => {
+    if (nextMode === 'visual' && !validateResponseFormatJson(form.getValues('responseFormatJson')).valid) {
+      setVisualEditorBlocked(true);
+      return;
+    }
+    setVisualEditorBlocked(false);
+    setSchemaEditorMode(nextMode);
+  };
+
+  // Narrow subscription (rather than `form.watch(...)`) so the warning can clear itself as soon
+  // as the user fixes the JSON, without re-subscribing the whole modal to every keystroke.
+  const watchedResponseFormatJson = useWatch({ control: form.control, name: 'responseFormatJson' });
+  const showVisualEditorBlockedWarning =
+    visualEditorBlocked && !validateResponseFormatJson(watchedResponseFormatJson).valid;
 
   const modalElement = (
     <FormProvider {...form}>
@@ -341,15 +359,53 @@ export const useCreatePromptModal = ({
                 description="Hint for the structured output field in the prompt creation modal"
               />
             </FormUI.Hint>
-            <RHFControlledComponents.TextArea
-              control={form.control}
-              id="mlflow.prompts.create.response_format"
-              componentId="mlflow.prompts.create.response_format"
-              name="responseFormatJson"
-              autoSize={{ minRows: 4, maxRows: 12 }}
-              placeholder='{"type": "object", "properties": { ... }}'
-              validationState={form.formState.errors.responseFormatJson ? 'error' : undefined}
-            />
+
+            <SegmentedControlGroup
+              componentId="mlflow.prompts.create.response_format.mode"
+              name="mlflow.prompts.create.response_format.mode"
+              value={schemaEditorMode}
+              onChange={(e) => handleSchemaModeChange(e.target.value as 'code' | 'visual')}
+            >
+              <SegmentedControlButton value="code">
+                <FormattedMessage
+                  defaultMessage="Code Editor"
+                  description="Label for the code editor mode of the structured output schema field in the prompt creation modal"
+                />
+              </SegmentedControlButton>
+              <SegmentedControlButton value="visual">
+                <FormattedMessage
+                  defaultMessage="Visual Editor"
+                  description="Label for the visual editor mode of the structured output schema field in the prompt creation modal"
+                />
+              </SegmentedControlButton>
+            </SegmentedControlGroup>
+            {showVisualEditorBlockedWarning && (
+              <FormUI.Message
+                type="warning"
+                message={intl.formatMessage({
+                  defaultMessage: 'Fix the JSON schema before switching to the visual editor.',
+                  description: 'Warning shown when the structured output JSON schema cannot be parsed into the visual editor',
+                })}
+              />
+            )}
+            <Spacer size="sm" />
+
+            {schemaEditorMode === 'visual' ? (
+              <ResponseFormatSchemaBuilder
+                schemaText={form.getValues('responseFormatJson')}
+                onSchemaChange={(next: string) => form.setValue('responseFormatJson', next)}
+              />
+            ) : (
+              <RHFControlledComponents.TextArea
+                control={form.control}
+                id="mlflow.prompts.create.response_format"
+                componentId="mlflow.prompts.create.response_format"
+                name="responseFormatJson"
+                autoSize={{ minRows: 4, maxRows: 12 }}
+                placeholder='{"type": "object", "properties": { ... }}'
+                validationState={form.formState.errors.responseFormatJson ? 'error' : undefined}
+              />
+            )}
             {form.formState.errors.responseFormatJson && (
               <FormUI.Message type="error" message={form.formState.errors.responseFormatJson.message} />
             )}
@@ -397,6 +453,8 @@ export const useCreatePromptModal = ({
         : '',
     });
     setShowAdvancedSettings(Boolean(hasModelConfig || responseFormat !== undefined));
+    setSchemaEditorMode('code');
+    setVisualEditorBlocked(false);
     setOpen(true);
   };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
@@ -61,3 +61,19 @@ export interface PromptModelConfigFormData {
   presencePenalty?: string;
   stopSequences?: string;
 }
+
+export type SchemaPropertyType = 'string' | 'number' | 'integer' | 'boolean' | 'enum';
+
+/**
+ * A single field in the visual (field-by-field) JSON schema editor for structured output.
+ */
+export interface SchemaProperty {
+  // Local id for React key / lookups, not part of the emitted schema
+  id: string;
+  name: string;
+  type: SchemaPropertyType;
+  isArray: boolean;
+  required: boolean;
+  // Only used when type === 'enum'; emitted as the JSON schema `enum` keyword
+  enumValues: string[];
+}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.test.ts
@@ -6,8 +6,10 @@ import {
   getModelConfigFromTags,
   getResponseFormatFromTags,
   validateResponseFormatJson,
+  jsonSchemaToProperties,
+  propertiesToJsonSchema,
 } from './utils';
-import type { PromptModelConfig, PromptModelConfigFormData } from './types';
+import type { PromptModelConfig, PromptModelConfigFormData, SchemaProperty } from './types';
 
 describe('Model Config Utils', () => {
   describe('formDataToModelConfig', () => {
@@ -272,6 +274,167 @@ describe('Response format (structured output) utils', () => {
         valid: false,
         error: 'Structured output must be a JSON object (e.g. a JSON schema).',
       });
+    });
+  });
+});
+
+describe('Schema builder utils', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+    },
+    required: ['name'],
+  };
+
+  describe('jsonSchemaToProperties', () => {
+    test('returns an empty array for an empty string', () => {
+      expect(jsonSchemaToProperties('')).toEqual([]);
+    });
+
+    test('returns an empty array for invalid JSON without throwing', () => {
+      expect(() => jsonSchemaToProperties('{ broken')).not.toThrow();
+      expect(jsonSchemaToProperties('{ broken')).toEqual([]);
+    });
+
+    test('preserves property ordering from propertyOrdering when present, for backwards compatibility', () => {
+      const schemaWithCustomOrdering = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          priority: { type: 'string', enum: ['low', 'medium', 'high'] },
+        },
+        propertyOrdering: ['priority', 'name', 'tags'],
+        required: ['name'],
+      };
+
+      const properties = jsonSchemaToProperties(JSON.stringify(schemaWithCustomOrdering));
+      expect(properties.map((p) => p.name)).toEqual(['priority', 'name', 'tags']);
+    });
+
+    test('ignores `required` entries with no matching property', () => {
+      const withGhost = JSON.stringify({
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name', 'ghost'],
+      });
+
+      const result = JSON.parse(propertiesToJsonSchema(jsonSchemaToProperties(withGhost)));
+
+      expect(result.required).toEqual(['name']);
+    });
+
+    test('falls back to string for types the visual editor does not support', () => {
+      const withUnsupportedType = JSON.stringify({
+        type: 'object',
+        properties: { meta: { type: 'object' }, count: { type: 'integer' } },
+      });
+
+      const properties = jsonSchemaToProperties(withUnsupportedType);
+
+      expect(properties.map((p) => [p.name, p.type])).toEqual([
+        ['meta', 'string'],
+        ['count', 'integer'],
+      ]);
+    });
+  });
+
+  describe('propertiesToJsonSchema', () => {
+    test('skips properties with an empty name', () => {
+      const properties: SchemaProperty[] = [
+        { id: '1', name: '', type: 'string', isArray: false, required: false, enumValues: [] },
+        { id: '2', name: 'valid', type: 'string', isArray: false, required: false, enumValues: [] },
+      ];
+
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result.properties).toEqual({ valid: { type: 'string' } });
+    });
+
+    test('filters out empty enum values', () => {
+      const properties: SchemaProperty[] = [
+        { id: '1', name: 'priority', type: 'enum', isArray: false, required: false, enumValues: ['low', 'medium', ''] },
+      ];
+
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result.properties.priority).toEqual({ type: 'string', enum: ['low', 'medium'] });
+    });
+
+    test('deduplicates enum values while preserving order', () => {
+      const properties: SchemaProperty[] = [
+        {
+          id: '1',
+          name: 'priority',
+          type: 'enum',
+          isArray: false,
+          required: false,
+          enumValues: ['low', 'medium', 'low', 'high', 'medium'],
+        },
+      ];
+
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result.properties.priority).toEqual({ type: 'string', enum: ['low', 'medium', 'high'] });
+    });
+
+    test('omits the enum keyword when no non-empty values remain', () => {
+      const properties: SchemaProperty[] = [
+        { id: '1', name: 'priority', type: 'enum', isArray: false, required: false, enumValues: ['', '  '] },
+      ];
+
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result.properties.priority).toEqual({ type: 'string' });
+    });
+
+    test('emits an array of enum values as an array with enum on the items', () => {
+      const properties: SchemaProperty[] = [
+        {
+          id: '1',
+          name: 'tags',
+          type: 'enum',
+          isArray: true,
+          required: false,
+          enumValues: ['low', 'medium', 'high'],
+        },
+      ];
+
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result.properties.tags).toEqual({
+        type: 'array',
+        items: { type: 'string', enum: ['low', 'medium', 'high'] },
+      });
+    });
+
+    test('omits the required key when no property is marked required', () => {
+      const properties: SchemaProperty[] = [
+        { id: '1', name: 'name', type: 'string', isArray: false, required: false, enumValues: [] },
+      ];
+
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result).not.toHaveProperty('required');
+    });
+  });
+
+  describe('jsonSchemaToProperties / propertiesToJsonSchema round-trip', () => {
+    test('produces an equivalent schema', () => {
+      const properties = jsonSchemaToProperties(JSON.stringify(schema));
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(result).toEqual(schema);
+    });
+
+    test('preserves field order', () => {
+      const properties = jsonSchemaToProperties(JSON.stringify(schema));
+      const result = JSON.parse(propertiesToJsonSchema(properties));
+
+      expect(Object.keys(result.properties)).toEqual(['name', 'tags', 'priority']);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -6,6 +6,8 @@ import type {
   PromptModelConfigFormData,
   RegisteredPrompt,
   RegisteredPromptVersion,
+  SchemaProperty,
+  SchemaPropertyType,
 } from './types';
 import { MLFLOW_LINKED_PROMPTS_TAG } from '../../constants';
 
@@ -290,4 +292,72 @@ export const validateResponseFormatJson = (value: string): { valid: boolean; err
     const message = e instanceof Error ? e.message : 'Invalid JSON';
     return { valid: false, error: message };
   }
+};
+
+let idCounter = 0;
+export const nextSchemaPropertyId = () => `prop_${Date.now()}_${idCounter++}`;
+
+/**
+ * Parse a JSON schema string into a flat list of properties for the visual editor.
+ * Returns an empty list if the schema is empty or fails to parse.
+ */
+export const jsonSchemaToProperties = (schemaText: string): SchemaProperty[] => {
+  if (!schemaText?.trim()) return [];
+  try {
+    const schema = JSON.parse(schemaText);
+    const props = schema.properties ?? {};
+    const required: string[] = Array.isArray(schema.required) ? schema.required : [];
+    // Read for compatibility with schemas that use Gemini's `propertyOrdering`; never written.
+    const order: string[] = Array.isArray(schema.propertyOrdering) ? schema.propertyOrdering : Object.keys(props);
+
+    return order
+      .filter((name) => name in props)
+      .map((name) => {
+        const def = props[name] ?? {};
+        const isArray = def.type === 'array';
+        const inner = isArray ? (def.items ?? {}) : def;
+        const isEnum = Array.isArray(inner.enum);
+        const knownTypes: SchemaPropertyType[] = ['string', 'number', 'integer', 'boolean'];
+        const type: SchemaPropertyType = isEnum
+          ? 'enum'
+          : knownTypes.includes(inner.type)
+            ? inner.type
+            : 'string';
+        const enumValues: string[] = isEnum ? inner.enum.map(String) : [];
+        return { id: nextSchemaPropertyId(), name, type, isArray, required: required.includes(name), enumValues };
+      });
+  } catch {
+    // Invalid JSON: caller should fall back to the code editor
+    return [];
+  }
+};
+
+/**
+ * Convert a list of visual editor properties back into a JSON schema string.
+ * Properties with an empty name are skipped.
+ */
+export const propertiesToJsonSchema = (properties: SchemaProperty[]): string => {
+  const validProps = properties.filter((p) => p.name.trim());
+
+  const propertyDef = (p: SchemaProperty) => {
+    if (p.type === 'enum') {
+      // JSON Schema requires `enum` values to be unique; omit the keyword entirely rather
+      // than emitting an invalid empty array.
+      const values = Array.from(new Set(p.enumValues.map((v) => v.trim()).filter((v) => v)));
+      return values.length > 0 ? { type: 'string', enum: values } : { type: 'string' };
+    }
+    return { type: p.type };
+  };
+
+  const requiredNames = validProps.filter((p) => p.required).map((p) => p.name.trim());
+
+  const schema = {
+    type: 'object',
+    properties: Object.fromEntries(
+      validProps.map((p) => [p.name.trim(), p.isArray ? { type: 'array', items: propertyDef(p) } : propertyDef(p)]),
+    ),
+    ...(requiredNames.length > 0 ? { required: requiredNames } : {}),
+  };
+
+  return JSON.stringify(schema, null, 2);
 };


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24948

### What changes are proposed in this pull request?

Adds a "Visual Editor" mode for the structured output (`response_format`) field in
the prompt creation modal, as an alternative to the existing raw JSON textarea.

- `ResponseFormatSchemaBuilder.tsx` (new): field-by-field editor. Each property has
  a name, a type (`string` / `number` / `integer` / `boolean` / `enum`), an array
  toggle, a required toggle, and a delete action. Enum values are edited as
  individual rows, so values containing commas are supported.
- `useCreatePromptModal.tsx`: a `SegmentedControlGroup` switches between
  "Code Editor" (existing textarea, still the default) and "Visual Editor". Both
  modes write to the same `responseFormatJson` form field, so validation and
  submission are untouched. Switching to visual mode is refused with an inline
  warning while the current JSON does not parse, so it can never discard a user's
  in-progress text.
- `utils.ts`: `jsonSchemaToProperties` / `propertiesToJsonSchema` convert between
  the schema string and the editor's flat property list.
- `types.ts`: `SchemaProperty` / `SchemaPropertyType`.

No backend, API, or storage changes, the persisted `response_format` has the same
shape as before

Two deliberate limitations worth flagging:

- Nested objects are out of scope for this first iteration. A bare
  `{"type": "object"}` is not a valid strict schema for most providers, so `object`
  is not offered in the type dropdown. A hand-written schema containing a nested
  object will have that property parsed as `string` when switching into the visual
  editor.
- `propertyOrdering` is read (for compatibility with Gemini-style schemas) but never
  written; plain JSON key order already survives the round trip.

@serena-ruan the layout here is a first pass, happy to rework the row layout, the
toggle labels, and the mode switcher to match existing MLflow patterns. Let me know
what you'd like it to look like.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests:
- `utils.test.ts`: round-trip conversion, field ordering, enum trimming/dedup/empty
  handling, `required` omission, and the fallback for unsupported types.
- `ResponseFormatSchemaBuilder.test.tsx`: adding, editing, and removing properties
  and enum values; the array and required toggles; the enum controls appearing only
  for `enum`.

Manual: created prompts in both modes against a local `mlflow server`, switched back
and forth mid-edit, and confirmed the resulting `response_format` matches what the
code editor produces.

**Demo** - creating a prompt with an enum + integer + array schema in the visual
editor, then switching back to Code Editor to show the generated JSON:

<img width="1280" height="667" alt="output" src="https://github.com/user-attachments/assets/7d5b91a2-1f70-43e3-8e5b-bacb0628059e" />

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The prompt creation modal now offers a visual, field-by-field editor for structured
output schemas, alongside the existing raw JSON editor.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
