### PR TITLE
Report the review result on the smoke run too

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -326,6 +326,7 @@ jobs:
             resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
           }
 
+          console.log(resultLine);
           fs.writeFileSync('/tmp/result-body.md', resultLine);
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
           JS
@@ -337,8 +338,8 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          # split(...)[0] drops any status block from an earlier attempt, so a
-          # re-run replaces it instead of stacking another one below it.
+          # split(...)[0] strips the "Review running..." placeholder that React
+          # appended, so the result replaces it rather than stacking below it.
           {
             gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
               --jq '.body | split("\n\n---\n\n🚀 ")[0]'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -332,28 +332,18 @@ jobs:
 
       - name: Report review results
         if: always() && github.event_name == 'issue_comment'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.app-token-write.outputs.token }}
-          retries: 3
-          script: |
-            const fs = require('fs');
-            const { owner, repo } = context.repo;
-            const { comment } = context.payload;
-            const resultLine = fs.readFileSync('/tmp/result-body.md', 'utf8');
+        env:
+          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body > /tmp/current-comment.md
+          python <<'PY'
+          from pathlib import Path
 
-            const { data: currentComment } = await github.rest.issues.getComment({
-              owner,
-              repo,
-              comment_id: comment.id,
-            });
-
-            const originalBody = currentComment.body.split('\n\n---\n\n🚀 ')[0];
-            const updatedBody = `${originalBody}\n\n---\n\n${resultLine}`;
-
-            await github.rest.issues.updateComment({
-              owner,
-              repo,
-              comment_id: comment.id,
-              body: updatedBody
-            });
+          # Drop any status block from an earlier attempt so a re-run replaces it.
+          original = Path("/tmp/current-comment.md").read_text().split("\n\n---\n\n🚀 ")[0].rstrip()
+          result = Path("/tmp/result-body.md").read_text()
+          Path("/tmp/updated-comment.md").write_text(f"{original}\n\n---\n\n{result}")
+          PY
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -277,7 +277,7 @@ jobs:
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
-          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '/review' }}
         run: |
           node <<'JS'
           const fs = require('fs');
@@ -328,10 +328,7 @@ jobs:
           console.log(resultLine);
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
 
-          const commentBody = process.env.COMMENT_BODY;
-          if (commentBody) {
-            fs.writeFileSync('/tmp/updated-comment.md', `${commentBody}\n\n---\n\n${resultLine}`);
-          }
+          fs.writeFileSync('/tmp/updated-comment.md', `${process.env.COMMENT_BODY}\n\n---\n\n${resultLine}`);
           JS
 
       - name: Report review results

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -272,12 +272,67 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      - name: Report review results
-        if: always() && github.event_name == 'issue_comment'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      # Builds the result body without any token, so the smoke run exercises it
+      # too. The job summary is where it lands when there is no comment to post.
+      - name: Build result body
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
+        run: |
+          node <<'JS'
+          const fs = require('fs');
+          const jobStatus = process.env.JOB_STATUS;
+          const model = process.env.MODEL;
+          const jobRunUrl = process.env.JOB_RUN_URL;
+
+          const outputPath = '/tmp/output.jsonl';
+          let claudeOutput = '';
+          try {
+            if (fs.existsSync(outputPath)) {
+              claudeOutput = fs.readFileSync(outputPath, 'utf8');
+            }
+          } catch (e) {
+            console.log('Failed to read Claude output file:', e);
+          }
+
+          let resultEvent = null;
+          if (claudeOutput) {
+            try {
+              const events = claudeOutput.trim().split('\n').filter(Boolean).map(JSON.parse);
+              resultEvent = events.findLast(({ type }) => type === 'result');
+            } catch (e) {
+              console.log('Failed to parse Claude output as JSON:', e);
+            }
+          }
+
+          const failed = jobStatus !== 'success' || resultEvent?.is_error;
+          const icon = failed ? '❌' : '✅';
+          const verb = failed ? 'failed' : 'completed';
+          let resultLine = `${icon} [Review](${jobRunUrl}) ${verb}`;
+
+          if (resultEvent) {
+            const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
+            const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
+            const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
+            resultLine += ` (${model}, ${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
+            const summary = resultEvent.is_error ? 'Error' : 'Result';
+            const formatted = JSON.stringify(resultEvent, null, 2);
+            resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;
+            if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
+              resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
+            }
+          } else if (failed) {
+            resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
+          }
+
+          fs.writeFileSync('/tmp/result-body.md', resultLine);
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
+          JS
+
+      - name: Report review results
+        if: always() && github.event_name == 'issue_comment'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token-write.outputs.token }}
           retries: 3
@@ -285,52 +340,7 @@ jobs:
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const { comment } = context.payload;
-            const jobStatus = process.env.JOB_STATUS;
-            const model = process.env.MODEL;
-
-            // Read Claude output from file instead of environment variable
-            const outputPath = '/tmp/output.jsonl';
-            let claudeOutput = '';
-            try {
-              if (fs.existsSync(outputPath)) {
-                claudeOutput = fs.readFileSync(outputPath, 'utf8');
-              }
-            } catch (e) {
-              console.log('Failed to read Claude output file:', e);
-            }
-
-            let resultEvent = null;
-            if (claudeOutput) {
-              try {
-                const events = claudeOutput.trim().split('\n').filter(Boolean).map(JSON.parse);
-                resultEvent = events.findLast(({ type }) => type === 'result');
-              } catch (e) {
-                console.log('Failed to parse Claude output as JSON:', e);
-              }
-            }
-
-            const jobRunUrl = process.env.JOB_RUN_URL;
-            const failed = jobStatus !== 'success' || resultEvent?.is_error;
-            const icon = failed ? '❌' : '✅';
-            const verb = failed ? 'failed' : 'completed';
-            let resultLine = `${icon} [Review](${jobRunUrl}) ${verb}`;
-
-            if (resultEvent) {
-              const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
-              const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
-              const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
-              resultLine += ` (${model}, ${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
-              const summary = resultEvent.is_error ? 'Error' : 'Result';
-              const formatted = JSON.stringify(resultEvent, null, 2);
-              resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;
-              if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
-                resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
-              }
-            } else if (failed) {
-              resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
-            }
-
-            console.log('Result line to post:', resultLine);
+            const resultLine = fs.readFileSync('/tmp/result-body.md', 'utf8');
 
             const { data: currentComment } = await github.rest.issues.getComment({
               owner,

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -272,13 +272,12 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      # Builds the result body without any token, so the smoke run exercises it
-      # too. The job summary is where it lands when there is no comment to post.
       - name: Build result body
         if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
         run: |
           node <<'JS'
           const fs = require('fs');
@@ -327,8 +326,12 @@ jobs:
           }
 
           console.log(resultLine);
-          fs.writeFileSync('/tmp/result-body.md', resultLine);
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
+
+          const commentBody = process.env.COMMENT_BODY;
+          if (commentBody) {
+            fs.writeFileSync('/tmp/updated-comment.md', `${commentBody}\n\n---\n\n${resultLine}`);
+          }
           JS
 
       - name: Report review results
@@ -338,14 +341,4 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          # split(...)[0] strips the "Review running..." placeholder that React
-          # appended, so the result replaces it rather than stacking below it.
-          {
-            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
-              --jq '.body | split("\n\n---\n\n🚀 ")[0]'
-            echo
-            echo "---"
-            echo
-            cat /tmp/result-body.md
-          } > /tmp/updated-comment.md
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -337,13 +337,14 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body > /tmp/current-comment.md
-          python <<'PY'
-          from pathlib import Path
-
-          # Drop any status block from an earlier attempt so a re-run replaces it.
-          original = Path("/tmp/current-comment.md").read_text().split("\n\n---\n\n🚀 ")[0].rstrip()
-          result = Path("/tmp/result-body.md").read_text()
-          Path("/tmp/updated-comment.md").write_text(f"{original}\n\n---\n\n{result}")
-          PY
+          # split(...)[0] drops any status block from an earlier attempt, so a
+          # re-run replaces it instead of stacking another one below it.
+          {
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+              --jq '.body | split("\n\n---\n\n🚀 ")[0]'
+            echo
+            echo "---"
+            echo
+            cat /tmp/result-body.md
+          } > /tmp/updated-comment.md
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -326,8 +326,6 @@ jobs:
           }
 
           console.log(resultLine);
-          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
-
           fs.writeFileSync('/tmp/updated-comment.md', `${process.env.COMMENT_BODY}\n\n---\n\n${resultLine}`);
           JS
 

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -403,6 +403,7 @@ jobs:
             resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
           }
 
+          console.log(resultLine);
           fs.writeFileSync('/tmp/result-body.md', resultLine);
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
           JS
@@ -414,8 +415,8 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          # split(...)[0] drops any status block from an earlier attempt, so a
-          # re-run replaces it instead of stacking another one below it.
+          # split(...)[0] strips the status block that React appended, so the
+          # result replaces it rather than stacking below it.
           {
             gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
               --jq '.body | split("<!-- ui-review-status -->")[0] | sub("\\s+$";"")'

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -409,32 +409,21 @@ jobs:
 
       - name: Report review results
         if: always() && github.event_name == 'issue_comment'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.app-token-write.outputs.token }}
-          retries: 3
-          script: |
-            const fs = require('fs');
-            const { owner, repo } = context.repo;
-            const { comment } = context.payload;
-            const resultLine = fs.readFileSync('/tmp/result-body.md', 'utf8');
+        env:
+          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body > /tmp/current-comment.md
+          python <<'PY'
+          from pathlib import Path
 
-            const { data: currentComment } = await github.rest.issues.getComment({
-              owner,
-              repo,
-              comment_id: comment.id,
-            });
-
-            const MARKER = '<!-- ui-review-status -->';
-            const originalBody = currentComment.body.split(MARKER)[0].replace(/\s+$/, '');
-            const updatedBody = `${originalBody}\n\n${MARKER}\n\n---\n\n${resultLine}`;
-
-            await github.rest.issues.updateComment({
-              owner,
-              repo,
-              comment_id: comment.id,
-              body: updatedBody,
-            });
+          MARKER = "<!-- ui-review-status -->"
+          original = Path("/tmp/current-comment.md").read_text().split(MARKER)[0].rstrip()
+          result = Path("/tmp/result-body.md").read_text()
+          Path("/tmp/updated-comment.md").write_text(f"{original}\n\n{MARKER}\n\n---\n\n{result}")
+          PY
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md
 
       - name: Redact secrets from transcript
         if: always()

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -403,8 +403,6 @@ jobs:
           }
 
           console.log(resultLine);
-          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
-
           const MARKER = '<!-- ui-review-status -->';
           const base = process.env.COMMENT_BODY.split(MARKER)[0].replace(/\s+$/, '');
           fs.writeFileSync('/tmp/updated-comment.md', `${base}\n\n${MARKER}\n\n---\n\n${resultLine}`);

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -352,13 +352,12 @@ jobs:
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/ui-review-comment.md
           fi
 
-      # Builds the result body without any token, so the smoke run exercises it
-      # too. The job summary is where it lands when there is no comment to post.
       - name: Build result body
         if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
         run: |
           node <<'JS'
           const fs = require('fs');
@@ -404,8 +403,14 @@ jobs:
           }
 
           console.log(resultLine);
-          fs.writeFileSync('/tmp/result-body.md', resultLine);
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
+
+          const commentBody = process.env.COMMENT_BODY;
+          if (commentBody) {
+            const MARKER = '<!-- ui-review-status -->';
+            const base = commentBody.split(MARKER)[0].replace(/\s+$/, '');
+            fs.writeFileSync('/tmp/updated-comment.md', `${base}\n\n${MARKER}\n\n---\n\n${resultLine}`);
+          }
           JS
 
       - name: Report review results
@@ -415,18 +420,6 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          # split(...)[0] strips the status block that React appended, so the
-          # result replaces it rather than stacking below it.
-          {
-            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
-              --jq '.body | split("<!-- ui-review-status -->")[0] | sub("\\s+$";"")'
-            echo
-            echo "<!-- ui-review-status -->"
-            echo
-            echo "---"
-            echo
-            cat /tmp/result-body.md
-          } > /tmp/updated-comment.md
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md
 
       - name: Redact secrets from transcript

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -352,12 +352,64 @@ jobs:
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/ui-review-comment.md
           fi
 
-      - name: Report review results
-        if: always() && github.event_name == 'issue_comment'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      # Builds the result body without any token, so the smoke run exercises it
+      # too. The job summary is where it lands when there is no comment to post.
+      - name: Build result body
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
+        run: |
+          node <<'JS'
+          const fs = require('fs');
+          const jobStatus = process.env.JOB_STATUS;
+          const model = process.env.MODEL;
+          const jobRunUrl = process.env.JOB_RUN_URL;
+
+          const outputPath = '/tmp/ui-output.jsonl';
+          let claudeOutput = '';
+          try {
+            if (fs.existsSync(outputPath)) {
+              claudeOutput = fs.readFileSync(outputPath, 'utf8');
+            }
+          } catch (e) {
+            console.log('Failed to read Claude output file:', e);
+          }
+
+          let resultEvent = null;
+          if (claudeOutput) {
+            try {
+              const events = claudeOutput.trim().split('\n').filter(Boolean).map(JSON.parse);
+              resultEvent = events.findLast(({ type }) => type === 'result');
+            } catch (e) {
+              console.log('Failed to parse Claude output as JSON:', e);
+            }
+          }
+
+          const failed = jobStatus !== 'success' || resultEvent?.is_error;
+          const icon = failed ? '❌' : '✅';
+          const verb = failed ? 'failed' : 'completed';
+          let resultLine = `${icon} [UI Review](${jobRunUrl}) ${verb}`;
+
+          if (resultEvent) {
+            const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
+            const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
+            const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
+            resultLine += ` (${model}, ${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
+            if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
+              resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
+            }
+          } else if (failed) {
+            resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
+          }
+
+          fs.writeFileSync('/tmp/result-body.md', resultLine);
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
+          JS
+
+      - name: Report review results
+        if: always() && github.event_name == 'issue_comment'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token-write.outputs.token }}
           retries: 3
@@ -365,46 +417,7 @@ jobs:
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const { comment } = context.payload;
-            const jobStatus = process.env.JOB_STATUS;
-            const model = process.env.MODEL;
-
-            const outputPath = '/tmp/ui-output.jsonl';
-            let claudeOutput = '';
-            try {
-              if (fs.existsSync(outputPath)) {
-                claudeOutput = fs.readFileSync(outputPath, 'utf8');
-              }
-            } catch (e) {
-              console.log('Failed to read Claude output file:', e);
-            }
-
-            let resultEvent = null;
-            if (claudeOutput) {
-              try {
-                const events = claudeOutput.trim().split('\n').filter(Boolean).map(JSON.parse);
-                resultEvent = events.findLast(({ type }) => type === 'result');
-              } catch (e) {
-                console.log('Failed to parse Claude output as JSON:', e);
-              }
-            }
-
-            const jobRunUrl = process.env.JOB_RUN_URL;
-            const failed = jobStatus !== 'success' || resultEvent?.is_error;
-            const icon = failed ? '❌' : '✅';
-            const verb = failed ? 'failed' : 'completed';
-            let resultLine = `${icon} [UI Review](${jobRunUrl}) ${verb}`;
-
-            if (resultEvent) {
-              const seconds = (resultEvent.duration_ms / 1000).toFixed(1);
-              const tokens = (resultEvent.usage?.input_tokens ?? 0) + (resultEvent.usage?.output_tokens ?? 0);
-              const cost = (Math.round(resultEvent.total_cost_usd * 100) / 100).toFixed(2);
-              resultLine += ` (${model}, ${seconds}s, ${resultEvent.num_turns} turns, ${tokens} tokens, $${cost})`;
-              if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
-                resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
-              }
-            } else if (failed) {
-              resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;
-            }
+            const resultLine = fs.readFileSync('/tmp/result-body.md', 'utf8');
 
             const { data: currentComment } = await github.rest.issues.getComment({
               owner,

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -357,7 +357,7 @@ jobs:
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
-          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '/ui-review' }}
         run: |
           node <<'JS'
           const fs = require('fs');
@@ -405,12 +405,9 @@ jobs:
           console.log(resultLine);
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${resultLine}\n`);
 
-          const commentBody = process.env.COMMENT_BODY;
-          if (commentBody) {
-            const MARKER = '<!-- ui-review-status -->';
-            const base = commentBody.split(MARKER)[0].replace(/\s+$/, '');
-            fs.writeFileSync('/tmp/updated-comment.md', `${base}\n\n${MARKER}\n\n---\n\n${resultLine}`);
-          }
+          const MARKER = '<!-- ui-review-status -->';
+          const base = process.env.COMMENT_BODY.split(MARKER)[0].replace(/\s+$/, '');
+          fs.writeFileSync('/tmp/updated-comment.md', `${base}\n\n${MARKER}\n\n---\n\n${resultLine}`);
           JS
 
       - name: Report review results

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -414,15 +414,18 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq .body > /tmp/current-comment.md
-          python <<'PY'
-          from pathlib import Path
-
-          MARKER = "<!-- ui-review-status -->"
-          original = Path("/tmp/current-comment.md").read_text().split(MARKER)[0].rstrip()
-          result = Path("/tmp/result-body.md").read_text()
-          Path("/tmp/updated-comment.md").write_text(f"{original}\n\n{MARKER}\n\n---\n\n{result}")
-          PY
+          # split(...)[0] drops any status block from an earlier attempt, so a
+          # re-run replaces it instead of stacking another one below it.
+          {
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+              --jq '.body | split("<!-- ui-review-status -->")[0] | sub("\\s+$";"")'
+            echo
+            echo "<!-- ui-review-status -->"
+            echo
+            echo "---"
+            echo
+            cat /tmp/result-body.md
+          } > /tmp/updated-comment.md
           gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md
 
       - name: Redact secrets from transcript


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #24971 and #24972

### What changes are proposed in this pull request?

`Report review results` only ran on `issue_comment`, so its transcript parsing and result formatting (the part most likely to break) were never exercised by the `pull_request` smoke run. Split into two steps in both `review.yml` and `ui-review.yml`:

- **Build result body** — `always()`, no token at all. Parses the transcript, prints the result line, and assembles the updated comment into `/tmp/updated-comment.md`.
- **Report review results** — still `issue_comment` only, and now a single `gh api ... -X PATCH` rather than `actions/github-script`.

The comment is assembled from `github.event.comment.body`, which is the trigger comment as of the event, before `React to comment` appended its placeholder. That is exactly the text the old code recovered by re-fetching the comment and splitting the placeholder back off, so both the GET and the split are gone. On the smoke run that variable stands in a synthetic `/review`, which keeps the build step branchless: both paths run identical code, and only the PATCH is gated.

Note this drops `retries: 3`, which `github-script` provided and `gh api` has no equivalent for. The remaining exposure is one unretried PATCH; a transient failure leaves the comment showing "running...", with the review itself unaffected.

### How is this PR tested?

- [x] Manual tests

Ran the extracted build scripts against synthetic transcripts for the smoke path, a real path with args (`/review -m opus`), and ui-review's marker variant. The smoke runs on this PR then printed the assembled result end to end:

```
✅ [Review](https://github.com/mlflow/mlflow/actions/runs/31262725510/job/93115940232?pr=24973) completed (claude-opus-5, 325.0s, 23 turns, 21177 tokens, $1.33)
✅ [UI Review](https://github.com/mlflow/mlflow/actions/runs/31262725380/job/93115960459?pr=24973) completed (claude-opus-5, 34.8s, 5 turns, 1442 tokens, $0.17)
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release