### PR TITLE
Skip V4/UC trace IDs in `LiveSpan.add_link` instead of normalizing

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1043,7 +1043,7 @@ class LiveSpan(Span):
         # Span links are not supported for Unity Catalog (V4) traces. Warn and skip rather than
         # silently normalizing the V4 trace ID to raw OTel hex (see #25080); this matches how
         # V4-trace links are dropped at span construction.
-        if link.trace_id and link.trace_id.startswith(TRACE_ID_V4_PREFIX):
+        if link.trace_id is not None and link.trace_id.startswith(TRACE_ID_V4_PREFIX):
             _logger.warning(
                 "Span links are not currently supported for Unity Catalog traces. "
                 "The link to trace '%s' will be skipped.",

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1040,6 +1040,17 @@ class LiveSpan(Span):
                 INVALID_PARAMETER_VALUE,
             )
 
+        # Span links are not supported for Unity Catalog (V4) traces. Warn and skip rather than
+        # silently normalizing the V4 trace ID to raw OTel hex (see #25080); this matches how
+        # V4-trace links are dropped at span construction.
+        if link.trace_id and link.trace_id.startswith(TRACE_ID_V4_PREFIX):
+            _logger.warning(
+                "Span links are not currently supported for Unity Catalog traces. "
+                "The link to trace '%s' will be skipped.",
+                link.trace_id,
+            )
+            return
+
         # Validate and forward to the underlying OTel span so external exporters can see links
         try:
             link_trace_id_hex = parse_trace_id_v4(link.trace_id)[1].removeprefix(

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1061,7 +1061,7 @@ class LiveSpan(Span):
             trace_id_int.to_bytes(16, "big")
             span_id_int.to_bytes(8, "big")
             otel_context = build_otel_context(trace_id_int, span_id_int)
-        except (ValueError, OverflowError, MlflowException) as e:
+        except (ValueError, OverflowError, AttributeError, MlflowException) as e:
             raise MlflowException(
                 f"Invalid link: trace_id={link.trace_id!r}, span_id={link.span_id!r}. "
                 "trace_id must be a valid MLflow trace ID or hex string, and "

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -989,6 +989,9 @@ def test_add_link_rejects_invalid_ids():
         with pytest.raises(MlflowException, match="Invalid link"):
             span.add_link(Link(trace_id="tr-abc123", span_id="aabbccddeeff0011aabbccddeeff0011"))
 
+        with pytest.raises(MlflowException, match="Invalid link"):
+            span.add_link(Link(trace_id=None, span_id="aabbccddeeff0011"))
+
         assert len(span.links) == 0
 
 
@@ -1008,6 +1011,7 @@ def test_add_link_skips_v4_trace_id():
         assert len(otel_span.links) == 0
         mock_warning.assert_called_once()
         assert "Unity Catalog" in mock_warning.call_args.args[0]
+        assert mock_warning.call_args.args[1] == "trace:/catalog.schema/abc123"
 
 
 def test_span_seeds_links_from_otel_span():

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -992,6 +992,24 @@ def test_add_link_rejects_invalid_ids():
         assert len(span.links) == 0
 
 
+def test_add_link_skips_v4_trace_id():
+    from mlflow.entities.link import Link
+
+    trace_id = "tr-12345"
+    tracer = _get_tracer("test")
+    with tracer.start_as_current_span("test_span") as otel_span:
+        span = create_mlflow_span(otel_span, trace_id=trace_id)
+
+        with mock.patch("mlflow.entities.span._logger.warning") as mock_warning:
+            span.add_link(Link(trace_id="trace:/catalog.schema/abc123", span_id="aabbccddeeff0011"))
+
+        # V4/UC trace links are not supported: skipped, not normalized or stored.
+        assert len(span.links) == 0
+        assert len(otel_span.links) == 0
+        mock_warning.assert_called_once()
+        assert "Unity Catalog" in mock_warning.call_args.args[0]
+
+
 def test_span_seeds_links_from_otel_span():
     trace_id = "tr-12345"
     otel_link = trace_api.Link(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25080 (Python half). The TypeScript `addLink` half is tracked by #23480.

### What changes are proposed in this pull request?

Span links are not supported for Unity Catalog (V4) traces. `LiveSpan.add_link` nonetheless ran the trace ID through `parse_trace_id_v4()`, silently normalizing a V4 id (`trace:/<location>/<hex>`) to raw OTel hex and storing a link that can never be honored for V4/UC traces.

This makes `add_link` **warn and skip** a V4 trace ID up front instead of normalizing it — matching how V4-trace links are already dropped at span construction (`LiveSpan.__init__`). Since all higher-level APIs (`trace()`, `start_span()`, etc.) delegate to `add_link`, this is the single validation point.

Chose warn-and-skip (over raising) for consistency with the existing construction-time behavior and to avoid breaking higher-level `links=` flows.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New `test_add_link_skips_v4_trace_id` asserts a V4 trace-id link is warned and not stored (and not forwarded to the OTel span). Existing `tests/entities/test_span.py` add_link tests and `tests/tracing/test_span_links_api.py` pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.