### PR TITLE
Fix flaky `test_search_traces_yields_expected_dataframe_contents` by flushing before snapshotting

### DIFF
--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1223,13 +1223,13 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         model.predict(2, 5)
         time.sleep(0.1)
 
-        # get_trace(flush=True) only flushes when the first fetch misses. If the batch span
-        # processor happens to export during the sleep above, the trace info is already
-        # fetchable while the async span write (which adds the mlflow.trace.spansLocation
-        # tag) is still in flight, and the snapshot would miss tags that search_traces
-        # sees later. Flush explicitly so the snapshot always reflects fully committed data.
+        # If the batch span processor happens to export during the sleep above, the trace
+        # info is already fetchable while the async span write (which adds the
+        # mlflow.trace.spansLocation tag) is still in flight, and get_trace(flush=True)
+        # would return the partial snapshot without flushing (it only flushes on a miss).
+        # Flush explicitly so the snapshot always reflects fully committed data.
         mlflow.flush_trace_async_logging()
-        trace = mlflow.get_trace(mlflow.get_last_active_trace_id(), flush=True)
+        trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
         expected_traces.append(trace)
 
     df = mlflow.search_traces(max_results=10, order_by=["timestamp ASC"], flush=True)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1223,6 +1223,12 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         model.predict(2, 5)
         time.sleep(0.1)
 
+        # get_trace(flush=True) only flushes when the first fetch misses. If the batch span
+        # processor happens to export during the sleep above, the trace info is already
+        # fetchable while the async span write (which adds the mlflow.trace.spansLocation
+        # tag) is still in flight, and the snapshot would miss tags that search_traces
+        # sees later. Flush explicitly so the snapshot always reflects fully committed data.
+        mlflow.flush_trace_async_logging()
         trace = mlflow.get_trace(mlflow.get_last_active_trace_id(), flush=True)
         expected_traces.append(trace)
 


### PR DESCRIPTION
### Related Issues/PRs

Fixes a flaky CI failure: https://github.com/mlflow/mlflow/actions/runs/31379403605/job/93426039984

```
E   AssertionError: assert df.iloc[idx].tags == trace.info.tags
E   Left contains 1 more item:
E   {'mlflow.trace.spansLocation': 'TRACKING_STORE'}
```

### What changes are proposed in this pull request?

With async trace logging, a trace is written by two independent export-queue tasks: `_log_trace` (trace info + artifact upload) and `_log_spans` (span rows + the `mlflow.trace.spansLocation` tag), and `get_trace(flush=True)` only flushes when its first fetch misses. When the batch span processor's 5s timer fires inside the test's 0.1s sleep, `_log_trace` commits before the snapshot fetch while `_log_spans` is still in flight, so the snapshot succeeds without flushing and misses a tag that the final `search_traces(flush=True)` (which does wait) sees.

<img width="990" height="700" alt="Timeline of the failing interleaving: the batch span processor timer fires inside the test's 0.1s sleep, _log_trace commits before get_trace fetches, and _log_spans commits the spansLocation tag afterwards" src="https://github.com/user-attachments/assets/82f92257-7aab-4695-b242-89c470b3fa4c" />

Fix: call `mlflow.flush_trace_async_logging()` before each snapshot so it always reflects fully committed data. An alternative of making `get_trace(flush=True)` flush unconditionally was prototyped but rejected: it turns every call into a full export-queue barrier (~2s wall clock even on an idle queue, dominated by the consumer thread's 1s poll timeout) and would slow per-row clone read-backs in the genai eval harness.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Reproduced the race deterministically with a pytest plugin that shrinks the batch span processor interval to 10ms and delays `TracingClient.log_spans` by 1s: the test failed every run with the exact CI assertion before this change and passes after it.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release