### PR TITLE
fix: Stop `SearchUtils._get_value` from silently dropping dataset IN clause values

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -471,11 +471,11 @@ class SearchUtils:
             elif isinstance(token, Parenthesis):
                 if key not in ("name", "digest", "context"):
                     raise MlflowException(
-                        "Only the dataset 'name' and 'digest' supports comparison with a list of "
-                        "quoted string values.",
+                        "Only the dataset 'name', 'digest', and 'context' support comparison "
+                        "with a list of quoted string values.",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
-                return cls._parse_run_ids(token)
+                return cls._parse_list_from_sql_token(token)
             else:
                 raise MlflowException(
                     "Expected a quoted string value for dataset attributes. "

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -386,6 +386,74 @@ def test_correct_filtering(filter_string, matching_runs):
     assert set(filtered_runs) == {runs[i] for i in matching_runs}
 
 
+@pytest.mark.parametrize(
+    ("filter_string", "matching_runs"),
+    [
+        ("datasets.digest IN ('06409663', 'A1B2C3D4')", [0, 1]),
+        ("datasets.name IN ('123', 'MyDataset')", [0, 1]),
+        ("datasets.context IN ('2024', 'Train')", [0, 1]),
+        ("datasets.digest IN ('06409663')", [0]),
+        ("datasets.name IN ('MyDataset')", [1]),
+        ("datasets.context IN ('Train')", [1]),
+    ],
+)
+def test_dataset_in_clause_with_digits_and_uppercase(filter_string, matching_runs):
+    runs = [
+        Run(
+            run_info=RunInfo(
+                run_id="r1",
+                experiment_id=0,
+                user_id="user-id",
+                status=RunStatus.to_string(RunStatus.FINISHED),
+                start_time=0,
+                end_time=1,
+                lifecycle_stage=LifecycleStage.ACTIVE,
+            ),
+            run_data=RunData(metrics=[], params=[], tags=[]),
+            run_inputs=RunInputs(
+                dataset_inputs=[
+                    DatasetInput(
+                        dataset=Dataset(
+                            name="123",
+                            digest="06409663",
+                            source_type="src",
+                            source="s",
+                        ),
+                        tags=[InputTag(MLFLOW_DATASET_CONTEXT, "2024")],
+                    )
+                ]
+            ),
+        ),
+        Run(
+            run_info=RunInfo(
+                run_id="r2",
+                experiment_id=0,
+                user_id="user-id",
+                status=RunStatus.to_string(RunStatus.FINISHED),
+                start_time=0,
+                end_time=1,
+                lifecycle_stage=LifecycleStage.ACTIVE,
+            ),
+            run_data=RunData(metrics=[], params=[], tags=[]),
+            run_inputs=RunInputs(
+                dataset_inputs=[
+                    DatasetInput(
+                        dataset=Dataset(
+                            name="MyDataset",
+                            digest="A1B2C3D4",
+                            source_type="src",
+                            source="s",
+                        ),
+                        tags=[InputTag(MLFLOW_DATASET_CONTEXT, "Train")],
+                    )
+                ]
+            ),
+        ),
+    ]
+    filtered_runs = SearchUtils.filter(runs, filter_string)
+    assert set(filtered_runs) == {runs[i] for i in matching_runs}
+
+
 def test_filter_runs_by_start_time():
     runs = [
         Run(


### PR DESCRIPTION
### Related Issues/PRs

Closes #25011

### What changes are proposed in this pull request?

`SearchUtils._get_value()` uses `_parse_run_ids()` for the `_DATASET_IDENTIFIER` branch when parsing `IN (...)` lists. `_parse_run_ids` applies an `islower()` filter designed for `run_id` (a MySQL case-insensitivity workaround). This silently discards any list element where `str.islower()` returns `False` — which includes **pure-digit strings** (e.g., `'06409663'.islower() == False`), not just strings with uppercase letters.

This is the same class of bug fixed for `_ATTRIBUTE_IDENTIFIER` in #24964.

Changes:
- Replace `_parse_run_ids(token)` with `_parse_list_from_sql_token(token)` in the dataset branch — dataset fields (`name`, `digest`, `context`) are never run IDs, so the `islower()` filter should not apply
- Fix inaccurate error message that omitted `context` from the list of fields supporting `IN` comparison
- Add regression tests covering pure-digit and uppercase values for all three dataset fields

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added 6 parametrized test cases in `test_dataset_in_clause_with_digits_and_uppercase` covering:
- Pure-digit digest (`'06409663'`), uppercase digest (`'A1B2C3D4'`)
- Numeric name (`'123'`), mixed-case name (`'MyDataset'`)
- Numeric context (`'2024'`), title-case context (`'Train'`)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where `datasets.digest IN (...)`, `datasets.name IN (...)`, and `datasets.context IN (...)` search filters silently dropped list elements that are pure digits or contain uppercase letters.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release