### PR TITLE
Add `bypass-protect` label as an escape hatch for the `protect` check

### DIFF
--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -1,5 +1,21 @@
 module.exports = async ({ github, context }) => {
   const { owner, repo } = context.repo;
+
+  // A bypass-protect grant only covers the commits it was reviewed against:
+  // drop the label when new commits are pushed so protect re-enforces.
+  if (context.payload.action === "synchronize") {
+    const { labels, number } = context.payload.pull_request;
+    if (labels.some(({ name }) => name === "bypass-protect")) {
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: number,
+        name: "bypass-protect",
+      });
+    }
+    return;
+  }
+
   const { body, number: issue_number } = context.payload.issue || context.payload.pull_request;
   const pattern = /- \[(.*?)\]\s*`(.+?)`/g;
   // Labels extracted from the issue/PR body

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -9,6 +9,8 @@ on:
     types:
       - opened
       - edited
+      # To drop the bypass-protect label when new commits are pushed
+      - synchronize
 
 defaults:
   run:

--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -21,6 +21,26 @@ module.exports = async ({ github, context }) => {
 
   const IGNORED_WORKFLOWS = new Set([".github/workflows/rerun.yml"]);
 
+  // Escape hatch for failures unrelated to the PR. Read via the API rather than
+  // the payload, which goes stale when a run is manually re-run. One read at
+  // startup suffices: any label change cancels in-flight runs and re-triggers
+  // this workflow.
+  const BYPASS_LABEL = "bypass-protect";
+  // A single request suffices: GitHub caps labels at 100 per issue
+  const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+    owner,
+    repo,
+    issue_number: context.payload.pull_request.number,
+    per_page: 100,
+  });
+  if (labels.some(({ name }) => name === BYPASS_LABEL)) {
+    console.log(
+      `⚠️ The '${BYPASS_LABEL}' label is applied; passing without checking statuses. ` +
+        "Remove the label to re-enable enforcement."
+    );
+    return;
+  }
+
   async function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -170,7 +190,9 @@ module.exports = async ({ github, context }) => {
 
     if (checks.some(({ status }) => status === STATE.failure)) {
       throw new Error(
-        "This job ensures that all checks except for this one have passed to prevent accidental auto-merges."
+        "This job ensures that all checks except for this one have passed to prevent accidental " +
+          `auto-merges. If the failures are known to be unrelated to this PR, a maintainer can ` +
+          `apply the '${BYPASS_LABEL}' label to bypass this check.`
       );
     }
 

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -9,6 +9,9 @@ on:
       - opened
       - synchronize
       - reopened
+      # Re-evaluate when the bypass-protect label is applied or removed
+      - labeled
+      - unlabeled
   merge_group:
     types:
       - checks_requested
@@ -32,6 +35,7 @@ jobs:
     permissions:
       checks: read # to read check statuses
       actions: read # to read workflow runs and jobs
+      pull-requests: read # to read PR labels for the bypass-protect escape hatch
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25030. Requires #25037 (without the body-labeling allowlist, `bypass-protect` could be self-applied via a checked checkbox in the PR description).

### What changes are proposed in this pull request?

The `protect` job fails whenever any check on the PR head is red, with no override. That blocks merging even when a failure is provably unrelated to the PR — e.g. #25030 was held up by a `TracesV4PageContent` test that had been failing on master itself for several runs.

This PR adds an escape hatch: applying the `bypass-protect` label (requires triage permission) makes `protect` pass, with a prominent log line noting the bypass. New `labeled`/`unlabeled` triggers re-run `protect` on any label change so it takes effect immediately (one extra API call per run to read labels, so manual re-runs can't act on a stale payload). The labeling workflow drops the label whenever new commits are pushed, so a grant only covers the commits it was reviewed against.

Note: the `bypass-protect` label needs to be created in the repo settings when this merges.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`node --check` on the scripts; workflow schema and conftest policy pre-commit hooks pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)