### PR TITLE
Drop unused `contents: read` from the review write tokens

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -107,7 +107,6 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: read
           permission-pull-requests: write
       - name: Resolve job URL
         env:

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -109,7 +109,6 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: read
           permission-pull-requests: write
 
       - name: Resolve job URL


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #24971

### What changes are proposed in this pull request?

The `app-token-write` tokens in `review.yml` and `ui-review.yml` grant `contents: read`, but no step using them reads repo content — `actions/checkout` and the Claude step both take `app-token-read`, and `upload-artifact` uses the runner's own token. Every remaining consumer (updating the trigger comment, `POST /pulls/{n}/reviews`, listing/patching the summary comment) is covered by `pull-requests: write`. The read token keeps its `contents: read`, which is what checkout uses.

Note this cannot be exercised by the `pull_request` smoke run: the write token is only minted on `issue_comment`, and every step that uses it is gated the same way. Since `issue_comment` workflows always run from the default branch, the check is a `/review` after this merges — the failure mode is a 403 when posting, with nothing at risk.

### How is this PR tested?

- [x] Manual tests

Traced every consumer of the write token in both workflows; see above. Verified post-merge with a live `/review`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release