### PR TITLE
Add public RunData.metric_objects() accessor

### DIFF
--- a/mlflow/entities/run_data.py
+++ b/mlflow/entities/run_data.py
@@ -37,6 +37,20 @@ class RunData(_MlflowObject):
         """
         return self._metrics
 
+    def metric_objects(self):
+        """
+        List of :py:class:`mlflow.entities.Metric` objects for the current run.
+
+        Unlike :py:attr:`metrics`, which maps each metric key to its latest value, this exposes the
+        full ``Metric`` objects (including ``step`` and ``timestamp``). For each metric key, the
+        entry is the most recently logged value at the largest step.
+
+        This is a method rather than a property because :class:`~mlflow.entities._mlflow_object.
+        _MlflowObject` reflects over properties to build its dictionary form, and ``Metric`` objects
+        are not part of that serialized representation.
+        """
+        return self._metric_objs
+
     @property
     def params(self):
         """Dictionary of param key (string) -> param value for the current run."""

--- a/mlflow/entities/run_data.py
+++ b/mlflow/entities/run_data.py
@@ -45,11 +45,11 @@ class RunData(_MlflowObject):
         full ``Metric`` objects (including ``step`` and ``timestamp``). For each metric key, the
         entry is the most recently logged value at the largest step.
 
-        This is a method rather than a property because :class:`~mlflow.entities._mlflow_object.
-        _MlflowObject` reflects over properties to build its dictionary form, and ``Metric`` objects
-        are not part of that serialized representation.
+        This is a method rather than a property because ``_MlflowObject`` reflects over properties
+        to build its dictionary form, and ``Metric`` objects are not part of that serialized
+        representation. A shallow copy is returned so callers cannot mutate the run's backing list.
         """
-        return self._metric_objs
+        return list(self._metric_objs)
 
     @property
     def params(self):

--- a/mlflow/system_metrics/system_metrics_monitor.py
+++ b/mlflow/system_metrics/system_metrics_monitor.py
@@ -97,7 +97,7 @@ class SystemMetricsMonitor:
         # `get_metric_history`, which would materialize the entire metric history into memory and
         # is prohibitively expensive for long-running runs (see GH issue #22991).
         max_step = None
-        for metric in run.data._metric_objs:
+        for metric in run.data.metric_objects():
             if metric.key.startswith(self._metrics_prefix):
                 max_step = metric.step if max_step is None else max(max_step, metric.step)
         return 0 if max_step is None else max_step + 1

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -20,7 +20,8 @@ def _check_tags(tags_dict, expected_tags):
 
 def _check(rd, metrics, params, tags):
     assert isinstance(rd, RunData)
-    _check_metrics(rd._metric_objs, rd.metrics, metrics)
+    assert rd.metric_objects() == rd._metric_objs
+    _check_metrics(rd.metric_objects(), rd.metrics, metrics)
     _check_params(rd.params, params)
     _check_tags(rd.tags, tags)
 


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to the review discussion on #23401.

### What changes are proposed in this pull request?

`RunData` exposes metrics only as `run.data.metrics`, a `{key: value}` dict that drops each metric's `step` and `timestamp`. Callers that need the full `Metric` objects (e.g. to read the latest logged `step`) currently have to reach into the private `run.data._metric_objs` list — there is no public path.

This PR adds a public `RunData.metric_objects()` accessor that returns the list of `Metric` objects. For each metric key, the entry is the most recently logged value at the largest step, mirroring how the backend stores populate the underlying list.

It is intentionally a **method, not a property**: `_MlflowObject.__iter__` reflects over declared properties to build the object's dict/serialized form, so exposing this as a property would leak `metric_objects` into `dict(run_data)` and break `from_dictionary` round-tripping (which would then pass an unexpected `metric_objects=` kwarg into `__init__`). A method keeps the serialization surface unchanged.

Motivation: #23401 changes `SystemMetricsMonitor._get_next_logging_step()` to read the resume step from `run.data._metric_objs` instead of materializing the full metric history. That is correct but reaches into a private attribute. Once this accessor lands, that call site can be switched to the public `metric_objects()` — a small follow-up after #23401 merges.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

`tests/entities/test_run_data.py` now exercises `metric_objects()` (asserting it matches the internal list and carries key/value/step/timestamp), and the existing `dict(rd)` / proto round-trip assertions confirm the serialized form is unaffected.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds a public `RunData.metric_objects()` accessor returning the run's `Metric` objects (with `step` and `timestamp`).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>
#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release