### PR TITLE
Prevent object-store artifact deletion from removing sibling paths

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -86,6 +86,20 @@ def _retry_with_new_creds(try_func, creds_func, orig_creds=None):
         return try_func(new_creds)
 
 
+def _is_object_key_within_path(object_key: str, path: str) -> bool:
+    """
+    Return whether an object-store key belongs to a path.
+
+    Prefix listings can include sibling keys such as ``foobar`` when querying ``foo``, so require
+    either an exact match or a ``/`` boundary. An empty path represents the repository root.
+    """
+    if not path:
+        return True
+    if path.endswith("/"):
+        return object_key.startswith(path)
+    return object_key == path or object_key.startswith(f"{path}/")
+
+
 def _sanitize_path_component_for_windows(component: str) -> str:
     """
     Sanitize a path component by replacing Windows-invalid characters with underscores.

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -14,7 +14,11 @@ from mlflow.entities.multipart_upload import (
 from mlflow.environment_variables import MLFLOW_ARTIFACT_UPLOAD_DOWNLOAD_TIMEOUT
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
-from mlflow.store.artifact.artifact_repo import ArtifactRepository, MultipartUploadMixin
+from mlflow.store.artifact.artifact_repo import (
+    ArtifactRepository,
+    MultipartUploadMixin,
+    _is_object_key_within_path,
+)
 from mlflow.utils.credentials import get_default_host_creds
 
 
@@ -223,7 +227,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
         try:
             blobs = container_client.list_blobs(name_starts_with=dest_path)
-            blob_list = list(blobs)
+            blob_list = [blob for blob in blobs if _is_object_key_within_path(blob.name, dest_path)]
             if not blob_list:
                 raise MlflowException(f"No such file or directory: '{dest_path}'")
 

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -20,6 +20,7 @@ from mlflow.exceptions import _UnsupportedMultipartUploadException
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
     MultipartUploadMixin,
+    _is_object_key_within_path,
     _retry_with_new_creds,
 )
 from mlflow.utils import get_installed_version
@@ -189,7 +190,8 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         gcs_bucket = self._get_bucket(bucket_name)
         blobs = gcs_bucket.list_blobs(prefix=f"{dest_path}")
         for blob in blobs:
-            blob.delete()
+            if _is_object_key_within_path(blob.name, dest_path):
+                blob.delete()
 
     @staticmethod
     def _validate_support_mpu():

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -15,7 +15,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_artifacts_pb2 import ArtifactCredentialInfo
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.store.artifact.artifact_repo import _retry_with_new_creds
+from mlflow.store.artifact.artifact_repo import _is_object_key_within_path, _retry_with_new_creds
 from mlflow.store.artifact.cloud_artifact_repo import (
     CloudArtifactRepository,
     _complete_futures,
@@ -398,7 +398,8 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=dest_path
                 )
-                keys.append({"Key": file_path})
+                if _is_object_key_within_path(file_path, dest_path):
+                    keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(
                     Bucket=self.bucket,

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -33,6 +33,7 @@ from mlflow.store.artifact.artifact_repo import (
     MultipartDownloadMixin,
     MultipartUploadMixin,
     PresignedUploadMixin,
+    _is_object_key_within_path,
 )
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 
@@ -547,7 +548,8 @@ class S3ArtifactRepository(
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=dest_path
                 )
-                keys.append({"Key": file_path})
+                if _is_object_key_within_path(file_path, dest_path):
+                    keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(
                     Bucket=bucket, Delete={"Objects": keys}, **self._bucket_owner_params

--- a/tests/store/artifact/test_artifact_repo.py
+++ b/tests/store/artifact/test_artifact_repo.py
@@ -9,6 +9,7 @@ from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
+    _is_object_key_within_path,
     _sanitize_path_component_for_windows,
     _sanitize_path_for_windows,
 )
@@ -26,6 +27,24 @@ _PARENT_MODEL_FILE = _PARENT_MODEL_DIR + "/" + _MODEL_FILE
 _EMPTY_DIR = "emptydir"
 _DUMMY_FILE_SIZE = 123
 _EMPTY_FILE_SIZE = 0
+
+
+@pytest.mark.parametrize(
+    ("object_key", "path", "expected"),
+    [
+        ("anything", "", True),
+        ("root/foo", "root/foo", True),
+        ("root/foo/file.txt", "root/foo", True),
+        ("root/foo", "root/foo/", False),
+        ("root/foo/", "root/foo/", True),
+        ("root/foo/file.txt", "root/foo/", True),
+        ("root/foobar", "root/foo", False),
+        ("root/foo_baz", "root/foo", False),
+        ("/root/foo", "root/foo", False),
+    ],
+)
+def test_is_object_key_within_path(object_key, path, expected):
+    assert _is_object_key_within_path(object_key, path) is expected
 
 
 class ArtifactRepositoryImpl(ArtifactRepository):

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -506,6 +506,41 @@ def test_delete_artifacts_directory(mock_client):
     mock_client.get_container_client().delete_blob.assert_any_call(blob_props_2.name)
 
 
+@pytest.mark.parametrize("artifact_path", ["foo", "foo/"])
+def test_delete_artifacts_preserves_prefix_siblings(mock_client, artifact_path):
+    repo = AzureBlobArtifactRepository(TEST_URI, client=mock_client)
+    target = BlobProperties()
+    target.name = posixpath.join(TEST_ROOT_PATH, "foo/file")
+    sibling_dir = BlobProperties()
+    sibling_dir.name = posixpath.join(TEST_ROOT_PATH, "foobar/keep")
+    sibling_file = BlobProperties()
+    sibling_file.name = posixpath.join(TEST_ROOT_PATH, "foo_baz")
+    mock_client.get_container_client().list_blobs.return_value = [
+        target,
+        sibling_dir,
+        sibling_file,
+    ]
+
+    repo.delete_artifacts(artifact_path)
+
+    mock_client.get_container_client().list_blobs.assert_called_once_with(
+        name_starts_with=posixpath.join(TEST_ROOT_PATH, artifact_path)
+    )
+    mock_client.get_container_client().delete_blob.assert_called_once_with(target.name)
+
+
+def test_delete_artifacts_raises_when_only_sibling_path_matches_prefix(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, client=mock_client)
+    sibling = BlobProperties()
+    sibling.name = posixpath.join(TEST_ROOT_PATH, "foobar/keep")
+    mock_client.get_container_client().list_blobs.return_value = [sibling]
+
+    with pytest.raises(MlflowException, match="No such file or directory"):
+        repo.delete_artifacts("foo")
+
+    mock_client.get_container_client().delete_blob.assert_not_called()
+
+
 def test_delete_artifacts_nonexistent_path(mock_client):
     repo = AzureBlobArtifactRepository(TEST_URI, client=mock_client)
 

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -295,8 +295,8 @@ def test_download_artifacts_downloads_expected_content(mock_client, tmp_path):
 
 
 def test_delete_artifacts(mock_client):
-    experiment_root_path = "/experiment_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + experiment_root_path, client=mock_client)
+    experiment_root_path = "experiment_id"
+    repo = GCSArtifactRepository(f"gs://test_bucket/{experiment_root_path}", client=mock_client)
 
     def delete_file():
         del obj_mock.name
@@ -304,7 +304,7 @@ def test_delete_artifacts(mock_client):
         return obj_mock
 
     obj_mock = mock.Mock()
-    run_id_path = experiment_root_path + "run_id/"
+    run_id_path = experiment_root_path + "/run_id/"
     file_path = "file"
     attrs = {"name": run_id_path + file_path, "size": 1, "delete.side_effect": delete_file}
     obj_mock.configure_mock(**attrs)
@@ -341,6 +341,31 @@ def test_delete_artifacts(mock_client):
     repo.delete_artifacts()
     artifact_file_names = [obj.path for obj in repo.list_artifacts()]
     assert not artifact_file_names
+
+
+@pytest.mark.parametrize("artifact_path", ["foo", "foo/"])
+def test_delete_artifacts_preserves_prefix_siblings(mock_client, artifact_path):
+    repo = GCSArtifactRepository("gs://test_bucket/root", client=mock_client)
+    target = mock.Mock(name="target")
+    target.name = "root/foo/file.txt"
+    sibling_dir = mock.Mock(name="sibling_dir")
+    sibling_dir.name = "root/foobar/keep.txt"
+    sibling_file = mock.Mock(name="sibling_file")
+    sibling_file.name = "root/foo_baz.txt"
+    mock_client.bucket.return_value.list_blobs.return_value = [
+        target,
+        sibling_dir,
+        sibling_file,
+    ]
+
+    repo.delete_artifacts(artifact_path)
+
+    mock_client.bucket.return_value.list_blobs.assert_called_once_with(
+        prefix=posixpath.join("root", artifact_path)
+    )
+    target.delete.assert_called_once_with()
+    sibling_dir.delete.assert_not_called()
+    sibling_file.delete.assert_not_called()
 
 
 def test_gcs_mpu_arguments():

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -358,6 +358,27 @@ def test_delete_artifacts_single_object(s3_artifact_repo, tmp_path):
     assert s3_artifact_repo.list_artifacts() == []
 
 
+def test_delete_artifacts_preserves_prefix_siblings(s3_artifact_repo, tmp_path):
+    target = tmp_path / "target.txt"
+    sibling_dir_file = tmp_path / "keep.txt"
+    sibling_file = tmp_path / "foo_baz.txt"
+    target.write_text("target")
+    sibling_dir_file.write_text("sibling directory file")
+    sibling_file.write_text("sibling file")
+
+    s3_artifact_repo.log_artifact(target, artifact_path="foo")
+    s3_artifact_repo.log_artifact(sibling_dir_file, artifact_path="foobar")
+    s3_artifact_repo.log_artifact(sibling_file)
+
+    s3_artifact_repo.delete_artifacts("foo")
+
+    assert s3_artifact_repo.list_artifacts("foo") == []
+    assert [artifact.path for artifact in s3_artifact_repo.list_artifacts("foobar")] == [
+        "foobar/keep.txt"
+    ]
+    assert "foo_baz.txt" in [artifact.path for artifact in s3_artifact_repo.list_artifacts()]
+
+
 @pytest.mark.parametrize("artifact_path", ["subdir", "subdir/"])
 def test_list_and_delete_artifacts_path(s3_artifact_repo, tmp_path, artifact_path):
     subdir = tmp_path / "subdir"


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #24821

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Before this change, object-store artifact deletion relied on string-prefix listings without enforcing path boundaries. As a result, deleting `foo` could also delete sibling keys such as `foobar/keep.txt` or `foo_baz.txt`.

This PR adds a shared object-key boundary check and applies it to S3, optimized S3, GCS, and Azure Blob artifact deletion. For non-root paths, an object is deleted only when its key exactly matches the requested path or falls under its `/` boundary.

Existing provider-specific trailing-slash and missing-artifact behavior is preserved.

The existing GCS deletion test fixture was also corrected because its blob key had a leading slash inconsistent with the repository prefix. This mismatch was previously masked by the unfiltered deletion logic.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Added coverage for:

- Exact object and nested-path boundary matching
- Directory-like and file-like sibling prefixes
- S3 and optimized S3 deletion through the shared repository fixture
- GCS and Azure Blob handling of `foo` and `foo/`
- Azure Blob behavior when a raw prefix listing contains only sibling keys

### Does this PR require documentation update?

- [x] No.
### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Object-store artifact deletion no longer removes sibling artifacts whose paths share the same string prefix.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
