### PR TITLE
Account for datetime schema enforcement in pytorch datetime test

### DIFF
--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1320,7 +1320,11 @@ def test_log_model_with_datetime_input():
     assert model_info.signature.inputs.inputs[0].type == DataType.datetime
     pyfunc_model = mlflow.pyfunc.load_model(model_info.model_uri)
     with torch.no_grad():
-        input_tensor = torch.from_numpy(df.to_numpy(dtype=np.float32))
+        # Schema enforcement normalizes datetime columns to nanosecond precision, so build the
+        # expected input the same way. pandas 3 defaults to microseconds, which would otherwise
+        # make the two paths differ by a factor of 1000 once cast to float.
+        enforced = df.astype({"datetime": "datetime64[ns]"})
+        input_tensor = torch.from_numpy(enforced.to_numpy(dtype=np.float32))
         expected_result = model(input_tensor)
     with torch.no_grad():
         np.testing.assert_array_almost_equal(pyfunc_model.predict(df), expected_result, decimal=4)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`test_log_model_with_datetime_input` compares two paths that are not equivalent:

- `expected_result` is computed from the raw frame via `df.to_numpy(dtype=np.float32)`.
- `pyfunc_model.predict(df)` runs schema enforcement first, then `data.to_numpy(dtype=np.float32)` in `mlflow/pytorch/__init__.py`.

Schema enforcement normalizes datetime columns to nanoseconds (`_enforce_mlflow_datatype` in `mlflow/models/utils.py`, plus `DataType.datetime` being defined as `datetime64[ns]`). Under pandas 2 that was a no-op because `pd.date_range` already produced `datetime64[ns]`, so the two paths agreed by coincidence.

pandas 3 defaults to microseconds, and pandas 3 requires Python >= 3.11, so this only shows up in #25085:

```
pandas 2.3.3  date_range dtype: datetime64[ns]  int64: 1640995200000000000
pandas 3.0.5  date_range dtype: datetime64[us]  int64: 1640995200000000
```

Once cast to float the two paths differ by exactly 1000x, which is the reported failure (`4.4713e16` actual vs `4.4713e13` expected).

Building the expected input from the same normalized representation fixes the comparison. Verified that `df.astype({"datetime": "datetime64[ns]"}).to_numpy(np.float32)` is array-equal to what `_enforce_schema` produces, while the raw frame is not. The `astype` is a no-op on pandas 2, so this is inert on the current minimum.

Note this is deliberately not a change to the enforcement itself. Normalizing to a fixed resolution is what keeps a model trained on pandas 2 data scoring consistently after a pandas 3 upgrade; removing it would silently rescale datetime features for existing models.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release