### PR TITLE
[1/6] basic-auth: fail-closed authorization net + coverage guard

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1179,6 +1179,10 @@ MLFLOW_SERVER_X_FRAME_OPTIONS = _EnvironmentVariable(
     "MLFLOW_SERVER_X_FRAME_OPTIONS", str, "SAMEORIGIN"
 )
 
+#: Deny (403) authenticated requests to routes with no authorization decision in the
+#: built-in basic-auth app (fail-closed). Off by default. (default: ``False``)
+MLFLOW_BASIC_AUTH_FAIL_CLOSED = _BooleanEnvironmentVariable("MLFLOW_BASIC_AUTH_FAIL_CLOSED", False)
+
 #: Specifies the max length (in chars) of an experiment's artifact location.
 #: The default is 2048.
 MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH = _EnvironmentVariable(

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -51,6 +51,7 @@ from mlflow.entities.model_registry import RegisteredModel
 from mlflow.environment_variables import (
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
     _MLFLOW_SGI_NAME,
+    MLFLOW_BASIC_AUTH_FAIL_CLOSED,
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
     MLFLOW_RBAC_SEED_DEFAULT_ROLES,
@@ -3066,6 +3067,103 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
     return None
 
 
+# Fail-closed net (opt-in via MLFLOW_BASIC_AUTH_FAIL_CLOSED).
+_PUBLIC_ROUTE_SUFFIXES = (
+    "/mlflow/server-info",  # capability discovery; no tenant data
+)
+
+# Routes that self-authorize (e.g. filter results by the caller) rather than via a
+# before-request validator.
+_HANDLER_INTERNAL_AUTHZ_SUFFIXES = (
+    "/mlflow/runs/search",
+    "/graphql",
+)
+
+# Ungated route families, temporarily exempt from fail-closed until each is gated
+# (removed one at a time; when empty the flag can be flipped on).
+_KNOWN_UNGATED_ROUTE_MARKERS = (
+    "/mlflow/datasets/",
+    "/mlflow/issues",
+    "/mlflow/jobs/",
+    "/gateway/budgets/",
+    "/gateway/guardrails/",
+    "/gateway/provider-config",
+    "/gateway/secrets/",
+    "/gateway/supported-providers",
+    "/gateway/supported-models",
+    "/gateway/endpoints/list",
+    "/gateway/model-definitions/list",
+    "/mlflow/artifacts/presigned-upload-url",
+    "/mlflow/demo/",
+    "/mlflow/genai/evaluate/invoke",
+    "/api/2.0/mlflow/metrics/get-history-bulk-interval",
+)
+
+# Native FastAPI routes (served by the FastAPI permission middleware, not _before_request)
+# that lack an authorization validator. Empty today — a coverage test asserts every native
+# route resolves a validator. Runtime fail-closed enforcement for FastAPI is a follow-up.
+_KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS = ()
+
+
+def _is_known_ungated_route(path: str) -> bool:
+    # Anchor markers to a segment boundary: "/mlflow/issues" matches "/mlflow/issues"
+    # and "/mlflow/issues/..." but not "/mlflow/issues-other".
+    for marker in _KNOWN_UNGATED_ROUTE_MARKERS:
+        if marker.endswith("/"):
+            if marker in path:
+                return True
+            continue
+        start = 0
+        while (idx := path.find(marker, start)) != -1:
+            end = idx + len(marker)
+            if end == len(path) or path[end] == "/":
+                return True
+            start = idx + 1
+    return False
+
+
+_API_VERSION_PREFIX_RE = re.compile(r"/(?:ajax-)?api/\d+\.\d+")
+
+
+def _matches_route_suffix(path: str, suffixes: tuple[str, ...]) -> bool:
+    # Match a suffix only as a whole path (e.g. /graphql) or directly under an API
+    # version prefix — never as an incidental tail of an unrelated route.
+    for suffix in suffixes:
+        if path == suffix:
+            return True
+        if path.endswith(suffix) and _API_VERSION_PREFIX_RE.fullmatch(path[: -len(suffix)]):
+            return True
+    return False
+
+
+def _strip_static_prefix(path: str) -> str:
+    static_prefix = os.environ.get(STATIC_PREFIX_ENV_VAR, "").rstrip("/")
+    if static_prefix and path.startswith(static_prefix):
+        return path[len(static_prefix) :]
+    return path
+
+
+def _authorized_outside_before_request(req) -> bool:
+    # Authorized outside a before-request validator: public allowlist, a
+    # self-authorizing handler, or an after-request filter.
+    path = req.path
+    method = req.method
+    # Suffix matching anchors on the API version prefix, so strip any configured
+    # static prefix first (mirroring _find_fastapi_validator); otherwise public/internal
+    # routes would wrongly fail closed under --static-prefix.
+    unprefixed = _strip_static_prefix(path)
+    if _matches_route_suffix(unprefixed, _PUBLIC_ROUTE_SUFFIXES):
+        return True
+    if _matches_route_suffix(unprefixed, _HANDLER_INTERNAL_AUTHZ_SUFFIXES):
+        return True
+    if (path, method) in AFTER_REQUEST_HANDLERS:
+        return True
+    return any(
+        pat.fullmatch(path) and m == method
+        for (pat, m) in WORKSPACE_PARAMETERIZED_AFTER_REQUEST_HANDLERS
+    )
+
+
 @catch_mlflow_exception
 def _before_request():
     if is_unprotected_route(request.path):
@@ -3097,9 +3195,20 @@ def _before_request():
         if not validator():
             return make_forbidden_response()
     elif _is_proxy_artifact_path(request.path):
-        if validator := _get_proxy_artifact_validator(request.method, request.view_args):
-            if not validator():
+        proxy_validator = _get_proxy_artifact_validator(request.method, request.view_args)
+        if proxy_validator is None:
+            # Unrecognized method on a proxy-artifact URL: fail closed when the flag is on.
+            if MLFLOW_BASIC_AUTH_FAIL_CLOSED.get():
                 return make_forbidden_response()
+        elif not proxy_validator():
+            return make_forbidden_response()
+    elif (
+        MLFLOW_BASIC_AUTH_FAIL_CLOSED.get()
+        and not _authorized_outside_before_request(request)
+        and not _is_known_ungated_route(request.path)
+    ):
+        # No authorization decision resolved for this route: deny (fail-closed).
+        return make_forbidden_response()
 
 
 def set_can_manage_experiment_permission(resp: Response):

--- a/tests/server/auth/test_authorization_coverage.py
+++ b/tests/server/auth/test_authorization_coverage.py
@@ -1,0 +1,108 @@
+# CI guard for the basic-auth dispatcher: every Flask route must resolve to an
+# authorization decision, or be listed in the debt list _KNOWN_UNGATED_ROUTE_MARKERS.
+
+from mlflow.server import auth as a
+from mlflow.server.handlers import get_endpoints
+
+
+class _Req:
+    def __init__(self, path, method):
+        self.path = path
+        self.method = method
+
+
+def _is_covered(path, method):
+    req = _Req(path, method)
+    return (
+        a.is_unprotected_route(path)
+        or a._find_validator(req) is not None
+        or a._is_proxy_artifact_path(path)
+        or a._authorized_outside_before_request(req)
+    )
+
+
+def _all_routes():
+    seen = set()
+    for path, handler, methods in get_endpoints():
+        if getattr(handler, "__name__", str(handler)) == "_not_implemented":
+            continue
+        for method in methods:
+            if (path, method) not in seen:
+                seen.add((path, method))
+                yield path, method
+
+
+def test_no_new_ungated_routes():
+    uncovered = sorted(
+        f"{method:6} {path}"
+        for path, method in _all_routes()
+        if not _is_covered(path, method) and not a._is_known_ungated_route(path)
+    )
+    assert not uncovered, (
+        "Routes with no authorization decision that are not in the documented debt "
+        "list (_KNOWN_UNGATED_ROUTE_MARKERS). Add a before-request validator, an "
+        "after-request filter, a self-authorizing handler + allowlist entry, or an "
+        "explicit public-route entry:\n" + "\n".join(uncovered)
+    )
+
+
+def test_known_ungated_markers_are_not_stale():
+    matched = set()
+    for path, method in _all_routes():
+        if _is_covered(path, method):
+            continue
+        for marker in a._KNOWN_UNGATED_ROUTE_MARKERS:
+            if marker in path:
+                matched.add(marker)
+    stale = [m for m in a._KNOWN_UNGATED_ROUTE_MARKERS if m not in matched]
+    assert not stale, (
+        "Debt markers that no longer match any ungated route (their family is now "
+        f"gated — remove them from _KNOWN_UNGATED_ROUTE_MARKERS): {stale}"
+    )
+
+
+def _fastapi_native_routes():
+    # Routers served directly by FastAPI (Flask is mounted separately and authorized by
+    # _before_request, so it is out of scope for this guard).
+    from mlflow.server.fastapi_app import (
+        artifact_router,
+        assistant_router,
+        gateway_router,
+        job_api_router,
+        mcp_server_router,
+        otel_router,
+    )
+
+    def _methods(route):
+        return [
+            m
+            for m in sorted(getattr(route, "methods", None) or ["GET"])
+            if m not in ("HEAD", "OPTIONS")
+        ]
+
+    for router in (artifact_router, assistant_router, gateway_router, job_api_router, otel_router):
+        for route in router.routes:
+            for method in _methods(route):
+                yield route.path, method
+    # The MCP router is mounted under versioned prefixes; prepend one to form full paths.
+    mcp_prefix = next(iter(a.get_mcp_server_api_route_prefixes())).rstrip("/")
+    for route in mcp_server_router.routes:
+        for method in _methods(route):
+            yield mcp_prefix + route.path, method
+
+
+def test_no_ungated_fastapi_native_routes():
+    # The FastAPI permission middleware is fail-open for routes with no validator; this
+    # guard makes a new native route without one a failing test rather than a silent hole.
+    uncovered = sorted(
+        f"{method:6} {path}"
+        for path, method in _fastapi_native_routes()
+        if a._find_fastapi_validator(path, method) is None
+        and not a.is_unprotected_route(path)
+        and not any(m in path for m in a._KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS)
+    )
+    assert not uncovered, (
+        "Native FastAPI routes with no authorization validator that are not documented in "
+        "_KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS. Add a validator branch in "
+        "_find_fastapi_validator, or document the exemption:\n" + "\n".join(uncovered)
+    )

--- a/tests/server/auth/test_fail_closed_flag.py
+++ b/tests/server/auth/test_fail_closed_flag.py
@@ -1,0 +1,86 @@
+# Tests for the MLFLOW_BASIC_AUTH_FAIL_CLOSED flag: wiring, the decision predicates,
+# and the end-to-end 403 that _before_request returns when the flag is on.
+
+from mlflow.environment_variables import MLFLOW_BASIC_AUTH_FAIL_CLOSED
+from mlflow.server import auth as a
+
+
+class _Req:
+    def __init__(self, path, method="GET"):
+        self.path = path
+        self.method = method
+
+
+def test_flag_defaults_off():
+    assert MLFLOW_BASIC_AUTH_FAIL_CLOSED.get() is False
+
+
+def test_flag_reads_env(monkeypatch):
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    assert MLFLOW_BASIC_AUTH_FAIL_CLOSED.get() is True
+
+
+def test_unlisted_route_is_denied_when_fail_closed():
+    req = _Req("/api/3.0/mlflow/brand-new-feature/do-thing", "POST")
+    assert not a._is_known_ungated_route(req.path)
+    assert not a._authorized_outside_before_request(req)
+
+
+def test_authorized_elsewhere_is_recognized():
+    assert a._authorized_outside_before_request(_Req("/api/3.0/mlflow/server-info"))
+    assert a._authorized_outside_before_request(_Req("/api/2.0/mlflow/runs/search", "POST"))
+
+
+def test_public_suffix_not_matched_as_incidental_tail():
+    # Anchored to an API-version prefix, so an unrelated route ending in the same
+    # segments is not treated as authorized.
+    assert not a._authorized_outside_before_request(
+        _Req("/api/2.0/mlflow/evil/passthrough/mlflow/runs/search", "POST")
+    )
+    assert a._authorized_outside_before_request(_Req("/ajax-api/2.0/mlflow/runs/search", "POST"))
+
+
+def test_public_routes_recognized_under_static_prefix(monkeypatch):
+    # Under --static-prefix the request path carries the prefix; public/internal routes
+    # must still be recognized (else they wrongly fail closed).
+    from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
+
+    monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/custom-prefix")
+    assert a._authorized_outside_before_request(_Req("/custom-prefix/api/3.0/mlflow/server-info"))
+    assert a._authorized_outside_before_request(
+        _Req("/custom-prefix/api/2.0/mlflow/runs/search", "POST")
+    )
+    assert a._authorized_outside_before_request(_Req("/custom-prefix/graphql"))
+
+
+def _fake_basic_auth():
+    from werkzeug.datastructures import Authorization
+
+    return Authorization("basic", {"username": "u"})
+
+
+def test_before_request_returns_403_for_ungated_route_when_fail_closed(monkeypatch):
+    import flask
+
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    monkeypatch.setattr(a, "authenticate_request", _fake_basic_auth)
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+
+    app = flask.Flask(__name__)
+    with app.test_request_context("/api/3.0/mlflow/brand-new-feature/do-thing", method="POST"):
+        resp = a._before_request()
+    assert resp is not None
+    assert resp.status_code == 403
+
+
+def test_before_request_allows_ungated_route_when_flag_off(monkeypatch):
+    import flask
+
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "false")
+    monkeypatch.setattr(a, "authenticate_request", _fake_basic_auth)
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+
+    app = flask.Flask(__name__)
+    with app.test_request_context("/api/3.0/mlflow/brand-new-feature/do-thing", method="POST"):
+        resp = a._before_request()
+    assert resp is None


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25066, #25067, #25069, #25070, #25071 — PR **1 of a 6-PR stack** that hardens
basic-auth authorization coverage one route family at a time.

### What changes are proposed in this pull request?

**The hole this stack closes**

- `mlflow/server/auth`'s `_before_request` authorizes via an allowlist and **fails open**: any
  authenticated request whose route resolves *no* validator is allowed through.
- So every route added to the tracking server was reachable by any logged-in user until someone
  remembered to gate it — and nothing flagged the omission, so gaps accumulated silently across
  the datasets, issues, jobs, and gateway route families (closed by the rest of this stack).

**This PR — the structural net (no route behavior change on its own):**

- `MLFLOW_BASIC_AUTH_FAIL_CLOSED` environment variable (default **off**): when enabled, an
  authenticated request that resolves no authorization decision and is not otherwise authorized is
  denied (403) instead of allowed.
- CI coverage guard (`test_no_new_ungated_routes`): fails when a newly registered route has no
  authorization decision and is not in the documented debt list `_KNOWN_UNGATED_ROUTE_MARKERS` —
  turning "someone forgot to gate a route" from a silent gap into a failing test.
- The debt list currently grandfathers the known ungated families; the stacked PRs remove each
  marker as its validator lands, emptying the list so the flag can be flipped on in a future release.

### How is this PR tested?

- [x] New unit/integration tests

`tests/server/auth/test_authorization_coverage.py`, `tests/server/auth/test_fail_closed_flag.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds the opt-in `MLFLOW_BASIC_AUTH_FAIL_CLOSED` environment variable (default off) for the built-in basic-auth server; behavior is unchanged unless it is enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
