### PR TITLE
[7/8] basic-auth: fail-closed enforcement for native FastAPI routes

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -42,6 +42,7 @@ from flask import (
 )
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import Response as StarletteResponse
+from starlette.routing import BaseRoute, Match, Mount
 from werkzeug.datastructures import Authorization
 
 from mlflow import MlflowException
@@ -5602,6 +5603,16 @@ def _apply_fastapi_response_filter(
     )
 
 
+def _native_fastapi_routes(app: FastAPI) -> list[BaseRoute]:
+    # Routes served directly by FastAPI, excluding the mounted Flask app (authorized via Flask).
+    return [route for route in app.routes if not isinstance(route, Mount)]
+
+
+def _scope_matches_native_route(native_routes: list[BaseRoute], scope) -> bool:
+    # True if the request matches a native FastAPI route (vs a path delegated to Flask).
+    return any(route.matches(scope)[0] == Match.FULL for route in native_routes)
+
+
 def add_fastapi_permission_middleware(app: FastAPI) -> None:
     """
     Add permission middleware to FastAPI app for routes not handled by Flask.
@@ -5627,6 +5638,8 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
     Args:
         app: The FastAPI application instance.
     """
+    # Snapshot native routes so the fail-closed check can tell them from Flask-delegated paths.
+    native_routes = _native_fastapi_routes(app)
 
     @app.middleware("http")
     async def fastapi_permission_middleware(request, call_next):
@@ -5639,6 +5652,14 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
         # Find validator for this route
         validator = _find_fastapi_validator(path, request.method)
         if validator is None:
+            # Fail-closed (opt-in via MLFLOW_BASIC_AUTH_FAIL_CLOSED): deny a native FastAPI
+            # route with no validator. Flask-delegated paths pass through (authorized by Flask).
+            if (
+                MLFLOW_BASIC_AUTH_FAIL_CLOSED.get()
+                and _scope_matches_native_route(native_routes, request.scope)
+                and not any(marker in path for marker in _KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS)
+            ):
+                return PlainTextResponse("Permission denied", status_code=HTTPStatus.FORBIDDEN)
             return await call_next(request)
 
         # Authenticate using either the custom authorization_function (via Flask

--- a/tests/server/auth/test_fastapi_fail_closed.py
+++ b/tests/server/auth/test_fastapi_fail_closed.py
@@ -1,0 +1,62 @@
+# Runtime fail-closed enforcement for the FastAPI permission middleware: a native
+# FastAPI route with no validator is denied when MLFLOW_BASIC_AUTH_FAIL_CLOSED is on,
+# while paths delegated to the mounted Flask app pass through untouched.
+
+from fastapi import FastAPI
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from mlflow.server import auth as a
+
+
+async def _flask_like(scope, receive, send):
+    # Stand-in for the mounted Flask WSGI app.
+    await PlainTextResponse("flask-ok")(scope, receive, send)
+
+
+def _build_client(monkeypatch):
+    # No route resolves a validator, and nothing is "unprotected", so the fail-closed
+    # branch is what decides native routes.
+    monkeypatch.setattr(a, "is_unprotected_route", lambda path: False)
+    monkeypatch.setattr(a, "_find_fastapi_validator", lambda path, method: None)
+
+    app = FastAPI()
+
+    @app.get("/api/3.0/mlflow/native-new-feature")
+    async def native():
+        return PlainTextResponse("native-ok")
+
+    app.mount("/flask", _flask_like)
+    a.add_fastapi_permission_middleware(app)
+    return TestClient(app)
+
+
+def test_native_route_without_validator_denied_when_fail_closed(monkeypatch):
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    client = _build_client(monkeypatch)
+    assert client.get("/api/3.0/mlflow/native-new-feature").status_code == 403
+
+
+def test_native_route_allowed_when_flag_off(monkeypatch):
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "false")
+    client = _build_client(monkeypatch)
+    resp = client.get("/api/3.0/mlflow/native-new-feature")
+    assert resp.status_code == 200
+    assert resp.text == "native-ok"
+
+
+def test_flask_delegated_path_passes_through_even_when_fail_closed(monkeypatch):
+    # A path served only by the mounted Flask app is not a native route, so the
+    # middleware must not deny it — Flask's _before_request authorizes it downstream.
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    client = _build_client(monkeypatch)
+    resp = client.get("/flask/anything")
+    assert resp.status_code == 200
+    assert resp.text == "flask-ok"
+
+
+def test_documented_marker_exempts_native_route(monkeypatch):
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    monkeypatch.setattr(a, "_KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS", ("/mlflow/native-new-feature",))
+    client = _build_client(monkeypatch)
+    assert client.get("/api/3.0/mlflow/native-new-feature").status_code == 200


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25065 (introduces the flag + FastAPI coverage guard) — stacked on the tip of
that 6-PR series (#25071). Addresses reviewer follow-ups on #25065 about the FastAPI surface.

### What changes are proposed in this pull request?

**The hole being closed**

- The FastAPI permission middleware authorizes routes served directly by FastAPI (gateway
  invocations, otel, jobs, assistant, artifacts, MCP), which bypass Flask's `_before_request`.
- It **failed open**: a native route resolving no validator (`_find_fastapi_validator` →
  `None`) was passed straight through — the FastAPI analog of the fail-open Flask dispatcher.
- (All 53 current native routes already resolve a validator, so there is no active gap today;
  the risk was a *future* native route added without one.)

**The fix** — mirror the Flask fail-closed net on the FastAPI surface:

- When `MLFLOW_BASIC_AUTH_FAIL_CLOSED` is enabled, a native FastAPI route with no validator
  (and not documented in `_KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS`) is denied (403) instead of
  allowed.
- Native-vs-Flask is decided by the app's own routing (Starlette route matching), excluding
  the mounted Flask WSGI app — so paths delegated to Flask pass through and are authorized by
  `_before_request` as before.

Default **off**, so behavior is unchanged unless the flag is enabled; the deny branch is inert
for today's routes (all validated) and only guards against future ungated native routes. The
CI coverage guard (`test_no_ungated_fastapi_native_routes`, added in #25065) remains the
compile-time complement.

Not in scope (separate follow-up): strengthening the job/assistant native routes from
authentication-only to resource-level authorization.

### How is this PR tested?

- [x] New unit tests

`tests/server/auth/test_fastapi_fail_closed.py`: native route without a validator is denied
when the flag is on; allowed when off; a path delegated to the mounted Flask app passes
through even with the flag on; a documented marker exempts a native route.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When `MLFLOW_BASIC_AUTH_FAIL_CLOSED` is enabled, native FastAPI routes with no authorization validator are now denied (fail-closed), matching the Flask behavior.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
