### PR TITLE
Keep Anthropic API key out of the Claude step in `review.yml` via a local proxy

### DIFF
--- a/.claude/scripts/anthropic-proxy.mjs
+++ b/.claude/scripts/anthropic-proxy.mjs
@@ -1,0 +1,51 @@
+// Forwarding proxy that holds the Anthropic API key so the Claude CLI process
+// (and anything it spawns) never sees it. Stdin carries two lines: the real
+// API key, then a per-run client key callers must present as x-api-key. Both
+// live only in this process's heap — never in /proc/<pid>/environ or argv.
+import http from "node:http";
+import https from "node:https";
+import { text } from "node:stream/consumers";
+
+const PORT = 8082;
+
+const [KEY, CLIENT_KEY] = (await text(process.stdin)).split("\n").map((s) => s.trim());
+if (!KEY || !CLIENT_KEY) {
+  console.error("anthropic-proxy: expected API key and client key on stdin");
+  process.exit(1);
+}
+
+const server = http.createServer((req, res) => {
+  console.log(`anthropic-proxy: ${req.method} ${req.url}`);
+  if (req.url === "/healthz" || req.url === "/api/hello") {
+    res.writeHead(200).end("ok");
+    return;
+  }
+  if (req.headers["x-api-key"] !== CLIENT_KEY) {
+    res.writeHead(401).end("unauthorized");
+    return;
+  }
+  if (!["GET", "POST"].includes(req.method) || !req.url.startsWith("/v1/")) {
+    res.writeHead(403).end("forbidden");
+    return;
+  }
+  const headers = { ...req.headers, host: "api.anthropic.com", "x-api-key": KEY };
+  delete headers.authorization;
+  const upstream = https.request(
+    { host: "api.anthropic.com", path: req.url, method: req.method, headers },
+    (up) => {
+      res.writeHead(up.statusCode, up.headers);
+      up.pipe(res); // pipe to preserve SSE streaming
+    }
+  );
+  upstream.on("error", (err) => {
+    if (!res.headersSent) {
+      res.writeHead(502);
+    }
+    res.end(`anthropic-proxy: upstream error: ${err.message}`);
+  });
+  req.pipe(upstream);
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`anthropic-proxy: listening on 127.0.0.1:${PORT}`);
+});

--- a/.claude/scripts/anthropic-proxy.mjs
+++ b/.claude/scripts/anthropic-proxy.mjs
@@ -15,7 +15,9 @@ if (!KEY || !CLIENT_KEY) {
 }
 
 const server = http.createServer((req, res) => {
-  console.log(`anthropic-proxy: ${req.method} ${req.url}`);
+  // Log the path only: the log is dumped into the public workflow log, so
+  // keep query strings out of it.
+  console.log(`anthropic-proxy: ${req.method} ${req.url.split("?")[0]}`);
   if (req.url === "/healthz" || req.url === "/api/hello") {
     res.writeHead(200).end("ok");
     return;
@@ -33,7 +35,10 @@ const server = http.createServer((req, res) => {
   const upstream = https.request(
     { host: "api.anthropic.com", path: req.url, method: req.method, headers },
     (up) => {
-      res.writeHead(up.statusCode, up.headers);
+      // Node decodes chunked framing on the upstream response and re-frames
+      // what we write, so drop hop-by-hop headers instead of echoing them.
+      const { "transfer-encoding": _te, connection: _conn, ...respHeaders } = up.headers;
+      res.writeHead(up.statusCode, respHeaders);
       up.pipe(res); // pipe to preserve SSE streaming
     }
   );

--- a/.claude/scripts/anthropic-proxy.mjs
+++ b/.claude/scripts/anthropic-proxy.mjs
@@ -2,11 +2,16 @@
 // (and anything it spawns) never sees it. Stdin carries two lines: the real
 // API key, then a per-run client key callers must present as x-api-key. Both
 // live only in this process's heap — never in /proc/<pid>/environ or argv.
+//
+// NOTE for reviewers and agents: in CI this proxy serves the Claude CLI's own
+// API traffic on 127.0.0.1:8082. Do not kill, restart, or port-squat the
+// running instance (e.g. `pkill -f anthropic-proxy`) — that severs the review's
+// own API connection. To experiment, run a copy with PORT=<other port>.
 import http from "node:http";
 import https from "node:https";
 import { text } from "node:stream/consumers";
 
-const PORT = 8082;
+const PORT = Number(process.env.PORT ?? 8082);
 
 const [KEY, CLIENT_KEY] = (await text(process.stdin)).split("\n").map((s) => s.trim());
 if (!KEY || !CLIENT_KEY) {

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/review.yml"
+      - ".claude/scripts/anthropic-proxy.mjs"
       - ".claude/skills/pr-review/**"
 
 concurrency:
@@ -179,9 +180,10 @@ jobs:
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
       # The Claude step never sees the real API key: the proxy holds it and the
-      # CLI talks to the proxy with a random per-run client key. Both keys are
-      # passed via stdin (printf is a bash builtin) so they appear in no
-      # process's env or argv.
+      # CLI talks to the proxy with a random per-run client key. The real key
+      # is passed via stdin (printf is a bash builtin) so it appears in no
+      # process's env or argv, and --disable-sigusr1 blocks same-UID processes
+      # from recovering it through a signal-triggered inspector session.
       - name: Start Anthropic proxy
         id: proxy
         env:
@@ -190,9 +192,10 @@ jobs:
           CLIENT_KEY=$(openssl rand -hex 32)
           echo "client-key=$CLIENT_KEY" >> "$GITHUB_OUTPUT"
           printf '%s\n%s' "$ANTHROPIC_API_KEY" "$CLIENT_KEY" \
-            | env -u ANTHROPIC_API_KEY node .claude/scripts/anthropic-proxy.mjs &
+            | env -u ANTHROPIC_API_KEY node --disable-sigusr1 .claude/scripts/anthropic-proxy.mjs \
+              > /tmp/anthropic-proxy.log 2>&1 &
           timeout 10 bash -c 'until curl -sf -o /dev/null http://127.0.0.1:8082/healthz; do sleep 0.5; done' \
-            || { echo "::error::Anthropic proxy failed to start"; exit 1; }
+            || { echo "::error::Anthropic proxy failed to start"; cat /tmp/anthropic-proxy.log; exit 1; }
 
       - name: Review
         id: review
@@ -228,6 +231,12 @@ jobs:
             cat "$OUTPUT_FILE"
             exit $EXIT_CODE
           fi
+
+      # The runner stops reading the proxy's stdout once its own step ends, so
+      # the proxy writes to a file and we dump it here for diagnosability.
+      - name: Show proxy log
+        if: always()
+        run: cat /tmp/anthropic-proxy.log || true
 
       - name: Validate review payload
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -178,12 +178,29 @@ jobs:
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
+      # The Claude step never sees the real API key: the proxy holds it and the
+      # CLI talks to the proxy with a random per-run client key. Both keys are
+      # passed via stdin (printf is a bash builtin) so they appear in no
+      # process's env or argv.
+      - name: Start Anthropic proxy
+        id: proxy
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
+        run: |
+          CLIENT_KEY=$(openssl rand -hex 32)
+          echo "client-key=$CLIENT_KEY" >> "$GITHUB_OUTPUT"
+          printf '%s\n%s' "$ANTHROPIC_API_KEY" "$CLIENT_KEY" \
+            | env -u ANTHROPIC_API_KEY node .claude/scripts/anthropic-proxy.mjs &
+          timeout 10 bash -c 'until curl -sf -o /dev/null http://127.0.0.1:8082/healthz; do sleep 0.5; done' \
+            || { echo "::error::Anthropic proxy failed to start"; exit 1; }
+
       - name: Review
         id: review
         env:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
-          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: http://127.0.0.1:8082
+          ANTHROPIC_API_KEY: ${{ steps.proxy.outputs.client-key }}
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
@@ -232,10 +249,11 @@ jobs:
         run: |
           gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input /tmp/review-payload.json
 
+      # The API key stays in the proxy and never reaches the Claude step's
+      # env, so only the app tokens need redacting.
       - name: Redact secrets from transcript
         if: always()
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
           GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
           GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
         run: |
@@ -248,7 +266,7 @@ jobs:
           if not path.exists():
               sys.exit(0)
           data = path.read_text()
-          for name in ("ANTHROPIC_API_KEY", "GH_TOKEN_READ", "GH_TOKEN_WRITE"):
+          for name in ("GH_TOKEN_READ", "GH_TOKEN_WRITE"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
           path.write_text(data)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -263,6 +263,7 @@ jobs:
         env:
           GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
           GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
+          PROXY_CLIENT_KEY: ${{ steps.proxy.outputs.client-key }}
         run: |
           python <<'PY'
           import os
@@ -273,7 +274,7 @@ jobs:
           if not path.exists():
               sys.exit(0)
           data = path.read_text()
-          for name in ("GH_TOKEN_READ", "GH_TOKEN_WRITE"):
+          for name in ("GH_TOKEN_READ", "GH_TOKEN_WRITE", "PROXY_CLIENT_KEY"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
           path.write_text(data)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -249,8 +249,6 @@ jobs:
         run: |
           gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input /tmp/review-payload.json
 
-      # The API key stays in the proxy and never reaches the Claude step's
-      # env, so only the app tokens need redacting.
       - name: Redact secrets from transcript
         if: always()
         env:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The review workflow previously put `ANTHROPIC_API_KEY` in the Claude step's env, where every subprocess Claude spawns inherits it (an `env` dump or `os.environ` read triggered by prompt injection would leak it, and it could land in the uploaded transcript).

This PR routes the Claude CLI through a small dependency-free Node proxy (`.claude/scripts/anthropic-proxy.mjs`) instead:

- The real key is piped to the proxy over **stdin** (`printf` is a bash builtin and the env var is stripped with `env -u`), so it lives only in the proxy's heap: it appears in no process's `/proc/<pid>/environ` or argv. Same-UID memory reads are blocked by Yama `ptrace_scope=1` on the Ubuntu runner images.
- The Claude step gets `ANTHROPIC_BASE_URL=http://127.0.0.1:8082` and a random per-run client key as `ANTHROPIC_API_KEY`; the proxy rejects requests without it, only forwards `GET`/`POST` on `/v1/*` (so it can't be used as a generic relay), and swaps in the real key.
- The transcript redaction step no longer needs the API key (it can't reach the transcript anymore), which also avoids re-exposing the secret in a later step's env.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested locally with the proxy running and a bogus upstream key:

- `/healthz` returns 200; requests without/with a wrong client key get 401; valid client key on a non-`/v1` path gets 403; valid client key on `/v1/messages` is forwarded to `api.anthropic.com` (401 `authentication_error` from upstream proves forwarding).
- `ANTHROPIC_BASE_URL=http://127.0.0.1:8082 ANTHROPIC_API_KEY=<client-key> claude --print "say hi"` reaches the proxy (`HEAD /api/hello` probe answered 200, then `POST /v1/messages?beta=true` forwarded upstream), confirming the CLI honors the base URL and the SSE plumbing.

The `pull_request` smoke run on this PR exercises the full path with the real key.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)