### PR TITLE
Remove `git add` from `check-component-ids` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -284,7 +284,6 @@ repos:
               echo
               echo "Auto-regenerating componentId registry..."
               node .github/actions/check-component-ids/regenerate.js
-              git add .github/actions/check-component-ids/componentId-registry.js
               exit 1
             fi
           '


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25030

### What changes are proposed in this pull request?

Remove the `git add` line from the `check-component-ids` pre-commit hook. On failure, the hook now regenerates the registry and exits 1 without staging the result, like the repo's other fixer hooks (prettier, ruff): pre-commit reports "files were modified by this hook", and the user stages the regenerated registry and recommits.

No other hook auto-stages its output, and mutating the index from inside a hook interacts subtly with pre-commit's stash/restore of unstaged changes.

### How is this PR tested?

- [x] Manual tests

Removed a registry entry to force a mismatch, ran `pre-commit run check-component-ids`: the hook regenerated the registry, exited 1, and left the index untouched (registry shows as an unstaged modification). A second run with the registry in sync passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)