### PR TITLE
fix(uiux): image chart card media overflows the card body outside fullscreen

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsImageChartCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/RunsChartsImageChartCard.tsx
@@ -106,7 +106,11 @@ export const RunsChartsImageChartCard = ({
       css={{
         display: 'flex',
         flexDirection: 'column',
-        height: fullScreen ? '100%' : undefined,
+        // The card wrapper has a definite height (ChartCard.common defaults to 360).
+        // Leaving this auto outside fullscreen left the scrolling body below with no
+        // height to divide, so the media sized itself from the card's width instead.
+        height: '100%',
+        minHeight: 0,
         width: '100%',
         overflow: 'hidden',
         marginTop: theme.spacing.sm,
@@ -116,6 +120,7 @@ export const RunsChartsImageChartCard = ({
       <div
         css={{
           flex: 1,
+          minHeight: 0,
           overflow: 'auto',
         }}
       >

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ImageGridPlot.common.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ImageGridPlot.common.tsx
@@ -96,7 +96,7 @@ export const ImagePlot = ({ imageUrl, compressedImageUrl, imageSize, maxImageSiz
   }, [compressedImageUrl]);
 
   return (
-    <div css={{ width: imageSize || '100%', height: imageSize || '100%' }}>
+    <div css={{ width: imageSize || '100%', height: imageSize || '100%', minHeight: 0 }}>
       <div css={{ display: 'contents' }}>
         {compressedImageUrl === undefined || imageLoading ? (
           <div
@@ -120,7 +120,9 @@ export const ImagePlot = ({ imageUrl, compressedImageUrl, imageSize, maxImageSiz
               width: imageSize || '100%',
               aspectRatio: '1',
               maxWidth: maxImageSize,
-              maxHeight: maxImageSize,
+              // Bound by height as well as width so a square image shrinks to fit a
+              // short card rather than overflowing it.
+              maxHeight: maxImageSize ?? '100%',
               backgroundColor: theme.colors.backgroundSecondary,
               '.rc-image': {
                 cursor: 'pointer',

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ImageGridSingleKeyPlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/charts/ImageGridSingleKeyPlot.tsx
@@ -24,7 +24,16 @@ export const ImageGridSingleKeyPlot = ({
     return <EmptyImageGridPlot />;
   }
   return (
-    <div css={{ display: 'flex', justifyContent: 'flex-start', flexWrap: 'wrap', gap: theme.spacing.xs }}>
+    <div
+      css={{
+        display: 'flex',
+        justifyContent: 'flex-start',
+        flexWrap: 'wrap',
+        gap: theme.spacing.xs,
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
       {displayRuns.map((run: RunsChartsRunData) => {
         // There is exactly one key in this plot
         const imageMetadataByStep = Object.values(run.images[cardConfig.imageKeys[0]]).reduce(
@@ -43,6 +52,12 @@ export const ImageGridSingleKeyPlot = ({
               border: `1px solid transparent`,
               borderRadius: theme.borders.borderRadiusSm,
               padding: theme.spacing.sm,
+              // Column so the run header keeps its natural height and the media
+              // absorbs the remainder of the card.
+              display: 'flex',
+              flexDirection: 'column',
+              maxHeight: '100%',
+              minHeight: 0,
               '&:hover': {
                 border: `1px solid ${theme.colors.border}`,
                 backgroundColor: theme.colors.tableBackgroundUnselectedHover,


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23204

No dedicated issue exists for this defect; I hit it while implementing step-indexed video for #23204 and it reproduces on `master` with no video involved. Happy to file one if you would prefer the PR reference a triaged issue.

### What changes are proposed in this pull request?

Image chart cards scroll their body whenever the card is wider than it is tall, which is the default three-across layout, so a logged-image chart at the default card height of 360px shows a scrollbar and clips the run header.

`ChartCard.common` gives every card a definite height, defaulting to 360. `RunsChartsImageChartCard` then sets `height: fullScreen ? '100%' : undefined` on its body, which discards that height outside fullscreen. The scrolling container below it is `flex: 1` with nothing to divide, so it becomes content-sized, and `ImagePlot` sizes its media cell with `aspectRatio: '1'` against `width: '100%'`. The media therefore takes its height from the card's *width*, roughly 470px in a three-across layout, inside a 360px card.

This carries the height through the cascade instead:

- `RunsChartsImageChartCard`: the body takes `height: '100%'` unconditionally with `minHeight: 0`, and the scrolling container gets `minHeight: 0`.
- `ImageGridSingleKeyPlot`: the grid container takes `height: '100%'` and `minHeight: 0`, and each per-run cell becomes a flex column so the run header keeps its natural height and the media absorbs the remainder.
- `ImageGridPlot.common`: the media cell is bounded by `maxHeight: '100%'` as well as by width.

Images keep `aspectRatio: '1'` and stay square. They shrink when the card is shorter than it is wide, where previously they overflowed it. Fullscreen behaviour is unchanged.

### How is this PR tested?

- [x] Manual tests

Logged eight steps of 480x360 images to a run with `mlflow.log_image(key=..., step=...)` and viewed the resulting chart at the default card height, at a resized card, and in fullscreen.

Verified programmatically rather than by eye, by walking every `overflow-y: auto` element in the rendered page and comparing `scrollHeight` to `clientHeight`. Before the change the card body reports a scrollable overflow; after it reports none.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Image chart cards no longer scroll their body when the card is wider than it is tall; logged images shrink to fit the card instead of overflowing it.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - The PR will be mentioned in the "Bug Fixes" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
