### PR TITLE
Fix uncaught KeyError in MlflowTraceTimeoutCache.expire()

### DIFF
--- a/mlflow/tracing/utils/timeout.py
+++ b/mlflow/tracing/utils/timeout.py
@@ -208,7 +208,9 @@ class MlflowTraceTimeoutCache(_TimedCache):
 
         # End the expired traces and set the status to ERROR in background thread
         for request_id in expired:
-            trace = self[request_id]
+            trace = self.get(request_id)
+            if trace is None:
+                continue
             if root_span := trace.get_root_span():
                 try:
                     root_span.set_status(SpanStatusCode.ERROR)
@@ -222,8 +224,7 @@ class MlflowTraceTimeoutCache(_TimedCache):
 
                 # NB: root_span.end() should pop the trace from the cache. But we need to
                 # double-check it because it may not happens due to some errors.
-                if request_id in self:
-                    del self[request_id]
+                self.pop(request_id, None)
 
     def _get_expired_traces(self) -> list[str]:
         """

--- a/tests/tracing/utils/test_timeout.py
+++ b/tests/tracing/utils/test_timeout.py
@@ -160,3 +160,21 @@ def test_handle_timeout_update(monkeypatch):
     traces = get_traces()
     assert len(traces) == 3
     assert traces[0].info.status == SpanStatusCode.OK
+
+
+def test_expire_does_not_raise_keyerror_for_stale_snapshot(monkeypatch):
+    # A request_id returned by _get_expired_traces() may be removed concurrently
+    # (atexit clear(), a second expire(), or pop_trace) before expire() reads it.
+    # expire() must skip the missing id instead of raising KeyError.
+    cache = MlflowTraceTimeoutCache(timeout=1, maxsize=10)
+    cache["tr1"] = _Trace(None)
+    monkeypatch.setattr(cache, "_get_expired_traces", lambda: ["tr1"])
+    del cache["tr1"]  # simulate a concurrent remover between snapshot and access
+    cache.expire()  # must NOT raise (raises KeyError on base)
+
+    # The valid path still works: a trace that is still present is expired normally.
+    cache["tr2"] = _Trace(None, span_dict={"root": _mock_span("tr2_root")})
+    monkeypatch.setattr(cache, "_get_expired_traces", lambda: ["tr2"])
+    cache.expire()
+    assert "tr2" not in cache
+    cache.clear()  # stop the daemon thread


### PR DESCRIPTION
### Related Issues/PRs

Closes #24610

### What changes are proposed in this pull request?

`MlflowTraceTimeoutCache.expire()` collects expired request ids via `_get_expired_traces()` and then accesses each one with `self[request_id]`. If an entry is removed between the snapshot and the access - for example when the atexit-registered `clear()` races the background expire thread at process exit, or when `InMemoryTraceManager.pop_trace()` removes a trace while the expire loop is running - the unguarded dict access raises an uncaught `KeyError`. Inside `_expire_check_loop` this exception breaks the loop, so timed-out traces silently stop being flushed.

This change makes `expire()` tolerate a stale snapshot: expired ids are read with `self.get(request_id)` and skipped when no longer present, and cleanup uses `self.pop(request_id, None)`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_expire_does_not_raise_keyerror_for_stale_snapshot` in `tests/tracing/utils/test_timeout.py`, which deterministically forces the snapshot-then-removal interleaving and asserts `expire()` does not raise.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes an uncaught `KeyError` in the trace timeout cache that could occur when traces expire concurrently with process exit, and prevents the background expiration loop from stopping after such an error.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: ...
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/uiux`: ...
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] ...

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - ...
- [ ] `rn/feature` - ...
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - ...

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release