### PR TITLE
Stabilize flaky `CompareRunPage` fallback test

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
@@ -188,6 +188,7 @@ describe('CompareRunPage', () => {
     await waitFor(() => {
       expect(getRunSpy).toHaveBeenCalledTimes(runUuids.length);
     });
+    expect(getRunSpy.mock.calls.map(([{ run_id }]: [{ run_id: string }]) => run_id)).toEqual(runUuids);
     expect(searchRunsRequestBodies).toHaveLength(0);
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
@@ -1,4 +1,4 @@
-import { jest, describe, beforeAll, beforeEach, test, expect } from '@jest/globals';
+import { jest, describe, afterEach, beforeAll, beforeEach, test, expect } from '@jest/globals';
 import { IntlProvider } from 'react-intl';
 import { render, screen, waitFor } from '../../common/utils/TestUtils.react18';
 import CompareRunPage, { COMPARE_RUNS_SEARCH_RUN_LIMIT } from './CompareRunPage';
@@ -9,6 +9,7 @@ import { setupServer } from '../../common/utils/setup-msw';
 import { rest } from 'msw';
 import { EXPERIMENT_RUNS_MOCK_STORE } from './experiment-page/fixtures/experiment-runs.fixtures';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { MlflowService } from '../sdk/MlflowService';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(60000);
@@ -50,12 +51,10 @@ describe('CompareRunPage', () => {
   };
 
   let searchRunsRequestBodies: { filter?: string; max_results?: number; run_view_type?: string }[] = [];
-  let getRunRequestCount = 0;
-
-  const countingRunsHandler = rest.get('/ajax-api/2.0/mlflow/runs/get', (req, res, ctx) => {
-    getRunRequestCount += 1;
-    return res(ctx.json({ experiments: [] }));
-  });
+  // Individual run fetches are observed via a service spy instead of an MSW handler: the fallback
+  // test fires over a thousand of them, and that many interceptor round-trips routinely exceed
+  // even the 60s timeout on loaded CI workers.
+  let getRunSpy: any;
 
   const server = setupServer(
     // Setup handlers for the API calls
@@ -71,7 +70,12 @@ describe('CompareRunPage', () => {
 
   beforeEach(() => {
     searchRunsRequestBodies = [];
-    getRunRequestCount = 0;
+    // The response body is irrelevant: the mocked store has no reducers consuming it
+    getRunSpy = jest.spyOn(MlflowService, 'getRun').mockResolvedValue({} as any);
+  });
+
+  afterEach(() => {
+    getRunSpy.mockRestore();
   });
 
   const createPageUrl = ({
@@ -157,7 +161,7 @@ describe('CompareRunPage', () => {
     });
     // An empty `run_id IN ()` filter is rejected by the server, so no search should be made
     expect(searchRunsRequestBodies).toHaveLength(0);
-    expect(getRunRequestCount).toBe(0);
+    expect(getRunSpy).not.toHaveBeenCalled();
   });
 
   test('should fetch all compared runs using a single search request', async () => {
@@ -174,16 +178,15 @@ describe('CompareRunPage', () => {
     expect(requestBody.max_results).toBe(runUuids.length);
     // Deleted runs should still show up in the comparison
     expect(requestBody.run_view_type).toBe('ALL');
-    expect(getRunRequestCount).toBe(0);
+    expect(getRunSpy).not.toHaveBeenCalled();
   });
 
   test('should fall back to fetching runs individually when there are too many to search for', async () => {
-    server.resetHandlers(countingRunsHandler, apiHandlers.artifactsSuccess, apiHandlers.experimentsSuccess);
     const runUuids = Array.from({ length: COMPARE_RUNS_SEARCH_RUN_LIMIT + 1 }, (_, index) => `run-${index}`);
     renderTestComponent(createPageUrl({ runUuids }));
 
     await waitFor(() => {
-      expect(getRunRequestCount).toBe(runUuids.length);
+      expect(getRunSpy).toHaveBeenCalledTimes(runUuids.length);
     });
     expect(searchRunsRequestBodies).toHaveLength(0);
   });


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25028

### What changes are proposed in this pull request?

The `CompareRunPage` fallback test (added in #24894) fired 1001 real MSW round-trips, taking ~26s locally and routinely exceeding even the 60s timeout on loaded CI workers; it timed out in 4 of the last 8 failed JS workflow runs. Observe `MlflowService.getRun` via a spy instead; the test now runs in ~0.2s and the sibling tests' "no individual fetches" assertions (previously vacuous, since the counting handler was never registered for them) are now meaningful.

Failure samples:

| Run | Date (UTC) | Trigger |
|---|---|---|
| [31546610346](https://github.com/mlflow/mlflow/actions/runs/31546610346/job/93960380864) | Aug 11 23:28 | push to master (the push that added the test) |
| [31580098875](https://github.com/mlflow/mlflow/actions/runs/31580098875/job/94060962839) | Aug 12 08:49 | push to master |
| [31581585562](https://github.com/mlflow/mlflow/actions/runs/31581585562/job/94065650849) | Aug 12 09:08 | pull request |
| [31584108287](https://github.com/mlflow/mlflow/actions/runs/31584108287/job/94073801239) | Aug 12 09:42 | push to master |

each failing with:

```
 FAIL  src/experiment-tracking/components/CompareRunPage.test.tsx (78.86 s)
  ● CompareRunPage › should fall back to fetching runs individually when there are too many to search for

    thrown: "Exceeded timeout of 60000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
```

Even when passing, the test alone took 26s+ (26467ms locally on an idle machine).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)