### PR TITLE
Fix mock assertions that never ran

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -751,6 +751,8 @@ def _log_parameter_search_results_as_artifact(cv_results_df, run_id):
 
 # Log how many child runs will be created vs omitted based on `max_tuning_runs`.
 def _log_child_runs_info(max_tuning_runs, total_runs):
+    # More runs can be requested than the search produced, and only the available ones are logged
+    max_tuning_runs = min(max_tuning_runs, total_runs)
     rest = total_runs - max_tuning_runs
 
     # Set logging statement for runs to be logged.

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -201,7 +201,7 @@ def test_if_getting_input_example_fails(logger):
             + error_msg
         ),
     ]
-    assert logger.warning.has_calls(calls)
+    logger.warning.assert_has_calls(calls)
 
 
 def test_if_model_signature_inference_fails(logger):

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -168,21 +168,24 @@ def test_autolog_throws_error_with_negative_max_tuning_runs():
 
 
 @pytest.mark.parametrize(
-    ("max_tuning_runs", "total_runs", "output_statement"),
+    ("max_tuning_runs", "total_runs", "logging_phrase", "omitting_phrase"),
     [
-        (0, 4, "Logging no runs, all will be omitted"),
-        (0, 1, "Logging no runs, one run will be omitted"),
-        (1, 1, "Logging the best run, no runs will be omitted"),
-        (5, 4, "Logging all runs, no runs will be omitted"),
-        (4, 4, "Logging all runs, no runs will be omitted"),
-        (2, 5, "Logging the 2 best runs, 3 runs will be omitted"),
+        (0, 4, "no runs", "4 runs"),
+        (0, 1, "no runs", "one run"),
+        (1, 1, "the best run", "no runs"),
+        (5, 4, "the 5 best runs", "no runs"),
+        (4, 4, "the 4 best runs", "no runs"),
+        (2, 5, "the 2 best runs", "3 runs"),
     ],
 )
-def test_autolog_max_tuning_runs_logs_info_correctly(max_tuning_runs, total_runs, output_statement):
+def test_autolog_max_tuning_runs_logs_info_correctly(
+    max_tuning_runs, total_runs, logging_phrase, omitting_phrase
+):
     with mock.patch("mlflow.sklearn.utils._logger.info") as mock_info:
         _log_child_runs_info(max_tuning_runs, total_runs)
-        mock_info.assert_called_once()
-        mock_info.called_once_with(output_statement)
+        mock_info.assert_called_once_with(
+            "Logging %s, %s will be omitted.", logging_phrase, omitting_phrase
+        )
 
 
 def test_autolog_does_not_terminate_active_run():
@@ -671,6 +674,8 @@ def test_autolog_emits_warning_message_when_score_fails():
     mlflow.sklearn.autolog()
 
     model = sklearn.cluster.KMeans()
+    # `score` is inherited, and which base class defines it varies across scikit-learn versions
+    score_qualname = model.score.__qualname__
 
     @functools.wraps(model.score)
     def throwing_score(X, y=None, sample_weight=None):
@@ -680,9 +685,8 @@ def test_autolog_emits_warning_message_when_score_fails():
 
     with mlflow.start_run(), mock.patch("mlflow.sklearn.utils._logger.warning") as mock_warning:
         model.fit(*get_iris())
-        mock_warning.assert_called_once()
-        mock_warning.called_once_with(
-            "KMeans.score failed. The 'training_score' metric will not be recorded. "
+        mock_warning.assert_called_once_with(
+            f"{score_qualname} failed. The 'training_score' metric will not be recorded. "
             "Scoring error: EXCEPTION"
         )
 
@@ -696,19 +700,18 @@ def test_autolog_emits_warning_message_when_metric_fails():
     model = sklearn.svm.SVC()
 
     @functools.wraps(sklearn.metrics.precision_score)
-    def throwing_metrics(y_true, y_pred):
+    def throwing_metrics(*args, **kwargs):
         raise Exception("EXCEPTION")
 
+    # Patch with `new`, not a mock: the warning message reads the metric's `__qualname__`
     with (
         mlflow.start_run(),
         mock.patch("mlflow.sklearn.utils._logger.warning") as mock_warning,
-        mock.patch("sklearn.metrics.precision_score", side_effect=throwing_metrics),
+        mock.patch("sklearn.metrics.precision_score", new=throwing_metrics),
     ):
         model.fit(*get_iris())
-        mock_warning.assert_called_once()
-        mock_warning.called_once_with(
-            "SVC.precision_score failed. "
-            "The 'precision_score' metric will not be recorded. "
+        mock_warning.assert_called_once_with(
+            "precision_score failed. The metric training_precision_score will not be recorded. "
             "Metric error: EXCEPTION"
         )
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -173,7 +173,7 @@ def test_autolog_throws_error_with_negative_max_tuning_runs():
         (0, 4, "no runs", "4 runs"),
         (0, 1, "no runs", "one run"),
         (1, 1, "the best run", "no runs"),
-        (5, 4, "the 5 best runs", "no runs"),
+        (5, 4, "the 4 best runs", "no runs"),
         (4, 4, "the 4 best runs", "no runs"),
         (2, 5, "the 2 best runs", "3 runs"),
     ],

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -317,7 +317,7 @@ def test_fit_with_a_list_of_params(dataset_binomial):
             with mlflow.start_run():
                 with mock.patch("mlflow.pyspark.ml._logger.warning") as mock_warning:
                     lr_model_iter = lr.fit(dataset_binomial, params=params)
-                    mock_warning.called_once_with(
+                    mock_warning.assert_called_once_with(
                         _get_warning_msg_for_fit_call_with_a_list_of_params(lr)
                     )
             assert isinstance(list(lr_model_iter)[0], LinearRegressionModel)
@@ -387,7 +387,7 @@ def test_should_log_model(
         with mlflow.start_run():
             lor_model = lor.fit(dataset_binomial)
         assert not _should_log_model(lor_model)
-        mock_warning.called_once_with(_get_warning_msg_for_skip_log_model(lor_model))
+        mock_warning.assert_called_once_with(_get_warning_msg_for_skip_log_model(lor_model))
         assert not _should_log_model(ova1_model)
         assert not _should_log_model(pipeline_model)
         assert not _should_log_model(nested_pipeline_model)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -461,7 +461,7 @@ def test_load_spark_model_from_models_uri(
         mock_download_artifacts.reset_mock()
         mlflow.spark.load_model(f"models:/{model_name}@Champion")
         mock_download_artifacts.assert_called_once_with("", None, **kwargs)
-        assert get_model_version_by_alias_mock.called_with(model_name, "Champion")
+        get_model_version_by_alias_mock.assert_called_with(model_name, "Champion")
 
 
 @pytest.mark.parametrize("should_start_run", [False, True])

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -579,10 +579,14 @@ def test_client_search_traces_with_large_results(mock_store, mock_artifact_repo)
     )
     assert len(results) == 100
     assert mock_store.batch_get_traces.call_count == 10
-    mock_store.batch_get_traces.assert_has_calls([
-        mock.call([f"trace:/catalog.schema/{j * 10 + i}" for i in range(10)], "catalog.schema")
-        for j in range(10)
-    ])
+    mock_store.batch_get_traces.assert_has_calls(
+        [
+            mock.call([f"trace:/catalog.schema/{j * 10 + i}" for i in range(10)], "catalog.schema")
+            for j in range(10)
+        ],
+        # The batches are fetched concurrently, so the call order is not deterministic
+        any_order=True,
+    )
     mock_artifact_repo.download_trace_data.assert_not_called()
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -579,7 +579,7 @@ def test_client_search_traces_with_large_results(mock_store, mock_artifact_repo)
     )
     assert len(results) == 100
     assert mock_store.batch_get_traces.call_count == 10
-    assert mock_store.batch_get_traces.has_calls([
+    mock_store.batch_get_traces.assert_has_calls([
         mock.call([f"trace:/catalog.schema/{j * 10 + i}" for i in range(10)], "catalog.schema")
         for j in range(10)
     ])


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

Eight mock assertions across five test files call `has_calls` / `called_once_with` / `called_with` instead of the `assert_`-prefixed methods. On a mock these are ordinary child attributes, so they return a truthy `Mock` and verify nothing; six of them aren't even wrapped in an `assert`.

Python 3.12 added an `_ATTRIB_DENY_LIST` to `NonCallableMock.__getattr__` (`any_call`, `called`, `called_once`, `called_once_with`, `called_with`, `has_calls`, `not_called`), so on 3.12+ these raise `AttributeError: 'has_calls' is not a valid assertion` and fail the test. This surfaced on the Python 3.11 probe, which bumps the `Test requirements` workflow from 3.11 to 3.12. The change is undocumented (not in the 3.12 "What's New", and `unsafe` in the `unittest.mock` docs still lists only the `assert`-ish prefixes); the tracker issue is python/cpython#100690.

Turning them into real assertions exposed three sklearn expectations that had drifted:

- `_log_child_runs_info` logs lazily (`info("Logging %s, %s will be omitted.", ...)`), not with a preformatted string, so the parametrized cases now carry the two phrases separately. Two cases expected `"Logging all runs, ..."`, which the code has never produced.
- `KMeans.score` is inherited, so the qualname in the warning depends on which base class defines it (`_BaseKMeans` today). Derived from the method instead of hardcoded.
- `precision_score` was patched with a `MagicMock`, which has no `__qualname__`. The metric lookup died on that instead of on the injected exception, and the warning came from the outer handler (`Failed to autolog metrics for SVC. Logging error: __qualname__`). Patched with `new=` so the intended code path runs.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release