### PR TITLE
Use `gh` CLI instead of `actions/github-script` in `review.yml`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -115,21 +115,14 @@ jobs:
           echo "JOB_RUN_URL=$JOB_RUN_URL" >> "$GITHUB_ENV"
       - name: React to comment
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.app-token-write.outputs.token }}
-          retries: 3
-          script: |
-            const { comment } = context.payload;
-            const message = `🚀 [Review running...](${process.env.JOB_RUN_URL})`;
-            const updatedBody = `${comment.body}\n\n---\n\n${message}`;
-
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: comment.id,
-              body: updatedBody,
-            });
+        env:
+          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          printf '%s\n\n---\n\n🚀 [Review running...](%s)' "$COMMENT_BODY" "$JOB_RUN_URL" \
+            | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24977

### What changes are proposed in this pull request?

Replace the `actions/github-script` step in `review.yml` with a `gh api` call.

- "React to comment" was the only `actions/github-script` usage in `review.yml`, so the job no longer downloads that action at startup.
- The sibling "Report review results" step already performs the same comment PATCH via `gh api`, and [`.claude/rules/github-actions.md`](https://github.com/mlflow/mlflow/blob/master/.claude/rules/github-actions.md) prefers `gh` CLI for simple API operations.
- The comment body reaches the script through `env:` rather than `${{ }}` interpolation, as `deny_interpolation_in_run` requires.

Trade-off: `gh api` has no retry flag, so `retries: 3` is gone. This matches "Report review results", which has never had retries.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The `pull_request` trigger on this workflow smoke-tests the change on this PR.

Verified locally:

- The rendered body is byte-identical to the old JS template: `<comment>\n\n---\n\n🚀 [Review running...](<url>)`, no trailing newline.
- `gh help api` documents `@-` as read-from-stdin, and the magic type conversion (`true`/`false`/`null`/integers) applies only to literal values, not the `@` file/stdin branch, so the body is always sent as a string. Confirmed `-F body=@-` is accepted against a live read-only endpoint.
- `conftest --namespace mlflow --policy .github/policy.rego`: 37/37 pass. `actionlint`: clean.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release