### PR TITLE
Nudge PR authors to attach media when a PR changes UI code

### DIFF
--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -1,8 +1,39 @@
 const ACTIVITY_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_REPOS_TO_DISPLAY = 10;
 
+const UI_SOURCE_PREFIX = "mlflow/server/js/src/";
+const UI_SOURCE_EXTENSIONS = [".tsx", ".jsx", ".ts", ".js", ".css", ".scss", ".less"];
+const UI_SOURCE_EXCLUDES = [".test.", ".stories.", "__snapshots__/"];
+
+const MEDIA_PATTERNS = [
+  /!\[[^\]]*\]\([^)]+\)/, // markdown image
+  /<(img|video)\b/i,
+  /https:\/\/github\.com\/user-attachments\/assets\//i,
+  /https:\/\/(user-images|private-user-images)\.githubusercontent\.com\//i,
+  /https?:\/\/\S+\.(png|jpe?g|gif|webp|mp4|mov|webm)\b/i,
+];
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasUiChanges(files) {
+  return files.some(({ filename }) => {
+    if (!filename.startsWith(UI_SOURCE_PREFIX)) {
+      return false;
+    }
+    if (!UI_SOURCE_EXTENSIONS.some((ext) => filename.endsWith(ext))) {
+      return false;
+    }
+    return !UI_SOURCE_EXCLUDES.some((pattern) => filename.includes(pattern));
+  });
+}
+
+function hasVisibleMedia(body) {
+  // Strip HTML comments first. The PR template ships a "screenshot, video" hint as a comment,
+  // and media pasted inside a comment block isn't rendered either.
+  const visible = (body || "").replace(/<!--[\s\S]*?-->/g, "");
+  return MEDIA_PATTERNS.some((pattern) => pattern.test(visible));
 }
 
 async function getRecentActivity(github, username) {
@@ -174,6 +205,28 @@ ${activitySection}
         "The PR description is missing required sections. " +
         "Please use the [PR template](https://raw.githubusercontent.com/mlflow/mlflow/master/.github/pull_request_template.md)."
     );
+  }
+
+  if (!hasVisibleMedia(body)) {
+    try {
+      const files = await github.paginate(github.rest.pulls.listFiles, {
+        owner,
+        repo,
+        pull_number: issue_number,
+        per_page: 100,
+      });
+      if (hasUiChanges(files)) {
+        messages.push(
+          "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
+            "This PR changes front-end code, but the description doesn't show what the change " +
+            "looks like. Please attach a screenshot or screen recording of the UI change so " +
+            "reviewers can see it without checking out the branch. If the change isn't visible " +
+            "in the UI, feel free to ignore this."
+        );
+      }
+    } catch (e) {
+      console.log("Failed to fetch changed files:", e);
+    }
   }
 
   if (messages.length > 0) {

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -201,10 +201,9 @@ ${activitySection}
       if (hasUiChanges(files)) {
         messages.push(
           "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
-            "This PR changes front-end code, but the description has no screenshot or screen " +
-            "recording. Please attach one, including a before/after pair if you're changing " +
-            "existing UI. This check only runs when the PR is opened, so ignore this if it's " +
-            "a false alert."
+            "This PR changes front-end code, but the description has no screenshot or " +
+            "screen recording. Please attach one, including a before/after pair if " +
+            "you're changing existing UI. Ignore this if it's a false alert."
         );
       }
     } catch (e) {

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -203,8 +203,10 @@ ${activitySection}
           "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
             "This PR changes front-end code, but the description doesn't show what the change " +
             "looks like. Please attach a screenshot or screen recording of the UI change so " +
-            "reviewers can see it without checking out the branch. If the change isn't visible " +
-            "in the UI, feel free to ignore this."
+            "reviewers can see it without checking out the branch.\n\n" +
+            "This check only runs when the PR is opened and doesn't re-run afterwards, so please " +
+            "ignore this if it's a false alert (e.g. you've since attached media, or the change " +
+            "isn't visible in the UI)."
         );
       }
     } catch (e) {

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -200,7 +200,7 @@ ${activitySection}
       });
       if (hasUiChanges(files)) {
         messages.push(
-          "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
+          "#### &#x1F5BC;&#xFE0F; Missing visual media\n\n" +
             "This PR changes front-end code, but the description has no screenshot or " +
             "screen recording. Please attach one to the PR description, including a " +
             "before/after pair if you're changing existing UI. Ignore this if it's a false alert."

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -1,39 +1,22 @@
 const ACTIVITY_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_REPOS_TO_DISPLAY = 10;
 
-const UI_SOURCE_PREFIX = "mlflow/server/js/src/";
-const UI_SOURCE_EXTENSIONS = [".tsx", ".jsx", ".ts", ".js", ".css", ".scss", ".less"];
-const UI_SOURCE_EXCLUDES = [".test.", ".stories.", "__snapshots__/"];
-
-const MEDIA_PATTERNS = [
-  /!\[[^\]]*\]\([^)]+\)/, // markdown image
-  /<(img|video)\b/i,
-  /https:\/\/github\.com\/user-attachments\/assets\//i,
-  /https:\/\/(user-images|private-user-images)\.githubusercontent\.com\//i,
-  /https?:\/\/\S+\.(png|jpe?g|gif|webp|mp4|mov|webm)\b/i,
-];
+const UI_FILE = /^mlflow\/server\/js\/src\/.+\.(tsx|jsx|ts|js|css|scss|less)$/;
+const MEDIA =
+  /!\[[^\]]*\]\([^)]+\)|<(img|video)\b|https:\/\/github\.com\/user-attachments\/|https?:\/\/\S+\.(png|jpe?g|gif|webp|mp4|mov|webm)\b/i;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function hasUiChanges(files) {
-  return files.some(({ filename }) => {
-    if (!filename.startsWith(UI_SOURCE_PREFIX)) {
-      return false;
-    }
-    if (!UI_SOURCE_EXTENSIONS.some((ext) => filename.endsWith(ext))) {
-      return false;
-    }
-    return !UI_SOURCE_EXCLUDES.some((pattern) => filename.includes(pattern));
-  });
+  return files.some(({ filename }) => UI_FILE.test(filename) && !filename.includes(".test."));
 }
 
 function hasVisibleMedia(body) {
   // Strip HTML comments first. The PR template ships a "screenshot, video" hint as a comment,
   // and media pasted inside a comment block isn't rendered either.
-  const visible = (body || "").replace(/<!--[\s\S]*?-->/g, "");
-  return MEDIA_PATTERNS.some((pattern) => pattern.test(visible));
+  return MEDIA.test((body || "").replace(/<!--[\s\S]*?-->/g, ""));
 }
 
 async function getRecentActivity(github, username) {

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -201,12 +201,9 @@ ${activitySection}
       if (hasUiChanges(files)) {
         messages.push(
           "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
-            "This PR changes front-end code, but the description doesn't show what the change " +
-            "looks like. Please attach a screenshot or screen recording of the UI change so " +
-            "reviewers can see it without checking out the branch.\n\n" +
-            "This check only runs when the PR is opened and doesn't re-run afterwards, so please " +
-            "ignore this if it's a false alert (e.g. you've since attached media, or the change " +
-            "isn't visible in the UI)."
+            "This PR changes front-end code, but the description has no screenshot or screen " +
+            "recording. Please attach one. This check only runs when the PR is opened, so " +
+            "ignore this if it's a false alert."
         );
       }
     } catch (e) {

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -202,8 +202,8 @@ ${activitySection}
         messages.push(
           "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
             "This PR changes front-end code, but the description has no screenshot or " +
-            "screen recording. Please attach one, including a before/after pair if " +
-            "you're changing existing UI. Ignore this if it's a false alert."
+            "screen recording. Please attach one to the PR description, including a " +
+            "before/after pair if you're changing existing UI. Ignore this if it's a false alert."
         );
       }
     } catch (e) {

--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -202,8 +202,9 @@ ${activitySection}
         messages.push(
           "#### &#x1F5BC;&#xFE0F; Missing screenshot\n\n" +
             "This PR changes front-end code, but the description has no screenshot or screen " +
-            "recording. Please attach one. This check only runs when the PR is opened, so " +
-            "ignore this if it's a false alert."
+            "recording. Please attach one, including a before/after pair if you're changing " +
+            "existing UI. This check only runs when the PR is opened, so ignore this if it's " +
+            "a false alert."
         );
       }
     } catch (e) {


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`advice.js` now nudges the author to attach a screenshot or screen recording when a PR changes front-end code but its description has no visible media.

Kept simple, so false alarms are expected: `.test.` is the only exclusion and the check runs on `opened` only. The message says to ignore it if it's a false alert.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked the two helpers with a throwaway node script (27 cases, all passing). There's no test harness for `.github/workflows/*.js`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

