### PR TITLE
docs: add TypeScript examples to Kubernetes auth page

### DIFF
--- a/docs/docs/self-hosting/security/kubernetes.mdx
+++ b/docs/docs/self-hosting/security/kubernetes.mdx
@@ -1,3 +1,7 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import TabsWrapper from "@site/src/components/TabsWrapper";
+
 # Kubernetes Authentication
 
 MLflow includes built-in request auth providers for Kubernetes environments. These providers automatically add authorization headers to outgoing MLflow client requests using Kubernetes credentials.
@@ -23,11 +27,26 @@ The `kubernetes` provider adds only a bearer token. The `kubernetes-namespaced` 
 
 ## Prerequisites
 
-Install the `kubernetes` Python package:
+<TabsWrapper>
+<Tabs groupId="programming-language">
+<TabItem value="python" label="Python" default>
 
 ```bash
 pip install mlflow[kubernetes]
 ```
+
+</TabItem>
+<TabItem value="typescript" label="TypeScript">
+
+```bash
+npm install @mlflow/core
+```
+
+`@kubernetes/client-node` is automatically installed alongside `@mlflow/core` for kubeconfig-based credential resolution.
+
+</TabItem>
+</Tabs>
+</TabsWrapper>
 
 ## Configuration
 
@@ -63,11 +82,15 @@ This is the default path for pods with a service account mounted (which is the s
 When service account files are not available, the provider falls back to kubeconfig:
 
 - **Namespace**: Extracted from the active context
-- **Token**: Resolved via the Kubernetes Python client's `ApiClient`, which handles exec-based auth flows (EKS, GKE, AKS, OpenShift, OIDC)
+- **Token**: Resolved via the Kubernetes client library, which handles exec-based auth flows (EKS, GKE, AKS, OpenShift, OIDC)
 
 ## Usage
 
 Once configured, no code changes are needed. All MLflow client calls will automatically include the authorization headers with values sourced from Kubernetes:
+
+<TabsWrapper>
+<Tabs groupId="programming-language">
+<TabItem value="python" label="Python" default>
 
 ```python
 import mlflow
@@ -79,4 +102,35 @@ with mlflow.start_run():
     mlflow.log_metric("accuracy", 0.95)
 ```
 
-If a workspace is explicitly set (e.g., via `mlflow.set_workspace()`), it takes priority over the Kubernetes namespace. The namespace from Kubernetes credentials is used as a default when no workspace is specified.
+</TabItem>
+<TabItem value="typescript" label="TypeScript">
+
+```typescript
+import * as mlflow from "@mlflow/core";
+
+mlflow.init({
+  trackingUri: "http://mlflow-server:5000",
+  experimentId: "0",
+});
+
+const processRequest = mlflow.trace(
+  async (prompt: string) => {
+    return `Processed: ${prompt}`;
+  },
+  { name: "process-request" }
+);
+
+await processRequest("Hello from Kubernetes!");
+```
+
+:::note
+The TypeScript SDK supports [tracing](/genai/tracing) for GenAI applications. [Experiment tracking](/ml/tracking/quickstart) APIs (`start_run`, `log_param`, `log_metric`) are available in the Python SDK only.
+:::
+
+</TabItem>
+</Tabs>
+</TabsWrapper>
+
+If a workspace is explicitly set (via `MLFLOW_WORKSPACE`, or additionally `mlflow.set_workspace()` in Python), it takes priority over the Kubernetes namespace. The namespace from Kubernetes credentials is used as a default when no workspace is specified.
+
+Similarly, if `MLFLOW_TRACKING_TOKEN` is set, it is used as the bearer token instead of resolving one from Kubernetes credentials.


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->
> **Note:** The TypeScript SDK's Kubernetes auth support (#24243) is merged but not yet published to npm. This docs update can be merged once the next `@mlflow/core` npm release ships.
>
> This docs page also assumes that both SDKs follow the same auth precedence rules (e.g., `MLFLOW_TRACKING_TOKEN` overrides k8s-resolved token, `username/password` are ignored). The TS SDK already implements this; the Python SDK fix is tracked in #25082.
### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to #24243

### What changes are proposed in this pull request?

Add TypeScript examples alongside existing Python examples on the Kubernetes authentication docs page (`docs/docs/self-hosting/security/kubernetes.mdx`).

- Rename `.md` to `.mdx` for JSX tab support
- Add Python/TypeScript tabs to Prerequisites and Usage sections
- Make kubeconfig token description language-neutral


<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Manual tests

Verified the page renders correctly with `npm run start` in `docs/`.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Examples
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.


<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->
- [x] This PR can wait for the next minor release
