### PR TITLE
Retry pyenv clone in `setup-pyenv` action to tolerate transient network failures

### DIFF
--- a/.github/actions/setup-pyenv/action.yml
+++ b/.github/actions/setup-pyenv/action.yml
@@ -20,7 +20,18 @@ runs:
       shell: bash
       run: |
         # Pin to pyenv v2.6.25 by tag + SHA verification for reproducible builds
-        git clone --branch v2.6.25 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        # Retry the clone to tolerate transient network/DNS failures on the runner
+        for attempt in 1 2 3; do
+          rm -rf "$HOME/.pyenv"
+          if git clone --branch v2.6.25 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"; then
+            break
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "::error::Failed to clone pyenv after 3 attempts"
+            exit 1
+          fi
+          sleep $((attempt * 10))
+        done
         actual_sha=$(git -C "$HOME/.pyenv" rev-parse HEAD)
         expected_sha="aa2e8b82605b8ba085dd15f7a31fe1990fabdcfa"
         if [ "$actual_sha" != "$expected_sha" ]; then


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Wrap the pyenv `git clone` in the `setup-pyenv` composite action in a bounded retry loop (3 attempts with backoff).

Why: a transient DNS failure on a hosted runner killed a job before any tests ran:
https://github.com/mlflow/mlflow/actions/runs/31569202941/job/94027439444

```
Cloning into '/home/runner/.pyenv'...
fatal: unable to access 'https://github.com/pyenv/pyenv.git/': Could not resolve host: github.com
##[error]Process completed with exit code 128.
```

This clone is the only raw, un-retried github.com fetch in the action (apt and uv have their own retry behavior). Each attempt removes any partial `~/.pyenv` left by a failed clone, and the existing SHA verification still runs after a successful clone, so the version pinning is unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)