### PR TITLE
Add `Scorer.where()` to scope a scorer to evaluation rows by tag

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -267,6 +267,23 @@ def evaluate(
             inputs, outputs, and other additional contexts. MLflow provides pre-defined
             scorers, but you can also define custom ones.
 
+            A scorer can be scoped to a subset of rows with ``scorer.where(filter_string)``,
+            where ``filter_string`` is a ``search_traces``-style filter over the row's tags
+            (e.g. ``"tags.`category` = 'billing'"``). A scoped scorer runs only on rows whose
+            tags match; an unscoped scorer runs on every row.
+
+            .. code-block:: python
+
+                from mlflow.genai.scorers import Correctness, Safety
+
+                mlflow.genai.evaluate(
+                    data=dataset,
+                    scorers=[
+                        Correctness(),  # every row
+                        Safety().where("tags.`pii` = 'true'"),  # only rows tagged pii=true
+                    ],
+                )
+
         predict_fn: The target function to be evaluated. The specified function will be
             executed for each row in the input dataset, and outputs will be used for
             scoring.

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -268,9 +268,12 @@ def evaluate(
             scorers, but you can also define custom ones.
 
             A scorer can be scoped to a subset of rows with ``scorer.where(filter_string)``,
-            where ``filter_string`` is a ``search_traces``-style filter over the row's tags
+            where ``filter_string`` filters on the row's **tags** only, using MLflow's
+            ``search_traces`` filter grammar restricted to tag clauses
             (e.g. ``"tags.`category` = 'billing'"``). A scoped scorer runs only on rows whose
-            tags match; an unscoped scorer runs on every row.
+            tags match; an unscoped scorer runs on every row. The filter matches tags known
+            before scoring (the dataset ``tags`` column or tags already on input traces), not
+            tags added at runtime inside a ``predict_fn``.
 
             .. code-block:: python
 

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -142,8 +142,12 @@ class EvalItem:
         if is_none_or_nan(expectations):
             expectations = {}
 
-        # Extract tags column from the dataset.
+        # Extract tags column from the dataset. A mixed dataset where only some rows set tags
+        # yields a pandas NaN here, so coerce it (like the sibling columns) to avoid a downstream
+        # ``'float' object has no attribute 'get'`` when a scorer's ``where()`` filter reads it.
         tags = row.get(InputDatasetColumn.TAGS, {})
+        if is_none_or_nan(tags):
+            tags = {}
 
         # Extract source column from the dataset.
         source = row.get(InputDatasetColumn.SOURCE)

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -118,8 +118,6 @@ class EvalItem:
             inputs=None,
             outputs=None,
             expectations=None,
-            # Carry the trace's own tags so scorers scoped with `.where()` can match on them.
-            tags=dict(trace.info.tags) if trace.info.tags else None,
             trace=trace,
         )
 

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -118,6 +118,8 @@ class EvalItem:
             inputs=None,
             outputs=None,
             expectations=None,
+            # Carry the trace's own tags so scorers scoped with `.where()` can match on them.
+            tags=dict(trace.info.tags) if trace.info.tags else None,
             trace=trace,
         )
 

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -73,6 +73,7 @@ from mlflow.genai.evaluation.utils import (
     PGBAR_FORMAT,
     is_none_or_nan,
     make_code_type_assessment_source,
+    row_matches_scorer_filter,
     standardize_scorer_value,
     validate_tags,
 )
@@ -95,6 +96,22 @@ _logger = logging.getLogger(__name__)
 
 
 AUTO_INITIAL_RPS = 10.0
+
+
+def _scorers_for_item(eval_item: EvalItem, single_turn_scorers: list[Scorer]) -> list[Scorer]:
+    """Select the scorers that apply to one row.
+
+    A scorer scoped with ``.where(filter_string)`` runs only on rows whose tags match the
+    filter; an unscoped scorer runs on every row.
+    """
+    if not any(scorer.row_filter for scorer in single_turn_scorers):
+        return single_turn_scorers
+    return [
+        scorer
+        for scorer in single_turn_scorers
+        if scorer.row_filter is None
+        or row_matches_scorer_filter(eval_item.tags, scorer.row_filter)
+    ]
 
 
 def _merge_scorer_stats_dicts(target: dict[str, ScorerStat], source: dict[str, ScorerStat]) -> None:
@@ -444,10 +461,11 @@ class _ScoreSubmitter:
     def submit(self, idx: int) -> Future:
         """Submit a score task for eval item *idx* and return the future."""
         _logger.debug(f"Predict completed for item {idx}, submitting score")
+        eval_item = self._eval_items[idx]
         future = self._pool.submit(
             self._timed_score,
-            self._eval_items[idx],
-            self._single_turn_scorers,
+            eval_item,
+            _scorers_for_item(eval_item, self._single_turn_scorers),
             self._run_id,
             self._limiter,
             self._max_retries,

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -109,9 +109,30 @@ def _scorers_for_item(eval_item: EvalItem, single_turn_scorers: list[Scorer]) ->
     return [
         scorer
         for scorer in single_turn_scorers
-        if scorer.row_filter is None
-        or row_matches_scorer_filter(eval_item.tags, scorer.row_filter)
+        if scorer.row_filter is None or row_matches_scorer_filter(eval_item.tags, scorer.row_filter)
     ]
+
+
+def _warn_unmatched_scoped_scorers(
+    eval_items: list[EvalItem], single_turn_scorers: list[Scorer]
+) -> None:
+    """Warn for each ``.where()``-scoped scorer that matches no row in the dataset.
+
+    A scoped scorer that matches zero rows produces no metric at all, so a typo in a tag key or
+    value would otherwise fail silently (``result.passed`` stays ``True`` with no indication the
+    scorer never ran). A legitimately empty match is possible, so this warns rather than raises.
+    """
+    for scorer in single_turn_scorers:
+        if scorer.row_filter is None:
+            continue
+        if not any(row_matches_scorer_filter(item.tags, scorer.row_filter) for item in eval_items):
+            _logger.warning(
+                "Scorer '%s' is scoped with where(%r) but no rows in the dataset match that "
+                "filter, so it produced no results. Check the filter's tag keys and values "
+                "against the tags on your dataset.",
+                scorer.name,
+                scorer.row_filter,
+            )
 
 
 def _merge_scorer_stats_dicts(target: dict[str, ScorerStat], source: dict[str, ScorerStat]) -> None:
@@ -697,6 +718,7 @@ def run(
     experiment_id = mlflow.get_run(run_id).info.experiment_id
 
     single_turn_scorers, multi_turn_scorers = classify_scorers(scorers)
+    _warn_unmatched_scoped_scorers(eval_items, single_turn_scorers)
     session_groups = group_traces_by_session(eval_items) if multi_turn_scorers else {}
     # Every eval item goes through the score pool (even with no single-turn
     # scorers, _run_score still logs expectations and tags), so each item

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -464,3 +464,31 @@ def validate_tags(tags: Any) -> None:
 
     if errors:
         raise MlflowException.invalid_parameter_value("Invalid tags:\n  - " + "\n  - ".join(errors))
+
+
+class _RowTags:
+    """Minimal object exposing ``.tags`` so ``SearchTraceUtils`` can match a row's tags."""
+
+    def __init__(self, tags: dict[str, str] | None):
+        self.tags = tags or {}
+
+
+def row_matches_scorer_filter(tags: dict[str, str] | None, filter_string: str) -> bool:
+    """Whether a row's ``tags`` satisfy a scorer's ``where()`` filter string.
+
+    ``filter_string`` is an MLflow ``search_traces``-style filter, but only tag clauses
+    (e.g. ``tags.`category` = 'billing'``) are supported here; a clause on anything else
+    raises, since a dataset row only carries tags.
+    """
+    from mlflow.utils.search_utils import SearchTraceUtils
+
+    parsed = SearchTraceUtils.parse_search_filter_for_search_traces(filter_string)
+    for clause in parsed:
+        if clause.get("type") != SearchTraceUtils._TAG_IDENTIFIER:
+            raise MlflowException.invalid_parameter_value(
+                "Scorer filters set with `where()` may only reference tags, e.g. "
+                "\"tags.`category` = 'billing'\". "
+                f"Got a filter on '{clause.get('key')}'."
+            )
+    row = _RowTags(tags)
+    return all(SearchTraceUtils._does_trace_match_clause(row, clause) for clause in parsed)

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -13,8 +13,10 @@ from mlflow.genai.evaluation.constant import (
     AgentEvaluationReserverKey,
 )
 from mlflow.genai.scorers import Scorer
+from mlflow.genai.scorers.base import _parse_tag_filter
 from mlflow.models import EvaluationMetric
 from mlflow.tracing.utils.search import traces_to_df
+from mlflow.utils.search_utils import SearchTraceUtils
 
 try:
     # `pandas` is not required for `mlflow-skinny`.
@@ -470,25 +472,19 @@ class _RowTags:
     """Minimal object exposing ``.tags`` so ``SearchTraceUtils`` can match a row's tags."""
 
     def __init__(self, tags: dict[str, str] | None):
-        self.tags = tags or {}
+        # A dataset row may carry no tags at all (``None``) or a pandas ``NaN`` when only some
+        # rows in a mixed dataset set tags; either coerces to an empty tag dict.
+        self.tags = tags if isinstance(tags, dict) else {}
 
 
 def row_matches_scorer_filter(tags: dict[str, str] | None, filter_string: str) -> bool:
     """Whether a row's ``tags`` satisfy a scorer's ``where()`` filter string.
 
-    ``filter_string`` is an MLflow ``search_traces``-style filter, but only tag clauses
-    (e.g. ``tags.`category` = 'billing'``) are supported here; a clause on anything else
-    raises, since a dataset row only carries tags.
+    ``filter_string`` uses MLflow's ``search_traces`` filter grammar restricted to tag clauses
+    (e.g. ``tags.`category` = 'billing'``); a clause on anything else raises, since a dataset
+    row only carries tags. ``.where()`` validates this up front, so the raising path here is a
+    defensive fallback.
     """
-    from mlflow.utils.search_utils import SearchTraceUtils
-
-    parsed = SearchTraceUtils.parse_search_filter_for_search_traces(filter_string)
-    for clause in parsed:
-        if clause.get("type") != SearchTraceUtils._TAG_IDENTIFIER:
-            raise MlflowException.invalid_parameter_value(
-                "Scorer filters set with `where()` may only reference tags, e.g. "
-                "\"tags.`category` = 'billing'\". "
-                f"Got a filter on '{clause.get('key')}'."
-            )
+    parsed = _parse_tag_filter(filter_string)
     row = _RowTags(tags)
     return all(SearchTraceUtils._does_trace_match_clause(row, clause) for clause in parsed)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -33,6 +33,7 @@ from mlflow.tracking._tracking_service.utils import get_tracking_uri
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import is_databricks_uri
+from mlflow.utils.search_utils import SearchTraceUtils
 
 _logger = logging.getLogger(__name__)
 
@@ -287,6 +288,32 @@ def _record_scorer_call_with_context(func):
     return wrapper
 
 
+def _parse_tag_filter(filter_string: str) -> list[dict[str, Any]]:
+    """Parse a :meth:`Scorer.where` filter and require every clause to reference a tag.
+
+    Uses the raw search parser, not the ``search_traces`` variant: the latter rewrites reserved
+    keys (e.g. ``tags.`name``` becomes the trace-name tag, ``tags.`timestamp``` becomes
+    ``timestamp_ms``), which would silently change which tag a filter matches. Only tag clauses
+    are supported, since an evaluation row carries only tags; a clause on anything else
+    (``trace.status``, a bare ``name``, ``metadata.*``) raises. Returns the parsed clauses so
+    callers can match them without re-parsing.
+    """
+    try:
+        parsed = SearchTraceUtils.parse_search_filter(filter_string)
+    except MlflowException as e:
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid filter string {filter_string!r} passed to `where()`: {e.message}"
+        ) from e
+    for clause in parsed:
+        if clause.get("type") != SearchTraceUtils._TAG_IDENTIFIER:
+            raise MlflowException.invalid_parameter_value(
+                "Scorer filters set with `where()` may only reference tags, e.g. "
+                "\"tags.`category` = 'billing'\". "
+                f"Got a filter on '{clause.get('key')}'."
+            )
+    return parsed
+
+
 class Scorer(BaseModel):
     name: str
     aggregations: list[_AggregationType] | None = None
@@ -301,10 +328,11 @@ class Scorer(BaseModel):
     # testing concern and is intentionally not serialized. ``None`` falls back to
     # the default rule (yes/no or bool).
     _pass_if: Callable[[Any], bool] | None = PrivateAttr(default=None)
-    # Row filter set via ``.where()``. When set, this scorer only runs on
-    # ``mlflow.genai.evaluate`` rows whose tags match this ``search_traces``-style filter
-    # string. In-process only: it is an offline evaluation concern, is intentionally not
-    # serialized, and is unrelated to the monitoring ``_sampling_config.filter_string``.
+    # Tag filter set via ``.where()``. When set, this scorer only runs on
+    # ``mlflow.genai.evaluate`` rows whose tags match this filter (tag clauses only, e.g.
+    # ``tags.`category` = 'billing'``). In-process only: it is an offline evaluation concern,
+    # is intentionally not serialized, and is unrelated to the monitoring
+    # ``_sampling_config.filter_string``.
     _row_filter: str | None = PrivateAttr(default=None)
 
     def __init_subclass__(cls, **kwargs):
@@ -355,11 +383,13 @@ class Scorer(BaseModel):
         """Get the filter string for this scorer."""
         return self._sampling_config.filter_string if self._sampling_config else None
 
+    @experimental(version="3.16.0")
     @property
     def row_filter(self) -> str | None:
         """Tag filter set via :meth:`where`; ``None`` means the scorer runs on every row."""
         return self._row_filter
 
+    @experimental(version="3.16.0")
     def where(self, filter_string: str) -> "Scorer":
         """Scope this scorer to evaluation rows whose tags match ``filter_string``.
 
@@ -368,9 +398,16 @@ class Scorer(BaseModel):
         filter runs on every row as usual.
 
         Args:
-            filter_string: An MLflow ``search_traces``-style filter over the row's tags, e.g.
-                ``"tags.`category` = 'billing'"``. Only tag clauses are supported; ``AND``,
-                ``!=`` and ``IS [NOT] NULL`` work as in ``search_traces``.
+            filter_string: A filter over the row's **tags** only, using MLflow's ``search_traces``
+                filter grammar restricted to tag clauses, e.g. ``"tags.`category` = 'billing'"``.
+                ``AND``, ``=``, ``!=`` and ``IS [NOT] NULL`` are supported. A clause on anything
+                other than a tag (e.g. ``trace.status``, a bare ``name``, or ``metadata.*``)
+                raises, since an evaluation row carries only tags.
+
+        .. note::
+            The filter matches on tags known before scoring: the dataset ``tags`` column, or
+            tags already present on input traces. Tags added at runtime inside a ``predict_fn``
+            (e.g. via ``mlflow.update_current_trace(tags=...)``) are not visible to the filter.
 
         Example:
             .. code-block:: python
@@ -395,6 +432,9 @@ class Scorer(BaseModel):
                 f"Scorer '{self.name}' is a session-level scorer and cannot be scoped with "
                 f"`where()`. Row-tag filters apply to per-row (single-turn) scorers only."
             )
+        # Fail fast: reject an invalid or non-tag filter here, at construction, rather than
+        # per row deep inside the evaluation harness.
+        _parse_tag_filter(filter_string)
         new_scorer = self.model_copy()
         new_scorer._row_filter = filter_string
         return new_scorer
@@ -1720,6 +1760,16 @@ def make_scorer_ensemble(
     if not scorers:
         raise MlflowException.invalid_parameter_value(
             "make_scorer_ensemble requires at least one sub-scorer."
+        )
+
+    # An ensemble runs all its sub-scorers and reduces them to one Feedback, and row filtering
+    # only reads ``row_filter`` on the top-level scorer -- a sub-scorer's ``where()`` would be
+    # silently ignored. Reject it here and point the user at scoping the ensemble instead.
+    if scoped := [s.name for s in scorers if s.row_filter is not None]:
+        raise MlflowException.invalid_parameter_value(
+            f"Sub-scorers passed to make_scorer_ensemble must not be scoped with `where()` "
+            f"(got scoped sub-scorer(s): {scoped}). Scope the ensemble itself instead, e.g. "
+            f"`make_scorer_ensemble(...).where(\"tags.`k` = 'v'\")`."
         )
 
     levels = {s.is_session_level_scorer for s in scorers}

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -301,6 +301,11 @@ class Scorer(BaseModel):
     # testing concern and is intentionally not serialized. ``None`` falls back to
     # the default rule (yes/no or bool).
     _pass_if: Callable[[Any], bool] | None = PrivateAttr(default=None)
+    # Row filter set via ``.where()``. When set, this scorer only runs on
+    # ``mlflow.genai.evaluate`` rows whose tags match this ``search_traces``-style filter
+    # string. In-process only: it is an offline evaluation concern, is intentionally not
+    # serialized, and is unrelated to the monitoring ``_sampling_config.filter_string``.
+    _row_filter: str | None = PrivateAttr(default=None)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -349,6 +354,50 @@ class Scorer(BaseModel):
     def filter_string(self) -> str | None:
         """Get the filter string for this scorer."""
         return self._sampling_config.filter_string if self._sampling_config else None
+
+    @property
+    def row_filter(self) -> str | None:
+        """Tag filter set via :meth:`where`; ``None`` means the scorer runs on every row."""
+        return self._row_filter
+
+    def where(self, filter_string: str) -> "Scorer":
+        """Scope this scorer to evaluation rows whose tags match ``filter_string``.
+
+        Returns a copy of this scorer that, during :func:`mlflow.genai.evaluate`, only runs on
+        rows whose tags satisfy ``filter_string`` and is skipped on the rest. A scorer with no
+        filter runs on every row as usual.
+
+        Args:
+            filter_string: An MLflow ``search_traces``-style filter over the row's tags, e.g.
+                ``"tags.`category` = 'billing'"``. Only tag clauses are supported; ``AND``,
+                ``!=`` and ``IS [NOT] NULL`` work as in ``search_traces``.
+
+        Example:
+            .. code-block:: python
+
+                import mlflow
+                from mlflow.genai.scorers import Correctness, Safety
+
+                mlflow.genai.evaluate(
+                    data=dataset,
+                    scorers=[
+                        Correctness(),  # every row
+                        Safety().where("tags.`pii` = 'true'"),  # only rows tagged pii=true
+                    ],
+                )
+        """
+        if not isinstance(filter_string, str) or not filter_string.strip():
+            raise MlflowException.invalid_parameter_value(
+                "`filter_string` passed to `where()` must be a non-empty string."
+            )
+        if self.is_session_level_scorer:
+            raise MlflowException.invalid_parameter_value(
+                f"Scorer '{self.name}' is a session-level scorer and cannot be scoped with "
+                f"`where()`. Row-tag filters apply to per-row (single-turn) scorers only."
+            )
+        new_scorer = self.model_copy()
+        new_scorer._row_filter = filter_string
+        return new_scorer
 
     @property
     def status(self) -> ScorerStatus:

--- a/tests/genai/evaluate/test_tag_scoped_scorers.py
+++ b/tests/genai/evaluate/test_tag_scoped_scorers.py
@@ -1,0 +1,192 @@
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.entities import EvalItem
+from mlflow.genai.evaluation.harness import _scorers_for_item
+from mlflow.genai.evaluation.utils import row_matches_scorer_filter
+from mlflow.genai.scorers.base import scorer
+from mlflow.genai.scorers.builtin_scorers import Safety, UserFrustration
+
+
+@scorer
+def always_true(outputs) -> bool:
+    return True
+
+
+@scorer
+def always_false(outputs) -> bool:
+    return False
+
+
+def _values(result, scorer_name: str) -> list[Any]:
+    return result.result_df[f"{scorer_name}/value"].tolist()
+
+
+# ---- row_matches_scorer_filter ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tags", "filter_string", "expected"),
+    [
+        ({"category": "billing"}, "tags.`category` = 'billing'", True),
+        ({"category": "greeting"}, "tags.`category` = 'billing'", False),
+        ({}, "tags.`category` = 'billing'", False),
+        ({"category": "greeting"}, "tags.`category` != 'billing'", True),
+        ({"pii": "x"}, "tags.`pii` IS NOT NULL", True),
+        ({"other": "x"}, "tags.`pii` IS NULL", True),
+        (
+            {"category": "billing", "reviewed": "true"},
+            "tags.`category` = 'billing' AND tags.`reviewed` = 'true'",
+            True,
+        ),
+        (
+            {"category": "billing"},
+            "tags.`category` = 'billing' AND tags.`reviewed` = 'true'",
+            False,
+        ),
+    ],
+)
+def test_row_matches_scorer_filter(tags: dict[str, str], filter_string: str, expected: bool):
+    assert row_matches_scorer_filter(tags, filter_string) is expected
+
+
+def test_row_matches_scorer_filter_none_tags():
+    assert row_matches_scorer_filter(None, "tags.`category` = 'billing'") is False
+
+
+def test_row_matches_scorer_filter_rejects_non_tag_clause():
+    with pytest.raises(MlflowException, match="may only reference tags"):
+        row_matches_scorer_filter({"category": "billing"}, "trace.status = 'OK'")
+
+
+# ---- Scorer.where -------------------------------------------------------------
+
+
+def test_where_returns_copy_and_sets_filter():
+    scoped = always_true.where("tags.`category` = 'billing'")
+
+    assert scoped is not always_true
+    assert always_true.row_filter is None
+    assert scoped.row_filter == "tags.`category` = 'billing'"
+    assert scoped.name == always_true.name
+
+
+def test_where_on_builtin_scorer():
+    scoped = Safety().where("tags.`pii` = 'true'")
+
+    assert isinstance(scoped, Safety)
+    assert scoped.row_filter == "tags.`pii` = 'true'"
+
+
+@pytest.mark.parametrize("bad", ["", "   ", None])
+def test_where_rejects_empty_filter(bad):
+    with pytest.raises(MlflowException, match="must be a non-empty string"):
+        always_true.where(bad)
+
+
+def test_where_rejects_session_level_scorer():
+    with pytest.raises(MlflowException, match="session-level scorer"):
+        UserFrustration().where("tags.`x` = 'y'")
+
+
+# ---- _scorers_for_item --------------------------------------------------------
+
+
+def _eval_item(tags=None) -> EvalItem:
+    return EvalItem(request_id="r", inputs={"q": "a"}, outputs="x", expectations={}, tags=tags)
+
+
+def test_scorers_for_item_returns_same_list_when_no_filters():
+    scorers = [always_true, always_false]
+
+    assert _scorers_for_item(_eval_item({"category": "billing"}), scorers) is scorers
+
+
+def test_scorers_for_item_keeps_matching_scoped_scorer():
+    scoped = always_false.where("tags.`category` = 'billing'")
+
+    result = _scorers_for_item(_eval_item({"category": "billing"}), [always_true, scoped])
+
+    assert [s.name for s in result] == ["always_true", "always_false"]
+
+
+def test_scorers_for_item_drops_non_matching_scoped_scorer():
+    scoped = always_false.where("tags.`category` = 'billing'")
+
+    result = _scorers_for_item(_eval_item({"category": "greeting"}), [always_true, scoped])
+
+    assert [s.name for s in result] == ["always_true"]
+
+
+def test_scorers_for_item_untagged_row_only_runs_unscoped():
+    scoped = always_false.where("tags.`category` = 'billing'")
+
+    result = _scorers_for_item(_eval_item(tags=None), [always_true, scoped])
+
+    assert [s.name for s in result] == ["always_true"]
+
+
+# ---- end-to-end ---------------------------------------------------------------
+
+
+def test_scoped_scorer_runs_only_on_matching_rows():
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}},
+        {"inputs": {"q": "b"}, "outputs": "y", "tags": {"category": "greeting"}},
+    ]
+
+    result = mlflow.genai.evaluate(
+        data=data,
+        scorers=[always_true, always_false.where("tags.`category` = 'billing'")],
+    )
+
+    # The unscoped scorer ran on every row; the scoped one on exactly the one matching row.
+    assert _values(result, "always_true") == [True, True]
+    scoped_values = _values(result, "always_false")
+    assert [v for v in scoped_values if not pd.isna(v)] == [False]
+
+
+def test_scoped_scorer_metric_aggregates_over_matched_rows_only():
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}},
+        {"inputs": {"q": "b"}, "outputs": "y", "tags": {"category": "greeting"}},
+        {"inputs": {"q": "c"}, "outputs": "z", "tags": {"category": "greeting"}},
+    ]
+
+    result = mlflow.genai.evaluate(
+        data=data,
+        scorers=[always_true, always_false.where("tags.`category` = 'billing'")],
+    )
+
+    # always_false ran on the one billing row and returned False, so its mean is 0.0 —
+    # not diluted by the two rows it never ran on.
+    assert result.metrics["always_false/mean"] == 0.0
+    assert result.metrics["always_true/mean"] == 1.0
+
+
+def test_scoped_scorer_matches_dataframe_tags_column():
+    data = pd.DataFrame([
+        {"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}},
+        {"inputs": {"q": "b"}, "outputs": "y", "tags": {"category": "greeting"}},
+    ])
+
+    result = mlflow.genai.evaluate(
+        data=data,
+        scorers=[always_true, always_false.where("tags.`category` = 'billing'")],
+    )
+
+    assert result.metrics["always_false/mean"] == 0.0
+
+
+def test_unresolvable_filter_clause_errors_at_evaluate():
+    data = [{"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}}]
+
+    with pytest.raises(MlflowException, match="may only reference tags"):
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[always_false.where("trace.status = 'OK'")],
+        )

--- a/tests/genai/evaluate/test_tag_scoped_scorers.py
+++ b/tests/genai/evaluate/test_tag_scoped_scorers.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import pandas as pd
@@ -8,7 +9,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.evaluation.entities import EvalItem
 from mlflow.genai.evaluation.harness import _scorers_for_item
 from mlflow.genai.evaluation.utils import row_matches_scorer_filter
-from mlflow.genai.scorers.base import scorer
+from mlflow.genai.scorers.base import make_scorer_ensemble, scorer
 from mlflow.genai.scorers.builtin_scorers import Safety, UserFrustration
 
 
@@ -48,6 +49,11 @@ def _values(result, scorer_name: str) -> list[Any]:
             "tags.`category` = 'billing' AND tags.`reviewed` = 'true'",
             False,
         ),
+        # Tag keys that collide with reserved trace fields must match the literal tag, not be
+        # rewritten (`name` -> the trace-name tag, `timestamp` -> `timestamp_ms`).
+        ({"name": "custom"}, "tags.`name` = 'custom'", True),
+        ({"name": "other"}, "tags.`name` = 'custom'", False),
+        ({"timestamp": "noon"}, "tags.`timestamp` = 'noon'", True),
     ],
 )
 def test_row_matches_scorer_filter(tags: dict[str, str], filter_string: str, expected: bool):
@@ -91,6 +97,45 @@ def test_where_rejects_empty_filter(bad):
 def test_where_rejects_session_level_scorer():
     with pytest.raises(MlflowException, match="session-level scorer"):
         UserFrustration().where("tags.`x` = 'y'")
+
+
+@pytest.mark.parametrize(
+    "non_tag_filter",
+    [
+        "trace.status = 'OK'",
+        "name = 'x'",
+        "metadata.`run_id` = 'r'",
+    ],
+)
+def test_where_rejects_non_tag_clause_at_construction(non_tag_filter):
+    # Fail fast: a non-tag clause is rejected when the scorer is scoped, not per row at eval time.
+    with pytest.raises(MlflowException, match="may only reference tags"):
+        always_true.where(non_tag_filter)
+
+
+def test_where_rejects_malformed_filter():
+    with pytest.raises(MlflowException, match="Invalid filter string"):
+        always_true.where("not a valid filter")
+
+
+def test_where_on_ensemble_scopes_whole_ensemble():
+    ens = make_scorer_ensemble(
+        name="ens", scorers=[always_true, always_false], ensemble_fn="agg_all"
+    )
+    scoped = ens.where("tags.`category` = 'billing'")
+
+    assert scoped.row_filter == "tags.`category` = 'billing'"
+
+
+def test_make_scorer_ensemble_rejects_scoped_sub_scorer():
+    # A sub-scorer's `where()` would be silently ignored (only the top-level scorer's row_filter
+    # is read), so it is rejected at construction.
+    with pytest.raises(MlflowException, match="must not be scoped with"):
+        make_scorer_ensemble(
+            name="ens",
+            scorers=[always_true.where("tags.`x` = 'y'"), always_false],
+            ensemble_fn="agg_all",
+        )
 
 
 # ---- _scorers_for_item --------------------------------------------------------
@@ -151,21 +196,28 @@ def test_scoped_scorer_runs_only_on_matching_rows():
 
 
 def test_scoped_scorer_metric_aggregates_over_matched_rows_only():
+    # A row-varying scorer: True only when q == "a". Of the two billing rows it is scoped to,
+    # one matches and one doesn't, so the matched-only mean is 0.5. If scoping were broken and
+    # it ran on all four rows the mean would be 0.25 — so this assertion is load-bearing.
+    @scorer
+    def q_is_a(inputs) -> bool:
+        return inputs["q"] == "a"
+
     data = [
         {"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}},
-        {"inputs": {"q": "b"}, "outputs": "y", "tags": {"category": "greeting"}},
+        {"inputs": {"q": "b"}, "outputs": "y", "tags": {"category": "billing"}},
         {"inputs": {"q": "c"}, "outputs": "z", "tags": {"category": "greeting"}},
+        {"inputs": {"q": "d"}, "outputs": "w", "tags": {"category": "greeting"}},
     ]
 
     result = mlflow.genai.evaluate(
         data=data,
-        scorers=[always_true, always_false.where("tags.`category` = 'billing'")],
+        scorers=[q_is_a.where("tags.`category` = 'billing'")],
     )
 
-    # always_false ran on the one billing row and returned False, so its mean is 0.0 —
-    # not diluted by the two rows it never ran on.
-    assert result.metrics["always_false/mean"] == 0.0
-    assert result.metrics["always_true/mean"] == 1.0
+    assert result.metrics["q_is_a/mean"] == 0.5
+    # The two greeting rows the scorer never ran on carry no value.
+    assert [v for v in _values(result, "q_is_a") if not pd.isna(v)] == [True, False]
 
 
 def test_scoped_scorer_matches_dataframe_tags_column():
@@ -182,14 +234,53 @@ def test_scoped_scorer_matches_dataframe_tags_column():
     assert result.metrics["always_false/mean"] == 0.0
 
 
-def test_unresolvable_filter_clause_errors_at_evaluate():
-    data = [{"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}}]
+def _capture_harness_warnings() -> tuple[logging.Handler, list[str]]:
+    """A handler attached directly to the harness logger; the ``mlflow`` logger sets
+    ``propagate=False``, so pytest's root-level ``caplog`` never sees these records.
+    """
+    messages: list[str] = []
 
-    with pytest.raises(MlflowException, match="may only reference tags"):
-        mlflow.genai.evaluate(
-            data=data,
-            scorers=[always_false.where("trace.status = 'OK'")],
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            messages.append(record.getMessage())
+
+    return _Capture(level=logging.WARNING), messages
+
+
+def test_mixed_dataset_with_untagged_rows_runs():
+    # A row that omits `tags` becomes a pandas NaN cell; the scoped scorer must skip it rather
+    # than crash on `NaN.get(...)`.
+    data = [
+        {"inputs": {"q": "a"}, "outputs": "x", "tags": {"pii": "true"}},
+        {"inputs": {"q": "b"}, "outputs": "y"},
+    ]
+
+    result = mlflow.genai.evaluate(
+        data=data,
+        scorers=[always_true, always_false.where("tags.`pii` = 'true'")],
+    )
+
+    assert _values(result, "always_true") == [True, True]
+    scoped_values = _values(result, "always_false")
+    assert [v for v in scoped_values if not pd.isna(v)] == [False]
+
+
+def test_zero_match_scoped_scorer_warns_and_is_dropped():
+    handler, messages = _capture_harness_warnings()
+    logger = logging.getLogger("mlflow.genai.evaluation.harness")
+    logger.addHandler(handler)
+    try:
+        result = mlflow.genai.evaluate(
+            data=[{"inputs": {"q": "a"}, "outputs": "x", "tags": {"category": "billing"}}],
+            scorers=[always_true, always_false.where("tags.`category` = 'nonexistent'")],
         )
+    finally:
+        logger.removeHandler(handler)
+
+    assert any("always_false" in m and "no rows in the dataset match" in m for m in messages)
+    # A zero-match scorer produces no metric at all; the unscoped scorer is unaffected.
+    assert result.metrics["always_true/mean"] == 1.0
+    assert "always_false/mean" not in result.metrics
 
 
 def test_scoped_scorer_matches_trace_tags(monkeypatch, tmp_path):

--- a/tests/genai/evaluate/test_tag_scoped_scorers.py
+++ b/tests/genai/evaluate/test_tag_scoped_scorers.py
@@ -190,3 +190,29 @@ def test_unresolvable_filter_clause_errors_at_evaluate():
             data=data,
             scorers=[always_false.where("trace.status = 'OK'")],
         )
+
+
+def test_scoped_scorer_matches_trace_tags(monkeypatch, tmp_path):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", f"sqlite:///{tmp_path / 'mlflow.db'}")
+    mlflow.set_experiment("tag-scoped-trace")
+
+    @mlflow.trace
+    def app(q):
+        mlflow.update_current_trace(tags={"category": "billing" if q == "a" else "greeting"})
+        return "refund" if q == "a" else "hi"
+
+    trace_ids = []
+    for q in ("a", "b"):
+        app(q)
+        trace_ids.append(mlflow.get_last_active_trace_id())
+    traces = [mlflow.get_trace(tid, flush=True) for tid in trace_ids]
+
+    # A list of Trace objects flows through `traces_to_df`, which surfaces each trace's tags
+    # as the row's `tags`, so `.where()` matches on them.
+    result = mlflow.genai.evaluate(
+        data=traces,
+        scorers=[always_true, always_false.where("tags.`category` = 'billing'")],
+    )
+
+    scoped_values = _values(result, "always_false")
+    assert [v for v in scoped_values if not pd.isna(v)] == [False]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`mlflow.genai.evaluate()` runs every scorer against every row. This adds `scorer.where(filter_string)`, which returns a copy of the scorer that only runs on rows whose tags match `filter_string`. An unscoped scorer still runs on every row.

```python
from mlflow.genai.scorers import Correctness, Safety

mlflow.genai.evaluate(
    data=dataset,
    scorers=[
        Correctness(),                          # every row
        Safety().where("tags.`pii` = 'true'"),  # only rows tagged pii=true
    ],
)
```

Design notes:

- **Filter is an MLflow `search_traces`-style filter over the row's tags**, e.g. `` tags.`category` = 'billing' ``. Matching reuses the existing filter grammar and its in-memory evaluator (`SearchTraceUtils`), so `AND` / `!=` / `IS [NOT] NULL` work as they do in `search_traces`. Matching is scoped to tag clauses; a clause on anything else (e.g. `trace.status`) raises, since a dataset row only carries tags.
- **`where()` returns a copy** (via `model_copy`) and lives on the base `Scorer`, so built-in and custom `@scorer` scorers both get it. The filter is held in a private, in-process-only attribute — not serialized, and separate from the monitoring `ScorerSamplingConfig.filter_string`.
- **Aggregation:** a scoped scorer's metric is averaged over only the rows it ran on, not the full row count.
- **Row tags** come from the dataset record's `tags`, the `tags` column of in-memory data, or — for a list of `Trace` objects — the trace's own tags (surfaced by `traces_to_df` as the row's `tags`). So `.where()` matches on all three, with no change to the trace-to-row plumbing.
- **Session-level scorers** cannot be scoped — `where()` on one raises, since row-tag filtering is inherently single-turn.

No dataset, schema, proto, or backend changes — this is a pure `evaluate()`-side feature, OSS only.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New `tests/genai/evaluate/test_tag_scoped_scorers.py` covers the tag matcher (`=`, `!=`, `AND`, `IS [NOT] NULL`, missing tags, non-tag-clause rejection), `where()` (copy semantics, builtins, empty-filter and session-level rejection), per-row scorer selection, and end-to-end runs asserting a scoped scorer runs only on matching rows and its metric aggregates over just those rows.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

Added `Scorer.where()` with a docstring/example and a usage block in the `mlflow.genai.evaluate()` docstring.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [ ] No.
- [x] Yes. Please link the corresponding PR or explain how you plan to update it.

The evaluation skill's description of how scorers apply to a dataset should mention scoping a scorer to a subset of rows with `.where()`. Happy to follow up once the API is settled.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.genai.evaluate()` scorers can now be scoped to a subset of rows by tag with `scorer.where("tags.`key` = 'value'")`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.