### PR TITLE
Map OpenInference prompt-cache token counts in `OpenInferenceTranslator`

### DIFF
--- a/docs/docs/genai/tracing/opentelemetry/attribute-mapping.mdx
+++ b/docs/docs/genai/tracing/opentelemetry/attribute-mapping.mdx
@@ -70,11 +70,13 @@ Inputs and outputs can also be extracted from span events:
 
 **Token Usage:**
 
-| Source Attribute                   | MLflow Token Field |
-| ---------------------------------- | ------------------ |
-| `gen_ai.usage.input_tokens`        | `input_tokens`     |
-| `gen_ai.usage.output_tokens`       | `output_tokens`    |
-| _(calculated from input + output)_ | `total_tokens`     |
+| Source Attribute                           | MLflow Token Field            |
+| ------------------------------------------ | ----------------------------- |
+| `gen_ai.usage.input_tokens`                | `input_tokens`                |
+| `gen_ai.usage.output_tokens`               | `output_tokens`               |
+| _(calculated from input + output)_         | `total_tokens`                |
+| `gen_ai.usage.cache_read.input_tokens`     | `cache_read_input_tokens`     |
+| `gen_ai.usage.cache_creation.input_tokens` | `cache_creation_input_tokens` |
 
 **Model:**
 
@@ -101,11 +103,13 @@ Based on the [OpenInference semantic conventions](https://github.com/Arize-ai/op
 
 **Token Usage:**
 
-| Source Attribute             | MLflow Token Field |
-| ---------------------------- | ------------------ |
-| `llm.token_count.prompt`     | `input_tokens`     |
-| `llm.token_count.completion` | `output_tokens`    |
-| `llm.token_count.total`      | `total_tokens`     |
+| Source Attribute                             | MLflow Token Field            |
+| -------------------------------------------- | ----------------------------- |
+| `llm.token_count.prompt`                     | `input_tokens`                |
+| `llm.token_count.completion`                 | `output_tokens`               |
+| `llm.token_count.total`                      | `total_tokens`                |
+| `llm.token_count.prompt_details.cache_read`  | `cache_read_input_tokens`     |
+| `llm.token_count.prompt_details.cache_write` | `cache_creation_input_tokens` |
 
 **Model:**
 

--- a/mlflow/tracing/otel/translation/open_inference.py
+++ b/mlflow/tracing/otel/translation/open_inference.py
@@ -39,6 +39,8 @@ class OpenInferenceTranslator(OtelSchemaTranslator):
     INPUT_TOKEN_KEY = "llm.token_count.prompt"
     OUTPUT_TOKEN_KEY = "llm.token_count.completion"
     TOTAL_TOKEN_KEY = "llm.token_count.total"
+    CACHE_READ_INPUT_TOKEN_KEY = "llm.token_count.prompt_details.cache_read"
+    CACHE_CREATION_INPUT_TOKEN_KEY = "llm.token_count.prompt_details.cache_write"
 
     # Input/Output attribute keys
     # Reference: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py

--- a/tests/tracing/otel/test_span_translation.py
+++ b/tests/tracing/otel/test_span_translation.py
@@ -354,6 +354,53 @@ def test_translate_token_usage_with_partial_cache_fields():
     assert TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage
 
 
+def test_translate_token_usage_with_openinference_cache_fields():
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "llm.token_count.prompt": 100,
+            "llm.token_count.completion": 50,
+            "llm.token_count.prompt_details.cache_read": 80,
+            "llm.token_count.prompt_details.cache_write": 20,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 80
+    assert usage[TokenUsageKey.CACHE_CREATION_INPUT_TOKENS] == 20
+
+
+def test_translate_token_usage_with_partial_openinference_cache_fields():
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "llm.token_count.prompt": 100,
+            "llm.token_count.completion": 50,
+            "llm.token_count.prompt_details.cache_read": 80,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+    assert usage[TokenUsageKey.CACHE_READ_INPUT_TOKENS] == 80
+    assert TokenUsageKey.CACHE_CREATION_INPUT_TOKENS not in usage
+
+
 @pytest.mark.parametrize(
     ("attributes", "expected_input", "expected_output", "expected_total"),
     [
@@ -826,6 +873,27 @@ def test_translate_cost_edge_cases(
         }
     else:
         assert SpanAttributeKey.LLM_COST not in result["attributes"]
+
+
+def test_translate_cost_forwards_openinference_cache_tokens(mock_litellm_cost):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "llm.model_name": '"gpt-4o-mini"',
+            "llm.token_count.prompt": 100,
+            "llm.token_count.completion": 50,
+            "llm.token_count.prompt_details.cache_read": 80,
+            "llm.token_count.prompt_details.cache_write": 20,
+        }
+    }
+    span.to_dict.return_value = span_dict
+
+    translate_span_when_storing(span)
+
+    assert mock_litellm_cost.call_args.kwargs["cache_read_input_tokens"] == 80
+    assert mock_litellm_cost.call_args.kwargs["cache_creation_input_tokens"] == 20
 
 
 def test_update_token_usage_with_cached_tokens():


### PR DESCRIPTION
### Related Issues/PRs

Closes #24759

### What changes are proposed in this pull request?

`OpenInferenceTranslator` declared only `INPUT_TOKEN_KEY` / `OUTPUT_TOKEN_KEY` / `TOTAL_TOKEN_KEY`, so `CACHE_READ_INPUT_TOKEN_KEY` and `CACHE_CREATION_INPUT_TOKEN_KEY` inherited `None` from `OtelSchemaTranslator` and the base accessors short-circuited on the falsy key. Prompt-cache counts carried by ingested OpenInference spans were dropped before `mlflow.chat.tokenUsage` was written, while `GenAiTranslator` has mapped the equivalent keys since #22748 — so identical counts survived or vanished purely by which semantic convention the sender spoke.

This is not only a display gap. `calculate_cost_by_model_and_token_usage` forwards the cache tiers to litellm when they are present, so without them the entire cache-read volume is priced at the full input rate (3.3x over-statement on the span in the issue).

The change is two class attributes mirroring `genai_semconv.py`; no base-class or accessor change is needed.

```python
CACHE_READ_INPUT_TOKEN_KEY = "llm.token_count.prompt_details.cache_read"
CACHE_CREATION_INPUT_TOKEN_KEY = "llm.token_count.prompt_details.cache_write"
```

Both names are stable OpenInference semantic conventions (`SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ` / `..._CACHE_WRITE`) and are already emitted by the anthropic, bedrock, agno and langchain instrumentors. `cache_write` maps to `cache_creation_input_tokens` as a direct identity — the OpenInference anthropic instrumentor populates that attribute from `usage.cache_creation_input_tokens`.

Three notes on scope, to pre-empt the obvious review questions:

- **`llm.token_count.prompt_details.cache_input` is deliberately not mapped.** It is a third OpenInference cache key, but only `openinference-instrumentation-litellm` emits it, and it is populated there from `prompt_tokens_details.text_tokens` — the non-cached remainder, not a cache-read count. Mapping it to `cache_read_input_tokens` would mis-price.
- **The docs change touches the GenAI table as well as the OpenInference one.** The OTLP attribute reference documented no cache mapping for any convention; listing it for OpenInference alone would leave the table inconsistent, so the two GenAI rows (already true of the code before this PR) are included.
- **`TraceloopTranslator` has the same missing-cache-keys shape**, and #24869 (litellm autolog) is an adjacent but separate code path. Neither is touched here — happy to file a follow-up issue for the Traceloop one if you'd like it tracked.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Three tests added to `tests/tracing/otel/test_span_translation.py`, alongside the existing GenAI cache cases: both cache fields present, only `cache_read` present (the keys stay optional), and one that pins the cost path by asserting the tiers reach the pricing call. Each was confirmed to fail before the fix. `tests/tracing/otel/` is 276 passed.

Manual verification with the issue's reproduction — identical token counts under both conventions, before and after:

```
# before
OpenInference  usage={'input_tokens': 12300, 'output_tokens': 300, 'total_tokens': 12600}
OpenInference  cost={'input_cost': 0.0369, 'output_cost': 0.0045, 'total_cost': 0.041400}
OTel GenAI     usage={..., 'cache_read_input_tokens': 11000, 'cache_creation_input_tokens': 1000}
OTel GenAI     cost={'input_cost': 0.00795, 'output_cost': 0.0045, 'total_cost': 0.012450}

# after
OpenInference  usage={..., 'cache_read_input_tokens': 11000, 'cache_creation_input_tokens': 1000}
OpenInference  cost={'input_cost': 0.00795, 'output_cost': 0.0045, 'total_cost': 0.012450}
OTel GenAI     usage={..., 'cache_read_input_tokens': 11000, 'cache_creation_input_tokens': 1000}
OTel GenAI     cost={'input_cost': 0.00795, 'output_cost': 0.0045, 'total_cost': 0.012450}
```

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

The OTLP attribute mapping reference now lists the cache rows for both conventions.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Prompt-cache token counts on ingested OpenInference OTLP spans are now recorded in `mlflow.chat.tokenUsage` and priced with the cache tiers, instead of being dropped and billed at the full input rate.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
