### PR TITLE
Fix example scripts that break on Python 3.11

### DIFF
--- a/examples/evaluation/evaluate_on_multiclass_classifier.py
+++ b/examples/evaluation/evaluate_on_multiclass_classifier.py
@@ -9,7 +9,7 @@ X, y = make_classification(n_samples=10000, n_classes=10, n_informative=5, rando
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
 
 with mlflow.start_run() as run:
-    model = LogisticRegression(solver="liblinear").fit(X_train, y_train)
+    model = LogisticRegression().fit(X_train, y_train)
     model_info = mlflow.sklearn.log_model(model, name="model")
     result = mlflow.evaluate(
         model_info.model_uri,

--- a/examples/keras/train.py
+++ b/examples/keras/train.py
@@ -25,7 +25,7 @@ print("Loading data...")
 print(len(x_train), "train sequences")
 print(len(x_test), "test sequences")
 
-num_classes = np.max(y_train) + 1
+num_classes = int(np.max(y_train) + 1)
 print(num_classes, "classes")
 
 print("Vectorizing sequence data...")

--- a/examples/sktime/python_env.yaml
+++ b/examples/sktime/python_env.yaml
@@ -2,4 +2,4 @@ build_dependencies:
   - pip
 dependencies:
   - mlflow<3,>=2.1
-  - sktime==0.16.0
+  - sktime==1.1.0


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

Three of the five `examples` failures on the Python 3.11 probe. Each one is a dependency version that only becomes reachable once the minimum Python is raised, so all three fixes are inert on 3.10.

- `sktime==0.16.0` declares `requires-python <3.11`, so pip cannot resolve it at all. Bumped to 1.1.0 (`>=3.10,<3.15`), which runs the example unchanged — no import moves needed despite the major bump. Verified end-to-end on both 3.10 and 3.11.
- Keras now validates `not isinstance(units, int)`, and `np.max(y_train) + 1` is an `np.int64`, so `Dense(num_classes)` raises `Received an invalid value for units, expected a positive integer. Received: units=46`.
- scikit-learn 1.8 dropped the implicit one-vs-rest wrapper for the `liblinear` solver, which now raises on the example's 10-class data. Dropped the argument so it uses the default `lbfgs`; confirmed it fits without convergence warnings on 1.9.0.

The remaining two `examples` failures are `xgboost/xgboost_sklearn`, which needs the `xgboost<3.1.0` constraint revisited (xgboost 3.0.5 lacks the `_estimator_type` mixin scikit-learn 1.8 requires). That is a separate change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Ran the sktime example end-to-end in fresh 3.10 and 3.11 virtualenvs. Reproduced the Keras `units` and scikit-learn `liblinear` failures against keras 3.15.1 / scikit-learn 1.9.0 and confirmed both fixes clear them.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release