### PR TITLE
Pin `pandas<3` for older prophet and transformers in cross version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -389,6 +389,8 @@ prophet:
       ">= 0.0.0": ["numpy<2"]
       # cmdstanpy>=1.3.0 is not compatible with prophet<=1.2.0: https://github.com/facebook/prophet/issues/2697
       "<= 1.2.0": ["cmdstanpy<1.3.0"]
+      # `Prophet.fit` raises "cannot reindex on an axis with duplicate labels" under pandas 3.
+      "< 1.2.2": ["pandas<3"]
       # Avoid holidays 0.25 due to https://github.com/dr-prodigy/python-holidays/issues/1200 on
       # older version of prophet. Compatibility updates have been released as part of the 1.1.4
       # release of prophet.
@@ -500,6 +502,8 @@ transformers:
         ]
       # peft >= 0.14 relies on classes from newer versions of transformers
       "< 4.45": ["peft<0.14.0"]
+      # The TAPAS tokenizer raises "len() of unsized object" under pandas 3, fixed in 5.10.4.
+      "< 5.10.4": ["pandas<3"]
       # peft >= 0.18 requires transformers.modeling_layers which was added in transformers 4.52.0
       "< 4.52": ["peft<0.18.0"]
       ">= 4.38.2": ["tf-keras"] # Transformers doesn't support Keras 3.0. tf-keras needs to be installed.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

pandas 3.0 requires Python >= 3.11, so it is unreachable while our minimum is 3.10. Once cross version tests move to 3.11 the resolver jumps from pandas 2.3.x to 3.0, and two flavors break in library code:

- prophet < 1.2.2: `ValueError: cannot reindex on an axis with duplicate labels`, raised inside `Prophet.fit`. The test fixture frame is byte identical under pandas 2 and 3 (same shape, unique index, same dtypes), so the incompatibility is prophet's, not ours.
- transformers < 5.10.4 (`models` only): `TypeError: len() of unsized object` from the TAPAS table-QA tokenizer, in `transformers/models/tapas/tokenization_tapas.py`. Same family as the 5.0.0 TAPAS breakage already recorded in `unsupported`.

Boundaries are taken from the #25085 matrix: prophet 1.1.6/1.1.7 fail and 1.2.2/1.3.0 pass; transformers `models` fails through 5.6.2 and passes from 5.10.4, while `autologging` passes throughout and is left alone.

Pinning per version range keeps the old versions under test rather than raising the tested minimums, matching #25088. Inert today, since 3.10 already caps pandas at 2.x.

Note that statsmodels fails the same probe for an unrelated reason (our own fixture uses the `M` and `AS` offset aliases that pandas 3 removed), so it is not pinned here and needs a fixture fix instead.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release