### PR TITLE
Regenerate claude-code pricing snapshot in `update-model-catalog` workflow

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Fetch and transform model catalog
         run: uv run python dev/update_model_catalog.py
 
+      - name: Regenerate claude-code pricing snapshot
+        working-directory: libs/typescript
+        run: |
+          # --ignore-scripts skips the root `prepare` script, which builds every
+          # workspace package; sync:pricing only needs node and prettier.
+          npm ci --ignore-scripts
+          npm run -C integrations/claude-code sync:pricing
+
       - name: Run pre-commit on generated files
         run: |
           uv sync --locked --only-group lint
@@ -55,7 +63,7 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet mlflow/utils/model_catalog/; then
+          if git diff --quiet mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -78,7 +86,7 @@ jobs:
           git config user.email 'mlflow-app[bot]@users.noreply.github.com'
           branch="update-model-catalog"
           git checkout -b "$branch"
-          git add mlflow/utils/model_catalog/
+          git add mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
           git commit -m "Update model catalog from upstream sources"
           git push -f -u origin "$branch"
           existing_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25043

### What changes are proposed in this pull request?

The `update-model-catalog` workflow refreshes `mlflow/utils/model_catalog/*.json` but never regenerates the TypeScript SDK's pricing snapshot (`libs/typescript/integrations/claude-code/src/anthropicPricing.ts`), so any Anthropic pricing change makes the bot's PR fail `tests/anthropicPricing.test.ts` (see #25043, fixed manually). Run `npm run sync:pricing` in the workflow and include the regenerated file in the diff check and commit so future catalog PRs stay green.

### How is this PR tested?

- [x] Manual tests

Ran the added commands locally on the #25043 branch; they produced the exact snapshot update that fixed its failing check ([`1a2a97c837`](https://github.com/mlflow/mlflow/pull/25043/commits/1a2a97c8372a1785ede2fd4edc35c5e828cc5637)).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
