### PR TITLE
Bound pandas in logged requirements for prophet <1.2.2

### DIFF
--- a/mlflow/prophet/__init__.py
+++ b/mlflow/prophet/__init__.py
@@ -78,6 +78,11 @@ def get_default_pip_requirements():
     if Version(prophet.__version__) <= Version("1.2.0"):
         pip_deps.append("cmdstanpy<1.3.0")
 
+    # `Prophet.fit` raises "cannot reindex on an axis with duplicate labels" under pandas 3, and
+    # these versions do not declare the bound themselves (1.2.2 does, and 1.3.0 supports pandas 3)
+    if Version(prophet.__version__) < Version("1.2.2"):
+        pip_deps.append("pandas<3")
+
     return pip_deps
 
 

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -297,6 +297,22 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert prophet_custom_env_parsed == saved_conda_env_parsed
 
 
+@pytest.mark.parametrize(
+    ("version", "bounded"),
+    [
+        ("1.1.6", True),
+        ("1.2.1", True),
+        # 1.2.2 declares `pandas<3` itself and 1.3.0 supports pandas 3
+        ("1.2.2", False),
+        ("1.3.0", False),
+    ],
+)
+def test_default_pip_requirements_bounds_pandas_for_old_prophet(version, bounded):
+    with mock.patch.object(prophet, "__version__", version):
+        reqs = mlflow.prophet.get_default_pip_requirements()
+    assert ("pandas<3" in reqs) is bounded
+
+
 def test_model_save_persists_requirements_in_mlflow_model_directory(
     prophet_model, model_path, prophet_custom_env
 ):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`test_pyfunc_serve_and_score` fails for prophet 1.1.6 and 1.1.7 on the Python 3.11 probe, and the cross-version `pandas<3` pin added in #25090 does not help: the scoring server rebuilds its environment from the *model's own* `requirements.txt`, which contains only `mlflow`, `prophet==<version>` and `cmdstanpy<1.3.0`. pandas 3 gets installed there and the server never starts.

prophet <=1.2.1 declares only `pandas>=1.0.4`, so nothing stops that. Added the bound to the flavor's default pip requirements, alongside the existing `cmdstanpy<1.3.0` conditional.

Boundary, verified release by release:

| prophet | declared pandas bound | pandas 3 at runtime |
| --- | --- | --- |
| 1.1.6 / 1.1.7 / 1.2.0 / 1.2.1 | `>=1.0.4` (no cap) | breaks: `ValueError: cannot reindex on an axis with duplicate labels` |
| 1.2.2 | `<3,>=1.0.4` (self-capped) | pip refuses to resolve it |
| 1.3.0 | `>=1.0.4` (cap removed) | works |

So the bound is needed exactly below 1.2.2, matching the existing entry in `ml-package-versions.yml`. That entry governs the CI test environment and is still required; this one governs what gets written into logged models.

`test_pyfunc_serve_and_score` could instead pass `pandas<3` via `extra_pip_requirements`, as it already does for `holidays<=0.24` and `pandas<2`. That turns CI green but leaves the underlying problem: a user who logs a prophet 1.1.6 model today gets a `requirements.txt` that cannot rebuild a working serving environment. Putting the bound in the flavor matches the neighbouring `cmdstanpy<1.3.0` conditional, which caps a dependency for old prophet for the same reason.

Inert on Python 3.10, where pandas 3 is not installable at all.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Reproduced the failure with prophet 1.1.6 + pandas 3.0.5 and confirmed `pandas<3` fixes it, then checked 1.2.1 (still broken), 1.2.2 (unresolvable) and 1.3.0 (works) to pin the boundary. Added a parametrized test over those four versions.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Models logged with prophet <1.2.2 now record a `pandas<3` requirement, so the environment rebuilt at serving time matches what the model can actually run with.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
