### PR TITLE
[4/6] basic-auth: gate job routes on per-job ownership

### DIFF
--- a/mlflow/entities/_job.py
+++ b/mlflow/entities/_job.py
@@ -24,6 +24,7 @@ class Job(_MlflowObject):
         last_update_time: int,
         workspace: str | None = None,
         status_details: dict[str, Any] | None = None,
+        creator: str | None = None,
     ):
         super().__init__()
         self._job_id = job_id
@@ -37,6 +38,7 @@ class Job(_MlflowObject):
         self._last_update_time = last_update_time
         self._workspace = resolve_entity_workspace_name(workspace)
         self._status_details = status_details
+        self._creator = creator
 
     @property
     def job_id(self) -> str:
@@ -111,6 +113,11 @@ class Job(_MlflowObject):
     def workspace(self) -> str | None:
         """Workspace associated with this job."""
         return self._workspace
+
+    @property
+    def creator(self) -> str | None:
+        """Username of the authenticated user who created the job, or ``None``."""
+        return self._creator
 
     @property
     def status_details(self) -> dict[str, Any] | None:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -327,6 +327,8 @@ from mlflow.server.auth.routes import (
     GRANT_USER_PERMISSION,
     HOME,
     INVOKE_SCORER,
+    JOB_CANCEL,
+    JOB_GET,
     LIST_CURRENT_USER_PERMISSIONS,
     LIST_ROLE_PERMISSIONS,
     LIST_ROLE_USERS,
@@ -1397,6 +1399,21 @@ def sender_is_admin():
     """Validate if the sender is admin"""
     username = authenticate_request().username
     return store.get_user(username).is_admin
+
+
+def validate_is_job_owner():
+    # Jobs have no experiment scope, so ownership is the boundary: the recorded
+    # creator must match the caller. Missing creator or missing job -> denied.
+    from mlflow.server.jobs import get_job
+
+    job_id = _get_request_param("job_id")
+    try:
+        creator = get_job(job_id).creator
+    except MlflowException as e:
+        if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+            return False
+        raise
+    return creator is not None and creator == authenticate_request().username
 
 
 def _is_workspace_admin(user_id: int, workspace: str) -> bool:
@@ -3237,6 +3254,14 @@ def authenticate_request_basic_auth() -> Authorization | Response:
     return make_basic_auth_response()
 
 
+# Job routes carry a <job_id> path parameter, so they need regex matching. Both the
+# per-id fetch and cancel routes are gated on job ownership.
+JOB_BEFORE_REQUEST_VALIDATORS = {
+    (_re_compile_path(JOB_GET), "GET"): validate_is_job_owner,
+    (_re_compile_path(JOB_CANCEL), "PATCH"): validate_is_job_owner,
+}
+
+
 def _find_validator(req: Request) -> Callable[[], bool] | None:
     """
     Finds the validator matching the request path and method.
@@ -3279,6 +3304,21 @@ def _find_validator(req: Request) -> Callable[[], bool] | None:
             None,
         )
         return validator if validator is not None else lambda: False
+
+    # Job routes (/mlflow/jobs/<job_id>, cancel), ownership-gated. The /mlflow/jobs/ substring
+    # is a coarse gate: any path under it that isn't a real job route (including a crafted
+    # /prefix/mlflow/jobs/... path) fails closed here rather than falling through, which is the
+    # safe direction. Matches the sibling dataset/issue branches.
+    if "/mlflow/jobs/" in req.path:
+        route_validator = next(
+            (
+                handler
+                for (pat, method), handler in JOB_BEFORE_REQUEST_VALIDATORS.items()
+                if pat.fullmatch(req.path) and method == req.method
+            ),
+            None,
+        )
+        return route_validator if route_validator is not None else lambda: False
 
     # Whole /mlflow/issues/ family; unknown paths fail closed, except the not-yet-gated
     # routes tracked in _KNOWN_UNGATED_ROUTE_MARKERS (e.g. invoke), which fall through.
@@ -3328,7 +3368,6 @@ _HANDLER_INTERNAL_AUTHZ_SUFFIXES = (
 # (removed one at a time; when empty the flag can be flipped on).
 _KNOWN_UNGATED_ROUTE_MARKERS = (
     "/mlflow/issues/invoke",
-    "/mlflow/jobs/",
     "/gateway/budgets/",
     "/gateway/guardrails/",
     "/gateway/provider-config",

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -88,3 +88,5 @@ GATEWAY_SUPPORTED_MODELS = _get_ajax_path("/mlflow/gateway/supported-models", ve
 GATEWAY_PROVIDER_CONFIG = _get_ajax_path("/mlflow/gateway/provider-config", version=3)
 GATEWAY_SECRETS_CONFIG = _get_ajax_path("/mlflow/gateway/secrets/config", version=3)
 INVOKE_SCORER = _get_ajax_path("/mlflow/scorer/invoke", version=3)
+JOB_GET = _get_ajax_path("/mlflow/jobs/<job_id>", version=3)
+JOB_CANCEL = _get_ajax_path("/mlflow/jobs/cancel/<job_id>", version=3)

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -137,6 +137,18 @@ def job(
     return decorator
 
 
+def _current_authenticated_user() -> str | None:
+    # The basic-auth plugin stamps g.mlflow_authenticated_user; recorded as the job
+    # creator for per-job ownership. None when auth is off or no request context.
+    try:
+        from flask import g, has_request_context
+    except ImportError:
+        return None
+    if not has_request_context():
+        return None
+    return getattr(g, "mlflow_authenticated_user", None)
+
+
 def submit_job(
     function: Callable[..., Any],
     params: dict[str, Any],
@@ -220,7 +232,9 @@ def submit_job(
 
     job_store = _get_job_store()
     serialized_params = json.dumps(params)
-    job = job_store.create_job(fn_meta.name, serialized_params, timeout)
+    job = job_store.create_job(
+        fn_meta.name, serialized_params, timeout, creator=_current_authenticated_user()
+    )
     # Only propagate workspace to subprocess when workspaces are enabled
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
 

--- a/mlflow/store/db_migrations/versions/b7e2c1a4d9f3_add_jobs_creator.py
+++ b/mlflow/store/db_migrations/versions/b7e2c1a4d9f3_add_jobs_creator.py
@@ -1,0 +1,27 @@
+"""add creator column to jobs
+
+Nullable username of the job's creator, for basic-auth per-job ownership.
+
+Create Date: 2026-08-13 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7e2c1a4d9f3"
+down_revision = "17e22815139b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Batch mode so the ALTER runs on SQLite as well as server DBs.
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.add_column(sa.Column("creator", sa.String(255), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.drop_column("creator")

--- a/mlflow/store/jobs/abstract_store.py
+++ b/mlflow/store/jobs/abstract_store.py
@@ -18,7 +18,13 @@ class AbstractJobStore(ABC):
         return False
 
     @abstractmethod
-    def create_job(self, job_name: str, params: str, timeout: float | None = None) -> Job:
+    def create_job(
+        self,
+        job_name: str,
+        params: str,
+        timeout: float | None = None,
+        creator: str | None = None,
+    ) -> Job:
         """
         Create a new job with the specified function and parameters.
 
@@ -26,6 +32,7 @@ class AbstractJobStore(ABC):
             job_name: The static job name that identifies the decorated job function
             params: The job parameters that are serialized as a JSON string
             timeout: The job execution timeout in seconds
+            creator: Username of the authenticated user creating the job, or ``None``
 
         Returns:
             Job entity instance

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -86,7 +86,13 @@ class SqlAlchemyJobStore(AbstractJobStore):
             instance.workspace = DEFAULT_WORKSPACE_NAME
         return instance
 
-    def create_job(self, job_name: str, params: str, timeout: float | None = None) -> Job:
+    def create_job(
+        self,
+        job_name: str,
+        params: str,
+        timeout: float | None = None,
+        creator: str | None = None,
+    ) -> Job:
         """
         Create a new job with the specified function and parameters.
 
@@ -94,6 +100,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job_name: The static job name that identifies the decorated job function
             params: The job parameters that are serialized as a JSON string
             timeout: The job execution timeout in seconds
+            creator: Username of the authenticated user creating the job, or ``None``
 
         Returns:
             Job entity instance
@@ -112,6 +119,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
                     status=JobStatus.PENDING.to_int(),
                     result=None,
                     last_update_time=creation_time,
+                    creator=creator,
                 )
             )
 

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2413,6 +2413,14 @@ class SqlJob(Base):
     Stores additional job status details.
     """
 
+    creator = Column(String(255), nullable=True)
+    """
+    Username who created the job, for per-job ownership. ``NULL`` in three distinct cases:
+    the job was submitted with authentication disabled, the submitter was unauthenticated,
+    or the row predates this column's migration. ``NULL`` therefore does not by itself imply
+    an anonymous submitter.
+    """
+
     __table_args__ = (
         PrimaryKeyConstraint("id", name="jobs_pk"),
         Index(
@@ -2449,6 +2457,7 @@ class SqlJob(Base):
             last_update_time=self.last_update_time,
             workspace=self.workspace,
             status_details=self.status_details,
+            creator=self.creator,
         )
 
 

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -93,6 +93,7 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) COLLATE "SQL_Latin1_General_CP1_CI_AS" DEFAULT ('default') NOT NULL,
 	status_details NVARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	creator VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -94,6 +94,7 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	status_details JSON,
+	creator VARCHAR(255),
 	PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -94,6 +94,7 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default'::character varying NOT NULL,
 	status_details JSON,
+	creator VARCHAR(255),
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -94,6 +94,7 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	status_details JSON,
+	creator VARCHAR(255),
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -94,6 +94,7 @@ CREATE TABLE jobs (
 	last_update_time BIGINT NOT NULL,
 	workspace VARCHAR(63) DEFAULT 'default' NOT NULL,
 	status_details JSON,
+	creator VARCHAR(255),
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/server/auth/test_authorization_coverage.py
+++ b/tests/server/auth/test_authorization_coverage.py
@@ -1,6 +1,8 @@
 # CI guard for the basic-auth dispatcher: every Flask route must resolve to an
 # authorization decision, or be listed in the debt list _KNOWN_UNGATED_ROUTE_MARKERS.
 
+from types import SimpleNamespace
+
 from mlflow.server import auth as a
 from mlflow.server.handlers import get_endpoints
 
@@ -136,3 +138,21 @@ def test_no_ungated_fastapi_native_routes():
         "_KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS. Add a validator branch in "
         "_find_fastapi_validator, or document the exemption:\n" + "\n".join(uncovered)
     )
+
+
+def test_jobs_owner_check(monkeypatch):
+    # Jobs get/cancel are gated on ownership — the recorded creator must match the
+    # caller; a different creator or no creator is denied (admins bypass upstream).
+    import mlflow.server.jobs as jobs_mod
+
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="alice"))
+    monkeypatch.setattr(a, "_get_request_param", lambda p: "job-1")
+
+    monkeypatch.setattr(jobs_mod, "get_job", lambda jid: SimpleNamespace(creator="alice"))
+    assert a.validate_is_job_owner() is True
+
+    monkeypatch.setattr(jobs_mod, "get_job", lambda jid: SimpleNamespace(creator="bob"))
+    assert a.validate_is_job_owner() is False
+
+    monkeypatch.setattr(jobs_mod, "get_job", lambda jid: SimpleNamespace(creator=None))
+    assert a.validate_is_job_owner() is False

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -1088,3 +1088,19 @@ def test_subproc_entry_telemetry(tmp_path, monkeypatch):
 
     mock_set_telemetry.assert_called_once()
     mock_client.flush.assert_called_once()
+
+
+def test_create_job_records_creator(tmp_path: Path, workspaces_enabled):
+    # creator round-trips through both stores; optional when unauthenticated.
+    backend_store_uri = f"sqlite:///{tmp_path / 'test.db'}"
+    store_cls = WorkspaceAwareSqlAlchemyJobStore if workspaces_enabled else SqlAlchemyJobStore
+    store = store_cls(backend_store_uri)
+
+    job = store.create_job("test.function", "{}", creator="alice")
+    assert job.creator == "alice"
+    assert store.get_job(job.job_id).creator == "alice"
+
+    # creator is optional (job created without authentication)
+    anon = store.create_job("test.function", "{}")
+    assert anon.creator is None
+    assert store.get_job(anon.job_id).creator is None


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25067 — PR **4 of a 6-PR stack** (builds on #25067). Stack: #25065 → #25066 → #25067 →
**#25069 (this)** → #25070 → #25071.

### What changes are proposed in this pull request?

**The hole being fixed**

- `GET /mlflow/jobs/<job_id>` and `PATCH /mlflow/jobs/cancel/<job_id>` shipped with **no
  authorization validator**, and jobs recorded **no owner**.
- Under fail-open basic-auth, any authenticated user could **read another user's job (its
  parameters and results) and cancel it** — and there was no resource on the job to derive a
  permission from.

**The fix**

- New **nullable** `creator` column on the `jobs` table (Alembic migration `b7e2c1a4d9f3`, plus the
  `Job` entity, store signatures, and the four dialect schema snapshots). Nullable so jobs created
  without authentication (or before the migration) simply have no creator.
- `server.jobs.submit_job` stamps the creator from `g.mlflow_authenticated_user`.
- `validate_is_job_owner` allows a job only when its recorded creator matches the caller; a
  different creator, no creator, or a missing job is denied for non-admins (admins bypass upstream).
  Routing goes through `_find_validator`'s `/mlflow/jobs/` branch, which fails closed for unknown
  paths. Removes the jobs entry from `_KNOWN_UNGATED_ROUTE_MARKERS`.

### How is this PR tested?

- [x] New unit/integration tests

`test_jobs_owner_check` (owner allowed; different/absent creator denied), `test_create_job_records_creator`
(creator round-trips through both the base and workspace-aware stores; optional when absent), and the
four-dialect schema-parity snapshots.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The built-in basic-auth server now restricts job fetch/cancel to the job's creator (admins exempt); a nullable `jobs.creator` column is added via migration.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
