### PR TITLE
[Custom View] Submit custom view build prompts directly to Assistant

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -1,12 +1,19 @@
 import { describe, test, expect, jest, beforeEach, beforeAll } from '@jest/globals';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { AssistantChatPanel, AssistantMessageBody, groupParts } from './AssistantChatPanel';
 import * as AssistantService from './AssistantService';
-import type { AssistantPart, ChatMessage, ProviderInfo, ResolvedProviderInfo, TokenUsage } from './types';
+import type {
+  AssistantPart,
+  ChatMessage,
+  PendingAutomaticMessage,
+  ProviderInfo,
+  ResolvedProviderInfo,
+  TokenUsage,
+} from './types';
 import { useLogTelemetryEvent } from '../telemetry/hooks/useLogTelemetryEvent';
 import type { Endpoint } from '../gateway/types';
 
@@ -23,6 +30,7 @@ const mockSendMessage = jest.fn();
 const mockSelectProvider = jest.fn();
 const mockCancelSession = jest.fn();
 const mockClearPendingPrompt = jest.fn();
+const mockSendPendingAutomaticMessage = jest.fn();
 const mockRefreshConfig = jest.fn((options?: { silent?: boolean }) => {
   void options;
   return Promise.resolve();
@@ -30,6 +38,7 @@ const mockRefreshConfig = jest.fn((options?: { silent?: boolean }) => {
 const mockRespondToPermission = jest.fn();
 let mockSetupComplete = true;
 let mockPendingPrompt: string | null = null;
+let mockPendingAutomaticMessage: PendingAutomaticMessage | null = null;
 let mockActiveProvider: ResolvedProviderInfo | null = null;
 let mockProviders: ProviderInfo[] = [];
 let mockGatewayVendorOptions: Record<string, string[]> = {};
@@ -79,11 +88,14 @@ jest.mock('./AssistantContext', () => ({
     gatewayVendorOptions: mockGatewayVendorOptions,
     needsApiKey: mockNeedsApiKey,
     pendingPrompt: mockPendingPrompt,
+    pendingAutomaticMessage: mockPendingAutomaticMessage,
     canUseAssistant: mockCanUseAssistant,
     tokenUsage: mockTokenUsage,
     openPanel: jest.fn(),
     closePanel: jest.fn(),
     sendMessage: mockSendMessage,
+    sendMessageWhenReady: jest.fn(),
+    sendPendingAutomaticMessage: mockSendPendingAutomaticMessage,
     selectProvider: mockSelectProvider,
     prefillPrompt: jest.fn(),
     clearPendingPrompt: mockClearPendingPrompt,
@@ -134,11 +146,13 @@ describe('AssistantChatPanel', () => {
     mockSelectProvider.mockClear();
     mockCancelSession.mockClear();
     mockClearPendingPrompt.mockClear();
+    mockSendPendingAutomaticMessage.mockClear();
     mockRefreshConfig.mockClear();
     mockRespondToPermission.mockClear();
     mockUpdateConfig.mockClear();
     mockSetupComplete = true;
     mockPendingPrompt = null;
+    mockPendingAutomaticMessage = null;
     mockActiveProvider = null;
     mockProviders = [];
     mockGatewayVendorOptions = {};
@@ -299,6 +313,39 @@ describe('AssistantChatPanel', () => {
     expect(
       screen.getByText('Add your OpenAI API key to continue, or pick another provider below.'),
     ).toBeInTheDocument();
+  });
+
+  test('a queued automatic message uses the key prompt and sends after the key is saved', async () => {
+    mockActiveProvider = {
+      name: 'mlflow_gateway',
+      model: 'mlflow-assistant-openai',
+      auto_selected: true,
+      model_provider: 'openai',
+      provider_model: 'gpt-5.5',
+      model_options: ['gpt-5.5'],
+      requires_api_key: true,
+      has_api_key: false,
+      supports_client_tools: true,
+    };
+    mockNeedsApiKey = true;
+    mockPendingAutomaticMessage = {
+      message: 'Build my custom trace view',
+      options: { newSession: true },
+    };
+    const user = userEvent.setup();
+    renderChatPanel();
+
+    expect(
+      screen.getByText('Add your OpenAI API key to continue, or pick another provider below.'),
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ask a question...')).toHaveValue('');
+
+    await user.type(screen.getByPlaceholderText('sk-...'), 'sk-test');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(mockSendPendingAutomaticMessage).toHaveBeenCalledTimes(1));
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockRefreshConfig).toHaveBeenCalledTimes(1);
   });
 
   test('an api_key_missing stream error also shows the inline key prompt', () => {

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -348,6 +348,27 @@ describe('AssistantChatPanel', () => {
     expect(mockRefreshConfig).toHaveBeenCalledTimes(1);
   });
 
+  test('a queued automatic message does not show the key prompt when the provider needs no key', () => {
+    mockActiveProvider = {
+      name: 'ollama',
+      model: 'llama3.2',
+      auto_selected: true,
+      model_options: [],
+      requires_api_key: false,
+      has_api_key: false,
+      supports_client_tools: true,
+    };
+    mockNeedsApiKey = false;
+    mockPendingAutomaticMessage = {
+      message: 'Build my custom trace view',
+      options: { newSession: true },
+    };
+    renderChatPanel();
+
+    expect(screen.queryByText(/Add your .* API key to continue/)).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ask a question...')).toHaveValue('');
+  });
+
   test('an api_key_missing stream error also shows the inline key prompt', () => {
     mockActiveProvider = {
       name: 'mlflow_gateway',

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -612,7 +612,7 @@ const ChatPanelContent = ({ onOpenSettings }: { onOpenSettings: () => void }) =>
           <RecoverableErrorCallout errorCode={errorCode} error={error} onOpenSettings={onOpenSettings} />
         )}
         {(pendingKeyMessage != null ||
-          pendingAutomaticMessage != null ||
+          (pendingAutomaticMessage != null && needsApiKey) ||
           errorCode === AssistantErrorCode.ApiKeyMissing) &&
           activeProvider && (
             <ApiKeyPrompt

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -442,6 +442,8 @@ const ChatPanelContent = ({ onOpenSettings }: { onOpenSettings: () => void }) =>
     refreshConfig,
     pendingPrompt,
     clearPendingPrompt,
+    pendingAutomaticMessage,
+    sendPendingAutomaticMessage,
     pendingPermission,
     respondToPermission,
   } = useAssistant();
@@ -497,14 +499,23 @@ const ChatPanelContent = ({ onOpenSettings }: { onOpenSettings: () => void }) =>
     // so the prompt hides immediately instead of lingering while a refresh runs.
     // (The key is already saved server-side; the send carries it.) If the prompt
     // came from a failed send rather than a queued message, retry that turn.
-    if (message) {
+    if (pendingAutomaticMessage) {
+      sendPendingAutomaticMessage();
+    } else if (message) {
       sendMessage(message);
     } else {
       regenerateLastMessage();
     }
     // Update the resolved-provider / needsApiKey state in the background.
     refreshConfig();
-  }, [pendingKeyMessage, sendMessage, regenerateLastMessage, refreshConfig]);
+  }, [
+    pendingKeyMessage,
+    pendingAutomaticMessage,
+    sendPendingAutomaticMessage,
+    sendMessage,
+    regenerateLastMessage,
+    refreshConfig,
+  ]);
 
   // If the key prompt is dismissed sideways (e.g. the user switches provider from
   // the picker instead of entering a key), put the stashed message back in the
@@ -600,23 +611,26 @@ const ChatPanelContent = ({ onOpenSettings }: { onOpenSettings: () => void }) =>
         {errorCode && RECOVERABLE_ERROR_CODES.has(errorCode) && (
           <RecoverableErrorCallout errorCode={errorCode} error={error} onOpenSettings={onOpenSettings} />
         )}
-        {(pendingKeyMessage != null || errorCode === AssistantErrorCode.ApiKeyMissing) && activeProvider && (
-          <ApiKeyPrompt
-            providerId={activeProvider.name}
-            providerName={
-              (activeProvider.name === GATEWAY_PROVIDER_ID && activeProvider.model_provider
-                ? getLlmProviderDisplay(activeProvider.model_provider)?.name
-                : undefined) ??
-              getAssistantProvider(activeProvider.name)?.name ??
-              activeProvider.name
-            }
-            gatewayVendor={
-              activeProvider.name === GATEWAY_PROVIDER_ID ? (activeProvider.model_provider ?? undefined) : undefined
-            }
-            providerModel={activeProvider.provider_model}
-            onSaved={handleApiKeySaved}
-          />
-        )}
+        {(pendingKeyMessage != null ||
+          pendingAutomaticMessage != null ||
+          errorCode === AssistantErrorCode.ApiKeyMissing) &&
+          activeProvider && (
+            <ApiKeyPrompt
+              providerId={activeProvider.name}
+              providerName={
+                (activeProvider.name === GATEWAY_PROVIDER_ID && activeProvider.model_provider
+                  ? getLlmProviderDisplay(activeProvider.model_provider)?.name
+                  : undefined) ??
+                getAssistantProvider(activeProvider.name)?.name ??
+                activeProvider.name
+              }
+              gatewayVendor={
+                activeProvider.name === GATEWAY_PROVIDER_ID ? (activeProvider.model_provider ?? undefined) : undefined
+              }
+              providerModel={activeProvider.provider_model}
+              onSaved={handleApiKeySaved}
+            />
+          )}
         <div
           css={{
             display: 'flex',

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -172,6 +172,35 @@ describe('AssistantContext — reset() tears down the active stream', () => {
     expect(result.current.sessionId).toBeNull();
     expect(result.current.messages).toHaveLength(0);
   });
+
+  it('atomically sends a new-session message without reusing the current session id', async () => {
+    const { result } = await renderAssistant();
+
+    await act(async () => {
+      result.current.sendMessage('old turn');
+    });
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-OLD');
+      result.current.prefillPrompt('stale composer prompt');
+    });
+    expect(result.current.sessionId).toBe('session-OLD');
+
+    mockSendMessageStream.mockClear();
+    fakeEventSource.close.mockClear();
+    await act(async () => {
+      result.current.sendMessage('fresh turn', { newSession: true });
+    });
+
+    expect(fakeEventSource.close).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageStream.mock.calls[0][0]).not.toHaveProperty('session_id');
+    expect(mockSendMessageStream.mock.calls[0][0]).toMatchObject({ message: 'fresh turn' });
+    expect(result.current.pendingPrompt).toBeNull();
+    expect(result.current.messages.map(({ role, content }) => ({ role, content }))).toEqual([
+      { role: 'user', content: 'fresh turn' },
+      { role: 'assistant', content: '' },
+    ]);
+  });
 });
 
 describe('AssistantContext — reset() during the in-flight send window', () => {

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -329,6 +329,31 @@ describe('AssistantContext — pendingPrompt seed', () => {
     expect(result.current.pendingPrompt).toBeNull();
   });
 
+  it('direct send clears a queued pendingPrompt when continuing an established session', async () => {
+    const { result } = await renderAssistant();
+
+    await act(async () => {
+      result.current.sendMessage('first turn');
+    });
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-1');
+      capturedCallbacks?.onDone();
+      result.current.prefillPrompt('STALE SEED');
+    });
+    expect(result.current.pendingPrompt).toBe('STALE SEED');
+
+    mockSendMessageStream.mockClear();
+    await act(async () => {
+      result.current.sendMessage('direct follow-up');
+    });
+
+    expect(result.current.pendingPrompt).toBeNull();
+    expect(mockSendMessageStream.mock.calls[0][0]).toMatchObject({
+      session_id: 'session-1',
+      message: 'direct follow-up',
+    });
+  });
+
   // completing setup must NOT drop a queued prompt, so it can be
   // consumed once the chat input appears post-setup.
   it('keeps pendingPrompt across completeSetup() (seed survives setup refresh)', async () => {

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -380,6 +380,90 @@ describe('AssistantContext — pendingPrompt seed', () => {
   });
 });
 
+describe('AssistantContext — automatic message delivery', () => {
+  it('sends immediately when a configured provider is ready', async () => {
+    mockGetProviders.mockResolvedValue({
+      providers: [],
+      resolved: resolvedProvider({ name: 'ollama', auto_selected: false }),
+    });
+    const { result } = await renderAssistant();
+
+    await act(async () => {
+      result.current.sendMessageWhenReady('build a view', { newSession: true });
+    });
+
+    expect(result.current.pendingAutomaticMessage).toBeNull();
+    expect(mockSendMessageStream.mock.calls[0][0]).toMatchObject({ message: 'build a view' });
+    expect(mockSendMessageStream.mock.calls[0][0]).not.toHaveProperty('session_id');
+  });
+
+  it('queues during setup and drains automatically after a provider resolves', async () => {
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.sendMessageWhenReady('build after setup', { newSession: true });
+    });
+    expect(mockSendMessageStream).not.toHaveBeenCalled();
+    expect(result.current.pendingAutomaticMessage).toEqual({
+      message: 'build after setup',
+      options: { newSession: true },
+    });
+
+    mockGetProviders.mockResolvedValue({
+      providers: [],
+      resolved: resolvedProvider({ name: 'ollama', auto_selected: false }),
+    });
+    await act(async () => {
+      await result.current.refreshConfig();
+    });
+
+    await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalledTimes(1));
+    expect(mockSendMessageStream.mock.calls[0][0]).toMatchObject({ message: 'build after setup' });
+    expect(mockSendMessageStream.mock.calls[0][0]).not.toHaveProperty('session_id');
+    expect(result.current.pendingAutomaticMessage).toBeNull();
+  });
+
+  it('keeps a missing-key message queued until explicitly released after key setup', async () => {
+    mockGetProviders.mockResolvedValue({
+      providers: [],
+      resolved: resolvedProvider({
+        name: 'mlflow_gateway',
+        requires_api_key: true,
+        has_api_key: false,
+        supports_client_tools: true,
+      }),
+    });
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.sendMessageWhenReady('build after key', { newSession: true });
+    });
+    expect(mockSendMessageStream).not.toHaveBeenCalled();
+    expect(result.current.pendingAutomaticMessage?.message).toBe('build after key');
+
+    await act(async () => {
+      result.current.sendPendingAutomaticMessage();
+    });
+
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageStream.mock.calls[0][0]).toMatchObject({ message: 'build after key' });
+    expect(mockSendMessageStream.mock.calls[0][0]).not.toHaveProperty('session_id');
+    expect(result.current.pendingAutomaticMessage).toBeNull();
+  });
+
+  it('abandons a queued automatic message when the panel closes', async () => {
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.sendMessageWhenReady('abandon me', { newSession: true });
+      result.current.closePanel();
+    });
+
+    expect(result.current.pendingAutomaticMessage).toBeNull();
+    expect(mockSendMessageStream).not.toHaveBeenCalled();
+  });
+});
+
 describe('upsertToolCalls', () => {
   test('appends a new tool call with running status', () => {
     const result = upsertToolCalls([], [{ id: 't1', name: 'Bash', input: { command: 'ls' } }]);

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -392,6 +392,7 @@ describe('AssistantContext — automatic message delivery', () => {
       result.current.sendMessageWhenReady('build a view', { newSession: true });
     });
 
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
     expect(result.current.pendingAutomaticMessage).toBeNull();
     expect(mockSendMessageStream.mock.calls[0][0]).toMatchObject({ message: 'build a view' });
     expect(mockSendMessageStream.mock.calls[0][0]).not.toHaveProperty('session_id');

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -746,8 +746,6 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       setError(null);
       setErrorCode(null);
       setIsStreaming(true);
-      // A direct send supersedes any prompt queued for the composer.
-      setPendingPrompt(null);
       // A new message supersedes any prompt the user was deciding on. Clearing it
       // here drops the stale Allow/Deny so it can't resume the abandoned turn; the
       // backend closes the orphaned tool call out as cancelled.
@@ -902,6 +900,9 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   const handleSendMessage = useCallback(
     async (message: string, options?: { newSession?: boolean }) => {
+      // A direct send supersedes any prompt queued for the composer, regardless
+      // of whether it starts a fresh thread or continues the current one.
+      setPendingPrompt(null);
       if (options?.newSession) {
         // Reset and start through the explicit fresh-chat path in the same
         // action. Calling reset() followed by the regular session-aware branch

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -12,6 +12,7 @@ import {
   type ChatMessage,
   type PermissionRequest,
   type PendingClientToolCall,
+  type PendingAutomaticMessage,
   type AssistantProviderSelection,
   type ProviderInfo,
   type ProvidersResponse,
@@ -19,6 +20,7 @@ import {
   type ToolUseInfo,
   type ToolResultInfo,
   type TokenUsage,
+  type SendMessageOptions,
 } from './types';
 import {
   cancelSession as cancelSessionApi,
@@ -287,6 +289,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   const [pendingPermission, setPendingPermission] = useState<PermissionRequest | null>(null);
   const [pendingClientToolCall, setPendingClientToolCall] = useState<PendingClientToolCall | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [pendingAutomaticMessage, setPendingAutomaticMessage] = useState<PendingAutomaticMessage | null>(null);
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>(() => normalizeTokenUsage(persistedChat.tokenUsage));
 
   // Setup state
@@ -687,6 +690,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     // Drop any queued prompt — closing the panel is an abandon, so a stale seed shouldn't
     // inject into an unrelated chat opened later.
     setPendingPrompt(null);
+    setPendingAutomaticMessage(null);
   }, [setIsPanelOpen]);
 
   const prefillPrompt = useCallback((prompt: string) => setPendingPrompt(prompt), []);
@@ -717,6 +721,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     openTextBufferRef.current = '';
     setPendingPermission(null);
     setPendingClientToolCall(null);
+    setPendingAutomaticMessage(null);
   }, [setPersistedChat]);
 
   // Begin a new in-flight send: stamp a fresh token in closure,
@@ -899,10 +904,11 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   }, [pendingClientToolCall, submitClientToolResult]);
 
   const handleSendMessage = useCallback(
-    async (message: string, options?: { newSession?: boolean }) => {
+    async (message: string, options?: SendMessageOptions) => {
       // A direct send supersedes any prompt queued for the composer, regardless
       // of whether it starts a fresh thread or continues the current one.
       setPendingPrompt(null);
+      setPendingAutomaticMessage(null);
       if (options?.newSession) {
         // Reset and start through the explicit fresh-chat path in the same
         // action. Calling reset() followed by the regular session-aware branch
@@ -986,6 +992,50 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       failStreamingTurn,
     ],
   );
+
+  const sendPendingAutomaticMessage = useCallback(() => {
+    if (!pendingAutomaticMessage) {
+      return;
+    }
+    const { message, options } = pendingAutomaticMessage;
+    setPendingAutomaticMessage(null);
+    handleSendMessage(message, options);
+  }, [pendingAutomaticMessage, handleSendMessage]);
+
+  const sendMessageWhenReady = useCallback(
+    (message: string, options?: SendMessageOptions) => {
+      // Automatic delivery is distinct from composer prefilling: retain the
+      // message and its session options until the selected provider can send it.
+      setPendingPrompt(null);
+      if (!canUseAssistant || isLoadingConfig || !setupComplete || !activeProvider || needsApiKey) {
+        setPendingAutomaticMessage({ message, options });
+        return;
+      }
+      handleSendMessage(message, options);
+    },
+    [canUseAssistant, isLoadingConfig, setupComplete, activeProvider, needsApiKey, handleSendMessage],
+  );
+
+  useEffect(() => {
+    if (
+      pendingAutomaticMessage &&
+      canUseAssistant &&
+      !isLoadingConfig &&
+      setupComplete &&
+      activeProvider &&
+      !needsApiKey
+    ) {
+      sendPendingAutomaticMessage();
+    }
+  }, [
+    pendingAutomaticMessage,
+    canUseAssistant,
+    isLoadingConfig,
+    setupComplete,
+    activeProvider,
+    needsApiKey,
+    sendPendingAutomaticMessage,
+  ]);
 
   const handleCancelSession = useCallback(() => {
     if (!sessionId || !isStreaming) return;
@@ -1123,6 +1173,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     gatewayVendorOptions,
     needsApiKey,
     pendingPrompt,
+    pendingAutomaticMessage,
     pendingPermission,
     pendingClientToolCall,
     canUseAssistant,
@@ -1131,6 +1182,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     openPanel,
     closePanel,
     sendMessage: handleSendMessage,
+    sendMessageWhenReady,
+    sendPendingAutomaticMessage,
     selectProvider,
     prefillPrompt,
     clearPendingPrompt,
@@ -1164,6 +1217,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   gatewayVendorOptions: {},
   needsApiKey: false,
   pendingPrompt: null,
+  pendingAutomaticMessage: null,
   pendingPermission: null,
   pendingClientToolCall: null,
   canUseAssistant: false,
@@ -1171,6 +1225,8 @@ const disabledAssistantContext: AssistantAgentContextType = {
   openPanel: () => {},
   closePanel: () => {},
   sendMessage: () => {},
+  sendMessageWhenReady: () => {},
+  sendPendingAutomaticMessage: () => {},
   selectProvider: () => {},
   prefillPrompt: () => {},
   clearPendingPrompt: () => {},

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -746,6 +746,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       setError(null);
       setErrorCode(null);
       setIsStreaming(true);
+      // A direct send supersedes any prompt queued for the composer.
+      setPendingPrompt(null);
       // A new message supersedes any prompt the user was deciding on. Clearing it
       // here drops the stale Allow/Deny so it can't resume the abandoned turn; the
       // backend closes the orphaned tool call out as cancelled.
@@ -790,7 +792,6 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
         const result = await sendMessageStream(
           {
             message: prompt || '',
-            session_id: sessionId ?? undefined,
             experiment_id: pageContext['experimentId'] as string | undefined,
             context: pageContext,
           },
@@ -806,15 +807,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
         failStreamingTurn(err instanceof Error ? err.message : 'Failed to start chat');
       }
     },
-    [
-      sessionId,
-      beginRequest,
-      attachStreamIfCurrent,
-      flushPendingProvider,
-      getPageContext,
-      streamCallbacks,
-      failStreamingTurn,
-    ],
+    [beginRequest, attachStreamIfCurrent, flushPendingProvider, getPageContext, streamCallbacks, failStreamingTurn],
   );
 
   const respondToPermission = useCallback(
@@ -908,7 +901,15 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   }, [pendingClientToolCall, submitClientToolResult]);
 
   const handleSendMessage = useCallback(
-    async (message: string) => {
+    async (message: string, options?: { newSession?: boolean }) => {
+      if (options?.newSession) {
+        // Reset and start through the explicit fresh-chat path in the same
+        // action. Calling reset() followed by the regular session-aware branch
+        // would still see this render's stale sessionId closure.
+        reset();
+        startChat(message);
+        return;
+      }
       if (!sessionId) {
         startChat(message);
         return;
@@ -974,6 +975,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     },
     [
       sessionId,
+      reset,
       startChat,
       beginRequest,
       attachStreamIfCurrent,

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -1002,19 +1002,12 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     handleSendMessage(message, options);
   }, [pendingAutomaticMessage, handleSendMessage]);
 
-  const sendMessageWhenReady = useCallback(
-    (message: string, options?: SendMessageOptions) => {
-      // Automatic delivery is distinct from composer prefilling: retain the
-      // message and its session options until the selected provider can send it.
-      setPendingPrompt(null);
-      if (!canUseAssistant || isLoadingConfig || !setupComplete || !activeProvider || needsApiKey) {
-        setPendingAutomaticMessage({ message, options });
-        return;
-      }
-      handleSendMessage(message, options);
-    },
-    [canUseAssistant, isLoadingConfig, setupComplete, activeProvider, needsApiKey, handleSendMessage],
-  );
+  const sendMessageWhenReady = useCallback((message: string, options?: SendMessageOptions) => {
+    // Automatic delivery is distinct from composer prefilling: retain the
+    // message and its session options until the selected provider can send it.
+    setPendingPrompt(null);
+    setPendingAutomaticMessage({ message, options });
+  }, []);
 
   useEffect(() => {
     if (

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -226,6 +226,15 @@ export interface TokenUsage {
   costUsd: number | null;
 }
 
+export interface SendMessageOptions {
+  newSession?: boolean;
+}
+
+export interface PendingAutomaticMessage {
+  message: string;
+  options?: SendMessageOptions;
+}
+
 export interface AssistantAgentState {
   /** Whether the Assistant panel is open */
   isPanelOpen: boolean;
@@ -259,6 +268,8 @@ export interface AssistantAgentState {
   needsApiKey: boolean;
   /** A prompt queued to seed the chat input the next time it becomes visible (null when none) */
   pendingPrompt: string | null;
+  /** A message waiting for Assistant setup or credentials before it can be sent automatically */
+  pendingAutomaticMessage: PendingAutomaticMessage | null;
   /** A tool call awaiting the user's Yes/No decision, or null */
   pendingPermission: PermissionRequest | null;
   /** A tool call awaiting client-side execution (e.g. rendering a UI spec), or null */
@@ -275,7 +286,11 @@ export interface AssistantAgentActions {
   /** Close the Assistant panel */
   closePanel: () => void;
   /** Send a message to Assistant, optionally starting a fresh conversation */
-  sendMessage: (message: string, options?: { newSession?: boolean }) => void;
+  sendMessage: (message: string, options?: SendMessageOptions) => void;
+  /** Send immediately when ready, otherwise queue until setup or credentials are available */
+  sendMessageWhenReady: (message: string, options?: SendMessageOptions) => void;
+  /** Force-send the queued automatic message after external setup (e.g. API-key save) */
+  sendPendingAutomaticMessage: () => void;
   /** Optimistically switch the active provider (persisted on the next send). */
   selectProvider: (selection: AssistantProviderSelection) => void;
   /** Queue a prompt to seed the chat input the next time it's visible (survives setup/settings navigation) */

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -274,8 +274,8 @@ export interface AssistantAgentActions {
   openPanel: () => void;
   /** Close the Assistant panel */
   closePanel: () => void;
-  /** Send a message to Assistant */
-  sendMessage: (message: string) => void;
+  /** Send a message to Assistant, optionally starting a fresh conversation */
+  sendMessage: (message: string, options?: { newSession?: boolean }) => void;
   /** Optimistically switch the active provider (persisted on the next send). */
   selectProvider: (selection: AssistantProviderSelection) => void;
   /** Queue a prompt to seed the chat input the next time it's visible (survives setup/settings navigation) */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -57,7 +57,7 @@ const mockGetCustomViewAuthoringContext = jest.fn<() => any>(() => null);
 const mockLatchDispatchedCustomViewApplyTarget = jest.fn();
 
 let capturedConnectorProviderProps:
-  | { connector: { openAssistant?: (...args: any[]) => void; isStreaming?: boolean } }
+  | { connector: { openAssistant?: (...args: any[]) => void; isStreaming?: boolean; isPending?: boolean } }
   | undefined;
 let capturedDefinitionProviderProps:
   | { views: unknown[]; isLoaded: boolean; onPersistView?: unknown; canModifyPersistedViews?: boolean }
@@ -85,7 +85,8 @@ const mockUseAssistant = jest.mocked(useAssistant);
 const makeAssistant = (overrides: Record<string, unknown> = {}) => {
   const value = {
     openPanel: jest.fn(),
-    sendMessage: jest.fn(),
+    sendMessageWhenReady: jest.fn(),
+    pendingAutomaticMessage: null,
     isStreaming: false,
     activeProvider: null,
     ...overrides,
@@ -136,10 +137,10 @@ describe('ExperimentCustomViewProvider', () => {
       capturedConnectorProviderProps?.connector.openAssistant?.('Show me the failed spans', { newSession: true });
 
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
-      expect(assistant.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Show me the failed spans'), {
+      expect(assistant.sendMessageWhenReady).toHaveBeenCalledWith(expect.stringContaining('Show me the failed spans'), {
         newSession: true,
       });
-      expect(assistant.sendMessage).toHaveBeenCalledWith(expect.stringContaining('render_custom_view'), {
+      expect(assistant.sendMessageWhenReady).toHaveBeenCalledWith(expect.stringContaining('render_custom_view'), {
         newSession: true,
       });
     });
@@ -151,7 +152,7 @@ describe('ExperimentCustomViewProvider', () => {
       capturedConnectorProviderProps?.connector.openAssistant?.('Add a chart');
 
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
-      expect(assistant.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Add a chart'), undefined);
+      expect(assistant.sendMessageWhenReady).toHaveBeenCalledWith(expect.stringContaining('Add a chart'), undefined);
     });
 
     it('only opens the panel for "Edit with Assistant" when there is no prompt', () => {
@@ -161,7 +162,7 @@ describe('ExperimentCustomViewProvider', () => {
       capturedConnectorProviderProps?.connector.openAssistant?.();
 
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
-      expect(assistant.sendMessage).not.toHaveBeenCalled();
+      expect(assistant.sendMessageWhenReady).not.toHaveBeenCalled();
     });
 
     it('exposes the assistant context streaming state on the connector', () => {
@@ -169,6 +170,13 @@ describe('ExperimentCustomViewProvider', () => {
       renderProvider();
 
       expect(capturedConnectorProviderProps?.connector.isStreaming).toBe(true);
+    });
+
+    it('exposes whether an automatic Assistant message is queued', () => {
+      makeAssistant({ pendingAutomaticMessage: { message: 'queued build' } });
+      renderProvider();
+
+      expect(capturedConnectorProviderProps?.connector.isPending).toBe(true);
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -12,7 +12,7 @@ import type {
 } from '@databricks/web-shared/model-trace-explorer/custom-view';
 
 // This suite exercises ONLY the OSS-specific wiring (MLflow Assistant open/
-// reset/prefill + the Tier 1 client-tool pause/resume + the pull-based context
+// direct send + the Tier 1 client-tool pause/resume + the pull-based context
 // provider), not the Databricks Genie/MFE RPC wiring the universe equivalent of
 // this file tests — that plumbing does not exist in OSS.
 // `useExperimentCustomViewDefinition` / `useCanEditExperimentCustomViews` / the
@@ -85,8 +85,7 @@ const mockUseAssistant = jest.mocked(useAssistant);
 const makeAssistant = (overrides: Record<string, unknown> = {}) => {
   const value = {
     openPanel: jest.fn(),
-    prefillPrompt: jest.fn(),
-    reset: jest.fn(),
+    sendMessage: jest.fn(),
     isStreaming: false,
     activeProvider: null,
     ...overrides,
@@ -130,18 +129,19 @@ describe('ExperimentCustomViewProvider', () => {
   });
 
   describe('connector.openAssistant', () => {
-    it('starts a fresh session, opens the panel, and prefills a render_custom_view directive for a new build', () => {
+    it('opens the panel and directly submits a render_custom_view directive in a fresh session', () => {
       const assistant = makeAssistant();
       renderProvider();
 
       capturedConnectorProviderProps?.connector.openAssistant?.('Show me the failed spans', { newSession: true });
 
-      expect(assistant.reset).toHaveBeenCalledTimes(1);
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
-      expect(assistant.prefillPrompt).toHaveBeenCalledTimes(1);
-      const [prefilled] = jest.mocked(assistant.prefillPrompt).mock.calls[0];
-      expect(prefilled).toContain('Show me the failed spans');
-      expect(prefilled).toContain('render_custom_view');
+      expect(assistant.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Show me the failed spans'), {
+        newSession: true,
+      });
+      expect(assistant.sendMessage).toHaveBeenCalledWith(expect.stringContaining('render_custom_view'), {
+        newSession: true,
+      });
     });
 
     it('reuses the current session (no reset) for a prompted edit without newSession', () => {
@@ -150,20 +150,18 @@ describe('ExperimentCustomViewProvider', () => {
 
       capturedConnectorProviderProps?.connector.openAssistant?.('Add a chart');
 
-      expect(assistant.reset).not.toHaveBeenCalled();
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
-      expect(assistant.prefillPrompt).toHaveBeenCalledTimes(1);
+      expect(assistant.sendMessage).toHaveBeenCalledWith(expect.stringContaining('Add a chart'), undefined);
     });
 
-    it('only opens the panel for "Edit with Assistant" (no prompt), seeding nothing', () => {
+    it('only opens the panel for "Edit with Assistant" when there is no prompt', () => {
       const assistant = makeAssistant();
       renderProvider();
 
       capturedConnectorProviderProps?.connector.openAssistant?.();
 
-      expect(assistant.reset).not.toHaveBeenCalled();
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
-      expect(assistant.prefillPrompt).not.toHaveBeenCalled();
+      expect(assistant.sendMessage).not.toHaveBeenCalled();
     });
 
     it('exposes the assistant context streaming state on the connector', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -20,8 +20,8 @@ import { registerClientToolHandler } from '../../../../../assistant/clientToolHa
 import { registerAssistantContextProvider } from '../../../../../assistant/contextProviders';
 
 // The empty-state prompt box hands us the user's natural-language request. This
-// prompt is seeded ONLY for the initial build (handleSubmitPrompt); the edit flow
-// (handleEditWithAssistant) seeds nothing, just opens the panel.
+// prompt is submitted ONLY for the initial build (handleSubmitPrompt); the edit
+// flow (handleEditWithAssistant) sends nothing and just opens the panel.
 const buildRenderCustomViewPrompt = (request: string): string =>
   [`Build my custom trace view: "${request}".`, '', 'Use the `render_custom_view` tool to build this view.'].join('\n');
 
@@ -40,33 +40,27 @@ export const ExperimentCustomViewProvider = ({
 }) => {
   const { views, isLoaded, persistView } = useExperimentCustomViewDefinition(experimentId);
   const { canEdit: canModifyPersistedViews } = useCanEditExperimentCustomViews(experimentId);
-  const { openPanel, prefillPrompt, reset, isStreaming, activeProvider } = useAssistant();
+  const { openPanel, sendMessage, isStreaming, activeProvider } = useAssistant();
 
   const connector = useMemo<CustomViewAssistantConnector>(
     () => ({
       openAssistant: (prompt?: string, options?: OpenCustomViewAssistantOptions) => {
         const instruction = prompt?.trim();
-        // Building a brand-new custom view: start a FRESH assistant session so the
-        // build doesn't inherit an unrelated conversation. Edits omit newSession and
-        // reuse the current thread.
-        if (options?.newSession) {
-          reset();
-        }
         openPanel();
         // "Edit with assistant" (no instruction): just open/focus the panel. The
         // custom-view authoring context is already published while the tab is open
         // (see useCustomViewAssistantBridge), so the user can describe the change
         // with full context instead of us auto-triggering an unprompted rebuild.
         if (instruction) {
-          // Empty-state "Build with assistant": seed the composer with the directive
-          // for the user to review and send, rather than auto-firing it — MLflow
-          // Assistant always shows the user their own outgoing message.
-          prefillPrompt(buildRenderCustomViewPrompt(instruction));
+          // Submit the build directive immediately. A brand-new build requests a
+          // fresh Assistant thread atomically so it cannot inherit an unrelated
+          // conversation; prompted edits can continue the current thread.
+          sendMessage(buildRenderCustomViewPrompt(instruction), options);
         }
       },
       isStreaming,
     }),
-    [openPanel, prefillPrompt, reset, isStreaming],
+    [openPanel, sendMessage, isStreaming],
   );
 
   // Tier 1 (Gateway/Ollama): the assistant backend calls a real `render_custom_view`

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -40,7 +40,7 @@ export const ExperimentCustomViewProvider = ({
 }) => {
   const { views, isLoaded, persistView } = useExperimentCustomViewDefinition(experimentId);
   const { canEdit: canModifyPersistedViews } = useCanEditExperimentCustomViews(experimentId);
-  const { openPanel, sendMessage, isStreaming, activeProvider } = useAssistant();
+  const { openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming, activeProvider } = useAssistant();
 
   const connector = useMemo<CustomViewAssistantConnector>(
     () => ({
@@ -55,12 +55,13 @@ export const ExperimentCustomViewProvider = ({
           // Submit the build directive immediately. A brand-new build requests a
           // fresh Assistant thread atomically so it cannot inherit an unrelated
           // conversation; prompted edits can continue the current thread.
-          sendMessage(buildRenderCustomViewPrompt(instruction), options);
+          sendMessageWhenReady(buildRenderCustomViewPrompt(instruction), options);
         }
       },
       isStreaming,
+      isPending: Boolean(pendingAutomaticMessage),
     }),
-    [openPanel, sendMessage, isStreaming],
+    [openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
   );
 
   // Tier 1 (Gateway/Ollama): the assistant backend calls a real `render_custom_view`

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
@@ -67,6 +67,7 @@ const setBridge = (overrides: Partial<CustomViewAssistantBridge> = {}): CustomVi
     isAvailable: true,
     openAssistant: jest.fn(),
     isStreaming: false,
+    isPending: false,
     applyError: undefined,
     clearApplyError: jest.fn(),
     ...overrides,
@@ -297,6 +298,7 @@ describe('ModelTraceExplorerCustomView', () => {
 
   it('hands the typed prompt to the assistant and shows the building skeleton on submit', async () => {
     const openAssistant = jest.fn();
+    openAssistant.mockImplementation(() => setBridge({ openAssistant, isStreaming: true }));
     setBridge({ openAssistant });
     renderCustomView();
 
@@ -312,16 +314,12 @@ describe('ModelTraceExplorerCustomView', () => {
 
   it('keeps the building skeleton after streaming ends until a view is created', () => {
     const openAssistant = jest.fn();
+    openAssistant.mockImplementation(() => setBridge({ openAssistant, isStreaming: true }));
     setBridge({ openAssistant, isStreaming: false });
     const { rerender } = renderCustomView();
 
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Show me the failed spans' } });
     fireEvent.click(screen.getByRole('button', { name: /Build with Assistant/ }));
-    expect(screen.getByText('Building this view…')).toBeInTheDocument();
-
-    // Streaming starts: the skeleton stays.
-    setBridge({ openAssistant, isStreaming: true });
-    rerender(customView());
     expect(screen.getByText('Building this view…')).toBeInTheDocument();
 
     // Streaming finishes but render_custom_view has not applied a view yet. The
@@ -332,32 +330,30 @@ describe('ModelTraceExplorerCustomView', () => {
     expect(screen.getByText('Building this view…')).toBeInTheDocument();
   });
 
-  it('does not revert to the prompt after a start timeout (no timeout guard)', () => {
-    jest.useFakeTimers();
-    try {
-      setBridge({ isStreaming: false });
-      renderCustomView();
+  it('keeps the prompt visible while queued and abandons cleanly when the queue is cleared', () => {
+    const openAssistant = jest.fn();
+    openAssistant.mockImplementation(() => setBridge({ openAssistant, isPending: true }));
+    setBridge({ openAssistant });
+    const { rerender } = renderCustomView();
 
-      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Show me the failed spans' } });
-      fireEvent.click(screen.getByRole('button', { name: /Build with Assistant/ }));
-      expect(screen.getByText('Building this view…')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Show me the failed spans' } });
+    fireEvent.click(screen.getByRole('button', { name: /Build with Assistant/ }));
 
-      // The MLflow connector never reports streaming, so an old start-timeout
-      // guard would have flashed the prompt back before render_custom_view
-      // completed. With no such guard, the skeleton persists past any window.
-      act(() => {
-        jest.advanceTimersByTime(60_000);
-      });
+    expect(screen.getByRole('textbox')).toHaveValue('Show me the failed spans');
+    expect(screen.getByRole('button', { name: /Build with Assistant/ })).toBeDisabled();
+    expect(screen.queryByText('Building this view…')).not.toBeInTheDocument();
 
-      expect(screen.getByText('Building this view…')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /Build with Assistant/ })).not.toBeInTheDocument();
-    } finally {
-      jest.useRealTimers();
-    }
+    setBridge({ openAssistant, isPending: false });
+    rerender(customView());
+
+    expect(screen.getByRole('textbox')).toHaveValue('Show me the failed spans');
+    expect(screen.getByRole('button', { name: /Build with Assistant/ })).toBeEnabled();
+    expect(screen.queryByText('Building this view…')).not.toBeInTheDocument();
   });
 
   it('clears the building skeleton and surfaces the error when the spec apply fails', () => {
     const openAssistant = jest.fn();
+    openAssistant.mockImplementation(() => setBridge({ openAssistant, isStreaming: true }));
     setBridge({ openAssistant });
     const { rerender } = renderCustomView();
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
@@ -240,6 +240,7 @@ export const ModelTraceExplorerCustomView = ({
 
   // The prompt typed in the empty-state box before/while a view is being built.
   const [instruction, setInstruction] = useState('');
+  const [isAwaitingAssistantDispatch, setIsAwaitingAssistantDispatch] = useState(false);
 
   const isInitialBuilding = cv.isBuilding;
   const { stopBuilding } = cv;
@@ -275,6 +276,7 @@ export const ModelTraceExplorerCustomView = ({
   // for an EXISTING view the authoring-context latch is authoritative instead
   // (see onSpec). Consumed (cleared) by the spec it launched.
   const pendingApplyTargetRef = useRef<CustomViewApplyTarget | undefined>(undefined);
+  const hasObservedPendingDispatchRef = useRef(false);
 
   // The rebuild effect mutates the processor model AFTER render (creating new
   // surface objects). We render by reading the SurfaceModel out of the processor
@@ -397,6 +399,8 @@ export const ModelTraceExplorerCustomView = ({
       draftViewIdRef.current = id;
     },
   });
+  const { isStreaming: isAssistantStreaming, isPending: isAssistantPending, clearApplyError } = assistant;
+  const { startBuilding } = cv;
 
   useEffect(() => {
     setInstruction('');
@@ -457,7 +461,7 @@ export const ModelTraceExplorerCustomView = ({
   // call is applied via onSpec. Used by the empty state.
   const handleSubmitPrompt = () => {
     const prompt = instruction.trim();
-    if (!cv.canPersist || !prompt || !assistant.openAssistant) {
+    if (!cv.canPersist || !prompt || !assistant.openAssistant || assistant.isPending || isAwaitingAssistantDispatch) {
       return;
     }
     try {
@@ -484,12 +488,48 @@ export const ModelTraceExplorerCustomView = ({
       instruction: prompt,
       createdAtMs: Date.now(),
     };
-    setInstruction('');
-    // Clear any leftover error from a prior failed build so the skeleton effect
-    // (which cancels on applyError) doesn't immediately suppress this retry.
-    assistant.clearApplyError();
-    cv.startBuilding();
+    hasObservedPendingDispatchRef.current = false;
+    setIsAwaitingAssistantDispatch(true);
   };
+
+  // A queued automatic message may wait on provider setup or an API key. Keep
+  // the prompt form visible until the Assistant actually begins streaming. If
+  // the panel closes first, its queue is cleared and this launch is abandoned
+  // without entering the building skeleton.
+  useEffect(() => {
+    if (!isAwaitingAssistantDispatch) {
+      return;
+    }
+    if (activeView) {
+      hasObservedPendingDispatchRef.current = false;
+      setIsAwaitingAssistantDispatch(false);
+      return;
+    }
+    if (isAssistantStreaming) {
+      setInstruction('');
+      clearApplyError();
+      startBuilding();
+      hasObservedPendingDispatchRef.current = false;
+      setIsAwaitingAssistantDispatch(false);
+      return;
+    }
+    if (isAssistantPending) {
+      hasObservedPendingDispatchRef.current = true;
+      return;
+    }
+    if (hasObservedPendingDispatchRef.current) {
+      pendingApplyTargetRef.current = undefined;
+      hasObservedPendingDispatchRef.current = false;
+      setIsAwaitingAssistantDispatch(false);
+    }
+  }, [
+    isAwaitingAssistantDispatch,
+    activeView,
+    isAssistantStreaming,
+    isAssistantPending,
+    clearApplyError,
+    startBuilding,
+  ]);
 
   // Clears the building skeleton once the built view exists (success) or the
   // spec apply failed (error). Do NOT clear on the isStreaming falling edge -
@@ -890,7 +930,9 @@ export const ModelTraceExplorerCustomView = ({
                 <div>
                   <AssistantSparkleButton
                     componentId="shared.model-trace-explorer.custom-view.build"
-                    disabled={!instruction.trim()}
+                    disabled={
+                      !instruction.trim() || assistant.isPending || assistant.isStreaming || isAwaitingAssistantDispatch
+                    }
                     onClick={handleSubmitPrompt}
                   >
                     <FormattedMessage

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.tsx
@@ -18,6 +18,7 @@ export type OpenCustomViewAssistantOptions = {
 export type CustomViewAssistantConnector = {
   openAssistant?: (prompt?: string, options?: OpenCustomViewAssistantOptions) => void;
   isStreaming?: boolean;
+  isPending?: boolean;
 };
 
 const CustomViewAssistantConnectorContext = createContext<CustomViewAssistantConnector>({});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/CustomViewAssistantConnector.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react';
 
 /** Options for opening the assistant chat panel. */
 export type OpenCustomViewAssistantOptions = {
-  // Start a FRESH assistant session (thread) before opening. Set only when
+  // Submit the prompt in a FRESH assistant session (thread). Set only when
   // building a brand-new custom view; edits reuse the current session so the
   // conversation continues.
   newSession?: boolean;
@@ -11,8 +11,8 @@ export type OpenCustomViewAssistantOptions = {
 
 /**
  * Connects the Custom View to the host application's agent (MLflow Assistant).
- * The host app provides a way to open the assistant chat panel (optionally
- * seeded with a prompt) and reports whether the assistant is currently
+ * The host app provides a way to open the assistant chat panel and optionally
+ * submit a prompt immediately, and reports whether the assistant is currently
  * streaming.
  */
 export type CustomViewAssistantConnector = {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
@@ -21,7 +21,11 @@ const activeView = (overrides: Partial<CustomView> = {}): CustomView => ({
   ...overrides,
 });
 
-const wrapperWithConnector = (connector: { openAssistant?: (prompt?: string) => void; isStreaming?: boolean }) =>
+const wrapperWithConnector = (connector: {
+  openAssistant?: (prompt?: string) => void;
+  isStreaming?: boolean;
+  isPending?: boolean;
+}) =>
   function Wrapper({ children }: { children: ReactNode }) {
     return (
       <CustomViewAssistantConnectorProvider connector={connector}>{children}</CustomViewAssistantConnectorProvider>
@@ -135,9 +139,9 @@ describe('useCustomViewAssistantBridge', () => {
     unmount();
   });
 
-  test('exposes the connector openAssistant/isStreaming when enabled', () => {
+  test('exposes the connector openAssistant/isStreaming/isPending when enabled', () => {
     const openAssistant = jest.fn();
-    const wrapper = wrapperWithConnector({ openAssistant, isStreaming: true });
+    const wrapper = wrapperWithConnector({ openAssistant, isStreaming: true, isPending: true });
     const { result, unmount } = renderHook(
       () => useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec: noopOnSpec }),
       { wrapper },
@@ -145,15 +149,16 @@ describe('useCustomViewAssistantBridge', () => {
 
     expect(result.current.isAvailable).toBe(true);
     expect(result.current.isStreaming).toBe(true);
+    expect(result.current.isPending).toBe(true);
     result.current.openAssistant?.('hi');
     expect(openAssistant).toHaveBeenCalledWith('hi');
 
     unmount();
   });
 
-  test('isAvailable is false and isStreaming/openAssistant are suppressed when disabled', () => {
+  test('isAvailable is false and connector state/actions are suppressed when disabled', () => {
     const openAssistant = jest.fn();
-    const wrapper = wrapperWithConnector({ openAssistant, isStreaming: true });
+    const wrapper = wrapperWithConnector({ openAssistant, isStreaming: true, isPending: true });
     const { result, unmount } = renderHook(
       () =>
         useCustomViewAssistantBridge({
@@ -168,6 +173,7 @@ describe('useCustomViewAssistantBridge', () => {
     expect(result.current.isAvailable).toBe(false);
     expect(result.current.openAssistant).toBeUndefined();
     expect(result.current.isStreaming).toBe(false);
+    expect(result.current.isPending).toBe(false);
 
     unmount();
   });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
@@ -13,6 +13,7 @@ export type CustomViewAssistantBridge = {
   isAvailable: boolean;
   openAssistant?: (prompt?: string, options?: OpenCustomViewAssistantOptions) => void;
   isStreaming: boolean;
+  isPending: boolean;
   applyError?: string;
   // Clears a leftover apply error, e.g. when the user retries a build so the
   // building skeleton isn't immediately suppressed by the previous failure.
@@ -114,6 +115,7 @@ export const useCustomViewAssistantBridge = ({
     isAvailable: Boolean(openAssistant),
     openAssistant,
     isStreaming: enabled && Boolean(connector.isStreaming),
+    isPending: enabled && Boolean(connector.isPending),
     applyError: enabled ? applyError : undefined,
     clearApplyError,
   };


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/25026/files) to review incremental changes.
- [stack/custom-view-6-forward-build-prompt-to-assistant](https://github.com/mlflow/mlflow/pull/25026) [[Files changed](https://github.com/mlflow/mlflow/pull/25026/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Builds on the Custom View UI in #24798 and the Assistant client-tool pause/resume bridge in #24796.

### What changes are proposed in this pull request?

This PR removes an extra interaction from the Custom View authoring flow. Clicking **Build with Assistant** now submits the generated `render_custom_view` directive directly to MLflow Assistant instead of only copying it into the chat composer and requiring the user to send it manually.

- Extends `sendMessage` with an optional `{ newSession: true }` mode for atomic fresh-thread sends.
- Ensures a fresh send never reuses a stale captured `session_id`, while closing/resetting the previous stream and clearing any queued composer prompt.
- Opens the Assistant panel and immediately sends new Custom View build requests in a fresh conversation.
- Keeps **Edit with Assistant** panel-only and preserves its existing conversation continuity.
- Adds regression coverage for stale-session isolation and direct Custom View prompt submission.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Verified with 103 tests across the affected Assistant and Custom View suites, TypeScript type checking, ESLint, Prettier, and `git diff --check`.

Before changes (custom view "build with assistant" only moves prompt into the MLflow Assistant composer chatbox):

<img width="2104" height="1045" alt="Screenshot 2026-08-12 at 1 18 04 PM" src="https://github.com/user-attachments/assets/bf78fd5f-1fc8-4da0-8a1c-4a41f3011bda" />

After changes (custom view "build with assistant" submits directly to MLflow Assistant):

https://github.com/user-attachments/assets/f186c8d3-e1c2-4981-8ad7-b08089e4897b

After changes (when API provider setup is not complete, build new views - will also stop and prompt the user for an API key before automatically sending the message to MLflow Assistant):

https://github.com/user-attachments/assets/f1450f81-5b8b-461b-90b3-fbef3ed1d359

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Custom View's **Build with Assistant** action now submits the build request immediately, eliminating the additional step of manually sending the prefilled Assistant message.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release