### PR TITLE
Probe dropping the `pyspark<4.1.0` pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,8 +251,6 @@ constraint-dependencies = [
   # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
   # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
   "xgboost<3.1.0",
-  # pyspark 4.1.0 causes issues with documentation build
-  "pyspark<4.1.0",
   # setuptools 82.0.0 removed pkg_resources, breaking packages that depend on it (e.g., sphinx)
   "setuptools<82",
 ]

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -1,7 +1,7 @@
 -r doc-min-requirements.txt
 tensorflow-cpu<=2.12.0; platform_system!="Darwin" or platform_machine!="arm64"
 tensorflow-macos<=2.12.0; platform_system=="Darwin" and platform_machine=="arm64"
-pyspark<4.1.0
+pyspark
 datasets
 # requried to run `log_figure` examples
 plotly

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -26,7 +26,7 @@ onnxruntime
 onnxscript
 tf2onnx
 # Required by mlflow.spark and using Delta with MLflow Tracking datasets
-pyspark<4.1.0
+pyspark
 # Required by mlflow.paddle
 paddlepaddle
 # Required by mlflow.prophet

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -34,7 +34,7 @@ tqdm[notebook]
 openai
 # Required for showing pytest stats
 psutil
-pyspark<4.1.0
+pyspark
 # Required for testing the opentelemetry exporter of tracing
 opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-exporter-otlp-proto-http

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,6 @@ members = [
     "skills",
 ]
 constraints = [
-    { name = "pyspark", specifier = "<4.1.0" },
     { name = "setuptools", specifier = "<82" },
     { name = "xgboost", specifier = "<3.1.0" },
 ]
@@ -2594,7 +2593,7 @@ name = "gunicorn"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
@@ -6835,12 +6834,12 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "4.0.4"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/27b5316543a4d724efef4ecc1cfcb42a9afcb8af33cfdff989164b9a4487/pyspark-4.0.4.tar.gz", hash = "sha256:7e119366364d48e3cda1b1efd1ebc6cd672949500667c9cabbeef858daba700f", size = 434312230, upload-time = "2026-07-15T11:15:10.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/33/c987434f5d50aa802779a004ca0fd45ee4350caab50554ad7283d5a22b50/pyspark-4.2.0.tar.gz", hash = "sha256:5ad689d53570ee1674193fd4f9bda065f0db3be9363a27d2a3406cc457b70b61", size = 450129423, upload-time = "2026-07-14T22:16:46Z" }
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

Experiment, not a merge candidate as-is: remove `pyspark<4.1.0` from all four places it appears and see what actually breaks.

The stated reason exists only in `pyproject.toml` ("pyspark 4.1.0 causes issues with documentation build"); `test-requirements.txt` and `extra-ml-requirements.txt` carry a bare, unexplained pin. Two things make it worth re-testing:

- The cap excludes 4.2.0 as well as 4.1.x, and 4.2.0 is the release that stopped importing the private `pandas.core.common._builtin_table`. pandas 3 removed it, which is currently five `pyfunc` failures on the Python 3.11 probe. That collateral has never been discussed anywhere in the repo.
- `ml-package-versions.yml` already declares spark `maximum: "4.2.0"`, and cross-version jobs strip these constraints, so the spark flavor is already exercised against 4.2.0. The pin was not protecting it.

`uv lock --upgrade-package pyspark` moves the lock from 4.0.4 to 4.2.0.

Provenance: the pin came from 454df873 in #19409, a DeepEval scorer documentation PR, two days after pyspark 4.1.0 was released. That commit changed a bare `pyspark` to `pyspark<4.1.0` in all four files at once and recorded the reason in `pyproject.toml` only; nothing in the PR discusses it. So this change is a revert to the pre-#19409 state rather than a new relaxation.

What this run should tell us:

- whether the doc build still fails, which would scope the pin to `doc-requirements.txt` alone
- whether any test job actually needed it

It cannot show the `_builtin_table` fix directly, since that needs pandas 3 and master is still on Python 3.10. Rebasing the probe onto this will.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
