### PR TITLE
fix: Handle non-serializable params in telemetry Record.to_dict (closes #5474)

### DIFF
--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -32,7 +32,7 @@ class Record:
             "timestamp_ns": self.timestamp_ns,
             "event_name": self.event_name,
             # dump params to string so we can parse them easily in ETL pipeline
-            "params": json.dumps(self.params) if self.params else None,
+            "params": json.dumps(self.params, default=str) if self.params else None,
             "status": self.status.value,
             "duration_ms": self.duration_ms,
         }


### PR DESCRIPTION
## What

When telemetry records contain params with non-JSON-serializable objects such as numpy arrays (common in ML model inputs/outputs), calling `json.dumps(self.params)` raises a TypeError, leading to failures when deploying models (e.g., in SageMaker).

## Fix

Add a `default=str` argument to the `json.dumps` call in `Record.to_dict` so that unsupported types are converted to their string representation instead of raising an exception.

Closes #5474