### PR TITLE
Fix health probes auth bypass when static prefix applied

### DIFF
--- a/mlflow/server/fastapi_security.py
+++ b/mlflow/server/fastapi_security.py
@@ -11,7 +11,6 @@ from mlflow.environment_variables import (
 )
 from mlflow.server.security_utils import (
     CORS_BLOCKED_MSG,
-    HEALTH_ENDPOINTS,
     INVALID_HOST_MSG,
     LOCALHOST_ORIGIN_PATTERNS,
     get_allowed_hosts_from_env,
@@ -19,6 +18,7 @@ from mlflow.server.security_utils import (
     get_default_allowed_hosts,
     is_allowed_host_header,
     is_api_endpoint,
+    is_health_endpoint,
     should_block_cors_request,
 )
 from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
@@ -37,7 +37,7 @@ class HostValidationMiddleware:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
-        if scope["path"] in HEALTH_ENDPOINTS:
+        if is_health_endpoint(scope["path"]):
             return await self.app(scope, receive, send)
 
         headers = dict(scope.get("headers", []))

--- a/mlflow/server/security.py
+++ b/mlflow/server/security.py
@@ -10,7 +10,6 @@ from mlflow.environment_variables import (
 )
 from mlflow.server.security_utils import (
     CORS_BLOCKED_MSG,
-    HEALTH_ENDPOINTS,
     INVALID_HOST_MSG,
     LOCALHOST_ORIGIN_PATTERNS,
     get_allowed_hosts_from_env,
@@ -18,6 +17,7 @@ from mlflow.server.security_utils import (
     get_default_allowed_hosts,
     is_allowed_host_header,
     is_api_endpoint,
+    is_health_endpoint,
     should_block_cors_request,
 )
 from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
@@ -74,7 +74,7 @@ def init_security_middleware(app: Flask) -> None:
 
         @app.before_request
         def validate_host():
-            if request.path in HEALTH_ENDPOINTS:
+            if is_health_endpoint(request.path):
                 return None
 
             if not is_allowed_host_header(allowed_hosts, host := request.headers.get("Host")):

--- a/mlflow/server/security_utils.py
+++ b/mlflow/server/security_utils.py
@@ -141,6 +141,17 @@ def is_api_endpoint(path: str) -> bool:
     )
 
 
+def is_health_endpoint(path: str) -> bool:
+    """Check if a path is a health endpoint that is exempt from host validation."""
+    # Imported lazily to keep this shared module's own import graph light.
+    from mlflow.server.handlers import _add_static_prefix
+
+    # Health routes are registered with ``_add_static_prefix``, so under
+    # ``--static-prefix`` they are served from e.g. ``/mlflow/health``. Accept both
+    # forms so health checks stay exempt on prefixed deployments.
+    return any(path in (endpoint, _add_static_prefix(endpoint)) for endpoint in HEALTH_ENDPOINTS)
+
+
 def is_allowed_host_header(allowed_hosts: list[str], host: str) -> bool:
     """Validate if the host header matches allowed patterns."""
     if not host:

--- a/mlflow/server/security_utils.py
+++ b/mlflow/server/security_utils.py
@@ -146,10 +146,12 @@ def is_health_endpoint(path: str) -> bool:
     # Imported lazily to keep this shared module's own import graph light.
     from mlflow.server.handlers import _add_static_prefix
 
-    # Health routes are registered with ``_add_static_prefix``, so under
-    # ``--static-prefix`` they are served from e.g. ``/mlflow/health``. Accept both
-    # forms so health checks stay exempt on prefixed deployments.
-    return any(path in (endpoint, _add_static_prefix(endpoint)) for endpoint in HEALTH_ENDPOINTS)
+    # Health routes are registered via ``_add_static_prefix``, so under
+    # ``--static-prefix`` they exist only at e.g. ``/mlflow/health``; the bare path
+    # has no route behind it and would only 404. Match the registered form alone so
+    # the exemption is never wider than the routes that exist. ``_add_static_prefix``
+    # is the identity when no prefix is set.
+    return any(path == _add_static_prefix(endpoint) for endpoint in HEALTH_ENDPOINTS)
 
 
 def is_allowed_host_header(allowed_hosts: list[str], host: str) -> bool:

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -284,9 +284,10 @@ def test_is_health_endpoint_handles_static_prefix(endpoint, monkeypatch: pytest.
     assert not is_health_endpoint(f"/myprefix{endpoint}")
 
     monkeypatch.setenv("_MLFLOW_STATIC_PREFIX", "/myprefix")
-    # Health routes are registered prefixed, but unprefixed probes stay exempt too.
+    # Only the registered (prefixed) route is exempt: the bare path has no route
+    # behind it under a prefix, so it must not waive host validation.
     assert is_health_endpoint(f"/myprefix{endpoint}")
-    assert is_health_endpoint(endpoint)
+    assert not is_health_endpoint(endpoint)
     assert not is_health_endpoint(f"/otherprefix{endpoint}")
     assert not is_health_endpoint(f"/myprefix{endpoint}z")
 
@@ -297,6 +298,8 @@ def test_is_health_endpoint_handles_static_prefix(endpoint, monkeypatch: pytest.
         ("/myprefix/health", 200),
         ("/myprefix/version", 200),
         ("/myprefix/test", 403),
+        # No route exists here under a prefix, so it must not skip host validation.
+        ("/health", 403),
     ],
 )
 def test_flask_health_exempt_from_host_validation_with_static_prefix(
@@ -320,6 +323,7 @@ def test_flask_health_exempt_from_host_validation_with_static_prefix(
         ("/myprefix/health", 200),
         ("/myprefix/version", 200),
         ("/myprefix/api/2.0/mlflow/experiments/list", 403),
+        ("/health", 403),
     ],
 )
 def test_fastapi_health_exempt_from_host_validation_with_static_prefix(

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -8,7 +8,11 @@ from werkzeug.test import Client
 
 from mlflow.server import security
 from mlflow.server.fastapi_security import init_fastapi_security
-from mlflow.server.security_utils import is_allowed_host_header, is_api_endpoint
+from mlflow.server.security_utils import (
+    is_allowed_host_header,
+    is_api_endpoint,
+    is_health_endpoint,
+)
 
 
 def test_default_allowed_hosts():
@@ -270,6 +274,73 @@ def test_endpoint_security_bypass(
     client = Client(test_app)
 
     response = client.get(endpoint, headers={"Host": host_header})
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize("endpoint", ["/health", "/version"])
+def test_is_health_endpoint_handles_static_prefix(endpoint, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("_MLFLOW_STATIC_PREFIX", raising=False)
+    assert is_health_endpoint(endpoint)
+    assert not is_health_endpoint(f"/myprefix{endpoint}")
+
+    monkeypatch.setenv("_MLFLOW_STATIC_PREFIX", "/myprefix")
+    # Health routes are registered prefixed, but unprefixed probes stay exempt too.
+    assert is_health_endpoint(f"/myprefix{endpoint}")
+    assert is_health_endpoint(endpoint)
+    assert not is_health_endpoint(f"/otherprefix{endpoint}")
+    assert not is_health_endpoint(f"/myprefix{endpoint}z")
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected_status"),
+    [
+        ("/myprefix/health", 200),
+        ("/myprefix/version", 200),
+        ("/myprefix/test", 403),
+    ],
+)
+def test_flask_health_exempt_from_host_validation_with_static_prefix(
+    endpoint, expected_status, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("_MLFLOW_STATIC_PREFIX", "/myprefix")
+    monkeypatch.setenv("MLFLOW_SERVER_ALLOWED_HOSTS", "localhost")
+
+    app = Flask(__name__)
+    for route in ("/myprefix/health", "/myprefix/version", "/myprefix/test"):
+        app.add_url_rule(route, route, lambda: "OK")
+    security.init_security_middleware(app)
+
+    response = Client(app).get(endpoint, headers={"Host": "evil.com"})
+    assert response.status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected_status"),
+    [
+        ("/myprefix/health", 200),
+        ("/myprefix/version", 200),
+        ("/myprefix/api/2.0/mlflow/experiments/list", 403),
+    ],
+)
+def test_fastapi_health_exempt_from_host_validation_with_static_prefix(
+    endpoint, expected_status, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("_MLFLOW_STATIC_PREFIX", "/myprefix")
+    monkeypatch.setenv("MLFLOW_SERVER_ALLOWED_HOSTS", "localhost")
+
+    app = FastAPI()
+
+    @app.get("/myprefix/health")
+    @app.get("/myprefix/version")
+    @app.get("/myprefix/api/2.0/mlflow/experiments/list")
+    async def endpoints():
+        return {"ok": True}
+
+    init_fastapi_security(app)
+
+    response = TestClient(app, raise_server_exceptions=False).get(
+        endpoint, headers={"Host": "evil.com"}
+    )
     assert response.status_code == expected_status
 
 


### PR DESCRIPTION
### Related Issues/PRs
Closes https://github.com/mlflow/mlflow/issues/25075
Closes https://github.com/mlflow/mlflow/issues/19691

Existing PR that seems stale: https://github.com/mlflow/mlflow/pull/19694

### What changes are proposed in this pull request?

•  [security_utils.py](https://github.com/mlflow/mlflow/pull/25114/changes#diff-9f2a3276887bec97f8c3b7ec04235de19e0835810326b4beb53d8529915e5443R144)  --> new  is_health_endpoint()  accepting both prefixed and unprefixed forms, mirroring the lazy-import pattern in  is_api_endpoint .
•  [fastapi_security.py](https://github.com/mlflow/mlflow/pull/25114/changes#diff-aa98f54b57b9ba390feb7bf4aaf7ca32508b995ef27136fbbf45067a195ce1c3R40) and [security.py](https://github.com/mlflow/mlflow/pull/25113/changes#diff-e2bb8ff4e37549f2009ccf3c84890c495e93fc0b99f160cadda01bb8c046daa5R77) --> use the helper instead of path in HEALTH_ENDPOINTS .
•  [tests/server/test_security.py](https://github.com/mlflow/mlflow/pull/25114/changes#diff-5679ece616954b41373c764c64691e8b7336b96d5e82bd18ae553c754961e111R280) --> regression tests for the helper plus end-to-end Flask and FastAPI security coverage.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Solves a [bug](https://github.com/mlflow/mlflow/issues/25075) when using mlflow behind a reverse proxy.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages


#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?
- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
