### PR TITLE
Use `job.check_run_id` to resolve the job URL in `review.yml` and `ui-review.yml`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -107,27 +107,13 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-actions: read
           permission-contents: read
           permission-pull-requests: write
       - name: Resolve job URL
         if: github.event_name == 'issue_comment'
         env:
-          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}?pr=${{ github.event.issue.number }}
         run: |
-          # first(...) // empty: pick exactly one id, or output nothing if no match.
-          JOB_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
-            --jq 'first(.jobs[] | select(.name == "review") | .id) // empty')
-          # Fall back to the workflow-run URL so downstream links are never malformed.
-          if [ -n "$JOB_ID" ]; then
-            JOB_RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID/job/$JOB_ID?pr=$PR_NUMBER"
-          else
-            JOB_RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID?pr=$PR_NUMBER"
-          fi
           echo "JOB_RUN_URL=$JOB_RUN_URL" >> "$GITHUB_ENV"
       - name: React to comment
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -110,9 +110,8 @@ jobs:
           permission-contents: read
           permission-pull-requests: write
       - name: Resolve job URL
-        if: github.event_name == 'issue_comment'
         env:
-          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}?pr=${{ github.event.issue.number }}
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}?pr=${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           echo "JOB_RUN_URL=$JOB_RUN_URL" >> "$GITHUB_ENV"
       - name: React to comment

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -109,27 +109,13 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-actions: read
           permission-contents: read
           permission-pull-requests: write
 
       - name: Resolve job URL
-        if: github.event_name == 'issue_comment'
         env:
-          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}?pr=${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
-          # first(...) // empty: pick exactly one id, or output nothing if no match.
-          JOB_ID=$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs" \
-            --jq 'first(.jobs[] | select(.name == "review") | .id) // empty')
-          if [ -n "$JOB_ID" ]; then
-            JOB_RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID/job/$JOB_ID?pr=$PR_NUMBER"
-          else
-            JOB_RUN_URL="https://github.com/$REPO/actions/runs/$RUN_ID?pr=$PR_NUMBER"
-          fi
           echo "JOB_RUN_URL=$JOB_RUN_URL" >> "$GITHUB_ENV"
 
       - name: React to comment


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/orgs/community/discussions/8945#discussioncomment-14374985

### What changes are proposed in this pull request?

`job.check_run_id` is now available in the `job` context and holds the numeric job ID the job URL needs, so `review.yml` and `ui-review.yml` no longer have to list a run's jobs and match by name to build their "running..." link. Replacing the lookup also removes the run-URL fallback (the ID always resolves) and the now-unused `permission-actions: read` scope on the write app token.

Two notes:

- The value is only readable from step-level `env` (the `job` context isn't available at job level), so the step stays, reduced to a single expression.
- The step no longer needs a token, so it is no longer gated on `issue_comment` and the `pull_request` smoke run now covers it.

### How is this PR tested?

- [x] Manual tests

The `review` smoke run on this PR logged the resolved value as `https://github.com/mlflow/mlflow/actions/runs/31260536253/job/93110585215?pr=24971`, matching the job ID the API reports for that job and returning 200.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release