### PR TITLE
Map S3 download 404 to `RESOURCE_DOES_NOT_EXIST`

### DIFF
--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -524,13 +524,24 @@ class S3ArtifactRepository(
             local_path: Absolute path where the file should be saved locally.
                 The parent directory must exist.
         """
+        from botocore.exceptions import ClientError
+
         (bucket, s3_root_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
         download_kwargs = (
             {"ExtraArgs": self._bucket_owner_params} if self._bucket_owner_params else {}
         )
-        s3_client.download_file(bucket, s3_full_path, local_path, **download_kwargs)
+        try:
+            s3_client.download_file(bucket, s3_full_path, local_path, **download_kwargs)
+        except ClientError as error:
+            error_code = error.response["Error"]["Code"]
+            mlflow_error_code = BOTO_TO_MLFLOW_ERROR.get(error_code, INTERNAL_ERROR)
+            error_message = error.response["Error"]["Message"]
+            raise MlflowException(
+                f"Failed to download {s3_full_path} from {self.artifact_uri}: {error_message}",
+                error_code=mlflow_error_code,
+            )
 
     def delete_artifacts(self, artifact_path=None):
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -292,6 +292,14 @@ def test_download_file_artifact_succeeds_when_artifact_root_is_s3_bucket_root(
         assert f.read() == file_a_text
 
 
+def test_download_file_missing_key_raises_resource_does_not_exist(s3_artifact_root, tmp_path):
+    repo = S3ArtifactRepository(posixpath.join(s3_artifact_root, "some/path"))
+
+    with pytest.raises(MlflowException, match="Failed to download") as exc_info:
+        repo._download_file("missing.txt", tmp_path / "missing.txt")
+    assert exc_info.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+
 def test_get_s3_file_upload_extra_args():
     os.environ.setdefault(
         "MLFLOW_S3_UPLOAD_EXTRA_ARGS",


### PR DESCRIPTION
### Related Issues/PRs

Closes #24535

### What changes are proposed in this pull request?

`S3ArtifactRepository._download_file` called `boto3`'s managed `download_file` without any error handling. When the S3 key is missing, botocore raises a raw `ClientError` (HTTP 404 — `download_file` performs an internal `HeadObject`, so a missing key surfaces as boto code `"404"`). That raw error propagates out of the artifact layer and is aggregated into `INTERNAL_ERROR` / HTTP 500, so a *missing artifact* looks like a *server fault* — and clients retry it, producing retry storms for a condition that will never succeed.

The fix wraps the `download_file` call in the exact `try/except ClientError` idiom the sibling paths in this same module already use — `_iterate_s3_paginated_results` (`list_artifacts`) and `get_download_presigned_url`. The boto error code is mapped through the existing `BOTO_TO_MLFLOW_ERROR` dict (which already maps `"404"` → `RESOURCE_DOES_NOT_EXIST`), so a missing key now raises `MlflowException(..., RESOURCE_DOES_NOT_EXIST)`. Only `_download_file` was left unwrapped; this brings it in line with its siblings. `OptimizedS3ArtifactRepository` has its own `_download_file` and is unaffected.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added `test_download_file_missing_key_raises_resource_does_not_exist` (moto-backed) mirroring the existing S3 error-handling tests. Red → green on this repo:

- **Without the fix:** `botocore.exceptions.ClientError: An error occurred (404) ...` propagates uncaught → `1 failed`.
- **With the fix:** raises `MlflowException` with `error_code == "RESOURCE_DOES_NOT_EXIST"` → `1 passed`.

```
uv run --with 'boto3' --with 'moto>=4.2.0,<5,!=4.2.5' \
  pytest tests/store/artifact/test_s3_artifact_repo.py \
  -k test_download_file_missing_key_raises_resource_does_not_exist
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Downloading a missing artifact from S3 now raises `MlflowException` with `RESOURCE_DOES_NOT_EXIST` instead of a raw `botocore` `ClientError` surfaced as `INTERNAL_ERROR` / HTTP 500.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---
_for the record: drafted with Claude Code, reviewed + verified locally by me._
