### PR TITLE
fix: Stop `SearchUtils._get_value` from silently dropping dataset IN clause values

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -471,11 +471,11 @@ class SearchUtils:
             elif isinstance(token, Parenthesis):
                 if key not in ("name", "digest", "context"):
                     raise MlflowException(
-                        "Only the dataset 'name' and 'digest' supports comparison with a list of "
-                        "quoted string values.",
+                        "Only the dataset 'name', 'digest', and 'context' support comparison "
+                        "with a list of quoted string values.",
                         error_code=INVALID_PARAMETER_VALUE,
                     )
-                return cls._parse_run_ids(token)
+                return cls._parse_list_from_sql_token(token)
             else:
                 raise MlflowException(
                     "Expected a quoted string value for dataset attributes. "

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
@@ -2026,6 +2026,65 @@ def test_search_runs_datasets(store: SqlAlchemyStore):
     assert {r.info.run_id for r in result} == {run_id3, run_id1, run_id2}
 
 
+def test_search_runs_datasets_in_clause_digits_and_uppercase(store: SqlAlchemyStore):
+    exp_id = _create_experiments(store, "test_search_runs_datasets_in_clause")
+    run1 = _run_factory(store, dict(_get_run_configs(exp_id), start_time=1))
+    run2 = _run_factory(store, dict(_get_run_configs(exp_id), start_time=2))
+
+    dataset1 = entities.Dataset(
+        name="123",
+        digest="06409663",
+        source_type="st1",
+        source="source1",
+        schema="schema1",
+        profile="profile1",
+    )
+    dataset2 = entities.Dataset(
+        name="MyDataset",
+        digest="A1B2C3D4",
+        source_type="st2",
+        source="source2",
+        schema="schema2",
+        profile="profile2",
+    )
+
+    context_tag1 = [entities.InputTag(key=MLFLOW_DATASET_CONTEXT, value="2024")]
+    context_tag2 = [entities.InputTag(key=MLFLOW_DATASET_CONTEXT, value="Train")]
+
+    store.log_inputs(run1.info.run_id, [entities.DatasetInput(dataset1, context_tag1)])
+    store.log_inputs(run2.info.run_id, [entities.DatasetInput(dataset2, context_tag2)])
+    run_id1 = run1.info.run_id
+    run_id2 = run2.info.run_id
+
+    result = store.search_runs(
+        [exp_id],
+        filter_string="datasets.name IN ('123', 'MyDataset')",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    assert {r.info.run_id for r in result} == {run_id1, run_id2}
+
+    result = store.search_runs(
+        [exp_id],
+        filter_string="datasets.digest IN ('06409663')",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    assert {r.info.run_id for r in result} == {run_id1}
+
+    result = store.search_runs(
+        [exp_id],
+        filter_string="datasets.digest IN ('A1B2C3D4')",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    assert {r.info.run_id for r in result} == {run_id2}
+
+    result = store.search_runs(
+        [exp_id],
+        filter_string="datasets.context IN ('2024', 'Train')",
+        run_view_type=ViewType.ACTIVE_ONLY,
+    )
+    assert {r.info.run_id for r in result} == {run_id1, run_id2}
+
+
 def test_search_runs_datasets_with_param_filters(store: SqlAlchemyStore):
     """Test that combining param/tag filters with dataset filters works correctly.
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -280,6 +280,66 @@ def test_search_datasets_is_workspace_scoped(workspace_tracking_store):
         assert workspace_tracking_store._search_datasets([exp_b_id]) == []
 
 
+def test_search_runs_datasets_in_clause_is_workspace_scoped(workspace_tracking_store):
+    exp_a_id, run_a = _create_run(workspace_tracking_store, "team-a", "exp-ds-a", "run-ds-a")
+    exp_b_id, run_b = _create_run(workspace_tracking_store, "team-b", "exp-ds-b", "run-ds-b")
+
+    dataset_a = Dataset(
+        name="123",
+        digest="06409663",
+        source_type="delta",
+        source="source-a",
+    )
+    dataset_b = Dataset(
+        name="MyDataset",
+        digest="A1B2C3D4",
+        source_type="delta",
+        source="source-b",
+    )
+
+    with WorkspaceContext("team-a"):
+        workspace_tracking_store.log_inputs(
+            run_a.info.run_id,
+            [DatasetInput(dataset_a, [InputTag(MLFLOW_DATASET_CONTEXT, "2024")])],
+        )
+
+    with WorkspaceContext("team-b"):
+        workspace_tracking_store.log_inputs(
+            run_b.info.run_id,
+            [DatasetInput(dataset_b, [InputTag(MLFLOW_DATASET_CONTEXT, "Train")])],
+        )
+
+    with WorkspaceContext("team-a"):
+        result = workspace_tracking_store.search_runs(
+            [exp_a_id],
+            filter_string="datasets.digest IN ('06409663')",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert {r.info.run_id for r in result} == {run_a.info.run_id}
+
+        result = workspace_tracking_store.search_runs(
+            [exp_a_id],
+            filter_string="datasets.digest IN ('A1B2C3D4')",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert result == []
+
+    with WorkspaceContext("team-b"):
+        result = workspace_tracking_store.search_runs(
+            [exp_b_id],
+            filter_string="datasets.context IN ('Train')",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert {r.info.run_id for r in result} == {run_b.info.run_id}
+
+        result = workspace_tracking_store.search_runs(
+            [exp_b_id],
+            filter_string="datasets.context IN ('2024')",
+            run_view_type=ViewType.ACTIVE_ONLY,
+        )
+        assert result == []
+
+
 def test_search_datasets_public_api_is_workspace_scoped(workspace_tracking_store):
     with WorkspaceContext("team-a"):
         exp_a_id = workspace_tracking_store.create_experiment("search-exp-a")

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -386,6 +386,74 @@ def test_correct_filtering(filter_string, matching_runs):
     assert set(filtered_runs) == {runs[i] for i in matching_runs}
 
 
+@pytest.mark.parametrize(
+    ("filter_string", "matching_runs"),
+    [
+        ("datasets.digest IN ('06409663', 'A1B2C3D4')", [0, 1]),
+        ("datasets.name IN ('123', 'MyDataset')", [0, 1]),
+        ("datasets.context IN ('2024', 'Train')", [0, 1]),
+        ("datasets.digest IN ('06409663')", [0]),
+        ("datasets.name IN ('MyDataset')", [1]),
+        ("datasets.context IN ('Train')", [1]),
+    ],
+)
+def test_dataset_in_clause_with_digits_and_uppercase(filter_string, matching_runs):
+    runs = [
+        Run(
+            run_info=RunInfo(
+                run_id="r1",
+                experiment_id=0,
+                user_id="user-id",
+                status=RunStatus.to_string(RunStatus.FINISHED),
+                start_time=0,
+                end_time=1,
+                lifecycle_stage=LifecycleStage.ACTIVE,
+            ),
+            run_data=RunData(metrics=[], params=[], tags=[]),
+            run_inputs=RunInputs(
+                dataset_inputs=[
+                    DatasetInput(
+                        dataset=Dataset(
+                            name="123",
+                            digest="06409663",
+                            source_type="src",
+                            source="s",
+                        ),
+                        tags=[InputTag(MLFLOW_DATASET_CONTEXT, "2024")],
+                    )
+                ]
+            ),
+        ),
+        Run(
+            run_info=RunInfo(
+                run_id="r2",
+                experiment_id=0,
+                user_id="user-id",
+                status=RunStatus.to_string(RunStatus.FINISHED),
+                start_time=0,
+                end_time=1,
+                lifecycle_stage=LifecycleStage.ACTIVE,
+            ),
+            run_data=RunData(metrics=[], params=[], tags=[]),
+            run_inputs=RunInputs(
+                dataset_inputs=[
+                    DatasetInput(
+                        dataset=Dataset(
+                            name="MyDataset",
+                            digest="A1B2C3D4",
+                            source_type="src",
+                            source="s",
+                        ),
+                        tags=[InputTag(MLFLOW_DATASET_CONTEXT, "Train")],
+                    )
+                ]
+            ),
+        ),
+    ]
+    filtered_runs = SearchUtils.filter(runs, filter_string)
+    assert set(filtered_runs) == {runs[i] for i in matching_runs}
+
+
 def test_filter_runs_by_start_time():
     runs = [
         Run(


### PR DESCRIPTION
### Related Issues/PRs

Closes #25011

### What changes are proposed in this pull request?

`SearchUtils._get_value()` uses `_parse_run_ids()` for the `_DATASET_IDENTIFIER` branch when parsing `IN (...)` lists. `_parse_run_ids` applies an `islower()` filter designed for `run_id` (a MySQL case-insensitivity workaround). This silently discards any list element where `str.islower()` returns `False` — which includes **pure-digit strings** (e.g., `'06409663'.islower() == False`), not just strings with uppercase letters.

Note: the attribute branch (`_ATTRIBUTE_IDENTIFIER`) also calls `_parse_run_ids`, but that usage is correct — `validate_list_supported` restricts attribute `IN` to `run_id` only, where the `islower()` filter is legitimate. The dataset branch is the one that needs the unfiltered parser, since dataset fields (`name`, `digest`, `context`) are never run IDs.

Changes:
- Replace `_parse_run_ids(token)` with `_parse_list_from_sql_token(token)` in the dataset branch — dataset fields (`name`, `digest`, `context`) are never run IDs, so the `islower()` filter should not apply
- Fix inaccurate error message that omitted `context` from the list of fields supporting `IN` comparison
- Add regression tests covering pure-digit and uppercase values for all three dataset fields

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

**In-memory (SearchUtils.filter):** 6 parametrized test cases in `test_dataset_in_clause_with_digits_and_uppercase` covering:
- Pure-digit digest (`'06409663'`), uppercase digest (`'A1B2C3D4'`)
- Numeric name (`'123'`), mixed-case name (`'MyDataset'`)
- Numeric context (`'2024'`), title-case context (`'Train'`)

**Store-level (SqlAlchemyStore.search_runs, full SQL path):**
- `test_search_runs_datasets_in_clause_digits_and_uppercase` — exercises digit-only and uppercase values across `name`, `digest`, and `context` IN clauses end-to-end. Runs with both workspace-disabled and workspace-enabled via the existing `store` fixture.
- `test_search_runs_datasets_in_clause_is_workspace_scoped` — verifies cross-workspace isolation for dataset IN filters with digit/uppercase values.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where `datasets.digest IN (...)`, `datasets.name IN (...)`, and `datasets.context IN (...)` search filters silently dropped list elements that are pure digits or contain uppercase letters.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release