### PR TITLE
Pin `scikit-learn<1.8` for older xgboost and catboost in cross version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -159,6 +159,10 @@ xgboost:
     maximum: "3.3.0"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
+      # scikit-learn 1.8.0 dropped the attribute-based estimator type that
+      # `XGBModel._get_type` relies on, so older xgboost raises
+      # "`_estimator_type` undefined" against it.
+      "< 3.1.3": ["scikit-learn<1.8"]
     run: |
       pytest tests/xgboost/test_xgboost_model_export.py
 
@@ -167,6 +171,7 @@ xgboost:
     maximum: "3.3.0"
     requirements:
       ">= 0.0.0": ["scikit-learn", "matplotlib"]
+      "< 3.1.3": ["scikit-learn<1.8"]
     run: |
       pytest tests/xgboost/test_xgboost_autolog.py
 
@@ -204,6 +209,9 @@ catboost:
     maximum: "1.2.10"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
+      # scikit-learn 1.8.0 requires estimators to implement `__sklearn_tags__`,
+      # which catboost only started providing in 1.2.9.
+      "< 1.2.9": ["scikit-learn<1.8"]
       "< 1.3": ["numpy<2"]
     run: |
       pytest tests/catboost/test_catboost_model_export.py


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

scikit-learn 1.8.0 requires Python >= 3.11, so it is unreachable while our minimum is 3.10. As soon as cross version tests move to 3.11 the resolver jumps from 1.7.2 to 1.8+, and older xgboost/catboost break against it:

- xgboost < 3.1.3: ``TypeError: `_estimator_type` undefined`` from `XGBModel._get_type`, because 1.8.0 dropped the attribute-based estimator type.
- catboost < 1.2.9: `AttributeError: 'CatBoostRegressor' object has no attribute '__sklearn_tags__'`, because 1.8.0 requires estimators to implement it.

Both boundaries were bisected directly (xgboost 3.1.2 fails / 3.1.3 passes, catboost 1.2.8 fails / 1.2.9 passes, both against scikit-learn 1.8.0 and 1.9.0 on Python 3.11; 1.7.2 passes everywhere).

Pinning per version range keeps the old versions under test instead of raising the tested minimums. This is inert today (3.10 already caps scikit-learn at 1.7.2) and prevents 9 cross version jobs from breaking when the minimum moves, as seen in #25085.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release