### PR TITLE
Bump model serving image to Ubuntu 24.04 and Python 3.11

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -21,7 +21,7 @@ PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
 SETUP_PYENV = r"""# Setup pyenv
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 RUN git clone \
     --depth 1 \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -33,8 +33,9 @@ RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python3.11 python3.11-distutils \
-    # Remove python3-blinker to avoid pip uninstall conflicts
-    && apt remove -y python3-blinker \
+    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
+    # since deadsnakes Python keeps Debian's dist-packages on sys.path
+    && apt remove -y python3-blinker python3-cryptography \
     && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -14,7 +14,7 @@ from mlflow.version import VERSION
 
 _logger = logging.getLogger(__name__)
 
-UBUNTU_BASE_IMAGE = "ubuntu:22.04"
+UBUNTU_BASE_IMAGE = "ubuntu:24.04"
 PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
 
 
@@ -32,10 +32,10 @@ RUN apt install -y software-properties-common \
     && apt update \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y python3.10 python3.10-distutils \
+    && apt install -y python3.11 python3.11-distutils \
     # Remove python3-blinker to avoid pip uninstall conflicts
     && apt remove -y python3-blinker \
-    && ln -s -f $(which python3.10) /usr/bin/python \
+    && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 """  # noqa: E501

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -75,7 +75,7 @@ def build_docker(
             mlflow will be installed into the environment after it has been activated.
             The version of installed mlflow will be the same as the one used to invoke this command.
         base_image: Base image for the Docker image. If not specified, the default image is either
-            UBUNTU_BASE_IMAGE = "ubuntu:22.04" or PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
+            UBUNTU_BASE_IMAGE = "ubuntu:24.04" or PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
             Note: If custom image is used, there are no guarantees that the image will work. You
             may find greater compatibility by building your image on top of the ubuntu images. In
             addition, you must install Java and virtualenv to have the image work properly.

--- a/tests/resources/dockerfile/Dockerfile_conda
+++ b/tests/resources/dockerfile/Dockerfile_conda
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -18,8 +18,9 @@ RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python3.11 python3.11-distutils \
-    # Remove python3-blinker to avoid pip uninstall conflicts
-    && apt remove -y python3-blinker \
+    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
+    # since deadsnakes Python keeps Debian's dist-packages on sys.path
+    && apt remove -y python3-blinker python3-cryptography \
     && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -6,7 +6,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get insta
 # Setup pyenv
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 RUN git clone \
     --depth 1 \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
@@ -17,10 +17,10 @@ RUN apt install -y software-properties-common \
     && apt update \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y python3.10 python3.10-distutils \
+    && apt install -y python3.11 python3.11-distutils \
     # Remove python3-blinker to avoid pip uninstall conflicts
     && apt remove -y python3-blinker \
-    && ln -s -f $(which python3.10) /usr/bin/python \
+    && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -18,8 +18,9 @@ RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python3.11 python3.11-distutils \
-    # Remove python3-blinker to avoid pip uninstall conflicts
-    && apt remove -y python3-blinker \
+    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
+    # since deadsnakes Python keeps Debian's dist-packages on sys.path
+    && apt remove -y python3-blinker python3-cryptography \
     && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -6,7 +6,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get insta
 # Setup pyenv
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 RUN git clone \
     --depth 1 \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
@@ -17,10 +17,10 @@ RUN apt install -y software-properties-common \
     && apt update \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y python3.10 python3.10-distutils \
+    && apt install -y python3.11 python3.11-distutils \
     # Remove python3-blinker to avoid pip uninstall conflicts
     && apt remove -y python3-blinker \
-    && ln -s -f $(which python3.10) /usr/bin/python \
+    && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -18,8 +18,9 @@ RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python3.11 python3.11-distutils \
-    # Remove python3-blinker to avoid pip uninstall conflicts
-    && apt remove -y python3-blinker \
+    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
+    # since deadsnakes Python keeps Debian's dist-packages on sys.path
+    && apt remove -y python3-blinker python3-cryptography \
     && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -6,7 +6,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get insta
 # Setup pyenv
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 RUN git clone \
     --depth 1 \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
@@ -17,10 +17,10 @@ RUN apt install -y software-properties-common \
     && apt update \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y python3.10 python3.10-distutils \
+    && apt install -y python3.11 python3.11-distutils \
     # Remove python3-blinker to avoid pip uninstall conflicts
     && apt remove -y python3-blinker \
-    && ln -s -f $(which python3.10) /usr/bin/python \
+    && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_conda
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_conda
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -18,8 +18,9 @@ RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python3.11 python3.11-distutils \
-    # Remove python3-blinker to avoid pip uninstall conflicts
-    && apt remove -y python3-blinker \
+    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
+    # since deadsnakes Python keeps Debian's dist-packages on sys.path
+    && apt remove -y python3-blinker python3-cryptography \
     && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -6,7 +6,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get insta
 # Setup pyenv
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 RUN git clone \
     --depth 1 \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
@@ -17,10 +17,10 @@ RUN apt install -y software-properties-common \
     && apt update \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y python3.10 python3.10-distutils \
+    && apt install -y python3.11 python3.11-distutils \
     # Remove python3-blinker to avoid pip uninstall conflicts
     && apt remove -y python3-blinker \
-    && ln -s -f $(which python3.10) /usr/bin/python \
+    && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -18,8 +18,9 @@ RUN apt install -y software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python3.11 python3.11-distutils \
-    # Remove python3-blinker to avoid pip uninstall conflicts
-    && apt remove -y python3-blinker \
+    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
+    # since deadsnakes Python keeps Debian's dist-packages on sys.path
+    && apt remove -y python3-blinker python3-cryptography \
     && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -6,7 +6,7 @@ RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get insta
 # Setup pyenv
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 RUN git clone \
     --depth 1 \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -1,5 +1,5 @@
 # Build an image that can serve mlflow models.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
@@ -17,10 +17,10 @@ RUN apt install -y software-properties-common \
     && apt update \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
-    && apt install -y python3.10 python3.10-distutils \
+    && apt install -y python3.11 python3.11-distutils \
     # Remove python3-blinker to avoid pip uninstall conflicts
     && apt remove -y python3-blinker \
-    && ln -s -f $(which python3.10) /usr/bin/python \
+    && ln -s -f $(which python3.11) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`UBUNTU_BASE_IMAGE` was `ubuntu:22.04` with Python 3.10 from the deadsnakes PPA. Two reasons to move both:

- Python 3.10 reaches EOL in 2026-10, and the image installing it is what makes `pip install /opt/mlflow` fail once `requires-python` moves to `>=3.11`. In #25085 this single template accounts for 10 spark cross version jobs plus the `test_build_docker*` and `test_build_and_push_container` failures.
- Ubuntu 22.04 leaves standard support on 2027-04-01, only months after that. 24.04 runs to 2029-05-31.

24.04 rather than staying on 22.04 because deadsnakes publishes `python3.11-distutils` for noble but not for jammy, so `apt install python3.11 python3.11-distutils` has no candidate on 22.04. `openjdk-11-jdk`, the template's default JDK, is still in noble's archive.

The `tests/resources/dockerfile/*` fixtures are the expected output of this template and move with it.

### How is this PR tested?

- [x] Existing unit/integration tests

`tests/pyfunc/docker/test_docker.py` and `tests/sagemaker/test_cli.py` diff the generated Dockerfile against the fixtures, and the `models` / `python` jobs build the image for real.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Model serving images built by `mlflow models build-docker` and `mlflow sagemaker build-and-push-container` are now based on Ubuntu 24.04 with Python 3.11, instead of Ubuntu 22.04 with Python 3.10.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release