### PR TITLE
[Custom View] Add custom view deletion

### DIFF
--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -2224,6 +2224,8 @@ module.exports = {
   "shared.model-trace-explorer.custom-view.apply-error": "",
   "shared.model-trace-explorer.custom-view.build": "",
   "shared.model-trace-explorer.custom-view.create-view": "",
+  "shared.model-trace-explorer.custom-view.delete-view-modal": "",
+  "shared.model-trace-explorer.custom-view.delete-view-modal-open-button": "",
   "shared.model-trace-explorer.custom-view.draft-indicator": "",
   "shared.model-trace-explorer.custom-view.edit": "",
   "shared.model-trace-explorer.custom-view.markdown.link": "",

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -3,10 +3,12 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { ExperimentCustomViewProvider } from './ExperimentCustomViewProvider';
+import { useExperimentCustomViewDefinition } from './hooks/custom-view/useExperimentCustomViewDefinition';
 import { useAssistant } from '../../../../../assistant/AssistantContext';
 import type { ClientToolHandler } from '../../../../../assistant/clientToolHandlers';
 import type { AssistantContextProvider } from '../../../../../assistant/contextProviders';
 import type {
+  CustomView,
   CustomViewApplyResult,
   RenderCustomViewSpec,
 } from '@databricks/web-shared/model-trace-explorer/custom-view';
@@ -16,8 +18,10 @@ import type {
 // (and their inputs captured) so this test is isolated to the provider's own
 // wiring logic.
 jest.mock('./hooks/custom-view/useExperimentCustomViewDefinition', () => ({
-  useExperimentCustomViewDefinition: jest.fn(() => ({ views: [], isLoaded: true, persistView: undefined })),
+  useExperimentCustomViewDefinition: jest.fn(),
 }));
+
+const mockUseExperimentCustomViewDefinition = jest.mocked(useExperimentCustomViewDefinition);
 
 let mockCanEdit = { canEdit: true, isLoading: false };
 jest.mock('./hooks/custom-view/useCanEditExperimentCustomViews', () => ({
@@ -57,7 +61,13 @@ let capturedConnectorProviderProps:
   | { connector: { openAssistant?: (...args: any[]) => void; isStreaming?: boolean; isPending?: boolean } }
   | undefined;
 let capturedDefinitionProviderProps:
-  | { views: unknown[]; isLoaded: boolean; onPersistView?: unknown; canModifyPersistedViews?: boolean }
+  | {
+      views: unknown[];
+      isLoaded: boolean;
+      onPersistView?: unknown;
+      onDeleteView?: unknown;
+      canModifyPersistedViews?: boolean;
+    }
   | undefined;
 
 jest.mock('@databricks/web-shared/model-trace-explorer/custom-view', () => ({
@@ -106,6 +116,7 @@ describe('ExperimentCustomViewProvider', () => {
     capturedContextProvider = undefined;
     capturedConnectorProviderProps = undefined;
     capturedDefinitionProviderProps = undefined;
+    mockUseExperimentCustomViewDefinition.mockReturnValue({ views: [], isLoaded: true });
     mockCanEdit = { canEdit: true, isLoading: false };
     mockGetCurrentApplierSessionId.mockReturnValue('session-1');
     mockGetCustomViewAuthoringContext.mockReturnValue(null);
@@ -117,12 +128,17 @@ describe('ExperimentCustomViewProvider', () => {
     expect(screen.getByText('child content')).toBeInTheDocument();
   });
 
-  it('passes the loaded views and persist permission through to the definition provider', () => {
+  it('passes loaded views, mutation callbacks, and permission through to the definition provider', () => {
+    const persistView = jest.fn<(view: CustomView) => Promise<void>>().mockResolvedValue(undefined);
+    const deleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+    mockUseExperimentCustomViewDefinition.mockReturnValue({ views: [], isLoaded: true, persistView, deleteView });
     makeAssistant();
     mockCanEdit = { canEdit: false, isLoading: false };
     renderProvider();
 
     expect(capturedDefinitionProviderProps?.isLoaded).toBe(true);
+    expect(capturedDefinitionProviderProps?.onPersistView).toBe(persistView);
+    expect(capturedDefinitionProviderProps?.onDeleteView).toBe(deleteView);
     expect(capturedDefinitionProviderProps?.canModifyPersistedViews).toBe(false);
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -46,7 +46,7 @@ export const ExperimentCustomViewProvider = ({
   experimentId?: string;
   children: ReactNode;
 }) => {
-  const { views, isLoaded, persistView } = useExperimentCustomViewDefinition(experimentId);
+  const { views, isLoaded, persistView, deleteView } = useExperimentCustomViewDefinition(experimentId);
   const { canEdit: canModifyPersistedViews } = useCanEditExperimentCustomViews(experimentId);
   const { openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming, activeProvider } = useAssistant();
   const clientToolDelivery = activeProvider?.client_tool_delivery;
@@ -125,6 +125,7 @@ export const ExperimentCustomViewProvider = ({
         views={views}
         isLoaded={isLoaded}
         onPersistView={persistView}
+        onDeleteView={deleteView}
         canModifyPersistedViews={canModifyPersistedViews}
       >
         {children}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts
@@ -98,6 +98,7 @@ describe('useExperimentCustomViewDefinition', () => {
   let queryClient: QueryClient;
   let mockGetExperiment: jest.SpiedFunction<typeof MlflowService.getExperiment>;
   let mockSetExperimentTag: jest.SpiedFunction<typeof MlflowService.setExperimentTag>;
+  let mockDeleteExperimentTag: jest.SpiedFunction<typeof MlflowService.deleteExperimentTag>;
 
   beforeEach(() => {
     queryClient = new QueryClient({
@@ -109,6 +110,7 @@ describe('useExperimentCustomViewDefinition', () => {
     jest.clearAllMocks();
     mockGetExperiment = jest.spyOn(MlflowService, 'getExperiment').mockResolvedValue(getExperimentResponse([]));
     mockSetExperimentTag = jest.spyOn(MlflowService, 'setExperimentTag').mockResolvedValue({});
+    mockDeleteExperimentTag = jest.spyOn(MlflowService, 'deleteExperimentTag').mockResolvedValue({});
   });
 
   describe('load path', () => {
@@ -386,14 +388,38 @@ describe('useExperimentCustomViewDefinition', () => {
     });
   });
 
+  describe('delete path', () => {
+    it('hard deletes the saved-view tag and invalidates the cached views', async () => {
+      const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderDefinition(queryClient, EXPERIMENT_ID);
+      await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+      const deleteView = result.current.deleteView;
+      if (!deleteView) {
+        throw new Error('deleteView should be defined when an experiment id is present');
+      }
+      await deleteView('view-1');
+
+      expect(mockDeleteExperimentTag).toHaveBeenCalledWith({
+        experiment_id: EXPERIMENT_ID,
+        key: viewTagKey('view-1'),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['experiment-custom-views', EXPERIMENT_ID] }),
+      );
+    });
+  });
+
   describe('without an experiment id', () => {
-    it('reports loaded, exposes no persist callback, and never fetches', () => {
+    it('reports loaded, exposes no mutation callbacks, and never fetches', () => {
       const { result } = renderDefinition(queryClient, undefined);
 
       expect(result.current.isLoaded).toBe(true);
       expect(result.current.views).toEqual([]);
       expect(result.current.persistView).toBeUndefined();
+      expect(result.current.deleteView).toBeUndefined();
       expect(mockGetExperiment).not.toHaveBeenCalled();
+      expect(mockDeleteExperimentTag).not.toHaveBeenCalled();
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.ts
@@ -83,10 +83,11 @@ export type ExperimentCustomViewDefinition = {
   // Undefined (no experiment scope) → the host falls back to a session-local,
   // non-persisting engine.
   persistView?: (view: CustomView) => Promise<void>;
+  deleteView?: (id: string) => Promise<void>;
 };
 
 /**
- * Loads + persists the experiment's saved custom views, one experiment tag per
+ * Loads + persists/deletes the experiment's saved custom views, one experiment tag per
  * view (`mlflow.customView.view.v1.<id>`). Returns a no-op-free persist
  * callback only when an experiment id is present; without one the caller's
  * session-local fallback engages.
@@ -124,9 +125,24 @@ export const useExperimentCustomViewDefinition = (experimentId?: string): Experi
     [persistMutation],
   );
 
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await MlflowService.deleteExperimentTag({ experiment_id: experimentId, key: viewTagKey(id) });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  const deleteView = useCallback(
+    async (id: string) => {
+      await deleteMutation.mutateAsync(id);
+    },
+    [deleteMutation],
+  );
+
   return {
     views: views ?? [],
     isLoaded: experimentId ? !isLoading : true,
     persistView: experimentId ? persistView : undefined,
+    deleteView: experimentId ? deleteView : undefined,
   };
 };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2211,6 +2211,10 @@
     "defaultMessage": "Link prompts to your traces by loading your registered prompts inside the traced function.",
     "description": "Helper text describing how to link prompts when no prompt records are available"
   },
+  "7b9zBN": {
+    "defaultMessage": "Delete the view \"{name}\"? This removes it from the experiment for everyone.",
+    "description": "Confirmation text when deleting a named custom trace view"
+  },
   "7cd+cQ": {
     "defaultMessage": "Trace Archival Retention",
     "description": "Label for displaying the experiment trace archival retention"
@@ -2958,6 +2962,10 @@
   "AanBxl": {
     "defaultMessage": "my-endpoint",
     "description": "Placeholder for endpoint name input"
+  },
+  "Aar6YZ": {
+    "defaultMessage": "Delete view",
+    "description": "Menu item to delete the current custom trace view"
   },
   "AawxF/": {
     "defaultMessage": "Edit Endpoint Name",
@@ -7983,6 +7991,10 @@
     "defaultMessage": "Cost: {input} in / {output} out",
     "description": "Model cost per token"
   },
+  "WFT25v": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button label on the delete-custom-view modal"
+  },
   "WGN2f3": {
     "defaultMessage": "Register model",
     "description": "Run page > Header > Register model dropdown > Button label when some models are not registered"
@@ -9798,6 +9810,10 @@
   "dmN/nA": {
     "defaultMessage": "Name",
     "description": "Queue settings: name field label"
+  },
+  "dnoeCa": {
+    "defaultMessage": "Delete view",
+    "description": "Title of the delete-custom-view confirmation modal"
   },
   "dp7Jva": {
     "defaultMessage": "Cancel",
@@ -13771,6 +13787,10 @@
     "defaultMessage": "my-api-key",
     "description": "Placeholder for API key name input"
   },
+  "tcQ02J": {
+    "defaultMessage": "Delete",
+    "description": "Confirm button label on the delete-custom-view modal"
+  },
   "tiQptW": {
     "defaultMessage": "Learn more",
     "description": "Link to the documentation page for GenAI evaluation"
@@ -14186,6 +14206,10 @@
   "vqWexj": {
     "defaultMessage": "Back to experiment list",
     "description": "Tooltip for experiments button"
+  },
+  "vsxMvp": {
+    "defaultMessage": "Delete this view? This removes it from the experiment for everyone.",
+    "description": "Confirmation text when deleting an unnamed custom trace view"
   },
   "vtQvcd": {
     "defaultMessage": "Save version",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.test.tsx
@@ -38,13 +38,26 @@ describe('useCustomViewDefinitionState', () => {
       useCustomViewDefinitionState(NO_VIEWS, true, jest.fn<() => Promise<void>>(), true),
     );
     expect(withPersist.result.current.canPersist).toBe(true);
+    expect(withPersist.result.current.canDelete).toBe(false);
+
+    const withDelete = renderHook(() =>
+      useCustomViewDefinitionState(NO_VIEWS, true, noopPersistView, true, jest.fn<() => Promise<void>>()),
+    );
+    expect(withDelete.result.current.canDelete).toBe(true);
   });
 
   it('reports canPersist false when a persist callback exists but edit permission is denied', () => {
     const { result } = renderHook(() =>
-      useCustomViewDefinitionState(NO_VIEWS, true, jest.fn<() => Promise<void>>(), false),
+      useCustomViewDefinitionState(
+        NO_VIEWS,
+        true,
+        jest.fn<() => Promise<void>>(),
+        false,
+        jest.fn<() => Promise<void>>(),
+      ),
     );
     expect(result.current.canPersist).toBe(false);
+    expect(result.current.canDelete).toBe(false);
   });
 
   it('does not create or update working views when modification permission is denied', () => {
@@ -546,17 +559,31 @@ describe('useCustomViewDefinitionState', () => {
     expect(result.current.views).toEqual(SINGLE_VIEW);
     expect(result.current.activeViewId).toBe('a');
     expect(result.current.isSaving).toBe(false);
+
+    let applied: boolean | undefined;
+    act(() => {
+      applied = result.current.upsertViewContent(makeView('a', { label: 'updated' }));
+    });
+    expect(applied).toBe(true);
+    expect(result.current.activeView?.label).toBe('updated');
   });
 
-  it('does not allow an in-flight update to resurrect a deleted view', async () => {
-    const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+  it('rejects an update that lands while deletion is in flight', async () => {
+    let resolveDelete: () => void = () => {};
+    const onDeleteView = jest.fn<(id: string) => Promise<void>>(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+    );
     const { result } = renderHook(() =>
       useCustomViewDefinitionState(SINGLE_VIEW, true, noopPersistView, true, onDeleteView),
     );
 
     act(() => result.current.selectView('a'));
-    await act(async () => {
-      await result.current.deleteView('a');
+    let deletePromise: Promise<void> | undefined;
+    act(() => {
+      deletePromise = result.current.deleteView('a');
     });
 
     let applied: boolean | undefined;
@@ -565,6 +592,13 @@ describe('useCustomViewDefinitionState', () => {
     });
 
     expect(applied).toBe(false);
+    expect(result.current.views).toEqual(SINGLE_VIEW);
+
+    await act(async () => {
+      resolveDelete();
+      await deletePromise;
+    });
+
     expect(result.current.views).toEqual([]);
     expect(result.current.activeViewId).toBeUndefined();
   });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.test.tsx
@@ -514,6 +514,61 @@ describe('useCustomViewDefinitionState', () => {
     }
   });
 
+  it('deletes a persisted view and clears the active selection', async () => {
+    const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+    const initialViews = [makeView('a'), makeView('b')];
+    const { result } = renderHook(() =>
+      useCustomViewDefinitionState(initialViews, true, noopPersistView, true, onDeleteView),
+    );
+
+    act(() => result.current.selectView('a'));
+    await act(async () => {
+      await result.current.deleteView('a');
+    });
+
+    expect(onDeleteView).toHaveBeenCalledWith('a');
+    expect(result.current.views.map((view) => view.id)).toEqual(['b']);
+    expect(result.current.activeViewId).toBeUndefined();
+  });
+
+  it('keeps the view and surfaces the error when deletion fails', async () => {
+    const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockRejectedValue(new Error('delete exploded'));
+    const { result } = renderHook(() =>
+      useCustomViewDefinitionState(SINGLE_VIEW, true, noopPersistView, true, onDeleteView),
+    );
+
+    act(() => result.current.selectView('a'));
+    await act(async () => {
+      await result.current.deleteView('a');
+    });
+
+    expect(result.current.saveError).toBe('delete exploded');
+    expect(result.current.views).toEqual(SINGLE_VIEW);
+    expect(result.current.activeViewId).toBe('a');
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('does not allow an in-flight update to resurrect a deleted view', async () => {
+    const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useCustomViewDefinitionState(SINGLE_VIEW, true, noopPersistView, true, onDeleteView),
+    );
+
+    act(() => result.current.selectView('a'));
+    await act(async () => {
+      await result.current.deleteView('a');
+    });
+
+    let applied: boolean | undefined;
+    act(() => {
+      applied = result.current.upsertViewContent(makeView('a'));
+    });
+
+    expect(applied).toBe(false);
+    expect(result.current.views).toEqual([]);
+    expect(result.current.activeViewId).toBeUndefined();
+  });
+
   it('keeps isSaving true until the LAST of two overlapping mutations settles', async () => {
     // Two independently controllable persists so we can settle them out of order.
     const resolvers: Array<() => void> = [];

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.tsx
@@ -24,6 +24,9 @@ export type CustomViewDefinitionContextValue = {
   // wired AND the host reports experiment edit permission). False for read-only
   // users and the session-local fallback outside the experiment provider.
   canPersist: boolean;
+  // Whether persisted views can be deleted (delete callback wired AND the host
+  // reports experiment edit permission).
+  canDelete: boolean;
   isSaving: boolean;
   // Whether the active view differs from its persisted counterpart (or has none).
   isDirty: boolean;
@@ -122,6 +125,7 @@ export const useCustomViewDefinitionState = (
   onDeleteView?: (id: string) => Promise<void>,
 ): CustomViewDefinitionContextValue => {
   const canPersist = Boolean(onPersistView) && Boolean(canModifyPersistedViews);
+  const canDelete = Boolean(onDeleteView) && Boolean(canModifyPersistedViews);
   const [views, setViews] = useState<CustomView[]>(initialViews);
   const [persistedViews, setPersistedViews] = useState<CustomView[]>(initialViews);
   // No view is selected by default: the host shows a "Select a custom view"
@@ -345,26 +349,30 @@ export const useCustomViewDefinitionState = (
   const deleteView = useCallback(
     async (id: string) => {
       setSaveError(undefined);
-      if (!canPersist) {
+      if (!canDelete || !onDeleteView) {
         return;
       }
       beginSaving();
+      // Tombstone before the backend request so an Assistant response that lands
+      // while deletion is in flight cannot update a view the user chose to delete.
+      deletedViewIdsRef.current.add(id);
       try {
-        if (onDeleteView && persistedViews.some((view) => view.id === id)) {
+        if (persistedViews.some((view) => view.id === id)) {
           await onDeleteView(id);
         }
         hasLocalEditsRef.current = true;
-        deletedViewIdsRef.current.add(id);
         setPersistedViews((prev) => prev.filter((view) => view.id !== id));
         setViews((prev) => prev.filter((view) => view.id !== id));
         setActiveViewId((current) => (current === id ? undefined : current));
       } catch (error) {
+        // The view remains when persistence fails, so allow subsequent updates.
+        deletedViewIdsRef.current.delete(id);
         setSaveError(error instanceof Error ? error.message : 'Failed to delete the custom view.');
       } finally {
         endSaving();
       }
     },
-    [canPersist, onDeleteView, persistedViews, beginSaving, endSaving],
+    [canDelete, onDeleteView, persistedViews, beginSaving, endSaving],
   );
 
   return {
@@ -375,6 +383,7 @@ export const useCustomViewDefinitionState = (
     draftName,
     isLoaded,
     canPersist,
+    canDelete,
     isSaving,
     isDirty,
     isActivePersisted,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.tsx
@@ -72,6 +72,7 @@ export type CustomViewDefinitionContextValue = {
   // saveActiveView, which commits the full dirty working copy. Resolves when the
   // persist settles; callers may ignore the returned promise.
   renameView: (id: string, name: string) => Promise<void>;
+  deleteView: (id: string) => Promise<void>;
   // Mark that an initial build has been launched (shows the building skeleton
   // until the spec applies or the build errors).
   startBuilding: () => void;
@@ -112,12 +113,13 @@ const upsertById = (views: CustomView[], view: CustomView): CustomView[] => {
 // Core state hook shared by the persistent provider and the session-local
 // fallback. It manages the working view registry + active selection, tracks
 // per-view dirtiness against the last persisted snapshot, and (when given)
-// delegates persistence to `onPersistView`.
+// delegates persistence to `onPersistView` / `onDeleteView`.
 export const useCustomViewDefinitionState = (
   initialViews: CustomView[],
   isLoaded: boolean,
   onPersistView?: (view: CustomView) => Promise<void>,
   canModifyPersistedViews?: boolean,
+  onDeleteView?: (id: string) => Promise<void>,
 ): CustomViewDefinitionContextValue => {
   const canPersist = Boolean(onPersistView) && Boolean(canModifyPersistedViews);
   const [views, setViews] = useState<CustomView[]>(initialViews);
@@ -129,7 +131,7 @@ export const useCustomViewDefinitionState = (
   const [activeViewId, setActiveViewId] = useState<string | undefined>(undefined);
   const [isDraft, setIsDraft] = useState(false);
   const [draftName, setDraftName] = useState('');
-  // Count of in-flight persistence mutations (save / rename) rather than a
+  // Count of in-flight persistence mutations (save / rename / delete) rather than a
   // boolean: with a shared boolean, whichever of two overlapping mutations
   // finished first would clear the flag while the other is still writing,
   // re-enabling the UI mid-flight. isSaving stays true until the LAST one settles.
@@ -140,10 +142,16 @@ export const useCustomViewDefinitionState = (
   const [saveError, setSaveError] = useState<string | undefined>(undefined);
   const [isBuilding, setIsBuilding] = useState(false);
 
+  // Ids of views deleted in this session. `upsertViewContent` refuses them, so a
+  // write that was already in flight when the user deleted its target cannot
+  // bring the view back. A ref is sufficient because nothing renders from it and
+  // every reader is a callback that must see the latest set.
+  const deletedViewIdsRef = useRef<Set<string>>(new Set());
+
   // Keep the working set in sync with `initialViews` while the session is still
   // pristine — this adopts views that load ASYNCHRONOUSLY (arriving as a new
   // `initialViews` reference after mount, even if `isLoaded` was already true).
-  // Once the user diverges (creates / saves a view) we stop, so a later refetch
+  // Once the user diverges (creates / saves / deletes a view) we stop, so a later refetch
   // can't clobber unsaved local edits. The active selection is left untouched
   // (no default) so the host shows the placeholder until the user picks a view.
   //
@@ -221,6 +229,9 @@ export const useCustomViewDefinitionState = (
   const upsertViewContent = useCallback(
     (view: CustomView) => {
       if (!canPersist) {
+        return false;
+      }
+      if (deletedViewIdsRef.current.has(view.id)) {
         return false;
       }
       hasLocalEditsRef.current = true;
@@ -331,6 +342,31 @@ export const useCustomViewDefinitionState = (
     [canPersist, onPersistView, persistedViews, beginSaving, endSaving],
   );
 
+  const deleteView = useCallback(
+    async (id: string) => {
+      setSaveError(undefined);
+      if (!canPersist) {
+        return;
+      }
+      beginSaving();
+      try {
+        if (onDeleteView && persistedViews.some((view) => view.id === id)) {
+          await onDeleteView(id);
+        }
+        hasLocalEditsRef.current = true;
+        deletedViewIdsRef.current.add(id);
+        setPersistedViews((prev) => prev.filter((view) => view.id !== id));
+        setViews((prev) => prev.filter((view) => view.id !== id));
+        setActiveViewId((current) => (current === id ? undefined : current));
+      } catch (error) {
+        setSaveError(error instanceof Error ? error.message : 'Failed to delete the custom view.');
+      } finally {
+        endSaving();
+      }
+    },
+    [canPersist, onDeleteView, persistedViews, beginSaving, endSaving],
+  );
+
   return {
     views,
     activeViewId,
@@ -351,28 +387,31 @@ export const useCustomViewDefinitionState = (
     upsertViewContent,
     saveActiveView,
     renameView,
+    deleteView,
     startBuilding,
     stopBuilding,
   };
 };
 
 // Generic provider: experiment-tracking wires this up with the loaded views +
-// persist callback that writes per-view experiment tags. Mounted high enough
+// persist/delete callbacks that write per-view experiment tags. Mounted high enough
 // (e.g. in the traces table) that it survives drawer close / trace cycling.
 export const CustomViewDefinitionProvider = ({
   views,
   isLoaded,
   onPersistView,
+  onDeleteView,
   canModifyPersistedViews,
   children,
 }: {
   views: CustomView[];
   isLoaded: boolean;
   onPersistView?: (view: CustomView) => Promise<void>;
+  onDeleteView?: (id: string) => Promise<void>;
   canModifyPersistedViews?: boolean;
   children: ReactNode;
 }): JSX.Element => {
-  const value = useCustomViewDefinitionState(views, isLoaded, onPersistView, canModifyPersistedViews);
+  const value = useCustomViewDefinitionState(views, isLoaded, onPersistView, canModifyPersistedViews, onDeleteView);
   return <CustomViewDefinitionContext.Provider value={value}>{children}</CustomViewDefinitionContext.Provider>;
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
@@ -115,6 +115,7 @@ const renderWithProvider = () =>
 
 const renderWithPersistProvider = (canModifyPersistedViews: boolean, views: CustomView[] = [persistedView]) => {
   const onPersistView = jest.fn<(view: CustomView) => Promise<void>>().mockResolvedValue(undefined);
+  const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
   render(
     <IntlProvider locale="en" messages={{}}>
       <DesignSystemProvider>
@@ -123,6 +124,7 @@ const renderWithPersistProvider = (canModifyPersistedViews: boolean, views: Cust
             views={views}
             isLoaded
             onPersistView={onPersistView}
+            onDeleteView={onDeleteView}
             canModifyPersistedViews={canModifyPersistedViews}
           >
             <ModelTraceExplorerCustomView modelTraceInfo={modelTraceInfo} />
@@ -131,7 +133,7 @@ const renderWithPersistProvider = (canModifyPersistedViews: boolean, views: Cust
       </DesignSystemProvider>
     </IntlProvider>,
   );
-  return { onPersistView };
+  return { onPersistView, onDeleteView };
 };
 
 const renderWithChangingPermission = (canModifyPersistedViews: boolean) => {
@@ -516,6 +518,25 @@ describe('ModelTraceExplorerCustomView', () => {
 
     // A readable view: rename is enabled (not aria-disabled).
     expect(screen.getByRole('menuitem', { name: /Rename view/ })).not.toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('menuitem', { name: /Delete view/ })).toBeInTheDocument();
+  });
+
+  it('confirms and deletes the selected persisted view', async () => {
+    setBridge();
+    const { onDeleteView } = renderWithPersistProvider(true);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Select a custom view/ }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: /name-v1/ }));
+    await user.click(screen.getByRole('button', { name: 'More view options' }));
+    await user.click(screen.getByRole('menuitem', { name: /Delete view/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: /Delete view/ });
+    expect(within(dialog).getByText(/Delete the view "name-v1"/)).toBeInTheDocument();
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    expect(onDeleteView).toHaveBeenCalledWith('v1');
+    expect(await screen.findByText('Build a custom trace view')).toBeInTheDocument();
   });
 
   it('disables (not hides) Rename view for an unreadable persisted view', async () => {
@@ -532,6 +553,7 @@ describe('ModelTraceExplorerCustomView', () => {
 
     // Rename is rendered but disabled (not removed from the menu).
     expect(screen.getByRole('menuitem', { name: /Rename view/ })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('menuitem', { name: /Delete view/ })).not.toHaveAttribute('aria-disabled', 'true');
   });
 
   it('disables Rename for a valid-shape view whose template fails validation (Case-2 unreadable derived at selection)', async () => {
@@ -551,6 +573,7 @@ describe('ModelTraceExplorerCustomView', () => {
 
     await user.click(screen.getByRole('button', { name: 'More view options' }));
     expect(screen.getByRole('menuitem', { name: /Rename view/ })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('menuitem', { name: /Delete view/ })).not.toHaveAttribute('aria-disabled', 'true');
   });
 
   it('renames the selected view: prefills the current name and persists the trimmed new name against the saved template', async () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
@@ -521,6 +521,34 @@ describe('ModelTraceExplorerCustomView', () => {
     expect(screen.getByRole('menuitem', { name: /Delete view/ })).toBeInTheDocument();
   });
 
+  it('hides Delete view when the provider does not supply a delete callback', async () => {
+    setBridge();
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <DesignSystemProvider>
+          <QueryClientProvider client={new QueryClient()}>
+            <CustomViewDefinitionProvider
+              views={[persistedView]}
+              isLoaded
+              onPersistView={noopPersistView}
+              canModifyPersistedViews
+            >
+              <ModelTraceExplorerCustomView modelTraceInfo={modelTraceInfo} />
+            </CustomViewDefinitionProvider>
+          </QueryClientProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Select a custom view/ }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: /name-v1/ }));
+    await user.click(screen.getByRole('button', { name: 'More view options' }));
+
+    expect(screen.getByRole('menuitem', { name: /Rename view/ })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Delete view/ })).not.toBeInTheDocument();
+  });
+
   it('confirms and deletes the selected persisted view', async () => {
     setBridge();
     const { onDeleteView } = renderWithPersistProvider(true);
@@ -537,6 +565,49 @@ describe('ModelTraceExplorerCustomView', () => {
 
     expect(onDeleteView).toHaveBeenCalledWith('v1');
     expect(await screen.findByText('Build a custom trace view')).toBeInTheDocument();
+  });
+
+  it('deletes the view the modal was opened for when selection changes in the background', async () => {
+    setBridge();
+    const viewA = makeView('v1');
+    const viewB = makeView('v2');
+    const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+    const selectViewRef: { current?: (id: string) => void } = {};
+    render(
+      <IntlProvider locale="en" messages={{}}>
+        <DesignSystemProvider>
+          <QueryClientProvider client={new QueryClient()}>
+            <CustomViewDefinitionProvider
+              views={[viewA, viewB]}
+              isLoaded
+              onPersistView={noopPersistView}
+              onDeleteView={onDeleteView}
+              canModifyPersistedViews
+            >
+              <ModelTraceExplorerCustomView modelTraceInfo={modelTraceInfo} />
+              <SelectViewProbe selectViewRef={selectViewRef} />
+            </CustomViewDefinitionProvider>
+          </QueryClientProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Select a custom view/ }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: /name-v1/ }));
+    await user.click(screen.getByRole('button', { name: 'More view options' }));
+    await user.click(screen.getByRole('menuitem', { name: /Delete view/ }));
+
+    const dialog = await screen.findByRole('dialog', { name: /Delete view/ });
+    expect(within(dialog).getByText(/Delete the view "name-v1"/)).toBeInTheDocument();
+
+    act(() => selectViewRef.current?.('v2'));
+    expect(within(dialog).getByText(/Delete the view "name-v1"/)).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    expect(onDeleteView).toHaveBeenCalledWith('v1');
+    expect(onDeleteView).not.toHaveBeenCalledWith('v2');
+    expect(await screen.findByRole('button', { name: /name-v2/ })).toBeInTheDocument();
   });
 
   it('disables (not hides) Rename view for an unreadable persisted view', async () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
@@ -18,6 +18,7 @@ import {
   SparkleFillIcon,
   SparkleIcon,
   Tooltip,
+  TrashIcon,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
@@ -256,6 +257,7 @@ export const ModelTraceExplorerCustomView = ({
   // background selection change (e.g. an assistant apply) can't retarget the
   // rename.
   const [renameTargetId, setRenameTargetId] = useState<string | undefined>(undefined);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const surfaceId = activeView ? surfaceIdForView(activeView) : '';
   const surface = activeView ? processor.model.getSurface(surfaceId) : undefined;
@@ -615,6 +617,15 @@ export const ModelTraceExplorerCustomView = ({
     cv.renameView(renameTargetId, name);
   };
 
+  const handleDelete = () => {
+    const id = cv.activeViewId;
+    if (!id) {
+      return;
+    }
+    cv.deleteView(id);
+    setDeleteModalOpen(false);
+  };
+
   // Shown for a view that has not been saved yet (empty user-provided name): the
   // in-progress draft and any built-but-unsaved view. Views are keyed/selected by
   // `id`, so several unsaved views sharing this label never collide.
@@ -785,6 +796,18 @@ export const ModelTraceExplorerCustomView = ({
                       </span>
                     </Tooltip>
                   )}
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  componentId="shared.model-trace-explorer.custom-view.delete-view-modal-open-button"
+                  onClick={() => setDeleteModalOpen(true)}
+                >
+                  <DropdownMenu.IconWrapper>
+                    <TrashIcon />
+                  </DropdownMenu.IconWrapper>
+                  <FormattedMessage
+                    defaultMessage="Delete view"
+                    description="Menu item to delete the current custom trace view"
+                  />
                 </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu.Root>
@@ -1049,6 +1072,41 @@ export const ModelTraceExplorerCustomView = ({
             }
           }}
         />
+      </Modal>
+
+      <Modal
+        componentId="shared.model-trace-explorer.custom-view.delete-view-modal"
+        visible={deleteModalOpen}
+        title={intl.formatMessage({
+          defaultMessage: 'Delete view',
+          description: 'Title of the delete-custom-view confirmation modal',
+        })}
+        onCancel={() => setDeleteModalOpen(false)}
+        onOk={handleDelete}
+        okText={intl.formatMessage({
+          defaultMessage: 'Delete',
+          description: 'Confirm button label on the delete-custom-view modal',
+        })}
+        cancelText={intl.formatMessage({
+          defaultMessage: 'Cancel',
+          description: 'Cancel button label on the delete-custom-view modal',
+        })}
+        okButtonProps={{ danger: true }}
+      >
+        <Typography.Text>
+          {activeView?.name
+            ? intl.formatMessage(
+                {
+                  defaultMessage: 'Delete the view "{name}"? This removes it from the experiment for everyone.',
+                  description: 'Confirmation text when deleting a named custom trace view',
+                },
+                { name: activeView.name },
+              )
+            : intl.formatMessage({
+                defaultMessage: 'Delete this view? This removes it from the experiment for everyone.',
+                description: 'Confirmation text when deleting an unnamed custom trace view',
+              })}
+        </Typography.Text>
       </Modal>
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
@@ -257,7 +257,9 @@ export const ModelTraceExplorerCustomView = ({
   // background selection change (e.g. an assistant apply) can't retarget the
   // rename.
   const [renameTargetId, setRenameTargetId] = useState<string | undefined>(undefined);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  // Capture the delete target so a background selection change cannot retarget
+  // the confirmation modal to another view.
+  const [deleteTarget, setDeleteTarget] = useState<Pick<CustomView, 'id' | 'name'> | undefined>(undefined);
 
   const surfaceId = activeView ? surfaceIdForView(activeView) : '';
   const surface = activeView ? processor.model.getSurface(surfaceId) : undefined;
@@ -617,13 +619,19 @@ export const ModelTraceExplorerCustomView = ({
     cv.renameView(renameTargetId, name);
   };
 
-  const handleDelete = () => {
-    const id = cv.activeViewId;
-    if (!id) {
+  const handleOpenDelete = () => {
+    if (!activeView) {
       return;
     }
-    cv.deleteView(id);
-    setDeleteModalOpen(false);
+    setDeleteTarget({ id: activeView.id, name: activeView.name });
+  };
+
+  const handleDelete = () => {
+    if (!deleteTarget) {
+      return;
+    }
+    cv.deleteView(deleteTarget.id);
+    setDeleteTarget(undefined);
   };
 
   // Shown for a view that has not been saved yet (empty user-provided name): the
@@ -746,7 +754,7 @@ export const ModelTraceExplorerCustomView = ({
               />
             </AssistantSparkleButton>
           )}
-          {activeView && cv.isActivePersisted && cv.canPersist && (
+          {activeView && cv.isActivePersisted && (cv.canPersist || cv.canDelete) && (
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
                 <Button
@@ -760,55 +768,60 @@ export const ModelTraceExplorerCustomView = ({
                 />
               </DropdownMenu.Trigger>
               <DropdownMenu.Content align="end" minWidth={150}>
-                <DropdownMenu.Item
-                  componentId="shared.model-trace-explorer.custom-view.rename"
-                  onClick={handleOpenRename}
-                  disabled={cv.isActivePersistedUnreadable}
-                >
-                  <DropdownMenu.IconWrapper>
-                    <PencilIcon />
-                  </DropdownMenu.IconWrapper>
-                  <FormattedMessage
-                    defaultMessage="Rename view"
-                    description="Menu item to rename the current custom trace view"
-                  />
-                  {cv.isActivePersistedUnreadable && (
-                    <Tooltip
-                      componentId="shared.model-trace-explorer.custom-view.rename-disabled-reason"
-                      side="right"
-                      content={intl.formatMessage({
-                        defaultMessage: 'Rebuild this invalid view with the assistant and save it to enable renaming.',
-                        description:
-                          'Tooltip explaining why renaming is disabled for a custom view whose saved definition is unreadable',
-                      })}
-                    >
-                      <span
-                        css={{
-                          display: 'inline-flex',
-                          marginLeft: 'auto',
-                          paddingLeft: theme.spacing.xs,
-                          color: theme.colors.textSecondary,
-                          pointerEvents: 'all',
-                        }}
-                        onClick={(e) => e.stopPropagation()}
+                {cv.canPersist && (
+                  <DropdownMenu.Item
+                    componentId="shared.model-trace-explorer.custom-view.rename"
+                    onClick={handleOpenRename}
+                    disabled={cv.isActivePersistedUnreadable}
+                  >
+                    <DropdownMenu.IconWrapper>
+                      <PencilIcon />
+                    </DropdownMenu.IconWrapper>
+                    <FormattedMessage
+                      defaultMessage="Rename view"
+                      description="Menu item to rename the current custom trace view"
+                    />
+                    {cv.isActivePersistedUnreadable && (
+                      <Tooltip
+                        componentId="shared.model-trace-explorer.custom-view.rename-disabled-reason"
+                        side="right"
+                        content={intl.formatMessage({
+                          defaultMessage:
+                            'Rebuild this invalid view with the assistant and save it to enable renaming.',
+                          description:
+                            'Tooltip explaining why renaming is disabled for a custom view whose saved definition is unreadable',
+                        })}
                       >
-                        <InfoIcon aria-hidden />
-                      </span>
-                    </Tooltip>
-                  )}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  componentId="shared.model-trace-explorer.custom-view.delete-view-modal-open-button"
-                  onClick={() => setDeleteModalOpen(true)}
-                >
-                  <DropdownMenu.IconWrapper>
-                    <TrashIcon />
-                  </DropdownMenu.IconWrapper>
-                  <FormattedMessage
-                    defaultMessage="Delete view"
-                    description="Menu item to delete the current custom trace view"
-                  />
-                </DropdownMenu.Item>
+                        <span
+                          css={{
+                            display: 'inline-flex',
+                            marginLeft: 'auto',
+                            paddingLeft: theme.spacing.xs,
+                            color: theme.colors.textSecondary,
+                            pointerEvents: 'all',
+                          }}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <InfoIcon aria-hidden />
+                        </span>
+                      </Tooltip>
+                    )}
+                  </DropdownMenu.Item>
+                )}
+                {cv.canDelete && (
+                  <DropdownMenu.Item
+                    componentId="shared.model-trace-explorer.custom-view.delete-view-modal-open-button"
+                    onClick={handleOpenDelete}
+                  >
+                    <DropdownMenu.IconWrapper>
+                      <TrashIcon />
+                    </DropdownMenu.IconWrapper>
+                    <FormattedMessage
+                      defaultMessage="Delete view"
+                      description="Menu item to delete the current custom trace view"
+                    />
+                  </DropdownMenu.Item>
+                )}
               </DropdownMenu.Content>
             </DropdownMenu.Root>
           )}
@@ -1076,12 +1089,12 @@ export const ModelTraceExplorerCustomView = ({
 
       <Modal
         componentId="shared.model-trace-explorer.custom-view.delete-view-modal"
-        visible={deleteModalOpen}
+        visible={Boolean(deleteTarget)}
         title={intl.formatMessage({
           defaultMessage: 'Delete view',
           description: 'Title of the delete-custom-view confirmation modal',
         })}
-        onCancel={() => setDeleteModalOpen(false)}
+        onCancel={() => setDeleteTarget(undefined)}
         onOk={handleDelete}
         okText={intl.formatMessage({
           defaultMessage: 'Delete',
@@ -1094,13 +1107,13 @@ export const ModelTraceExplorerCustomView = ({
         okButtonProps={{ danger: true }}
       >
         <Typography.Text>
-          {activeView?.name
+          {deleteTarget?.name
             ? intl.formatMessage(
                 {
                   defaultMessage: 'Delete the view "{name}"? This removes it from the experiment for everyone.',
                   description: 'Confirmation text when deleting a named custom trace view',
                 },
-                { name: activeView.name },
+                { name: deleteTarget.name },
               )
             : intl.formatMessage({
                 defaultMessage: 'Delete this view? This removes it from the experiment for everyone.',


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a delete action for saved custom trace views, matching the managed MLflow experience. The action confirms the deletion, hard-deletes the backing experiment tag, refreshes cached views, and prevents an in-flight Assistant update from restoring a deleted view.

### How is this PR tested?

- [x] New unit/integration tests

Focused frontend suites: 93 tests passed. ESLint, Prettier, TypeScript, i18n, and pre-commit checks also pass.

<img width="2996" height="1531" alt="Screenshot 2026-08-13 at 14 49 08" src="https://github.com/user-attachments/assets/fcdfe758-732c-43bf-99eb-f8d9296507f7" />

https://github.com/user-attachments/assets/290cc8a4-a654-4a2f-a535-25727bf56dfe



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Users can now delete saved custom trace views from an experiment.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
