### PR TITLE
Make `update-model-catalog` workflow testable on pull requests

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -5,9 +5,6 @@ on:
     # Run every weekday (Mon-Fri) at 00:00 and 12:00 UTC
     - cron: "0 0,12 * * 1-5"
   workflow_dispatch:
-  # pull_request runs only the generate job as a dry run: it fetches,
-  # regenerates, and uploads the patch without a write token; the publish
-  # job (tag push, PR creation, release publish) is skipped.
   pull_request:
     paths:
       - .github/workflows/update-model-catalog.yml

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Pin to the trigger commit so both jobs see the same tree and the
+          # patch created here applies cleanly in `publish` even if the branch
+          # advances between the two jobs.
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: ./.github/actions/setup-python
@@ -99,6 +103,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -19,7 +19,7 @@ defaults:
 permissions: {}
 
 env:
-  GENERATED_PATHS: mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
+  CATALOG_PATHS: mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
 
 jobs:
   generate:
@@ -64,12 +64,12 @@ jobs:
       - name: Check for changes and create patch
         id: diff
         run: |
-          git --no-pager diff --stat -- $GENERATED_PATHS
-          if git diff --quiet -- $GENERATED_PATHS; then
+          git --no-pager diff --stat -- $CATALOG_PATHS
+          if git diff --quiet -- $CATALOG_PATHS; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff -- $GENERATED_PATHS > model-catalog.patch
+            git diff -- $CATALOG_PATHS > model-catalog.patch
           fi
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -126,7 +126,7 @@ jobs:
           git config user.email 'mlflow-app[bot]@users.noreply.github.com'
           branch="update-model-catalog"
           git checkout -b "$branch"
-          git add $GENERATED_PATHS
+          git add $CATALOG_PATHS
           git commit -m "Update model catalog from upstream sources"
           git push -f -u origin "$branch"
           existing_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -22,7 +22,7 @@ env:
   CATALOG_PATHS: mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
 
 jobs:
-  generate:
+  sync:
     if: github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -81,8 +81,8 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: generate
-    if: github.event_name != 'pull_request' && needs.generate.outputs.changed == 'true'
+    needs: sync
+    if: github.event_name != 'pull_request' && needs.sync.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -5,8 +5,8 @@ on:
     # Run every weekday (Mon-Fri) at 00:00 and 12:00 UTC
     - cron: "0 0,12 * * 1-5"
   workflow_dispatch:
-  # pull_request runs are a dry run: fetch, regenerate, and diff without a
-  # write token, skipping the tag push, PR creation, and release publish.
+  # pull_request runs only the dry-run job: fetch, regenerate, and diff
+  # without a write token, tag push, PR creation, or release publish.
   pull_request:
     paths:
       - .github/workflows/update-model-catalog.yml
@@ -21,8 +21,48 @@ defaults:
 permissions: {}
 
 jobs:
+  dry-run:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-python
+        with:
+          pin-micro-version: false
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Fetch and transform model catalog
+        run: uv run python dev/update_model_catalog.py
+
+      - name: Regenerate claude-code pricing snapshot
+        working-directory: libs/typescript
+        run: |
+          # --ignore-scripts skips the root `prepare` script, which builds every
+          # workspace package; sync:pricing only needs node and prettier.
+          npm ci --ignore-scripts
+          npm run -C integrations/claude-code sync:pricing
+
+      - name: Run pre-commit on generated files
+        run: |
+          uv sync --locked --only-group lint
+          uv run --no-sync pre-commit install --install-hooks
+          uv run --no-sync pre-commit run install-bin -a -v
+          # pre-commit exits 1 when it auto-fixes files (e.g. prettier reformats JSON).
+          # That's expected — the fixes are picked up by the subsequent git diff.
+          uv run --no-sync pre-commit run --files mlflow/utils/model_catalog/*.json || true
+
+      - name: Show what would be committed
+        run: git --no-pager diff --stat
+
   update-model-catalog:
-    if: github.repository == 'mlflow/mlflow'
+    if: github.event_name != 'pull_request' && github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -30,7 +70,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        if: github.event_name != 'pull_request'
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
@@ -39,15 +78,9 @@ jobs:
           permission-pull-requests: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: github.event_name != 'pull_request'
         with:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: github.event_name == 'pull_request'
-        with:
-          persist-credentials: false
 
       - uses: ./.github/actions/setup-python
         with:
@@ -85,7 +118,7 @@ jobs:
           fi
 
       - name: Update model-catalog/latest tag
-        if: github.event_name != 'pull_request' && steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true'
         run: |
           git fetch origin master --depth=1
           git tag -f model-catalog/latest origin/master
@@ -93,7 +126,7 @@ jobs:
 
       - name: Create or update pull request
         id: pr
-        if: github.event_name != 'pull_request' && steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -130,7 +163,7 @@ jobs:
           exit 1
 
       - name: Publish to GitHub Releases
-        if: github.event_name != 'pull_request' && steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash dev/publish_model_catalog.sh

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -33,9 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Pin to the trigger commit so both jobs see the same tree and the
-          # patch created here applies cleanly in `publish` even if the branch
-          # advances between the two jobs.
+          # Pin both jobs to the same commit so the patch applies cleanly in `publish`
           ref: ${{ github.sha }}
           persist-credentials: false
 

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -5,8 +5,9 @@ on:
     # Run every weekday (Mon-Fri) at 00:00 and 12:00 UTC
     - cron: "0 0,12 * * 1-5"
   workflow_dispatch:
-  # pull_request runs only the dry-run job: fetch, regenerate, and diff
-  # without a write token, tag push, PR creation, or release publish.
+  # pull_request runs only the generate job as a dry run: it fetches,
+  # regenerates, and uploads the patch without a write token; the publish
+  # job (tag push, PR creation, release publish) is skipped.
   pull_request:
     paths:
       - .github/workflows/update-model-catalog.yml
@@ -20,13 +21,18 @@ defaults:
 
 permissions: {}
 
+env:
+  CHANGED_PATHS: mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
+
 jobs:
-  dry-run:
-    if: github.event_name == 'pull_request'
+  generate:
+    if: github.repository == 'mlflow/mlflow'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -58,11 +64,28 @@ jobs:
           # That's expected — the fixes are picked up by the subsequent git diff.
           uv run --no-sync pre-commit run --files mlflow/utils/model_catalog/*.json || true
 
-      - name: Show what would be committed
-        run: git --no-pager diff --stat
+      - name: Check for changes and create patch
+        id: diff
+        run: |
+          git --no-pager diff --stat -- $CHANGED_PATHS
+          if git diff --quiet -- $CHANGED_PATHS; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff -- $CHANGED_PATHS > model-catalog.patch
+          fi
 
-  update-model-catalog:
-    if: github.event_name != 'pull_request' && github.repository == 'mlflow/mlflow'
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.diff.outputs.changed == 'true'
+        with:
+          name: model-catalog-patch
+          path: model-catalog.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: generate
+    if: github.event_name != 'pull_request' && needs.generate.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -82,43 +105,16 @@ jobs:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: ./.github/actions/setup-python
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pin-micro-version: false
+          name: model-catalog-patch
 
-      - uses: ./.github/actions/setup-node
-
-      - name: Fetch and transform model catalog
-        run: uv run python dev/update_model_catalog.py
-
-      - name: Regenerate claude-code pricing snapshot
-        working-directory: libs/typescript
+      - name: Apply patch
         run: |
-          # --ignore-scripts skips the root `prepare` script, which builds every
-          # workspace package; sync:pricing only needs node and prettier.
-          npm ci --ignore-scripts
-          npm run -C integrations/claude-code sync:pricing
-
-      - name: Run pre-commit on generated files
-        run: |
-          uv sync --locked --only-group lint
-          uv run --no-sync pre-commit install --install-hooks
-          uv run --no-sync pre-commit run install-bin -a -v
-          # pre-commit exits 1 when it auto-fixes files (e.g. prettier reformats JSON).
-          # That's expected — the fixes are picked up by the subsequent git diff.
-          uv run --no-sync pre-commit run --files mlflow/utils/model_catalog/*.json || true
-
-      - name: Check for changes
-        id: diff
-        run: |
-          if git diff --quiet mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
+          git apply model-catalog.patch
+          rm model-catalog.patch
 
       - name: Update model-catalog/latest tag
-        if: steps.diff.outputs.changed == 'true'
         run: |
           git fetch origin master --depth=1
           git tag -f model-catalog/latest origin/master
@@ -126,7 +122,6 @@ jobs:
 
       - name: Create or update pull request
         id: pr
-        if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -134,7 +129,7 @@ jobs:
           git config user.email 'mlflow-app[bot]@users.noreply.github.com'
           branch="update-model-catalog"
           git checkout -b "$branch"
-          git add mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
+          git add $CHANGED_PATHS
           git commit -m "Update model catalog from upstream sources"
           git push -f -u origin "$branch"
           existing_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
@@ -163,7 +158,6 @@ jobs:
           exit 1
 
       - name: Publish to GitHub Releases
-        if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash dev/publish_model_catalog.sh

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -5,6 +5,14 @@ on:
     # Run every weekday (Mon-Fri) at 00:00 and 12:00 UTC
     - cron: "0 0,12 * * 1-5"
   workflow_dispatch:
+  # pull_request runs are a dry run: fetch, regenerate, and diff without a
+  # write token, skipping the tag push, PR creation, and release publish.
+  pull_request:
+    paths:
+      - .github/workflows/update-model-catalog.yml
+      - dev/update_model_catalog.py
+      - dev/publish_model_catalog.sh
+      - libs/typescript/integrations/claude-code/scripts/sync-anthropic-pricing.mjs
 
 defaults:
   run:
@@ -22,6 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: github.event_name != 'pull_request'
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
@@ -30,9 +39,15 @@ jobs:
           permission-pull-requests: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name != 'pull_request'
         with:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-python
         with:
@@ -70,7 +85,7 @@ jobs:
           fi
 
       - name: Update model-catalog/latest tag
-        if: steps.diff.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' && steps.diff.outputs.changed == 'true'
         run: |
           git fetch origin master --depth=1
           git tag -f model-catalog/latest origin/master
@@ -78,7 +93,7 @@ jobs:
 
       - name: Create or update pull request
         id: pr
-        if: steps.diff.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' && steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -115,7 +130,7 @@ jobs:
           exit 1
 
       - name: Publish to GitHub Releases
-        if: steps.diff.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' && steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: bash dev/publish_model_catalog.sh

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -19,7 +19,7 @@ defaults:
 permissions: {}
 
 env:
-  CHANGED_PATHS: mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
+  GENERATED_PATHS: mlflow/utils/model_catalog/ libs/typescript/integrations/claude-code/src/anthropicPricing.ts
 
 jobs:
   generate:
@@ -64,12 +64,12 @@ jobs:
       - name: Check for changes and create patch
         id: diff
         run: |
-          git --no-pager diff --stat -- $CHANGED_PATHS
-          if git diff --quiet -- $CHANGED_PATHS; then
+          git --no-pager diff --stat -- $GENERATED_PATHS
+          if git diff --quiet -- $GENERATED_PATHS; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff -- $CHANGED_PATHS > model-catalog.patch
+            git diff -- $GENERATED_PATHS > model-catalog.patch
           fi
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -126,7 +126,7 @@ jobs:
           git config user.email 'mlflow-app[bot]@users.noreply.github.com'
           branch="update-model-catalog"
           git checkout -b "$branch"
-          git add $CHANGED_PATHS
+          git add $GENERATED_PATHS
           git commit -m "Update model catalog from upstream sources"
           git push -f -u origin "$branch"
           existing_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')

--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -9,7 +9,6 @@ on:
     paths:
       - .github/workflows/update-model-catalog.yml
       - dev/update_model_catalog.py
-      - dev/publish_model_catalog.sh
       - libs/typescript/integrations/claude-code/scripts/sync-anthropic-pricing.mjs
 
 defaults:
@@ -66,6 +65,8 @@ jobs:
       - name: Check for changes and create patch
         id: diff
         run: |
+          # Intent-to-add so new files (e.g. a new provider catalog) show up in the diff
+          git add -N -- $CATALOG_PATHS
           git --no-pager diff --stat -- $CATALOG_PATHS
           if git diff --quiet -- $CATALOG_PATHS; then
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25047

### What changes are proposed in this pull request?

Changes to the `update-model-catalog` workflow (e.g. #25047) currently can't be tested before merging since it only triggers on schedule/dispatch. Split the workflow into two jobs:

- `sync` (read-only, all triggers): fetches the catalog, regenerates the claude-code pricing snapshot, runs pre-commit, and uploads the resulting diff as a patch artifact.
- `publish` (schedule/dispatch only, write token): downloads and applies the patch, then pushes the tag, creates/updates the bot PR, and publishes the release, same as before.

A path-filtered `pull_request` trigger runs only `sync`, so workflow/script changes get a dry run on their own PR (this PR exercises it). The split also drops the write token and `persist-credentials` from the job that runs the catalog-fetch and npm code.

### How is this PR tested?

- [x] Manual tests

The `sync` dry-run job runs on this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
