### PR TITLE
Exclude `mlflow/server/js` from the docs workflow path triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - pyproject.toml
       - uv.lock
       - mlflow/**
+      - "!mlflow/server/js/**"
       - docs/**
       - .github/workflows/docs.yml
       - .github/actions/setup-node/**
@@ -20,6 +21,7 @@ on:
       - pyproject.toml
       - uv.lock
       - mlflow/**
+      - "!mlflow/server/js/**"
       - docs/**
       - .github/workflows/docs.yml
       - .github/actions/setup-node/**


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25030

### What changes are proposed in this pull request?

Add `!mlflow/server/js/**` to `docs.yml`'s `push` and `pull_request` path filters so UI-only changes stop triggering the docs build. The docs workflow builds the Docusaurus site from `docs/` and the Python API reference from docstrings under `mlflow/`; nothing in it consumes the React app, which is caught only because `mlflow/**` contains it. Same negation idiom as `tracing-benchmark.yml`.

Safe to skip: master's ruleset only requires `protect` and `lint`, so no required check can be left pending. `preview-docs.yml` chains off `docs` via `workflow_run` and inherits the skip; `build-docs.yml` doesn't trigger on `mlflow/**`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified `docs/` and the docs build scripts have no references to `mlflow/server/js`, and checked master's required status checks via the rulesets API.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)