### PR TITLE
Document trace usage/cost aggregation contract in `_aggregate_from_nodes`

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -224,6 +224,17 @@ def _aggregate_from_nodes(
 
     Avoids double-counting by skipping nodes whose ancestors already have the data.
 
+    Trace-level usage (``CHAT_USAGE``) and cost (``LLM_COST``) are produced by two
+    *independent* calls to this function, each deduping on its own attribute. They
+    reconcile for the common leaf-only integrations (direct providers, langchain,
+    llama_index, crewai, autogen, ag2), where usage sits on the same priced LLM spans as
+    cost so both boundaries coincide. They can differ only when a span carries usage but
+    no cost -- a rollup-on-parent integration (e.g. pydantic_ai, dspy, agno) that sets
+    cumulative usage on an unpriced agent/module span; even then a faithful rollup (parent
+    usage == sum of priced leaves) still reconciles. A cache-heavy trace whose cost looks
+    large relative to ``total_tokens`` is a separate token-accounting gap (``total_tokens``
+    excludes cache tokens that cost is priced on), not this aggregation.
+
     Args:
         nodes: List of span nodes to aggregate from.
         keys: Keys to aggregate. Always included in the result.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25007, #25020 (reference only).

### What changes are proposed in this pull request?

Adds a docstring note to `_aggregate_from_nodes` in `mlflow/tracing/utils/__init__.py` documenting the trace-level usage/cost aggregation contract:

- Token usage (`CHAT_USAGE`) and cost (`LLM_COST`) are aggregated by two independent per-attribute passes.
- They reconcile for the common leaf-only integrations (direct providers, langchain, llama_index, crewai, autogen, ag2), where usage sits on the same priced LLM spans as cost.
- They can differ only when a span carries usage but no cost — a rollup-on-parent integration (e.g. pydantic_ai, dspy, agno) that sets cumulative usage on an unpriced agent/module span; a faithful rollup still reconciles.
- A cache-heavy trace whose cost looks large relative to `total_tokens` is a separate token-accounting gap (`total_tokens` excludes cache tokens that cost is priced on), not this aggregation.

Documentation-only; no behavior change. This captures the outcome of the #25007/#25020 investigation so the same misunderstanding doesn't recur.

### How is this PR tested?

- [x] Existing unit/integration tests

No functional change. `ruff check`, `ruff format --check`, and `clint` pass on the modified file.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.