### PR TITLE
Skip V4/UC trace IDs in `LiveSpan.addLink` instead of normalizing

### DIFF
--- a/libs/typescript/core/src/core/entities/span.ts
+++ b/libs/typescript/core/src/core/entities/span.ts
@@ -13,6 +13,7 @@ import {
   toSpanLogLevel,
   NO_OP_SPAN_TRACE_ID,
   TRACE_ID_PREFIX,
+  TRACE_ID_V4_PREFIX,
 } from '../constants';
 import { defaultLogLevelForSpanType } from '../log_level';
 import { parseTraceIdV4 } from '../utils/trace_id';
@@ -410,6 +411,16 @@ export class LiveSpan extends Span {
    */
   addLink(link: SpanLink): void {
     if (!this._span.isRecording()) {
+      return;
+    }
+
+    // Span links are not supported for Unity Catalog (V4) traces. Warn and skip rather than
+    // silently normalizing the V4 trace ID to raw OTel hex (see #25080).
+    if (link.traceId?.startsWith(TRACE_ID_V4_PREFIX)) {
+      console.warn(
+        `Span links are not currently supported for Unity Catalog traces. ` +
+          `The link to trace '${link.traceId}' will be skipped.`,
+      );
       return;
     }
 

--- a/libs/typescript/core/tests/core/entities/span.test.ts
+++ b/libs/typescript/core/tests/core/entities/span.test.ts
@@ -442,6 +442,48 @@ describe('Span', () => {
       }
     });
 
+    it('should warn and skip V4 trace IDs in addLink()', () => {
+      const traceId = 'tr-12345';
+      const span = tracer.startSpan('test');
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      try {
+        const mlflowSpan = createMlflowSpan(span, traceId) as LiveSpan;
+
+        mlflowSpan.addLink(
+          new SpanLink({
+            traceId: 'trace:/catalog.schema/0123456789abcdef0123456789abcdef',
+            spanId: '0123456789abcdef',
+            attributes: { type: 'causality' },
+          }),
+        );
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Span links are not currently supported for Unity Catalog traces. ' +
+              "The link to trace 'trace:/catalog.schema/0123456789abcdef0123456789abcdef' will be skipped.",
+          ),
+        );
+        expect(mlflowSpan.links).toHaveLength(0);
+        expect(mlflowSpan._span.links).toHaveLength(0);
+
+        mlflowSpan.addLink(
+          new SpanLink({
+            traceId: 'tr-0123456789abcdef0123456789abcdef',
+            spanId: 'fedcba9876543210',
+          }),
+        );
+
+        expect(mlflowSpan.links).toHaveLength(1);
+        expect(mlflowSpan.links[0].traceId).toBe('tr-0123456789abcdef0123456789abcdef');
+        expect(mlflowSpan._span.links).toHaveLength(1);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        warnSpy.mockRestore();
+        span.end();
+      }
+    });
+
     it('should add multiple links to a span', () => {
       const traceId = 'tr-12345';
       const span = tracer.startSpan('test');


### PR DESCRIPTION
### Related Issues/PRs

Closes #25080 (TypeScript half; the Python half was merged in #25097). Span links were added to the TypeScript SDK in #23480.

### What changes are proposed in this pull request?

Span links are not supported for Unity Catalog (V4) traces, but `LiveSpan.addLink` accepted a V4 id (`trace:/<location>/<hex>`) anyway: it ran the ID through `parseTraceIdV4()`, silently stripped it to raw OTel hex, and stored a link that can never be honored for V4/UC traces.

This changes `addLink` to **warn and skip** a V4 trace ID up front instead of normalizing it. It mirrors the Python-side fix in #25097: the guard condition and warning message are identical, and it warns rather than raising so higher-level `links` flows (`startSpan()`, `trace()`) keep working. All higher-level APIs delegate to `addLink`, so this is the single validation point.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

The new test `should warn and skip V4 trace IDs in addLink()` asserts that a V4 trace-id link warns exactly once, is not stored, and is not forwarded to the underlying OTel span, and that a subsequent V3 link is still added normally. The test fails without the source change.

Locally (Node 22) I ran all server-independent core jest suites (17 suites / 196 tests, including the full `span.test.ts`), workspace-wide prettier and eslint, and the tsc build for core and all integrations. I could not run the tracking-server-dependent suites locally because of a port conflict on this machine; CI covers them.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release