### PR TITLE
Parse schema datetimes as nanoseconds under pandas 3

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -327,7 +327,15 @@ def cast_df_types_according_to_schema(pdf, schema):
                 elif isinstance(col_type_spec, AnyType):
                     pass
                 elif isinstance(col_type_spec, DataType) and col_type_spec == DataType.datetime:
-                    pdf[col_name] = pd.to_datetime(pdf[col_name])
+                    parsed = pd.to_datetime(pdf[col_name])
+                    # pandas 3 parses to microseconds by default, but `DataType.datetime` is
+                    # nanoseconds. `.dt.unit` is absent before pandas 2, which is always
+                    # nanoseconds.
+                    if pd.api.types.is_datetime64_any_dtype(parsed) and (
+                        getattr(parsed.dt, "unit", "ns") != "ns"
+                    ):
+                        parsed = parsed.dt.as_unit("ns")
+                    pdf[col_name] = parsed
                 else:
                     # In pandas 3.0+, string columns with NaN are inferred as StringDtype
                     # instead of object. Skip casting StringDtype to object/numpy str as they

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -541,7 +541,7 @@ def test_dataframe_from_json_parses_datetime_as_nanoseconds(value):
         pandas_orient="records",
         schema=Schema([ColSpec("datetime", "datetime")]),
     )
-    assert parsed["datetime"].dt.unit == "ns"
+    assert getattr(parsed["datetime"].dt, "unit", "ns") == "ns"
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -522,13 +522,26 @@ def test_dataframe_from_json():
     )
     expected = pd.DataFrame(
         {
-            "datetime": pd.to_datetime([
-                "2022-01-01T00:00:00",
-                "2022-01-02T03:04:05",
-            ])
+            "datetime": np.array(
+                ["2022-01-01T00:00:00", "2022-01-02T03:04:05"],
+                dtype=DataType.datetime.to_pandas(),
+            )
         },
     )
     pd.testing.assert_frame_equal(parsed, expected)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2022-01-01T00:00:00", "2022-01-01", "2022-01-01T00:00:00+02:00"],
+)
+def test_dataframe_from_json_parses_datetime_as_nanoseconds(value):
+    parsed = dataframe_from_raw_json(
+        json.dumps([{"datetime": value}]),
+        pandas_orient="records",
+        schema=Schema([ColSpec("datetime", "datetime")]),
+    )
+    assert parsed["datetime"].dt.unit == "ns"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`DataType.datetime` is declared as `datetime64[ns]` in `mlflow/types/schema.py`, and `_enforce_mlflow_datatype` normalizes to that. The JSON deserializer did not: it returned whatever `pd.to_datetime` produced, which pandas 3 defaults to microseconds. Round-tripping an input example therefore came back as `datetime64[us]` and disagreed with its own schema.

```
AssertionError: Attributes of DataFrame.iloc[:, 4] (column name="e") are different
Attribute "dtype" are different
[left]:  datetime64[us]
[right]: datetime64[ns]
```

`proto_json_utils.py` now normalizes the unit, preserving any timezone (`.astype("datetime64[ns]")` would raise on tz-aware columns). `.dt.unit` does not exist before pandas 2, where datetimes are always nanoseconds, so the conversion is skipped there and the change is inert on pandas 2.

The `else` branch just below already carries a pandas 3 accommodation for `StringDtype`; the datetime branch was missed.

`test_dataframe_from_json` built its expectation from `pd.to_datetime` too, so both sides drifted together and the resolution was never actually pinned. It now states `datetime64[ns]` explicitly, via `DataType.datetime.to_pandas()` so it tracks the schema declaration.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Ran `tests/utils/test_proto_json_utils.py` on pandas 2.3.3 / Python 3.10 and pandas 3.0.5 / Python 3.11: 30 passed each. Confirmed the two failures this fixes, `test_model_log_with_input_example_succeeds` and `test_model_input_example_with_params_log_load_succeeds`, now pass under pandas 3. Added a parametrized test covering naive, date-only and timezone-aware values.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Datetime columns parsed from JSON against a model signature are now always nanosecond resolution, matching `DataType.datetime`, rather than following the pandas default.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release