### PR TITLE
Restrict body-driven labeling to an allowlist of label prefixes

### DIFF
--- a/.github/workflows/labeling.js
+++ b/.github/workflows/labeling.js
@@ -29,9 +29,17 @@ module.exports = async ({ github, context }) => {
     })
   ).map(({ name }) => name);
 
-  // Exclude labels that are not available in the repository or have been added/removed by a user
+  // Only labels with these prefixes can be managed via the issue/PR body. Anything else
+  // (e.g. `LGTM`) must be applied manually by a maintainer.
+  const allowedPrefixes = ["area/", "rn/", "domain/"];
+
+  // Exclude labels that are not allowed to be managed via the body, are not available in the
+  // repository, or have been added/removed by a user
   const labels = bodyLabels.filter(
-    ({ name }) => repoLabels.includes(name) && !userLabels.includes(name)
+    ({ name }) =>
+      allowedPrefixes.some((prefix) => name.startsWith(prefix)) &&
+      repoLabels.includes(name) &&
+      !userLabels.includes(name)
   );
   console.log("Labels to add/remove:", labels);
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25035

### What changes are proposed in this pull request?

`labeling.js` applies any existing repo label that appears as a checked checkbox in the issue/PR body. Since it runs on `pull_request_target` with `pull-requests: write`, a PR author can self-apply operational labels (e.g. `LGTM`, `Acknowledged`, `priority/critical-urgent`) from a fork just by editing their PR description.

Restrict body-driven labeling to the prefixes actually offered by the issue/PR templates (`area/`, `rn/`, `domain/`); anything else must be applied manually by a maintainer.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`node --check` on the script; pre-commit hooks pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)