### PR TITLE
Use `--permission-mode auto` for `/pr-review` and `/ui-review`, and surface permission denials

### DIFF
--- a/.claude/scripts/stream.sh
+++ b/.claude/scripts/stream.sh
@@ -17,11 +17,23 @@ tee "${1:-/dev/null}" \
     elif .type == "user" then
       .message.content[]?
       | select(.type == "tool_result")
-      | "📥 tool_result (\(.content | tostring | length) chars)\(if .is_error then " ❌" else "" end)"
+      | (.content | tostring) as $c
+      # Denials arrive as ordinary is_error results, so flag them with their reason.
+      | if .is_error and ($c | test("Permission for this action was denied")) then
+          "🚫 permission denied: \($c[0:200])"
+        else
+          "📥 tool_result (\($c | length) chars)\(if .is_error then " ❌" else "" end)"
+        end
     elif .type == "system" and .subtype == "init" then
       "🚀 init: \(.model) (v\(.claude_code_version), session \(.session_id[0:8]))"
     elif .type == "result" then
       "✅ Done (\((.duration_ms / 100 | round) / 10)s, \(.num_turns) turns, \(.usage.input_tokens + .usage.output_tokens) tokens, $\(.total_cost_usd * 100 | round / 100))"
+      + (
+        (.permission_denials // [])
+        | if length == 0 then ""
+          else "\n🚫 \(length) permission denial(s): " + (map("\(.tool_name)(\(.tool_input | tostring | .[0:120]))") | join("; "))
+          end
+      )
     else
       empty
     end'

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,13 +2,6 @@
 name: pr-review
 description: Review a GitHub pull request and emit a validated local review payload (comments + approval decision)
 disable-model-invocation: true
-allowed-tools:
-  - Read
-  - Skill
-  - Bash
-  - Grep
-  - Glob
-  - Edit(//tmp/review-payload.json)
 argument-hint: "<owner_repo> <pr_number> [extra_context]"
 arguments: [owner_repo, pr_number, extra_context]
 ---

--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -2,20 +2,6 @@
 name: ui-review
 description: Review a GitHub PR's UI/UX changes by launching the MLflow web app, driving a headless agent-browser over the changed surfaces, and writing a Markdown UI-review comment body (findings + screenshots) for the workflow to post.
 disable-model-invocation: true
-allowed-tools:
-  - Read
-  - Grep
-  - Glob
-  - Skill
-  - Bash(agent-browser:*)
-  - Bash(npx agent-browser:*)
-  - Bash(gh pr view:*)
-  - Bash(gh api:*)
-  - Bash(curl:*)
-  - Bash(git diff:*)
-  - Bash(git show:*)
-  - Bash(uv run --package skills skills:*)
-  - Edit(//tmp/ui-review-body.md)
 argument-hint: "<owner_repo> <pr_number> <app_url>"
 arguments: [owner_repo, pr_number, app_url]
 ---

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -225,6 +225,7 @@ jobs:
             --effort "$EFFORT" \
             --max-budget-usd 5 \
             --permission-mode auto \
+            --allowed-tools "Bash(uv run --package skills skills:*)" \
             --print \
             --verbose \
             --output-format stream-json \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -224,6 +224,7 @@ jobs:
             --model "$MODEL" \
             --effort "$EFFORT" \
             --max-budget-usd 5 \
+            --permission-mode auto \
             --print \
             --verbose \
             --output-format stream-json \

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -275,6 +275,7 @@ jobs:
             --model "$MODEL" \
             --effort "$EFFORT" \
             --max-budget-usd 8 \
+            --permission-mode auto \
             --print \
             --verbose \
             --output-format stream-json \

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -276,6 +276,7 @@ jobs:
             --effort "$EFFORT" \
             --max-budget-usd 8 \
             --permission-mode auto \
+            --allowed-tools "Bash(uv run --package skills skills:*)" \
             --print \
             --verbose \
             --output-format stream-json \


### PR DESCRIPTION
### Related Issues/PRs

None

### What changes are proposed in this pull request?

`claude` exposes `--permission-mode auto` as a real CLI flag that works under `--print`, so the review agents no longer need hand-maintained `allowed-tools` lists in their skill frontmatter. Both `review.yml` and `ui-review.yml` gain the flag, and both skills drop the list.

The two allowlists were not equally load-bearing:

- `pr-review` granted bare `Bash` with no argument scoping, so it never constrained shell access at all. Its only real narrowing was `Edit(//tmp/review-payload.json)`, which `Bash` could trivially bypass anyway.
- `ui-review` did scope commands (`Bash(agent-browser:*)`, `Bash(gh api:*)`, etc.), so this is a genuine widening there.

In both workflows the containment that matters is unchanged: the only GitHub token exposed to Claude is the read-only one (`permission-contents: read`, `permission-pull-requests: read`), and posting stays in separate write-scoped steps that validate the payload first.

`auto` alone turned out to be too unreliable for the one command each skill *must* run, so both invocations also pin it explicitly:

```
--allowed-tools "Bash(uv run --package skills skills:*)"
```

See the smoke-run evidence below for why.

`stream.sh` also learns to report denials. One arrived as a bare `📥 tool_result (936 chars) ❌`, which reads exactly like a command that simply failed, and the reason was recoverable only from the uploaded JSONL. It now prints the reason inline and repeats a summary on the `✅ Done` line:

```
🚫 permission denied: Permission for this action was denied by the Claude Code auto mode classifier. Reason: Blocked by classifier. ...
✅ Done (236.5s, 19 turns, 9480 tokens, $0.5)
🚫 1 permission denial(s): Bash({"command":"uv run --package skills skills validate-review /tmp/review-payload.json"})
```

### How is this PR tested?

- [x] Manual tests

Verified locally on Claude Code 2.1.226 that `auto` actually grants tools in a non-interactive session, with `manual` as the control. A bare `echo` is a bad probe (it gets auto-approved either way, presumably classified as safe), so the probe is a `Write`:

| `--permission-mode` | `Write` tool | file created | `permission_denials` |
| --- | --- | --- | --- |
| `manual` | blocked: "this session is non-interactive so the prompt can't be approved here" | no | 1 recorded |
| `auto` | approved | yes | none |

This PR is also self-testing: `review.yml` and `ui-review.yml` both trigger on changes to their own paths and to their skills, so the smoke runs exercise the new mode end-to-end with posting gated off.

The first smoke run ([31248611594](https://github.com/mlflow/mlflow/actions/runs/31248611594)) passed on `auto` alone, but its transcript is the reason for the `--allowed-tools` pin. It ran `Bash` x14, `Skill` x1, `Read` x1, `Write` x1, and recorded one denial:

```
tool:   Bash(uv run --package skills skills validate-review /tmp/review-payload.json)
result: "Permission for this action was denied by the Claude Code auto mode classifier.
         Reason: Blocked by classifier."
```

That is the payload validation step the skill requires to finish. The agent retried the identical command and it passed the second time, which is the only reason the job went green; a second denial would have left no `/tmp/review-payload.json` and failed the "Validate review payload" step. Pinning the `skills` CLI takes the classifier off that path.

The transcript also confirms the mode is live end to end (`mode: auto` in the init event) and that the agent now uses `Write` for `/tmp/review-payload.json` directly, where the old `Edit(...)`-scoped allowlist forced a Bash heredoc.

Known gap: `ui-review`'s smoke run is green with no denials, but it made zero `agent-browser` calls — it correctly short-circuits because this PR has no rendered surface. That path can only be exercised by a PR touching `mlflow/server/js/src/**`, so `agent-browser` under the `auto` classifier is untested here. If it ever gets vetoed, the fix is to add it to the same `--allowed-tools` pin.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
