### PR TITLE
[Custom View] Support local Assistant providers with structured responses

### DIFF
--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -80,9 +80,12 @@ The decoded string must start with "[", end with "]", and contain nothing after 
 
 def _parse_stringified_messages(value: str) -> Any:
     try:
-        return json.loads(value)
+        parsed = json.loads(value)
     except json.JSONDecodeError as e:
         raise ValueError("messages must be a JSON-encoded array") from e
+    if not isinstance(parsed, list):
+        raise ValueError("messages must be a JSON-encoded array")
+    return parsed
 
 
 class CustomViewResponse(BaseModel):

--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -82,6 +82,17 @@ def _decode_stringified_messages(value: str) -> Any:
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError:
+        try:
+            parsed, end = json.JSONDecoder().raw_decode(value)
+        except json.JSONDecodeError:
+            parsed = None
+        else:
+            # Codex can close the strict outer response envelope inside the string,
+            # leaving a complete A2UI array followed by an extra `}`. Discard only
+            # a short suffix of unmatched closing delimiters; never repair content.
+            trailing = value[end:].strip()
+            if isinstance(parsed, list) and 0 < len(trailing) <= 4 and set(trailing) <= {"}", "]"}:
+                return parsed
         # The browser owns A2UI validation and bounded repair. Preserve malformed
         # payloads so they reach that lifecycle instead of terminating on the server.
         return value

--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -78,6 +78,8 @@ the transport encoding: the decoded value must be the same A2UI message array de
 The decoded string must start with "[", end with "]", and contain nothing after that final "]".
 """
 
+# This per-provider-request budget repairs malformed response envelopes. Browser-side
+# A2UI validation has a separate budget, and each browser repair starts a new request.
 _MAX_STRUCTURED_RESPONSE_REPAIRS = 1
 
 

--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -1,0 +1,187 @@
+"""Custom View delivery for structured-output providers (Claude Code and Codex).
+
+This module converts a structured response envelope into a terminal ``client_tool_call``.
+Native-tool providers use ``tool_executor`` instead.
+"""
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from mlflow.assistant.types import Event, Message, TextBlock, ToolUseBlock
+
+RENDER_CUSTOM_VIEW_TOOL_NAME = "render_custom_view"
+
+CUSTOM_VIEW_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["message", RENDER_CUSTOM_VIEW_TOOL_NAME]},
+        "text": {
+            "type": "string",
+            "description": (
+                "The conversational response shown in chat. For a rendered view, briefly "
+                "describe what was created or changed."
+            ),
+        },
+        "title": {
+            "type": "string",
+            "description": (
+                "A short display title when type is render_custom_view; otherwise an empty string."
+            ),
+        },
+        "messages": {
+            "type": "array",
+            "description": (
+                "The complete A2UI message list when type is render_custom_view; otherwise empty."
+            ),
+            "items": {"type": "object"},
+        },
+    },
+    "required": ["type", "text", "title", "messages"],
+    "additionalProperties": False,
+}
+
+# Codex's --output-schema uses strict OpenAI structured outputs, where every object
+# must declare a closed set of properties. A2UI messages are intentionally open-ended,
+# so encode that array as JSON within the otherwise strict response envelope.
+STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA: dict[str, Any] = {
+    **CUSTOM_VIEW_RESPONSE_SCHEMA,
+    "properties": {
+        **CUSTOM_VIEW_RESPONSE_SCHEMA["properties"],
+        "messages": {
+            "type": "string",
+            "description": (
+                "The complete A2UI message array encoded as JSON when type is "
+                "render_custom_view; otherwise the JSON string '[]'."
+            ),
+        },
+    },
+}
+
+CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS = f"""\
+Your final response MUST match the provided JSON schema. Set "type" to
+"{RENDER_CUSTOM_VIEW_TOOL_NAME}" only when the user asks to build or modify the custom view;
+put the complete A2UI specification in "messages" and a short view name in "title". For any
+other response, set "type" to "message", answer in "text", and return an empty "title" and
+"messages" array. Do not call a render tool and do not wrap the JSON in a code fence.
+"""
+
+STRINGIFIED_CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS = f"""\
+{CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS}
+For this provider, the response schema defines "messages" as a string. JSON-encode the complete
+A2UI message array into that string. For a normal message, return "messages": "[]". This is only
+the transport encoding: the decoded value must be the same A2UI message array described above.
+The decoded string must start with "[", end with "]", and contain nothing after that final "]".
+"""
+
+_MAX_STRUCTURED_RESPONSE_REPAIRS = 1
+
+
+@dataclass(frozen=True)
+class StructuredResponseRetry:
+    """Provider-independent state and prompt for a bounded structured-output repair."""
+
+    attempts: int = 0
+
+    def next_attempt(self, error: Exception) -> tuple[str, "StructuredResponseRetry"] | None:
+        if self.attempts >= _MAX_STRUCTURED_RESPONSE_REPAIRS:
+            return None
+
+        detail = str(error) or repr(error)
+        prompt = (
+            "Your previous structured response failed validation:\n"
+            f"{detail}\n\n"
+            "Regenerate the complete response and follow the same output schema exactly. "
+            "Return only the schema-conforming response."
+        )
+        return prompt, StructuredResponseRetry(attempts=self.attempts + 1)
+
+
+def _parse_stringified_messages(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as original_error:
+        try:
+            parsed, end = json.JSONDecoder().raw_decode(value)
+        except json.JSONDecodeError:
+            raise ValueError("messages must be a JSON-encoded array") from original_error
+
+        # Codex can close the strict outer response envelope inside the string,
+        # leaving an otherwise complete A2UI array followed by an extra `}`. Only
+        # discard a short suffix of unmatched closing delimiters; do not guess at
+        # truncated JSON or repair content within the array.
+        trailing = value[end:].strip()
+        if isinstance(parsed, list) and 0 < len(trailing) <= 4 and set(trailing) <= {"}", "]"}:
+            return parsed
+        raise ValueError("messages must be a JSON-encoded array") from original_error
+
+
+class CustomViewResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["message", "render_custom_view"]
+    text: str
+    title: str
+    messages: list[dict[str, Any]]
+
+    @field_validator("messages", mode="before")
+    @classmethod
+    def parse_stringified_messages(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return _parse_stringified_messages(value)
+        return value
+
+    @model_validator(mode="after")
+    def validate_action_fields(self) -> "CustomViewResponse":
+        # Match the browser's top-level acceptance rule: render actions need
+        # content, while title and conversational text may be empty.
+        if self.type == RENDER_CUSTOM_VIEW_TOOL_NAME and not self.messages:
+            raise ValueError("render_custom_view responses require non-empty messages")
+        return self
+
+
+def parse_custom_view_response(value: Any) -> CustomViewResponse:
+    if isinstance(value, str):
+        value = json.loads(value)
+    return CustomViewResponse.model_validate(value)
+
+
+def custom_view_response_events(response: CustomViewResponse) -> list[Event]:
+    events = []
+    if response.text:
+        events.append(
+            Event.from_message(Message(role="assistant", content=[TextBlock(text=response.text)]))
+        )
+
+    if response.type == RENDER_CUSTOM_VIEW_TOOL_NAME:
+        request_id = str(uuid.uuid4())
+        tool_input = {"title": response.title, "messages": response.messages}
+        events.extend([
+            Event.from_message(
+                Message(
+                    role="assistant",
+                    content=[
+                        ToolUseBlock(
+                            id=request_id,
+                            name=RENDER_CUSTOM_VIEW_TOOL_NAME,
+                            input=tool_input,
+                        )
+                    ],
+                )
+            ),
+            Event.from_client_tool_call(
+                request_id,
+                RENDER_CUSTOM_VIEW_TOOL_NAME,
+                tool_input,
+                continuation="terminal",
+            ),
+        ])
+    return events
+
+
+def is_custom_view_request(context: dict[str, Any] | None) -> bool:
+    return bool(context and context.get("customTraceView"))

--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -6,10 +6,9 @@ Native-tool providers use ``tool_executor`` instead.
 
 import json
 import uuid
-from dataclasses import dataclass
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from mlflow.assistant.types import Event, Message, TextBlock, ToolUseBlock
 
@@ -78,48 +77,12 @@ the transport encoding: the decoded value must be the same A2UI message array de
 The decoded string must start with "[", end with "]", and contain nothing after that final "]".
 """
 
-# This per-provider-request budget repairs malformed response envelopes. Browser-side
-# A2UI validation has a separate budget, and each browser repair starts a new request.
-_MAX_STRUCTURED_RESPONSE_REPAIRS = 1
-
-
-@dataclass(frozen=True)
-class StructuredResponseRetry:
-    """Provider-independent state and prompt for a bounded structured-output repair."""
-
-    attempts: int = 0
-
-    def next_attempt(self, error: Exception) -> tuple[str, "StructuredResponseRetry"] | None:
-        if self.attempts >= _MAX_STRUCTURED_RESPONSE_REPAIRS:
-            return None
-
-        detail = str(error) or repr(error)
-        prompt = (
-            "Your previous structured response failed validation:\n"
-            f"{detail}\n\n"
-            "Regenerate the complete response and follow the same output schema exactly. "
-            "Return only the schema-conforming response."
-        )
-        return prompt, StructuredResponseRetry(attempts=self.attempts + 1)
-
 
 def _parse_stringified_messages(value: str) -> Any:
     try:
         return json.loads(value)
-    except json.JSONDecodeError as original_error:
-        try:
-            parsed, end = json.JSONDecoder().raw_decode(value)
-        except json.JSONDecodeError:
-            raise ValueError("messages must be a JSON-encoded array") from original_error
-
-        # Codex can close the strict outer response envelope inside the string,
-        # leaving an otherwise complete A2UI array followed by an extra `}`. Only
-        # discard a short suffix of unmatched closing delimiters; do not guess at
-        # truncated JSON or repair content within the array.
-        trailing = value[end:].strip()
-        if isinstance(parsed, list) and 0 < len(trailing) <= 4 and set(trailing) <= {"}", "]"}:
-            return parsed
-        raise ValueError("messages must be a JSON-encoded array") from original_error
+    except json.JSONDecodeError as e:
+        raise ValueError("messages must be a JSON-encoded array") from e
 
 
 class CustomViewResponse(BaseModel):
@@ -136,14 +99,6 @@ class CustomViewResponse(BaseModel):
         if isinstance(value, str):
             return _parse_stringified_messages(value)
         return value
-
-    @model_validator(mode="after")
-    def validate_action_fields(self) -> "CustomViewResponse":
-        # Match the browser's top-level acceptance rule: render actions need
-        # content, while title and conversational text may be empty.
-        if self.type == RENDER_CUSTOM_VIEW_TOOL_NAME and not self.messages:
-            raise ValueError("render_custom_view responses require non-empty messages")
-        return self
 
 
 def parse_custom_view_response(value: Any) -> CustomViewResponse:

--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -78,14 +78,14 @@ The decoded string must start with "[", end with "]", and contain nothing after 
 """
 
 
-def _decode_stringified_messages(value: str) -> Any:
+def _parse_stringified_messages(value: str) -> Any:
     try:
         parsed = json.loads(value)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as original_error:
         try:
             parsed, end = json.JSONDecoder().raw_decode(value)
         except json.JSONDecodeError:
-            parsed = None
+            raise ValueError("messages must be a JSON-encoded array") from original_error
         else:
             # Codex can close the strict outer response envelope inside the string,
             # leaving a complete A2UI array followed by an extra `}`. Discard only
@@ -93,10 +93,10 @@ def _decode_stringified_messages(value: str) -> Any:
             trailing = value[end:].strip()
             if isinstance(parsed, list) and 0 < len(trailing) <= 4 and set(trailing) <= {"}", "]"}:
                 return parsed
-        # The browser owns A2UI validation and bounded repair. Preserve malformed
-        # payloads so they reach that lifecycle instead of terminating on the server.
-        return value
-    return parsed if isinstance(parsed, list) else value
+        raise ValueError("messages must be a JSON-encoded array") from original_error
+    if not isinstance(parsed, list):
+        raise ValueError("messages must be a JSON-encoded array")
+    return parsed
 
 
 class CustomViewResponse(BaseModel):
@@ -105,13 +105,13 @@ class CustomViewResponse(BaseModel):
     type: Literal["message", "render_custom_view"]
     text: str
     title: str
-    messages: list[Any] | str
+    messages: list[dict[str, Any]]
 
     @field_validator("messages", mode="before")
     @classmethod
-    def decode_stringified_messages(cls, value: Any) -> Any:
+    def parse_stringified_messages(cls, value: Any) -> Any:
         if isinstance(value, str):
-            return _decode_stringified_messages(value)
+            return _parse_stringified_messages(value)
         return value
 
 

--- a/mlflow/assistant/custom_view.py
+++ b/mlflow/assistant/custom_view.py
@@ -78,14 +78,14 @@ The decoded string must start with "[", end with "]", and contain nothing after 
 """
 
 
-def _parse_stringified_messages(value: str) -> Any:
+def _decode_stringified_messages(value: str) -> Any:
     try:
         parsed = json.loads(value)
-    except json.JSONDecodeError as e:
-        raise ValueError("messages must be a JSON-encoded array") from e
-    if not isinstance(parsed, list):
-        raise ValueError("messages must be a JSON-encoded array")
-    return parsed
+    except json.JSONDecodeError:
+        # The browser owns A2UI validation and bounded repair. Preserve malformed
+        # payloads so they reach that lifecycle instead of terminating on the server.
+        return value
+    return parsed if isinstance(parsed, list) else value
 
 
 class CustomViewResponse(BaseModel):
@@ -94,13 +94,13 @@ class CustomViewResponse(BaseModel):
     type: Literal["message", "render_custom_view"]
     text: str
     title: str
-    messages: list[dict[str, Any]]
+    messages: list[Any] | str
 
     @field_validator("messages", mode="before")
     @classmethod
-    def parse_stringified_messages(cls, value: Any) -> Any:
+    def decode_stringified_messages(cls, value: Any) -> Any:
         if isinstance(value, str):
-            return _parse_stringified_messages(value)
+            return _decode_stringified_messages(value)
         return value
 
 

--- a/mlflow/assistant/providers/base.py
+++ b/mlflow/assistant/providers/base.py
@@ -70,10 +70,11 @@ class AssistantProvider(ABC):
 
     @property
     def client_tool_delivery(self) -> ClientToolDelivery:
-        """How this provider delivers actions that must be executed by the client.
+        """How this provider delivers actions executed by the client.
 
-        ``tool`` providers pause and resume around a native client-tool call.
-        ``structured`` providers encode the action in their terminal structured output.
+        ``tool`` pauses and resumes around a native client-tool call, ``structured`` encodes the
+        action in a schema-constrained final response, and ``unsupported`` cannot request
+        client-executed tools.
         """
         return "unsupported"
 

--- a/mlflow/assistant/providers/base.py
+++ b/mlflow/assistant/providers/base.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable
+from typing import Any, AsyncGenerator, Callable, Literal
 
 from mlflow.assistant.config import AssistantConfig, ProviderConfig
 from mlflow.assistant.types import Event
+
+ClientToolDelivery = Literal["tool", "structured", "unsupported"]
 
 
 @lru_cache(maxsize=10)
@@ -67,15 +69,13 @@ class AssistantProvider(ABC):
         return False
 
     @property
-    def supports_client_tools(self) -> bool:
-        """Whether this provider can pause a turn on a CLIENT-executed tool call (see
-        ``tool_executor.CLIENT_TOOLS``) and resume it once the client posts a result,
-        e.g. rendering an agent-authored UI spec in the browser. CLI-based providers
-        (Claude Code, Codex) have no such mid-stream channel without MCP plumbing, so
-        features that need this fall back to a convention (e.g. a fenced code block)
-        for those providers instead.
+    def client_tool_delivery(self) -> ClientToolDelivery:
+        """How this provider delivers actions that must be executed by the client.
+
+        ``tool`` providers pause and resume around a native client-tool call.
+        ``structured`` providers encode the action in their terminal structured output.
         """
-        return False
+        return "unsupported"
 
     @abstractmethod
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -13,8 +13,16 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable
+from typing import Any, AsyncGenerator, Callable, Literal
 
+from mlflow.assistant.custom_view import (
+    CUSTOM_VIEW_RESPONSE_SCHEMA,
+    CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS,
+    StructuredResponseRetry,
+    custom_view_response_events,
+    is_custom_view_request,
+    parse_custom_view_response,
+)
 from mlflow.assistant.providers.base import (
     AssistantProvider,
     CLINotInstalledError,
@@ -343,6 +351,10 @@ class ClaudeCodeProvider(AssistantProvider):
     def description(self) -> str:
         return "AI-powered assistant using Claude Code CLI"
 
+    @property
+    def client_tool_delivery(self) -> Literal["structured"]:
+        return "structured"
+
     def is_available(self) -> bool:
         return shutil.which("claude") is not None
 
@@ -414,6 +426,7 @@ class ClaudeCodeProvider(AssistantProvider):
         mlflow_session_id: str | None = None,
         cwd: Path | None = None,
         context: dict[str, Any] | None = None,
+        _structured_response_retry: StructuredResponseRetry = StructuredResponseRetry(),
     ) -> AsyncGenerator[Event, None]:
         """
         Stream responses from Claude Code CLI asynchronously.
@@ -426,6 +439,7 @@ class ClaudeCodeProvider(AssistantProvider):
             cwd: Working directory for Claude Code CLI
             context: Additional context for the assistant, such as information from
                 the current UI page the user is viewing (e.g., experimentId, traceId)
+            _structured_response_retry: Internal state for a bounded structured-output repair
 
         Yields:
             Event objects
@@ -442,6 +456,9 @@ class ClaudeCodeProvider(AssistantProvider):
             user_message = f"<context>\n{json.dumps(context)}\n</context>\n\n{prompt}"
         else:
             user_message = prompt
+        structured_custom_view = is_custom_view_request(context)
+        if structured_custom_view:
+            user_message = f"{user_message}\n\n{CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS}"
 
         # Build command
         # Note: --verbose is required when using --output-format=stream-json with -p.
@@ -462,6 +479,8 @@ class ClaudeCodeProvider(AssistantProvider):
 
         system_prompt = _build_system_prompt(tracking_uri)
         config = load_config_or_default(self.name)
+        if structured_custom_view:
+            cmd.extend(["--json-schema", json.dumps(CUSTOM_VIEW_RESPONSE_SCHEMA)])
 
         # Handle permission mode
         if config.permissions.full_access:
@@ -485,7 +504,9 @@ class ClaudeCodeProvider(AssistantProvider):
             cmd.extend(["--resume", session_id])
 
         process = None
-        system_prompt_path = None
+        system_prompt_path: str | None = None
+        structured_response: Any | None = None
+        structured_session_id: str | None = None
         try:
             # Write the system prompt to a temp file referenced with
             # --append-system-prompt-file. mkstemp (rather than NamedTemporaryFile)
@@ -547,11 +568,20 @@ class ClaudeCodeProvider(AssistantProvider):
 
                         if self._should_filter_out_message(data):
                             continue
+                        if structured_custom_view:
+                            data = self._filter_structured_output_text(data)
+                        if data is None:
+                            continue
 
                         # Emit token usage before the result event, which closes
                         # the stream on the client once received.
                         if data.get("type") == "result" and (usage := data.get("usage")):
                             yield self._build_usage_event(usage, data.get("total_cost_usd"))
+
+                        if data.get("type") == "result" and structured_custom_view:
+                            structured_response = data.get("structured_output", data.get("result"))
+                            structured_session_id = data.get("session_id")
+                            continue
 
                         if msg := self._parse_message_to_event(data):
                             yield msg
@@ -581,6 +611,33 @@ class ClaudeCodeProvider(AssistantProvider):
                     or f"Process exited with code {process.returncode}"
                 )
                 yield Event.from_error(error_msg)
+            elif structured_custom_view:
+                result_session_id = structured_session_id or session_id
+                try:
+                    response = parse_custom_view_response(structured_response)
+                except Exception as e:
+                    repair = _structured_response_retry.next_attempt(e)
+                    if repair and result_session_id:
+                        repair_prompt, next_retry = repair
+                        async for event in self.astream(
+                            repair_prompt,
+                            tracking_uri,
+                            session_id=result_session_id,
+                            mlflow_session_id=mlflow_session_id,
+                            cwd=cwd,
+                            context=context,
+                            _structured_response_retry=next_retry,
+                        ):
+                            yield event
+                        return
+                    yield Event.from_error(f"Claude Code returned invalid Custom View output: {e}")
+                    return
+                if not result_session_id:
+                    yield Event.from_error("Claude Code result did not include a session ID")
+                    return
+                for event in custom_view_response_events(response):
+                    yield event
+                yield Event.from_result(result=None, session_id=result_session_id)
 
         except Exception as e:
             _logger.exception("Error running Claude Code CLI")
@@ -788,3 +845,21 @@ class ClaudeCodeProvider(AssistantProvider):
             and block.get("text", "").startswith("Base directory for this skill:")
             for block in content
         )
+
+    @staticmethod
+    def _filter_structured_output_text(data: dict[str, Any]) -> dict[str, Any] | None:
+        """Hide the JSON final answer; its parsed fields are emitted from the result event."""
+        if data.get("type") != "assistant":
+            return data
+
+        message = data.get("message", {})
+        content = message.get("content")
+        if not isinstance(content, list):
+            return data
+
+        filtered = [block for block in content if block.get("type") != "text"]
+        if len(filtered) == len(content):
+            return data
+        if not filtered:
+            return None
+        return {**data, "message": {**message, "content": filtered}}

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -567,6 +567,7 @@ class ClaudeCodeProvider(AssistantProvider):
                             continue
                         if structured_custom_view:
                             data = self._filter_structured_output_text(data)
+                        # Suppress the structured JSON envelope from the visible chat stream.
                         if data is None:
                             continue
 
@@ -615,7 +616,10 @@ class ClaudeCodeProvider(AssistantProvider):
                 try:
                     response = parse_custom_view_response(structured_response)
                 except Exception as e:
-                    yield Event.from_error(f"Claude Code returned invalid Custom View output: {e}")
+                    yield Event.from_error(
+                        f"Claude Code returned invalid Custom View output: {e}",
+                        session_id=structured_session_id,
+                    )
                     return
                 for event in custom_view_response_events(response):
                     yield event

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -18,7 +18,6 @@ from typing import Any, AsyncGenerator, Callable, Literal
 from mlflow.assistant.custom_view import (
     CUSTOM_VIEW_RESPONSE_SCHEMA,
     CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS,
-    StructuredResponseRetry,
     custom_view_response_events,
     is_custom_view_request,
     parse_custom_view_response,
@@ -426,7 +425,6 @@ class ClaudeCodeProvider(AssistantProvider):
         mlflow_session_id: str | None = None,
         cwd: Path | None = None,
         context: dict[str, Any] | None = None,
-        _structured_response_retry: StructuredResponseRetry = StructuredResponseRetry(),
     ) -> AsyncGenerator[Event, None]:
         """
         Stream responses from Claude Code CLI asynchronously.
@@ -439,7 +437,6 @@ class ClaudeCodeProvider(AssistantProvider):
             cwd: Working directory for Claude Code CLI
             context: Additional context for the assistant, such as information from
                 the current UI page the user is viewing (e.g., experimentId, traceId)
-            _structured_response_retry: Internal state for a bounded structured-output repair
 
         Yields:
             Event objects
@@ -616,20 +613,6 @@ class ClaudeCodeProvider(AssistantProvider):
                 try:
                     response = parse_custom_view_response(structured_response)
                 except Exception as e:
-                    repair = _structured_response_retry.next_attempt(e)
-                    if repair and result_session_id:
-                        repair_prompt, next_retry = repair
-                        async for event in self.astream(
-                            repair_prompt,
-                            tracking_uri,
-                            session_id=result_session_id,
-                            mlflow_session_id=mlflow_session_id,
-                            cwd=cwd,
-                            context=context,
-                            _structured_response_retry=next_retry,
-                        ):
-                            yield event
-                        return
                     yield Event.from_error(f"Claude Code returned invalid Custom View output: {e}")
                     return
                 if not result_session_id:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -609,18 +609,17 @@ class ClaudeCodeProvider(AssistantProvider):
                 )
                 yield Event.from_error(error_msg)
             elif structured_custom_view:
-                result_session_id = structured_session_id or session_id
+                if not structured_session_id:
+                    yield Event.from_error("Claude Code result did not include a session ID")
+                    return
                 try:
                     response = parse_custom_view_response(structured_response)
                 except Exception as e:
                     yield Event.from_error(f"Claude Code returned invalid Custom View output: {e}")
                     return
-                if not result_session_id:
-                    yield Event.from_error("Claude Code result did not include a session ID")
-                    return
                 for event in custom_view_response_events(response):
                     yield event
-                yield Event.from_result(result=None, session_id=result_session_id)
+                yield Event.from_result(result=None, session_id=structured_session_id)
 
         except Exception as e:
             _logger.exception("Error running Claude Code CLI")

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -267,6 +267,11 @@ class CodexProvider(AssistantProvider):
                 yield Event.from_error(error_msg)
             else:
                 if structured_custom_view:
+                    if structured_response_text is None:
+                        yield Event.from_error(
+                            "Codex did not return a structured Custom View response"
+                        )
+                        return
                     try:
                         response = parse_custom_view_response(structured_response_text)
                     except Exception as e:

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -269,13 +269,17 @@ class CodexProvider(AssistantProvider):
                 if structured_custom_view:
                     if structured_response_text is None:
                         yield Event.from_error(
-                            "Codex did not return a structured Custom View response"
+                            "Codex did not return a structured Custom View response",
+                            session_id=thread_id or session_id,
                         )
                         return
                     try:
                         response = parse_custom_view_response(structured_response_text)
                     except Exception as e:
-                        yield Event.from_error(f"Codex returned invalid Custom View output: {e}")
+                        yield Event.from_error(
+                            f"Codex returned invalid Custom View output: {e}",
+                            session_id=thread_id or session_id,
+                        )
                         return
                     for event in custom_view_response_events(response):
                         yield event

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -11,7 +11,6 @@ from typing import Any, AsyncGenerator, Callable, Literal
 from mlflow.assistant.custom_view import (
     STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA,
     STRINGIFIED_CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS,
-    StructuredResponseRetry,
     custom_view_response_events,
     is_custom_view_request,
     parse_custom_view_response,
@@ -125,7 +124,6 @@ class CodexProvider(AssistantProvider):
         mlflow_session_id: str | None = None,
         cwd: Path | None = None,
         context: dict[str, Any] | None = None,
-        _structured_response_retry: StructuredResponseRetry = StructuredResponseRetry(),
     ) -> AsyncGenerator[Event, None]:
         codex_path = shutil.which(_CODEX_BINARY)
         if not codex_path:
@@ -272,21 +270,6 @@ class CodexProvider(AssistantProvider):
                     try:
                         response = parse_custom_view_response(structured_response_text)
                     except Exception as e:
-                        repair = _structured_response_retry.next_attempt(e)
-                        repair_session_id = thread_id or session_id
-                        if repair and repair_session_id:
-                            repair_prompt, next_retry = repair
-                            async for event in self.astream(
-                                repair_prompt,
-                                tracking_uri,
-                                session_id=repair_session_id,
-                                mlflow_session_id=mlflow_session_id,
-                                cwd=cwd,
-                                context=context,
-                                _structured_response_retry=next_retry,
-                            ):
-                                yield event
-                            return
                         yield Event.from_error(f"Codex returned invalid Custom View output: {e}")
                         return
                     for event in custom_view_response_events(response):

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -163,28 +163,31 @@ class CodexProvider(AssistantProvider):
         ]
 
         schema_path: Path | None = None
-        if structured_custom_view:
-            fd, raw_schema_path = tempfile.mkstemp(
-                prefix="mlflow-custom-view-", suffix=".schema.json"
-            )
-            schema_path = Path(raw_schema_path)
-            with os.fdopen(fd, "w") as schema_file:
-                json.dump(STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA, schema_file)
-            cmd.extend(["--output-schema", str(schema_path)])
-
-        if config.model and config.model != "default":
-            cmd.extend(["-m", config.model])
-
-        if session_id:
-            cmd.extend(["resume", session_id])
-
-        cmd.append("-")
-
+        schema_fd: int | None = None
         thread_id = ""
         structured_response_text: str | None = None
         codex_error: str | None = None
         process = None
         try:
+            if structured_custom_view:
+                schema_fd, raw_schema_path = tempfile.mkstemp(
+                    prefix="mlflow-custom-view-", suffix=".schema.json"
+                )
+                schema_path = Path(raw_schema_path)
+                schema_file = os.fdopen(schema_fd, "w")
+                schema_fd = None  # fdopen owns and closes the descriptor from here.
+                with schema_file:
+                    json.dump(STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA, schema_file)
+                cmd.extend(["--output-schema", str(schema_path)])
+
+            if config.model and config.model != "default":
+                cmd.extend(["-m", config.model])
+
+            if session_id:
+                cmd.extend(["resume", session_id])
+
+            cmd.append("-")
+
             process = await asyncio.create_subprocess_exec(
                 *cmd,
                 stdin=asyncio.subprocess.PIPE,
@@ -294,13 +297,21 @@ class CodexProvider(AssistantProvider):
             _logger.exception("Error running Codex CLI")
             yield Event.from_exception(e)
         finally:
+            if schema_fd is not None:
+                try:
+                    os.close(schema_fd)
+                except OSError:
+                    _logger.warning("Failed to close temp Custom View schema file descriptor")
             if mlflow_session_id:
                 clear_process_pid(mlflow_session_id)
             if process is not None and process.returncode is None:
                 process.kill()
                 await process.wait()
             if schema_path:
-                schema_path.unlink(missing_ok=True)
+                try:
+                    schema_path.unlink(missing_ok=True)
+                except OSError:
+                    _logger.warning("Failed to remove temp Custom View schema file %s", schema_path)
 
     @staticmethod
     def _unwrap_error_message(message: Any) -> str | None:

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -4,9 +4,18 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable
+from typing import Any, AsyncGenerator, Callable, Literal
 
+from mlflow.assistant.custom_view import (
+    STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA,
+    STRINGIFIED_CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS,
+    StructuredResponseRetry,
+    custom_view_response_events,
+    is_custom_view_request,
+    parse_custom_view_response,
+)
 from mlflow.assistant.providers.base import (
     AssistantProvider,
     CLINotInstalledError,
@@ -36,6 +45,10 @@ class CodexProvider(AssistantProvider):
     @property
     def description(self) -> str:
         return "AI-powered assistant using the Codex CLI"
+
+    @property
+    def client_tool_delivery(self) -> Literal["structured"]:
+        return "structured"
 
     def is_available(self) -> bool:
         return shutil.which(_CODEX_BINARY) is not None
@@ -112,6 +125,7 @@ class CodexProvider(AssistantProvider):
         mlflow_session_id: str | None = None,
         cwd: Path | None = None,
         context: dict[str, Any] | None = None,
+        _structured_response_retry: StructuredResponseRetry = StructuredResponseRetry(),
     ) -> AsyncGenerator[Event, None]:
         codex_path = shutil.which(_CODEX_BINARY)
         if not codex_path:
@@ -127,6 +141,9 @@ class CodexProvider(AssistantProvider):
             user_text = f"<context>\n{json.dumps(context)}\n</context>\n\n{prompt}"
         else:
             user_text = prompt
+        structured_custom_view = is_custom_view_request(context)
+        if structured_custom_view:
+            user_text = f"{user_text}\n\n{STRINGIFIED_CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS}"
 
         if session_id:
             user_message = user_text
@@ -145,6 +162,16 @@ class CodexProvider(AssistantProvider):
             "--skip-git-repo-check",
         ]
 
+        schema_path: Path | None = None
+        if structured_custom_view:
+            fd, raw_schema_path = tempfile.mkstemp(
+                prefix="mlflow-custom-view-", suffix=".schema.json"
+            )
+            schema_path = Path(raw_schema_path)
+            with os.fdopen(fd, "w") as schema_file:
+                json.dump(STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA, schema_file)
+            cmd.extend(["--output-schema", str(schema_path)])
+
         if config.model and config.model != "default":
             cmd.extend(["-m", config.model])
 
@@ -154,6 +181,8 @@ class CodexProvider(AssistantProvider):
         cmd.append("-")
 
         thread_id = ""
+        structured_response_text: str | None = None
+        codex_error: str | None = None
         process = None
         try:
             process = await asyncio.create_subprocess_exec(
@@ -186,8 +215,27 @@ class CodexProvider(AssistantProvider):
                 except json.JSONDecodeError:
                     continue
 
+                if data.get("type") == "error":
+                    codex_error = self._unwrap_error_message(data.get("message"))
+                    continue
+
+                if data.get("type") == "turn.failed":
+                    codex_error = self._unwrap_error_message(
+                        (data.get("error") or {}).get("message")
+                    )
+                    continue
+
                 if data.get("type") == "thread.started":
                     thread_id = data.get("thread_id", "")
+                    continue
+
+                item = data.get("item") or {}
+                if (
+                    structured_custom_view
+                    and data.get("type") == "item.completed"
+                    and item.get("type") == "agent_message"
+                ):
+                    structured_response_text = item.get("text")
                     continue
 
                 # Emit token usage before the result event, which closes the
@@ -211,11 +259,35 @@ class CodexProvider(AssistantProvider):
                 assert process.stderr is not None
                 stderr_bytes = await process.stderr.read()
                 error_msg = (
-                    stderr_bytes.decode("utf-8", errors="replace").strip()
+                    codex_error
+                    or stderr_bytes.decode("utf-8", errors="replace").strip()
                     or f"Process exited with code {process.returncode}"
                 )
                 yield Event.from_error(error_msg)
             else:
+                if structured_custom_view:
+                    try:
+                        response = parse_custom_view_response(structured_response_text)
+                    except Exception as e:
+                        repair = _structured_response_retry.next_attempt(e)
+                        repair_session_id = thread_id or session_id
+                        if repair and repair_session_id:
+                            repair_prompt, next_retry = repair
+                            async for event in self.astream(
+                                repair_prompt,
+                                tracking_uri,
+                                session_id=repair_session_id,
+                                mlflow_session_id=mlflow_session_id,
+                                cwd=cwd,
+                                context=context,
+                                _structured_response_retry=next_retry,
+                            ):
+                                yield event
+                            return
+                        yield Event.from_error(f"Codex returned invalid Custom View output: {e}")
+                        return
+                    for event in custom_view_response_events(response):
+                        yield event
                 yield Event.from_result(result=None, session_id=thread_id)
 
         except Exception as e:
@@ -227,6 +299,31 @@ class CodexProvider(AssistantProvider):
             if process is not None and process.returncode is None:
                 process.kill()
                 await process.wait()
+            if schema_path:
+                schema_path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _unwrap_error_message(message: Any) -> str | None:
+        value = message
+        for _ in range(4):
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError:
+                    return value
+            elif isinstance(value, dict):
+                error = value.get("error")
+                if isinstance(error, dict) and error.get("message"):
+                    value = error["message"]
+                elif value.get("message"):
+                    value = value["message"]
+                else:
+                    return json.dumps(value)
+            elif value is None:
+                return None
+            else:
+                return str(value)
+        return str(value)
 
     @staticmethod
     def _build_usage_event(usage: dict[str, Any], model: str | None) -> Event:

--- a/mlflow/assistant/providers/openai_compatible.py
+++ b/mlflow/assistant/providers/openai_compatible.py
@@ -14,7 +14,7 @@ import logging
 import uuid
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Literal
 
 import aiohttp
 
@@ -290,10 +290,10 @@ class OpenAICompatibleProvider(AssistantProvider):
         return self._allows_remote_access
 
     @property
-    def supports_client_tools(self) -> bool:
+    def client_tool_delivery(self) -> Literal["tool"]:
         # Schema-based providers: the tool loop below pauses on a CLIENT_TOOLS call
         # and resumes on the next stream once a result is posted (see astream()).
-        return True
+        return "tool"
 
     def is_available(self) -> bool:
         return True

--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from mlflow.assistant.config import PermissionsConfig
+from mlflow.assistant.custom_view import RENDER_CUSTOM_VIEW_TOOL_NAME
 
 _logger = logging.getLogger(__name__)
 
@@ -13,7 +14,6 @@ _FILE_TOOLS = {"Read", "Write", "Edit"}
 # Restricted mode only permits MLflow CLI and Python; anything else needs Full Access.
 _ALLOWED_BASH_COMMANDS = {"mlflow", "python3", "python"}
 
-RENDER_CUSTOM_VIEW_TOOL_NAME = "render_custom_view"
 # Tools executed on the CLIENT (browser), not the server: the assistant loop pauses the turn and
 # waits for a client-submitted result instead of routing the call through execute_tool/the static
 # permission gate. See openai_compatible.py's tool loop.

--- a/mlflow/assistant/types.py
+++ b/mlflow/assistant/types.py
@@ -113,13 +113,22 @@ class Event(BaseModel):
 
     @classmethod
     def from_client_tool_call(
-        cls, request_id: str, tool_name: str, tool_input: dict[str, Any]
+        cls,
+        request_id: str,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        *,
+        continuation: Literal["resume", "terminal"] = "resume",
     ) -> "Event":
         """A tool call the CLIENT (not the server) must execute, e.g. rendering an
-        agent-authored UI spec in the browser. Ends the turn the same way a
-        permission request does: the client posts the result to resume.
+        agent-authored UI spec in the browser. ``resume`` calls pause the provider
+        until the result is posted; ``terminal`` calls come from structured final
+        output and finish after the browser executes them without resuming the model.
         """
+        data = {"request_id": request_id, "tool_name": tool_name, "tool_input": tool_input}
+        if continuation == "terminal":
+            data["continuation"] = continuation
         return cls(
             type=EventType.CLIENT_TOOL_CALL,
-            data={"request_id": request_id, "tool_name": tool_name, "tool_input": tool_input},
+            data=data,
         )

--- a/mlflow/assistant/types.py
+++ b/mlflow/assistant/types.py
@@ -75,8 +75,11 @@ class Event(BaseModel):
         return f"event: {self.type}\ndata: {json.dumps(self.data)}\n\n"
 
     @classmethod
-    def from_error(cls, error: str) -> "Event":
-        return cls(type=EventType.ERROR, data={"error": error})
+    def from_error(cls, error: str, session_id: str | None = None) -> "Event":
+        data = {"error": error}
+        if session_id:
+            data["session_id"] = session_id
+        return cls(type=EventType.ERROR, data=data)
 
     @classmethod
     def from_exception(cls, exc: Exception) -> "Event":

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -162,6 +162,8 @@ assistant_router = APIRouter(
     route_class=_AssistantAPIRoute,
 )
 
+_TURN_SCOPED_CONTEXT_KEYS = {"customTraceView"}
+
 
 class MessageRequest(BaseModel):
     message: str
@@ -359,7 +361,12 @@ async def send_message(request: MessageRequest) -> MessageResponse:
         session = SessionManager.create(
             context=request.context, working_dir=Path(project_path) if project_path else None
         )
-    elif request.context:
+    else:
+        # Page context is merged for conversation continuity, but feature modes
+        # are turn-scoped. Remove omitted transient keys so leaving a feature
+        # cannot keep later turns in its provider/output mode.
+        for key in _TURN_SCOPED_CONTEXT_KEYS - request.context.keys():
+            session.context.pop(key, None)
         session.update_context(request.context)
 
     # Store the pending message with role

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -27,6 +27,7 @@ from mlflow.assistant.providers import (
 )
 from mlflow.assistant.providers.base import (
     AssistantProvider,
+    ClientToolDelivery,
     CLINotInstalledError,
     NotAuthenticatedError,
     ProviderNotConfiguredError,
@@ -195,9 +196,9 @@ class ProviderInfo(BaseModel):
     requires_api_key: bool
     has_api_key: bool
     allows_remote_access: bool
-    # Whether this provider can pause a turn on a CLIENT-executed tool call and
-    # resume it once the client posts a result. See AssistantProvider.supports_client_tools.
-    supports_client_tools: bool = False
+    # How client-executed actions are delivered: as native tool calls, terminal
+    # structured output, or not supported by this provider.
+    client_tool_delivery: ClientToolDelivery = "unsupported"
     model_options: list[str] = Field(default_factory=list)
 
 
@@ -207,7 +208,7 @@ class ResolvedProviderInfo(BaseModel):
     auto_selected: bool
     requires_api_key: bool
     has_api_key: bool
-    supports_client_tools: bool = False
+    client_tool_delivery: ClientToolDelivery = "unsupported"
     model_provider: str | None = None
     model_options: list[str] = Field(default_factory=list)
     provider_model: str | None = None
@@ -294,7 +295,7 @@ def _resolved_provider_info(
         auto_selected=auto_selected,
         requires_api_key=False,
         has_api_key=False,
-        supports_client_tools=provider.supports_client_tools,
+        client_tool_delivery=provider.client_tool_delivery,
     )
     if provider.name == MlflowGatewayProvider.GATEWAY_PROVIDER_NAME:
         if vendor := _gateway_vendor_from_managed_endpoint(model):
@@ -593,7 +594,7 @@ async def get_providers() -> ProvidersResponse:
             requires_api_key=False,
             has_api_key=False,
             allows_remote_access=provider.allows_remote_access,
-            supports_client_tools=provider.supports_client_tools,
+            client_tool_delivery=provider.client_tool_delivery,
             model_options=[],
         )
         for provider in providers

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -450,10 +450,11 @@ async def stream_response(request: Request, session_id: str) -> StreamingRespons
             context=context,
         ):
             # Store provider session ID if returned (for conversation continuity).
-            # On a paused turn this persists the history with the unanswered
-            # tool_call so a later resume can continue from it.
-            if event.type == EventType.DONE:
-                session.provider_session_id = event.data.get("session_id")
+            # On a paused or failed turn this lets a later request resume the same
+            # provider conversation instead of losing its history.
+            provider_session_id = event.data.get("session_id")
+            if event.type in {EventType.DONE, EventType.ERROR} and provider_session_id:
+                session.provider_session_id = provider_session_id
                 SessionManager.save(session_id, session)
 
             yield event.to_sse_event()

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -298,7 +298,7 @@ describe('AssistantChatPanel', () => {
       model_options: ['gpt-5.5', 'gpt-5-mini'],
       requires_api_key: true,
       has_api_key: false,
-      supports_client_tools: true,
+      client_tool_delivery: 'tool',
     };
     mockNeedsApiKey = true;
     const user = userEvent.setup();
@@ -379,7 +379,7 @@ describe('AssistantChatPanel', () => {
       model_options: ['gpt-5.5', 'gpt-5-mini'],
       requires_api_key: true,
       has_api_key: false,
-      supports_client_tools: true,
+      client_tool_delivery: 'tool',
     };
     mockError = 'OpenAI requires an API key.';
     mockErrorCode = 'api_key_missing';

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -325,7 +325,7 @@ describe('AssistantChatPanel', () => {
       model_options: ['gpt-5.5'],
       requires_api_key: true,
       has_api_key: false,
-      supports_client_tools: true,
+      client_tool_delivery: 'tool',
     };
     mockNeedsApiKey = true;
     mockPendingAutomaticMessage = {
@@ -356,7 +356,7 @@ describe('AssistantChatPanel', () => {
       model_options: [],
       requires_api_key: false,
       has_api_key: false,
-      supports_client_tools: true,
+      client_tool_delivery: 'tool',
     };
     mockNeedsApiKey = false;
     mockPendingAutomaticMessage = {

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -836,6 +836,61 @@ describe('AssistantContext — client_tool_call auto-resume', () => {
     unregister();
   });
 
+  it('completes a terminal call with no registered handler without posting a result', async () => {
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+
+    const callbacks = capturedCallbacks;
+    await act(async () => {
+      await callbacks?.onClientToolCall?.({
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        toolName: 'unregistered_tool',
+        toolInput: {},
+        continuation: 'terminal',
+      });
+      callbacks?.onDone();
+    });
+
+    expect(mockSubmitClientToolResult).not.toHaveBeenCalled();
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingClientToolCall).toBeNull();
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('completes a terminal non-retryable handler error without starting a repair', async () => {
+    const unregister = registerClientToolHandler('render_custom_view', async () => ({
+      content: 'Custom View rendering failed',
+      isError: true,
+      retryable: false,
+    }));
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+
+    const callbacks = capturedCallbacks;
+    await act(async () => {
+      await callbacks?.onClientToolCall?.({
+        sessionId: 'session-1',
+        requestId: 'req-1',
+        toolName: 'render_custom_view',
+        toolInput: { title: 'Trace Summary', messages: [] },
+        continuation: 'terminal',
+      });
+      callbacks?.onDone();
+    });
+
+    expect(mockSubmitClientToolResult).not.toHaveBeenCalled();
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingClientToolCall).toBeNull();
+    expect(result.current.isStreaming).toBe(false);
+
+    unregister();
+  });
+
   it('starts a hidden structured repair turn with the validation error and original context', async () => {
     const originalContext = {
       experimentId: 'exp-1',

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -896,7 +896,9 @@ describe('AssistantContext — client_tool_call auto-resume', () => {
           toolInput: { title: 'Trace Summary', messages: [] },
           continuation: 'terminal',
         });
+        callbacks?.onDone();
       });
+      expect(result.current.isStreaming).toBe(attempt < 2);
     }
 
     expect(mockSendMessageStream).toHaveBeenCalledTimes(3);

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -38,7 +38,7 @@ const resolvedProvider = (overrides: Partial<ResolvedProviderInfo> = {}): Resolv
   auto_selected: true,
   requires_api_key: false,
   has_api_key: false,
-  supports_client_tools: false,
+  client_tool_delivery: 'unsupported',
   ...overrides,
 });
 
@@ -50,7 +50,7 @@ const providerInfo = (overrides: Partial<ProviderInfo> & { name: string }): Prov
   requires_api_key: false,
   has_api_key: false,
   allows_remote_access: false,
-  supports_client_tools: false,
+  client_tool_delivery: 'unsupported',
   model_options: [],
   ...overrides,
 });
@@ -61,12 +61,13 @@ jest.mock('./AssistantService', () => ({
   getConfig: jest.fn(),
   getProviders: jest.fn(),
   updateConfig: jest.fn(() => Promise.resolve({})),
-  cancelSession: jest.fn(),
+  cancelSession: jest.fn(() => Promise.resolve({ message: 'cancelled' })),
   submitClientToolResult: jest.fn(),
 }));
 
+let mockPageContext: Record<string, unknown> = {};
 jest.mock('./AssistantPageContext', () => ({
-  useAssistantPageContextActions: () => ({ getContext: () => ({}) }),
+  useAssistantPageContextActions: () => ({ getContext: () => mockPageContext }),
 }));
 
 const mockSendMessageStream = jest.mocked(AssistantService.sendMessageStream);
@@ -95,6 +96,7 @@ beforeEach(() => {
   localStorage.clear();
   fakeEventSource = { close: jest.fn() };
   capturedCallbacks = undefined;
+  mockPageContext = {};
   mockGetConfig.mockResolvedValue({ providers: {}, projects: {} });
   mockGetProviders.mockResolvedValue({ providers: [], resolved: null });
   mockSendMessageStream.mockImplementation(async (_req, callbacks) => {
@@ -796,14 +798,146 @@ describe('AssistantContext — a new message supersedes a pending permission pro
 });
 
 describe('AssistantContext — client_tool_call auto-resume', () => {
-  const pauseAtClientTool = (overrides: Partial<{ toolName: string; toolInput: Record<string, unknown> }> = {}) => {
-    capturedCallbacks?.onClientToolCall?.({
+  const pauseAtClientTool = (
+    overrides: Partial<{
+      toolName: string;
+      toolInput: Record<string, unknown>;
+      continuation: 'resume' | 'terminal';
+    }> = {},
+  ) => {
+    return capturedCallbacks?.onClientToolCall?.({
       sessionId: 'session-1',
       requestId: 'req-1',
       toolName: overrides.toolName ?? 'render_custom_view',
       toolInput: overrides.toolInput ?? { title: 'Trace Summary', messages: [] },
+      ...(overrides.continuation ? { continuation: overrides.continuation } : {}),
     });
   };
+
+  it('executes a terminal structured-output call without posting a result', async () => {
+    const unregister = registerClientToolHandler('render_custom_view', async () => ({
+      content: 'rendered terminal output',
+      isError: false,
+    }));
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+
+    await act(async () => {
+      await pauseAtClientTool({ continuation: 'terminal' });
+    });
+
+    expect(mockSubmitClientToolResult).not.toHaveBeenCalled();
+    expect(fakeEventSource.close).not.toHaveBeenCalled();
+    expect(result.current.pendingClientToolCall).toBeNull();
+    expect(result.current.isStreaming).toBe(true);
+
+    unregister();
+  });
+
+  it('starts a hidden structured repair turn with the validation error and original context', async () => {
+    const originalContext = {
+      experimentId: 'exp-1',
+      customTraceView: { guide: 'structured guide', currentTemplate: [{ id: 'existing-root' }] },
+    };
+    mockPageContext = originalContext;
+    const unregister = registerClientToolHandler('render_custom_view', async () => ({
+      content: 'Unknown component "Widget"',
+      isError: true,
+      retryable: true,
+    }));
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+    mockPageContext = {
+      experimentId: 'exp-1',
+      customTraceView: { guide: 'different view', currentTemplate: [{ id: 'different-root' }] },
+    };
+
+    await act(async () => {
+      await pauseAtClientTool({ continuation: 'terminal' });
+    });
+
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+    const repairRequest = mockSendMessageStream.mock.calls[1][0];
+    expect(repairRequest).toMatchObject({
+      session_id: 'session-1',
+      experiment_id: 'exp-1',
+      context: originalContext,
+    });
+    expect(repairRequest.message).toContain('Unknown component \\"Widget\\"');
+    expect(repairRequest.message).toContain('automatic repair 1/2');
+    expect(result.current.isStreaming).toBe(true);
+
+    unregister();
+  });
+
+  it('bounds structured Custom View repair to two attempts', async () => {
+    mockPageContext = { customTraceView: { guide: 'structured guide' } };
+    const unregister = registerClientToolHandler('render_custom_view', async () => ({
+      content: 'Invalid component',
+      isError: true,
+      retryable: true,
+    }));
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const callbacks = capturedCallbacks;
+      await act(async () => {
+        await callbacks?.onClientToolCall?.({
+          sessionId: 'session-1',
+          requestId: `req-${attempt}`,
+          toolName: 'render_custom_view',
+          toolInput: { title: 'Trace Summary', messages: [] },
+          continuation: 'terminal',
+        });
+      });
+    }
+
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+    expect(mockSendMessageStream.mock.calls[2][0].message).toContain('automatic repair 2/2');
+
+    unregister();
+  });
+
+  it('does not start a repair after cancellation while browser validation is pending', async () => {
+    mockPageContext = { customTraceView: { guide: 'structured guide' } };
+    let finishValidation!: (result: { content: string; isError: true; retryable: true }) => void;
+    const unregister = registerClientToolHandler(
+      'render_custom_view',
+      () =>
+        new Promise((resolve) => {
+          finishValidation = resolve;
+        }),
+    );
+    const { result } = await renderAssistant();
+    await act(async () => {
+      result.current.sendMessage('build me a view');
+    });
+    act(() => {
+      capturedCallbacks?.onSessionId?.('session-1');
+    });
+
+    let terminalExecution: void | Promise<void> = undefined;
+    act(() => {
+      terminalExecution = pauseAtClientTool({ continuation: 'terminal' });
+    });
+    act(() => {
+      result.current.cancelSession();
+    });
+    await act(async () => {
+      finishValidation({ content: 'Invalid component', isError: true, retryable: true });
+      await terminalExecution;
+    });
+
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    unregister();
+  });
 
   it('runs the registered handler and submits its result to resume the stream', async () => {
     const handler = jest.fn(async (toolInput: Record<string, any>) => ({

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -433,7 +433,7 @@ describe('AssistantContext — automatic message delivery', () => {
         name: 'mlflow_gateway',
         requires_api_key: true,
         has_api_key: false,
-        supports_client_tools: true,
+        client_tool_delivery: 'tool',
       }),
     });
     const { result } = await renderAssistant();

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -43,6 +43,8 @@ const AssistantReactContext = createContext<AssistantAgentContextType | null>(nu
 // Cap the persisted transcript by JSON string length (UTF-16 code units — what localStorage counts),
 // keeping it well under the ~5 MB localStorage limit.
 const MAX_PERSISTED_CHARS = 1_500_000;
+// This browser budget repairs schema-valid envelopes rejected by A2UI validation. It is
+// independent of the provider's envelope-repair budget, which resets for each request.
 const MAX_STRUCTURED_CUSTOM_VIEW_REPAIRS = 2;
 const MAX_CUSTOM_VIEW_ERROR_CHARS = 4000;
 

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -43,8 +43,8 @@ const AssistantReactContext = createContext<AssistantAgentContextType | null>(nu
 // Cap the persisted transcript by JSON string length (UTF-16 code units — what localStorage counts),
 // keeping it well under the ~5 MB localStorage limit.
 const MAX_PERSISTED_CHARS = 1_500_000;
-// This browser budget repairs schema-valid envelopes rejected by A2UI validation. It is
-// independent of the provider's envelope-repair budget, which resets for each request.
+// Structured providers only parse the response envelope on the server. The browser owns
+// semantic A2UI validation and this bounded repair lifecycle.
 const MAX_STRUCTURED_CUSTOM_VIEW_REPAIRS = 2;
 const MAX_CUSTOM_VIEW_ERROR_CHARS = 4000;
 

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -43,6 +43,17 @@ const AssistantReactContext = createContext<AssistantAgentContextType | null>(nu
 // Cap the persisted transcript by JSON string length (UTF-16 code units — what localStorage counts),
 // keeping it well under the ~5 MB localStorage limit.
 const MAX_PERSISTED_CHARS = 1_500_000;
+const MAX_STRUCTURED_CUSTOM_VIEW_REPAIRS = 2;
+const MAX_CUSTOM_VIEW_ERROR_CHARS = 4000;
+
+const buildCustomViewRepairPrompt = (error: string, attempt: number): string => {
+  const boundedError = error.slice(0, MAX_CUSTOM_VIEW_ERROR_CHARS);
+  return [
+    `The browser rejected the Custom View from your previous response (automatic repair ${attempt}/${MAX_STRUCTURED_CUSTOM_VIEW_REPAIRS}).`,
+    `Validation error: ${JSON.stringify(boundedError)}`,
+    "Regenerate the complete Custom View and fix this error. Preserve the user's requested design and the current template where possible. Return the corrected view using the structured Custom View response format; do not merely explain the error.",
+  ].join('\n\n');
+};
 
 // Exported as base + version (not a precomputed key) so this module does no work at import time:
 // `useLocalStorage` builds the full key from these, and tests build it via `buildStorageKey`.
@@ -101,8 +112,9 @@ const withGuard = (isCurrent: () => boolean, callbacks: SendMessageStreamCallbac
       typeof fn === 'function'
         ? (...args: unknown[]) => {
             if (isCurrent()) {
-              fn(...args);
+              return fn(...args);
             }
+            return undefined;
           }
         : fn,
     ]),
@@ -156,7 +168,7 @@ const activeProviderFromSelection = (
       requires_api_key: selection.requiresApiKey ?? false,
       has_api_key: selection.hasApiKey ?? true,
       // The gateway is always backed by OpenAICompatibleProvider server-side.
-      supports_client_tools: true,
+      client_tool_delivery: 'tool',
       model_provider: selection.gatewayVendor,
       provider_model: selection.providerModel ?? null,
       model_options: selection.modelOptions ?? [],
@@ -170,7 +182,7 @@ const activeProviderFromSelection = (
     auto_selected: false,
     requires_api_key: provider?.requires_api_key ?? false,
     has_api_key: provider?.has_api_key ?? false,
-    supports_client_tools: provider?.supports_client_tools ?? false,
+    client_tool_delivery: provider?.client_tool_delivery ?? 'unsupported',
     model_options: provider?.model_options ?? [],
   };
 };
@@ -336,6 +348,36 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   // guarded callbacks no-op and its stream is closed instead of leaking into new state.
   const activeRequestRef = useRef<symbol | null>(null);
 
+  // Structured Custom View errors start hidden repair turns. This ref bounds the
+  // retries for one user-initiated turn and resets at every terminal/user action.
+  const structuredRepairAttemptsRef = useRef(0);
+
+  // Keep every automatic repair bound to the authoring context and apply target
+  // captured for the original user turn, even if the live selection changes.
+  const structuredRepairContextRef = useRef<Record<string, unknown> | null>(null);
+
+  // Automatic repair reuses the ordinary callback set, but its tool handler is
+  // itself one of those callbacks. A ref breaks that dependency cycle.
+  const streamCallbacksRef = useRef<SendMessageStreamCallbacks | null>(null);
+
+  // Begin a new in-flight send: stamp a fresh token in closure,
+  // return a checker for whether this send is still the active one.
+  const beginRequest = useCallback(() => {
+    const token = Symbol();
+    activeRequestRef.current = token;
+    return () => activeRequestRef.current === token;
+  }, []);
+
+  // Store the resolved stream if its send is still current, otherwise close the orphan.
+  const attachStreamIfCurrent = useCallback((isCurrent: () => boolean, result: SendMessageStreamResult): boolean => {
+    if (!isCurrent()) {
+      result.eventSource?.close();
+      return false;
+    }
+    eventSourceRef.current = result.eventSource;
+    return true;
+  }, []);
+
   // Throttle streaming updates to avoid overwhelming React with re-renders
   const rafPendingRef = useRef<number | null>(null);
 
@@ -423,6 +465,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setActiveTools([]);
     setPendingPermission(null);
     setPendingClientToolCall(null);
+    structuredRepairAttemptsRef.current = 0;
+    structuredRepairContextRef.current = null;
   }, [closeStreamingMessage]);
 
   const handleStatus = useCallback((status: string) => {
@@ -490,10 +534,6 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
   const handlePermissionRequest = useCallback((request: PermissionRequest) => {
     setPendingPermission(request);
-  }, []);
-
-  const handleClientToolCall = useCallback((request: PendingClientToolCall) => {
-    setPendingClientToolCall(request);
   }, []);
 
   // Setup actions
@@ -625,6 +665,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       setActiveTools([]);
       setPendingPermission(null);
       setPendingClientToolCall(null);
+      structuredRepairAttemptsRef.current = 0;
+      structuredRepairContextRef.current = null;
       closeStreamingMessage({ reason: TurnEndReason.Failed, error: errorMsg });
     },
     [closeStreamingMessage],
@@ -636,6 +678,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setActiveTools([]);
     setPendingPermission(null);
     setPendingClientToolCall(null);
+    structuredRepairAttemptsRef.current = 0;
+    structuredRepairContextRef.current = null;
     eventSourceRef.current = null;
     if (rafPendingRef.current !== null) {
       cancelAnimationFrame(rafPendingRef.current);
@@ -643,6 +687,86 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     }
     closeStreamingMessage({ reason: TurnEndReason.Interrupted });
   }, [closeStreamingMessage]);
+
+  const handleClientToolCall = useCallback(
+    async (request: PendingClientToolCall) => {
+      if (request.continuation !== 'terminal') {
+        setPendingClientToolCall(request);
+        return;
+      }
+
+      const originatingRequest = activeRequestRef.current;
+      const isOriginatingRequestCurrent = () =>
+        originatingRequest !== null && activeRequestRef.current === originatingRequest;
+      const handler = getClientToolHandler(request.toolName);
+      if (!handler) {
+        if (isOriginatingRequestCurrent()) {
+          resolveToolCall({
+            toolUseId: request.requestId,
+            content: `No handler is registered for client tool "${request.toolName}".`,
+            isError: true,
+          });
+        }
+        return;
+      }
+
+      let result;
+      try {
+        result = await handler(request.toolInput);
+      } catch (err) {
+        result = {
+          content: err instanceof Error ? err.message : 'Client tool execution failed',
+          isError: true,
+          retryable: false,
+        };
+      }
+      if (!isOriginatingRequestCurrent()) {
+        return;
+      }
+
+      resolveToolCall({
+        toolUseId: request.requestId,
+        content: result.content,
+        isError: Boolean(result.isError),
+      });
+
+      if (!result.isError || !result.retryable) {
+        return;
+      }
+      if (structuredRepairAttemptsRef.current >= MAX_STRUCTURED_CUSTOM_VIEW_REPAIRS) {
+        return;
+      }
+
+      const pageContext = structuredRepairContextRef.current;
+      const callbacks = streamCallbacksRef.current;
+      if (!pageContext?.['customTraceView'] || !callbacks) {
+        return;
+      }
+
+      structuredRepairAttemptsRef.current += 1;
+      const attempt = structuredRepairAttemptsRef.current;
+      setActiveTools([]);
+      setCurrentStatus(`Repairing custom view (${attempt}/${MAX_STRUCTURED_CUSTOM_VIEW_REPAIRS})`);
+      const isCurrent = beginRequest();
+      try {
+        const repairResult = await sendMessageStream(
+          {
+            session_id: request.sessionId,
+            message: buildCustomViewRepairPrompt(result.content, attempt),
+            experiment_id: pageContext['experimentId'] as string | undefined,
+            context: pageContext,
+          },
+          withGuard(isCurrent, callbacks),
+        );
+        attachStreamIfCurrent(isCurrent, repairResult);
+      } catch (err) {
+        if (isCurrent()) {
+          failStreamingTurn(err instanceof Error ? err.message : 'Failed to repair the custom view');
+        }
+      }
+    },
+    [attachStreamIfCurrent, beginRequest, failStreamingTurn, resolveToolCall],
+  );
 
   // Shared SSE callback wiring for startChat, handleSendMessage, respondToPermission and
   // regenerate. Each call site wraps this in `withGuard(isCurrent, streamCallbacks)` so a
@@ -675,6 +799,10 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       handleClientToolCall,
     ],
   );
+
+  useEffect(() => {
+    streamCallbacksRef.current = streamCallbacks;
+  }, [streamCallbacks]);
 
   // Actions
   const openPanel = useCallback(() => {
@@ -722,30 +850,13 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setPendingPermission(null);
     setPendingClientToolCall(null);
     setPendingAutomaticMessage(null);
+    structuredRepairAttemptsRef.current = 0;
+    structuredRepairContextRef.current = null;
   }, [setPersistedChat]);
-
-  // Begin a new in-flight send: stamp a fresh token in closure,
-  // return a checker for whether this send is
-  // still the active one (i.e. not superseded by a reset/cancel that ran during its POST).
-  const beginRequest = useCallback(() => {
-    const token = Symbol();
-    activeRequestRef.current = token;
-    return () => activeRequestRef.current === token;
-  }, []);
-
-  // Store the resolved stream if its send is still current, otherwise close the orphan. Returns
-  // whether it was attached
-  const attachStreamIfCurrent = useCallback((isCurrent: () => boolean, result: SendMessageStreamResult): boolean => {
-    if (!isCurrent()) {
-      result.eventSource?.close();
-      return false;
-    }
-    eventSourceRef.current = result.eventSource;
-    return true;
-  }, []);
 
   const startChat = useCallback(
     async (prompt?: string) => {
+      structuredRepairAttemptsRef.current = 0;
       const isCurrent = beginRequest();
 
       setError(null);
@@ -792,6 +903,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
           await flushPendingProvider();
         }
         const pageContext = getPageContext();
+        structuredRepairContextRef.current = pageContext['customTraceView'] ? pageContext : null;
         const result = await sendMessageStream(
           {
             message: prompt || '',
@@ -871,11 +983,12 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     [pendingClientToolCall, beginRequest, attachStreamIfCurrent, streamCallbacks, failStreamingTurn],
   );
 
-  // A client_tool_call needs no user interaction (unlike a permission prompt):
+  // A paused client_tool_call needs no user interaction (unlike a permission prompt):
   // look up the feature-registered handler for the tool name (see
   // clientToolHandlers.ts), run it, and report the result to resume the stream.
   // No registered handler (e.g. the owning feature isn't mounted) reports an
-  // error so the paused turn doesn't hang forever.
+  // error so the paused turn doesn't hang forever. Terminal structured-output
+  // calls are handled after the provider's done event and never enter this slot.
   useEffect(() => {
     if (!pendingClientToolCall) {
       return;
@@ -922,6 +1035,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
         return;
       }
 
+      structuredRepairAttemptsRef.current = 0;
       const isCurrent = beginRequest();
 
       setError(null);
@@ -963,6 +1077,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
         // Send message and stream response
         const pageContext = getPageContext();
+        structuredRepairContextRef.current = pageContext['customTraceView'] ? pageContext : null;
         const result = await sendMessageStream(
           {
             session_id: sessionId,
@@ -1063,6 +1178,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     setActiveTools([]);
     setPendingPermission(null);
     setPendingClientToolCall(null);
+    structuredRepairAttemptsRef.current = 0;
+    structuredRepairContextRef.current = null;
   }, [sessionId, isStreaming, closeStreamingMessage]);
 
   const regenerateLastMessage = useCallback(async () => {
@@ -1077,6 +1194,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
       return; // No user message to regenerate from
     }
 
+    structuredRepairAttemptsRef.current = 0;
     const isCurrent = beginRequest();
 
     const userMessageContent = messages[lastUserMessageIndex].content;
@@ -1120,6 +1238,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
 
       // Re-send the last user message
       const pageContext = getPageContext();
+      structuredRepairContextRef.current = pageContext['customTraceView'] ? pageContext : null;
       const result = await sendMessageStream(
         {
           session_id: sessionId ?? undefined,

--- a/mlflow/server/js/src/assistant/AssistantProviderPicker.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantProviderPicker.test.tsx
@@ -25,7 +25,7 @@ const providerInfo = (overrides: Partial<ProviderInfo> & { name: string; display
   requires_api_key: false,
   has_api_key: false,
   allows_remote_access: false,
-  supports_client_tools: false,
+  client_tool_delivery: 'unsupported',
   model_options: [],
   ...overrides,
 });
@@ -36,7 +36,7 @@ const resolvedProvider = (overrides: Partial<ResolvedProviderInfo> = {}): Resolv
   auto_selected: true,
   requires_api_key: false,
   has_api_key: false,
-  supports_client_tools: false,
+  client_tool_delivery: 'unsupported',
   ...overrides,
 });
 

--- a/mlflow/server/js/src/assistant/AssistantService.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantService.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { fetchAPI } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { resumeStream, sendMessageStream, submitClientToolResult, processContentBlocks } from './AssistantService';
-import type { ToolUseInfo, ToolResultInfo } from './types';
+import type { PendingClientToolCall, ToolUseInfo, ToolResultInfo } from './types';
 
 // jest.mock is hoisted above imports by babel-jest, so the mock still applies.
 jest.mock('@mlflow/mlflow/src/common/utils/FetchUtils', () => ({
@@ -132,7 +132,7 @@ describe('sendMessageStream permission_request event', () => {
   });
 
   test('a client_tool_call SSE event invokes onClientToolCall and closes the stream', async () => {
-    const onClientToolCall = jest.fn();
+    const onClientToolCall = jest.fn<(request: PendingClientToolCall) => void>();
     await sendMessageStream(
       { message: 'build me a view' },
       {
@@ -160,6 +160,54 @@ describe('sendMessageStream permission_request event', () => {
     // Like a permission_request, the turn ends here: the client executes the tool and
     // resumes via submitClientToolResult.
     expect(es.readyState).toBe(FakeEventSource.CLOSED);
+  });
+
+  test('a terminal client_tool_call completes only after the browser handler finishes', async () => {
+    let finishClientTool: (() => void) | undefined;
+    const onClientToolCall = jest.fn(
+      (_request: PendingClientToolCall) =>
+        new Promise<void>((resolve) => {
+          finishClientTool = resolve;
+        }),
+    );
+    const onDone = jest.fn();
+    await sendMessageStream(
+      { message: 'build me a view' },
+      {
+        onMessage: jest.fn(),
+        onError: jest.fn(),
+        onDone,
+        onClientToolCall,
+      },
+    );
+
+    const es = FakeEventSource.instances[0];
+    es.emit('client_tool_call', {
+      request_id: 'req-terminal',
+      tool_name: 'render_custom_view',
+      tool_input: { title: 'Trace Summary', messages: [] },
+      continuation: 'terminal',
+    });
+
+    // Terminal execution waits for `done`, after the backend has persisted the
+    // provider session needed by a possible automatic repair turn.
+    expect(onClientToolCall).not.toHaveBeenCalled();
+    expect(es.readyState).not.toBe(FakeEventSource.CLOSED);
+
+    es.emit('done', {});
+    expect(onClientToolCall).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      requestId: 'req-terminal',
+      toolName: 'render_custom_view',
+      toolInput: { title: 'Trace Summary', messages: [] },
+      continuation: 'terminal',
+    });
+    expect(es.readyState).toBe(FakeEventSource.CLOSED);
+    expect(onDone).not.toHaveBeenCalled();
+
+    finishClientTool?.();
+    await Promise.resolve();
+    expect(onDone).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mlflow/server/js/src/assistant/AssistantService.ts
+++ b/mlflow/server/js/src/assistant/AssistantService.ts
@@ -128,7 +128,7 @@ export interface SendMessageStreamCallbacks {
   onToolResult?: (result: ToolResultInfo) => void;
   onInterrupted?: () => void;
   onPermissionRequest?: (request: PermissionRequest) => void;
-  onClientToolCall?: (request: PendingClientToolCall) => void;
+  onClientToolCall?: (request: PendingClientToolCall) => void | Promise<void>;
   onUsage?: (usage: {
     prompt_tokens: number;
     completion_tokens: number;
@@ -163,6 +163,7 @@ const attachStreamListeners = (
     onClientToolCall,
     onUsage,
   } = callbacks;
+  let terminalClientToolCall: PendingClientToolCall | null = null;
 
   // Listen for 'message' events (contains assistant's response)
   // Backend sends: {"message": {"role": "assistant", "content": "..."}}
@@ -222,31 +223,49 @@ const attachStreamListeners = (
     eventSource.close();
   });
 
-  // A 'client_tool_call' also ENDS the turn: the tool must be executed by the
-  // client (e.g. rendering an agent-authored UI spec), not the server. We
-  // surface it and close the stream; the result is delivered via
-  // submitClientToolResult, which opens a fresh stream to continue.
+  // Native client tool calls pause the provider and resume on a fresh stream.
+  // Structured-output providers emit a terminal call instead. Defer terminal
+  // execution until `done` so the backend has persisted the provider's latest
+  // session before a browser validation error starts an automatic repair turn.
   eventSource.addEventListener('client_tool_call', (event) => {
+    let continuation: PendingClientToolCall['continuation'] = 'resume';
     try {
       const data = JSON.parse((event as MessageEvent).data);
-      onClientToolCall?.({
+      continuation = data.continuation === 'terminal' ? 'terminal' : 'resume';
+      const request: PendingClientToolCall = {
         sessionId,
         requestId: data.request_id,
         toolName: data.tool_name,
         toolInput: data.tool_input ?? {},
-      });
+        ...(continuation === 'terminal' ? { continuation } : {}),
+      };
+      if (continuation === 'terminal') {
+        terminalClientToolCall = request;
+      } else {
+        onClientToolCall?.(request);
+      }
     } catch (err) {
       onError('Failed to read a client tool call from the assistant.');
     }
-    eventSource.close();
+    if (continuation === 'resume') {
+      eventSource.close();
+    }
   });
 
   // Listen for 'done' event (completion)
   // Backend sends: {"result": null, "session_id": "..."}
   eventSource.addEventListener('done', () => {
-    onToolUse?.([]);
-    onDone();
     eventSource.close();
+    const finish = async () => {
+      if (terminalClientToolCall) {
+        await onClientToolCall?.(terminalClientToolCall);
+      }
+      onToolUse?.([]);
+      onDone();
+    };
+    void finish().catch((error) => {
+      onError(error instanceof Error ? error.message : 'Failed to execute the client tool.');
+    });
   });
 
   // Listen for 'interrupted' event (cancelled by user)

--- a/mlflow/server/js/src/assistant/AssistantService.ts
+++ b/mlflow/server/js/src/assistant/AssistantService.ts
@@ -260,6 +260,8 @@ const attachStreamListeners = (
       if (terminalClientToolCall) {
         await onClientToolCall?.(terminalClientToolCall);
       }
+      // Starting an automatic repair rotates the active request token, so these
+      // guarded callbacks become no-ops instead of finalizing the repair stream.
       onToolUse?.([]);
       onDone();
     };

--- a/mlflow/server/js/src/assistant/clientToolHandlers.ts
+++ b/mlflow/server/js/src/assistant/clientToolHandlers.ts
@@ -12,6 +12,8 @@
 export interface ClientToolResult {
   content: string;
   isError?: boolean;
+  /** Whether a structured-output provider may automatically retry with this error. */
+  retryable?: boolean;
 }
 
 export type ClientToolHandler = (toolInput: Record<string, any>) => Promise<ClientToolResult>;

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -87,6 +87,8 @@ export interface PendingClientToolCall {
   requestId: string;
   toolName: string;
   toolInput: Record<string, any>;
+  /** Whether the provider pauses for a result or ends after the browser executes the tool. */
+  continuation?: 'resume' | 'terminal';
 }
 
 /**
@@ -138,6 +140,9 @@ export interface KnownAssistantContext {
 /** All known context keys */
 export type AssistantContextKey = keyof KnownAssistantContext;
 
+/** How a provider delivers actions that must be executed by the client. */
+export type ClientToolDelivery = 'tool' | 'structured' | 'unsupported';
+
 /** One provider as reported by the `/providers` discovery endpoint. */
 export interface ProviderInfo {
   name: string;
@@ -148,13 +153,7 @@ export interface ProviderInfo {
   requires_api_key: boolean;
   has_api_key: boolean;
   allows_remote_access: boolean;
-  /**
-   * Whether this provider can pause a turn on a CLIENT-executed tool call (see
-   * `clientToolHandlers.ts`) and resume it once the client posts a result. False for
-   * CLI-based providers (Claude Code, Codex), which have no such mid-stream channel
-   * without MCP plumbing.
-   */
-  supports_client_tools: boolean;
+  client_tool_delivery: ClientToolDelivery;
   /** Curated model options for simple assistant controls; empty when provider decides. */
   model_options: string[];
 }
@@ -166,8 +165,8 @@ export interface ResolvedProviderInfo {
   auto_selected: boolean;
   requires_api_key: boolean;
   has_api_key: boolean;
-  /** See `ProviderInfo.supports_client_tools`. */
-  supports_client_tools: boolean;
+  /** See `ProviderInfo.client_tool_delivery`. */
+  client_tool_delivery: ClientToolDelivery;
   /** LLM provider behind a gateway endpoint (e.g. 'openai'); null/absent otherwise. */
   model_provider?: string | null;
   /** Curated vendor model choices when resolved to an assistant-managed Gateway endpoint. */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -51,6 +51,7 @@ const mockWaitForCustomViewSpecApplier = jest.fn<(sessionId: string | undefined)
 const mockGetCurrentApplierSessionId = jest.fn<() => string | undefined>(() => 'session-1');
 const mockGetCustomViewAuthoringContext = jest.fn<() => any>(() => null);
 const mockLatchDispatchedCustomViewApplyTarget = jest.fn();
+const mockBuildCustomViewAuthoringGuide = jest.fn((mode: string) => `the-${mode}-guide`);
 
 let capturedConnectorProviderProps:
   | { connector: { openAssistant?: (...args: any[]) => void; isStreaming?: boolean; isPending?: boolean } }
@@ -69,7 +70,7 @@ jest.mock('@databricks/web-shared/model-trace-explorer/custom-view', () => ({
     return <>{props.children}</>;
   },
   RENDER_CUSTOM_VIEW_TOOL_NAME: 'render_custom_view',
-  buildCustomViewAuthoringGuide: () => 'the-guide',
+  buildCustomViewAuthoringGuide: (mode: string) => mockBuildCustomViewAuthoringGuide(mode),
   getCurrentApplierSessionId: () => mockGetCurrentApplierSessionId(),
   getCustomViewAuthoringContext: () => mockGetCustomViewAuthoringContext(),
   latchDispatchedCustomViewApplyTarget: (target: unknown) => mockLatchDispatchedCustomViewApplyTarget(target),
@@ -151,6 +152,19 @@ describe('ExperimentCustomViewProvider', () => {
       expect(assistant.sendMessageWhenReady).toHaveBeenCalledWith(expect.stringContaining('Add a chart'), undefined);
     });
 
+    it('submits structured-output instructions for a structured local provider', () => {
+      const assistant = makeAssistant({
+        activeProvider: { client_tool_delivery: 'structured' },
+      });
+      renderProvider();
+
+      capturedConnectorProviderProps?.connector.openAssistant?.('Show me the failed spans');
+
+      const [message] = jest.mocked(assistant.sendMessageWhenReady).mock.calls[0];
+      expect(message).toContain('structured Custom View response format');
+      expect(message).not.toContain('Use the `render_custom_view` tool');
+    });
+
     it('only opens the panel for "Edit with Assistant" when there is no prompt', () => {
       const assistant = makeAssistant();
       renderProvider();
@@ -222,13 +236,13 @@ describe('ExperimentCustomViewProvider', () => {
 
       const result = await capturedToolHandler!({ title: 'My view', messages: [] });
 
-      expect(result).toEqual({ content: 'Unknown component "Widget"', isError: true });
+      expect(result).toEqual({ content: 'Unknown component "Widget"', isError: true, retryable: true });
     });
   });
 
   describe('pull-based assistant context provider', () => {
-    it('does not register a context provider when the active provider lacks client-tool support', () => {
-      makeAssistant({ activeProvider: { supports_client_tools: false } });
+    it('does not register a context provider when Custom View delivery is unsupported', () => {
+      makeAssistant({ activeProvider: { client_tool_delivery: 'unsupported' } });
       renderProvider();
 
       expect(mockRegisterAssistantContextProvider).not.toHaveBeenCalled();
@@ -241,15 +255,15 @@ describe('ExperimentCustomViewProvider', () => {
       expect(mockRegisterAssistantContextProvider).not.toHaveBeenCalled();
     });
 
-    it('registers a context provider once the active provider supports client tools', () => {
-      makeAssistant({ activeProvider: { supports_client_tools: true } });
+    it('registers a context provider for native tool delivery', () => {
+      makeAssistant({ activeProvider: { client_tool_delivery: 'tool' } });
       renderProvider();
 
       expect(mockRegisterAssistantContextProvider).toHaveBeenCalledWith('customTraceView', expect.any(Function));
     });
 
     it('returns null and latches nothing when there is no published authoring context', () => {
-      makeAssistant({ activeProvider: { supports_client_tools: true } });
+      makeAssistant({ activeProvider: { client_tool_delivery: 'tool' } });
       mockGetCustomViewAuthoringContext.mockReturnValue(null);
       renderProvider();
 
@@ -258,7 +272,7 @@ describe('ExperimentCustomViewProvider', () => {
     });
 
     it('latches the apply target and returns the guide + trace sample + current template', () => {
-      makeAssistant({ activeProvider: { supports_client_tools: true } });
+      makeAssistant({ activeProvider: { client_tool_delivery: 'structured' } });
       const applyTarget = { id: 'v1', name: 'My view', instruction: 'do it', createdAtMs: 1 };
       mockGetCustomViewAuthoringContext.mockReturnValue({
         guide: 'the-guide',
@@ -272,10 +286,11 @@ describe('ExperimentCustomViewProvider', () => {
 
       expect(mockLatchDispatchedCustomViewApplyTarget).toHaveBeenCalledWith(applyTarget);
       expect(result).toEqual({
-        guide: 'the-guide',
+        guide: 'the-structured-guide',
         traceSample: { foo: 'bar' },
         currentTemplate: [{ id: 'root' }],
       });
+      expect(mockBuildCustomViewAuthoringGuide).toHaveBeenCalledWith('structured');
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -288,7 +288,6 @@ describe('ExperimentCustomViewProvider', () => {
       makeAssistant({ activeProvider: { client_tool_delivery: 'structured' } });
       const applyTarget = { id: 'v1', name: 'My view', instruction: 'do it', createdAtMs: 1 };
       mockGetCustomViewAuthoringContext.mockReturnValue({
-        guide: 'the-guide',
         traceSample: { foo: 'bar' },
         currentTemplate: [{ id: 'root' }],
         applyTarget,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -230,13 +230,26 @@ describe('ExperimentCustomViewProvider', () => {
       makeAssistant();
       const applier = jest
         .fn<(spec: RenderCustomViewSpec) => Promise<CustomViewApplyResult>>()
-        .mockResolvedValue({ ok: false, error: 'Unknown component "Widget"' });
+        .mockResolvedValue({ ok: false, error: 'Unknown component "Widget"', retryable: true });
       mockWaitForCustomViewSpecApplier.mockResolvedValue(applier);
       renderProvider();
 
       const result = await capturedToolHandler!({ title: 'My view', messages: [] });
 
       expect(result).toEqual({ content: 'Unknown component "Widget"', isError: true, retryable: true });
+    });
+
+    it('does not retry non-validation applier failures', async () => {
+      makeAssistant();
+      const applier = jest
+        .fn<(spec: RenderCustomViewSpec) => Promise<CustomViewApplyResult>>()
+        .mockResolvedValue({ ok: false, error: 'Custom views cannot be modified.', retryable: false });
+      mockWaitForCustomViewSpecApplier.mockResolvedValue(applier);
+      renderProvider();
+
+      const result = await capturedToolHandler!({ title: 'My view', messages: [] });
+
+      expect(result).toEqual({ content: 'Custom views cannot be modified.', isError: true, retryable: false });
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -49,6 +49,7 @@ export const ExperimentCustomViewProvider = ({
   const { views, isLoaded, persistView } = useExperimentCustomViewDefinition(experimentId);
   const { canEdit: canModifyPersistedViews } = useCanEditExperimentCustomViews(experimentId);
   const { openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming, activeProvider } = useAssistant();
+  const clientToolDelivery = activeProvider?.client_tool_delivery;
 
   const connector = useMemo<CustomViewAssistantConnector>(
     () => ({
@@ -63,14 +64,14 @@ export const ExperimentCustomViewProvider = ({
           // Submit the build directive immediately. A brand-new build requests a
           // fresh Assistant thread atomically so it cannot inherit an unrelated
           // conversation; prompted edits can continue the current thread.
-          const delivery = activeProvider?.client_tool_delivery === 'structured' ? 'structured' : 'tool';
+          const delivery = clientToolDelivery === 'structured' ? 'structured' : 'tool';
           sendMessageWhenReady(buildRenderCustomViewPrompt(instruction, delivery), options);
         }
       },
       isStreaming,
       isPending: Boolean(pendingAutomaticMessage),
     }),
-    [activeProvider, openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
+    [clientToolDelivery, openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
   );
 
   // The assistant backend delivers a `render_custom_view` client action. API-based
@@ -98,10 +99,10 @@ export const ExperimentCustomViewProvider = ({
   // serve the turn. The guide matches the provider's native-tool or structured-output
   // delivery mode so the model never receives conflicting output instructions.
   useEffect(() => {
-    if (!activeProvider?.client_tool_delivery || activeProvider.client_tool_delivery === 'unsupported') {
+    if (!clientToolDelivery || clientToolDelivery === 'unsupported') {
       return undefined;
     }
-    const deliveryMode = activeProvider.client_tool_delivery === 'structured' ? 'structured' : 'tool';
+    const deliveryMode = clientToolDelivery === 'structured' ? 'structured' : 'tool';
     return registerAssistantContextProvider('customTraceView', () => {
       const ctx = getCustomViewAuthoringContext();
       if (!ctx) {
@@ -116,7 +117,7 @@ export const ExperimentCustomViewProvider = ({
         currentTemplate: ctx.currentTemplate,
       };
     });
-  }, [activeProvider]);
+  }, [clientToolDelivery]);
 
   return (
     <CustomViewAssistantConnectorProvider connector={connector}>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -22,8 +22,16 @@ import { registerAssistantContextProvider } from '../../../../../assistant/conte
 // The empty-state prompt box hands us the user's natural-language request. This
 // prompt is submitted ONLY for the initial build (handleSubmitPrompt); the edit
 // flow (handleEditWithAssistant) sends nothing and just opens the panel.
-const buildRenderCustomViewPrompt = (request: string): string =>
-  [`Build my custom trace view: "${request}".`, '', 'Use the `render_custom_view` tool to build this view.'].join('\n');
+// The structured Custom View response format is defined and validated by the backend
+// in mlflow/assistant/custom_view.py; this prompt only selects that delivery contract.
+const buildRenderCustomViewPrompt = (request: string, delivery: 'tool' | 'structured'): string =>
+  [
+    `Build my custom trace view: "${request}".`,
+    '',
+    delivery === 'tool'
+      ? 'Use the `render_custom_view` tool to build this view.'
+      : 'Return the view using the structured Custom View response format.',
+  ].join('\n');
 
 /**
  * Wires the trace explorer's Custom View feature to the experiment's persistence
@@ -55,20 +63,21 @@ export const ExperimentCustomViewProvider = ({
           // Submit the build directive immediately. A brand-new build requests a
           // fresh Assistant thread atomically so it cannot inherit an unrelated
           // conversation; prompted edits can continue the current thread.
-          sendMessageWhenReady(buildRenderCustomViewPrompt(instruction), options);
+          const delivery = activeProvider?.client_tool_delivery === 'structured' ? 'structured' : 'tool';
+          sendMessageWhenReady(buildRenderCustomViewPrompt(instruction, delivery), options);
         }
       },
       isStreaming,
       isPending: Boolean(pendingAutomaticMessage),
     }),
-    [openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
+    [activeProvider, openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
   );
 
-  // Tier 1 (Gateway/Ollama): the assistant backend calls a real `render_custom_view`
-  // client tool and pauses the turn; this handler runs it by handing the spec to
-  // whichever Custom View host is currently registered (the applier), then reports
-  // the result back to resume the stream. Scoped to the session that was active
-  // when the call started, so a different tab remounting mid-call can't steal it.
+  // The assistant backend delivers a `render_custom_view` client action. API-based
+  // providers use a native tool call; local providers translate structured final
+  // output into a terminal action. This handler hands the spec to whichever Custom View host is
+  // registered, scoped to the session that was active when the call started so a
+  // different tab remounting mid-call can't steal it.
   useEffect(() => {
     return registerClientToolHandler(RENDER_CUSTOM_VIEW_TOOL_NAME, async (toolInput) => {
       const applier = await waitForCustomViewSpecApplier(getCurrentApplierSessionId());
@@ -78,7 +87,7 @@ export const ExperimentCustomViewProvider = ({
       const result = await applier({ title: toolInput['title'], messages: toolInput['messages'] });
       return result.ok
         ? { content: 'The custom view was rendered successfully.' }
-        : { content: result.error, isError: true };
+        : { content: result.error, isError: true, retryable: true };
     });
   }, []);
 
@@ -86,15 +95,13 @@ export const ExperimentCustomViewProvider = ({
   // useCustomViewAssistantBridge) into the assistant's page context. Pull-based (read
   // at message-send time, see contextProviders.ts) rather than pushed into React
   // state, since whether to publish at all depends on which provider is about to
-  // serve the turn. Only providers that support a real client-tool call
-  // (`render_custom_view`) can act on this guide today — CLI providers (Claude
-  // Code, Codex) have no mid-stream client-tool channel without MCP plumbing, so
-  // publishing the guide for them would be a no-op at best. Support for those is
-  // tracked as a follow-up (a fenced-block convention), not yet implemented.
+  // serve the turn. The guide matches the provider's native-tool or structured-output
+  // delivery mode so the model never receives conflicting output instructions.
   useEffect(() => {
-    if (!activeProvider?.supports_client_tools) {
+    if (!activeProvider?.client_tool_delivery || activeProvider.client_tool_delivery === 'unsupported') {
       return undefined;
     }
+    const deliveryMode = activeProvider.client_tool_delivery === 'structured' ? 'structured' : 'tool';
     return registerAssistantContextProvider('customTraceView', () => {
       const ctx = getCustomViewAuthoringContext();
       if (!ctx) {
@@ -104,7 +111,7 @@ export const ExperimentCustomViewProvider = ({
       // returns lands on the right view even if the user switches views mid-turn.
       latchDispatchedCustomViewApplyTarget(ctx.applyTarget);
       return {
-        guide: buildCustomViewAuthoringGuide(),
+        guide: buildCustomViewAuthoringGuide(deliveryMode),
         traceSample: ctx.traceSample,
         currentTemplate: ctx.currentTemplate,
       };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -87,7 +87,7 @@ export const ExperimentCustomViewProvider = ({
       const result = await applier({ title: toolInput['title'], messages: toolInput['messages'] });
       return result.ok
         ? { content: 'The custom view was rendered successfully.' }
-        : { content: result.error, isError: true, retryable: true };
+        : { content: result.error, isError: true, retryable: result.retryable };
     });
   }, []);
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
@@ -45,7 +45,7 @@ import { validateAndPrepareMessages, validateTemplate } from './agent/validateA2
 import { resolveTemplate } from './resolveTemplate';
 import { useCustomViewAssistantBridge } from './assistant/useCustomViewAssistantBridge';
 import { getDispatchedCustomViewApplyTarget } from './assistant/customViewAuthoringContext';
-import type { RenderCustomViewSpec } from './assistant/customViewSpecApplier';
+import { CustomViewValidationError, type RenderCustomViewSpec } from './assistant/customViewSpecApplier';
 import {
   CUSTOM_VIEW_CATALOG_ID,
   type CustomViewData,
@@ -292,7 +292,7 @@ export const ModelTraceExplorerCustomView = ({
   const prepareTemplate = (spec: RenderCustomViewSpec): A2uiMessage[] => {
     const result = validateTemplate(spec);
     if (!result.ok) {
-      throw new Error(result.error);
+      throw new CustomViewValidationError(result.error);
     }
     return result.messages;
   };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/buildAgentPrompt.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/buildAgentPrompt.test.ts
@@ -12,6 +12,14 @@ describe('buildCustomViewAuthoringGuide', () => {
     expect(guide).toContain(`CALL the \`${RENDER_CUSTOM_VIEW_TOOL_NAME}\` tool`);
   });
 
+  test('provides a schema-envelope contract for structured-output providers', () => {
+    const guide = buildCustomViewAuthoringGuide('structured');
+    expect(guide).toContain('structured final response');
+    expect(guide).toContain('"type": "render_custom_view"');
+    expect(guide).toContain('"type" to "message"');
+    expect(guide).not.toContain(`CALL the \`${RENDER_CUSTOM_VIEW_TOOL_NAME}\` tool`);
+  });
+
   test('includes the catalog/binding/layout/example building blocks', () => {
     const guide = buildCustomViewAuthoringGuide();
     for (const shared of [

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/buildAgentPrompt.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/agent/buildAgentPrompt.ts
@@ -2,13 +2,14 @@
 // catalog / data-binding references and examples, the per-trace data snapshot,
 // and the MLflow Assistant authoring guide. Follows A2UI v0.9's "prompt-first"
 // contract: the schema + examples are embedded in the prompt and the model
-// passes the full message stream as the render_custom_view tool's "messages"
-// argument, which the host validates before processing.
+// delivers the full message stream through either the render_custom_view tool
+// or a schema-constrained final response, which the host validates before processing.
 
 import type { AgentAssessment } from '../customViewBuilders';
 import { A2UI_VERSION } from './validateA2uiMessages';
 
 export const RENDER_CUSTOM_VIEW_TOOL_NAME = 'render_custom_view';
+export type CustomViewDeliveryMode = 'tool' | 'structured';
 
 // One span's entry in the nodeMap JSON handed to the model. Keyed by span id,
 // this is just the trace's nodeMap serialized to plain JSON (no curated shape).
@@ -117,6 +118,20 @@ export const EXAMPLE: string = `Example — a heading plus a metrics row. Note: 
 }
 \`\`\``;
 
+const STRUCTURED_OUTPUT_RULES = [
+  `Output format rules (A2UI ${A2UI_VERSION}):`,
+  `1. Deliver the view in the provider's structured final response. Set "type" to "${RENDER_CUSTOM_VIEW_TOOL_NAME}", "text" to a short confirmation, "title" to a SHORT 2-5 word human-readable name, and "messages" to the complete A2UI message array described below. If the user is only asking a question and does not want the view changed, set "type" to "message", answer in "text", and return "title": "" and "messages": []. Do NOT call a render tool or wrap the response in a code fence.`,
+  ...OUTPUT_RULES.split('\n').slice(2),
+].join('\n');
+
+const STRUCTURED_EXAMPLE = EXAMPLE.replace(
+  '{ "title", "messages" } wrapper',
+  '{ "type", "text", "title", "messages" } envelope',
+).replace(
+  '{\n  "title": "Trace Summary",',
+  '{\n  "type": "render_custom_view",\n  "text": "Created a reusable trace summary view.",\n  "title": "Trace Summary",',
+);
+
 export const CARD_STYLE_EXAMPLE: string = `Example — a DECORATED card (apply this styling pattern to every card: titled heading, caption, then bound content). Here a summary card shows bound metrics and the root span's input via a "spanField" marker (note there is NO literal span id or per-trace value):
 \`\`\`json
 [
@@ -223,16 +238,16 @@ export const buildAgentDataSnapshot = (data: AgentTraceData): Record<string, unk
 };
 
 // Static authoring guide handed to MLflow Assistant via page context (the
-// assistant has no built-in knowledge of A2UI or the custom view). Delivery is
-// via a real `render_custom_view` tool call — see supports_client_tools on the
-// backend provider, which gates whether this guide is published at all. CLI
-// providers (Claude Code, Codex) have no mid-stream client-tool channel and are
-// not supported yet (see the fenced-block-convention follow-up in the plan).
-export const buildCustomViewAuthoringGuide = (): string => {
+// assistant has no built-in knowledge of A2UI or the custom view).
+export const buildCustomViewAuthoringGuide = (deliveryMode: CustomViewDeliveryMode = 'tool'): string => {
+  const deliveryInstruction =
+    deliveryMode === 'tool'
+      ? `When (and only when) the user asks you to build, change, or update the custom view, CALL the \`${RENDER_CUSTOM_VIEW_TOOL_NAME}\` tool. Pass two arguments: "title" (a short 2-5 word view name, e.g. "Trace Summary", "Span Cards" — NOT the user's raw words) and "messages" (the FULL A2UI message stream as a JSON array). Calling the tool is the ONLY way the view updates — do NOT print the JSON spec as a chat message or in a code fence, because nothing applies a spec that is merely written in chat (the view will silently stay unchanged). After the tool call succeeds, reply with a short natural-language confirmation of what changed. If the user is just asking a question (not requesting a view change), answer normally without calling the tool.`
+      : `When (and only when) the user asks you to build, change, or update the custom view, return the COMPLETE view using the provider's structured final-response schema. Set "type" to "${RENDER_CUSTOM_VIEW_TOOL_NAME}", include a short confirmation in "text", a short 2-5 word view name in "title", and the FULL A2UI message stream in "messages". If the user is just asking a question, set "type" to "message", answer in "text", and return an empty title and messages array.`;
   const intro = [
     'CUSTOM TRACE VIEW AUTHORING MODE.',
     'The user is viewing the "Custom View" tab of the MLflow trace explorer and wants you to BUILD or MODIFY an A2UI view ("custom view"). You author a REUSABLE, TRACE-AGNOSTIC TEMPLATE exactly ONCE: the host saves it and re-binds it to every trace the user cycles through WITHOUT calling you again. So you must NOT bake in the current trace\'s data. The "traceSample" in the context shows only the SHAPE of the data (so you can pick sensible sources and layout); never copy its concrete span ids, values, rows, or counts into the spec. Every data-bearing prop must be a binding MARKER (see the Data binding rules) that the host resolves per trace.',
-    `When (and only when) the user asks you to build, change, or update the custom view, CALL the \`${RENDER_CUSTOM_VIEW_TOOL_NAME}\` tool. Pass two arguments: "title" (a short 2-5 word view name, e.g. "Trace Summary", "Span Cards" — NOT the user's raw words) and "messages" (the FULL A2UI message stream as a JSON array). Calling the tool is the ONLY way the view updates — do NOT print the JSON spec as a chat message or in a code fence, because nothing applies a spec that is merely written in chat (the view will silently stay unchanged). After the tool call succeeds, reply with a short natural-language confirmation of what changed. If the user is just asking a question (not requesting a view change), answer normally without calling the tool.`,
+    deliveryInstruction,
     'Always pass the COMPLETE "messages" spec for the single view (not a diff) on every turn that updates it. When a "currentTemplate" is provided in the context, it is the existing reusable template (with its binding markers): KEEP its layout, component choices, and markers, and apply ONLY the change the user asked for. Do NOT replace markers with literal data and do NOT introduce trace-specific values. Re-pick the "title" whenever an edit changes what the view shows; keep the previous title for purely cosmetic edits (colors, spacing, minor wording).',
   ].join('\n');
 
@@ -241,8 +256,8 @@ export const buildCustomViewAuthoringGuide = (): string => {
     CATALOG_REFERENCE,
     BINDING_REFERENCE,
     LAYOUT_GUIDANCE,
-    OUTPUT_RULES,
-    EXAMPLE,
+    deliveryMode === 'structured' ? STRUCTURED_OUTPUT_RULES : OUTPUT_RULES,
+    deliveryMode === 'structured' ? STRUCTURED_EXAMPLE : EXAMPLE,
     CARD_STYLE_EXAMPLE,
     SPAN_CARD_EXAMPLE,
   ].join('\n\n');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.test.ts
@@ -8,7 +8,6 @@ import {
 } from './customViewAuthoringContext';
 
 const makeContext = (overrides: Partial<CustomViewAuthoringContext> = {}): CustomViewAuthoringContext => ({
-  guide: 'guide text',
   traceSample: { metrics: { status: 'OK' } },
   ...overrides,
 });
@@ -32,8 +31,8 @@ describe('customViewAuthoringContext', () => {
   });
 
   test('a later registration overwrites the earlier one (last-writer-wins)', () => {
-    const first = makeContext({ guide: 'first' });
-    const second = makeContext({ guide: 'second' });
+    const first = makeContext({ traceSample: { id: 'first' } });
+    const second = makeContext({ traceSample: { id: 'second' } });
     const unregisterFirst = registerCustomViewAuthoringContext(first);
     const unregisterSecond = registerCustomViewAuthoringContext(second);
 
@@ -44,8 +43,8 @@ describe('customViewAuthoringContext', () => {
   });
 
   test('unregistering a superseded registration is a no-op (does not clear the current one)', () => {
-    const first = makeContext({ guide: 'first' });
-    const second = makeContext({ guide: 'second' });
+    const first = makeContext({ traceSample: { id: 'first' } });
+    const second = makeContext({ traceSample: { id: 'second' } });
     const unregisterFirst = registerCustomViewAuthoringContext(first);
     const unregisterSecond = registerCustomViewAuthoringContext(second);
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewAuthoringContext.ts
@@ -1,18 +1,17 @@
 /**
- * Module-level store for the Custom View authoring context (the A2UI guide + the
- * current trace's data snapshot + the active view's template). The Custom View
- * host lives deep inside the trace drawer (web-shared), while the assistant's
- * page context is assembled at a higher level; rather than thread per-trace
- * state up through every layer, the host registers the current authoring
- * context here and the assistant's context plugin reads it when building the
- * agent prompt. Last-writer-wins (a single Custom View tab is open at a time).
+ * Module-level store for the Custom View authoring context (the current trace's
+ * data snapshot + the active view's template). The Custom View host lives deep
+ * inside the trace drawer (web-shared), while the assistant's page context is
+ * assembled at a higher level; rather than thread per-trace state up through
+ * every layer, the host registers the current authoring context here and the
+ * assistant's context plugin reads it when building the agent prompt.
+ * Last-writer-wins (a single Custom View tab is open at a time).
  */
 import type { A2uiMessage } from '@a2ui/web_core/v0_9';
 
 import type { CustomViewApplyTarget } from '../customViewDefinition';
 
 export type CustomViewAuthoringContext = {
-  guide: string;
   currentTemplate?: A2uiMessage[];
   traceSample: Record<string, unknown>;
   // The view `currentTemplate` was taken from. Published alongside the template

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewSpecApplier.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/customViewSpecApplier.ts
@@ -11,7 +11,9 @@ export type RenderCustomViewSpec = {
   messages: unknown;
 };
 
-export type CustomViewApplyResult = { ok: true } | { ok: false; error: string };
+export class CustomViewValidationError extends Error {}
+
+export type CustomViewApplyResult = { ok: true } | { ok: false; error: string; retryable: boolean };
 
 export type CustomViewSpecApplier = (spec: RenderCustomViewSpec) => Promise<CustomViewApplyResult>;
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
@@ -6,7 +6,11 @@ import type { AgentTraceData } from '../agent/buildAgentPrompt';
 import type { CustomView } from '../customViewDefinition';
 import { CustomViewAssistantConnectorProvider } from './CustomViewAssistantConnector';
 import { getCustomViewAuthoringContext } from './customViewAuthoringContext';
-import { getCustomViewSpecApplier, type RenderCustomViewSpec } from './customViewSpecApplier';
+import {
+  CustomViewValidationError,
+  getCustomViewSpecApplier,
+  type RenderCustomViewSpec,
+} from './customViewSpecApplier';
 import { useCustomViewAssistantBridge } from './useCustomViewAssistantBridge';
 
 const traceData = (): AgentTraceData => ({ metrics: { status: 'OK' } });
@@ -111,9 +115,26 @@ describe('useCustomViewAssistantBridge', () => {
       applyResult = await applier?.({ title: 't', messages: [] });
     });
 
-    expect(applyResult).toEqual({ ok: false, error: 'invalid template' });
+    expect(applyResult).toEqual({ ok: false, error: 'invalid template', retryable: false });
     expect(result.current.applyError).toBe('invalid template');
 
+    unmount();
+  });
+
+  test('marks validation failures as retryable', async () => {
+    const onSpec = jest.fn(async () => {
+      throw new CustomViewValidationError('unknown component');
+    });
+    const { unmount } = renderHook(() =>
+      useCustomViewAssistantBridge({ data: traceData(), activeView: activeView(), onSpec }),
+    );
+
+    let applyResult;
+    await act(async () => {
+      applyResult = await getCustomViewSpecApplier()?.({ title: 't', messages: [] });
+    });
+
+    expect(applyResult).toEqual({ ok: false, error: 'unknown component', retryable: true });
     unmount();
   });
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.test.tsx
@@ -44,7 +44,7 @@ afterEach(() => {
 });
 
 describe('useCustomViewAssistantBridge', () => {
-  test('publishes the authoring context (guide + trace sample + template + applyTarget) while enabled', () => {
+  test('publishes the authoring context (trace sample + template + applyTarget) while enabled', () => {
     const view = activeView({ template: [{ version: 'v0.9' } as any] });
     const { unmount } = renderHook(() =>
       useCustomViewAssistantBridge({ data: traceData(), activeView: view, onSpec: noopOnSpec }),
@@ -52,7 +52,6 @@ describe('useCustomViewAssistantBridge', () => {
 
     const context = getCustomViewAuthoringContext();
     expect(context).not.toBeNull();
-    expect(context?.guide).toContain('CUSTOM TRACE VIEW AUTHORING MODE');
     expect(context?.currentTemplate).toBe(view.template);
     expect(context?.applyTarget).toMatchObject({ id: 'view-1', name: 'My view' });
     expect(context?.traceSample).toMatchObject({ metrics: { status: 'OK' } });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { buildAgentDataSnapshot, buildCustomViewAuthoringGuide, type AgentTraceData } from '../agent/buildAgentPrompt';
+import { buildAgentDataSnapshot, type AgentTraceData } from '../agent/buildAgentPrompt';
 import { toCustomViewApplyTarget, type CustomView } from '../customViewDefinition';
 import { useCustomViewAssistantConnector, type OpenCustomViewAssistantOptions } from './CustomViewAssistantConnector';
 import { registerCustomViewAuthoringContext } from './customViewAuthoringContext';
@@ -9,9 +9,6 @@ import {
   registerCustomViewSpecApplier,
   type RenderCustomViewSpec,
 } from './customViewSpecApplier';
-
-// The static authoring guide is computed once — it has no per-trace state.
-const AUTHORING_GUIDE = buildCustomViewAuthoringGuide();
 
 export type CustomViewAssistantBridge = {
   isAvailable: boolean;
@@ -28,8 +25,8 @@ export type CustomViewAssistantBridge = {
  * Bridges the Custom View host to the host application's agent (MLflow
  * Assistant). It:
  *
- * 1. publishes the current authoring context (guide + this trace's snapshot +
- *    the active view's template) to a module-level store so the assistant's
+ * 1. publishes the current authoring context (this trace's snapshot + the
+ *    active view's template) to a module-level store so the assistant's
  *    context plugin can include it in the agent prompt;
  * 2. registers an applier so native tool calls and terminal structured responses
  *    can hand the agent-produced spec back to this host's `onSpec` (validate + render);
@@ -76,7 +73,6 @@ export const useCustomViewAssistantBridge = ({
       return;
     }
     return registerCustomViewAuthoringContext({
-      guide: AUTHORING_GUIDE,
       currentTemplate: activeView?.template,
       traceSample,
       applyTarget: activeView ? toCustomViewApplyTarget(activeView) : undefined,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/assistant/useCustomViewAssistantBridge.ts
@@ -4,7 +4,11 @@ import { buildAgentDataSnapshot, buildCustomViewAuthoringGuide, type AgentTraceD
 import { toCustomViewApplyTarget, type CustomView } from '../customViewDefinition';
 import { useCustomViewAssistantConnector, type OpenCustomViewAssistantOptions } from './CustomViewAssistantConnector';
 import { registerCustomViewAuthoringContext } from './customViewAuthoringContext';
-import { registerCustomViewSpecApplier, type RenderCustomViewSpec } from './customViewSpecApplier';
+import {
+  CustomViewValidationError,
+  registerCustomViewSpecApplier,
+  type RenderCustomViewSpec,
+} from './customViewSpecApplier';
 
 // The static authoring guide is computed once — it has no per-trace state.
 const AUTHORING_GUIDE = buildCustomViewAuthoringGuide();
@@ -27,11 +31,8 @@ export type CustomViewAssistantBridge = {
  * 1. publishes the current authoring context (guide + this trace's snapshot +
  *    the active view's template) to a module-level store so the assistant's
  *    context plugin can include it in the agent prompt;
- * 2. registers an applier so the `render_custom_view` tool can hand the
- *    agent-produced spec back to this host's `onSpec` (validate + render).
- *    CLI-based providers (Claude Code, Codex) have no mid-stream client-tool
- *    channel without MCP plumbing and are not supported yet — a fenced-block
- *    convention for those is tracked as a follow-up;
+ * 2. registers an applier so native tool calls and terminal structured responses
+ *    can hand the agent-produced spec back to this host's `onSpec` (validate + render);
  * 3. exposes the connector's chat opener + streaming state.
  *
  * The agent itself (tool/skill registration, panel opening) is wired at a
@@ -97,7 +98,7 @@ export const useCustomViewAssistantBridge = ({
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to render the custom view.';
         setApplyError(message);
-        return { ok: false, error: message };
+        return { ok: false, error: message, retryable: error instanceof CustomViewValidationError };
       }
     });
   }, [enabled]);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/index.ts
@@ -37,6 +37,7 @@ export {
   registerCustomViewSpecApplier,
   getCurrentApplierSessionId,
   waitForCustomViewSpecApplier,
+  CustomViewValidationError,
   type CustomViewSpecApplier,
   type RenderCustomViewSpec,
   type CustomViewApplyResult,

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -1,4 +1,5 @@
 import errno
+import json
 import subprocess
 import tempfile
 from pathlib import Path
@@ -78,10 +79,9 @@ def test_is_available(which_return, expected):
         assert provider.is_available() is expected
 
 
-def test_supports_client_tools_is_false():
-    # A CLI-based provider has no mid-stream client-tool channel without MCP
-    # plumbing, so it inherits the base class's default of False.
-    assert ClaudeCodeProvider().supports_client_tools is False
+def test_uses_structured_client_tool_delivery():
+    provider = ClaudeCodeProvider()
+    assert provider.client_tool_delivery == "structured"
 
 
 def test_check_connection_runs_auth_verification_prompt():
@@ -236,6 +236,199 @@ async def test_astream_passes_cwd_and_env(tmp_path, monkeypatch):
     assert call_kwargs["cwd"] == tmp_path
     assert call_kwargs["env"]["MLFLOW_TRACKING_URI"] == "http://localhost:5000"
     assert call_kwargs["env"]["TEST_ENV_VAR"] == "test_value"
+
+
+@pytest.mark.asyncio
+async def test_astream_uses_custom_view_json_schema(tmp_path):
+    response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": [{"version": "v0.9", "updateComponents": {}}],
+    }
+    mock_process = _mock_process(
+        stdout_lines=[
+            json.dumps({
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": json.dumps(response)}]},
+            }).encode()
+            + b"\n",
+            json.dumps({
+                "type": "result",
+                "session_id": "claude-session",
+                "structured_output": response,
+            }).encode()
+            + b"\n",
+        ],
+        pid=None,
+    )
+
+    with (
+        patch(
+            "mlflow.assistant.providers.claude_code.shutil.which",
+            return_value="/usr/bin/claude",
+        ),
+        patch(
+            "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ) as mock_exec,
+    ):
+        provider = ClaudeCodeProvider()
+        events = [
+            event
+            async for event in provider.astream(
+                "build a view",
+                "http://localhost:5000",
+                session_id="previous-claude-session",
+                cwd=tmp_path,
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    args = mock_exec.call_args.args
+    schema = json.loads(args[args.index("--json-schema") + 1])
+    assert schema["required"] == ["type", "text", "title", "messages"]
+    assert args[args.index("--resume") + 1] == "previous-claude-session"
+    assert "--mcp-config" not in args
+    assert [event.type for event in events] == [
+        EventType.MESSAGE,
+        EventType.MESSAGE,
+        EventType.CLIENT_TOOL_CALL,
+        EventType.DONE,
+    ]
+    assert events[0].data["message"]["content"][0]["text"] == response["text"]
+    assert events[2].data["continuation"] == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_astream_repairs_invalid_custom_view_output_once(tmp_path):
+    invalid_response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": [],
+    }
+    valid_response = {
+        **invalid_response,
+        "messages": [{"version": "v0.9", "updateComponents": {}}],
+    }
+
+    def result_process(response):
+        return _mock_process(
+            stdout_lines=[
+                json.dumps({
+                    "type": "result",
+                    "session_id": "repair-session",
+                    "structured_output": response,
+                }).encode()
+                + b"\n"
+            ],
+            pid=None,
+        )
+
+    invalid_process = result_process(invalid_response)
+    valid_process = result_process(valid_response)
+    with (
+        patch(
+            "mlflow.assistant.providers.claude_code.shutil.which",
+            return_value="/usr/bin/claude",
+        ),
+        patch(
+            "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
+            side_effect=[invalid_process, valid_process],
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in ClaudeCodeProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                cwd=tmp_path,
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    assert mock_exec.call_count == 2
+    repair_args = mock_exec.call_args_list[1].args
+    assert repair_args[repair_args.index("--resume") + 1] == "repair-session"
+    repair_prompt = valid_process.stdin.write.call_args.args[0].decode()
+    assert "structured response failed validation" in repair_prompt
+    assert "non-empty messages" in repair_prompt
+    assert not any(event.type == EventType.ERROR for event in events)
+    assert [event.type for event in events] == [
+        EventType.MESSAGE,
+        EventType.MESSAGE,
+        EventType.CLIENT_TOOL_CALL,
+        EventType.DONE,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_astream_stops_after_one_invalid_custom_view_output_repair(tmp_path):
+    invalid_response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": [],
+    }
+
+    def invalid_process():
+        return _mock_process(
+            stdout_lines=[
+                json.dumps({
+                    "type": "result",
+                    "session_id": "repair-session",
+                    "structured_output": invalid_response,
+                }).encode()
+                + b"\n"
+            ],
+            pid=None,
+        )
+
+    with (
+        patch(
+            "mlflow.assistant.providers.claude_code.shutil.which",
+            return_value="/usr/bin/claude",
+        ),
+        patch(
+            "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
+            side_effect=[invalid_process(), invalid_process()],
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in ClaudeCodeProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                cwd=tmp_path,
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    assert mock_exec.call_count == 2
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "non-empty messages" in errors[0].data["error"]
+
+
+def test_filter_structured_output_text_preserves_tool_blocks():
+    message = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": '{"type":"message"}'},
+                {
+                    "type": "tool_use",
+                    "id": "tool-id",
+                    "name": "Bash",
+                    "input": {},
+                },
+            ]
+        },
+    }
+
+    filtered = ClaudeCodeProvider._filter_structured_output_text(message)
+    assert filtered["message"]["content"] == [message["message"]["content"][1]]
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -351,7 +351,7 @@ async def test_astream_forwards_empty_custom_view_messages_for_client_validation
 
 
 @pytest.mark.asyncio
-async def test_astream_does_not_retry_invalid_custom_view_transport(tmp_path):
+async def test_astream_forwards_invalid_custom_view_transport_for_client_validation(tmp_path):
     invalid_response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
@@ -392,9 +392,10 @@ async def test_astream_does_not_retry_invalid_custom_view_transport(tmp_path):
         ]
 
     mock_exec.assert_called_once()
-    errors = [event for event in events if event.type == EventType.ERROR]
-    assert len(errors) == 1
-    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
+    assert not any(event.type == EventType.ERROR for event in events)
+    client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
+    assert len(client_tool_calls) == 1
+    assert client_tool_calls[0].data["tool_input"]["messages"] == "not-json"
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -301,33 +301,24 @@ async def test_astream_uses_custom_view_json_schema(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_astream_repairs_invalid_custom_view_output_once(tmp_path):
-    invalid_response = {
+async def test_astream_forwards_empty_custom_view_messages_for_client_validation(tmp_path):
+    response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
         "title": "Trace Summary",
         "messages": [],
     }
-    valid_response = {
-        **invalid_response,
-        "messages": [{"version": "v0.9", "updateComponents": {}}],
-    }
-
-    def result_process(response):
-        return _mock_process(
-            stdout_lines=[
-                json.dumps({
-                    "type": "result",
-                    "session_id": "repair-session",
-                    "structured_output": response,
-                }).encode()
-                + b"\n"
-            ],
-            pid=None,
-        )
-
-    invalid_process = result_process(invalid_response)
-    valid_process = result_process(valid_response)
+    process = _mock_process(
+        stdout_lines=[
+            json.dumps({
+                "type": "result",
+                "session_id": "session-id",
+                "structured_output": response,
+            }).encode()
+            + b"\n"
+        ],
+        pid=None,
+    )
     with (
         patch(
             "mlflow.assistant.providers.claude_code.shutil.which",
@@ -335,7 +326,7 @@ async def test_astream_repairs_invalid_custom_view_output_once(tmp_path):
         ),
         patch(
             "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
-            side_effect=[invalid_process, valid_process],
+            return_value=process,
         ) as mock_exec,
     ):
         events = [
@@ -348,12 +339,7 @@ async def test_astream_repairs_invalid_custom_view_output_once(tmp_path):
             )
         ]
 
-    assert mock_exec.call_count == 2
-    repair_args = mock_exec.call_args_list[1].args
-    assert repair_args[repair_args.index("--resume") + 1] == "repair-session"
-    repair_prompt = valid_process.stdin.write.call_args.args[0].decode()
-    assert "structured response failed validation" in repair_prompt
-    assert "non-empty messages" in repair_prompt
+    mock_exec.assert_called_once()
     assert not any(event.type == EventType.ERROR for event in events)
     assert [event.type for event in events] == [
         EventType.MESSAGE,
@@ -361,29 +347,29 @@ async def test_astream_repairs_invalid_custom_view_output_once(tmp_path):
         EventType.CLIENT_TOOL_CALL,
         EventType.DONE,
     ]
+    assert events[2].data["tool_input"]["messages"] == []
 
 
 @pytest.mark.asyncio
-async def test_astream_stops_after_one_invalid_custom_view_output_repair(tmp_path):
+async def test_astream_does_not_retry_invalid_custom_view_transport(tmp_path):
     invalid_response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
         "title": "Trace Summary",
-        "messages": [],
+        "messages": "not-json",
     }
 
-    def invalid_process():
-        return _mock_process(
-            stdout_lines=[
-                json.dumps({
-                    "type": "result",
-                    "session_id": "repair-session",
-                    "structured_output": invalid_response,
-                }).encode()
-                + b"\n"
-            ],
-            pid=None,
-        )
+    process = _mock_process(
+        stdout_lines=[
+            json.dumps({
+                "type": "result",
+                "session_id": "session-id",
+                "structured_output": invalid_response,
+            }).encode()
+            + b"\n"
+        ],
+        pid=None,
+    )
 
     with (
         patch(
@@ -392,7 +378,7 @@ async def test_astream_stops_after_one_invalid_custom_view_output_repair(tmp_pat
         ),
         patch(
             "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
-            side_effect=[invalid_process(), invalid_process()],
+            return_value=process,
         ) as mock_exec,
     ):
         events = [
@@ -405,10 +391,10 @@ async def test_astream_stops_after_one_invalid_custom_view_output_repair(tmp_pat
             )
         ]
 
-    assert mock_exec.call_count == 2
+    mock_exec.assert_called_once()
     errors = [event for event in events if event.type == EventType.ERROR]
     assert len(errors) == 1
-    assert "non-empty messages" in errors[0].data["error"]
+    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
 
 
 def test_filter_structured_output_text_preserves_tool_blocks():

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -395,6 +395,7 @@ async def test_astream_does_not_retry_invalid_custom_view_transport(tmp_path):
     errors = [event for event in events if event.type == EventType.ERROR]
     assert len(errors) == 1
     assert "messages must be a JSON-encoded array" in errors[0].data["error"]
+    assert errors[0].data["session_id"] == "session-id"
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -351,7 +351,7 @@ async def test_astream_forwards_empty_custom_view_messages_for_client_validation
 
 
 @pytest.mark.asyncio
-async def test_astream_forwards_invalid_custom_view_transport_for_client_validation(tmp_path):
+async def test_astream_does_not_retry_invalid_custom_view_transport(tmp_path):
     invalid_response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
@@ -392,10 +392,9 @@ async def test_astream_forwards_invalid_custom_view_transport_for_client_validat
         ]
 
     mock_exec.assert_called_once()
-    assert not any(event.type == EventType.ERROR for event in events)
-    client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
-    assert len(client_tool_calls) == 1
-    assert client_tool_calls[0].data["tool_input"]["messages"] == "not-json"
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -397,6 +397,52 @@ async def test_astream_does_not_retry_invalid_custom_view_transport(tmp_path):
     assert "messages must be a JSON-encoded array" in errors[0].data["error"]
 
 
+@pytest.mark.asyncio
+async def test_astream_requires_session_id_in_structured_result(tmp_path):
+    response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": [{"version": "v0.9", "updateComponents": {}}],
+    }
+    process = _mock_process(
+        stdout_lines=[
+            json.dumps({
+                "type": "result",
+                "structured_output": response,
+            }).encode()
+            + b"\n"
+        ],
+        pid=None,
+    )
+
+    with (
+        patch(
+            "mlflow.assistant.providers.claude_code.shutil.which",
+            return_value="/usr/bin/claude",
+        ),
+        patch(
+            "mlflow.assistant.providers.claude_code.asyncio.create_subprocess_exec",
+            return_value=process,
+        ),
+    ):
+        events = [
+            event
+            async for event in ClaudeCodeProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                session_id="previous-session-id",
+                cwd=tmp_path,
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert errors[0].data["error"] == "Claude Code result did not include a session ID"
+    assert not any(event.type == EventType.CLIENT_TOOL_CALL for event in events)
+
+
 def test_filter_structured_output_text_preserves_tool_blocks():
     message = {
         "type": "assistant",

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -381,6 +382,75 @@ async def test_astream_uses_custom_view_output_schema():
     assert events[0].data["message"]["content"][0]["text"] == response["text"]
     assert events[2].data["tool_input"]["messages"] == [{"version": "v0.9", "updateComponents": {}}]
     assert events[2].data["continuation"] == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_astream_cleans_up_custom_view_schema_when_fdopen_fails(tmp_path):
+    schema_path = tmp_path / "custom-view.schema.json"
+    schema_fd = None
+
+    def make_schema_file(*args, **kwargs):
+        nonlocal schema_fd
+        schema_fd = os.open(schema_path, os.O_CREAT | os.O_RDWR)
+        return schema_fd, str(schema_path)
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch("mlflow.assistant.providers.codex.tempfile.mkstemp", side_effect=make_schema_file),
+        patch("mlflow.assistant.providers.codex.os.fdopen", side_effect=OSError("fdopen failed")),
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    assert schema_fd is not None
+    with pytest.raises(OSError, match="Bad file descriptor"):
+        os.fstat(schema_fd)
+    assert not schema_path.exists()
+    assert len(events) == 1
+    assert events[0].type == EventType.ERROR
+    assert "fdopen failed" in events[0].data["error"]
+
+
+@pytest.mark.asyncio
+async def test_astream_cleans_up_custom_view_schema_when_serialization_fails(tmp_path):
+    schema_path = tmp_path / "custom-view.schema.json"
+    schema_fd = None
+
+    def make_schema_file(*args, **kwargs):
+        nonlocal schema_fd
+        schema_fd = os.open(schema_path, os.O_CREAT | os.O_RDWR)
+        return schema_fd, str(schema_path)
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch("mlflow.assistant.providers.codex.tempfile.mkstemp", side_effect=make_schema_file),
+        patch(
+            "mlflow.assistant.providers.codex.json.dump",
+            side_effect=TypeError("schema serialization failed"),
+        ),
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    assert schema_fd is not None
+    with pytest.raises(OSError, match="Bad file descriptor"):
+        os.fstat(schema_fd)
+    assert not schema_path.exists()
+    assert len(events) == 1
+    assert events[0].type == EventType.ERROR
+    assert "schema serialization failed" in events[0].data["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,6 +16,7 @@ def _make_stdout_lines(*dicts) -> list[bytes]:
 def _mock_process(stdout_lines=None, returncode=0, stderr=b""):
     """Create a mock process with async stdout iteration and stdin support."""
     process = MagicMock()
+    process.pid = None
     process.returncode = returncode
 
     # Mock stdin (write, drain, close, wait_closed)
@@ -65,10 +67,9 @@ def test_is_available(which_return, expected):
         assert provider.is_available() is expected
 
 
-def test_supports_client_tools_is_false():
-    # A CLI-based provider has no mid-stream client-tool channel without MCP
-    # plumbing, so it inherits the base class's default of False.
-    assert CodexProvider().supports_client_tools is False
+def test_uses_structured_client_tool_delivery():
+    provider = CodexProvider()
+    assert provider.client_tool_delivery == "structured"
 
 
 def test_provider_name():
@@ -210,6 +211,54 @@ async def test_astream_yields_error_on_nonzero_exit():
 
 
 @pytest.mark.asyncio
+async def test_astream_prefers_structured_codex_error_over_stderr():
+    stdout_lines = _make_stdout_lines(
+        {
+            "type": "error",
+            "message": json.dumps({
+                "error_code": "BAD_REQUEST",
+                "message": json.dumps({
+                    "error": {"message": "Invalid schema for response_format 'codex_output_schema'"}
+                }),
+            }),
+        },
+        {
+            "type": "turn.failed",
+            "error": {
+                "message": json.dumps({
+                    "error_code": "BAD_REQUEST",
+                    "message": json.dumps({
+                        "error": {
+                            "message": "Invalid schema for response_format 'codex_output_schema'"
+                        }
+                    }),
+                })
+            },
+        },
+    )
+    mock_proc = _mock_process(
+        stdout_lines=stdout_lines,
+        returncode=1,
+        stderr=b"failed to refresh available models",
+    )
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ),
+    ):
+        events = [e async for e in CodexProvider().astream("hi", "http://localhost:5000")]
+
+    error_events = [e for e in events if e.type == EventType.ERROR]
+    assert len(error_events) == 1
+    assert error_events[0].data["error"] == (
+        "Invalid schema for response_format 'codex_output_schema'"
+    )
+
+
+@pytest.mark.asyncio
 async def test_astream_surfaces_non_empty_error_for_empty_exception():
     # A bare exception whose str() is "" (e.g. NotImplementedError()) must
     # still surface a diagnosable error rather than an empty `{"error": ""}`.
@@ -271,6 +320,172 @@ async def test_astream_builds_correct_command():
     assert "--ephemeral" not in args
     assert "--skip-git-repo-check" in args
     assert args[-1] == "-"
+
+
+@pytest.mark.asyncio
+async def test_astream_uses_custom_view_output_schema():
+    response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": json.dumps([{"version": "v0.9", "updateComponents": {}}]),
+    }
+    mock_proc = _mock_process(
+        stdout_lines=_make_stdout_lines(
+            {"type": "thread.started", "thread_id": "codex-thread"},
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": json.dumps(response)},
+            },
+            {"type": "turn.completed"},
+        )
+    )
+
+    captured_schema = None
+
+    async def capture_schema(*args, **kwargs):
+        nonlocal captured_schema
+        schema_path = args[args.index("--output-schema") + 1]
+        captured_schema = json.loads(Path(schema_path).read_text())
+        return mock_proc
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            side_effect=capture_schema,
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                session_id="previous-codex-thread",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    args = mock_exec.call_args.args
+    schema_path = args[args.index("--output-schema") + 1]
+    assert not Path(schema_path).exists()
+    assert captured_schema["properties"]["messages"]["type"] == "string"
+    assert args[args.index("resume") + 1] == "previous-codex-thread"
+    assert not any("mcp_servers" in str(arg) for arg in args)
+    assert [event.type for event in events] == [
+        EventType.MESSAGE,
+        EventType.MESSAGE,
+        EventType.CLIENT_TOOL_CALL,
+        EventType.DONE,
+    ]
+    assert events[0].data["message"]["content"][0]["text"] == response["text"]
+    assert events[2].data["tool_input"]["messages"] == [{"version": "v0.9", "updateComponents": {}}]
+    assert events[2].data["continuation"] == "terminal"
+
+
+@pytest.mark.asyncio
+async def test_astream_repairs_invalid_custom_view_output_once():
+    invalid_response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": "not-json",
+    }
+    valid_messages = [{"version": "v0.9", "updateComponents": {}}]
+    valid_response = {
+        **invalid_response,
+        "messages": json.dumps(valid_messages),
+    }
+    invalid_proc = _mock_process(
+        stdout_lines=_make_stdout_lines(
+            {"type": "thread.started", "thread_id": "repair-thread"},
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": json.dumps(invalid_response)},
+            },
+            {"type": "turn.completed"},
+        )
+    )
+    valid_proc = _mock_process(
+        stdout_lines=_make_stdout_lines(
+            {"type": "thread.started", "thread_id": "repair-thread"},
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": json.dumps(valid_response)},
+            },
+            {"type": "turn.completed"},
+        )
+    )
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            side_effect=[invalid_proc, valid_proc],
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    assert mock_exec.call_count == 2
+    repair_args = mock_exec.call_args_list[1].args
+    assert repair_args[repair_args.index("resume") + 1] == "repair-thread"
+    repair_prompt = valid_proc.stdin.write.call_args.args[0].decode()
+    assert "structured response failed validation" in repair_prompt
+    assert "messages must be a JSON-encoded array" in repair_prompt
+    assert not any(event.type == EventType.ERROR for event in events)
+    client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
+    assert len(client_tool_calls) == 1
+    assert client_tool_calls[0].data["tool_input"]["messages"] == valid_messages
+
+
+@pytest.mark.asyncio
+async def test_astream_stops_after_one_invalid_custom_view_output_repair():
+    invalid_response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": "not-json",
+    }
+
+    def invalid_process():
+        return _mock_process(
+            stdout_lines=_make_stdout_lines(
+                {"type": "thread.started", "thread_id": "repair-thread"},
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": json.dumps(invalid_response)},
+                },
+                {"type": "turn.completed"},
+            )
+        )
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            side_effect=[invalid_process(), invalid_process()],
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    assert mock_exec.call_count == 2
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -454,7 +454,7 @@ async def test_astream_cleans_up_custom_view_schema_when_serialization_fails(tmp
 
 
 @pytest.mark.asyncio
-async def test_astream_forwards_invalid_custom_view_transport_for_client_validation():
+async def test_astream_does_not_retry_invalid_custom_view_transport():
     invalid_response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
@@ -489,10 +489,9 @@ async def test_astream_forwards_invalid_custom_view_transport_for_client_validat
         ]
 
     mock_exec.assert_called_once()
-    assert not any(event.type == EventType.ERROR for event in events)
-    client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
-    assert len(client_tool_calls) == 1
-    assert client_tool_calls[0].data["tool_input"]["messages"] == "not-json"
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -538,6 +538,36 @@ async def test_astream_forwards_empty_custom_view_messages_for_client_validation
 
 
 @pytest.mark.asyncio
+async def test_astream_reports_missing_structured_custom_view_response():
+    process = _mock_process(
+        stdout_lines=_make_stdout_lines(
+            {"type": "thread.started", "thread_id": "thread-id"},
+            {"type": "turn.completed"},
+        )
+    )
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            return_value=process,
+        ),
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert errors[0].data["error"] == "Codex did not return a structured Custom View response"
+
+
+@pytest.mark.asyncio
 async def test_astream_includes_model_flag_when_configured(tmp_path):
     config_file = tmp_path / "config.json"
     config_file.write_text('{"providers": {"codex": {"model": "o4-mini"}}}')

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -454,7 +454,7 @@ async def test_astream_cleans_up_custom_view_schema_when_serialization_fails(tmp
 
 
 @pytest.mark.asyncio
-async def test_astream_does_not_retry_invalid_custom_view_transport():
+async def test_astream_forwards_invalid_custom_view_transport_for_client_validation():
     invalid_response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
@@ -489,9 +489,10 @@ async def test_astream_does_not_retry_invalid_custom_view_transport():
         ]
 
     mock_exec.assert_called_once()
-    errors = [event for event in events if event.type == EventType.ERROR]
-    assert len(errors) == 1
-    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
+    assert not any(event.type == EventType.ERROR for event in events)
+    client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
+    assert len(client_tool_calls) == 1
+    assert client_tool_calls[0].data["tool_input"]["messages"] == "not-json"
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -496,6 +496,49 @@ async def test_astream_forwards_invalid_custom_view_transport_for_client_validat
 
 
 @pytest.mark.asyncio
+async def test_astream_strips_trailing_delimiter_from_complete_custom_view_messages():
+    messages = [{"version": "v0.9", "updateComponents": {}}]
+    response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": f"{json.dumps(messages)}}}",
+    }
+    process = _mock_process(
+        stdout_lines=_make_stdout_lines(
+            {"type": "thread.started", "thread_id": "thread-id"},
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": json.dumps(response)},
+            },
+            {"type": "turn.completed"},
+        )
+    )
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            return_value=process,
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    mock_exec.assert_called_once()
+    assert not any(event.type == EventType.ERROR for event in events)
+    client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
+    assert len(client_tool_calls) == 1
+    assert client_tool_calls[0].data["tool_input"]["messages"] == messages
+
+
+@pytest.mark.asyncio
 async def test_astream_forwards_empty_custom_view_messages_for_client_validation():
     response = {
         "type": "render_custom_view",

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -492,6 +492,7 @@ async def test_astream_does_not_retry_invalid_custom_view_transport():
     errors = [event for event in events if event.type == EventType.ERROR]
     assert len(errors) == 1
     assert "messages must be a JSON-encoded array" in errors[0].data["error"]
+    assert errors[0].data["session_id"] == "thread-id"
 
 
 @pytest.mark.asyncio
@@ -608,6 +609,7 @@ async def test_astream_reports_missing_structured_custom_view_response():
     errors = [event for event in events if event.type == EventType.ERROR]
     assert len(errors) == 1
     assert errors[0].data["error"] == "Codex did not return a structured Custom View response"
+    assert errors[0].data["session_id"] == "thread-id"
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -454,21 +454,16 @@ async def test_astream_cleans_up_custom_view_schema_when_serialization_fails(tmp
 
 
 @pytest.mark.asyncio
-async def test_astream_repairs_invalid_custom_view_output_once():
+async def test_astream_does_not_retry_invalid_custom_view_transport():
     invalid_response = {
         "type": "render_custom_view",
         "text": "Created the trace summary.",
         "title": "Trace Summary",
         "messages": "not-json",
     }
-    valid_messages = [{"version": "v0.9", "updateComponents": {}}]
-    valid_response = {
-        **invalid_response,
-        "messages": json.dumps(valid_messages),
-    }
-    invalid_proc = _mock_process(
+    process = _mock_process(
         stdout_lines=_make_stdout_lines(
-            {"type": "thread.started", "thread_id": "repair-thread"},
+            {"type": "thread.started", "thread_id": "thread-id"},
             {
                 "type": "item.completed",
                 "item": {"type": "agent_message", "text": json.dumps(invalid_response)},
@@ -476,12 +471,44 @@ async def test_astream_repairs_invalid_custom_view_output_once():
             {"type": "turn.completed"},
         )
     )
-    valid_proc = _mock_process(
+
+    with (
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
+        patch(
+            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
+            return_value=process,
+        ) as mock_exec,
+    ):
+        events = [
+            event
+            async for event in CodexProvider().astream(
+                "build a view",
+                "http://localhost:5000",
+                context={"customTraceView": {"guide": "guide"}},
+            )
+        ]
+
+    mock_exec.assert_called_once()
+    errors = [event for event in events if event.type == EventType.ERROR]
+    assert len(errors) == 1
+    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
+
+
+@pytest.mark.asyncio
+async def test_astream_forwards_empty_custom_view_messages_for_client_validation():
+    response = {
+        "type": "render_custom_view",
+        "text": "Created the trace summary.",
+        "title": "Trace Summary",
+        "messages": "[]",
+    }
+
+    process = _mock_process(
         stdout_lines=_make_stdout_lines(
-            {"type": "thread.started", "thread_id": "repair-thread"},
+            {"type": "thread.started", "thread_id": "thread-id"},
             {
                 "type": "item.completed",
-                "item": {"type": "agent_message", "text": json.dumps(valid_response)},
+                "item": {"type": "agent_message", "text": json.dumps(response)},
             },
             {"type": "turn.completed"},
         )
@@ -491,7 +518,7 @@ async def test_astream_repairs_invalid_custom_view_output_once():
         patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
         patch(
             "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
-            side_effect=[invalid_proc, valid_proc],
+            return_value=process,
         ) as mock_exec,
     ):
         events = [
@@ -503,59 +530,11 @@ async def test_astream_repairs_invalid_custom_view_output_once():
             )
         ]
 
-    assert mock_exec.call_count == 2
-    repair_args = mock_exec.call_args_list[1].args
-    assert repair_args[repair_args.index("resume") + 1] == "repair-thread"
-    repair_prompt = valid_proc.stdin.write.call_args.args[0].decode()
-    assert "structured response failed validation" in repair_prompt
-    assert "messages must be a JSON-encoded array" in repair_prompt
+    mock_exec.assert_called_once()
     assert not any(event.type == EventType.ERROR for event in events)
     client_tool_calls = [event for event in events if event.type == EventType.CLIENT_TOOL_CALL]
     assert len(client_tool_calls) == 1
-    assert client_tool_calls[0].data["tool_input"]["messages"] == valid_messages
-
-
-@pytest.mark.asyncio
-async def test_astream_stops_after_one_invalid_custom_view_output_repair():
-    invalid_response = {
-        "type": "render_custom_view",
-        "text": "Created the trace summary.",
-        "title": "Trace Summary",
-        "messages": "not-json",
-    }
-
-    def invalid_process():
-        return _mock_process(
-            stdout_lines=_make_stdout_lines(
-                {"type": "thread.started", "thread_id": "repair-thread"},
-                {
-                    "type": "item.completed",
-                    "item": {"type": "agent_message", "text": json.dumps(invalid_response)},
-                },
-                {"type": "turn.completed"},
-            )
-        )
-
-    with (
-        patch("mlflow.assistant.providers.codex.shutil.which", return_value="/usr/bin/codex"),
-        patch(
-            "mlflow.assistant.providers.codex.asyncio.create_subprocess_exec",
-            side_effect=[invalid_process(), invalid_process()],
-        ) as mock_exec,
-    ):
-        events = [
-            event
-            async for event in CodexProvider().astream(
-                "build a view",
-                "http://localhost:5000",
-                context={"customTraceView": {"guide": "guide"}},
-            )
-        ]
-
-    assert mock_exec.call_count == 2
-    errors = [event for event in events if event.type == EventType.ERROR]
-    assert len(errors) == 1
-    assert "messages must be a JSON-encoded array" in errors[0].data["error"]
+    assert client_tool_calls[0].data["tool_input"]["messages"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_openai_compatible_provider.py
+++ b/tests/assistant/providers/test_openai_compatible_provider.py
@@ -6,6 +6,7 @@ import pytest
 
 from mlflow.assistant.config import PermissionsConfig
 from mlflow.assistant.providers.base import clear_config_cache
+from mlflow.assistant.providers.ollama import OllamaProvider
 from mlflow.assistant.providers.openai_compatible import (
     _MAX_SESSION_BYTES,
     OpenAICompatibleProvider,
@@ -109,17 +110,29 @@ def provider():
 @pytest.fixture(autouse=True)
 def config_file(tmp_path):
     cfg = tmp_path / "config.json"
-    cfg.write_text(json.dumps({"providers": {"oai_test": {"model": "model-a"}}}))
+    cfg.write_text(
+        json.dumps({
+            "providers": {
+                "oai_test": {"model": "model-a"},
+                "ollama": {"model": "llama3.2"},
+            }
+        })
+    )
     clear_config_cache()
     with patch("mlflow.assistant.config.CONFIG_PATH", cfg):
         yield cfg
     clear_config_cache()
 
 
-def test_supports_client_tools_is_true(provider):
+def test_uses_native_client_tool_delivery(provider):
     # Schema-based providers pause on a CLIENT_TOOLS call and resume on the next
     # stream once a result is posted (see the pause/resume tests below).
-    assert provider.supports_client_tools is True
+    assert provider.client_tool_delivery == "tool"
+
+
+def test_ollama_uses_native_client_tool_delivery():
+    provider = OllamaProvider()
+    assert provider.client_tool_delivery == "tool"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/assistant/test_custom_view.py
+++ b/tests/assistant/test_custom_view.py
@@ -50,6 +50,30 @@ def test_parse_response_with_stringified_messages():
     assert response.messages == messages
 
 
+def test_parse_response_strips_trailing_closing_delimiter_from_complete_messages():
+    messages = [{"version": "v0.9", "updateComponents": {}}]
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": f"{json.dumps(messages)}}}",
+    })
+
+    assert response.messages == messages
+
+
+def test_parse_response_preserves_non_delimiter_suffix_for_client_validation():
+    messages = f"{json.dumps([{'version': 'v0.9'}])} trailing"
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": messages,
+    })
+
+    assert response.messages == messages
+
+
 @pytest.mark.parametrize("messages", ["not-json", "{}", '"text"', "null"])
 def test_parse_response_leaves_invalid_stringified_messages_for_client_validation(messages):
     response = parse_custom_view_response({

--- a/tests/assistant/test_custom_view.py
+++ b/tests/assistant/test_custom_view.py
@@ -51,13 +51,14 @@ def test_parse_response_with_stringified_messages():
     assert response.messages == messages
 
 
-def test_parse_response_rejects_invalid_stringified_messages():
+@pytest.mark.parametrize("messages", ["not-json", "{}", '"text"', "null"])
+def test_parse_response_rejects_invalid_stringified_messages(messages):
     with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
         parse_custom_view_response({
             "type": "render_custom_view",
             "text": "Updated the view.",
             "title": "Trace Summary",
-            "messages": "not-json",
+            "messages": messages,
         })
 
 

--- a/tests/assistant/test_custom_view.py
+++ b/tests/assistant/test_custom_view.py
@@ -7,7 +7,6 @@ from pydantic import ValidationError
 from mlflow.assistant.custom_view import (
     CUSTOM_VIEW_RESPONSE_SCHEMA,
     STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA,
-    StructuredResponseRetry,
     custom_view_response_events,
     parse_custom_view_response,
 )
@@ -52,18 +51,6 @@ def test_parse_response_with_stringified_messages():
     assert response.messages == messages
 
 
-def test_parse_response_ignores_unmatched_trailing_closers_in_stringified_messages():
-    messages = [{"version": "v0.9", "updateComponents": {}}]
-    response = parse_custom_view_response({
-        "type": "render_custom_view",
-        "text": "Updated the view.",
-        "title": "Trace Summary",
-        "messages": f"{json.dumps(messages)}}}",
-    })
-
-    assert response.messages == messages
-
-
 def test_parse_response_rejects_invalid_stringified_messages():
     with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
         parse_custom_view_response({
@@ -71,17 +58,6 @@ def test_parse_response_rejects_invalid_stringified_messages():
             "text": "Updated the view.",
             "title": "Trace Summary",
             "messages": "not-json",
-        })
-
-
-@pytest.mark.parametrize("suffix", ["garbage", "} garbage", "}}}}}"])
-def test_parse_response_rejects_unsafe_stringified_messages_repair(suffix):
-    with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
-        parse_custom_view_response({
-            "type": "render_custom_view",
-            "text": "Updated the view.",
-            "title": "Trace Summary",
-            "messages": f"[]{suffix}",
         })
 
 
@@ -97,24 +73,15 @@ def test_parse_render_response_allows_empty_title():
 
 
 @pytest.mark.parametrize("messages", [[], "[]"])
-def test_parse_render_response_requires_messages(messages):
-    with pytest.raises(ValidationError, match="non-empty messages"):
-        parse_custom_view_response({
-            "type": "render_custom_view",
-            "text": "Updated the view.",
-            "title": "Trace Summary",
-            "messages": messages,
-        })
+def test_parse_render_response_leaves_empty_messages_for_client_validation(messages):
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": messages,
+    })
 
-
-def test_structured_response_retry_is_bounded_and_includes_validation_error():
-    retry = StructuredResponseRetry()
-
-    prompt, next_retry = retry.next_attempt(ValueError("messages cannot be empty"))
-
-    assert "structured response failed validation" in prompt
-    assert "messages cannot be empty" in prompt
-    assert next_retry.next_attempt(ValueError("still invalid")) is None
+    assert response.messages == []
 
 
 def test_render_response_emits_terminal_client_tool_call():

--- a/tests/assistant/test_custom_view.py
+++ b/tests/assistant/test_custom_view.py
@@ -1,0 +1,146 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from mlflow.assistant.custom_view import (
+    CUSTOM_VIEW_RESPONSE_SCHEMA,
+    STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA,
+    StructuredResponseRetry,
+    custom_view_response_events,
+    parse_custom_view_response,
+)
+from mlflow.assistant.types import EventType
+
+
+def test_response_schema_requires_fixed_envelope():
+    assert CUSTOM_VIEW_RESPONSE_SCHEMA["required"] == ["type", "text", "title", "messages"]
+    assert CUSTOM_VIEW_RESPONSE_SCHEMA["additionalProperties"] is False
+    assert STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA["properties"]["messages"]["type"] == "string"
+
+
+def test_parse_message_response_from_json():
+    response = parse_custom_view_response(
+        json.dumps({"type": "message", "text": "No change needed.", "title": "", "messages": []})
+    )
+
+    assert response.type == "message"
+    assert response.text == "No change needed."
+
+
+def test_parse_message_response_allows_empty_text():
+    response = parse_custom_view_response({
+        "type": "message",
+        "text": "",
+        "title": "",
+        "messages": [],
+    })
+
+    assert response.text == ""
+
+
+def test_parse_response_with_stringified_messages():
+    messages = [{"version": "v0.9", "updateComponents": {}}]
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": json.dumps(messages),
+    })
+
+    assert response.messages == messages
+
+
+def test_parse_response_ignores_unmatched_trailing_closers_in_stringified_messages():
+    messages = [{"version": "v0.9", "updateComponents": {}}]
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": f"{json.dumps(messages)}}}",
+    })
+
+    assert response.messages == messages
+
+
+def test_parse_response_rejects_invalid_stringified_messages():
+    with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
+        parse_custom_view_response({
+            "type": "render_custom_view",
+            "text": "Updated the view.",
+            "title": "Trace Summary",
+            "messages": "not-json",
+        })
+
+
+@pytest.mark.parametrize("suffix", ["garbage", "} garbage", "}}}}}"])
+def test_parse_response_rejects_unsafe_stringified_messages_repair(suffix):
+    with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
+        parse_custom_view_response({
+            "type": "render_custom_view",
+            "text": "Updated the view.",
+            "title": "Trace Summary",
+            "messages": f"[]{suffix}",
+        })
+
+
+def test_parse_render_response_allows_empty_title():
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "",
+        "messages": [{"version": "v0.9", "updateComponents": {}}],
+    })
+
+    assert response.title == ""
+
+
+@pytest.mark.parametrize("messages", [[], "[]"])
+def test_parse_render_response_requires_messages(messages):
+    with pytest.raises(ValidationError, match="non-empty messages"):
+        parse_custom_view_response({
+            "type": "render_custom_view",
+            "text": "Updated the view.",
+            "title": "Trace Summary",
+            "messages": messages,
+        })
+
+
+def test_structured_response_retry_is_bounded_and_includes_validation_error():
+    retry = StructuredResponseRetry()
+
+    prompt, next_retry = retry.next_attempt(ValueError("messages cannot be empty"))
+
+    assert "structured response failed validation" in prompt
+    assert "messages cannot be empty" in prompt
+    assert next_retry.next_attempt(ValueError("still invalid")) is None
+
+
+def test_render_response_emits_terminal_client_tool_call():
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": [{"version": "v0.9", "updateComponents": {}}],
+    })
+
+    with patch("mlflow.assistant.custom_view.uuid.uuid4", return_value="request-id"):
+        events = custom_view_response_events(response)
+
+    assert [event.type for event in events] == [
+        EventType.MESSAGE,
+        EventType.MESSAGE,
+        EventType.CLIENT_TOOL_CALL,
+    ]
+    assert events[0].data["message"]["content"][0]["text"] == "Updated the view."
+    assert events[1].data["message"]["content"][0]["name"] == "render_custom_view"
+    assert events[2].data == {
+        "request_id": "request-id",
+        "tool_name": "render_custom_view",
+        "tool_input": {
+            "title": "Trace Summary",
+            "messages": [{"version": "v0.9", "updateComponents": {}}],
+        },
+        "continuation": "terminal",
+    }

--- a/tests/assistant/test_custom_view.py
+++ b/tests/assistant/test_custom_view.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from mlflow.assistant.custom_view import (
     CUSTOM_VIEW_RESPONSE_SCHEMA,
@@ -62,32 +63,18 @@ def test_parse_response_strips_trailing_closing_delimiter_from_complete_messages
     assert response.messages == messages
 
 
-def test_parse_response_preserves_non_delimiter_suffix_for_client_validation():
-    messages = f"{json.dumps([{'version': 'v0.9'}])} trailing"
-    response = parse_custom_view_response({
-        "type": "render_custom_view",
-        "text": "Updated the view.",
-        "title": "Trace Summary",
-        "messages": messages,
-    })
-
-    assert response.messages == messages
-
-
-@pytest.mark.parametrize("messages", ["not-json", "{}", '"text"', "null"])
-def test_parse_response_leaves_invalid_stringified_messages_for_client_validation(messages):
-    response = parse_custom_view_response({
-        "type": "render_custom_view",
-        "text": "Updated the view.",
-        "title": "Trace Summary",
-        "messages": messages,
-    })
-
-    assert response.messages == messages
-
-    events = custom_view_response_events(response)
-    client_tool_call = next(event for event in events if event.type == EventType.CLIENT_TOOL_CALL)
-    assert client_tool_call.data["tool_input"]["messages"] == messages
+@pytest.mark.parametrize(
+    "messages",
+    ["not-json", "{}", '"text"', "null", f"{json.dumps([{'version': 'v0.9'}])} trailing"],
+)
+def test_parse_response_rejects_invalid_stringified_messages(messages):
+    with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
+        parse_custom_view_response({
+            "type": "render_custom_view",
+            "text": "Updated the view.",
+            "title": "Trace Summary",
+            "messages": messages,
+        })
 
 
 def test_parse_render_response_allows_empty_title():

--- a/tests/assistant/test_custom_view.py
+++ b/tests/assistant/test_custom_view.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 
 from mlflow.assistant.custom_view import (
     CUSTOM_VIEW_RESPONSE_SCHEMA,
@@ -52,14 +51,19 @@ def test_parse_response_with_stringified_messages():
 
 
 @pytest.mark.parametrize("messages", ["not-json", "{}", '"text"', "null"])
-def test_parse_response_rejects_invalid_stringified_messages(messages):
-    with pytest.raises(ValidationError, match="messages must be a JSON-encoded array"):
-        parse_custom_view_response({
-            "type": "render_custom_view",
-            "text": "Updated the view.",
-            "title": "Trace Summary",
-            "messages": messages,
-        })
+def test_parse_response_leaves_invalid_stringified_messages_for_client_validation(messages):
+    response = parse_custom_view_response({
+        "type": "render_custom_view",
+        "text": "Updated the view.",
+        "title": "Trace Summary",
+        "messages": messages,
+    })
+
+    assert response.messages == messages
+
+    events = custom_view_response_events(response)
+    client_tool_call = next(event for event in events if event.type == EventType.CLIENT_TOOL_CALL)
+    assert client_tool_call.data["tool_input"]["messages"] == messages
 
 
 def test_parse_render_response_allows_empty_title():

--- a/tests/assistant/test_types.py
+++ b/tests/assistant/test_types.py
@@ -43,3 +43,10 @@ def test_client_tool_call_event_serializes_to_a_valid_sse_frame():
         "tool_name": "render_custom_view",
         "tool_input": {"title": "t"},
     }
+
+
+def test_terminal_client_tool_call_carries_continuation():
+    event = Event.from_client_tool_call(
+        "req-1", "render_custom_view", {"title": "t"}, continuation="terminal"
+    )
+    assert event.data["continuation"] == "terminal"

--- a/tests/assistant/test_types.py
+++ b/tests/assistant/test_types.py
@@ -20,6 +20,14 @@ def test_from_exception_never_yields_empty_error(exc, expected):
     assert event.data["error"] == expected
 
 
+def test_from_error_includes_session_id_only_when_provided():
+    assert Event.from_error("boom").data == {"error": "boom"}
+    assert Event.from_error("boom", session_id="provider-session").data == {
+        "error": "boom",
+        "session_id": "provider-session",
+    }
+
+
 def test_from_client_tool_call_carries_request_id_tool_name_and_input():
     event = Event.from_client_tool_call(
         "req-1", "render_custom_view", {"title": "Trace Summary", "messages": []}

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -310,7 +310,7 @@ def test_get_providers_auto_resolves_available_default(client):
             "requires_api_key": False,
             "has_api_key": False,
             "allows_remote_access": False,
-            "supports_client_tools": False,
+            "client_tool_delivery": "unsupported",
             "model_options": [],
         }
     ]
@@ -320,12 +320,28 @@ def test_get_providers_auto_resolves_available_default(client):
         "auto_selected": True,
         "requires_api_key": False,
         "has_api_key": False,
-        "supports_client_tools": False,
+        "client_tool_delivery": "unsupported",
         "model_provider": None,
         "model_options": [],
         "provider_model": None,
     }
     assert data["gateway_vendor_options"]["openai"] == ["gpt-5.5"]
+
+
+def test_get_providers_reports_native_client_tool_delivery_for_ollama():
+    app = FastAPI()
+    app.include_router(assistant_router)
+    ollama_provider = OllamaProvider()
+
+    with (
+        patch("mlflow.server.assistant.api.list_providers", return_value=[ollama_provider]),
+        patch("mlflow.server.assistant.api._is_localhost", return_value=True),
+    ):
+        response = TestClient(app).get("/ajax-api/3.0/mlflow/assistant/providers")
+
+    assert response.status_code == 200
+    provider = response.json()["providers"][0]
+    assert provider["client_tool_delivery"] == "tool"
 
 
 def test_get_providers_resolves_selected_managed_gateway_endpoint():
@@ -357,7 +373,7 @@ def test_get_providers_resolves_selected_managed_gateway_endpoint():
         "auto_selected": False,
         "requires_api_key": False,
         "has_api_key": True,
-        "supports_client_tools": True,
+        "client_tool_delivery": "tool",
         "model_provider": "openai",
         "model_options": ["gpt-5.5"],
         "provider_model": "gpt-5.5",

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -149,6 +149,31 @@ def test_message(client):
     assert response.json()["session_id"] == session_id
 
 
+def test_message_clears_omitted_turn_scoped_context(client):
+    response = client.post(
+        "/ajax-api/3.0/mlflow/assistant/message",
+        json={
+            "message": "Build a view",
+            "context": {
+                "trace_id": "tr-123",
+                "customTraceView": {"guide": "authoring guide"},
+            },
+        },
+    )
+    session_id = response.json()["session_id"]
+
+    response = client.post(
+        "/ajax-api/3.0/mlflow/assistant/message",
+        json={"message": "What is 2+2?", "session_id": session_id},
+    )
+
+    assert response.status_code == 200
+    session = SessionManager.load(session_id)
+    assert session is not None
+    assert "customTraceView" not in session.context
+    assert session.context["trace_id"] == "tr-123"
+
+
 def test_message_stream_url_includes_static_prefix(client, monkeypatch):
     monkeypatch.setenv("_MLFLOW_STATIC_PREFIX", "/myprefix")
     response = client.post("/ajax-api/3.0/mlflow/assistant/message", json={"message": "Hello"})

--- a/tests/server/assistant/test_api.py
+++ b/tests/server/assistant/test_api.py
@@ -946,6 +946,59 @@ class _CaptureProvider(MockProvider):
         yield Event.from_result(result=None, session_id="prov-done")
 
 
+class _ErrorThenCaptureProvider(MockProvider):
+    def __init__(self):
+        self.session_ids: list[str | None] = []
+
+    async def astream(
+        self,
+        prompt,
+        tracking_uri,
+        session_id=None,
+        mlflow_session_id=None,
+        cwd=None,
+        context=None,
+    ):
+        self.session_ids.append(session_id)
+        if len(self.session_ids) == 1:
+            yield Event.from_error("invalid structured output", session_id="prov-error")
+        else:
+            assert session_id is not None
+            yield Event.from_result(result=None, session_id=session_id)
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_provider_session_id_from_error_for_next_turn():
+    from mlflow.server.assistant.api import stream_response
+
+    session_id = "f5f28c66-5ec6-46a1-9a2e-ca55fb64bf47"
+    session = SessionManager.create()
+    session.set_pending_message(role="user", content="build a view")
+    SessionManager.save(session_id, session)
+
+    mock_request = MagicMock()
+    mock_request.base_url = "http://localhost:5000/"
+    mock_request.client.host = "127.0.0.1"
+    provider = _ErrorThenCaptureProvider()
+
+    with patch("mlflow.server.assistant.api._get_selected_provider", return_value=provider):
+        response = await stream_response(mock_request, session_id)
+        first = "".join([chunk async for chunk in response.body_iterator])
+
+    assert "event: error" in first
+    session = SessionManager.load(session_id)
+    assert session is not None
+    assert session.provider_session_id == "prov-error"
+
+    session.set_pending_message(role="user", content="repair the view")
+    SessionManager.save(session_id, session)
+    with patch("mlflow.server.assistant.api._get_selected_provider", return_value=provider):
+        response = await stream_response(mock_request, session_id)
+        _ = "".join([chunk async for chunk in response.body_iterator])
+
+    assert provider.session_ids == [None, "prov-error"]
+
+
 @pytest.mark.asyncio
 async def test_stream_prefers_new_message_over_stale_tool_decision():
     """A pending message and a stale decision can coexist if a resume stream never


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24796

### What changes are proposed in this pull request?

This PR enables Custom View authoring for local MLflow Assistant providers while preserving the native client-tool lifecycle for API and OpenAI-compatible providers.

- Add a `client_tool_delivery` capability that distinguishes native tools, terminal structured responses, and unsupported providers.
- Use structured response envelopes for Claude Code and Codex CLI, translate valid envelopes into terminal `render_custom_view` client calls, and share a bounded validation-repair retry.
- Execute terminal client calls after provider completion and automatically repair retryable browser validation failures with the original authoring context.
- Keep Ollama and other OpenAI-compatible providers on ordinary tool schemas without provider-specific structured-output overhead.
- Align backend Custom View response validation with frontend acceptance rules.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Automated:

- `uv run pytest -q tests/assistant tests/server/assistant/test_api.py` (248 passed)
- Affected frontend Jest suites (117 passed)
- Repository pre-commit hooks, Ruff, Clint, and Prettier

Manual: verified Custom View creation through the MLflow web app with Claude Code, Codex CLI, and Ollama.
<img width="3002" height="1549" alt="Screenshot 2026-08-12 at 17 53 54" src="https://github.com/user-attachments/assets/c2369b9b-68b6-44a3-b964-e46974c92658" />
<img width="2997" height="1551" alt="Screenshot 2026-08-12 at 18 00 59" src="https://github.com/user-attachments/assets/8f7fc1b9-96a1-4147-8cd8-2e1d1fcf38ef" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow Assistant can now create, edit, and repair Custom Views when using Claude Code or Codex CLI; Ollama continues to use native tool calls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
