### PR TITLE
Sweep stale human branches after 180 days

### DIFF
--- a/.github/workflows/stale-branches.js
+++ b/.github/workflows/stale-branches.js
@@ -4,9 +4,10 @@
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // Days untouched before sweeping, by last-commit author. Bots recreate their
-// branches from scratch, so a stale one is a leftover. null exempts humans,
-// whose branches may hold work that lives nowhere else.
-const STALE_DAYS = { bot: 30, human: null };
+// branches from scratch, so a stale one is a leftover. Human branches get a far
+// longer grace period, since they may hold work that lives nowhere else.
+const BOT_STALE_DAYS = 30;
+const HUMAN_STALE_DAYS = 180;
 
 // Bot-pushed and never has a PR, so it passes every other filter.
 const EXCLUDED = new Set(["gh-pages"]);
@@ -67,11 +68,7 @@ const findStaleBranches = async (github, { owner, repo }, protectedBranches) => 
         continue;
       }
 
-      const staleDays = STALE_DAYS[isBotCommit(ref.target) ? "bot" : "human"];
-      if (staleDays === null) {
-        continue;
-      }
-
+      const staleDays = isBotCommit(ref.target) ? BOT_STALE_DAYS : HUMAN_STALE_DAYS;
       const days = Math.floor((Date.now() - new Date(ref.target.committedDate)) / MS_PER_DAY);
       if (days <= staleDays) {
         continue;


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24965

### What changes are proposed in this pull request?

The stale-branch sweeper exempted human-authored branches entirely (`human: null`). This gives them a 180-day cutoff instead, so long-abandoned branches get cleaned up while still leaving a wide grace period for work that lives nowhere else.

- `BOT_STALE_DAYS = 30` / `HUMAN_STALE_DAYS = 180`, picked by a ternary on the last commit's author.
- Drops the now-dead `staleDays === null` exemption branch.

Every other guard is unchanged: a branch is only swept if it has no open PR, is not protected, and is not in `EXCLUDED`.

### How is this PR tested?

- [x] Manual tests

The workflow already runs a dry-run preview on PRs touching these files, so the `preview` job on this PR lists exactly which branches the new cutoff catches, with a read-only token.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release