### PR TITLE
Fix case-sensitive HDFS nameservice resolution

### DIFF
--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -172,8 +172,13 @@ def hdfs_system(scheme, host, port):
 
 def _resolve_connection_params(artifact_uri):
     parsed = urllib.parse.urlparse(artifact_uri)
+    port = parsed.port
+    host = parsed.netloc.rsplit("@", 1)[-1]
+    if port is not None:
+        host = host.rsplit(":", 1)[0]
+    host = host.removeprefix("[").removesuffix("]") or None
 
-    return parsed.scheme, parsed.hostname, parsed.port, parsed.path
+    return parsed.scheme, host, port, parsed.path
 
 
 def _resolve_base_path(path, artifact_path):

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -24,7 +24,7 @@ def hdfs_system_mock():
 
 
 def test_log_artifact(hdfs_system_mock, tmp_path):
-    repo = HdfsArtifactRepository("hdfs://host_name:8020/hdfs/path")
+    repo = HdfsArtifactRepository("hdfs://MyHDFS-ns:8020/hdfs/path")
 
     local_file = tmp_path.joinpath("sample_file")
     local_file.write_text("PyArrow Works")
@@ -32,7 +32,7 @@ def test_log_artifact(hdfs_system_mock, tmp_path):
     repo.log_artifact(str(local_file), "more_path/some")
 
     hdfs_system_mock.assert_called_once_with(
-        extra_conf=None, host="hdfs://host_name", kerb_ticket=None, port=8020, user=None
+        extra_conf=None, host="hdfs://MyHDFS-ns", kerb_ticket=None, port=8020, user=None
     )
 
     upload_mock = hdfs_system_mock.return_value.open_output_stream


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #4909

### What changes are proposed in this pull request?

Preserve the original case of HDFS nameservice authorities when resolving artifact-store connection parameters. The parser now derives the host from the case-preserving `netloc` while continuing to separate user information, ports, and IPv6 brackets.

This prevents `urllib.parse` from lowercasing case-sensitive Hadoop nameservice identifiers before they are passed to PyArrow.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Updated the HDFS artifact regression coverage to use an uppercase nameservice and verified the complete focused test file:

`PYTHONPATH=. uv run --isolated --no-project --with mlflow-skinny --with pyarrow --with pytest pytest tests/store/artifact/test_hdfs_artifact_repo.py` (13 passed)

Also ran Ruff checks, Ruff formatting checks, and Clint on both changed files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

HDFS artifact stores now preserve case-sensitive nameservice identifiers from artifact URIs, allowing nameservices containing uppercase characters to connect correctly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
