### PR TITLE
fix: Only initialize tables for empty databases to prevent migration conflicts (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -93,7 +93,7 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     from mlflow.utils.file_utils import ExclusiveFileLock
 
     if os.name == "nt":
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
         return
 
@@ -102,7 +102,7 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
         usedforsecurity=False,
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow to 3.8.x, running `mlflow db upgrade` on an existing database fails with `Table 'secrets' already exists`.

The root cause is `_safe_initialize_tables` uses `_all_tables_exist()` to decide whether to run `_initialize_tables`, which calls `InitialBase.metadata.create_all()`. If the database has old tables but is missing a newly added table (e.g., `secrets`), `_all_tables_exist()` returns False, and `_initialize_tables` runs `create_all`, creating the new table prematurely. Then the subsequent Alembic migration tries to create the same table again, causing the error.

## Fix
Change `_safe_initialize_tables` to only run `_initialize_tables` when the database is completely empty (i.e., `_is_empty_database()` returns True). This ensures `create_all` is not called on existing databases; instead, schema evolution is handled solely by Alembic migrations via `upgrade_db`. This prevents duplicate table creation and makes upgrades idempotent.

Closes #19943