### PR TITLE
Show tool errors inline in `stream.sh`

### DIFF
--- a/.claude/scripts/stream.sh
+++ b/.claude/scripts/stream.sh
@@ -18,22 +18,15 @@ tee "${1:-/dev/null}" \
       .message.content[]?
       | select(.type == "tool_result")
       | (.content | tostring) as $c
-      # Denials arrive as ordinary is_error results, so flag them with their reason.
-      | if .is_error and ($c | test("Permission for this action was denied")) then
-          "🚫 permission denied: \($c[0:200])"
+      | if .is_error then
+          "❌ tool_result error: \($c[0:200])"
         else
-          "📥 tool_result (\($c | length) chars)\(if .is_error then " ❌" else "" end)"
+          "📥 tool_result (\($c | length) chars)"
         end
     elif .type == "system" and .subtype == "init" then
       "🚀 init: \(.model) (v\(.claude_code_version), session \(.session_id[0:8]))"
     elif .type == "result" then
       "✅ Done (\((.duration_ms / 100 | round) / 10)s, \(.num_turns) turns, \(.usage.input_tokens + .usage.output_tokens) tokens, $\(.total_cost_usd * 100 | round / 100))"
-      + (
-        (.permission_denials // [])
-        | if length == 0 then ""
-          else "\n🚫 \(length) permission denial(s): " + (map("\(.tool_name)(\(.tool_input | tostring | .[0:120]))") | join("; "))
-          end
-      )
     else
       empty
     end'


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

A failed tool call used to render as `📥 tool_result (63 chars) ❌` — the size, not the reason. The reason was already in the payload, so print it.

This also fixes a real blind spot. `stream.sh` special-cased permission denials by grepping for the CLI's `"Permission for this action was denied"` phrasing, but hook denials word their own message, so they fell through to the generic branch and only surfaced in the end-of-run `🚫 N permission denial(s)` summary, minutes after the fact and without a reason. Seen on [this run](https://github.com/mlflow/mlflow/actions/runs/31270394033), where a `python` heredoc was blocked by the `uv run` hook:

```
📥 tool_result (63 chars) ❌                                                  # before, at the time
🚫 1 permission denial(s): Bash({"command":"python - <<'EOF'\n...            # before, at the end
❌ tool_result error: Direct python/python3 execution detected. Use 'uv run' instead.   # after
```

With every error carrying its reason inline, both special cases become redundant and are dropped: the phrase-matching branch (which only ever caught CLI denials, giving the same concept two different markers) and the summary block (whose `permission_denials` is still posted in the result JSON that `review.yml` puts in the PR comment).

### How is this PR tested?

- [x] Manual tests

Ran both versions against the archived transcript of the run above and diffed the output.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release