### PR TITLE
[2/6] basic-auth: gate evaluation dataset routes on experiment permission

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -111,12 +111,14 @@ from mlflow.protos.review_queues_pb2 import (
     UpdateReviewQueue,
 )
 from mlflow.protos.service_pb2 import (
+    AddDatasetToExperiments,
     AttachModelToGatewayEndpoint,
     BatchGetTraceInfos,
     BatchGetTraces,
     CalculateTraceFilterCorrelation,
     CancelPromptOptimizationJob,
     CreateAssessment,
+    CreateDataset,
     CreateExperiment,
     CreateGatewayBudgetPolicy,
     CreateGatewayEndpoint,
@@ -129,6 +131,9 @@ from mlflow.protos.service_pb2 import (
     CreateRun,
     CreateWorkspace,
     DeleteAssessment,
+    DeleteDataset,
+    DeleteDatasetRecords,
+    DeleteDatasetTag,
     DeleteExperiment,
     DeleteExperimentTag,
     DeleteGatewayBudgetPolicy,
@@ -152,6 +157,9 @@ from mlflow.protos.service_pb2 import (
     EndTrace,
     FinalizeLoggedModel,
     GetAssessmentRequest,
+    GetDataset,
+    GetDatasetExperimentIds,
+    GetDatasetRecords,
     GetExperiment,
     GetExperimentByName,
     GetGatewayEndpoint,
@@ -183,13 +191,16 @@ from mlflow.protos.service_pb2 import (
     LogParam,
     QueryTraceMetrics,
     RegisterScorer,
+    RemoveDatasetFromExperiments,
     RestoreExperiment,
     RestoreRun,
+    SearchEvaluationDatasets,
     SearchExperiments,
     SearchLoggedModels,
     SearchPromptOptimizationJobs,
     SearchTraces,
     SearchTracesV3,
+    SetDatasetTags,
     SetExperimentTag,
     SetGatewayEndpointTag,
     SetLoggedModelTags,
@@ -206,6 +217,7 @@ from mlflow.protos.service_pb2 import (
     UpdateGatewaySecret,
     UpdateRun,
     UpdateWorkspace,
+    UpsertDatasetRecords,
 )
 from mlflow.protos.service_pb2 import (
     GetGatewayBudgetPolicy as GetGatewayBudgetPolicy,
@@ -2932,6 +2944,122 @@ WEBHOOK_BEFORE_REQUEST_VALIDATORS = {
     for method in methods
 }
 
+
+# Evaluation datasets are experiment-scoped: derive permissions from the associated
+# experiment(s), like runs and traces.
+def _dataset_experiment_permissions():
+    dataset_id = _get_request_param("dataset_id")
+    username = authenticate_request().username
+    try:
+        experiment_ids = _get_tracking_store().get_dataset_experiment_ids(dataset_id)
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return [], []
+        raise
+    return experiment_ids, [_get_experiment_permission(eid, username) for eid in experiment_ids]
+
+
+def validate_can_read_dataset():
+    experiment_ids, permissions = _dataset_experiment_permissions()
+    return bool(experiment_ids) and all(p.can_read for p in permissions)
+
+
+def validate_can_update_dataset():
+    experiment_ids, permissions = _dataset_experiment_permissions()
+    return bool(experiment_ids) and all(p.can_update for p in permissions)
+
+
+def validate_can_delete_dataset():
+    experiment_ids, permissions = _dataset_experiment_permissions()
+    return bool(experiment_ids) and all(p.can_delete for p in permissions)
+
+
+def _experiment_ids_from_request():
+    # Read experiment_ids from JSON when present, else query args (like _get_request_param).
+    if request.is_json:
+        body = request.get_json(silent=True)
+        if isinstance(body, dict):
+            return list(body.get("experiment_ids", []))
+    return request.args.getlist("experiment_ids")
+
+
+def validate_can_create_dataset():
+    experiment_ids = _experiment_ids_from_request()
+    username = authenticate_request().username
+    return bool(experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_update for eid in experiment_ids
+    )
+
+
+def validate_can_search_evaluation_datasets():
+    # Require the caller to scope the search to experiment(s) they can read, so an
+    # empty request cannot enumerate every dataset on the server.
+    experiment_ids = _experiment_ids_from_request()
+    username = authenticate_request().username
+    return bool(experiment_ids) and all(
+        _get_experiment_permission(eid, username).can_read for eid in experiment_ids
+    )
+
+
+def validate_can_add_dataset_to_experiments():
+    # Also require UPDATE on the experiment(s) being attached, not just the dataset's
+    # current ones, so a caller can't link an experiment they don't control.
+    if not validate_can_update_dataset():
+        return False
+    username = authenticate_request().username
+    added = _experiment_ids_from_request()
+    return bool(added) and all(
+        _get_experiment_permission(eid, username).can_update for eid in added
+    )
+
+
+# {dataset_id}-based routes; regex-matched (path parameters).
+DATASET_BEFORE_REQUEST_HANDLERS = {
+    GetDataset: validate_can_read_dataset,
+    DeleteDataset: validate_can_delete_dataset,
+    SetDatasetTags: validate_can_update_dataset,
+    DeleteDatasetTag: validate_can_update_dataset,
+    UpsertDatasetRecords: validate_can_update_dataset,
+    GetDatasetRecords: validate_can_read_dataset,
+    DeleteDatasetRecords: validate_can_update_dataset,
+    GetDatasetExperimentIds: validate_can_read_dataset,
+    AddDatasetToExperiments: validate_can_add_dataset_to_experiments,
+    RemoveDatasetFromExperiments: validate_can_update_dataset,
+}
+
+
+def get_dataset_before_request_handler(request_class):
+    return DATASET_BEFORE_REQUEST_HANDLERS.get(request_class)
+
+
+DATASET_BEFORE_REQUEST_VALIDATORS = {
+    (_re_compile_path(http_path), method): handler
+    for http_path, handler, methods in get_endpoints(get_dataset_before_request_handler)
+    for method in methods
+    if handler in DATASET_BEFORE_REQUEST_HANDLERS.values()
+}
+
+
+# create/search have no path parameters; register them in the exact-match table so the
+# {dataset_id} regex can't shadow /datasets/search or /datasets/create.
+DATASET_EXACT_BEFORE_REQUEST_HANDLERS = {
+    CreateDataset: validate_can_create_dataset,
+    SearchEvaluationDatasets: validate_can_search_evaluation_datasets,
+}
+
+
+def get_dataset_exact_before_request_handler(request_class):
+    return DATASET_EXACT_BEFORE_REQUEST_HANDLERS.get(request_class)
+
+
+BEFORE_REQUEST_VALIDATORS.update({
+    (http_path, method): handler
+    for http_path, handler, methods in get_endpoints(get_dataset_exact_before_request_handler)
+    for method in methods
+    if handler in DATASET_EXACT_BEFORE_REQUEST_HANDLERS.values()
+})
+
+
 _AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
 
 
@@ -3051,6 +3179,18 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
     if validator := BEFORE_REQUEST_VALIDATORS.get((req.path, req.method)):
         return validator
 
+    # Whole /mlflow/datasets/ family; unknown paths under the prefix fail closed.
+    if "/mlflow/datasets/" in req.path:
+        validator = next(
+            (
+                v
+                for (pat, method), v in DATASET_BEFORE_REQUEST_VALIDATORS.items()
+                if pat.fullmatch(req.path) and method == req.method
+            ),
+            None,
+        )
+        return validator if validator is not None else lambda: False
+
     # Trace routes with path parameters (e.g. /mlflow/traces/<request_id>/tags).
     # Unknown paths under this prefix are denied (fail-closed) rather than skipped.
     if "/mlflow/traces/" in req.path:
@@ -3082,7 +3222,6 @@ _HANDLER_INTERNAL_AUTHZ_SUFFIXES = (
 # Ungated route families, temporarily exempt from fail-closed until each is gated
 # (removed one at a time; when empty the flag can be flipped on).
 _KNOWN_UNGATED_ROUTE_MARKERS = (
-    "/mlflow/datasets/",
     "/mlflow/issues",
     "/mlflow/jobs/",
     "/gateway/budgets/",

--- a/tests/server/auth/test_authorization_coverage.py
+++ b/tests/server/auth/test_authorization_coverage.py
@@ -46,6 +46,23 @@ def test_no_new_ungated_routes():
     )
 
 
+def test_all_dataset_routes_resolve_a_real_validator():
+    # Guard against a dataset route silently hitting the hard-deny lambda fallback in
+    # _find_validator (which test_no_new_ungated_routes would still count as gated).
+    real = set(a.DATASET_BEFORE_REQUEST_HANDLERS.values()) | set(
+        a.DATASET_EXACT_BEFORE_REQUEST_HANDLERS.values()
+    )
+    unresolved = sorted(
+        f"{method:6} {path}"
+        for path, method in _all_routes()
+        if "/mlflow/datasets/" in path and a._find_validator(_Req(path, method)) not in real
+    )
+    assert not unresolved, (
+        "Dataset routes that fall through to the hard-deny fallback instead of a real "
+        "validator (add them to DATASET_BEFORE_REQUEST_HANDLERS):\n" + "\n".join(unresolved)
+    )
+
+
 def test_known_ungated_markers_are_not_stale():
     matched = set()
     for path, method in _all_routes():

--- a/tests/server/auth/test_dataset_authorization.py
+++ b/tests/server/auth/test_dataset_authorization.py
@@ -1,0 +1,95 @@
+# Unit tests for the evaluation-dataset authorization validators and route routing.
+
+from types import SimpleNamespace
+
+import flask
+
+import mlflow.server.auth as a
+
+
+class _Req:
+    def __init__(self, path, method):
+        self.path = path
+        self.method = method
+
+
+def _perm(read=False, update=False, delete=False):
+    return SimpleNamespace(can_read=read, can_update=update, can_delete=delete)
+
+
+def _validator_name(path, method):
+    v = a._find_validator(_Req(path, method))
+    return getattr(v, "__name__", v)
+
+
+def test_literal_routes_not_shadowed_by_dataset_id_wildcard():
+    # /datasets/search and /datasets/create must resolve to their own validators, not be
+    # captured by the {dataset_id} regex (which matches a single non-slash segment).
+    assert _validator_name("/api/3.0/mlflow/datasets/search", "GET") == (
+        "validate_can_search_evaluation_datasets"
+    )
+    assert _validator_name("/api/3.0/mlflow/datasets/search", "POST") == (
+        "validate_can_search_evaluation_datasets"
+    )
+    assert (
+        _validator_name("/api/3.0/mlflow/datasets/create", "POST") == "validate_can_create_dataset"
+    )
+    assert _validator_name("/api/3.0/mlflow/datasets/d-abc", "GET") == "validate_can_read_dataset"
+
+
+def _mock_dataset(monkeypatch, exp_ids, perms):
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="u"))
+    monkeypatch.setattr(a, "_get_request_param", lambda p: "d-1")
+    monkeypatch.setattr(
+        a,
+        "_get_tracking_store",
+        lambda: SimpleNamespace(get_dataset_experiment_ids=lambda did: exp_ids),
+    )
+    monkeypatch.setattr(a, "_get_experiment_permission", lambda eid, user: perms[eid])
+
+
+def test_read_gated_on_experiment_permission(monkeypatch):
+    _mock_dataset(monkeypatch, ["e1"], {"e1": _perm(read=True)})
+    assert a.validate_can_read_dataset() is True
+    _mock_dataset(monkeypatch, ["e1"], {"e1": _perm(read=False)})
+    assert a.validate_can_read_dataset() is False
+
+
+def test_update_and_delete_gated(monkeypatch):
+    _mock_dataset(monkeypatch, ["e1"], {"e1": _perm(update=True, delete=False)})
+    assert a.validate_can_update_dataset() is True
+    assert a.validate_can_delete_dataset() is False
+
+
+def test_multi_experiment_requires_permission_on_all(monkeypatch):
+    _mock_dataset(monkeypatch, ["e1", "e2"], {"e1": _perm(read=True), "e2": _perm(read=False)})
+    assert a.validate_can_read_dataset() is False
+
+
+def test_zero_experiment_dataset_denied_for_non_admin(monkeypatch):
+    _mock_dataset(monkeypatch, [], {})
+    assert a.validate_can_read_dataset() is False
+    assert a.validate_can_update_dataset() is False
+    assert a.validate_can_delete_dataset() is False
+
+
+def _run_add(monkeypatch, current, added, perms):
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="u"))
+    monkeypatch.setattr(a, "_get_request_param", lambda p: "d-1")
+    monkeypatch.setattr(
+        a,
+        "_get_tracking_store",
+        lambda: SimpleNamespace(get_dataset_experiment_ids=lambda did: current),
+    )
+    monkeypatch.setattr(a, "_get_experiment_permission", lambda eid, user: perms[eid])
+    with flask.Flask(__name__).test_request_context(json={"experiment_ids": added}):
+        return a.validate_can_add_dataset_to_experiments()
+
+
+def test_add_to_experiments_requires_update_on_current_and_added(monkeypatch):
+    both = {"A": _perm(update=True), "B": _perm(update=True)}
+    assert _run_add(monkeypatch, ["A"], ["B"], both) is True
+    # can't attach an experiment you don't control
+    assert _run_add(monkeypatch, ["A"], ["B"], {"A": _perm(update=True), "B": _perm()}) is False
+    # can't modify a dataset whose current experiment you don't control
+    assert _run_add(monkeypatch, ["A"], ["B"], {"A": _perm(), "B": _perm(update=True)}) is False


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25065 — PR **2 of a 6-PR stack** (builds on #25065). Stack: #25065 → **#25066 (this)** →
#25067 → #25069 → #25070 → #25071.

### What changes are proposed in this pull request?

**The hole being fixed**

- The Evaluation Dataset REST APIs under `/mlflow/datasets/*` (create, get, records read/write,
  tags, add/remove-experiments, search, delete) shipped with **no authorization validator**.
- Because the basic-auth dispatcher fails open, any authenticated user — even one holding
  `NO_PERMISSIONS` — could **read, modify, enumerate, and delete another user's evaluation datasets
  and their records**, regardless of experiment permissions.

**The fix**

Datasets are experiment-scoped, so authorize each route from its associated experiment(s), the way
runs and traces already are:

- get / records-read / experiment-ids → `can_read` on all associated experiments
- create / tags / records-write / add- & remove-experiments → `can_update`
- delete → `can_delete`
- search → must be scoped to experiment(s) the caller can read (an unscoped search cannot enumerate
  every dataset on the server)

Routing goes through `_find_validator`'s `/mlflow/datasets/` branch, which fails closed for any
unknown path under the prefix. Removes the datasets entry from `_KNOWN_UNGATED_ROUTE_MARKERS`.

### How is this PR tested?

- [x] New unit/integration tests

Coverage guard now resolves every `/mlflow/datasets/*` route to a validator; the end-to-end 403
regression test lands in the sibling Issues PR (#25067), which shares the fixture.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The built-in basic-auth server now enforces the associated experiment's permission on the evaluation dataset APIs; requests without that permission are denied (403).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
