### PR TITLE
Replace pandas offset aliases removed in pandas 3 in statsmodels fixtures

### DIFF
--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -111,7 +111,7 @@ def wls_model():
 def recursivels_model():
     # Recursive Least Squares
     dta = sm.datasets.copper.load_pandas().data
-    dta.index = pd.date_range("1951-01-01", "1975-01-01", freq="YS")
+    dta.index = pd.date_range("1951-01-01", "1975-01-01", freq=pd.offsets.YearBegin())
     endog = dta.WORLDCONSUMPTION
 
     # To the regressors in the dataset, we add a column of ones for an intercept
@@ -227,7 +227,7 @@ def arma_model():
     maparams = np.array([1, 0.65, 0.35])
     nobs = 250
     y = arma_generate_sample(arparams, maparams, nobs)
-    dates = pd.date_range("1980-1-1", freq="ME", periods=nobs)
+    dates = pd.date_range("1980-1-1", freq=pd.offsets.MonthEnd(), periods=nobs)
     y = pd.Series(y, index=dates)
 
     arima = ARIMA(y, order=(2, 0, 2), trend="n")

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -111,7 +111,7 @@ def wls_model():
 def recursivels_model():
     # Recursive Least Squares
     dta = sm.datasets.copper.load_pandas().data
-    dta.index = pd.date_range("1951-01-01", "1975-01-01", freq="AS")
+    dta.index = pd.date_range("1951-01-01", "1975-01-01", freq="YS")
     endog = dta.WORLDCONSUMPTION
 
     # To the regressors in the dataset, we add a column of ones for an intercept
@@ -227,7 +227,7 @@ def arma_model():
     maparams = np.array([1, 0.65, 0.35])
     nobs = 250
     y = arma_generate_sample(arparams, maparams, nobs)
-    dates = pd.date_range("1980-1-1", freq="M", periods=nobs)
+    dates = pd.date_range("1980-1-1", freq="ME", periods=nobs)
     y = pd.Series(y, index=dates)
 
     arima = ARIMA(y, order=(2, 0, 2), trend="n")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`tests/statsmodels/model_fixtures.py` builds date indexes with the `AS` and `M` offset aliases. Both were deprecated in pandas 2.2 and removed in pandas 3.0, so every statsmodels test errors during fixture setup once pandas 3 is installed:

```
tests/statsmodels/model_fixtures.py:230: in arma_model
    dates = pd.date_range("1980-1-1", freq="M", periods=nobs)
E   ValueError: 'M' is no longer supported for offsets. Please use 'ME' instead.
```

pandas 3.0 requires Python >= 3.11, which is why this only shows up in #25085. Unlike the prophet and transformers failures in #25090, this is our own test code rather than a library incompatibility, so a `pandas<3` pin would be the wrong fix. It also explains why all four statsmodels jobs fail, with no working version boundary to pin against.

`AS` -> `YS` and `M` -> `ME` are the documented replacements and produce identical indexes on pandas 2 (verified: `AS == YS` and `M == ME` both hold on 2.3.3, 25 and 250 entries respectively), so this is a no-op on the current minimum and a fix on 3.11.

These were the only two offset aliases in the repo; every other `freq=` is a Keras/Lightning `save_freq="epoch"`.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release