### PR TITLE
Fix env-var leak flakiness in `test_serving_artifacts_auto_scopes_workspace_paths`

### DIFF
--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -474,6 +474,7 @@ def test_serving_artifacts_honors_workspace_override(workspace_tracking_store, m
 
 def test_create_experiment_requires_effective_artifact_root(workspace_tracking_store, monkeypatch):
     monkeypatch.delenv("_MLFLOW_SERVER_SERVE_ARTIFACTS", raising=False)
+    monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)
     workspace_tracking_store.artifact_root_uri = None
 
     class EmptyProvider:

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -371,6 +371,7 @@ def test_artifact_locations_are_scoped_to_workspace(workspace_tracking_store):
 
 
 def test_serving_artifacts_auto_scopes_workspace_paths(workspace_tracking_store, monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)
     monkeypatch.setenv("_MLFLOW_SERVER_SERVE_ARTIFACTS", "true")
     workspace_tracking_store.artifact_root_uri = "mlflow-artifacts:/artifacts"
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23401 (surfaced this flaky failure in an unrelated shard)

### What changes are proposed in this pull request?

`test_serving_artifacts_auto_scopes_workspace_paths` installs a fake workspace provider that only implements `resolve_artifact_root`, not `resolve_trace_archival_config`. `create_experiment` only calls `resolve_trace_archival_config` when `MLFLOW_TRACE_ARCHIVAL_CONFIG` is set, so the test passes in isolation.

Under CI sharding (`pytest-split`), a sibling test in the same shard can leave `MLFLOW_TRACE_ARCHIVAL_CONFIG` set in the process environment, causing `create_experiment` to invoke the missing method and fail with:

```
AttributeError: 'TrackingProvider' object has no attribute 'resolve_trace_archival_config'
```

This adds `monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)` at the start of the test, matching the defensive pattern already used by the sibling tests in the same file.

### How is this PR tested?

- [x] Existing unit/integration tests

Reproduced the CI failure locally by exporting `MLFLOW_TRACE_ARCHIVAL_CONFIG` before running the test (fails with the exact `AttributeError`), then confirmed the test passes with the same env var set after the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release