### PR TITLE
Enrich `mlflow scorers list --builtin` with the full scorer catalog

### DIFF
--- a/mlflow/cli/scorers.py
+++ b/mlflow/cli/scorers.py
@@ -1,14 +1,51 @@
+import inspect
 import json
-from typing import Literal
+from typing import Any, Literal
 
 import click
 
 from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID
 from mlflow.genai.judges import make_judge
-from mlflow.genai.scorers import get_all_scorers
+from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers import list_scorers as list_scorers_api
 from mlflow.mcp.decorator import mlflow_mcp
 from mlflow.utils.string_utils import _create_table
+
+# Fields defined on the Scorer base class, excluded when deriving the constructor
+# arguments a built-in scorer requires.
+_SCORER_BASE_FIELDS = set(Scorer.model_fields)
+
+
+def _builtin_scorer_catalog() -> list[dict[str, Any]]:
+    """Describe every built-in scorer by reading its class, without instantiating it.
+
+    ``get_all_scorers()`` only returns scorers instantiable with no arguments, so
+    scorers with required constructor arguments (``Guidelines``, ``RegexMatch``,
+    ``ResponseLength``, ``ConversationalGuidelines``) never appear. Reading fields off
+    the class instead surfaces all of them, along with the data contract and the
+    arguments needed to construct each one.
+    """
+    from mlflow.genai.scorers.builtin_scorers import _get_all_concrete_builtin_scorers
+
+    catalog = []
+    for cls in _get_all_concrete_builtin_scorers():
+        fields = cls.model_fields
+        required_columns = fields["required_columns"].default
+        session_prop = inspect.getattr_static(cls, "is_session_level_scorer", None)
+        catalog.append({
+            "name": fields["name"].default,
+            "description": fields["description"].default,
+            "required_columns": sorted(required_columns) if required_columns else [],
+            "session_level": session_prop.fget(cls)
+            if isinstance(session_prop, property)
+            else False,
+            "required_args": sorted(
+                name
+                for name, field in fields.items()
+                if field.is_required() and name not in _SCORER_BASE_FIELDS
+            ),
+        })
+    return sorted(catalog, key=lambda s: s["name"])
 
 
 class DictParamType(click.ParamType):
@@ -76,6 +113,12 @@ def list_scorers(
     """
     List registered scorers for an experiment, or list all built-in scorers.
 
+    With ``--builtin``, the output describes every built-in scorer: the columns it
+    requires, whether it is session-level, and any arguments needed to construct it
+    (e.g. ``Guidelines`` needs ``guidelines``). Scorers with required arguments are
+    included, unlike ``get_all_scorers()``, which only returns those instantiable with
+    defaults.
+
     \b
     Examples:
 
@@ -113,17 +156,34 @@ def list_scorers(
             "registered scorers for an experiment."
         )
 
-    # Get scorers based on mode
-    scorers = get_all_scorers() if builtin else list_scorers_api(experiment_id=experiment_id)
+    if builtin:
+        scorer_data = _builtin_scorer_catalog()
+        if output == "json":
+            click.echo(json.dumps({"scorers": scorer_data}, indent=2))
+        else:
+            table = [
+                [
+                    s["name"],
+                    ", ".join(s["required_columns"]) or "-",
+                    "yes" if s["session_level"] else "no",
+                    ", ".join(s["required_args"]) or "-",
+                    s["description"] or "",
+                ]
+                for s in scorer_data
+            ]
+            click.echo(
+                _create_table(
+                    table,
+                    headers=["Scorer Name", "Requires", "Session", "Args", "Description"],
+                )
+            )
+        return
 
-    # Format scorer data for output
+    scorers = list_scorers_api(experiment_id=experiment_id)
     scorer_data = [{"name": scorer.name, "description": scorer.description} for scorer in scorers]
-
     if output == "json":
-        result = {"scorers": scorer_data}
-        click.echo(json.dumps(result, indent=2))
+        click.echo(json.dumps({"scorers": scorer_data}, indent=2))
     else:
-        # Table output format
         table = [[s["name"], s["description"] or ""] for s in scorer_data]
         click.echo(_create_table(table, headers=["Scorer Name", "Description"]))
 

--- a/mlflow/cli/scorers.py
+++ b/mlflow/cli/scorers.py
@@ -1,19 +1,25 @@
-import inspect
 import json
 from typing import Any, Literal
 
 import click
+from pydantic_core import PydanticUndefined
 
 from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID
 from mlflow.genai.judges import make_judge
-from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers import list_scorers as list_scorers_api
+from mlflow.genai.scorers.builtin_scorers import (
+    BuiltInScorer,
+    SessionLevelScorer,
+    _get_all_concrete_builtin_scorers,
+)
 from mlflow.mcp.decorator import mlflow_mcp
 from mlflow.utils.string_utils import _create_table
 
-# Fields defined on the Scorer base class, excluded when deriving the constructor
-# arguments a built-in scorer requires.
-_SCORER_BASE_FIELDS = set(Scorer.model_fields)
+# Fields shared by all built-in scorers (name, description, required_columns,
+# inference_params, extra_headers). Excluded when deriving the constructor arguments a
+# specific scorer requires, so only scorer-specific required fields (e.g. Guidelines'
+# ``guidelines``) are reported.
+_SHARED_SCORER_FIELDS = set(BuiltInScorer.model_fields)
 
 
 def _builtin_scorer_catalog() -> list[dict[str, Any]]:
@@ -24,25 +30,38 @@ def _builtin_scorer_catalog() -> list[dict[str, Any]]:
     ``ResponseLength``, ``ConversationalGuidelines``) never appear. Reading fields off
     the class instead surfaces all of them, along with the data contract and the
     arguments needed to construct each one.
-    """
-    from mlflow.genai.scorers.builtin_scorers import _get_all_concrete_builtin_scorers
 
+    Reports the statically declared requirements only. Some scorers enforce
+    additional, alternative, or conditional requirements at construction or evaluation
+    time that this flat view does not represent:
+
+    - ``required_columns`` reflects the field default; scorers such as ``correctness``,
+      ``equivalence``, and ``expectations_guidelines`` require one of
+      ``expectations/expected_response`` or ``expectations/expected_facts`` (enforced in
+      ``validate_columns()``).
+    - ``required_args`` lists individually required constructor fields; it does not
+      capture one-of requirements such as ``response_length`` needing at least one of
+      ``min_length`` or ``max_length`` (enforced by a model validator).
+    """
     catalog = []
     for cls in _get_all_concrete_builtin_scorers():
         fields = cls.model_fields
-        required_columns = fields["required_columns"].default
-        session_prop = inspect.getattr_static(cls, "is_session_level_scorer", None)
+        required_columns_field = fields.get("required_columns")
+        required_columns = (
+            required_columns_field.default
+            if required_columns_field is not None
+            and required_columns_field.default is not PydanticUndefined
+            else None
+        )
         catalog.append({
             "name": fields["name"].default,
             "description": fields["description"].default,
             "required_columns": sorted(required_columns) if required_columns else [],
-            "session_level": session_prop.fget(cls)
-            if isinstance(session_prop, property)
-            else False,
+            "session_level": issubclass(cls, SessionLevelScorer),
             "required_args": sorted(
                 name
                 for name, field in fields.items()
-                if field.is_required() and name not in _SCORER_BASE_FIELDS
+                if field.is_required() and name not in _SHARED_SCORER_FIELDS
             ),
         })
     return sorted(catalog, key=lambda s: s["name"])

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -2269,8 +2269,13 @@ class BuiltInSessionLevelScorer(BuiltInScorer, SessionLevelScorer):
     implementation details should inherit from SessionLevelScorer directly.
     """
 
-    # All functionality now inherited from SessionLevelScorer
-    # BuiltInScorer provides special serialization for public API
+    # Re-declared because BuiltInScorer precedes SessionLevelScorer in the MRO, so
+    # BuiltInScorer's ``set()`` default would otherwise shadow SessionLevelScorer's
+    # ``{"trace"}``, leaving session scorers with an empty (incorrect) data contract.
+    required_columns: set[str] = {"trace"}
+
+    # Remaining functionality is inherited from SessionLevelScorer;
+    # BuiltInScorer provides special serialization for public API.
 
 
 @format_docstring(_MODEL_API_DOC)

--- a/tests/cli/test_scorers.py
+++ b/tests/cli/test_scorers.py
@@ -636,8 +636,9 @@ def test_list_builtin_scorers_includes_data_contract(runner):
     # Retrieval scorers require RETRIEVER trace data.
     assert scorers["retrieval_groundedness"]["required_columns"] == ["inputs", "trace"]
 
-    # Session-level scorers are flagged; single-turn scorers are not.
+    # Session-level scorers are flagged and require trace data; single-turn are not.
     assert scorers["user_frustration"]["session_level"] is True
+    assert scorers["user_frustration"]["required_columns"] == ["trace"]
     assert scorers["correctness"]["session_level"] is False
     assert scorers["correctness"]["required_args"] == []
 

--- a/tests/cli/test_scorers.py
+++ b/tests/cli/test_scorers.py
@@ -610,13 +610,46 @@ def test_list_builtin_scorers_shows_all_available_scorers(runner):
     result = runner.invoke(commands, ["list", "--builtin", "--output", "json"])
     assert result.exit_code == 0
 
-    expected_scorers = get_all_scorers()
-    expected_names = {scorer.name for scorer in expected_scorers}
+    # The catalog is a superset of get_all_scorers(): it also includes scorers with
+    # required constructor arguments, which get_all_scorers() cannot instantiate.
+    default_names = {scorer.name for scorer in get_all_scorers()}
 
     data = json.loads(result.output)
     actual_names = {s["name"] for s in data["scorers"]}
 
-    assert actual_names == expected_names
+    assert default_names <= actual_names
+    assert {"guidelines", "regex_match", "response_length"} <= actual_names
+    assert {"guidelines", "regex_match", "response_length"}.isdisjoint(default_names)
+
+
+def test_list_builtin_scorers_includes_data_contract(runner):
+    result = runner.invoke(commands, ["list", "--builtin", "--output", "json"])
+    assert result.exit_code == 0
+
+    scorers = {s["name"]: s for s in json.loads(result.output)["scorers"]}
+
+    # Constructor-arg scorer surfaces its required args and data contract.
+    assert scorers["guidelines"]["required_args"] == ["guidelines"]
+    assert scorers["regex_match"]["required_args"] == ["pattern"]
+    assert scorers["regex_match"]["required_columns"] == ["outputs"]
+
+    # Retrieval scorers require RETRIEVER trace data.
+    assert scorers["retrieval_groundedness"]["required_columns"] == ["inputs", "trace"]
+
+    # Session-level scorers are flagged; single-turn scorers are not.
+    assert scorers["user_frustration"]["session_level"] is True
+    assert scorers["correctness"]["session_level"] is False
+    assert scorers["correctness"]["required_args"] == []
+
+
+def test_list_builtin_scorers_table_has_new_columns(runner):
+    result = runner.invoke(commands, ["list", "--builtin"])
+    assert result.exit_code == 0
+
+    for header in ("Scorer Name", "Requires", "Session", "Args", "Description"):
+        assert header in result.output
+    # The arg-requiring scorer that get_all_scorers() omits is present.
+    assert "guidelines" in result.output
 
 
 def test_list_scorers_mutually_exclusive_flags(runner, experiment):

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1522,22 +1522,23 @@ def test_user_frustration_with_session():
 
 
 @pytest.mark.parametrize(
-    "scorer_cls",
+    ("scorer_cls", "kwargs"),
     [
-        UserFrustration,
-        ConversationCompleteness,
-        ConversationalSafety,
-        ConversationalToolCallEfficiency,
-        ConversationalRoleAdherence,
-        KnowledgeRetention,
+        (UserFrustration, {}),
+        (ConversationCompleteness, {}),
+        (ConversationalSafety, {}),
+        (ConversationalToolCallEfficiency, {}),
+        (ConversationalRoleAdherence, {}),
+        (KnowledgeRetention, {}),
+        (ConversationalGuidelines, {"guidelines": "Be polite"}),
     ],
 )
-def test_session_level_scorers_require_trace_column(scorer_cls):
+def test_session_level_scorers_require_trace_column(scorer_cls, kwargs):
     # BuiltInScorer precedes SessionLevelScorer in the MRO; without an explicit
     # re-declaration its empty default shadows SessionLevelScorer's {"trace"}.
     from mlflow.genai.scorers.builtin_scorers import MissingColumnsException
 
-    scorer = scorer_cls()
+    scorer = scorer_cls(**kwargs)
     assert scorer.required_columns == {"trace"}
 
     with pytest.raises(MissingColumnsException, match="trace"):

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1521,6 +1521,31 @@ def test_user_frustration_with_session():
         mock_invoke_judge.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "scorer_cls",
+    [
+        UserFrustration,
+        ConversationCompleteness,
+        ConversationalSafety,
+        ConversationalToolCallEfficiency,
+        ConversationalRoleAdherence,
+        KnowledgeRetention,
+    ],
+)
+def test_session_level_scorers_require_trace_column(scorer_cls):
+    # BuiltInScorer precedes SessionLevelScorer in the MRO; without an explicit
+    # re-declaration its empty default shadows SessionLevelScorer's {"trace"}.
+    from mlflow.genai.scorers.builtin_scorers import MissingColumnsException
+
+    scorer = scorer_cls()
+    assert scorer.required_columns == {"trace"}
+
+    with pytest.raises(MissingColumnsException, match="trace"):
+        scorer.validate_columns(set())
+
+    scorer.validate_columns({"trace"})
+
+
 def test_user_frustration_with_custom_name_and_model(monkeypatch: pytest.MonkeyPatch):
     session_id = "test_session_456"
     traces = []


### PR DESCRIPTION
### Related Issues/PRs

Relates to the [MLflow Skills](https://github.com/mlflow/skills) `build-a-scorer` skill, which currently hand-maintains a fallback table of built-in scorers.

### What changes are proposed in this pull request?

**1. Enrich `mlflow scorers list --builtin`.** The command was built from `get_all_scorers()`, which only returns scorers that can be instantiated with default arguments. This had two consequences:

- **Scorers with required constructor arguments were silently omitted** — `Guidelines`, `RegexMatch`, `ResponseLength`, and `ConversationalGuidelines` never appeared, so the command implied they did not exist. These are exactly the code/rule scorers users are pointed to first.
- **The output carried only name + description** — not the data each scorer needs, so it couldn't answer "which scorer can I actually use given my data?".

The catalog is now read from the scorer classes instead of instantiating them (via `_get_all_concrete_builtin_scorers()`, which already returns all built-ins). The `--builtin` output covers **all 24** built-in scorers and, per scorer, reports:

- `required_columns` — the data contract (e.g. retrieval scorers need `inputs, trace`)
- `session_level` — whether it is a session-level scorer
- `required_args` — arguments needed to construct it (e.g. `Guidelines` needs `guidelines`)

Table output gains `Requires`, `Session`, and `Args` columns; JSON output gains the three corresponding keys. The registered-scorers path (`--experiment-id`) is unchanged.

The catalog reflects statically declared requirements only. Alternative/conditional requirements enforced at evaluation time — e.g. `correctness` needing one of `expectations/expected_response`/`expected_facts`, or `response_length`'s one-of `min_length`/`max_length` — are documented as a known limitation rather than represented in the flat schema.

**2. Fix session scorers reporting an empty `required_columns`.** Surfaced while building the catalog: `BuiltInSessionLevelScorer` subclasses (`UserFrustration`, the `Conversational*` scorers, `KnowledgeRetention`) exposed `required_columns == set()` instead of `{"trace"}`, because `BuiltInScorer` precedes `SessionLevelScorer` in the MRO and its empty default shadowed the correct one. The field is now re-declared on the subclass. The runtime effect elsewhere is benign — `valid_data_for_builtin_scorers` only logs missing columns, and session evaluation always supplies traces — but the CLI displayed the wrong contract, so the class fix and the CLI change are the same fix.

Before (20 scorers, name + description):

```
Scorer Name            Description
correctness            Check whether the expected facts...
```

After (24 scorers, full contract):

```
Scorer Name    Requires         Session  Args        Description
guidelines     inputs, outputs  no       guidelines  Evaluate whether the agent's response follows...
regex_match    outputs          no       pattern     Check whether output matches a regular expression...
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`tests/cli/test_scorers.py` pass. The test that asserted exact equality with `get_all_scorers()` now asserts the catalog is a superset; new tests cover the data-contract fields and the new table columns. A new parametrized regression in `tests/genai/scorers/test_builtin_scorers.py` asserts every `BuiltInSessionLevelScorer` reports `required_columns == {"trace"}` and rejects trace-less data. The existing built-in scorer and serialization suites pass unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] Yes. Please link the corresponding PR or explain how you plan to update it.

The `build-a-scorer` skill currently carries a hand-maintained table of built-in scorers as a fallback for when the runtime introspection command can't import MLflow. This enriched CLI is intended to replace that table with a `mlflow scorers list --builtin --output json` call, in a follow-up Skills PR.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow scorers list --builtin` now lists all built-in scorers (including those with required constructor arguments) and reports each scorer's required columns, session-level flag, and constructor arguments. Fixes session-level scorers reporting an empty `required_columns` instead of `{"trace"}`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
