### PR TITLE
Drop cross version testing for pyspark < 3.4.4

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -315,17 +315,14 @@ spark:
       pyspark --version
 
   models:
-    minimum: "3.2.1"
+    minimum: "3.4.4"
     maximum: "4.2.0"
-    java:
-      "<= 3.4.1": "11"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and
     # autologging use cases in environments where newer versions of pyspark are available
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
     requirements:
       ">= 0.0.0": ["boto3", "scikit-learn", "pyarrow", "numpy<2"]
-      "< 3.4.0": ["pandas<2"]
       ">= 3.5.0": ["torch<2.6.0", "scikit-learn", "torcheval"]
       ">= 3.5.0, < dev": ["pyspark[connect]"]
     run: |
@@ -344,17 +341,14 @@ spark:
       fi
 
   autologging:
-    minimum: "3.3.0"
+    minimum: "3.4.4"
     maximum: "4.2.0"
-    java:
-      "<= 3.4.1": "11"
     # NB: Allow unreleased maximum versions for the pyspark package to support models and
     # autologging use cases in environments where newer versions of pyspark are available
     # prior to their release on PyPI (e.g. Databricks)
     allow_unreleased_max_version: True
     requirements:
       ">= 0.0.0": ["scikit-learn", "numpy<2"]
-      "< 3.4.0": ["pandas<2"]
     run: |
       # Build Java package
       # Pyspark 4.0 ('dev' version) exclusively supports Scala 2.13

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -334,11 +334,11 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "pyspark"
         },
         "models": {
-            "minimum": "3.2.1",
+            "minimum": "3.4.4",
             "maximum": "4.2.0"
         },
         "autologging": {
-            "minimum": "3.3.0",
+            "minimum": "3.4.4",
             "maximum": "4.2.0"
         }
     },

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -737,7 +737,8 @@ def test_is_autologging_integration_supported(flavor, module_version, expected_r
     [
         ("pyspark.ml", "99.0.0.dev0", False),
         ("pyspark.ml", "3.5.0.dev0", True),
-        ("pyspark.ml", "3.3.0.dev0", True),
+        ("pyspark.ml", "3.4.4.dev0", True),
+        ("pyspark.ml", "3.3.0.dev0", False),
         ("pyspark.ml", "3.2.1.dev0", False),
         ("pyspark.ml", "3.1.2.dev0", False),
         ("pyspark.ml", "3.0.1.dev0", False),


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

Raise the tested pyspark minimum from 3.2.1 (models) and 3.3.0 (autologging) to 3.4.4.

These releases are end of life on every axis that matters:

- **Upstream**: Apache Spark maintains minor releases for roughly 18 months. 3.2.4 (2023-04-13) and 3.3.4 (2023-12-16) were the final releases of their lines, and 3.3.0 shipped 2022-06-15.
- **Databricks**: no supported Databricks Runtime ships Spark 3.2 or 3.3. The runtimes that did, 11.3 LTS (Spark 3.3.0) and 12.2 LTS (Spark 3.3.2), are both out of support. The oldest supported today is Spark 3.4.1 on DBR 13.3 LTS, which itself reaches end of support on 2026-08-22.
- **Python**: pyspark only began declaring Python 3.11 support in 3.4.0. 3.2.x declares up to 3.9 and 3.3.4 up to 3.10, while `requires-python` stays at `>=3.6`/`>=3.7`, so pip installs them onto 3.11 anyway and they fail at runtime. In #25085 these versions fail with `_pickle.PicklingError: Could not serialize object: IndexError: tuple index out of range` from the vendored `pyspark.cloudpickle`, which cannot be fixed with a pin since pyspark vendors its own copy.

Two specifiers become dead once the floor moves and are removed:

- `"< 3.4.0": ["pandas<2"]` in both blocks, which would otherwise fail `validate_requirements` since it matches no tested version.
- `java: "<= 3.4.1": "11"`, since no tested version is `<= 3.4.1`. Every remaining version already resolves to the default Java 17, so this is a no-op.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The minimum supported pyspark version for the `spark` flavor is now 3.4.4. Older releases are end of life upstream and are not shipped by any supported Databricks Runtime.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release