### PR TITLE
Align `dtype` precedence across load and dict-input save paths

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -1643,7 +1643,9 @@ def _build_pipeline_from_model_input(model_dict: dict[str, Any], task: str | Non
     # Copy so renaming the dtype key does not mutate the caller's dict
     model_dict = dict(model_dict)
     if dtype_val := model_dict.pop(_TORCH_DTYPE_KEY, None):
-        model_dict[_get_torch_dtype_kwarg_name()] = dtype_val
+        # setdefault so an explicit `dtype` entry wins over `torch_dtype`; the load path
+        # and transformers itself give `dtype` the same precedence
+        model_dict.setdefault(_get_torch_dtype_kwarg_name(), dtype_val)
 
     try:
         with suppress_logs("transformers.pipelines.base", filter_regex=_PEFT_PIPELINE_ERROR_MSG):

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -436,8 +436,12 @@ def _capture_transformers_log_messages():
 
 def _reset_transformers_warning_once_cache():
     # `logger.warning_once` deduplicates for the lifetime of the process; reset it so a
-    # warning consumed by an earlier test cannot mask one triggered here.
-    transformers.utils.logging.warning_once.cache_clear()
+    # warning consumed by an earlier test cannot mask one triggered here. The helper and
+    # its lru_cache wrapping are transformers internals, so no-op if either goes away.
+    warning_once = getattr(transformers.utils.logging, "warning_once", None)
+    cache_clear = getattr(warning_once, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
 
 
 def test_load_model_does_not_emit_torch_dtype_deprecation_warning(
@@ -502,6 +506,8 @@ def test_save_model_with_dict_input_dtype_does_not_emit_deprecation_warning(
 
     _reset_transformers_warning_once_cache()
     original_pipeline = transformers.pipeline
+    # The spy works only because _build_pipeline_from_model_input imports `pipeline` at
+    # call time; a module-level `from transformers import pipeline` would bypass the patch.
     with (
         _capture_transformers_log_messages() as messages,
         mock.patch("transformers.pipeline", side_effect=original_pipeline) as pipeline_spy,
@@ -520,6 +526,53 @@ def test_save_model_with_dict_input_dtype_does_not_emit_deprecation_warning(
     assert unexpected_kwarg not in pipeline_spy.call_args_list[0].kwargs
     # The caller's dict is not mutated.
     assert model_dict == original_model_dict
+
+
+@pytest.mark.skipif(
+    Version(transformers.__version__) < Version("4.56.0"),
+    reason="Passing `dtype` to transformers requires >= 4.56.0",
+)
+def test_build_pipeline_from_model_input_prefers_dtype_over_torch_dtype(
+    text_classification_pipeline,
+):
+    # `save_model` rejects a `dtype` key in the input dict, so exercise the helper
+    # directly; internal callers can still hand it both spellings.
+    model_dict = {
+        "model": text_classification_pipeline.model,
+        "tokenizer": text_classification_pipeline.tokenizer,
+        "torch_dtype": torch.float16,
+        "dtype": torch.float32,
+    }
+
+    original_pipeline = transformers.pipeline
+    with mock.patch("transformers.pipeline", side_effect=original_pipeline) as pipeline_spy:
+        _build_pipeline_from_model_input(model_dict, task="text-classification")
+
+    assert pipeline_spy.call_args.kwargs["dtype"] == torch.float32
+    assert "torch_dtype" not in pipeline_spy.call_args.kwargs
+
+
+def test_load_model_with_both_dtype_spellings_prefers_dtype(
+    text_classification_pipeline, model_path
+):
+    mlflow.transformers.save_model(
+        transformers_model=text_classification_pipeline,
+        path=model_path,
+    )
+
+    original_pipeline = transformers.pipeline
+    # bfloat16 differs from both the model's native float32 and the losing spelling's
+    # float16, so the final assert can only pass if `dtype` won and was applied.
+    with mock.patch("transformers.pipeline", side_effect=original_pipeline) as pipeline_spy:
+        loaded = mlflow.transformers.load_model(
+            model_path, torch_dtype=torch.float16, dtype=torch.bfloat16
+        )
+
+    expected_kwarg = _get_torch_dtype_kwarg_name()
+    unexpected_kwarg = "torch_dtype" if expected_kwarg == "dtype" else "dtype"
+    assert pipeline_spy.call_args.kwargs[expected_kwarg] == torch.bfloat16
+    assert unexpected_kwarg not in pipeline_spy.call_args.kwargs
+    assert loaded.model.dtype == torch.bfloat16
 
 
 def test_basic_save_model_and_load_vision_pipeline(small_vision_model, model_path, image_for_test):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25017 (addresses the non-blocking review notes)

### What changes are proposed in this pull request?

Follow-up to the review notes on #25017.

- `_build_pipeline_from_model_input` now uses `setdefault`, so an explicit `dtype` entry wins over `torch_dtype`. The load path and transformers itself already give `dtype` the same precedence. One finding from implementing this: the mixed-spelling case is unreachable through the public API, because `save_model` rejects a `dtype` key in the input dict (`_validate_transformers_model_dict`). So this is an internal-consistency fix, and the new test exercises the helper directly.
- The `warning_once` cache reset in the tests is now guarded with `getattr`, so it no longer assumes transformers keeps that helper or its lru_cache wrapping.
- The save-path test now has a comment explaining that the pipeline spy depends on the function-level `pipeline` import; hoisting it to module level would silently defeat the test.
- New test for the load path with both spellings passed at once: `dtype` wins. It asserts with `bfloat16`, which differs from the model's native dtype, so it cannot pass by accident.

No user-facing behavior changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

The new precedence test fails on current master (`assert torch.float16 == torch.float32`: the save path let `torch_dtype` overwrite `dtype`) and passes with this change. I ran the dtype-related test selection against transformers 5.14.1 and 4.55.4 locally: everything touched by this change passes on both. The helper-level test is skipped below 4.56.0, since passing `dtype` to transformers needs 4.56+.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release