### PR TITLE
fix: Treat existing non-MLflow tables as empty for DB initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -80,7 +80,13 @@ def _all_tables_exist(engine):
 def _is_empty_database(engine):
     # Alembic's bookkeeping table is ignored so a previously failed upgrade attempt
     # doesn't make the DB look populated.
-    return all(t.startswith("alembic_") for t in sqlalchemy.inspect(engine).get_table_names())
+    # Also ignore any tables that aren't part of the current MLflow schema, e.g., leftover
+    # 'secrets' table from a partially applied migration. This ensures we trigger
+    # _initialize_tables which will create all tables consistently and stamp Alembic.
+    return all(
+        t.startswith("alembic_") or t not in Base.metadata.tables
+        for t in sqlalchemy.inspect(engine).get_table_names()
+    )
 
 
 def _initialize_tables(engine):


### PR DESCRIPTION
## What
When upgrading from 3.7.0 to 3.8.x, `mlflow db upgrade` fails with "Table 'secrets' already exists" if a previous failed upgrade attempt left the `secrets` table behind. The root cause is that `_is_empty_database` only ignores tables starting with `alembic_`, so a database with leftover non-alembic tables (like `secrets`) is considered non-empty, causing `_initialize_tables` to be skipped. Then Alembic's upgrade tries to create those tables again, leading to a conflict.

## Fix
Update `_is_empty_database` to also ignore tables that are not part of the current MLflow metadata (`Base.metadata.tables`). If no MLflow table exists, the database is treated as empty, which triggers `_initialize_tables` to create all tables cleanly and stamp Alembic to the latest revision, avoiding duplicate table creation.

Closes #19943