### PR TITLE
Skip empty thinking blocks in `stream.sh`

### DIFF
--- a/.claude/scripts/stream.sh
+++ b/.claude/scripts/stream.sh
@@ -9,7 +9,7 @@ tee "${1:-/dev/null}" \
         "🤖 \(.text)"
       elif .type == "tool_use" then
         "🔧 \(.name)\(if .input then ": \(.input | tostring | .[0:200])" else "" end)"
-      elif .type == "thinking" then
+      elif .type == "thinking" and (.thinking | length) > 0 then
         "🧠 thinking (\(.thinking | length) chars)"
       else
         empty


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`stream.sh` renders every `thinking` block as `🧠 thinking (N chars)`, but the streamed blocks are usually empty, so the log fills with `🧠 thinking (0 chars)` lines that say nothing.

In the archived transcript of [this review run](https://github.com/mlflow/mlflow/actions/runs/31270394033), all 13 thinking blocks were empty — 13 of the 84 rendered lines. Skipping them drops the run to 71 lines; a non-empty block still renders as before.

### How is this PR tested?

- [x] Manual tests

Ran both versions against that transcript (84 → 71 lines, `🧠` count 13 → 0) and confirmed a non-empty block still prints.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release