### PR TITLE
[Custom View] Focus Assistant composer on authoring actions

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -30,6 +30,7 @@ const mockSendMessage = jest.fn();
 const mockSelectProvider = jest.fn();
 const mockCancelSession = jest.fn();
 const mockClearPendingPrompt = jest.fn();
+const mockClearComposerFocusRequest = jest.fn();
 const mockSendPendingAutomaticMessage = jest.fn();
 const mockRefreshConfig = jest.fn((options?: { silent?: boolean }) => {
   void options;
@@ -38,6 +39,7 @@ const mockRefreshConfig = jest.fn((options?: { silent?: boolean }) => {
 const mockRespondToPermission = jest.fn();
 let mockSetupComplete = true;
 let mockPendingPrompt: string | null = null;
+let mockPendingComposerFocus = false;
 let mockPendingAutomaticMessage: PendingAutomaticMessage | null = null;
 let mockActiveProvider: ResolvedProviderInfo | null = null;
 let mockProviders: ProviderInfo[] = [];
@@ -88,6 +90,7 @@ jest.mock('./AssistantContext', () => ({
     gatewayVendorOptions: mockGatewayVendorOptions,
     needsApiKey: mockNeedsApiKey,
     pendingPrompt: mockPendingPrompt,
+    pendingComposerFocus: mockPendingComposerFocus,
     pendingAutomaticMessage: mockPendingAutomaticMessage,
     canUseAssistant: mockCanUseAssistant,
     tokenUsage: mockTokenUsage,
@@ -99,6 +102,8 @@ jest.mock('./AssistantContext', () => ({
     selectProvider: mockSelectProvider,
     prefillPrompt: jest.fn(),
     clearPendingPrompt: mockClearPendingPrompt,
+    requestComposerFocus: jest.fn(),
+    clearComposerFocusRequest: mockClearComposerFocusRequest,
     regenerateLastMessage: jest.fn(),
     reset: jest.fn(),
     cancelSession: mockCancelSession,
@@ -129,13 +134,15 @@ jest.mock('../common/utils/RoutingUtils', () => ({
 const renderChatPanel = () => {
   // The settings escape hatch mounts a config hook that needs a QueryClient.
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return renderWithIntl(
+  const panel = () => (
     <QueryClientProvider client={queryClient}>
       <DesignSystemProvider>
         <AssistantChatPanel />
       </DesignSystemProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const result = renderWithIntl(panel());
+  return { ...result, rerenderChatPanel: () => result.rerender(panel()) };
 };
 
 describe('AssistantChatPanel', () => {
@@ -146,12 +153,14 @@ describe('AssistantChatPanel', () => {
     mockSelectProvider.mockClear();
     mockCancelSession.mockClear();
     mockClearPendingPrompt.mockClear();
+    mockClearComposerFocusRequest.mockClear();
     mockSendPendingAutomaticMessage.mockClear();
     mockRefreshConfig.mockClear();
     mockRespondToPermission.mockClear();
     mockUpdateConfig.mockClear();
     mockSetupComplete = true;
     mockPendingPrompt = null;
+    mockPendingComposerFocus = false;
     mockPendingAutomaticMessage = null;
     mockActiveProvider = null;
     mockProviders = [];
@@ -199,7 +208,7 @@ describe('AssistantChatPanel', () => {
   test('seed waits while setup is incomplete, then prefills the input after setup completes', async () => {
     mockSetupComplete = false;
     mockPendingPrompt = 'SEED';
-    const { rerender } = renderChatPanel();
+    const { rerenderChatPanel } = renderChatPanel();
 
     // Setup prompt is shown; no input yet; the seed has NOT been consumed.
     expect(screen.getByText('Welcome to MLflow Assistant')).toBeInTheDocument();
@@ -209,15 +218,54 @@ describe('AssistantChatPanel', () => {
 
     // Setup completes (provider selected) — ChatPanelContent mounts and consumes the seed.
     mockSetupComplete = true;
-    rerender(
-      <DesignSystemProvider>
-        <AssistantChatPanel />
-      </DesignSystemProvider>,
-    );
+    rerenderChatPanel();
 
     const textarea = await screen.findByDisplayValue('SEED');
     expect(textarea.tagName).toBe('TEXTAREA');
     expect(mockClearPendingPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  test('a focus-only request focuses the composer without changing its text', async () => {
+    mockPendingComposerFocus = true;
+    renderChatPanel();
+
+    const textarea = screen.getByPlaceholderText('Ask a question...');
+    await waitFor(() => expect(textarea).toHaveFocus());
+    expect(textarea).toHaveValue('');
+    expect(mockClearComposerFocusRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('a focus request waits for setup before focusing the composer', async () => {
+    mockSetupComplete = false;
+    mockPendingComposerFocus = true;
+    const { rerenderChatPanel } = renderChatPanel();
+
+    expect(screen.queryByPlaceholderText('Ask a question...')).not.toBeInTheDocument();
+    expect(mockClearComposerFocusRequest).not.toHaveBeenCalled();
+
+    mockSetupComplete = true;
+    rerenderChatPanel();
+
+    const textarea = await screen.findByPlaceholderText('Ask a question...');
+    await waitFor(() => expect(textarea).toHaveFocus());
+    expect(mockClearComposerFocusRequest).toHaveBeenCalledTimes(1);
+  });
+
+  test('a focus request refocuses an open composer without replacing draft text', async () => {
+    const user = userEvent.setup();
+    const { rerenderChatPanel } = renderChatPanel();
+    const textarea = screen.getByPlaceholderText('Ask a question...');
+    await user.type(textarea, 'draft edit request');
+    textarea.blur();
+    expect(textarea).not.toHaveFocus();
+
+    mockPendingComposerFocus = true;
+    rerenderChatPanel();
+
+    const refocusedTextarea = await screen.findByPlaceholderText('Ask a question...');
+    await waitFor(() => expect(refocusedTextarea).toHaveFocus());
+    expect(refocusedTextarea).toHaveValue('draft edit request');
+    expect(mockClearComposerFocusRequest).toHaveBeenCalledTimes(1);
   });
 
   test('renders a textarea for chat input', () => {

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.test.tsx
@@ -30,6 +30,7 @@ const mockSendMessage = jest.fn();
 const mockSelectProvider = jest.fn();
 const mockCancelSession = jest.fn();
 const mockClearPendingPrompt = jest.fn();
+const mockClearComposerFocusRequest = jest.fn();
 const mockForceSendPendingAutomaticMessage = jest.fn();
 const mockRefreshConfig = jest.fn((options?: { silent?: boolean }) => {
   void options;
@@ -152,6 +153,7 @@ describe('AssistantChatPanel', () => {
     mockSelectProvider.mockClear();
     mockCancelSession.mockClear();
     mockClearPendingPrompt.mockClear();
+    mockClearComposerFocusRequest.mockClear();
     mockForceSendPendingAutomaticMessage.mockClear();
     mockRefreshConfig.mockClear();
     mockRespondToPermission.mockClear();

--- a/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
+++ b/mlflow/server/js/src/assistant/AssistantChatPanel.tsx
@@ -442,6 +442,8 @@ const ChatPanelContent = ({ onOpenSettings }: { onOpenSettings: () => void }) =>
     refreshConfig,
     pendingPrompt,
     clearPendingPrompt,
+    pendingComposerFocus,
+    clearComposerFocusRequest,
     pendingAutomaticMessage,
     sendPendingAutomaticMessage,
     pendingPermission,
@@ -478,6 +480,13 @@ const ChatPanelContent = ({ onOpenSettings }: { onOpenSettings: () => void }) =>
       textareaRef.current?.focus();
     }
   }, [pendingPrompt, clearPendingPrompt]);
+
+  useEffect(() => {
+    if (pendingComposerFocus) {
+      textareaRef.current?.focus();
+      clearComposerFocusRequest();
+    }
+  }, [pendingComposerFocus, clearComposerFocusRequest]);
 
   // Deliver a message, first collecting the resolved provider's API key when it
   // is still missing (the ideal-flow popup: the first send doubles as setup).

--- a/mlflow/server/js/src/assistant/AssistantContext.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.test.tsx
@@ -382,6 +382,45 @@ describe('AssistantContext — pendingPrompt seed', () => {
   });
 });
 
+describe('AssistantContext — composer focus request', () => {
+  it('sets and clears a focus-only request', async () => {
+    const { result } = await renderAssistant();
+    expect(result.current.pendingComposerFocus).toBe(false);
+
+    act(() => {
+      result.current.requestComposerFocus();
+    });
+    expect(result.current.pendingComposerFocus).toBe(true);
+
+    act(() => {
+      result.current.clearComposerFocusRequest();
+    });
+    expect(result.current.pendingComposerFocus).toBe(false);
+  });
+
+  it('abandons an unconsumed focus request when the panel closes', async () => {
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.requestComposerFocus();
+      result.current.closePanel();
+    });
+
+    expect(result.current.pendingComposerFocus).toBe(false);
+  });
+
+  it('preserves a focus request across a fresh-session reset', async () => {
+    const { result } = await renderAssistant();
+
+    act(() => {
+      result.current.requestComposerFocus();
+      result.current.reset();
+    });
+
+    expect(result.current.pendingComposerFocus).toBe(true);
+  });
+});
+
 describe('AssistantContext — automatic message delivery', () => {
   it('sends immediately when a configured provider is ready', async () => {
     mockGetProviders.mockResolvedValue({

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -303,6 +303,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
   const [pendingPermission, setPendingPermission] = useState<PermissionRequest | null>(null);
   const [pendingClientToolCall, setPendingClientToolCall] = useState<PendingClientToolCall | null>(null);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [pendingComposerFocus, setPendingComposerFocus] = useState(false);
   const [pendingAutomaticMessage, setPendingAutomaticMessage] = useState<PendingAutomaticMessage | null>(null);
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>(() => normalizeTokenUsage(persistedChat.tokenUsage));
 
@@ -820,11 +821,14 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     // Drop any queued prompt — closing the panel is an abandon, so a stale seed shouldn't
     // inject into an unrelated chat opened later.
     setPendingPrompt(null);
+    setPendingComposerFocus(false);
     setPendingAutomaticMessage(null);
   }, [setIsPanelOpen]);
 
   const prefillPrompt = useCallback((prompt: string) => setPendingPrompt(prompt), []);
   const clearPendingPrompt = useCallback(() => setPendingPrompt(null), []);
+  const requestComposerFocus = useCallback(() => setPendingComposerFocus(true), []);
+  const clearComposerFocusRequest = useCallback(() => setPendingComposerFocus(false), []);
 
   const reset = useCallback(() => {
     // Invalidate any in-flight send still awaiting its POST: its captured token no longer matches,
@@ -1287,6 +1291,7 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     gatewayVendorOptions,
     needsApiKey,
     pendingPrompt,
+    pendingComposerFocus,
     pendingAutomaticMessage,
     pendingPermission,
     pendingClientToolCall,
@@ -1301,6 +1306,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     selectProvider,
     prefillPrompt,
     clearPendingPrompt,
+    requestComposerFocus,
+    clearComposerFocusRequest,
     regenerateLastMessage,
     reset,
     cancelSession: handleCancelSession,
@@ -1331,6 +1338,7 @@ const disabledAssistantContext: AssistantAgentContextType = {
   gatewayVendorOptions: {},
   needsApiKey: false,
   pendingPrompt: null,
+  pendingComposerFocus: false,
   pendingAutomaticMessage: null,
   pendingPermission: null,
   pendingClientToolCall: null,
@@ -1344,6 +1352,8 @@ const disabledAssistantContext: AssistantAgentContextType = {
   selectProvider: () => {},
   prefillPrompt: () => {},
   clearPendingPrompt: () => {},
+  requestComposerFocus: () => {},
+  clearComposerFocusRequest: () => {},
   regenerateLastMessage: () => {},
   reset: () => {},
   cancelSession: () => {},

--- a/mlflow/server/js/src/assistant/AssistantContext.tsx
+++ b/mlflow/server/js/src/assistant/AssistantContext.tsx
@@ -855,6 +855,8 @@ export const AssistantProvider = ({ children }: { children: ReactNode }) => {
     openTextBufferRef.current = '';
     setPendingPermission(null);
     setPendingClientToolCall(null);
+    // Intentionally preserve pendingComposerFocus: a new-session Custom View
+    // build requests focus before reset, and the fresh composer consumes it.
     setPendingAutomaticMessage(null);
     structuredRepairAttemptsRef.current = 0;
     structuredRepairContextRef.current = null;

--- a/mlflow/server/js/src/assistant/types.ts
+++ b/mlflow/server/js/src/assistant/types.ts
@@ -267,6 +267,8 @@ export interface AssistantAgentState {
   needsApiKey: boolean;
   /** A prompt queued to seed the chat input the next time it becomes visible (null when none) */
   pendingPrompt: string | null;
+  /** Whether the chat composer should receive focus once it is mounted */
+  pendingComposerFocus: boolean;
   /** A message waiting for Assistant setup or credentials before it can be sent automatically */
   pendingAutomaticMessage: PendingAutomaticMessage | null;
   /** A tool call awaiting the user's Yes/No decision, or null */
@@ -296,6 +298,10 @@ export interface AssistantAgentActions {
   prefillPrompt: (prompt: string) => void;
   /** Clear any queued prompt */
   clearPendingPrompt: () => void;
+  /** Focus the chat composer once it is available, without changing its text */
+  requestComposerFocus: () => void;
+  /** Clear a pending composer-focus request after it is consumed or abandoned */
+  clearComposerFocusRequest: () => void;
   /** Regenerate the last assistant response */
   regenerateLastMessage: () => void;
   /** Reset the conversation */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -82,6 +82,7 @@ const mockUseAssistant = jest.mocked(useAssistant);
 const makeAssistant = (overrides: Record<string, unknown> = {}) => {
   const value = {
     openPanel: jest.fn(),
+    requestComposerFocus: jest.fn(),
     sendMessageWhenReady: jest.fn(),
     pendingAutomaticMessage: null,
     isStreaming: false,
@@ -140,6 +141,7 @@ describe('ExperimentCustomViewProvider', () => {
       expect(assistant.sendMessageWhenReady).toHaveBeenCalledWith(expect.stringContaining('render_custom_view'), {
         newSession: true,
       });
+      expect(assistant.requestComposerFocus).toHaveBeenCalledTimes(1);
     });
 
     it('reuses the current session (no reset) for a prompted edit without newSession', () => {
@@ -150,6 +152,7 @@ describe('ExperimentCustomViewProvider', () => {
 
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
       expect(assistant.sendMessageWhenReady).toHaveBeenCalledWith(expect.stringContaining('Add a chart'), undefined);
+      expect(assistant.requestComposerFocus).toHaveBeenCalledTimes(1);
     });
 
     it('submits structured-output instructions for a structured local provider', () => {
@@ -173,6 +176,7 @@ describe('ExperimentCustomViewProvider', () => {
 
       expect(assistant.openPanel).toHaveBeenCalledTimes(1);
       expect(assistant.sendMessageWhenReady).not.toHaveBeenCalled();
+      expect(assistant.requestComposerFocus).toHaveBeenCalledTimes(1);
     });
 
     it('exposes the assistant context streaming state on the connector', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -48,7 +48,14 @@ export const ExperimentCustomViewProvider = ({
 }) => {
   const { views, isLoaded, persistView } = useExperimentCustomViewDefinition(experimentId);
   const { canEdit: canModifyPersistedViews } = useCanEditExperimentCustomViews(experimentId);
-  const { openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming, activeProvider } = useAssistant();
+  const {
+    openPanel,
+    requestComposerFocus,
+    sendMessageWhenReady,
+    pendingAutomaticMessage,
+    isStreaming,
+    activeProvider,
+  } = useAssistant();
   const clientToolDelivery = activeProvider?.client_tool_delivery;
 
   const connector = useMemo<CustomViewAssistantConnector>(
@@ -56,10 +63,10 @@ export const ExperimentCustomViewProvider = ({
       openAssistant: (prompt?: string, options?: OpenCustomViewAssistantOptions) => {
         const instruction = prompt?.trim();
         openPanel();
-        // "Edit with assistant" (no instruction): just open/focus the panel. The
-        // custom-view authoring context is already published while the tab is open
-        // (see useCustomViewAssistantBridge), so the user can describe the change
-        // with full context instead of us auto-triggering an unprompted rebuild.
+        requestComposerFocus();
+        // "Edit with assistant" (no instruction) only opens/focuses the panel. The
+        // custom-view authoring context is already published while the tab is open,
+        // so the user can describe the change without an unprompted rebuild.
         if (instruction) {
           // Submit the build directive immediately. A brand-new build requests a
           // fresh Assistant thread atomically so it cannot inherit an unrelated
@@ -71,7 +78,7 @@ export const ExperimentCustomViewProvider = ({
       isStreaming,
       isPending: Boolean(pendingAutomaticMessage),
     }),
-    [clientToolDelivery, openPanel, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
+    [clientToolDelivery, openPanel, requestComposerFocus, sendMessageWhenReady, pendingAutomaticMessage, isStreaming],
   );
 
   // The assistant backend delivers a `render_custom_view` client action. API-based


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Builds on the Custom View Assistant integration in #25026 and local-provider support in #25034.

### What changes are proposed in this pull request?

This PR focuses the MLflow Assistant composer whenever a user launches **Edit with Assistant** or **Build with Assistant** from Custom View.

- Adds a focus-only Assistant request that does not seed, clear, or overwrite composer text.
- Preserves the request while the panel or setup UI is mounting, then focuses once the composer is available.
- Refocuses an already-open composer while preserving any draft text.
- Clears an unconsumed focus request when the panel closes.
- Preserves focus across the fresh-session reset used by new Custom View builds.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Verified with 104 targeted Assistant and Custom View tests, TypeScript type-checking, ESLint, Prettier, and `git diff --check`.

https://github.com/user-attachments/assets/8be8dbfc-32a6-419d-93b9-37ec4c60944d

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Custom View authoring actions now focus the MLflow Assistant composer automatically without replacing draft text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release