### PR TITLE
Stabilize `TracesV4PageContent` pagination test

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.test.tsx
@@ -683,7 +683,7 @@ describe('TracesV4PageContent', () => {
 
       expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled();
       expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled();
-    });
+    }, 20000);
 
     test('an exactly-full last page → Next enabled; clicking it shows "No more results" with the bar still present', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });


### PR DESCRIPTION
### Related Issues/PRs

Failed CI job: https://github.com/mlflow/mlflow/actions/runs/31565323357/job/94020407355

### What changes are proposed in this pull request?

Increase the timeout for the heavy partial-final-page pagination test from Jest's default 5 seconds to 20 seconds. The test timed out under parallel jsdom CI load without an assertion failure, and this timeout matches neighboring heavy-render tests in the same file.

This reduces flakiness observed in the linked CI job.

### How is this PR tested?

Not run locally (timeout-only test change).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release