### PR TITLE
fix(tracing): align trace usage and cost aggregation

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -213,8 +213,7 @@ from mlflow.tracing.trace_archival_config import get_trace_archival_server_confi
 from mlflow.tracing.utils import (
     SpanAggregationNode,
     TraceJSONEncoder,
-    aggregate_cost_from_span_nodes,
-    aggregate_usage_from_span_nodes,
+    aggregate_usage_and_cost_from_span_nodes,
     generate_request_id_v2,
     try_json_loads,
 )
@@ -5306,17 +5305,21 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                                 continue
                             trace_tags_from_root_attr[tag_key] = tag_value
 
-            # Tree-aware aggregation matching the client-side aggregator
-            # (aggregate_usage_from_spans): rollup autologgers (e.g. pydantic_ai, agno,
-            # dspy) set cumulative usage on parent spans, so a flat sum over all spans
-            # would double-count parent and children.
+            # Tree-aware aggregation matching the client-side aggregator:
+            # rollup autologgers (e.g. pydantic_ai, agno, dspy) set cumulative usage on
+            # parent spans, so a flat sum over all spans would double-count parent and
+            # children. Usage and cost must use the same contributing span set because a
+            # wrapper can carry usage without having a model that can be priced.
+            aggregated_token_usage, aggregated_cost = aggregate_usage_and_cost_from_span_nodes(
+                usage_nodes, cost_nodes
+            )
             trace_aggregates[trace_id] = _TraceAggregate(
                 min_start_ms=min_start_ms,
                 max_end_ms=max_end_ms,
                 root_span_status=root_span_status,
                 trace_status=root_span_status or TraceState.IN_PROGRESS.value,
-                aggregated_token_usage=aggregate_usage_from_span_nodes(usage_nodes) or {},
-                aggregated_cost=aggregate_cost_from_span_nodes(cost_nodes) or {},
+                aggregated_token_usage=aggregated_token_usage,
+                aggregated_cost=aggregated_cost,
                 session_id=session_id,
                 user_id=user_id,
                 root_span_dict=root_span_dict,
@@ -5429,10 +5432,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
             # --- Phase 4: Batch-fetch existing metadata records (up to 3 queries) ---
             trace_ids_with_token_usage = [
-                tid for tid in all_trace_ids if trace_aggregates[tid].aggregated_token_usage
+                tid
+                for tid in all_trace_ids
+                if trace_aggregates[tid].aggregated_token_usage is not None
             ]
             trace_ids_with_cost = [
-                tid for tid in all_trace_ids if trace_aggregates[tid].aggregated_cost
+                tid for tid in all_trace_ids if trace_aggregates[tid].aggregated_cost is not None
             ]
             trace_ids_with_session = [
                 tid for tid in all_trace_ids if trace_aggregates[tid].session_id
@@ -5590,19 +5595,20 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 # (flag set AND an existing record is present). If the flag is set but no
                 # record exists yet (start_trace() lost the race or didn't include token
                 # usage), log_spans() must still write it to avoid data loss.
-                if aggregated_token_usage := agg.aggregated_token_usage:
+                if agg.aggregated_token_usage is not None:
                     existing_record = existing_token_usage.get(trace_id)
                     if trace_id not in finalized_trace_ids or not existing_record:
                         if trace_id in created_trace_ids:
-                            trace_token_usage = aggregated_token_usage
+                            trace_token_usage = agg.aggregated_token_usage
                         else:
                             # Recompute over the full span tree (stored + batch) instead
                             # of accumulating onto the stored value, so rollup parents
                             # arriving in a different batch than their children are
                             # de-duplicated. Spans logged by earlier calls are included
                             # via stored_usage_nodes, so overwriting is lossless.
-                            trace_token_usage = aggregate_usage_from_span_nodes(
-                                agg.usage_nodes + stored_usage_nodes[trace_id]
+                            trace_token_usage, _ = aggregate_usage_and_cost_from_span_nodes(
+                                agg.usage_nodes + stored_usage_nodes[trace_id],
+                                agg.cost_nodes + stored_cost_nodes[trace_id],
                             )
                         if trace_token_usage:
                             metadata_writes[TraceMetadataKey.TOKEN_USAGE] = json.dumps(
@@ -5615,17 +5621,20 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 # Cost metadata — skip only if start_trace() has already written the
                 # authoritative value (flag set AND existing record present). If the flag
                 # is set but no record exists, still write to avoid data loss.
-                if aggregated_cost := agg.aggregated_cost:
+                if agg.aggregated_cost is not None or existing_cost.get(trace_id):
                     existing_record = existing_cost.get(trace_id)
                     if trace_id not in finalized_trace_ids or not existing_record:
                         if trace_id in created_trace_ids:
-                            recorded_cost = aggregated_cost
+                            recorded_cost = agg.aggregated_cost
                         else:
-                            recorded_cost = aggregate_cost_from_span_nodes(
-                                agg.cost_nodes + stored_cost_nodes[trace_id]
+                            _, recorded_cost = aggregate_usage_and_cost_from_span_nodes(
+                                agg.usage_nodes + stored_usage_nodes[trace_id],
+                                agg.cost_nodes + stored_cost_nodes[trace_id],
                             )
                         if recorded_cost:
                             metadata_writes[TraceMetadataKey.COST] = json.dumps(recorded_cost)
+                        elif existing_record:
+                            session.delete(existing_record)
 
                 # Session ID metadata
                 if (
@@ -10161,8 +10170,8 @@ class _TraceAggregate:
     max_end_ms: int | None
     root_span_status: str | None
     trace_status: str
-    aggregated_token_usage: dict[str, Any] = field(default_factory=dict)
-    aggregated_cost: dict[str, Any] = field(default_factory=dict)
+    aggregated_token_usage: dict[str, Any] | None = None
+    aggregated_cost: dict[str, Any] | None = None
     session_id: str | None = None
     user_id: str | None = None
     root_span_dict: dict[str, Any] | None = None

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -33,8 +33,7 @@ from mlflow.tracing.fluent import _set_last_active_trace_id
 from mlflow.tracing.processor.otel_metrics_mixin import OtelMetricsMixin
 from mlflow.tracing.trace_manager import InMemoryTraceManager, _Trace
 from mlflow.tracing.utils import (
-    aggregate_cost_from_spans,
-    aggregate_usage_from_spans,
+    aggregate_usage_and_cost_from_spans,
     get_otel_attribute,
     maybe_get_dependencies_schemas,
     maybe_get_logged_model_id,
@@ -368,10 +367,11 @@ class BaseMlflowSpanProcessor(OtelMetricsMixin, SimpleSpanProcessor):
         # Aggregate token usage and cost as best-effort: this metadata is optional, and a
         # failure here must never abort root-span export / trace finalization (#24344).
         try:
-            if usage := aggregate_usage_from_spans(spans):
+            usage, cost = aggregate_usage_and_cost_from_spans(spans)
+            if usage:
                 trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
 
-            if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
+            if should_compute_cost_client_side() and cost:
                 trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
         except Exception as e:
             _logger.warning(

--- a/mlflow/tracing/processor/inference_table.py
+++ b/mlflow/tracing/processor/inference_table.py
@@ -20,8 +20,7 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
     _try_get_prediction_context,
-    aggregate_cost_from_spans,
-    aggregate_usage_from_spans,
+    aggregate_usage_and_cost_from_spans,
     generate_trace_id_v3,
     get_otel_attribute,
     maybe_get_dependencies_schemas,
@@ -143,10 +142,11 @@ class InferenceTableSpanProcessor(SimpleSpanProcessor):
             # Aggregate token usage and cost as best-effort: this metadata is optional, and
             # a failure here must never abort root-span export / trace finalization (#24344).
             try:
-                if usage := aggregate_usage_from_spans(spans):
+                usage, cost = aggregate_usage_and_cost_from_spans(spans)
+                if usage:
                     trace.info.request_metadata[TraceMetadataKey.TOKEN_USAGE] = json.dumps(usage)
 
-                if should_compute_cost_client_side() and (cost := aggregate_cost_from_spans(spans)):
+                if should_compute_cost_client_side() and cost:
                     trace.info.request_metadata[TraceMetadataKey.COST] = json.dumps(cost)
             except Exception as e:
                 _logger.warning(

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -234,9 +234,17 @@ def _aggregate_from_nodes(
     Returns:
         Aggregated dictionary with the keys, or None if no data found.
     """
-    totals: dict[str, int | float] = dict.fromkeys(keys, default)
-    has_data = False
+    return _aggregate_selected_nodes(
+        nodes,
+        _get_contributing_span_ids(nodes),
+        keys,
+        default,
+        optional_keys,
+    )
 
+
+def _get_contributing_span_ids(nodes: list[SpanAggregationNode]) -> set[str]:
+    """Return span IDs selected by the ancestor-wins aggregation rule."""
     node_ids = {node.span_id for node in nodes}
     children_map: defaultdict[str, list[SpanAggregationNode]] = defaultdict(list)
     roots: list[SpanAggregationNode] = []
@@ -256,6 +264,7 @@ def _aggregate_from_nodes(
     # each node's ancestor_has_data is fixed by its ancestor chain, not by sibling visit
     # order. So a plain stack (no reversed()) yields identical results.
     stack: list[tuple[SpanAggregationNode, bool]] = [(root, False) for root in roots]
+    contributing_span_ids: set[str] = set()
     while stack:
         node, ancestor_has_data = stack.pop()
 
@@ -263,17 +272,106 @@ def _aggregate_from_nodes(
         node_has_data = data is not None
 
         if node_has_data and not ancestor_has_data:
-            for k in keys:
-                totals[k] += data.get(k, default)
-            for k in optional_keys or []:
-                if k in data:
-                    totals[k] = totals.get(k, default) + data[k]
-            has_data = True
+            contributing_span_ids.add(node.span_id)
 
         next_ancestor_has_data = ancestor_has_data or node_has_data
         stack.extend(
             (child, next_ancestor_has_data) for child in children_map.get(node.span_id, [])
         )
+
+    return contributing_span_ids
+
+
+def _get_contributing_span_ids_for_usage_and_cost(
+    usage_nodes: list[SpanAggregationNode], cost_nodes: list[SpanAggregationNode]
+) -> set[str]:
+    """Select one ancestor-wins contribution set for usage and cost.
+
+    A usage-bearing ancestor wins for its whole subtree because cost is derived from usage. A
+    subtree with no usage data falls back to the cost ancestor-wins rule to preserve legacy
+    cost-only branches in mixed traces.
+    """
+    usage_by_id = {node.span_id: node for node in usage_nodes}
+    cost_by_id = {node.span_id: node for node in cost_nodes}
+    nodes_by_id = {node.span_id: node for node in usage_nodes}
+    nodes_by_id.update({node.span_id: node for node in cost_nodes})
+    children_map: defaultdict[str, list[str]] = defaultdict(list)
+    roots: list[str] = []
+
+    for node_id, node in nodes_by_id.items():
+        parent_id = node.parent_id
+        if parent_id and parent_id in nodes_by_id:
+            children_map[parent_id].append(node_id)
+        else:
+            roots.append(node_id)
+
+    subtree_has_usage: dict[str, bool] = {}
+    stack: list[tuple[str, bool]] = [(root, False) for root in roots]
+    while stack:
+        node_id, visited = stack.pop()
+        if visited:
+            usage_node = usage_by_id.get(node_id)
+            subtree_has_usage[node_id] = (
+                usage_node is not None and usage_node.data is not None
+            ) or any(subtree_has_usage[child_id] for child_id in children_map[node_id])
+            continue
+
+        stack.append((node_id, True))
+        stack.extend((child_id, False) for child_id in children_map[node_id])
+
+    contributing_span_ids: set[str] = set()
+    stack = [(root, False, False) for root in roots]
+    while stack:
+        node_id, ancestor_has_usage, ancestor_has_cost = stack.pop()
+        if ancestor_has_usage:
+            continue
+
+        usage_node = usage_by_id.get(node_id)
+        node_has_usage = usage_node is not None and usage_node.data is not None
+        cost_node = cost_by_id.get(node_id)
+        node_has_cost = cost_node is not None and cost_node.data is not None
+
+        if node_has_usage:
+            contributing_span_ids.add(node_id)
+            next_ancestor_has_usage = True
+            next_ancestor_has_cost = False
+        elif not subtree_has_usage[node_id] and node_has_cost and not ancestor_has_cost:
+            contributing_span_ids.add(node_id)
+            next_ancestor_has_usage = False
+            next_ancestor_has_cost = True
+        else:
+            next_ancestor_has_usage = False
+            next_ancestor_has_cost = ancestor_has_cost
+
+        stack.extend(
+            (child_id, next_ancestor_has_usage, next_ancestor_has_cost)
+            for child_id in children_map[node_id]
+        )
+
+    return contributing_span_ids
+
+
+def _aggregate_selected_nodes(
+    nodes: list[SpanAggregationNode],
+    selected_span_ids: set[str],
+    keys: list[str],
+    default: int | float,
+    optional_keys: list[str] | None = None,
+) -> dict[str, int | float] | None:
+    """Aggregate data from a preselected set of span nodes."""
+    totals: dict[str, int | float] = dict.fromkeys(keys, default)
+    has_data = False
+
+    for node in nodes:
+        if node.span_id not in selected_span_ids or node.data is None:
+            continue
+
+        for k in keys:
+            totals[k] += node.data.get(k, default)
+        for k in optional_keys or []:
+            if k in node.data:
+                totals[k] = totals.get(k, default) + node.data[k]
+        has_data = True
 
     if not has_data:
         return None
@@ -292,9 +390,52 @@ def _to_span_nodes(spans: list[LiveSpan], attribute_key: str) -> list[SpanAggreg
     ]
 
 
+def aggregate_usage_and_cost_from_span_nodes(
+    usage_nodes: list[SpanAggregationNode], cost_nodes: list[SpanAggregationNode]
+) -> tuple[dict[str, int] | None, dict[str, float] | None]:
+    """Aggregate usage and cost from one shared set of contributing spans.
+
+    Usage is the canonical contribution boundary because cost is derived from usage. Subtrees
+    without usage data use cost aggregation for compatibility with legacy cost-only branches.
+    """
+    contributing_span_ids = _get_contributing_span_ids_for_usage_and_cost(usage_nodes, cost_nodes)
+
+    return (
+        _aggregate_selected_nodes(
+            usage_nodes,
+            contributing_span_ids,
+            keys=[
+                TokenUsageKey.INPUT_TOKENS,
+                TokenUsageKey.OUTPUT_TOKENS,
+                TokenUsageKey.TOTAL_TOKENS,
+            ],
+            default=0,
+            optional_keys=TokenUsageKey.cache_keys(),
+        ),
+        _aggregate_selected_nodes(
+            cost_nodes,
+            contributing_span_ids,
+            keys=[CostKey.INPUT_COST, CostKey.OUTPUT_COST, CostKey.TOTAL_COST],
+            default=0.0,
+        ),
+    )
+
+
+def aggregate_usage_and_cost_from_spans(
+    spans: list[LiveSpan],
+) -> tuple[dict[str, int] | None, dict[str, float] | None]:
+    """Aggregate trace-level usage and cost from one shared set of contributing spans."""
+    spans = list(spans)
+    return aggregate_usage_and_cost_from_span_nodes(
+        _to_span_nodes(spans, SpanAttributeKey.CHAT_USAGE),
+        _to_span_nodes(spans, SpanAttributeKey.LLM_COST),
+    )
+
+
 def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
     """Aggregate token usage information from all spans in the trace."""
-    return aggregate_usage_from_span_nodes(_to_span_nodes(spans, SpanAttributeKey.CHAT_USAGE))
+    usage, _ = aggregate_usage_and_cost_from_spans(spans)
+    return usage
 
 
 def aggregate_usage_from_span_nodes(nodes: list[SpanAggregationNode]) -> dict[str, int] | None:
@@ -313,7 +454,8 @@ def aggregate_usage_from_span_nodes(nodes: list[SpanAggregationNode]) -> dict[st
 
 def aggregate_cost_from_spans(spans: list[LiveSpan]) -> dict[str, float] | None:
     """Aggregate cost information from all spans in the trace."""
-    return aggregate_cost_from_span_nodes(_to_span_nodes(spans, SpanAttributeKey.LLM_COST))
+    _, cost = aggregate_usage_and_cost_from_spans(spans)
+    return cost
 
 
 def aggregate_cost_from_span_nodes(nodes: list[SpanAggregationNode]) -> dict[str, float] | None:

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -4826,6 +4826,67 @@ def test_log_spans_cost_dedups_rollup_parent(store: SqlAlchemyStore, single_batc
     }
 
 
+def _usage_and_cost_rollup_trace_spans(trace_id: str) -> tuple[Span, list[Span]]:
+    wrapper = create_test_span(
+        trace_id,
+        name="agent",
+        span_id=1,
+        span_type="AGENT",
+        attributes={
+            SpanAttributeKey.CHAT_USAGE: {
+                "input_tokens": 120,
+                "output_tokens": 15,
+                "total_tokens": 135,
+            }
+        },
+    )
+    children = [
+        create_test_span(
+            trace_id,
+            name=f"llm_{i}",
+            span_id=10 + i,
+            parent_id=1,
+            span_type="LLM",
+            attributes={
+                SpanAttributeKey.CHAT_USAGE: {
+                    "input_tokens": 40,
+                    "output_tokens": 5,
+                    "total_tokens": 45,
+                },
+                SpanAttributeKey.LLM_COST: {
+                    "input_cost": 0.01,
+                    "output_cost": 0.005,
+                    "total_cost": 0.015,
+                },
+            },
+        )
+        for i in range(3)
+    ]
+    return wrapper, children
+
+
+@pytest.mark.parametrize("parent_first", [True, False])
+def test_log_spans_usage_and_cost_share_rollup_boundary(
+    store: SqlAlchemyStore, parent_first: bool
+) -> None:
+    experiment_id = store.create_experiment(f"test_log_spans_usage_cost_boundary_{parent_first}")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    wrapper, children = _usage_and_cost_rollup_trace_spans(trace_id)
+
+    batches = [[wrapper], children] if parent_first else [children, [wrapper]]
+    for batch in batches:
+        store.log_spans(experiment_id, batch)
+
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.token_usage == {
+        "input_tokens": 120,
+        "output_tokens": 15,
+        "total_tokens": 135,
+    }
+    assert trace_info.cost is None
+    assert TraceMetadataKey.COST not in trace_info.trace_metadata
+
+
 def test_log_spans_token_usage_deep_trace(store: SqlAlchemyStore) -> None:
     # A span chain deeper than Python's recursion limit (default 1000) must not blow up
     # the tree-aware aggregation (see #24344 for the client-side counterpart).

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -887,6 +887,57 @@ def test_log_spans_locks_and_recomputes_token_usage_in_workspace(workspace_track
         assert trace_info.token_usage["total_tokens"] == 300
 
 
+def test_log_spans_usage_and_cost_share_rollup_boundary_in_workspace(
+    workspace_tracking_store,
+):
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    wrapper = create_test_span(
+        trace_id,
+        name="agent",
+        span_id=1,
+        span_type="AGENT",
+        attributes={
+            SpanAttributeKey.CHAT_USAGE: {
+                "input_tokens": 120,
+                "output_tokens": 15,
+                "total_tokens": 135,
+            }
+        },
+    )
+    child = create_test_span(
+        trace_id,
+        name="llm",
+        span_id=2,
+        parent_id=1,
+        attributes={
+            SpanAttributeKey.CHAT_USAGE: {
+                "input_tokens": 40,
+                "output_tokens": 5,
+                "total_tokens": 45,
+            },
+            SpanAttributeKey.LLM_COST: {
+                "input_cost": 0.01,
+                "output_cost": 0.005,
+                "total_cost": 0.015,
+            },
+        },
+    )
+
+    with WorkspaceContext("team-a"):
+        exp_id = workspace_tracking_store.create_experiment("trace-usage-cost-boundary-workspace")
+        workspace_tracking_store.log_spans(exp_id, [child])
+        workspace_tracking_store.log_spans(exp_id, [wrapper])
+
+        trace_info = workspace_tracking_store.get_trace_info(trace_id)
+        assert trace_info.token_usage == {
+            "input_tokens": 120,
+            "output_tokens": 15,
+            "total_tokens": 135,
+        }
+        assert trace_info.cost is None
+        assert TraceMetadataKey.COST not in trace_info.trace_metadata
+
+
 def test_start_trace_conflict_update_is_workspace_scoped(workspace_tracking_store):
     trace_id = f"tr-{uuid.uuid4().hex}"
     initial_span = create_test_span(

--- a/tests/tracing/processor/test_mlflow_v3_processor.py
+++ b/tests/tracing/processor/test_mlflow_v3_processor.py
@@ -9,7 +9,9 @@ from mlflow.entities.span import LiveSpan
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.tracing.constant import (
+    CostKey,
     SpanAttributeKey,
+    TokenUsageKey,
     TraceMetadataKey,
 )
 from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
@@ -177,6 +179,70 @@ def test_on_end():
     assert trace_info.status == TraceStatus.OK
     assert trace_info.execution_time_ms == 4
     assert trace_info.tags == {}
+
+
+def test_on_end_aggregates_usage_and_cost_from_the_same_span_boundary():
+    trace_info = create_test_trace_info("request_id", 0)
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_manager.register_trace("trace_id", trace_info)
+
+    root_otel_span = create_mock_otel_span(
+        name="agent",
+        trace_id="trace_id",
+        span_id=1,
+        parent_id=None,
+        start_time=5_000_000,
+        end_time=9_000_000,
+    )
+    child_otel_span = create_mock_otel_span(
+        name="llm",
+        trace_id="trace_id",
+        span_id=2,
+        parent_id=1,
+        start_time=6_000_000,
+        end_time=8_000_000,
+    )
+    root = LiveSpan(root_otel_span, "request_id")
+    root.set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 60_000,
+            TokenUsageKey.OUTPUT_TOKENS: 17_000,
+            TokenUsageKey.TOTAL_TOKENS: 77_000,
+        },
+    )
+    child = LiveSpan(child_otel_span, "request_id")
+    child.set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 1_400_000,
+            TokenUsageKey.OUTPUT_TOKENS: 5_000,
+            TokenUsageKey.TOTAL_TOKENS: 1_405_000,
+        },
+    )
+    child.set_attribute(
+        SpanAttributeKey.LLM_COST,
+        {
+            CostKey.INPUT_COST: 4.2,
+            CostKey.OUTPUT_COST: 0.075,
+            CostKey.TOTAL_COST: 4.275,
+        },
+    )
+    trace_manager.register_span(root)
+    trace_manager.register_span(child)
+
+    processor = MlflowV3SpanProcessor(span_exporter=mock.MagicMock(), export_metrics=False)
+    with mock.patch(
+        "mlflow.tracing.processor.base_mlflow.should_compute_cost_client_side", return_value=True
+    ):
+        processor.on_end(root_otel_span)
+
+    assert json.loads(trace_info.request_metadata[TraceMetadataKey.TOKEN_USAGE]) == {
+        TokenUsageKey.INPUT_TOKENS: 60_000,
+        TokenUsageKey.OUTPUT_TOKENS: 17_000,
+        TokenUsageKey.TOTAL_TOKENS: 77_000,
+    }
+    assert TraceMetadataKey.COST not in trace_info.request_metadata
 
 
 # ── Batch span processor tests ──────────────────────────────────────────

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -408,6 +408,106 @@ def test_aggregate_cost_from_spans_skips_descendant_cost():
     }
 
 
+def test_aggregate_usage_and_cost_use_the_same_contributing_spans():
+    wrapper = LiveSpan(
+        create_mock_otel_span("trace_id", span_id=1, name="wrapper"), trace_id="tr-123"
+    )
+    wrapper.set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 60_000,
+            TokenUsageKey.OUTPUT_TOKENS: 17_000,
+            TokenUsageKey.TOTAL_TOKENS: 77_000,
+        },
+    )
+
+    children = []
+    for span_id, input_tokens, output_tokens, input_cost, output_cost in [
+        (2, 1_400_000, 5_000, 4.20, 0.075),
+        (3, 1_450_000, 8_000, 4.35, 0.120),
+    ]:
+        child = LiveSpan(
+            create_mock_otel_span("trace_id", span_id=span_id, name=f"llm_{span_id}", parent_id=1),
+            trace_id="tr-123",
+        )
+        child.set_attribute(
+            SpanAttributeKey.CHAT_USAGE,
+            {
+                TokenUsageKey.INPUT_TOKENS: input_tokens,
+                TokenUsageKey.OUTPUT_TOKENS: output_tokens,
+                TokenUsageKey.TOTAL_TOKENS: input_tokens + output_tokens,
+            },
+        )
+        child.set_attribute(
+            SpanAttributeKey.LLM_COST,
+            {
+                CostKey.INPUT_COST: input_cost,
+                CostKey.OUTPUT_COST: output_cost,
+                CostKey.TOTAL_COST: input_cost + output_cost,
+            },
+        )
+        children.append(child)
+
+    spans = [wrapper, *children]
+
+    assert aggregate_usage_from_spans(spans) == {
+        TokenUsageKey.INPUT_TOKENS: 60_000,
+        TokenUsageKey.OUTPUT_TOKENS: 17_000,
+        TokenUsageKey.TOTAL_TOKENS: 77_000,
+    }
+    assert aggregate_cost_from_spans(spans) is None
+
+
+def test_aggregate_usage_and_cost_preserve_mixed_cost_only_branches():
+    wrapper = LiveSpan(
+        create_mock_otel_span("trace_id", span_id=1, name="wrapper"), trace_id="tr-123"
+    )
+    wrapper.set_attribute(
+        SpanAttributeKey.CHAT_USAGE,
+        {
+            TokenUsageKey.INPUT_TOKENS: 60,
+            TokenUsageKey.OUTPUT_TOKENS: 17,
+            TokenUsageKey.TOTAL_TOKENS: 77,
+        },
+    )
+    child = LiveSpan(
+        create_mock_otel_span("trace_id", span_id=2, name="child", parent_id=1),
+        trace_id="tr-123",
+    )
+    child.set_attribute(
+        SpanAttributeKey.LLM_COST,
+        {
+            CostKey.INPUT_COST: 4.2,
+            CostKey.OUTPUT_COST: 0.075,
+            CostKey.TOTAL_COST: 4.275,
+        },
+    )
+    independent = LiveSpan(
+        create_mock_otel_span("trace_id", span_id=3, name="cost_only"), trace_id="tr-123"
+    )
+    independent.set_attribute(
+        SpanAttributeKey.LLM_COST,
+        {
+            CostKey.INPUT_COST: 0.1,
+            CostKey.OUTPUT_COST: 0.02,
+            CostKey.TOTAL_COST: 0.12,
+        },
+    )
+
+    spans = [wrapper, child, independent]
+
+    assert aggregate_usage_from_spans(spans) == {
+        TokenUsageKey.INPUT_TOKENS: 60,
+        TokenUsageKey.OUTPUT_TOKENS: 17,
+        TokenUsageKey.TOTAL_TOKENS: 77,
+    }
+    assert aggregate_cost_from_spans(spans) == {
+        CostKey.INPUT_COST: 0.1,
+        CostKey.OUTPUT_COST: 0.02,
+        CostKey.TOTAL_COST: 0.12,
+    }
+
+
 def test_maybe_get_request_id():
     assert maybe_get_request_id(is_evaluate=True) is None
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #25007

### What changes are proposed in this pull request?

Trace-level token usage and cost were aggregated with separate ancestor-wins traversals. A wrapper span could carry rolled-up usage without a model cost, so usage stopped at the wrapper while cost continued into priced child spans.

This change selects one contribution boundary from the trace tree and uses it for both aggregates. It preserves cost-only branches that have no usage data, and applies the same rule when SQLAlchemy recomputes aggregates from stored and incoming spans across batches. The client-side processors now calculate usage and cost together as well.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `pytest tests/tracing/utils/test_utils.py -q` (47 passed)
- `pytest tests/tracing/processor/test_mlflow_v3_processor.py -q` (18 passed)
- `pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py -q` (557 passed, 7 skipped)
- `pytest tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py -q` (73 passed)
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. This fixes trace metadata so token usage and cost are derived from the same contributing spans, avoiding inflated costs on traces with wrapper-level usage rollups.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
