### PR TITLE
Remove Databricks-specific comment from `ExperimentCustomViewProvider` test

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -11,10 +11,6 @@ import type {
   RenderCustomViewSpec,
 } from '@databricks/web-shared/model-trace-explorer/custom-view';
 
-// This suite exercises ONLY the OSS-specific wiring (MLflow Assistant open/
-// reset/prefill + the Tier 1 client-tool pause/resume + the pull-based context
-// provider), not the Databricks Genie/MFE RPC wiring the universe equivalent of
-// this file tests — that plumbing does not exist in OSS.
 // `useExperimentCustomViewDefinition` / `useCanEditExperimentCustomViews` / the
 // `@databricks/web-shared/model-trace-explorer/custom-view` barrel are stubbed
 // (and their inputs captured) so this test is isolated to the provider's own


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24798

### What changes are proposed in this pull request?

Remove the Databricks-specific explanatory comment from the OSS `ExperimentCustomViewProvider` test while retaining the relevant test-isolation documentation.

### How is this PR tested?

Not run (comment-only change).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release