### PR TITLE
fix: avoid recreating existing tables during DB upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -102,8 +102,14 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
         usedforsecurity=False,
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
-        if not _all_tables_exist(engine):
+        # Only initialize tables from ORM models if the database is completely empty.
+        # If tables already exist (e.g., from an older MLflow version), rely on Alembic
+        # migrations to add/alter tables. Re-running create_all on existing tables can
+        # cause "Table already exists" errors.
+        if _is_empty_database(engine):
             _initialize_tables(engine)
+        else:
+            _upgrade_db(engine)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What
When upgrading from MLflow 3.7.0 to 3.8.x, `mlflow db upgrade` fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_safe_initialize_tables` incorrectly calls `_initialize_tables` (which calls `InitialBase.metadata.create_all`) when the database contains tables but is not fully migrated. This attempts to recreate the `secrets` table, causing a conflict.

## Fix
Modified `_safe_initialize_tables` to only create ORM-defined tables when the database is completely empty (using `_is_empty_database`). If tables already exist, we skip `create_all` and directly invoke Alembic `_upgrade_db`, allowing migrations to handle schema changes without recreating existing tables.

Closes #19943