### PR TITLE
Pin `tensorflow>=2.19` for transformers model tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -485,7 +485,9 @@ transformers:
           "hf_transfer",
           "torch",
           "torchvision",
-          "tensorflow",
+          # TensorFlow < 2.19 is built against numpy 1.x and crashes ("_ARRAY_API not found")
+          # under the numpy 2.x that the rest of this set resolves to.
+          "tensorflow>=2.19",
           "peft", # optimized fine-tuning library developed by Hugging Face
           "accelerate", # required for large torch models where weights will not fit in RAM
           "librosa", # required for transformers audio pipelines for bitrate conversion


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25090

### What changes are proposed in this pull request?

The transformers `models` cross version tests started failing today with a numpy ABI error during `import transformers.pipelines`:

```
A module that was compiled using NumPy 1.x cannot be run in NumPy 2.2.6 as it may crash.
ImportError: numpy.core._multiarray_umath failed to import
RuntimeError: Failed to import transformers.pipelines
```

The resolver is picking `tensorflow==2.14.0`, which predates numpy 2 support and has no upper bound on numpy, so it lands alongside `numpy==2.2.6` and crashes on import. Nothing in the repo changed to cause this: `UV_EXCLUDE_NEWER=P7D` is a rolling window, and yesterday's nightly resolved `tensorflow==2.19.1` with `numpy==2.1.3` for the same jobs on the same Python 3.10.20.

Reproduced with `uv pip install --dry-run --python-version 3.10 --python-platform x86_64-unknown-linux-gnu` against the exact requirement set:

| requirements | tensorflow | numpy |
| --- | --- | --- |
| as-is on master | 2.14.0 | 2.2.6 |
| with `tensorflow>=2.19` | 2.19.1 | 2.1.3 |

The floor restores the combination the nightly was already using, and resolves identically for transformers 4.43.4, 4.55.4, 5.6.2, and 5.14.1. Only the `models` set is changed, since `autologging` has a different requirement list and is not affected.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release