### PR TITLE
Tell the `pr-review` skill to verify facts instead of hedging

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -81,6 +81,10 @@ The checkout is shallow, so nothing older than `HEAD^1` exists: `git log` and `g
 the shallow boundary rather than reaching the commit that actually introduced a line. Neither
 errors, so don't trust them for pre-change history.
 
+Verify rather than infer. A `grep` through the installed package, a `uv run python -c '...'`, or a
+quick search and fetch of the upstream docs will settle most questions in seconds, and an unverified
+finding should be dropped rather than hedged.
+
 Evaluate the changed code across these dimensions:
 
 - **Correctness**: logic errors, off-by-one, incorrect API usage, broken invariants, regressions in behavior


### PR DESCRIPTION
### Related Issues/PRs

Relates to #

### What changes are proposed in this pull request?

Adds one instruction to the analysis step of the `pr-review` skill: when a finding depends on
behavior the reviewer is unsure about, look it up instead of guessing.

The skill already tells the reviewer to drop hypothetical findings ("if the finding needs 'while
unlikely' or 'could potentially' to stand up, skip it"), but it never says the cheaper alternative
is usually available. Most of these questions are one `grep`, one `uv run python -c '...'`, or one
docs lookup away, and both `WebSearch` and `WebFetch` are available by default in `claude -p`. The
result should be fewer hedged comments and fewer wrong ones.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Prompt-only change to a skill file. Verified the `skills` pre-commit hook passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)