### PR TITLE
[BUG] Preserve provider-specific usage fields in OpenAI-compatible responses

### DIFF
--- a/mlflow/gateway/providers/openai_compatible.py
+++ b/mlflow/gateway/providers/openai_compatible.py
@@ -95,10 +95,12 @@ class OpenAICompatibleAdapter(ProviderAdapter):
         prompt_tokens_details = None
         if details := usage_data.get("prompt_tokens_details"):
             prompt_tokens_details = chat.PromptTokensDetails(**details)
+
+        usage = {
+            key: value for key, value in usage_data.items() if key != "prompt_tokens_details"
+        }
         return chat.ChatUsage(
-            prompt_tokens=usage_data.get("prompt_tokens"),
-            completion_tokens=usage_data.get("completion_tokens"),
-            total_tokens=usage_data.get("total_tokens"),
+            **usage,
             prompt_tokens_details=prompt_tokens_details,
         )
 

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -119,6 +119,22 @@ def test_default_api_base():
     assert provider._api_base == "https://api.test-provider.com/v1"
 
 
+def test_chat_preserves_provider_usage_fields():
+    response = _chat_response()
+    response["usage"].update(
+        {
+            "cost": 0.00123,
+            "cost_details": {"upstream_inference_cost": 0.00123},
+        }
+    )
+
+    result = OpenAICompatibleAdapter.model_to_chat(response, _make_endpoint_config())
+
+    assert result.usage is not None
+    assert result.usage.cost == 0.00123
+    assert result.usage.cost_details == {"upstream_inference_cost": 0.00123}
+
+
 def test_custom_api_base():
     provider = _make_provider(api_base="https://custom.example.com/v1")
     assert provider._api_base == "https://custom.example.com/v1"


### PR DESCRIPTION
## Related Issues/PRs

Closes #24997

## What changes are proposed in this pull request?

The OpenAI-compatible gateway adapter rebuilt `ChatUsage` from only the three standard token fields, which dropped provider-specific usage data such as OpenRouter's `cost` and `cost_details`.

This change forwards the remaining usage fields while keeping `prompt_tokens_details` converted to its dedicated model. Existing token fields and nested prompt details continue to work as before.

## How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `uv run --extra gateway --with sentence-transformers pytest tests/gateway/providers/test_openai_compatible.py -q` (24 passed)
- `uv run ruff check mlflow/gateway/providers/openai_compatible.py tests/gateway/providers/test_openai_compatible.py`

## Does this PR require documentation update?

- [x] No.

## Release Notes

#### Is this a user-facing change?

- [x] Yes. OpenAI-compatible gateway responses now preserve provider-specific fields included in the upstream `usage` object.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] Yes
- [x] No
