### PR TITLE
Authenticate `review.yml` via Databricks workload identity federation

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -263,21 +263,14 @@ jobs:
 
           OUTPUT_FILE="/tmp/output.jsonl"
 
-          # stream.sh echoes tool_use inputs to the job log as the session runs,
-          # and that log is public on this repo, so a token the agent minted and
-          # passed to a command would appear there live. ::add-mask:: only affects
-          # output written after it is registered, so register each credential as
-          # it is minted rather than waiting for the failure dump below. This
-          # narrows the exposure window to the poll interval; it does not close it.
-          # Pre-created here, so the helper's own 0600 opener never applies —
-          # tighten it now rather than leaving the file at the runner's umask.
+          # Records the credentials this job hands to Claude Code so the redaction
+          # step can scrub them from the uploaded transcript. Deliberately not
+          # more than that: a token the agent exchanges itself never passes
+          # through the helper, so no amount of bookkeeping here can cover it.
+          # The real bounds are the principal's entitlements and the ~5 minute
+          # expiry, not this file.
           : > "$MINT_TOKEN_SECRETS"
           chmod 600 "$MINT_TOKEN_SECRETS"
-          tail -F "$MINT_TOKEN_SECRETS" 2>/dev/null | while read -r token; do
-            [ -n "$token" ] && echo "::add-mask::$token"
-          done &
-          MASK_PID=$!
-          trap 'kill "$MASK_PID" 2>/dev/null || true' EXIT
 
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -85,9 +85,14 @@ jobs:
     needs: gate
     runs-on: ubuntu-latest
     # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
-    # minted below. `id-token: write` grants GITHUB_TOKEN no repo scope; it only
-    # enables OIDC JWT issuance for the Databricks token exchange, so the
-    # fail-closed stance above is preserved.
+    # minted below, and `id-token: write` grants GITHUB_TOKEN no repo scope.
+    #
+    # It does widen the blast radius on the Databricks side, though: it puts
+    # ACTIONS_ID_TOKEN_REQUEST_TOKEN in the job env, which the agent shares while
+    # reading untrusted diffs, so the agent can mint the service principal's token
+    # and reach anything that principal is entitled to — not only gateway
+    # inference. The bound is therefore the SP's own entitlements, which are kept
+    # to workspace access alone, plus the token's ~10 minute life.
     permissions:
       id-token: write
     # The OIDC subject is pinned to `repo:<org>/<repo>:environment:ai-gateway`,
@@ -220,6 +225,13 @@ jobs:
           DATABRICKS_TOKEN_AUDIENCE: ${{ vars.DATABRICKS_ACCOUNT_ID }}
           ANTHROPIC_BASE_URL: ${{ vars.DATABRICKS_HOST }}/ai-gateway/anthropic
           CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "300000"
+          MINT_TOKEN_LOG: ${{ runner.temp }}/mint-token.log
+          # Every credential the helper mints, so the redaction step below can
+          # scrub it from the uploaded transcript. The agent shares this job's
+          # OIDC environment and can mint a token itself while reviewing an
+          # untrusted diff, and stream.sh tees raw tool output into that
+          # transcript.
+          MINT_TOKEN_SECRETS: ${{ runner.temp }}/minted-tokens
           # The gateway's beta allowlist rejects several of the CLI's experimental
           # betas with HTTP 400, so they must be off on this path.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
@@ -259,6 +271,20 @@ jobs:
             echo "Error: Claude command failed with exit code $EXIT_CODE"
             cat "$OUTPUT_FILE"
             exit $EXIT_CODE
+          fi
+
+      # One line per apiKeyHelper invocation. A single line means the session
+      # finished inside one token's life and the refresh path went untested;
+      # several lines prove it fired. The expiry timestamps are the only direct
+      # measure of the federated token's lifetime, which the TTL above must
+      # stay under.
+      - name: Report gateway token refreshes
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/mint-token.log" ]; then
+            nl -ba "$RUNNER_TEMP/mint-token.log"
+          else
+            echo "apiKeyHelper never ran"
           fi
 
       - name: Validate review payload
@@ -301,6 +327,14 @@ jobs:
           for name in ("GH_TOKEN_READ", "GH_TOKEN_WRITE"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
+          # Every Databricks token minted during the run, including any the agent
+          # minted itself. Without this the transcript has no model-credential
+          # scrubbing, and it is uploaded as an artifact readable by anyone with
+          # repo read access.
+          minted = Path(os.environ["RUNNER_TEMP"]) / "minted-tokens"
+          if minted.exists():
+              for token in minted.read_text().split():
+                  data = data.replace(token, "***")
           path.write_text(data)
           PY
 
@@ -361,7 +395,7 @@ jobs:
             const formatted = JSON.stringify(resultEvent, null, 2);
             resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;
             if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
-              resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
+              resultLine += `\n\nThe model gateway is overloaded. Inference is served by the Databricks AI Gateway, not the Anthropic API, so check the workspace status and retry.`;
             }
           } else if (failed) {
             resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -90,10 +90,13 @@ jobs:
     # It does open a path on the Databricks side, though: it puts
     # ACTIONS_ID_TOKEN_REQUEST_TOKEN in the job env, which the agent shares while
     # reading untrusted diffs, so the agent can mint the service principal's token
-    # itself. Three things bound what that token can do — it is requested with the
-    # `ai-gateway` scope rather than `all-apis` so it only reaches inference, the
-    # principal's own entitlements are kept to workspace access alone, and it
-    # expires ~5 minutes after minting.
+    # itself. Two things bound what that token can do — the principal's own
+    # entitlements are kept to workspace access alone, and the token expires
+    # ~5 minutes after minting. The `ai-gateway` scope this job requests is not
+    # one of them: scope is chosen by the exchange request and the federation
+    # policy pins only issuer, subject, and audience, so an agent replaying the
+    # exchange can ask for `all-apis` instead. The scope narrows the credential
+    # this job hands to Claude Code, not what an attacker can obtain.
     permissions:
       id-token: write
     # The OIDC subject is pinned to `repo:<org>/<repo>:environment:ai-gateway`,
@@ -260,6 +263,22 @@ jobs:
 
           OUTPUT_FILE="/tmp/output.jsonl"
 
+          # stream.sh echoes tool_use inputs to the job log as the session runs,
+          # and that log is public on this repo, so a token the agent minted and
+          # passed to a command would appear there live. ::add-mask:: only affects
+          # output written after it is registered, so register each credential as
+          # it is minted rather than waiting for the failure dump below. This
+          # narrows the exposure window to the poll interval; it does not close it.
+          # Pre-created here, so the helper's own 0600 opener never applies —
+          # tighten it now rather than leaving the file at the runner's umask.
+          : > "$MINT_TOKEN_SECRETS"
+          chmod 600 "$MINT_TOKEN_SECRETS"
+          tail -F "$MINT_TOKEN_SECRETS" 2>/dev/null | while read -r token; do
+            [ -n "$token" ] && echo "::add-mask::$token"
+          done &
+          MASK_PID=$!
+          trap 'kill "$MASK_PID" 2>/dev/null || true' EXIT
+
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
           EXIT_CODE=0
@@ -279,10 +298,11 @@ jobs:
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
             echo "Error: Claude command failed with exit code $EXIT_CODE"
-            # This dumps the raw, unredacted transcript into the job log, ahead
-            # of the redaction step. A minted Databricks token is not a GitHub
-            # secret, so nothing masks it automatically the way it did when this
-            # ran on ANTHROPIC_API_KEY — register each one first.
+            # This dumps the raw, unredacted transcript into the job log, ahead of
+            # the redaction step. Re-register every credential synchronously: the
+            # background masker above may not have observed the most recent one,
+            # and a minted Databricks token is not a GitHub secret, so nothing
+            # masks it automatically the way it did under ANTHROPIC_API_KEY.
             if [ -s "$MINT_TOKEN_SECRETS" ]; then
               while read -r token; do
                 [ -n "$token" ] && echo "::add-mask::$token"
@@ -307,7 +327,10 @@ jobs:
           # reintroduce the mid-review 401 this TTL was chosen to avoid. Compare
           # rather than trust.
           ttl_s=$((CLAUDE_CODE_API_KEY_HELPER_TTL_MS / 1000))
-          shortest=$(grep -oE 'lifetime [0-9]+s' "$MINT_TOKEN_LOG" | grep -oE '[0-9]+' | sort -n | head -1)
+          # `|| true`: steps run under `-eo pipefail`, so a log with no parseable
+          # lifetime would abort this step and fail the job after a review that
+          # actually succeeded, before it could be posted.
+          shortest=$(grep -oE 'lifetime [0-9]+s' "$MINT_TOKEN_LOG" | grep -oE '[0-9]+' | sort -n | head -1 || true)
           if [ -n "$shortest" ] && [ "$shortest" -le "$ttl_s" ]; then
             echo "::warning::Token lifetime ${shortest}s is not above the ${ttl_s}s refresh interval; the credential can lapse mid-session."
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -195,17 +195,22 @@ jobs:
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
-      # Workload identity federation: the job's GitHub OIDC JWT is exchanged for
-      # a short-lived Databricks OAuth token, so no model credential is stored as
-      # a GitHub secret. The gateway fronts Databricks-hosted Claude endpoints,
-      # so there is no Anthropic API key anywhere in the chain.
+      # Workload identity federation: Claude Code invokes `apiKeyHelper` to
+      # exchange the job's GitHub OIDC JWT for a Databricks OAuth token, so no
+      # model credential is stored as a GitHub secret and none is ever written to
+      # the job environment. The gateway fronts Databricks-hosted Claude
+      # endpoints, so no Anthropic API key exists anywhere in the chain.
       #
-      # The token lives ~1h, well past this job's 30m ceiling, so a single
-      # exchange suffices and no refresh helper is needed. Workflows that can run
-      # longer would need Claude Code's `apiKeyHelper` to re-mint mid-session
-      # (note `databricks auth token` cannot do this — it is U2M-only).
-      - name: Mint Databricks gateway token
+      # Refreshing is mandatory, not an optimization: the federated token expires
+      # in ~10 minutes (measured — the ~1h figure in the docs describes U2M
+      # tokens), well inside the 20m Claude cap below. The helper TTL is kept
+      # under that lifetime so the credential is replaced before it lapses.
+      # `databricks auth token` cannot serve as the helper — it is U2M-only.
+      - name: Review
+        id: review
         env:
+          # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
+          GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
           DATABRICKS_AUTH_TYPE: github-oidc
@@ -213,28 +218,8 @@ jobs:
           # federation policy. Without it the SDK defaults the audience to the
           # workspace token endpoint URL, which the policy would reject.
           DATABRICKS_TOKEN_AUDIENCE: ${{ vars.DATABRICKS_ACCOUNT_ID }}
-        run: |
-          : "${DATABRICKS_HOST:?Set the DATABRICKS_HOST repository variable}"
-          : "${DATABRICKS_CLIENT_ID:?Set the DATABRICKS_CLIENT_ID repository variable}"
-          : "${DATABRICKS_TOKEN_AUDIENCE:?Set the DATABRICKS_ACCOUNT_ID repository variable}"
-          # The SDK owns the OIDC exchange protocol (fetching the Actions JWT and
-          # POSTing it to the workspace token endpoint), so the shape of that
-          # exchange is not hand-rolled here.
-          TOKEN=$(uv run --no-project --with databricks-sdk python -c '
-          from databricks.sdk.core import Config
-          print(Config().authenticate()["Authorization"].split(" ", 1)[1])
-          ')
-          echo "::add-mask::$TOKEN"
-          {
-            echo "ANTHROPIC_AUTH_TOKEN=$TOKEN"
-            echo "ANTHROPIC_BASE_URL=${DATABRICKS_HOST%/}/ai-gateway/anthropic"
-          } >> "$GITHUB_ENV"
-
-      - name: Review
-        id: review
-        env:
-          # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
-          GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
+          ANTHROPIC_BASE_URL: ${{ vars.DATABRICKS_HOST }}/ai-gateway/anthropic
+          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "300000"
           # The gateway's beta allowlist rejects several of the CLI's experimental
           # betas with HTTP 400, so they must be off on this path.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
@@ -242,12 +227,22 @@ jobs:
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
         run: |
+          : "${DATABRICKS_HOST:?Set the DATABRICKS_HOST repository variable}"
+          : "${DATABRICKS_CLIENT_ID:?Set the DATABRICKS_CLIENT_ID repository variable}"
+          : "${DATABRICKS_TOKEN_AUDIENCE:?Set the DATABRICKS_ACCOUNT_ID repository variable}"
+
+          # Absolute path: the helper runs with Claude's working directory, which
+          # the agent may change during the session.
+          jq -n --arg cmd "uv run --no-project $GITHUB_WORKSPACE/dev/mint_gateway_token.py" \
+            '{apiKeyHelper: $cmd}' > /tmp/claude-settings.json
+
           OUTPUT_FILE="/tmp/output.jsonl"
 
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
           EXIT_CODE=0
           timeout 20m claude \
+            --settings /tmp/claude-settings.json \
             --model "$MODEL" \
             --effort "$EFFORT" \
             --max-budget-usd 5 \
@@ -289,8 +284,8 @@ jobs:
       - name: Redact secrets from transcript
         if: always()
         env:
-          # ANTHROPIC_AUTH_TOKEN is already in the job env (set via GITHUB_ENV by
-          # the mint step), so it needs no binding here.
+          # No model credential to scrub: the Databricks token is minted inside
+          # Claude Code by `apiKeyHelper` and never reaches the job environment.
           GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
           GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
         run: |
@@ -303,7 +298,7 @@ jobs:
           if not path.exists():
               sys.exit(0)
           data = path.read_text()
-          for name in ("ANTHROPIC_AUTH_TOKEN", "GH_TOKEN_READ", "GH_TOKEN_WRITE"):
+          for name in ("GH_TOKEN_READ", "GH_TOKEN_WRITE"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
           path.write_text(data)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -102,6 +102,13 @@ jobs:
     # access, so its name is not review-specific.
     environment: ai-gateway
     timeout-minutes: 30
+    # Written by dev/mint_gateway_token.py, read by the steps that report token
+    # refreshes and scrub the transcript. Declared once at job level so those
+    # three steps cannot drift apart on the path — a silent rename would
+    # otherwise disable the scrubbing rather than fail.
+    env:
+      MINT_TOKEN_LOG: /tmp/mint-token.log
+      MINT_TOKEN_SECRETS: /tmp/minted-tokens
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -224,14 +231,9 @@ jobs:
           # workspace token endpoint URL, which the policy would reject.
           DATABRICKS_TOKEN_AUDIENCE: ${{ vars.DATABRICKS_ACCOUNT_ID }}
           ANTHROPIC_BASE_URL: ${{ vars.DATABRICKS_HOST }}/ai-gateway/anthropic
-          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "300000"
-          MINT_TOKEN_LOG: ${{ runner.temp }}/mint-token.log
-          # Every credential the helper mints, so the redaction step below can
-          # scrub it from the uploaded transcript. The agent shares this job's
-          # OIDC environment and can mint a token itself while reviewing an
-          # untrusted diff, and stream.sh tees raw tool output into that
-          # transcript.
-          MINT_TOKEN_SECRETS: ${{ runner.temp }}/minted-tokens
+          # Under the measured ~5 minute token lifetime, with margin. Setting it
+          # at the lifetime races the expiry rather than avoiding it.
+          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "120000"
           # The gateway's beta allowlist rejects several of the CLI's experimental
           # betas with HTTP 400, so they must be off on this path.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
@@ -269,6 +271,15 @@ jobs:
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
             echo "Error: Claude command failed with exit code $EXIT_CODE"
+            # This dumps the raw, unredacted transcript into the job log, ahead
+            # of the redaction step. A minted Databricks token is not a GitHub
+            # secret, so nothing masks it automatically the way it did when this
+            # ran on ANTHROPIC_API_KEY — register each one first.
+            if [ -s "$MINT_TOKEN_SECRETS" ]; then
+              while read -r token; do
+                [ -n "$token" ] && echo "::add-mask::$token"
+              done < "$MINT_TOKEN_SECRETS"
+            fi
             cat "$OUTPUT_FILE"
             exit $EXIT_CODE
           fi
@@ -281,8 +292,8 @@ jobs:
       - name: Report gateway token refreshes
         if: always()
         run: |
-          if [ -f "$RUNNER_TEMP/mint-token.log" ]; then
-            nl -ba "$RUNNER_TEMP/mint-token.log"
+          if [ -f "$MINT_TOKEN_LOG" ]; then
+            nl -ba "$MINT_TOKEN_LOG"
           else
             echo "apiKeyHelper never ran"
           fi
@@ -331,7 +342,7 @@ jobs:
           # minted itself. Without this the transcript has no model-credential
           # scrubbing, and it is uploaded as an artifact readable by anyone with
           # repo read access.
-          minted = Path(os.environ["RUNNER_TEMP"]) / "minted-tokens"
+          minted = Path(os.environ["MINT_TOKEN_SECRETS"])
           if minted.exists():
               for token in minted.read_text().split():
                   data = data.replace(token, "***")
@@ -395,7 +406,7 @@ jobs:
             const formatted = JSON.stringify(resultEvent, null, 2);
             resultLine += `\n<details><summary>${summary}</summary>\n\n\`\`\`json\n${formatted}\n\`\`\`\n\n</details>`;
             if (resultEvent.is_error && /529|Overloaded/i.test(resultEvent.result || '')) {
-              resultLine += `\n\nThe model gateway is overloaded. Inference is served by the Databricks AI Gateway, not the Anthropic API, so check the workspace status and retry.`;
+              resultLine += `\n\nThe Claude API is overloaded. Check [status.claude.com](https://status.claude.com/) and retry.`;
             }
           } else if (failed) {
             resultLine += `\n\nSee [workflow logs](${jobRunUrl}) for details.`;

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -87,12 +87,13 @@ jobs:
     # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
     # minted below, and `id-token: write` grants GITHUB_TOKEN no repo scope.
     #
-    # It does widen the blast radius on the Databricks side, though: it puts
+    # It does open a path on the Databricks side, though: it puts
     # ACTIONS_ID_TOKEN_REQUEST_TOKEN in the job env, which the agent shares while
     # reading untrusted diffs, so the agent can mint the service principal's token
-    # and reach anything that principal is entitled to — not only gateway
-    # inference. The bound is therefore the SP's own entitlements, which are kept
-    # to workspace access alone, plus the token's ~5 minute life.
+    # itself. Three things bound what that token can do — it is requested with the
+    # `ai-gateway` scope rather than `all-apis` so it only reaches inference, the
+    # principal's own entitlements are kept to workspace access alone, and it
+    # expires ~5 minutes after minting.
     permissions:
       id-token: write
     # The OIDC subject is pinned to `repo:<org>/<repo>:environment:ai-gateway`,
@@ -109,6 +110,13 @@ jobs:
     env:
       MINT_TOKEN_LOG: /tmp/mint-token.log
       MINT_TOKEN_SECRETS: /tmp/minted-tokens
+      # How often Claude Code re-invokes apiKeyHelper. This must stay below the
+      # federated token's real lifetime — measured at ~5 minutes, but Databricks
+      # owns that number and can change it, which is why the refresh report below
+      # compares the two rather than trusting this comment. Setting it at the
+      # lifetime races the expiry instead of avoiding it; an earlier revision
+      # minted once per job and died mid-review with `401 Invalid Token`.
+      CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "120000"
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -213,12 +221,9 @@ jobs:
       # the job environment. The gateway fronts Databricks-hosted Claude
       # endpoints, so no Anthropic API key exists anywhere in the chain.
       #
-      # Refreshing is mandatory, not an optimization: the federated token expires
-      # ~5 minutes after it is minted (measured from the token's own expiry — the
-      # ~1h figure in the docs describes U2M auth), far inside the 20m Claude cap
-      # below. The helper TTL is kept under that lifetime so the credential is
-      # replaced before it lapses.
-      # `databricks auth token` cannot serve as the helper — it is U2M-only.
+      # Refreshing is mandatory rather than an optimization; see the TTL in the
+      # job env above. `databricks auth token` cannot serve as the helper — it
+      # reads the U2M token cache and rejects machine-to-machine auth.
       - name: Review
         id: review
         env:
@@ -232,9 +237,6 @@ jobs:
           # workspace token endpoint URL, which the policy would reject.
           DATABRICKS_TOKEN_AUDIENCE: ${{ vars.DATABRICKS_ACCOUNT_ID }}
           ANTHROPIC_BASE_URL: ${{ vars.DATABRICKS_HOST }}/ai-gateway/anthropic
-          # Under the measured ~5 minute token lifetime, with margin. Setting it
-          # at the lifetime races the expiry rather than avoiding it.
-          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "120000"
           # The gateway's beta allowlist rejects several of the CLI's experimental
           # betas with HTTP 400, so they must be off on this path.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
@@ -245,6 +247,11 @@ jobs:
           : "${DATABRICKS_HOST:?Set the DATABRICKS_HOST repository variable}"
           : "${DATABRICKS_CLIENT_ID:?Set the DATABRICKS_CLIENT_ID repository variable}"
           : "${DATABRICKS_TOKEN_AUDIENCE:?Set the DATABRICKS_ACCOUNT_ID repository variable}"
+
+          # Resolve the helper's dependencies now. Its first invocation gates
+          # Claude's first API request, so a cold PyPI resolve there would surface
+          # as an opaque auth failure rather than an install failure.
+          uv sync --script "$GITHUB_WORKSPACE/dev/mint_gateway_token.py"
 
           # Absolute path: the helper runs with Claude's working directory, which
           # the agent may change during the session.
@@ -285,18 +292,24 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # One line per apiKeyHelper invocation. A single line means the session
-      # finished inside one token's life and the refresh path went untested;
-      # several lines prove it fired. The expiry timestamps are the only direct
-      # measure of the federated token's lifetime, which the TTL above must
-      # stay under.
+      # One line per apiKeyHelper invocation, and the only direct measurement of
+      # the token lifetime the TTL depends on.
       - name: Report gateway token refreshes
         if: always()
         run: |
-          if [ -f "$MINT_TOKEN_LOG" ]; then
-            nl -ba "$MINT_TOKEN_LOG"
-          else
+          if [ ! -f "$MINT_TOKEN_LOG" ]; then
             echo "apiKeyHelper never ran"
+            exit 0
+          fi
+          nl -ba "$MINT_TOKEN_LOG"
+
+          # Databricks owns the lifetime and can shorten it, which would silently
+          # reintroduce the mid-review 401 this TTL was chosen to avoid. Compare
+          # rather than trust.
+          ttl_s=$((CLAUDE_CODE_API_KEY_HELPER_TTL_MS / 1000))
+          shortest=$(grep -oE 'lifetime [0-9]+s' "$MINT_TOKEN_LOG" | grep -oE '[0-9]+' | sort -n | head -1)
+          if [ -n "$shortest" ] && [ "$shortest" -le "$ttl_s" ]; then
+            echo "::warning::Token lifetime ${shortest}s is not above the ${ttl_s}s refresh interval; the credential can lapse mid-session."
           fi
 
       - name: Validate review payload

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -85,40 +85,26 @@ jobs:
     needs: gate
     runs-on: ubuntu-latest
     # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
-    # minted below, and `id-token: write` grants GITHUB_TOKEN no repo scope.
-    #
-    # It does open a path on the Databricks side, though: it puts
-    # ACTIONS_ID_TOKEN_REQUEST_TOKEN in the job env, which the agent shares while
-    # reading untrusted diffs, so the agent can mint the service principal's token
-    # itself. Two things bound what that token can do — the principal's own
-    # entitlements are kept to workspace access alone, and the token expires
-    # ~5 minutes after minting. The `ai-gateway` scope this job requests is not
-    # one of them: scope is chosen by the exchange request and the federation
-    # policy pins only issuer, subject, and audience, so an agent replaying the
-    # exchange can ask for `all-apis` instead. The scope narrows the credential
-    # this job hands to Claude Code, not what an attacker can obtain.
+    # minted below, and `id-token: write` grants it no repo scope. It does put
+    # ACTIONS_ID_TOKEN_REQUEST_TOKEN in the job env, though, which the agent
+    # shares while reading untrusted diffs: it can mint the service principal's
+    # token itself, at any scope it likes. What bounds that is the principal's
+    # entitlements (workspace access only) and the ~5 minute expiry — not the
+    # `ai-gateway` scope this job requests, which the federation policy cannot
+    # pin.
     permissions:
       id-token: write
-    # The OIDC subject is pinned to `repo:<org>/<repo>:environment:ai-gateway`,
-    # which is stable across both triggers. Ref pinning would need two policies:
-    # `issue_comment` runs on the default branch, `pull_request` on the PR ref.
-    # The environment is shared by every workflow that needs gateway model
-    # access, so its name is not review-specific.
+    # Subject-pinned to `repo:<org>/<repo>:environment:ai-gateway`, which is
+    # stable across both triggers; ref pinning would need two policies, since
+    # `issue_comment` runs on the default branch and `pull_request` on the PR ref.
     environment: ai-gateway
     timeout-minutes: 30
-    # Written by dev/mint_gateway_token.py, read by the steps that report token
-    # refreshes and scrub the transcript. Declared once at job level so those
-    # three steps cannot drift apart on the path — a silent rename would
-    # otherwise disable the scrubbing rather than fail.
     env:
       MINT_TOKEN_LOG: /tmp/mint-token.log
       MINT_TOKEN_SECRETS: /tmp/minted-tokens
-      # How often Claude Code re-invokes apiKeyHelper. This must stay below the
-      # federated token's real lifetime — measured at ~5 minutes, but Databricks
-      # owns that number and can change it, which is why the refresh report below
-      # compares the two rather than trusting this comment. Setting it at the
-      # lifetime races the expiry instead of avoiding it; an earlier revision
-      # minted once per job and died mid-review with `401 Invalid Token`.
+      # Must stay below the federated token's lifetime, measured at ~5 minutes.
+      # Databricks owns that number, so the refresh report below checks it rather
+      # than trusting this comment.
       CLAUDE_CODE_API_KEY_HELPER_TTL_MS: "120000"
     steps:
       # Two app tokens with split scopes:
@@ -218,15 +204,10 @@ jobs:
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
-      # Workload identity federation: Claude Code invokes `apiKeyHelper` to
-      # exchange the job's GitHub OIDC JWT for a Databricks OAuth token, so no
-      # model credential is stored as a GitHub secret and none is ever written to
-      # the job environment. The gateway fronts Databricks-hosted Claude
-      # endpoints, so no Anthropic API key exists anywhere in the chain.
-      #
-      # Refreshing is mandatory rather than an optimization; see the TTL in the
-      # job env above. `databricks auth token` cannot serve as the helper — it
-      # reads the U2M token cache and rejects machine-to-machine auth.
+      # Claude Code's `apiKeyHelper` exchanges the job's GitHub OIDC JWT for a
+      # Databricks token, so no model credential is stored as a GitHub secret.
+      # The gateway fronts Databricks-hosted Claude endpoints, so there is no
+      # Anthropic API key anywhere in the chain.
       - name: Review
         id: review
         env:
@@ -235,9 +216,8 @@ jobs:
           DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
           DATABRICKS_AUTH_TYPE: github-oidc
-          # Must equal the `audiences` entry on the service principal's
-          # federation policy. Without it the SDK defaults the audience to the
-          # workspace token endpoint URL, which the policy would reject.
+          # Must equal the federation policy's `audiences`; the SDK otherwise
+          # defaults it to the token endpoint URL, which the policy rejects.
           DATABRICKS_TOKEN_AUDIENCE: ${{ vars.DATABRICKS_ACCOUNT_ID }}
           ANTHROPIC_BASE_URL: ${{ vars.DATABRICKS_HOST }}/ai-gateway/anthropic
           # The gateway's beta allowlist rejects several of the CLI's experimental
@@ -251,24 +231,17 @@ jobs:
           : "${DATABRICKS_CLIENT_ID:?Set the DATABRICKS_CLIENT_ID repository variable}"
           : "${DATABRICKS_TOKEN_AUDIENCE:?Set the DATABRICKS_ACCOUNT_ID repository variable}"
 
-          # Resolve the helper's dependencies now. Its first invocation gates
-          # Claude's first API request, so a cold PyPI resolve there would surface
-          # as an opaque auth failure rather than an install failure.
+          # Pre-resolve: the helper's first call gates Claude's first API request,
+          # where a cold PyPI resolve would look like an auth failure.
           uv sync --script "$GITHUB_WORKSPACE/dev/mint_gateway_token.py"
 
-          # Absolute path: the helper runs with Claude's working directory, which
-          # the agent may change during the session.
+          # Absolute path: the helper inherits Claude's working directory, which
+          # the agent may change.
           jq -n --arg cmd "uv run --no-project $GITHUB_WORKSPACE/dev/mint_gateway_token.py" \
             '{apiKeyHelper: $cmd}' > /tmp/claude-settings.json
 
           OUTPUT_FILE="/tmp/output.jsonl"
 
-          # Records the credentials this job hands to Claude Code so the redaction
-          # step can scrub them from the uploaded transcript. Deliberately not
-          # more than that: a token the agent exchanges itself never passes
-          # through the helper, so no amount of bookkeeping here can cover it.
-          # The real bounds are the principal's entitlements and the ~5 minute
-          # expiry, not this file.
           : > "$MINT_TOKEN_SECRETS"
           chmod 600 "$MINT_TOKEN_SECRETS"
 
@@ -291,11 +264,9 @@ jobs:
             echo "Warning: Claude command timed out after 20 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
             echo "Error: Claude command failed with exit code $EXIT_CODE"
-            # This dumps the raw, unredacted transcript into the job log, ahead of
-            # the redaction step. Re-register every credential synchronously: the
-            # background masker above may not have observed the most recent one,
-            # and a minted Databricks token is not a GitHub secret, so nothing
-            # masks it automatically the way it did under ANTHROPIC_API_KEY.
+            # Dumps the unredacted transcript into a public log, ahead of the
+            # redaction step. A minted token is not a GitHub secret, so nothing
+            # masks it the way it did under ANTHROPIC_API_KEY.
             if [ -s "$MINT_TOKEN_SECRETS" ]; then
               while read -r token; do
                 [ -n "$token" ] && echo "::add-mask::$token"
@@ -305,8 +276,8 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # One line per apiKeyHelper invocation, and the only direct measurement of
-      # the token lifetime the TTL depends on.
+      # One line per apiKeyHelper invocation, and the only measurement of the
+      # token lifetime the TTL depends on.
       - name: Report gateway token refreshes
         if: always()
         run: |
@@ -316,13 +287,11 @@ jobs:
           fi
           nl -ba "$MINT_TOKEN_LOG"
 
-          # Databricks owns the lifetime and can shorten it, which would silently
-          # reintroduce the mid-review 401 this TTL was chosen to avoid. Compare
-          # rather than trust.
+          # Databricks can shorten the lifetime, silently reintroducing the
+          # mid-review 401 the TTL was chosen to avoid.
           ttl_s=$((CLAUDE_CODE_API_KEY_HELPER_TTL_MS / 1000))
-          # `|| true`: steps run under `-eo pipefail`, so a log with no parseable
-          # lifetime would abort this step and fail the job after a review that
-          # actually succeeded, before it could be posted.
+          # `|| true`: under `-eo pipefail` an unparseable log would abort the
+          # step, failing the job after a review that actually succeeded.
           shortest=$(grep -oE 'lifetime [0-9]+s' "$MINT_TOKEN_LOG" | grep -oE '[0-9]+' | sort -n | head -1 || true)
           if [ -n "$shortest" ] && [ "$shortest" -le "$ttl_s" ]; then
             echo "::warning::Token lifetime ${shortest}s is not above the ${ttl_s}s refresh interval; the credential can lapse mid-session."

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -92,7 +92,7 @@ jobs:
     # reading untrusted diffs, so the agent can mint the service principal's token
     # and reach anything that principal is entitled to — not only gateway
     # inference. The bound is therefore the SP's own entitlements, which are kept
-    # to workspace access alone, plus the token's ~10 minute life.
+    # to workspace access alone, plus the token's ~5 minute life.
     permissions:
       id-token: write
     # The OIDC subject is pinned to `repo:<org>/<repo>:environment:ai-gateway`,
@@ -214,9 +214,10 @@ jobs:
       # endpoints, so no Anthropic API key exists anywhere in the chain.
       #
       # Refreshing is mandatory, not an optimization: the federated token expires
-      # in ~10 minutes (measured — the ~1h figure in the docs describes U2M
-      # tokens), well inside the 20m Claude cap below. The helper TTL is kept
-      # under that lifetime so the credential is replaced before it lapses.
+      # ~5 minutes after it is minted (measured from the token's own expiry — the
+      # ~1h figure in the docs describes U2M auth), far inside the 20m Claude cap
+      # below. The helper TTL is kept under that lifetime so the credential is
+      # replaced before it lapses.
       # `databricks auth token` cannot serve as the helper — it is U2M-only.
       - name: Review
         id: review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -85,9 +85,17 @@ jobs:
     needs: gate
     runs-on: ubuntu-latest
     # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
-    # minted below. Grant nothing so any future accidental use of GITHUB_TOKEN
-    # fails closed.
-    permissions: {}
+    # minted below. `id-token: write` grants GITHUB_TOKEN no repo scope; it only
+    # enables OIDC JWT issuance for the Databricks token exchange, so the
+    # fail-closed stance above is preserved.
+    permissions:
+      id-token: write
+    # The OIDC subject is pinned to `repo:<org>/<repo>:environment:ai-gateway`,
+    # which is stable across both triggers. Ref pinning would need two policies:
+    # `issue_comment` runs on the default branch, `pull_request` on the PR ref.
+    # The environment is shared by every workflow that needs gateway model
+    # access, so its name is not review-specific.
+    environment: ai-gateway
     timeout-minutes: 30
     steps:
       # Two app tokens with split scopes:
@@ -153,17 +161,26 @@ jobs:
           import os
           import sys
 
+          # The Databricks AI Gateway serves Claude through Foundation Model API
+          # endpoints, which are named `databricks-<model>` rather than by the
+          # first-party Anthropic IDs. The first-party IDs stay accepted as input
+          # so existing `/review -m claude-opus-5` comments keep working.
           MODEL_ALIASES = {
-              "fable": "claude-fable-5",
-              "opus": "claude-opus-5",
-              "sonnet": "claude-sonnet-5",
+              "fable": "databricks-claude-fable-5",
+              "opus": "databricks-claude-opus-5",
+              "sonnet": "databricks-claude-sonnet-5",
+              "claude-fable-5": "databricks-claude-fable-5",
+              "claude-opus-5": "databricks-claude-opus-5",
+              "claude-sonnet-5": "databricks-claude-sonnet-5",
           }
-          MODEL_CHOICES = [*MODEL_ALIASES, *MODEL_ALIASES.values()]
+          MODEL_CHOICES = [*MODEL_ALIASES, *dict.fromkeys(MODEL_ALIASES.values())]
           EFFORT_CHOICES = ["low", "medium", "high", "xhigh", "max"]
 
           labels = {l["name"] for l in json.loads(os.environ["LABELS_JSON"])}
           big = bool(labels & {"size/M", "size/L", "size/XL"})
-          default_model = "claude-opus-5" if big else "claude-sonnet-5"
+          default_model = (
+              "databricks-claude-opus-5" if big else "databricks-claude-sonnet-5"
+          )
 
           body = sys.stdin.read().removeprefix("/review")
 
@@ -178,12 +195,49 @@ jobs:
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
+      # Workload identity federation: the job's GitHub OIDC JWT is exchanged for
+      # a short-lived Databricks OAuth token, so no model credential is stored as
+      # a GitHub secret. The gateway fronts Databricks-hosted Claude endpoints,
+      # so there is no Anthropic API key anywhere in the chain.
+      #
+      # The token lives ~1h, well past this job's 30m ceiling, so a single
+      # exchange suffices and no refresh helper is needed. Workflows that can run
+      # longer would need Claude Code's `apiKeyHelper` to re-mint mid-session
+      # (note `databricks auth token` cannot do this — it is U2M-only).
+      - name: Mint Databricks gateway token
+        env:
+          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ vars.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_AUTH_TYPE: github-oidc
+          # Must equal the `audiences` entry on the service principal's
+          # federation policy. Without it the SDK defaults the audience to the
+          # workspace token endpoint URL, which the policy would reject.
+          DATABRICKS_TOKEN_AUDIENCE: ${{ vars.DATABRICKS_ACCOUNT_ID }}
+        run: |
+          : "${DATABRICKS_HOST:?Set the DATABRICKS_HOST repository variable}"
+          : "${DATABRICKS_CLIENT_ID:?Set the DATABRICKS_CLIENT_ID repository variable}"
+          : "${DATABRICKS_TOKEN_AUDIENCE:?Set the DATABRICKS_ACCOUNT_ID repository variable}"
+          # The SDK owns the OIDC exchange protocol (fetching the Actions JWT and
+          # POSTing it to the workspace token endpoint), so the shape of that
+          # exchange is not hand-rolled here.
+          TOKEN=$(uv run --no-project --with databricks-sdk python -c '
+          from databricks.sdk.core import Config
+          print(Config().authenticate()["Authorization"].split(" ", 1)[1])
+          ')
+          echo "::add-mask::$TOKEN"
+          {
+            echo "ANTHROPIC_AUTH_TOKEN=$TOKEN"
+            echo "ANTHROPIC_BASE_URL=${DATABRICKS_HOST%/}/ai-gateway/anthropic"
+          } >> "$GITHUB_ENV"
+
       - name: Review
         id: review
         env:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
-          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
+          # The gateway's beta allowlist rejects several of the CLI's experimental
+          # betas with HTTP 400, so they must be off on this path.
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
@@ -235,7 +289,8 @@ jobs:
       - name: Redact secrets from transcript
         if: always()
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
+          # ANTHROPIC_AUTH_TOKEN is already in the job env (set via GITHUB_ENV by
+          # the mint step), so it needs no binding here.
           GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
           GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
         run: |
@@ -248,7 +303,7 @@ jobs:
           if not path.exists():
               sys.exit(0)
           data = path.read_text()
-          for name in ("ANTHROPIC_API_KEY", "GH_TOKEN_READ", "GH_TOKEN_WRITE"):
+          for name in ("ANTHROPIC_AUTH_TOKEN", "GH_TOKEN_READ", "GH_TOKEN_WRITE"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
           path.write_text(data)

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -1,0 +1,47 @@
+# /// script
+# dependencies = ["databricks-sdk"]
+# ///
+"""Mint a short-lived Databricks OAuth token from a GitHub Actions OIDC JWT.
+
+`review.yml` routes Claude Code through the Databricks AI Gateway rather than the
+Anthropic API, so it needs a Databricks bearer token instead of an API key. The
+token comes from workload identity federation: GitHub issues an OIDC JWT scoped to
+the job, and the service principal's federation policy exchanges it for an OAuth
+token. Nothing is stored as a GitHub secret.
+
+The Databricks CLI cannot do this. `databricks auth token` reads the U2M token
+cache and explicitly rejects machine-to-machine auth, so the SDK owns the exchange.
+
+`DATABRICKS_TOKEN_AUDIENCE` must equal the `audiences` entry on the federation
+policy. Without it the SDK defaults the audience to the workspace token endpoint
+URL, which the policy rejects as a mismatch.
+
+Usage:
+  DATABRICKS_AUTH_TYPE=github-oidc uv run dev/mint_gateway_token.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from databricks.sdk.core import Config
+
+
+def main() -> None:
+    cfg = Config()
+    scheme, _, token = cfg.authenticate()["Authorization"].partition(" ")
+    if scheme != "Bearer" or not token:
+        sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {scheme!r}")
+    # Diagnostics go to stderr so stdout stays consumable as the bare credential.
+    # The federated token's lifetime is far shorter than a U2M token's (~10 min
+    # observed, not the ~1h the docs quote for U2M), and the caller's refresh
+    # interval has to stay inside it.
+    try:
+        print(f"Databricks token expires at {cfg.oauth_token().expiry}", file=sys.stderr)
+    except Exception as e:  # diagnostics must never fail the exchange
+        print(f"Could not read token expiry: {e}", file=sys.stderr)
+    print(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -90,15 +90,15 @@ def log_diagnostics(expiry: datetime | None) -> None:
 def record_token(token: str) -> None:
     """Append the minted credential to ``MINT_TOKEN_SECRETS`` for later scrubbing.
 
-    A CI caller shares its job environment with whatever it runs, so an agent can
-    mint a token itself, and a transcript that tees raw tool output will capture
-    it. Recording every minted value gives a redaction step something concrete to
-    scrub; the alternative is a transcript with no credential scrubbing at all.
+    This covers only the credentials handed out by this script. A caller shares
+    its environment with whatever else it runs, so an agent can perform its own
+    exchange and obtain a token this file never sees — that residual exposure is
+    bounded by the principal's entitlements and the token's short life, not here.
     """
     if not (path := os.environ.get("MINT_TOKEN_SECRETS")):
         return
     try:
-        with open(path, "a", opener=lambda p, f: os.open(p, f, 0o600)) as f:
+        with open(path, "a") as f:
             f.write(f"{token}\n")
     except OSError as e:
         print(f"Could not write {path}: {e}", file=sys.stderr)

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -1,32 +1,22 @@
 # /// script
 # dependencies = ["databricks-sdk"]
 # [tool.uv]
-# # Mirrors pyproject.toml's cooldown. `uv run --no-project` skips project
-# # discovery, so without this the repo's 7-day guard against freshly-published
-# # (possibly compromised) releases would not cover a dependency installed on a
-# # job that holds an OIDC identity.
+# # `uv run --no-project` skips project discovery, so pyproject's cooldown would
+# # not otherwise cover this dependency.
 # exclude-newer = "P7D"
 # ///
 """Mint a short-lived Databricks OAuth token from a GitHub Actions OIDC JWT.
 
-`review.yml` routes Claude Code through the Databricks AI Gateway rather than the
-Anthropic API, so it needs a Databricks bearer token instead of an API key. The
-token comes from workload identity federation: GitHub issues an OIDC JWT scoped to
-the job, and the service principal's federation policy exchanges it for an OAuth
-token. Nothing is stored as a GitHub secret.
-
-The Databricks CLI cannot do this. `databricks auth token` reads the U2M token
-cache and explicitly rejects machine-to-machine auth, so the SDK owns the exchange.
+`databricks auth token` cannot do this — it reads the U2M token cache and rejects
+machine-to-machine auth — so the SDK owns the exchange.
 
 `DATABRICKS_TOKEN_AUDIENCE` must equal the `audiences` entry on the federation
-policy. Without it the SDK defaults the audience to the workspace token endpoint
-URL, which the policy rejects as a mismatch.
+policy; the SDK otherwise defaults it to the workspace token endpoint URL, which
+the policy rejects.
 
 Usage:
   DATABRICKS_HOST=... DATABRICKS_CLIENT_ID=... DATABRICKS_TOKEN_AUDIENCE=... \
     DATABRICKS_AUTH_TYPE=github-oidc uv run dev/mint_gateway_token.py
-
-`MINT_TOKEN_LOG` and `MINT_TOKEN_SECRETS` are optional; see the functions below.
 """
 
 from __future__ import annotations
@@ -41,13 +31,8 @@ from databricks.sdk.oauth import Token
 
 
 def mint(cfg: Config, attempts: int = 3) -> Token:
-    """Exchange the OIDC JWT for a Databricks token, retrying transient failures.
-
-    The SDK posts to the token endpoint with a bare ``requests.post`` and no retry
-    adapter. A caller that refreshes every couple of minutes runs this many times
-    per session, so a single transient 5xx or network blip would end the session —
-    exactly the failure the refresh exists to prevent.
-    """
+    # The SDK's exchange is a bare `requests.post` with no retry adapter, and a
+    # refreshing caller runs it many times per session.
     for attempt in range(1, attempts + 1):
         try:
             return cfg.oauth_token()
@@ -61,20 +46,14 @@ def mint(cfg: Config, attempts: int = 3) -> Token:
 
 
 def log_diagnostics(expiry: datetime | None) -> None:
-    """Record when this token was minted and how long it is valid for.
+    """Log the token's lifetime, which callers size their refresh interval against.
 
-    Stdout is reserved for the bare credential, and a caller like Claude Code's
-    `apiKeyHelper` captures stderr into its own process, so a stderr-only line
-    never reaches the surrounding log. ``MINT_TOKEN_LOG`` makes the line count
-    (did a refresh fire?) and the lifetime observable to whoever set the caller's
-    refresh interval.
-
-    Diagnostics must never fail the exchange, so every step here is best-effort.
+    Stdout is the credential and `apiKeyHelper` swallows stderr, so `MINT_TOKEN_LOG`
+    is the only channel that reaches the surrounding log. Best-effort throughout:
+    diagnostics must never fail the exchange.
     """
-    # The SDK builds `expiry` from a naive local `datetime.now()`, so measuring it
-    # against an aware UTC clock is only accidentally correct on UTC runners.
-    # Match whatever tzinfo it carries — `datetime.now(None)` is naive local — and
-    # log the lifetime directly rather than leaving a subtraction to the reader.
+    # The SDK builds `expiry` from a naive local `datetime.now()`, so an aware UTC
+    # clock would only match on UTC runners. `datetime.now(None)` is naive local.
     now = datetime.now(expiry.tzinfo) if expiry else None
     lifetime = f"{(expiry - now).total_seconds():.0f}s" if expiry and now else "unknown"
     line = f"{datetime.now(timezone.utc).isoformat()} minted, lifetime {lifetime}"
@@ -88,12 +67,10 @@ def log_diagnostics(expiry: datetime | None) -> None:
 
 
 def record_token(token: str) -> None:
-    """Append the minted credential to ``MINT_TOKEN_SECRETS`` for later scrubbing.
+    """Record the credential for the caller to scrub from its logs.
 
-    This covers only the credentials handed out by this script. A caller shares
-    its environment with whatever else it runs, so an agent can perform its own
-    exchange and obtain a token this file never sees — that residual exposure is
-    bounded by the principal's entitlements and the token's short life, not here.
+    Covers only what this script hands out; an agent sharing the environment can
+    run its own exchange and obtain a token this never sees.
     """
     if not (path := os.environ.get("MINT_TOKEN_SECRETS")):
         return
@@ -105,24 +82,18 @@ def record_token(token: str) -> None:
 
 
 def main() -> None:
-    # Narrow the credential to gateway inference. The SDK's default `all-apis`
-    # would let a leaked token reach any workspace API the principal is entitled
-    # to, which is a wider blast radius than the Anthropic API key this replaces;
-    # `ai-gateway` is advertised by the workspace's OIDC discovery document and is
-    # the only capability a review actually needs.
+    # `ai-gateway` rather than the default `all-apis`: it is all a review needs.
+    # Not a control on an attacker, who can request any scope — see review.yml.
     cfg = Config(scopes=["ai-gateway"])
-    # This script prints a credential on stdout, so it must never be reachable by
-    # ambient auth. Without this guard, running it on a developer machine happily
-    # resolves the default ~/.databrickscfg profile and prints that PAT instead.
+    # This prints a credential on stdout, so ambient auth must never reach it —
+    # otherwise running it locally prints the default profile's PAT.
     if cfg.auth_type != "github-oidc":
         sys.exit(
             f"Refusing to print a {cfg.auth_type!r} credential. This script mints a "
             "federated token for CI; set DATABRICKS_AUTH_TYPE=github-oidc."
         )
-    # One exchange, and everything derived from it. The SDK builds a fresh
-    # credentials source per call, so `authenticate()` and `oauth_token()` each
-    # hit the token endpoint and return *different* tokens — calling both would
-    # print one credential while logging and scrubbing another.
+    # One exchange: the SDK mints a fresh token per call, so asking twice would
+    # print one credential and log another's expiry.
     token = mint(cfg)
     if token.token_type != "Bearer" or not token.access_token:
         sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {token.token_type!r}")

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -38,7 +38,7 @@ from datetime import datetime, timezone
 from databricks.sdk.core import Config
 
 
-def log_diagnostics(cfg: Config) -> None:
+def log_diagnostics(expiry: datetime | None) -> None:
     """Record when this token was minted and when it expires.
 
     Stdout is reserved for the bare credential, and a caller like Claude Code's
@@ -50,10 +50,6 @@ def log_diagnostics(cfg: Config) -> None:
 
     Diagnostics must never fail the exchange, so every step here is best-effort.
     """
-    try:
-        expiry = str(cfg.oauth_token().expiry)
-    except Exception as e:
-        expiry = f"unavailable ({e})"
     line = f"{datetime.now(timezone.utc).isoformat()} minted, expires {expiry}"
     print(line, file=sys.stderr)
     if path := os.environ.get("MINT_TOKEN_LOG"):
@@ -91,12 +87,16 @@ def main() -> None:
             f"Refusing to print a {cfg.auth_type!r} credential. This script mints a "
             "federated token for CI; set DATABRICKS_AUTH_TYPE=github-oidc."
         )
-    scheme, _, token = cfg.authenticate()["Authorization"].partition(" ")
-    if scheme != "Bearer" or not token:
-        sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {scheme!r}")
-    log_diagnostics(cfg)
-    record_token(token)
-    print(token)
+    # One exchange, and everything derived from it. The SDK builds a fresh
+    # credentials source per call, so `authenticate()` and `oauth_token()` each
+    # hit the token endpoint and return *different* tokens — calling both would
+    # print one credential while logging and scrubbing another.
+    token = cfg.oauth_token()
+    if token.token_type != "Bearer" or not token.access_token:
+        sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {token.token_type!r}")
+    log_diagnostics(token.expiry)
+    record_token(token.access_token)
+    print(token.access_token)
 
 
 if __name__ == "__main__":

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -1,5 +1,11 @@
 # /// script
 # dependencies = ["databricks-sdk"]
+# [tool.uv]
+# # Mirrors pyproject.toml's cooldown. `uv run --no-project` skips project
+# # discovery, so without this the repo's 7-day guard against freshly-published
+# # (possibly compromised) releases would not cover a dependency installed on a
+# # job that holds an OIDC identity.
+# exclude-newer = "P7D"
 # ///
 """Mint a short-lived Databricks OAuth token from a GitHub Actions OIDC JWT.
 
@@ -77,6 +83,14 @@ def record_token(token: str) -> None:
 
 def main() -> None:
     cfg = Config()
+    # This script prints a credential on stdout, so it must never be reachable by
+    # ambient auth. Without this guard, running it on a developer machine happily
+    # resolves the default ~/.databrickscfg profile and prints that PAT instead.
+    if cfg.auth_type != "github-oidc":
+        sys.exit(
+            f"Refusing to print a {cfg.auth_type!r} credential. This script mints a "
+            "federated token for CI; set DATABRICKS_AUTH_TYPE=github-oidc."
+        )
     scheme, _, token = cfg.authenticate()["Authorization"].partition(" ")
     if scheme != "Bearer" or not token:
         sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {scheme!r}")

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -33,9 +33,31 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from datetime import datetime, timezone
 
 from databricks.sdk.core import Config
+from databricks.sdk.oauth import Token
+
+
+def mint(cfg: Config, attempts: int = 3) -> Token:
+    """Exchange the OIDC JWT for a Databricks token, retrying transient failures.
+
+    The SDK posts to the token endpoint with a bare ``requests.post`` and no retry
+    adapter. A caller that refreshes every couple of minutes runs this many times
+    per session, so a single transient 5xx or network blip would end the session —
+    exactly the failure the refresh exists to prevent.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return cfg.oauth_token()
+        except Exception as e:
+            if attempt == attempts:
+                raise
+            delay = 2 ** (attempt - 1)
+            print(f"Token exchange failed ({e}); retrying in {delay}s", file=sys.stderr)
+            time.sleep(delay)
+    raise AssertionError("unreachable")
 
 
 def log_diagnostics(expiry: datetime | None) -> None:
@@ -101,7 +123,7 @@ def main() -> None:
     # credentials source per call, so `authenticate()` and `oauth_token()` each
     # hit the token endpoint and return *different* tokens — calling both would
     # print one credential while logging and scrubbing another.
-    token = cfg.oauth_token()
+    token = mint(cfg)
     if token.token_type != "Bearer" or not token.access_token:
         sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {token.token_type!r}")
     log_diagnostics(token.expiry)

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -39,18 +39,23 @@ from databricks.sdk.core import Config
 
 
 def log_diagnostics(expiry: datetime | None) -> None:
-    """Record when this token was minted and when it expires.
+    """Record when this token was minted and how long it is valid for.
 
     Stdout is reserved for the bare credential, and a caller like Claude Code's
     `apiKeyHelper` captures stderr into its own process, so a stderr-only line
-    never reaches the surrounding log. Appending to ``MINT_TOKEN_LOG`` keeps both
-    facts observable: the line count shows whether a refresh actually fired, and
-    the expiry timestamps give the federated token's real lifetime, which any
-    caller's refresh interval has to stay under.
+    never reaches the surrounding log. ``MINT_TOKEN_LOG`` makes the line count
+    (did a refresh fire?) and the lifetime observable to whoever set the caller's
+    refresh interval.
 
     Diagnostics must never fail the exchange, so every step here is best-effort.
     """
-    line = f"{datetime.now(timezone.utc).isoformat()} minted, expires {expiry}"
+    # The SDK builds `expiry` from a naive local `datetime.now()`, so measuring it
+    # against an aware UTC clock is only accidentally correct on UTC runners.
+    # Match whatever tzinfo it carries — `datetime.now(None)` is naive local — and
+    # log the lifetime directly rather than leaving a subtraction to the reader.
+    now = datetime.now(expiry.tzinfo) if expiry else None
+    lifetime = f"{(expiry - now).total_seconds():.0f}s" if expiry and now else "unknown"
+    line = f"{datetime.now(timezone.utc).isoformat()} minted, lifetime {lifetime}"
     print(line, file=sys.stderr)
     if path := os.environ.get("MINT_TOKEN_LOG"):
         try:
@@ -78,7 +83,12 @@ def record_token(token: str) -> None:
 
 
 def main() -> None:
-    cfg = Config()
+    # Narrow the credential to gateway inference. The SDK's default `all-apis`
+    # would let a leaked token reach any workspace API the principal is entitled
+    # to, which is a wider blast radius than the Anthropic API key this replaces;
+    # `ai-gateway` is advertised by the workspace's OIDC discovery document and is
+    # the only capability a review actually needs.
+    cfg = Config(scopes=["ai-gateway"])
     # This script prints a credential on stdout, so it must never be reachable by
     # ambient auth. Without this guard, running it on a developer machine happily
     # resolves the default ~/.databrickscfg profile and prints that PAT instead.

--- a/dev/mint_gateway_token.py
+++ b/dev/mint_gateway_token.py
@@ -17,14 +17,62 @@ policy. Without it the SDK defaults the audience to the workspace token endpoint
 URL, which the policy rejects as a mismatch.
 
 Usage:
-  DATABRICKS_AUTH_TYPE=github-oidc uv run dev/mint_gateway_token.py
+  DATABRICKS_HOST=... DATABRICKS_CLIENT_ID=... DATABRICKS_TOKEN_AUDIENCE=... \
+    DATABRICKS_AUTH_TYPE=github-oidc uv run dev/mint_gateway_token.py
+
+`MINT_TOKEN_LOG` and `MINT_TOKEN_SECRETS` are optional; see the functions below.
 """
 
 from __future__ import annotations
 
+import os
 import sys
+from datetime import datetime, timezone
 
 from databricks.sdk.core import Config
+
+
+def log_diagnostics(cfg: Config) -> None:
+    """Record when this token was minted and when it expires.
+
+    Stdout is reserved for the bare credential, and a caller like Claude Code's
+    `apiKeyHelper` captures stderr into its own process, so a stderr-only line
+    never reaches the surrounding log. Appending to ``MINT_TOKEN_LOG`` keeps both
+    facts observable: the line count shows whether a refresh actually fired, and
+    the expiry timestamps give the federated token's real lifetime, which any
+    caller's refresh interval has to stay under.
+
+    Diagnostics must never fail the exchange, so every step here is best-effort.
+    """
+    try:
+        expiry = str(cfg.oauth_token().expiry)
+    except Exception as e:
+        expiry = f"unavailable ({e})"
+    line = f"{datetime.now(timezone.utc).isoformat()} minted, expires {expiry}"
+    print(line, file=sys.stderr)
+    if path := os.environ.get("MINT_TOKEN_LOG"):
+        try:
+            with open(path, "a") as f:
+                f.write(f"{line}\n")
+        except OSError as e:
+            print(f"Could not write {path}: {e}", file=sys.stderr)
+
+
+def record_token(token: str) -> None:
+    """Append the minted credential to ``MINT_TOKEN_SECRETS`` for later scrubbing.
+
+    A CI caller shares its job environment with whatever it runs, so an agent can
+    mint a token itself, and a transcript that tees raw tool output will capture
+    it. Recording every minted value gives a redaction step something concrete to
+    scrub; the alternative is a transcript with no credential scrubbing at all.
+    """
+    if not (path := os.environ.get("MINT_TOKEN_SECRETS")):
+        return
+    try:
+        with open(path, "a", opener=lambda p, f: os.open(p, f, 0o600)) as f:
+            f.write(f"{token}\n")
+    except OSError as e:
+        print(f"Could not write {path}: {e}", file=sys.stderr)
 
 
 def main() -> None:
@@ -32,14 +80,8 @@ def main() -> None:
     scheme, _, token = cfg.authenticate()["Authorization"].partition(" ")
     if scheme != "Bearer" or not token:
         sys.exit(f"Expected a Bearer credential from the OIDC exchange, got {scheme!r}")
-    # Diagnostics go to stderr so stdout stays consumable as the bare credential.
-    # The federated token's lifetime is far shorter than a U2M token's (~10 min
-    # observed, not the ~1h the docs quote for U2M), and the caller's refresh
-    # interval has to stay inside it.
-    try:
-        print(f"Databricks token expires at {cfg.oauth_token().expiry}", file=sys.stderr)
-    except Exception as e:  # diagnostics must never fail the exchange
-        print(f"Could not read token expiry: {e}", file=sys.stderr)
+    log_diagnostics(cfg)
+    record_token(token)
     print(token)
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #none

### What changes are proposed in this pull request?

Replaces the `ANTHROPIC_API_KEY` secret in `review.yml` with GitHub OIDC workload identity federation.

Claude Code's `apiKeyHelper` runs `dev/mint_gateway_token.py`, which exchanges the job's OIDC JWT for a short-lived Databricks token, and inference goes to the workspace AI Gateway. The gateway fronts Databricks-hosted Claude endpoints, so **no Anthropic credential exists anywhere in the chain** — the key is removed, not relocated.

- `permissions: {}` becomes `{id-token: write}`, and the job joins the `ai-gateway` environment, which pins the OIDC subject to `repo:mlflow/mlflow:environment:ai-gateway`. That subject is stable across both triggers; ref pinning would need two policies.
- Models map to the gateway's Foundation Model API names (`databricks-claude-*`). The first-party IDs stay accepted as input, so existing `/review -m claude-opus-5` comments keep working.
- `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` is required — the gateway's beta allowlist rejects several of the CLI's experimental betas with HTTP 400.
- Refresh is mandatory, not an optimization: the federated token's measured lifetime is ~298s, so the helper TTL is 2 minutes and a step compares the two on every run. `databricks auth token` cannot serve as the helper; it reads the U2M token cache and rejects M2M auth.

Configuration lives on the `ai-gateway` environment as variables (`DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID`, `DATABRICKS_ACCOUNT_ID`) rather than secrets — none is a credential, and masking them would make diagnosis harder.

**Security tradeoff, stated plainly.** This removes a durable, inference-only credential and introduces an ephemeral, broader one. `id-token: write` puts `ACTIONS_ID_TOKEN_REQUEST_TOKEN` in the job env, which the agent shares while reading untrusted diffs, so the agent can mint the service principal's token itself — at any scope, since the federation policy API has no scope field. What bounds it is the principal's entitlements (workspace access only; no group memberships, no Unity Catalog grants) and the ~5 minute expiry. In exchange, nothing durable is stored in GitHub, and revocation is a policy edit rather than a rotation across every consumer.

**Debugging:** `databricks current-user me` with the same four env vars isolates a federation problem (policy, subject, audience, workspace assignment) from a downstream one.

### How is this PR tested?

- [x] Manual tests

The `pull_request` trigger fires on changes to `review.yml`, running `/pr-review` end to end against this PR with the Post step gated off. Verified across several runs: OIDC issuance, token exchange, refresh (5 mints across an 11-minute session, spanning multiple token lifetimes with no 401), gateway auth, and real reviews produced on `databricks-claude-{opus,sonnet,fable}-5`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
