### PR TITLE
Canonicalize model aliases and drop haiku in `/review` and `/ui-review`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -176,16 +176,12 @@ jobs:
           import os
           import sys
 
-          MODEL_CHOICES = [
-              "fable",
-              "opus",
-              "sonnet",
-              "haiku",
-              "claude-fable-5",
-              "claude-opus-5",
-              "claude-sonnet-5",
-              "claude-haiku-4-5",
-          ]
+          MODEL_ALIASES = {
+              "fable": "claude-fable-5",
+              "opus": "claude-opus-5",
+              "sonnet": "claude-sonnet-5",
+          }
+          MODEL_CHOICES = [*MODEL_ALIASES, *MODEL_ALIASES.values()]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
           labels = {l["name"] for l in json.loads(os.environ["LABELS_JSON"])}
@@ -198,8 +194,9 @@ jobs:
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
           args = parser.parse_args(body.split())
+          model = MODEL_ALIASES.get(args.model, args.model)
 
-          sys.stdout.write(f"model={args.model}\neffort={args.effort}\n")
+          sys.stdout.write(f"model={model}\neffort={args.effort}\n")
           EOF
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -179,16 +179,12 @@ jobs:
           import shlex
           import sys
 
-          MODEL_CHOICES = [
-              "fable",
-              "opus",
-              "sonnet",
-              "haiku",
-              "claude-fable-5",
-              "claude-opus-5",
-              "claude-sonnet-5",
-              "claude-haiku-4-5",
-          ]
+          MODEL_ALIASES = {
+              "fable": "claude-fable-5",
+              "opus": "claude-opus-5",
+              "sonnet": "claude-sonnet-5",
+          }
+          MODEL_CHOICES = [*MODEL_ALIASES, *MODEL_ALIASES.values()]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
           body = sys.stdin.read().strip().removeprefix("/ui-review")
@@ -202,8 +198,9 @@ jobs:
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default="claude-opus-5")
           parser.add_argument("-e", "--effort", choices=EFFORT_CHOICES, default="high")
           args = parser.parse_args(tokens)
+          model = MODEL_ALIASES.get(args.model, args.model)
 
-          sys.stdout.write(f"model={args.model}\neffort={args.effort}\n")
+          sys.stdout.write(f"model={model}\neffort={args.effort}\n")
           EOF
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24968

### What changes are proposed in this pull request?

- Resolve model aliases to canonical names in the parse step of both workflows, so the recorded model is `claude-opus-5` rather than `opus`. `MODEL_CHOICES` is now derived from the alias map, so the two can't drift.
- Drop `haiku` from the selection: a review that silently degrades to a much smaller model is worse than one that fails loudly, since a failure is visible and retryable.

### How is this PR tested?

- [x] Manual tests

Both smoke tests pass. The parse step was checked by extracting each heredoc and running it: aliases and canonical names resolve, `-m haiku` and `-m claude-haiku-4-5` are rejected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
