### PR TITLE
fix(gateway): preserve provider usage extras

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -364,7 +364,17 @@ class AnthropicAdapter(ProviderAdapter):
         prompt_tokens_details = None
         if cache_read is not None:
             prompt_tokens_details = chat.PromptTokensDetails(cached_tokens=cache_read)
-        extra = {}
+        extra = {
+            key: value
+            for key, value in usage_data.items()
+            if key
+            not in {
+                "input_tokens",
+                "output_tokens",
+                "cache_read_input_tokens",
+                "cache_creation_input_tokens",
+            }
+        }
         if cache_creation is not None:
             extra["cache_creation_input_tokens"] = cache_creation
         return chat.ChatUsage(

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -319,12 +319,24 @@ class GeminiAdapter(ProviderAdapter):
 
     @classmethod
     def _build_chat_usage(cls, usage_metadata: dict[str, Any]) -> chat_schema.ChatUsage:
+        extra = {
+            key: value
+            for key, value in usage_metadata.items()
+            if key
+            not in {
+                "promptTokenCount",
+                "candidatesTokenCount",
+                "totalTokenCount",
+                "cachedContentTokenCount",
+            }
+        }
         prompt_tokens_details = None
         if "cachedContentTokenCount" in usage_metadata:
             prompt_tokens_details = chat_schema.PromptTokensDetails(
                 cached_tokens=usage_metadata["cachedContentTokenCount"]
             )
         return chat_schema.ChatUsage(
+            **extra,
             prompt_tokens=usage_metadata.get("promptTokenCount"),
             completion_tokens=usage_metadata.get("candidatesTokenCount"),
             total_tokens=usage_metadata.get("totalTokenCount"),

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -1639,6 +1639,20 @@ def test_anthropic_adapter_build_chat_usage_without_cached_tokens():
     assert not hasattr(usage, "cache_creation_input_tokens")
 
 
+def test_anthropic_adapter_build_chat_usage_preserves_provider_specific_fields():
+    usage_data = {
+        "input_tokens": 50,
+        "output_tokens": 20,
+        "server_tool_use": {"web_search_requests": 1},
+        "service_tier": "standard_only",
+    }
+    usage = AnthropicAdapter._build_chat_usage(usage_data)
+
+    assert usage.model_dump()["server_tool_use"] == {"web_search_requests": 1}
+    assert usage.model_dump()["service_tier"] == "standard_only"
+    assert "input_tokens" not in usage.model_dump()
+
+
 def test_chat_to_model_translates_multimodal_image_content():
     # A user message with OpenAI-format multimodal content (text + an image_url base64
     # data URL) must be translated to Anthropic's native image block; the gateway path

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -1642,6 +1642,21 @@ def test_gemini_adapter_build_chat_usage_without_cached_tokens():
     assert usage.prompt_tokens_details is None
 
 
+def test_gemini_adapter_build_chat_usage_preserves_provider_specific_fields():
+    usage_metadata = {
+        "promptTokenCount": 50,
+        "candidatesTokenCount": 20,
+        "totalTokenCount": 70,
+        "thoughtsTokenCount": 12,
+        "trafficType": "ON_DEMAND",
+    }
+    usage = GeminiAdapter._build_chat_usage(usage_metadata)
+
+    assert usage.model_dump()["thoughtsTokenCount"] == 12
+    assert usage.model_dump()["trafficType"] == "ON_DEMAND"
+    assert "promptTokenCount" not in usage.model_dump()
+
+
 def test_chat_to_model_translates_multimodal_image_content():
     # A user message with OpenAI-format multimodal content (text + an image_url base64
     # data URL) must be translated to Gemini inlineData parts; the gateway path is how


### PR DESCRIPTION
### Related Issues/PRs

Closes #25006

### What changes are proposed in this pull request?

Preserve provider-specific usage fields returned by the Gemini and Anthropic adapters.

Both adapters normalize provider-native token names into MLflow's common `ChatUsage` fields. Previously, fields that were not part of that explicit mapping were dropped before constructing `ChatUsage`, even though `ChatUsage` allows extra fields. This patch forwards only the unmapped provider fields while keeping the existing token normalization and cache-token handling unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Focused verification:

- `pytest tests/gateway/providers/test_gemini.py::test_gemini_adapter_build_chat_usage_preserves_provider_specific_fields tests/gateway/providers/test_anthropic.py::test_anthropic_adapter_build_chat_usage_preserves_provider_specific_fields -q` — 2 passed
- `pytest tests/gateway/providers/test_gemini.py tests/gateway/providers/test_anthropic.py -k build_chat_usage -q` — 6 passed, 109 deselected
- Ruff check and format check passed for all four changed files
- `git diff --check` passed

The provider test files initially required missing local optional dependencies; I installed them only in the local virtual environment to run these tests and did not add any dependency files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Provider-specific usage metadata is now retained in normalized chat responses for the Gemini and Anthropic gateway adapters.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name=release-note-category></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

AI assistance was used while preparing this patch; the implementation and regression tests were reviewed against the existing adapter behavior.