### PR TITLE
[8/8] basic-auth: gate native FastAPI job routes on per-job ownership

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -5374,6 +5374,39 @@ def _get_require_authentication_validator() -> Callable[[str, StarletteRequest],
     return validator
 
 
+def _job_id_from_path(unprefixed_path: str) -> str | None:
+    # get (/jobs/<id>) and cancel (/jobs/cancel/<id>) carry a job id; submit and search do not.
+    tail = unprefixed_path.split("/ajax-api/3.0/jobs", 1)[-1].strip("/")
+    if not tail or tail == "search":
+        return None
+    if tail.startswith("cancel/"):
+        return tail[len("cancel/") :] or None
+    return tail
+
+
+def _get_job_route_validator(
+    path: str,
+) -> Callable[[str, StarletteRequest], Awaitable[bool]]:
+    # get/cancel by id are ownership-gated (admins bypass upstream); submit/search need only auth.
+    # NB: /jobs/search still returns all jobs — filtering to the caller is a tracked follow-up.
+    job_id = _job_id_from_path(path)
+
+    async def validator(username: str, request: StarletteRequest) -> bool:
+        if job_id is None:
+            return True
+        from mlflow.server.jobs import get_job
+
+        try:
+            creator = get_job(job_id).creator
+        except MlflowException as e:
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                return False
+            raise
+        return creator is not None and creator == username
+
+    return validator
+
+
 def _get_otel_validator(
     path: str,
 ) -> Callable[[str, StarletteRequest], Awaitable[bool]]:
@@ -5496,7 +5529,7 @@ def _find_fastapi_validator(
         return _get_otel_validator(unprefixed)
 
     if unprefixed.startswith("/ajax-api/3.0/jobs"):
-        return _get_require_authentication_validator()
+        return _get_job_route_validator(unprefixed)
 
     if unprefixed.startswith("/ajax-api/3.0/mlflow/assistant"):
         return _get_require_authentication_validator()

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -5,7 +5,7 @@ Internal job APIs for UI invocation
 import json
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from mlflow.entities._job import Job as JobEntity
@@ -68,15 +68,18 @@ class SubmitJobPayload(BaseModel):
 
 
 @job_api_router.post("/", response_model=Job)
-def submit_job(payload: SubmitJobPayload) -> Job:
+def submit_job(payload: SubmitJobPayload, request: Request) -> Job:
     from mlflow.server.jobs import submit_job
     from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
     job_name = payload.job_name
+    # Record the caller (stamped on request.state by the middleware; flask.g isn't populated
+    # there) as the job creator, so ownership checks on get/cancel recognize the submitter.
+    creator = getattr(request.state, "username", None)
     try:
         function_fullname = get_job_fn_fullname(job_name)
         function = _load_function(function_fullname)
-        job = submit_job(function, payload.params, payload.timeout)
+        job = submit_job(function, payload.params, payload.timeout, creator=creator)
         return Job.from_job_entity(job)
     except MlflowException as e:
         raise HTTPException(

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -154,6 +154,7 @@ def submit_job(
     params: dict[str, Any],
     timeout: float | None = None,
     extra_envs: dict[str, str] | None = None,
+    creator: str | None = None,
 ) -> JobEntity:
     """
     Submit a job to the job queue. The job is executed at most once.
@@ -179,6 +180,8 @@ def submit_job(
         params: The params to be passed to the job function.
         timeout: (optional) The job execution timeout, default None (no timeout)
         extra_envs: (optional) Additional environment variables to set in the job subprocess.
+        creator: (optional) Username to record as the job creator. When omitted, falls back to
+            the authenticated user stamped on ``flask.g`` by the basic-auth plugin.
 
     Returns:
         The job entity. You can call `get_job` API by the job id to get
@@ -232,9 +235,10 @@ def submit_job(
 
     job_store = _get_job_store()
     serialized_params = json.dumps(params)
-    job = job_store.create_job(
-        fn_meta.name, serialized_params, timeout, creator=_current_authenticated_user()
-    )
+    # FastAPI callers pass creator explicitly (no flask.g there); Flask callers fall back to g.
+    if creator is None:
+        creator = _current_authenticated_user()
+    job = job_store.create_job(fn_meta.name, serialized_params, timeout, creator=creator)
     # Only propagate workspace to subprocess when workspaces are enabled
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
 

--- a/tests/server/auth/test_fastapi_job_ownership.py
+++ b/tests/server/auth/test_fastapi_job_ownership.py
@@ -1,0 +1,99 @@
+# The native FastAPI job routes gate fetch/cancel-by-id on ownership (the recorded
+# creator must match the caller); submit and search only require authentication.
+
+import asyncio
+from types import SimpleNamespace
+
+import mlflow.server.jobs as jobs_mod
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.server import auth as a
+
+
+def _decide(path, method, username, monkeypatch, *, creator="alice", missing=False):
+    def _get_job(job_id):
+        if missing:
+            raise MlflowException("no such job", error_code=RESOURCE_DOES_NOT_EXIST)
+        return SimpleNamespace(creator=creator)
+
+    monkeypatch.setattr(jobs_mod, "get_job", _get_job)
+    validator = a._find_fastapi_validator(path, method)
+    return asyncio.run(validator(username, None))
+
+
+def test_get_job_owner_allowed(monkeypatch):
+    assert _decide("/ajax-api/3.0/jobs/job-1", "GET", "alice", monkeypatch, creator="alice") is True
+
+
+def test_get_job_non_owner_denied(monkeypatch):
+    assert _decide("/ajax-api/3.0/jobs/job-1", "GET", "bob", monkeypatch, creator="alice") is False
+
+
+def test_get_job_no_creator_denied(monkeypatch):
+    assert _decide("/ajax-api/3.0/jobs/job-1", "GET", "alice", monkeypatch, creator=None) is False
+
+
+def test_get_missing_job_denied(monkeypatch):
+    assert _decide("/ajax-api/3.0/jobs/job-x", "GET", "alice", monkeypatch, missing=True) is False
+
+
+def test_cancel_owner_allowed(monkeypatch):
+    path = "/ajax-api/3.0/jobs/cancel/job-1"
+    assert _decide(path, "PATCH", "alice", monkeypatch, creator="alice") is True
+
+
+def test_cancel_non_owner_denied(monkeypatch):
+    path = "/ajax-api/3.0/jobs/cancel/job-1"
+    assert _decide(path, "PATCH", "bob", monkeypatch, creator="alice") is False
+
+
+def test_submit_requires_only_authentication():
+    # POST /jobs/ has no job id: any authenticated user may submit (creator is recorded).
+    validator = a._find_fastapi_validator("/ajax-api/3.0/jobs/", "POST")
+    assert asyncio.run(validator("anyone", None)) is True
+
+
+def test_search_requires_only_authentication():
+    validator = a._find_fastapi_validator("/ajax-api/3.0/jobs/search", "POST")
+    assert asyncio.run(validator("anyone", None)) is True
+
+
+def test_job_id_from_path():
+    assert a._job_id_from_path("/ajax-api/3.0/jobs/abc") == "abc"
+    assert a._job_id_from_path("/ajax-api/3.0/jobs/cancel/abc") == "abc"
+    assert a._job_id_from_path("/ajax-api/3.0/jobs/") is None
+    assert a._job_id_from_path("/ajax-api/3.0/jobs/search") is None
+
+
+def _run_submit_handler(monkeypatch, request_state):
+    # Drive the native FastAPI submit handler with the pieces it resolves at call time
+    # stubbed out, capturing the creator it forwards to server.jobs.submit_job.
+    import mlflow.server.jobs as jobs_mod
+    import mlflow.server.jobs.utils as jobs_utils
+    from mlflow.server import job_api
+
+    captured = {}
+
+    def _fake_submit(function, params, timeout, creator=None):
+        captured["creator"] = creator
+        return SimpleNamespace()
+
+    monkeypatch.setattr(jobs_utils, "get_job_fn_fullname", lambda name: "pkg.fn")
+    monkeypatch.setattr(jobs_utils, "_load_function", lambda fullname: lambda: None)
+    monkeypatch.setattr(jobs_mod, "submit_job", _fake_submit)
+    monkeypatch.setattr(job_api.Job, "from_job_entity", classmethod(lambda cls, job: None))
+
+    payload = job_api.SubmitJobPayload(job_name="pkg.fn", params={}, timeout=None)
+    job_api.submit_job(payload, SimpleNamespace(state=request_state))
+    return captured["creator"]
+
+
+def test_submit_records_creator_from_request_state(monkeypatch):
+    # The FastAPI middleware stamps request.state.username; the handler must forward it as the
+    # creator so ownership checks on get/cancel recognize the submitter.
+    assert _run_submit_handler(monkeypatch, SimpleNamespace(username="alice")) == "alice"
+
+
+def test_submit_creator_none_when_unauthenticated(monkeypatch):
+    # No username on request.state (auth disabled) -> creator is None, not an error.
+    assert _run_submit_handler(monkeypatch, SimpleNamespace()) is None


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25069 (adds the `creator` column) and #25101 (FastAPI fail-closed) — stacked on
that series. Addresses the reviewer follow-up on #25065 that native FastAPI job/assistant
routes are only authentication-gated.

### What changes are proposed in this pull request?

**The hole being fixed**

- The native FastAPI job routes (served by the FastAPI middleware, bypassing Flask's
  `_before_request`) required only **authentication**, so any authenticated user could fetch
  (`GET /ajax-api/3.0/jobs/{job_id}`) or cancel (`PATCH /ajax-api/3.0/jobs/cancel/{job_id}`)
  **another user's job** — reading its params/results or cancelling it.

**The fix** — mirror the Flask job routes' ownership check on the FastAPI surface:

- Fetch/cancel **by id** are gated on ownership: the recorded `creator` must match the caller
  (admins bypass upstream in the middleware); a different creator or a missing job is denied.
- **Submit** (`POST /jobs/`) and **search** (`POST /jobs/search`) still require only
  authentication — submit records the caller as the creator.

**Deliberately out of scope (tracked follow-up):** `POST /jobs/search` still returns all jobs
regardless of creator (an enumeration leak). Filtering it to the caller needs two things this
PR doesn't touch: the `creator` field on the FastAPI `Job` response model, and POST support in
the FastAPI response-filter mechanism (currently GET-only). Called out so it isn't lost.

### How is this PR tested?

- [x] New unit tests

`tests/server/auth/test_fastapi_job_ownership.py`: owner allowed / non-owner, no-creator, and
missing-job denied for both get and cancel; submit and search require only authentication;
`_job_id_from_path` parsing. The FastAPI coverage guard still resolves every job route to a
validator.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The built-in basic-auth server now restricts the native FastAPI job fetch/cancel routes to the job's creator (admins exempt).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
