### PR TITLE
Preserve provider usage extras in OpenAI-compatible gateway

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -95,12 +95,10 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         prompt_tokens_details = None
         if details := usage_data.get("prompt_tokens_details"):
             prompt_tokens_details = chat.PromptTokensDetails(**details)
-        return chat.ChatUsage(
-            prompt_tokens=usage_data.get("prompt_tokens"),
-            completion_tokens=usage_data.get("completion_tokens"),
-            total_tokens=usage_data.get("total_tokens"),
-            prompt_tokens_details=prompt_tokens_details,
-        )
+        return chat.ChatUsage(**{
+            **usage_data,
+            "prompt_tokens_details": prompt_tokens_details,
+        })
 
     @classmethod
     def model_to_chat_streaming(

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -386,6 +386,39 @@ def test_model_to_chat():
     assert result.choices[0].message.content == "Hello!"
 
 
+def test_model_to_chat_preserves_provider_usage_fields():
+    config = _make_endpoint_config()
+    resp = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "test-model",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cost": 0.001,
+            "cost_details": {"upstream_inference_cost": 0.0008},
+            "prompt_tokens_details": {"cached_tokens": 2},
+        },
+    }
+
+    result = OpenAICompatibleAdapter.model_to_chat(resp, config)
+    usage = result.usage
+
+    assert usage.cost == 0.001
+    assert usage.cost_details == {"upstream_inference_cost": 0.0008}
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 2
+
+
 def test_model_to_embeddings():
     config = _make_endpoint_config()
     resp = {


### PR DESCRIPTION
### Related Issues/PRs

Closes #24997

### What changes are proposed in this pull request?

The OpenAI-compatible gateway currently rebuilds `ChatUsage` with only the
standard token fields. This drops provider-specific usage data such as
OpenRouter's `cost` and `cost_details`, even though `ChatUsage` is configured
to accept extra fields.

This change passes the full usage payload through to `ChatUsage` while keeping
the existing conversion for `prompt_tokens_details`. The regression test
covers both provider-level fields and nested token details.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Verified with:

```bash
uv run --frozen --extra gateway --with sentence-transformers pytest \
  tests/gateway/providers/test_openai_compatible.py -q
```

The focused provider test file passes with 24 tests.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The OpenAI-compatible gateway now preserves provider-specific usage metadata returned by upstream APIs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

### AI assistance disclosure

I used Codex to help inspect the issue, draft the patch, and write the regression test. I reviewed the final diff and test results before submitting this PR.
