### PR TITLE
fix: prevent partial DB initialization causing 'Table already exists' (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,11 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create tables if the database is empty. If any table already exists,
+    # it indicates a partial migration or existing schema, and we should let
+    # Alembic handle the migration to avoid conflicts like 'Table already exists'.
+    if _is_empty_database(engine):
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, `mlflow db upgrade` can fail with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_safe_initialize_tables` checks `_all_tables_exist`, which returns False when some new tables from 3.8.x are missing, even though the database already contains tables from a previous migration. It then calls `_initialize_tables`, which attempts `InitialBase.metadata.create_all`, but the `secrets` table already exists, causing a conflict.

## Fix
- Modified `_initialize_tables` to only run `InitialBase.metadata.create_all` when the database is completely empty (no user tables). If any tables already exist, we skip the initialization and rely on Alembic migrations (`_upgrade_db`) to create missing tables and handle schema evolution safely.
- This prevents the attempt to re-create tables that already exist due to a partial migration, avoiding the reported error.

Closes #19943