### PR TITLE
Make scoring server dtype assertions pandas 3 compatible

### DIFF
--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -530,7 +530,10 @@ def test_records_oriented_json_to_df():
     jstr, _ = pyfunc_scoring_server._split_data_and_params(jstr)
     df = pyfunc_scoring_server.infer_and_parse_data(jstr)
     assert set(df.columns) == {"zip", "cost", "score"}
-    assert {str(dt) for dt in df.dtypes} == {"object", "float64", "int64"}
+    # pandas 3 infers StringDtype where pandas 2 used object
+    assert pd.api.types.is_string_dtype(df["zip"])
+    assert df["cost"].dtype == "float64"
+    assert df["score"].dtype == "int64"
 
 
 def _shuffle_pdf(pdf):
@@ -554,7 +557,10 @@ def test_split_oriented_json_to_df():
     df = pyfunc_scoring_server.infer_and_parse_data(jstr)
 
     assert set(df.columns) == {"zip", "cost", "count"}
-    assert {str(dt) for dt in df.dtypes} == {"object", "float64", "int64"}
+    # pandas 3 infers StringDtype where pandas 2 used object
+    assert pd.api.types.is_string_dtype(df["zip"])
+    assert df["cost"].dtype == "float64"
+    assert df["count"].dtype == "int64"
 
 
 def test_parse_with_schema_csv(pandas_df_with_csv_types):
@@ -642,9 +648,15 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
         )
         response_json = json.loads(response.content)["predictions"]
 
-        # objects are not converted to pandas Strings at the moment
-        expected_types = {**pandas_df_with_all_types.dtypes, "string": np.dtype(object)}
-        assert response_json == [[k, str(v)] for k, v in expected_types.items()]
+        expected_types = {
+            **{k: str(v) for k, v in pandas_df_with_all_types.dtypes.items()},
+            # Schema enforcement normalizes datetimes to nanoseconds, while pandas 3 infers a
+            # coarser unit for the fixture
+            "datetime": "datetime64[ns]",
+            # "object" on pandas 2, "str" on pandas 3
+            "string": str(pd.Series([""]).dtype),
+        }
+        assert response_json == [[k, v] for k, v in expected_types.items()]
         response = score_model_in_process(
             model_uri=model_info.model_uri,
             data=json.dumps(
@@ -654,7 +666,7 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         )
         response_json = json.loads(response.content)["predictions"]
-        assert response_json == [[k, str(v)] for k, v in expected_types.items()]
+        assert response_json == [[k, v] for k, v in expected_types.items()]
 
         # Test 'inputs' format
         response = score_model_in_process(
@@ -663,7 +675,7 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
         )
         response_json = json.loads(response.content)["predictions"]
-        assert response_json == [[k, str(v)] for k, v in expected_types.items()]
+        assert response_json == [[k, v] for k, v in expected_types.items()]
 
 
 def test_serving_model_with_param_schema(sklearn_model, model_path):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

Three assertions in `tests/pyfunc/test_scoring_server.py` hard-code pandas 2 dtype names and fail once pandas 3 becomes installable (it requires Python >=3.11, so the 3.11 probe is what surfaces them). No library behavior changes.

- `test_records_oriented_json_to_df` and `test_split_oriented_json_to_df` compared a *set* of dtype names against `{"object", "float64", "int64"}`; pandas 3 yields `str` for the string column. Replaced with per-column checks using `pd.api.types.is_string_dtype`, which holds on both majors. This also strengthens the tests: the set form could not tell which column had which dtype, and the stated intent is specifically that `zip` is not converted to `int64`.
- `test_serving_model_with_schema` builds its expectation from the fixture's own dtypes. Two of them now disagree with what the server returns. The `string` column comes back as `str` rather than `object`, and `datetime` comes back as `datetime64[ns]` while pandas 3 infers `datetime64[s]` for the fixture literals. The `ns` here is correct and worth asserting explicitly: schema enforcement normalizes datetimes to nanoseconds regardless of input resolution. The string dtype name is derived from pandas rather than version-gated.

### How is this PR tested?

- [x] Existing unit/integration tests

Ran all three tests both ways: pandas 2.3.3 on Python 3.10 and pandas 3.0.5 on Python 3.11. 3 passed in each.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release