### PR TITLE
feat(gemini): autolog Gemini Interactions API (client.interactions.create)

### DIFF
--- a/mlflow/gemini/__init__.py
+++ b/mlflow/gemini/__init__.py
@@ -93,6 +93,30 @@ def autolog(
     except ImportError:
         pass
 
+    # Patch the Interactions API (google-genai >= 2.3.0).
+    # client.interactions.create / client.aio.interactions.create are the new primary interface
+    # for Gemini model and agent calls; without this patch they produce no MLflow trace.
+    try:
+        from google.genai._gaos.google_genai import (
+            AsyncGeminiNextGenInteractions,
+            GeminiNextGenInteractions,
+        )
+
+        safe_patch(
+            FLAVOR_NAME,
+            GeminiNextGenInteractions,
+            "create",
+            patched_class_call,
+        )
+        safe_patch(
+            FLAVOR_NAME,
+            AsyncGeminiNextGenInteractions,
+            "create",
+            async_patched_class_call,
+        )
+    except ImportError:
+        pass
+
     _record_event(
         AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
     )

--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -123,8 +123,15 @@ class TracingSession:
             self.span.record_exception(exc_val)
 
         try:
-            # Chat instances store model in _model attribute
-            if model := (self.inputs.get("model") or getattr(self.instance, "_model", None)):
+            # Chat instances store model in _model attribute; Interactions store it in the
+            # response object; kwargs-only APIs (Interactions.create) pack body args into "body".
+            _body = self.inputs.get("body") or {}
+            if model := (
+                self.inputs.get("model")
+                or (_body.get("model") if isinstance(_body, dict) else None)
+                or getattr(self.instance, "_model", None)
+                or getattr(self.output, "model", None)
+            ):
                 self.span.set_attribute(SpanAttributeKey.MODEL, model)
                 self.span.set_attribute(SpanAttributeKey.MODEL_PROVIDER, "gemini")
         except Exception as e:
@@ -290,6 +297,7 @@ def _get_span_type(task_name: str) -> str:
         "send_message": SpanType.CHAT_MODEL,
         "count_tokens": SpanType.LLM,
         "embed_content": SpanType.EMBEDDING,
+        "create": SpanType.LLM,  # Interactions API
     }
     return span_type_mapping.get(task_name, SpanType.UNKNOWN)
 
@@ -306,22 +314,37 @@ def _construct_full_inputs(func, *args, **kwargs):
 
 
 def _parse_usage(output):
-    usage = None
+    # GenerateContent / send_message / count_tokens response: has usage_metadata attribute.
+    usage_meta = None
     if hasattr(output, "usage_metadata"):
-        usage = output.usage_metadata
+        usage_meta = output.usage_metadata
     elif isinstance(output, dict):
-        usage = output.get("usage_metadata")
-    else:
-        return None
+        usage_meta = output.get("usage_metadata")
 
-    usage_dict = {}
-    if (prompt_tokens := usage.prompt_token_count) is not None:
-        usage_dict[TokenUsageKey.INPUT_TOKENS] = prompt_tokens
-    if (candidate_tokens := usage.candidates_token_count) is not None:
-        usage_dict[TokenUsageKey.OUTPUT_TOKENS] = candidate_tokens
-    if (total_tokens := usage.total_token_count) is not None:
-        usage_dict[TokenUsageKey.TOTAL_TOKENS] = total_tokens
-    if (cached_tokens := getattr(usage, "cached_content_token_count", None)) is not None:
-        usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached_tokens
+    if usage_meta is not None:
+        usage_dict = {}
+        if (prompt_tokens := usage_meta.prompt_token_count) is not None:
+            usage_dict[TokenUsageKey.INPUT_TOKENS] = prompt_tokens
+        if (candidate_tokens := usage_meta.candidates_token_count) is not None:
+            usage_dict[TokenUsageKey.OUTPUT_TOKENS] = candidate_tokens
+        if (total_tokens := usage_meta.total_token_count) is not None:
+            usage_dict[TokenUsageKey.TOTAL_TOKENS] = total_tokens
+        if (cached_tokens := getattr(usage_meta, "cached_content_token_count", None)) is not None:
+            usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached_tokens
+        return usage_dict or None
 
-    return usage_dict or None
+    # Interactions API response: has a .usage attribute with total_*_tokens fields.
+    inter_usage = getattr(output, "usage", None)
+    if inter_usage is not None and hasattr(inter_usage, "total_input_tokens"):
+        usage_dict = {}
+        if (input_tokens := inter_usage.total_input_tokens) is not None:
+            usage_dict[TokenUsageKey.INPUT_TOKENS] = input_tokens
+        if (output_tokens := inter_usage.total_output_tokens) is not None:
+            usage_dict[TokenUsageKey.OUTPUT_TOKENS] = output_tokens
+        if (total_tokens := inter_usage.total_tokens) is not None:
+            usage_dict[TokenUsageKey.TOTAL_TOKENS] = total_tokens
+        if (cached_tokens := inter_usage.total_cached_tokens) is not None:
+            usage_dict[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = cached_tokens
+        return usage_dict or None
+
+    return None

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from google import genai
+from google.genai import interactions as inter_types
 from packaging.version import Version
 
 import mlflow
@@ -744,3 +745,118 @@ def test_tracing_headers_injected_when_config_is_none(is_async):
         else:
             http_headers = getattr(getattr(config_input, "http_options", None), "headers", {}) or {}
         assert "traceparent" not in http_headers
+
+
+# ---------------------------------------------------------------------------
+# Interactions API tests
+# ---------------------------------------------------------------------------
+
+_DUMMY_INTERACTION_RESPONSE = inter_types.Interaction(
+    id="test-interaction-id",
+    model="gemini-2.5-flash",
+    status="completed",
+    usage=inter_types.Usage(
+        total_input_tokens=100,
+        total_output_tokens=50,
+        total_tokens=150,
+        total_cached_tokens=0,
+    ),
+    output_text="Hello from Interactions API",
+)
+
+_DUMMY_INTERACTION_RESPONSE_CACHED = inter_types.Interaction(
+    id="test-interaction-id-cached",
+    model="gemini-2.5-flash",
+    status="completed",
+    usage=inter_types.Usage(
+        total_input_tokens=100,
+        total_output_tokens=50,
+        total_tokens=150,
+        total_cached_tokens=80,
+    ),
+    output_text="Hello with cache",
+)
+
+
+def _interactions_create_sync(self, *, model=None, **kwargs):
+    return _DUMMY_INTERACTION_RESPONSE
+
+
+async def _interactions_create_async(self, *, model=None, **kwargs):
+    return _DUMMY_INTERACTION_RESPONSE
+
+
+def _interactions_create_cached_sync(self, *, model=None, **kwargs):
+    return _DUMMY_INTERACTION_RESPONSE_CACHED
+
+
+async def _interactions_create_cached_async(self, *, model=None, **kwargs):
+    return _DUMMY_INTERACTION_RESPONSE_CACHED
+
+
+def _do_interactions_create(is_async: bool, mock_fn):
+    client = genai.Client(api_key="dummy")
+    if is_async:
+        return asyncio.run(
+            client.aio.interactions.create(
+                model="gemini-2.5-flash",
+                input={"turns": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]},
+            )
+        )
+    else:
+        return client.interactions.create(
+            model="gemini-2.5-flash",
+            input={"turns": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]},
+        )
+
+
+def test_interactions_create_autolog(is_async):
+    patch_cls = "AsyncGeminiNextGenInteractions" if is_async else "GeminiNextGenInteractions"
+    mock_fn = _interactions_create_async if is_async else _interactions_create_sync
+
+    with patch(f"google.genai._gaos.google_genai.{patch_cls}.create", new=mock_fn):
+        mlflow.gemini.autolog()
+        _do_interactions_create(is_async, mock_fn)
+
+        traces = get_traces()
+        assert len(traces) == 1
+        assert traces[0].info.status == "OK"
+        assert len(traces[0].data.spans) == 1
+
+        span = traces[0].data.spans[0]
+        assert span.name == f"{patch_cls}.create"
+        assert span.span_type == SpanType.LLM
+        assert span.model_name == "gemini-2.5-flash"
+        assert span.outputs == _DUMMY_INTERACTION_RESPONSE.to_dict()
+        assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+            TokenUsageKey.INPUT_TOKENS: 100,
+            TokenUsageKey.OUTPUT_TOKENS: 50,
+            TokenUsageKey.TOTAL_TOKENS: 150,
+            TokenUsageKey.CACHE_READ_INPUT_TOKENS: 0,
+        }
+
+        mlflow.gemini.autolog(disable=True)
+        _do_interactions_create(is_async, mock_fn)
+
+        # No new trace after disable
+        traces = get_traces()
+        assert len(traces) == 1
+
+
+def test_interactions_create_cached_tokens(is_async):
+    patch_cls = "AsyncGeminiNextGenInteractions" if is_async else "GeminiNextGenInteractions"
+    mock_fn = _interactions_create_cached_async if is_async else _interactions_create_cached_sync
+
+    with patch(f"google.genai._gaos.google_genai.{patch_cls}.create", new=mock_fn):
+        mlflow.gemini.autolog()
+        _do_interactions_create(is_async, mock_fn)
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        TokenUsageKey.INPUT_TOKENS: 100,
+        TokenUsageKey.OUTPUT_TOKENS: 50,
+        TokenUsageKey.TOTAL_TOKENS: 150,
+        TokenUsageKey.CACHE_READ_INPUT_TOKENS: 80,
+    }


### PR DESCRIPTION
### Related Issues/PRs

Closes #24470

### What changes are proposed in this pull request?

Adds MLflow autologging for the Gemini Interactions API (`client.interactions.create` and `client.aio.interactions.create`).

When Gemini autologging is enabled, calls to the Interactions API are automatically traced. The implementation:

- Patches both the synchronous `interactions.create` and the asynchronous `client.aio.interactions.create` entry points in `mlflow/gemini/__init__.py`
- Extracts model name and token-usage metadata (input tokens, output tokens, total tokens, cached content tokens) from the `Interaction.usage` object in `mlflow/gemini/autolog.py`
- Extends `_parse_usage` to handle the `Interaction.usage` field format
- Extends `_get_span_type` to map the `create` method to `SpanType.LLM`
- Extends model-name extraction to check the response `.model` attribute and the `body` kwargs dict (needed for the kwargs-only Interactions API)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Two parameterised unit tests cover the synchronous and asynchronous Interactions API paths, including cached-content token extraction. Existing tests for `_parse_usage` continue to pass as the refactor preserves the original `usage_metadata` path.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Gemini autologging now traces calls made through the Interactions API (`client.interactions.create` / `client.aio.interactions.create`), capturing model name and full token-usage metadata including cached-content tokens.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release