### PR TITLE
Make tracing SDK cross-version jobs test the version they advertise

### DIFF
--- a/dev/flavors/src/flavors/_matrix.py
+++ b/dev/flavors/src/flavors/_matrix.py
@@ -497,23 +497,32 @@ async def expand_config(
             # Add tracing SDK test with the latest stable version
             if len(versions) > 0 and category == "autologging" and cfg.test_tracing_sdk:
                 version = max(versions)  # Test against the latest stable version
+                # Recompute the version-dependent fields for `version`. Reusing the ones left
+                # over from the loop above would pin this job to whichever version happened to
+                # be iterated last, which is the minimum appended by `versions.append(...)`.
+                requirements = [f"{package_info.pip_release}=={version}"]
+                requirements.extend(get_matched_requirements(cfg.requirements or {}, str(version)))
                 matrix.add(
                     MatrixItem(
                         name=f"{name}-tracing",
                         flavor=flavor,
                         category="tracing-sdk",
                         job_name=f"{name} / tracing-sdk / {version}",
-                        install=install,
+                        install=make_pip_install_command(requirements),
                         # --import-mode=importlib is required for testing tracing SDK
                         # (mlflow-tracing) works properly, without being affected by environment.
-                        run=run.replace("pytest", "pytest --import-mode=importlib"),
+                        run=remove_comments(cfg.run).replace(
+                            "pytest", "pytest --import-mode=importlib"
+                        ),
                         package=package_info.pip_release,
                         version=version,
-                        java=java,
+                        java=get_java_version(cfg.java, str(version)),
                         supported=version <= cfg.maximum,
                         free_disk_space=free_disk_space,
-                        python=python,
-                        runs_on=runs_on,
+                        python=get_python_version(
+                            cfg.python, package, str(version), package_info.repo
+                        ),
+                        runs_on=get_runs_on(cfg.runs_on, str(version)),
                     )
                 )
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to no existing issue. Found while investigating [this failed `pydantic_ai / tracing-sdk / 2.25.0` job](https://github.com/mlflow/mlflow/actions/runs/31059868188/job/94414717148), whose log shows it installing `pydantic-ai==0.4.10`.

### What changes are proposed in this pull request?

The `tracing-sdk` matrix item labels itself with `max(versions)` but reused `install`, `run`, `python`, `java`, and `runs_on` from the enclosing `for ver in versions:` loop. Those hold the last iterated version, and `versions.append(cfg.minimum)` puts the minimum last, so every `tracing-sdk` job installed the *oldest* supported version while advertising the newest. This PR recomputes the version-dependent fields for the selected version.

Because the version-conditional `requirements` were also resolved against the wrong version, a job could pick up pins meant for an old release. That is what the linked failure was: labelled 2.25.0, it installed `pydantic-ai==0.4.10`, matched the `< 2.0.0` rules, and died at collection on `ImportError: cannot import name 'GetSessionIdCallback'`. Real 2.25.0 uses `fastmcp` and never imports that symbol.

Worth flagging for reviewers: these jobs now genuinely exercise the latest releases for the first time, so some may surface real incompatibilities that were previously masked.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Ran the generator against `mlflow/ml-package-versions.yml` and compared each `tracing-sdk` job's label to the version its install command pins. Before: 17/17 mismatched. After: 17/17 match.

```
                    before                     after
pydantic_ai   label=2.25.0  installs=0.4.10    installs=2.25.0
openai        label=2.53.0  installs=1.97.2    installs=2.53.0
langchain     label=1.3.14  installs=1.0.0     installs=1.3.14
crewai        label=1.15.12 installs=0.152.0   installs=1.15.12
... (17 total)
```

`pydantic_ai` now resolves to `uv pip install --system 'pydantic-ai==2.25.0' 'mcp'`, correctly dropping the `mcp<2` and `opentelemetry-api<1.44` pins that only apply to older releases.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release