### PR TITLE
fix: Use checkfirst when creating initial tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
Fixes database upgrade failures when upgrading to MLflow 3.8.x on MySQL and other databases. The error `Table 'secrets' already exists` occurs because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, so it tries to create all initial tables even if they already exist.

## Fix
Changed `create_all` to pass `checkfirst=True`, which makes SQLAlchemy check for existing tables before creating each one, preventing duplicate creation errors on existing databases.

Closes #19943