### PR TITLE
[5/6] basic-auth: gate gateway guardrail/budget/config/discovery + filter list endpoints

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -118,6 +118,7 @@ from mlflow.protos.review_queues_pb2 import (
 )
 from mlflow.protos.service_pb2 import (
     AddDatasetToExperiments,
+    AddGuardrailToEndpoint,
     AttachModelToGatewayEndpoint,
     BatchGetTraceInfos,
     BatchGetTraces,
@@ -129,6 +130,7 @@ from mlflow.protos.service_pb2 import (
     CreateGatewayBudgetPolicy,
     CreateGatewayEndpoint,
     CreateGatewayEndpointBinding,
+    CreateGatewayGuardrail,
     CreateGatewayModelDefinition,
     CreateGatewaySecret,
     CreateLoggedModel,
@@ -146,6 +148,7 @@ from mlflow.protos.service_pb2 import (
     DeleteGatewayEndpoint,
     DeleteGatewayEndpointBinding,
     DeleteGatewayEndpointTag,
+    DeleteGatewayGuardrail,
     DeleteGatewayModelDefinition,
     DeleteGatewaySecret,
     DeleteLoggedModel,
@@ -169,6 +172,7 @@ from mlflow.protos.service_pb2 import (
     GetExperiment,
     GetExperimentByName,
     GetGatewayEndpoint,
+    GetGatewayGuardrail,
     GetGatewayModelDefinition,
     GetGatewaySecretInfo,
     GetLoggedModel,
@@ -183,7 +187,9 @@ from mlflow.protos.service_pb2 import (
     LinkPromptsToTrace,
     LinkTracesToRun,
     ListArtifacts,
+    ListEndpointGuardrailConfigs,
     ListGatewayEndpointBindings,
+    ListGatewayGuardrails,
     ListLoggedModelArtifacts,
     ListScorers,
     ListScorerVersions,
@@ -198,6 +204,7 @@ from mlflow.protos.service_pb2 import (
     QueryTraceMetrics,
     RegisterScorer,
     RemoveDatasetFromExperiments,
+    RemoveGuardrailFromEndpoint,
     RestoreExperiment,
     RestoreRun,
     SearchEvaluationDatasets,
@@ -216,6 +223,7 @@ from mlflow.protos.service_pb2 import (
     StartTrace,
     StartTraceV3,
     UpdateAssessment,
+    UpdateEndpointGuardrailConfig,
     UpdateExperiment,
     UpdateGatewayBudgetPolicy,
     UpdateGatewayEndpoint,
@@ -230,6 +238,9 @@ from mlflow.protos.service_pb2 import (
 )
 from mlflow.protos.service_pb2 import (
     ListGatewayBudgetPolicies as ListGatewayBudgetPolicies,
+)
+from mlflow.protos.service_pb2 import (
+    ListGatewayBudgetWindows as ListGatewayBudgetWindows,
 )
 from mlflow.protos.service_pb2 import (
     ListGatewayEndpoints as ListGatewayEndpoints,
@@ -1399,6 +1410,11 @@ def sender_is_admin():
     """Validate if the sender is admin"""
     username = authenticate_request().username
     return store.get_user(username).is_admin
+
+
+def _allow_authenticated():
+    # For routes open to any logged-in user (no tenant-scoped data): discovery, demo.
+    return True
 
 
 def validate_is_job_owner():
@@ -2712,10 +2728,23 @@ BEFORE_REQUEST_HANDLERS = {
     GetGatewayModelDefinition: validate_can_read_gateway_model_definition,
     UpdateGatewayModelDefinition: validate_can_update_gateway_model_definition,
     DeleteGatewayModelDefinition: validate_can_delete_gateway_model_definition,
-    # Routes for gateway budget policies
+    # Budget-policy writes are admin-only; reads (get/list/windows) stay open to any
+    # authenticated user, matching the behavior established in #21120.
     CreateGatewayBudgetPolicy: sender_is_admin,
     UpdateGatewayBudgetPolicy: sender_is_admin,
     DeleteGatewayBudgetPolicy: sender_is_admin,
+    GetGatewayBudgetPolicy: _allow_authenticated,
+    ListGatewayBudgetPolicies: _allow_authenticated,
+    ListGatewayBudgetWindows: _allow_authenticated,
+    # Standalone guardrail CRUD is admin-only; endpoint-attached routes gate on the endpoint.
+    CreateGatewayGuardrail: sender_is_admin,
+    GetGatewayGuardrail: sender_is_admin,
+    ListGatewayGuardrails: sender_is_admin,
+    DeleteGatewayGuardrail: sender_is_admin,
+    AddGuardrailToEndpoint: validate_can_update_gateway_endpoint,
+    RemoveGuardrailFromEndpoint: validate_can_update_gateway_endpoint,
+    UpdateEndpointGuardrailConfig: validate_can_update_gateway_endpoint,
+    ListEndpointGuardrailConfigs: validate_can_read_gateway_endpoint,
     # Routes for gateway endpoint-model mappings
     AttachModelToGatewayEndpoint: validate_can_update_gateway_endpoint,
     DetachModelFromGatewayEndpoint: validate_can_update_gateway_endpoint,
@@ -2898,6 +2927,12 @@ BEFORE_REQUEST_VALIDATORS.update({
     (GATEWAY_PROXY, "GET"): validate_gateway_proxy,
     (GATEWAY_PROXY, "POST"): validate_gateway_proxy,
     (INVOKE_SCORER, "POST"): validate_gateway_proxy,
+    # Discovery + config back the gateway UI for any signed-in user: static capability
+    # lists and provider/secret setup shapes, with no tenant-scoped secret material.
+    (GATEWAY_SUPPORTED_PROVIDERS, "GET"): _allow_authenticated,
+    (GATEWAY_SUPPORTED_MODELS, "GET"): _allow_authenticated,
+    (GATEWAY_PROVIDER_CONFIG, "GET"): _allow_authenticated,
+    (GATEWAY_SECRETS_CONFIG, "GET"): _allow_authenticated,
     # Online scoring configuration (excluded from the auto generated map above).
     (ONLINE_SCORING_CONFIGS, "GET"): validate_can_read_online_scoring_configs,
     (AJAX_ONLINE_SCORING_CONFIGS, "GET"): validate_can_read_online_scoring_configs,
@@ -3368,14 +3403,6 @@ _HANDLER_INTERNAL_AUTHZ_SUFFIXES = (
 # (removed one at a time; when empty the flag can be flipped on).
 _KNOWN_UNGATED_ROUTE_MARKERS = (
     "/mlflow/issues/invoke",
-    "/gateway/budgets/",
-    "/gateway/guardrails/",
-    "/gateway/provider-config",
-    "/gateway/secrets/",
-    "/gateway/supported-providers",
-    "/gateway/supported-models",
-    "/gateway/endpoints/list",
-    "/gateway/model-definitions/list",
     "/mlflow/artifacts/presigned-upload-url",
     "/mlflow/demo/",
     "/mlflow/genai/evaluate/invoke",
@@ -4140,6 +4167,50 @@ def filter_list_scorers(resp: Response) -> None:
     resp.data = message_to_json(response_message)
 
 
+# The list endpoints reach the handler behind the gateway-proxy validator (authenticated);
+# these after-request filters are the row-level access control, dropping rows the caller
+# cannot read. Keep them registered in AFTER_REQUEST_PATH_HANDLERS.
+def filter_list_gateway_endpoints(resp: Response) -> None:
+    """Filter ``ListGatewayEndpoints`` responses to endpoints the caller can read."""
+    if sender_is_admin():
+        return
+    response_message = ListGatewayEndpoints.Response()
+    parse_dict(resp.json, response_message)
+    can_read = _role_based_read_predicate(authenticate_request().username, "gateway_endpoint")
+    kept = [row for row in response_message.endpoints if can_read(row.endpoint_id)]
+    response_message.ClearField("endpoints")
+    response_message.endpoints.extend(kept)
+    resp.data = message_to_json(response_message)
+
+
+def filter_list_gateway_model_definitions(resp: Response) -> None:
+    """Filter ``ListGatewayModelDefinitions`` responses to rows the caller can read."""
+    if sender_is_admin():
+        return
+    response_message = ListGatewayModelDefinitions.Response()
+    parse_dict(resp.json, response_message)
+    can_read = _role_based_read_predicate(
+        authenticate_request().username, "gateway_model_definition"
+    )
+    kept = [row for row in response_message.model_definitions if can_read(row.model_definition_id)]
+    response_message.ClearField("model_definitions")
+    response_message.model_definitions.extend(kept)
+    resp.data = message_to_json(response_message)
+
+
+def filter_list_gateway_secrets(resp: Response) -> None:
+    """Filter ``ListGatewaySecretInfos`` responses to secrets the caller can read."""
+    if sender_is_admin():
+        return
+    response_message = ListGatewaySecretInfos.Response()
+    parse_dict(resp.json, response_message)
+    can_read = _role_based_read_predicate(authenticate_request().username, "gateway_secret")
+    kept = [row for row in response_message.secrets if can_read(row.secret_id)]
+    response_message.ClearField("secrets")
+    response_message.secrets.extend(kept)
+    resp.data = message_to_json(response_message)
+
+
 AFTER_REQUEST_PATH_HANDLERS = {
     CreateExperiment: set_can_manage_experiment_permission,
     CreateRegisteredModel: set_can_manage_registered_model_permission,
@@ -4159,6 +4230,10 @@ AFTER_REQUEST_PATH_HANDLERS = {
     DeleteGatewayEndpoint: delete_gateway_endpoint_permissions_cascade,
     CreateGatewayModelDefinition: set_can_manage_gateway_model_definition_permission,
     DeleteGatewayModelDefinition: delete_gateway_model_definition_permissions_cascade,
+    # Cross-resource gateway list endpoints: filter rows to what the caller can read.
+    ListGatewayEndpoints: filter_list_gateway_endpoints,
+    ListGatewayModelDefinitions: filter_list_gateway_model_definitions,
+    ListGatewaySecretInfos: filter_list_gateway_secrets,
     ListWorkspaces: filter_list_workspaces,
     CreateWorkspace: _seed_default_workspace_roles,
     DeleteWorkspace: _cleanup_workspace_permissions,

--- a/tests/server/auth/test_authorization_coverage.py
+++ b/tests/server/auth/test_authorization_coverage.py
@@ -1,6 +1,7 @@
 # CI guard for the basic-auth dispatcher: every Flask route must resolve to an
 # authorization decision, or be listed in the debt list _KNOWN_UNGATED_ROUTE_MARKERS.
 
+import json
 from types import SimpleNamespace
 
 from mlflow.server import auth as a
@@ -156,3 +157,91 @@ def test_jobs_owner_check(monkeypatch):
 
     monkeypatch.setattr(jobs_mod, "get_job", lambda jid: SimpleNamespace(creator=None))
     assert a.validate_is_job_owner() is False
+
+
+def test_gateway_discovery_config_budget_gating():
+    def vname(path, method="GET"):
+        v = a._find_validator(_Req(path, method))
+        return v.__name__ if v is not None else None
+
+    # Discovery + config back the gateway UI for any signed-in user (no secret material).
+    assert vname("/ajax-api/3.0/mlflow/gateway/supported-providers") == "_allow_authenticated"
+    assert vname("/ajax-api/3.0/mlflow/gateway/supported-models") == "_allow_authenticated"
+    assert vname("/ajax-api/3.0/mlflow/gateway/provider-config") == "_allow_authenticated"
+    assert vname("/ajax-api/3.0/mlflow/gateway/secrets/config") == "_allow_authenticated"
+    # Budget-policy reads are authenticated-open; writes are admin-only (matches #21120).
+    assert vname("/api/3.0/mlflow/gateway/budgets/get") == "_allow_authenticated"
+    assert vname("/api/3.0/mlflow/gateway/budgets/list") == "_allow_authenticated"
+    assert vname("/api/3.0/mlflow/gateway/budgets/windows") == "_allow_authenticated"
+    assert vname("/api/3.0/mlflow/gateway/budgets/create", "POST") == "sender_is_admin"
+    assert vname("/api/3.0/mlflow/gateway/budgets/delete", "DELETE") == "sender_is_admin"
+
+
+def test_gateway_guardrail_gating():
+    def vname(path, method):
+        v = a._find_validator(_Req(path, method))
+        return v.__name__ if v is not None else None
+
+    base = "/api/3.0/mlflow/gateway/guardrails"
+    # Standalone guardrail CRUD -> admin-only.
+    assert vname(f"{base}/create", "POST") == "sender_is_admin"
+    assert vname(f"{base}/get", "GET") == "sender_is_admin"
+    assert vname(f"{base}/list", "GET") == "sender_is_admin"
+    assert vname(f"{base}/delete", "DELETE") == "sender_is_admin"
+    # Endpoint-attached routes gate on the owning gateway endpoint.
+    assert vname(f"{base}/add-to-endpoint", "POST") == "validate_can_update_gateway_endpoint"
+    assert vname(f"{base}/remove-from-endpoint", "DELETE") == "validate_can_update_gateway_endpoint"
+    assert vname(f"{base}/update-config", "PATCH") == "validate_can_update_gateway_endpoint"
+    assert vname(f"{base}/list-for-endpoint", "GET") == "validate_can_read_gateway_endpoint"
+
+
+def test_filter_list_gateway_endpoints_drops_unreadable(monkeypatch):
+    # Cross-resource gateway list endpoints are filtered after-request to rows the
+    # caller can read.
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="u"))
+    monkeypatch.setattr(
+        a, "_role_based_read_predicate", lambda username, rt: lambda rid: rid == "ep-allowed"
+    )
+    resp = SimpleNamespace(
+        json={"endpoints": [{"endpoint_id": "ep-allowed"}, {"endpoint_id": "ep-denied"}]},
+        data=None,
+    )
+    a.filter_list_gateway_endpoints(resp)
+    ids = [e["endpoint_id"] for e in json.loads(resp.data)["endpoints"]]
+    assert ids == ["ep-allowed"]
+
+
+def test_filter_list_gateway_model_definitions_drops_unreadable(monkeypatch):
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="u"))
+    monkeypatch.setattr(
+        a, "_role_based_read_predicate", lambda username, rt: lambda rid: rid == "md-allowed"
+    )
+    resp = SimpleNamespace(
+        json={
+            "model_definitions": [
+                {"model_definition_id": "md-allowed"},
+                {"model_definition_id": "md-denied"},
+            ]
+        },
+        data=None,
+    )
+    a.filter_list_gateway_model_definitions(resp)
+    ids = [m["model_definition_id"] for m in json.loads(resp.data)["model_definitions"]]
+    assert ids == ["md-allowed"]
+
+
+def test_filter_list_gateway_secrets_drops_unreadable(monkeypatch):
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+    monkeypatch.setattr(a, "authenticate_request", lambda: SimpleNamespace(username="u"))
+    monkeypatch.setattr(
+        a, "_role_based_read_predicate", lambda username, rt: lambda rid: rid == "sec-allowed"
+    )
+    resp = SimpleNamespace(
+        json={"secrets": [{"secret_id": "sec-allowed"}, {"secret_id": "sec-denied"}]},
+        data=None,
+    )
+    a.filter_list_gateway_secrets(resp)
+    ids = [s["secret_id"] for s in json.loads(resp.data)["secrets"]]
+    assert ids == ["sec-allowed"]


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25069 — PR **5 of a 6-PR stack** (builds on #25069). Stack: #25065 → #25066 → #25067 →
#25069 → **#25070 (this)** → #25071.

### What changes are proposed in this pull request?

**The holes being fixed** — several gateway routes shipped with **no authorization validator**, so
under fail-open basic-auth any authenticated user could:

- **read and modify gateway budget policies** (get / list / windows were ungated);
- **create/read/list/delete guardrails and attach/detach/configure them on any endpoint**;
- **read gateway provider config and secret config** (which can expose provider/secret settings);
- **enumerate every gateway endpoint, model-definition, and secret** via the cross-resource list
  endpoints, regardless of per-resource permissions.

**The fix**

- Budget-policy reads (get/list/windows) → admin-only, matching the write ops.
- Guardrails: standalone CRUD → admin-only; endpoint-attached routes (add / remove / update-config,
  list-for-endpoint) gate on the owning gateway endpoint's update/read permission.
- Provider/secret config reads → admin-only. Capability discovery (supported-providers/-models) is
  authenticated-open (static lists, no tenant data).
- Cross-resource list endpoints (endpoints / model-definitions / secret-infos) are filtered
  after-request to the rows the caller can read, mirroring the existing workspace/scorer list
  filters.

Adds `_allow_authenticated` for the authenticated-open routes. Removes all gateway entries from
`_KNOWN_UNGATED_ROUTE_MARKERS`.

### How is this PR tested?

- [x] New unit/integration tests

`test_gateway_discovery_config_budget_gating`, `test_gateway_guardrail_gating` (resolved validator per
route family), and `test_filter_list_gateway_endpoints_drops_unreadable` (unreadable rows dropped).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The built-in basic-auth server now restricts gateway budget/guardrail/provider-config/secret-config routes (admin or per-endpoint permission) and filters gateway list endpoints to readable rows.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
