### PR TITLE
fix: avoid calling _initialize_tables on existing DBs (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -93,8 +93,10 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     from mlflow.utils.file_utils import ExclusiveFileLock
 
     if os.name == "nt":
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
+        else:
+            _upgrade_db(engine)
         return
 
     url_hash = hashlib.md5(
@@ -102,8 +104,10 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
         usedforsecurity=False,
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
+        else:
+            _upgrade_db(engine)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What
Fixes `mlflow db upgrade` failing with `Table 'secrets' already exists` when upgrading from 3.7.0 to 3.8.x.

## Fix
`_safe_initialize_tables` was using `_all_tables_exist` to decide whether to initialize tables. This is incorrect for non-empty databases that are just missing newly introduced tables (e.g., `secrets`). `_initialize_tables` runs `create_all` followed by `_upgrade_db`, which can cause Alembic migration errors when the DB is already partially migrated.

Changed the condition to `_is_empty_database`, so initialization only runs on truly empty databases. Non-empty databases now go straight to `_upgrade_db`, avoiding the erroneous `create_all` call.

Closes #19943