### PR TITLE
Patch `torch.load` before `importlib.import_module` in pytorch tests

### DIFF
--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -746,8 +746,12 @@ def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_tim
         return import_module_fn(module_name)
 
     with (
-        mock.patch("importlib.import_module") as import_mock,
+        # NB: `torch.load` must be patched before `importlib.import_module`. On Python 3.11+,
+        # `mock.patch` resolves its target via `pkgutil.resolve_name`, which calls
+        # `importlib.import_module`. Patching that first makes the `torch.load` target resolve
+        # to a `MagicMock` instead of the real module, so the patch never takes effect.
         mock.patch("torch.load") as torch_load_mock,
+        mock.patch("importlib.import_module") as import_mock,
     ):
         import_mock.side_effect = track_module_imports
         pyfunc.load_model(model_path)
@@ -783,8 +787,12 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
         return import_module_fn(module_name)
 
     with (
-        mock.patch("importlib.import_module") as import_mock,
+        # NB: `torch.load` must be patched before `importlib.import_module`. On Python 3.11+,
+        # `mock.patch` resolves its target via `pkgutil.resolve_name`, which calls
+        # `importlib.import_module`. Patching that first makes the `torch.load` target resolve
+        # to a `MagicMock` instead of the real module, so the patch never takes effect.
         mock.patch("torch.load") as torch_load_mock,
+        mock.patch("importlib.import_module") as import_mock,
     ):
         import_mock.side_effect = track_module_imports
         pyfunc.load_model(model_uri=model_uri)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_time` and `test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time` fail on Python 3.11 with:

```
AssertionError: expected call not found.
Expected: load(<ANY>, pickle_module=<module 'pickle' ...>, weights_only=False)
  Actual: not called.
```

The cause is patch ordering, not anything in the loader. Both tests enter the patches in this order:

```python
with (
    mock.patch("importlib.import_module") as import_mock,
    mock.patch("torch.load") as torch_load_mock,
):
    import_mock.side_effect = track_module_imports
```

`importlib.import_module` is replaced first, and its `side_effect` is only assigned inside the body. When the second patch then resolves the target string `"torch.load"`, it goes through a bare `MagicMock` and gets a `MagicMock` back instead of the real `torch` module, so `load` is set on a throwaway object and the real `torch.load` is never patched.

This is Python version dependent, which is why it only shows up in #25085:

| | `mock._get_target` uses `pkgutil.resolve_name` |
| --- | --- |
| 3.10 | No (old `_importer`, via `__import__`) |
| 3.11 | Yes, and `pkgutil.resolve_name` calls `importlib.import_module` |

Confirmed by instrumenting the test: inside the patch context, `torch.load is torch_load_mock` is `False` and `call_count` is 0, while `imported_modules` is `['mlflow.pytorch', 'pickle']`, i.e. the loader ran normally and did reach `torch.load`.

Swapping the order so `torch.load` resolves while `importlib.import_module` is still real fixes both tests. Verified locally on Python 3.11 with torch 2.13.0: both pass. The order is irrelevant on 3.10, so this is inert on the current minimum.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release