### PR TITLE
Expose `generate_rationale_first` through `make_judge`

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -884,6 +884,10 @@ class InstructionsJudge(Judge):
             )
         if self._inference_params is not None:
             pydantic_data["inference_params"] = self._inference_params
+        # Only serialize when enabled to keep existing (result-first) payloads unchanged;
+        # deserialization defaults this back to False when the key is absent.
+        if self._generate_rationale_first:
+            pydantic_data["generate_rationale_first"] = self._generate_rationale_first
 
         serialized_scorer = SerializedScorer(
             name=self.name,

--- a/mlflow/genai/judges/make_judge.py
+++ b/mlflow/genai/judges/make_judge.py
@@ -120,6 +120,7 @@ def make_judge(
     base_url: str | None = None,
     extra_headers: dict[str, str] | None = None,
     include_timing_in_conversation: bool = False,
+    generate_rationale_first: bool = False,
 ) -> Judge:
     """
     Create a custom MLflow judge instance.
@@ -175,6 +176,11 @@ def make_judge(
                         slowest spans) to assistant responses when evaluating conversations.
                         Useful for latency-aware evaluation. Default is False for backward
                         compatibility. Only applies when using {{ conversation }} template variable.
+        generate_rationale_first: If True, the judge emits its rationale before the final
+                        result value, so the verdict is conditioned on the reasoning. If False
+                        (the default, for backward compatibility), the result value is emitted
+                        first. Setting this to True can produce more consistent results by
+                        preventing the value from contradicting its own rationale.
 
     Returns:
         An InstructionsJudge instance configured with the provided parameters
@@ -281,6 +287,7 @@ def make_judge(
         feedback_value_type=feedback_value_type,
         aggregations=default_aggregations,
         include_timing_in_conversation=include_timing_in_conversation,
+        generate_rationale_first=generate_rationale_first,
         inference_params=inference_params,
         base_url=base_url,
         extra_headers=extra_headers,

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -531,6 +531,7 @@ class Scorer(BaseModel):
                     instructions=data["instructions"],
                     model=data["model"],
                     feedback_value_type=feedback_value_type,
+                    generate_rationale_first=data.get("generate_rationale_first", False),
                     inference_params=data.get("inference_params"),
                     aggregations=serialized.aggregations,
                 )

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -3739,6 +3739,25 @@ def test_make_judge_generate_rationale_first():
     assert [f.name for f in judge_rationale_first.get_output_fields()] == ["rationale", "result"]
 
 
+@pytest.mark.parametrize("generate_rationale_first", [True, False])
+def test_make_judge_generate_rationale_first_survives_serialization(generate_rationale_first):
+    judge = make_judge(
+        name="test_judge",
+        instructions="Evaluate {{ outputs }}",
+        model="openai:/gpt-4",
+        feedback_value_type=bool,
+        generate_rationale_first=generate_rationale_first,
+    )
+
+    deserialized = Scorer.model_validate(judge.model_dump())
+
+    assert deserialized._generate_rationale_first is generate_rationale_first
+    expected_order = (
+        ["rationale", "result"] if generate_rationale_first else ["result", "rationale"]
+    )
+    assert [f.name for f in deserialized.get_output_fields()] == expected_order
+
+
 @pytest.mark.parametrize(
     "description",
     [

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -3716,6 +3716,29 @@ def test_instructions_judge_generate_rationale_first():
     assert output_fields_rationale_first[1].value_type == Literal["good", "bad"]  # result
 
 
+def test_make_judge_generate_rationale_first():
+    # Default (False): result is emitted before rationale.
+    judge_default = make_judge(
+        name="test_judge",
+        instructions="Evaluate {{ outputs }}",
+        model="openai:/gpt-4",
+        feedback_value_type=bool,
+    )
+    assert judge_default._generate_rationale_first is False
+    assert [f.name for f in judge_default.get_output_fields()] == ["result", "rationale"]
+
+    # Opt in: rationale is emitted before result so the verdict follows the reasoning.
+    judge_rationale_first = make_judge(
+        name="test_judge_rationale_first",
+        instructions="Evaluate {{ outputs }}",
+        model="openai:/gpt-4",
+        feedback_value_type=bool,
+        generate_rationale_first=True,
+    )
+    assert judge_rationale_first._generate_rationale_first is True
+    assert [f.name for f in judge_rationale_first.get_output_fields()] == ["rationale", "result"]
+
+
 @pytest.mark.parametrize(
     "description",
     [


### PR DESCRIPTION
### Related Issues/PRs

Relates to internal ticket ES-2102979

### What changes are proposed in this pull request?

Custom judges created via the public `make_judge` API were locked into result-first output ordering. `InstructionsJudge.get_output_fields()` emits `result` before `rationale` unless `generate_rationale_first=True`, but `make_judge` never exposed that flag, so it always used the `False` default.

Because LLMs generate autoregressively, emitting `result` first means the verdict is produced before any reasoning tokens exist. The `rationale` that follows is then a post-hoc justification that can contradict the value it is supposed to explain — e.g. `value=False` next to a rationale that reasons the answer is correct.

This PR surfaces `generate_rationale_first` as a parameter on `make_judge`, defaulting to `False` to preserve existing behavior. Callers can now pass `generate_rationale_first=True` to get reason-first ordering, so the verdict is conditioned on the reasoning. This matches what MLflow's own built-in scorers already do internally (they all construct `InstructionsJudge` with `generate_rationale_first=True`).

```python
judge = make_judge(
    name="correctness",
    instructions="Is the {{ outputs }} correct given {{ inputs }}?",
    model="openai:/gpt-4",
    feedback_value_type=bool,
    generate_rationale_first=True,  # rationale is generated before the verdict
)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_make_judge_generate_rationale_first`, which verifies the public `make_judge` path yields `["result", "rationale"]` ordering by default and `["rationale", "result"]` when `generate_rationale_first=True`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

The new parameter is documented in the `make_judge` docstring.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`make_judge` now accepts a `generate_rationale_first` parameter (default `False`). Set it to `True` to have the judge generate its rationale before the final result value, producing more consistent verdicts that agree with their reasoning.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [x] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release