### PR TITLE
Pin `scipy<1.16` and `pandas<3` for older statsmodels in cross version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -290,12 +290,22 @@ statsmodels:
   models:
     minimum: "0.14.3"
     maximum: "0.14.6"
+    requirements:
+      # scipy 1.16.0 removed the private `scipy._lib._util._lazywhere` that
+      # statsmodels imports at module scope until 0.14.5.
+      "< 0.14.5": ["scipy<1.16"]
+      # pandas 3 changed `pandas.util._decorators.deprecate_kwarg`, which
+      # statsmodels calls at import time until 0.14.6.
+      "< 0.14.6": ["pandas<3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_model_export.py
 
   autologging:
     minimum: "0.14.3"
     maximum: "0.14.6"
+    requirements:
+      "< 0.14.5": ["scipy<1.16"]
+      "< 0.14.6": ["pandas<3"]
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

scipy 1.16.0 and pandas 3.0 both require Python >= 3.11, so neither is reachable while our minimum is 3.10. Once cross version tests move to 3.11, statsmodels below 0.14.6 fails at import time, before any test runs.

There are two distinct breakages with different cut-offs, bisected on Python 3.11:

| statsmodels | unpinned result |
| --- | --- |
| 0.14.3, 0.14.4 | `ImportError: cannot import name '_lazywhere' from 'scipy._lib._util'` |
| 0.14.5 | scipy fixed; `TypeError: deprecate_kwarg() missing 1 required positional argument: 'new_arg_name'` from pandas |
| 0.14.6 | works (scipy 1.17.1, pandas 3.0.5) |

So the pins are scoped separately rather than blanket-applied: `scipy<1.16` only below 0.14.5, and `pandas<3` below 0.14.6. Verified that 0.14.5 needs only the pandas pin (it resolves scipy 1.17.1 happily) and that 0.14.3 imports with both pins (scipy 1.15.3, pandas 2.3.3).

Pinning rather than raising the minimum, because unlike the pyspark case in #25098 these releases are current: 0.14.6 is the latest release and only shipped 2025-12-05, so a 0.14.6 floor would leave the flavor supporting exactly one version.

Inert today, since 3.10 already caps scipy below 1.16 and pandas below 3.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release