### PR TITLE
Fix remaining `torch_dtype` deprecation warnings on load and save paths

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -316,7 +316,8 @@ def save_model(
 
                 1. A transformers `Pipeline` instance.
                 2. A dictionary that maps required components of a pipeline to the named keys
-                    of ["model", "image_processor", "tokenizer", "feature_extractor"].
+                    of ["model", "image_processor", "tokenizer", "feature_extractor",
+                    "torch_dtype"].
                     The `model` key in the dictionary must map to a value that inherits from
                     `PreTrainedModel`, `TFPreTrainedModel`, or `FlaxPreTrainedModel`.
                     All other component entries in the dictionary must support the defined task
@@ -892,7 +893,8 @@ def log_model(
 
                 1. A transformers `Pipeline` instance.
                 2. A dictionary that maps required components of a pipeline to the named keys
-                    of ["model", "image_processor", "tokenizer", "feature_extractor"].
+                    of ["model", "image_processor", "tokenizer", "feature_extractor",
+                    "torch_dtype"].
                     The `model` key in the dictionary must map to a value that inherits from
                     `PreTrainedModel`, `TFPreTrainedModel`, or `FlaxPreTrainedModel`.
                     All other component entries in the dictionary must support the defined task
@@ -1424,13 +1426,12 @@ def _load_model(
         conf["device"] = device
         accelerate_model_conf["device"] = device
 
-    if dtype_val := (
-        # Accept either the legacy `torch_dtype` kwarg or the `dtype` name used by newer
-        # transformers versions, falling back to the value recorded in the flavor config.
-        kwargs.get(_TORCH_DTYPE_KEY)
-        or kwargs.get(_DTYPE_KEY)
-        or flavor_config.get(FlavorKey.TORCH_DTYPE)
-    ):
+    # Pop both dtype spellings so the `conf.update(**kwargs)` below cannot re-add a raw
+    # user-provided name on top of the renamed one. If both are passed, `dtype` wins,
+    # matching transformers' own precedence.
+    torch_dtype_arg = kwargs.pop(_TORCH_DTYPE_KEY, None)
+    dtype_arg = kwargs.pop(_DTYPE_KEY, None)
+    if dtype_val := dtype_arg or torch_dtype_arg or flavor_config.get(FlavorKey.TORCH_DTYPE):
         if isinstance(dtype_val, str):
             dtype_val = _deserialize_torch_dtype(dtype_val)
         # Newer transformers versions (>= 4.56.0) renamed the `torch_dtype` kwarg to `dtype` and
@@ -1638,6 +1639,11 @@ def _build_pipeline_from_model_input(model_dict: dict[str, Any], task: str | Non
     if task is None or task.startswith(_LLM_INFERENCE_TASK_PREFIX):
         default_task = _get_default_task_for_llm_inference_task(task)
         task = _get_task_for_model(model.name_or_path, default_task=default_task)
+
+    # Copy so renaming the dtype key does not mutate the caller's dict
+    model_dict = dict(model_dict)
+    if dtype_val := model_dict.pop(_TORCH_DTYPE_KEY, None):
+        model_dict[_get_torch_dtype_kwarg_name()] = dtype_val
 
     try:
         with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -9,6 +9,7 @@ import pathlib
 import re
 import shutil
 import textwrap
+from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
 
@@ -49,6 +50,7 @@ from mlflow.transformers import (
     get_default_conda_env,
     get_default_pip_requirements,
 )
+from mlflow.transformers.torch_utils import _get_torch_dtype_kwarg_name
 from mlflow.types.schema import Array, ColSpec, DataType, ParamSchema, ParamSpec, Schema
 from mlflow.utils.environment import _mlflow_conda_env
 
@@ -413,6 +415,31 @@ def test_basic_save_model_with_torch_dtype(text2text_generation_pipeline, model_
     assert loaded.model.dtype == torch.float32
 
 
+@contextmanager
+def _capture_transformers_log_messages():
+    # transformers >= 4.56.0 warns via `logger.warning_once` when the deprecated `torch_dtype`
+    # kwarg is passed to `from_pretrained`/`pipeline`, so capture the transformers logger output.
+    messages = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    handler = _CaptureHandler()
+    transformers_logger = logging.getLogger("transformers")
+    transformers_logger.addHandler(handler)
+    try:
+        yield messages
+    finally:
+        transformers_logger.removeHandler(handler)
+
+
+def _reset_transformers_warning_once_cache():
+    # `logger.warning_once` deduplicates for the lifetime of the process; reset it so a
+    # warning consumed by an earlier test cannot mask one triggered here.
+    transformers.utils.logging.warning_once.cache_clear()
+
+
 def test_load_model_does_not_emit_torch_dtype_deprecation_warning(
     text_classification_pipeline, model_path
 ):
@@ -427,25 +454,72 @@ def test_load_model_does_not_emit_torch_dtype_deprecation_warning(
     flavor_conf = Model.load(model_path).flavors[mlflow.transformers.FLAVOR_NAME]
     assert flavor_conf["torch_dtype"] == str(text_classification_pipeline.model.dtype)
 
-    # transformers >= 4.56.0 warns via `logger.warning_once` when the deprecated `torch_dtype`
-    # kwarg is passed to `from_pretrained`/`pipeline`, so capture the transformers logger output.
-    messages = []
-
-    class _CaptureHandler(logging.Handler):
-        def emit(self, record):
-            messages.append(record.getMessage())
-
-    handler = _CaptureHandler()
-    transformers_logger = logging.getLogger("transformers")
-    transformers_logger.addHandler(handler)
-    try:
+    _reset_transformers_warning_once_cache()
+    with _capture_transformers_log_messages() as messages:
         loaded = mlflow.transformers.load_model(model_path)
-    finally:
-        transformers_logger.removeHandler(handler)
 
     assert not any("torch_dtype` is deprecated" in msg for msg in messages)
     # The recorded dtype is still applied on load.
     assert loaded.model.dtype == text_classification_pipeline.model.dtype
+
+
+@pytest.mark.parametrize("dtype_kwarg", ["torch_dtype", "dtype"])
+def test_load_model_with_explicit_dtype_does_not_emit_deprecation_warning(
+    text_classification_pipeline, model_path, dtype_kwarg
+):
+    mlflow.transformers.save_model(
+        transformers_model=text_classification_pipeline,
+        path=model_path,
+    )
+
+    _reset_transformers_warning_once_cache()
+    original_pipeline = transformers.pipeline
+    with (
+        _capture_transformers_log_messages() as messages,
+        mock.patch("transformers.pipeline", side_effect=original_pipeline) as pipeline_spy,
+    ):
+        loaded = mlflow.transformers.load_model(model_path, **{dtype_kwarg: torch.float16})
+
+    assert not any("torch_dtype` is deprecated" in msg for msg in messages)
+    # Only the spelling the installed transformers version expects reaches `pipeline()`.
+    expected_kwarg = _get_torch_dtype_kwarg_name()
+    unexpected_kwarg = "torch_dtype" if expected_kwarg == "dtype" else "dtype"
+    assert pipeline_spy.call_args.kwargs[expected_kwarg] == torch.float16
+    assert unexpected_kwarg not in pipeline_spy.call_args.kwargs
+    # The explicitly requested dtype overrides the recorded one.
+    assert loaded.model.dtype == torch.float16
+
+
+def test_save_model_with_dict_input_dtype_does_not_emit_deprecation_warning(
+    text_classification_pipeline, model_path
+):
+    model_dict = {
+        "model": text_classification_pipeline.model,
+        "tokenizer": text_classification_pipeline.tokenizer,
+        "torch_dtype": torch.float16,
+    }
+    original_model_dict = dict(model_dict)
+
+    _reset_transformers_warning_once_cache()
+    original_pipeline = transformers.pipeline
+    with (
+        _capture_transformers_log_messages() as messages,
+        mock.patch("transformers.pipeline", side_effect=original_pipeline) as pipeline_spy,
+    ):
+        mlflow.transformers.save_model(
+            transformers_model=model_dict,
+            path=model_path,
+            task="text-classification",
+        )
+
+    assert not any("torch_dtype` is deprecated" in msg for msg in messages)
+    # The dtype is forwarded under the spelling the installed transformers version expects.
+    expected_kwarg = _get_torch_dtype_kwarg_name()
+    unexpected_kwarg = "torch_dtype" if expected_kwarg == "dtype" else "dtype"
+    assert pipeline_spy.call_args_list[0].kwargs[expected_kwarg] == torch.float16
+    assert unexpected_kwarg not in pipeline_spy.call_args_list[0].kwargs
+    # The caller's dict is not mutated.
+    assert model_dict == original_model_dict
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):


### PR DESCRIPTION
### Related Issues/PRs

Closes #25021 (follow-up to #24929)

### What changes are proposed in this pull request?

#24929 stopped the `torch_dtype is deprecated` warning for the main model load path, but two paths still trigger it on transformers >= 4.56:

- loading with an explicit dtype (`mlflow.transformers.load_model(uri, torch_dtype=...)`): the raw kwarg survives into `conf.update(**kwargs)` and reaches `pipeline()` under its deprecated name
- saving a components dict (`save_model(transformers_model={..., "torch_dtype": ...})`): `_build_pipeline_from_model_input` forwards the key to `pipeline()` as-is

This PR closes both. The load path now pops both the `torch_dtype` and `dtype` spellings from the kwargs and forwards a single argument under the name the installed transformers version expects. It reuses `_get_torch_dtype_kwarg_name()` from #24929 instead of adding a second helper. When both spellings are passed, `dtype` wins, which matches how transformers itself resolves them. The save path renames the key on a copy of the input dict, so the caller's dict stays untouched.

The MLmodel metadata format and the public `save_model`/`load_model` APIs are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Two new tests cover the two paths. Both fail on current master and pass with this change. The load test is parametrized over both spellings; the `dtype` spelling already worked on master, so that case passes there too. They spy on the kwargs that actually reach `pipeline()` and assert that only the version-appropriate spelling is present, and that no deprecation message shows up in the transformers logger output (the warning goes through `logger.warning_once`, which `pytest.warns` cannot catch). The expectations adapt to the installed transformers version, so the same tests exercise the old-name branch on pre-4.56 versions in the CI matrix.

I also ran the dtype-related test selection against transformers 5.14.1 and 4.55.4 locally: the tests for this change pass on both versions. On master with transformers 5.14.1, exactly the two new tests fail. The only local failure is a pre-existing float64 case that fails identically on master, because Apple Silicon's MPS backend has no float64 support.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `torch_dtype` deprecation warnings that still appeared when loading a transformers model with an explicit dtype or saving one from a components dict.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release