### PR TITLE
[3/6] basic-auth: gate issue routes on experiment permission

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -66,6 +66,12 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
+from mlflow.protos.issues_pb2 import (
+    CreateIssue,
+    GetIssue,
+    SearchIssues,
+    UpdateIssue,
+)
 from mlflow.protos.label_schemas_pb2 import (
     CreateLabelSchema,
     DeleteLabelSchema,
@@ -350,6 +356,7 @@ from mlflow.server.handlers import (
     _assert_item_type_string,
     _get_ajax_path,
     _get_model_registry_store,
+    _get_normalized_request_json,
     _get_request_message,
     _get_tracking_store,
     _get_validated_flask_request_json,
@@ -3060,6 +3067,88 @@ BEFORE_REQUEST_VALIDATORS.update({
 })
 
 
+# Issues are experiment-scoped: authorize from the associated experiment.
+def _issue_experiment_permission():
+    issue_id = _get_request_param("issue_id")
+    username = authenticate_request().username
+    experiment_id = _get_tracking_store().get_issue(issue_id).experiment_id
+    return _get_experiment_permission(experiment_id, username)
+
+
+def validate_can_read_issue():
+    try:
+        return _issue_experiment_permission().can_read
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return False
+        raise
+
+
+def validate_can_update_issue():
+    try:
+        return _issue_experiment_permission().can_update
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return False
+        raise
+
+
+def validate_can_create_issue():
+    # Use the same normalizer as the handler so a legacy double-encoded body is decoded
+    # rather than crashing the auth check with a 500 (a str has no .get).
+    experiment_id = _get_normalized_request_json().get("experiment_id")
+    if not experiment_id:
+        return False
+    username = authenticate_request().username
+    return _get_experiment_permission(experiment_id, username).can_update
+
+
+def validate_can_search_issues():
+    experiment_id = _get_normalized_request_json().get("experiment_id")
+    if not experiment_id:
+        return False
+    username = authenticate_request().username
+    return _get_experiment_permission(experiment_id, username).can_read
+
+
+ISSUE_BEFORE_REQUEST_HANDLERS = {
+    GetIssue: validate_can_read_issue,
+    UpdateIssue: validate_can_update_issue,
+}
+
+
+def get_issue_before_request_handler(request_class):
+    return ISSUE_BEFORE_REQUEST_HANDLERS.get(request_class)
+
+
+# Regex-matched (path parameter).
+ISSUE_BEFORE_REQUEST_VALIDATORS = {
+    (_re_compile_path(http_path), method): handler
+    for http_path, handler, methods in get_endpoints(get_issue_before_request_handler)
+    for method in methods
+    if handler in ISSUE_BEFORE_REQUEST_HANDLERS.values()
+}
+
+
+ISSUE_EXACT_BEFORE_REQUEST_HANDLERS = {
+    CreateIssue: validate_can_create_issue,
+    SearchIssues: validate_can_search_issues,
+}
+
+
+def get_issue_exact_before_request_handler(request_class):
+    return ISSUE_EXACT_BEFORE_REQUEST_HANDLERS.get(request_class)
+
+
+# Create/search have no path parameters -> exact-match table.
+BEFORE_REQUEST_VALIDATORS.update({
+    (http_path, method): handler
+    for http_path, handler, methods in get_endpoints(get_issue_exact_before_request_handler)
+    for method in methods
+    if handler in ISSUE_EXACT_BEFORE_REQUEST_HANDLERS.values()
+})
+
+
 _AJAX_API_PATH_PREFIX = "/ajax-api/2.0"
 
 
@@ -3191,6 +3280,22 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
         )
         return validator if validator is not None else lambda: False
 
+    # Whole /mlflow/issues/ family; unknown paths fail closed, except the not-yet-gated
+    # routes tracked in _KNOWN_UNGATED_ROUTE_MARKERS (e.g. invoke), which fall through.
+    if "/mlflow/issues/" in req.path:
+        validator = next(
+            (
+                v
+                for (pat, method), v in ISSUE_BEFORE_REQUEST_VALIDATORS.items()
+                if pat.fullmatch(req.path) and method == req.method
+            ),
+            None,
+        )
+        if validator is not None:
+            return validator
+        if not _is_known_ungated_route(req.path):
+            return lambda: False
+
     # Trace routes with path parameters (e.g. /mlflow/traces/<request_id>/tags).
     # Unknown paths under this prefix are denied (fail-closed) rather than skipped.
     if "/mlflow/traces/" in req.path:
@@ -3222,7 +3327,7 @@ _HANDLER_INTERNAL_AUTHZ_SUFFIXES = (
 # Ungated route families, temporarily exempt from fail-closed until each is gated
 # (removed one at a time; when empty the flag can be flipped on).
 _KNOWN_UNGATED_ROUTE_MARKERS = (
-    "/mlflow/issues",
+    "/mlflow/issues/invoke",
     "/mlflow/jobs/",
     "/gateway/budgets/",
     "/gateway/guardrails/",

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -6211,3 +6211,116 @@ def test_mcp_server_search_backfills_after_filtering(fastapi_client, monkeypatch
             assert len(page) == 2
 
     assert {s["name"] for s in all_readable} == set(readable)
+
+
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+def test_evaluation_dataset_and_issue_apis_require_experiment_permission(client):
+    # A NO_PERMISSIONS user must not read/tamper/enumerate/delete another user's
+    # datasets or issues; both are gated on the associated experiment's permission.
+    base = client.tracking_uri
+    owner, owner_pw = create_user(base)
+    attacker, attacker_pw = create_user(base)
+    owner_auth = (owner, owner_pw)
+    attacker_auth = (attacker, attacker_pw)
+
+    def post(path, auth, body):
+        return requests.post(f"{base}{path}", json=body, auth=auth)
+
+    # Owner creates an experiment (gaining MANAGE), a dataset with a record, and an issue.
+    exp_id = post("/api/2.0/mlflow/experiments/create", owner_auth, {"name": "owner-exp"}).json()[
+        "experiment_id"
+    ]
+    dataset_id = post(
+        "/api/3.0/mlflow/datasets/create",
+        owner_auth,
+        {"name": "owner-ds", "experiment_ids": [exp_id]},
+    ).json()["dataset"]["dataset_id"]
+    seed = post(
+        f"/api/3.0/mlflow/datasets/{dataset_id}/records",
+        owner_auth,
+        {"records": json.dumps([{"inputs": {"q": "secret"}, "expectations": {"a": "truth"}}])},
+    )
+    assert seed.status_code == 200
+    issue_id = post(
+        "/api/3.0/mlflow/issues",
+        owner_auth,
+        {"experiment_id": exp_id, "name": "sec", "description": "confidential"},
+    ).json()["issue"]["issue_id"]
+
+    # Control: the attacker genuinely lacks access to the experiment.
+    assert (
+        requests.get(
+            f"{base}/api/2.0/mlflow/experiments/get",
+            params={"experiment_id": exp_id},
+            auth=attacker_auth,
+        ).status_code
+        == 403
+    )
+
+    # Dataset reads and unscoped enumeration are denied.
+    assert (
+        requests.get(f"{base}/api/3.0/mlflow/datasets/{dataset_id}", auth=attacker_auth).status_code
+        == 403
+    )
+    assert (
+        requests.get(
+            f"{base}/api/3.0/mlflow/datasets/{dataset_id}/records", auth=attacker_auth
+        ).status_code
+        == 403
+    )
+    assert post("/api/3.0/mlflow/datasets/search", attacker_auth, {}).status_code == 403
+
+    # Dataset writes and deletes are denied.
+    assert (
+        post(
+            f"/api/3.0/mlflow/datasets/{dataset_id}/records",
+            attacker_auth,
+            {"records": json.dumps([{"inputs": {"q": "x"}, "expectations": {"a": "poison"}}])},
+        ).status_code
+        == 403
+    )
+    assert (
+        requests.delete(
+            f"{base}/api/3.0/mlflow/datasets/{dataset_id}", auth=attacker_auth
+        ).status_code
+        == 403
+    )
+
+    # Issue create, read, update, and search are denied.
+    assert (
+        post(
+            "/api/3.0/mlflow/issues",
+            attacker_auth,
+            {"experiment_id": exp_id, "name": "injected", "description": "injected"},
+        ).status_code
+        == 403
+    )
+    assert (
+        requests.get(f"{base}/api/3.0/mlflow/issues/{issue_id}", auth=attacker_auth).status_code
+        == 403
+    )
+    assert (
+        requests.patch(
+            f"{base}/api/3.0/mlflow/issues/{issue_id}",
+            json={"issue_id": issue_id, "description": "tampered"},
+            auth=attacker_auth,
+        ).status_code
+        == 403
+    )
+    assert (
+        post("/api/3.0/mlflow/issues/search", attacker_auth, {"experiment_id": exp_id}).status_code
+        == 403
+    )
+
+    # The legitimate owner still has full access — the record survived the attempted delete.
+    assert (
+        requests.get(f"{base}/api/3.0/mlflow/datasets/{dataset_id}", auth=owner_auth).status_code
+        == 200
+    )
+    assert (
+        requests.get(f"{base}/api/3.0/mlflow/issues/{issue_id}", auth=owner_auth).status_code == 200
+    )

--- a/tests/server/auth/test_authorization_coverage.py
+++ b/tests/server/auth/test_authorization_coverage.py
@@ -78,6 +78,19 @@ def test_known_ungated_markers_are_not_stale():
     )
 
 
+def test_unknown_issue_subpath_fails_closed():
+    # An unrecognized /mlflow/issues/ path resolves to a denying validator (not None), so
+    # it is denied even with MLFLOW_BASIC_AUTH_FAIL_CLOSED off, matching the dataset/trace
+    # branches, rather than silently falling through.
+    v = a._find_validator(_Req("/api/3.0/mlflow/issues/i-1/comments", "POST"))
+    assert v is not None
+    assert v() is False
+    # The invoke route is exempt from that hard-deny: it either has its own validator or is
+    # still tracked in the debt list, never the fail-closed fallback.
+    invoke = "/ajax-api/3.0/mlflow/issues/invoke"
+    assert a._is_known_ungated_route(invoke) or (invoke, "POST") in a.BEFORE_REQUEST_VALIDATORS
+
+
 def _fastapi_native_routes():
     # Routers served directly by FastAPI (Flask is mounted separately and authorized by
     # _before_request, so it is out of scope for this guard).

--- a/tests/server/auth/test_issue_authorization.py
+++ b/tests/server/auth/test_issue_authorization.py
@@ -1,0 +1,40 @@
+# Unit tests for the issue authorization validators' request-body handling.
+
+import json
+from types import SimpleNamespace
+
+import flask
+
+import mlflow.server.auth as a
+
+
+def _run(monkeypatch, validator, body, *, can_update=False, can_read=False):
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="u"))
+    monkeypatch.setattr(
+        a,
+        "_get_experiment_permission",
+        lambda eid, user: SimpleNamespace(can_update=can_update, can_read=can_read),
+    )
+    app = flask.Flask(__name__)
+    with app.test_request_context(data=body, content_type="application/json"):
+        return validator()
+
+
+def test_create_issue_handles_double_encoded_body(monkeypatch):
+    # Older clients post JSON double-encoded as a string; the validator must decode it like
+    # the handler does instead of raising AttributeError (a 500) on the str.
+    double_encoded = json.dumps(json.dumps({"experiment_id": "e1"}))
+    assert _run(monkeypatch, a.validate_can_create_issue, double_encoded, can_update=True) is True
+    assert _run(monkeypatch, a.validate_can_create_issue, double_encoded, can_update=False) is False
+
+
+def test_search_issues_handles_double_encoded_body(monkeypatch):
+    double_encoded = json.dumps(json.dumps({"experiment_id": "e1"}))
+    assert _run(monkeypatch, a.validate_can_search_issues, double_encoded, can_read=True) is True
+    assert _run(monkeypatch, a.validate_can_search_issues, double_encoded, can_read=False) is False
+
+
+def test_issue_validators_deny_empty_body(monkeypatch):
+    # No experiment_id to scope against -> fail closed rather than crash.
+    assert _run(monkeypatch, a.validate_can_create_issue, "", can_update=True) is False
+    assert _run(monkeypatch, a.validate_can_search_issues, "", can_read=True) is False


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25066 — PR **3 of a 6-PR stack** (builds on #25066). Stack: #25065 → #25066 →
**#25067 (this)** → #25069 → #25070 → #25071.

### What changes are proposed in this pull request?

**The hole being fixed**

- The Issue REST APIs — `POST /mlflow/issues` (create), `GET`/`PATCH /mlflow/issues/<issue_id>`
  (read/update), and `POST /mlflow/issues/search` — shipped with **no authorization validator**.
- Under fail-open basic-auth, any authenticated user could **read, tamper with, create, and
  enumerate issues on experiments they have no permission to**.

**The fix**

Issues are experiment-scoped, so authorize from the associated experiment:

- get → `can_read`; update → `can_update` on the issue's experiment
- create → `can_update` on the request's `experiment_id`
- search → `can_read` on the request's `experiment_id` (must be scoped)

Per-id routes resolve through `_find_validator`'s `/mlflow/issues/` branch (which falls through for
non-matching paths such as issue-detection invoke, gated in #25071); create/search resolve through
the exact-match table. Narrows the issues marker in `_KNOWN_UNGATED_ROUTE_MARKERS` to just the
still-ungated issue-detection invoke.

### How is this PR tested?

- [x] New unit/integration tests

`test_evaluation_dataset_and_issue_apis_require_experiment_permission` — an attacker holding
`NO_PERMISSIONS` is denied (403) read / write / enumerate / delete on another user's datasets **and**
issues, while the owner retains access (also covers the datasets PR #25066).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The built-in basic-auth server now enforces the associated experiment's permission on the issue APIs; requests without that permission are denied (403).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
