### PR TITLE
Warn about numpy downgrade risk from `databricks-agents`

### DIFF
--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -1,3 +1,48 @@
+import importlib.util
+import warnings
+
+import numpy as np
+
+
+def _warn_if_databricks_connect_downgraded_numpy() -> None:
+    """
+    Warn when `databricks-connect` (pulled in by `databricks-agents`, a dependency of
+    `mlflow.genai.datasets` on Databricks) appears to have downgraded numpy to <2 in
+    this environment, which can cause cryptic errors such as
+    `AttributeError: module 'numpy' has no attribute 'long'` in packages that require
+    `numpy>=2` (see #24690).
+    """
+    try:
+        numpy_major_version = int(np.__version__.split(".")[0])
+    except (ValueError, IndexError):
+        return
+
+    if numpy_major_version >= 2:
+        return
+
+    # find_spec raises ModuleNotFoundError, rather than returning None, when the
+    # "databricks" parent package isn't installed at all.
+    try:
+        databricks_connect_installed = importlib.util.find_spec("databricks.connect") is not None
+    except (ImportError, ValueError):
+        return
+
+    if not databricks_connect_installed:
+        return
+
+    warnings.warn(
+        f"Detected numpy {np.__version__} alongside `databricks-connect`, which pins "
+        "`numpy<2`. If this environment previously had `numpy>=2`, installing "
+        "`databricks-agents` (a dependency of `mlflow.genai.datasets` on Databricks) "
+        "likely downgraded numpy, which can break other packages that require "
+        "`numpy>=2`. Consider reinstalling `numpy>=2` or using a dedicated "
+        "environment for `databricks-agents`.",
+        stacklevel=2,
+    )
+
+
+_warn_if_databricks_connect_downgraded_numpy()
+
 from mlflow.genai import (
     datasets,
     judges,

--- a/mlflow/genai/datasets/__init__.py
+++ b/mlflow/genai/datasets/__init__.py
@@ -27,7 +27,12 @@ _logger = logging.getLogger(__name__)
 
 _ERROR_MSG = (
     "The `databricks-agents` package is required to use `mlflow.genai.datasets`. "
-    "Please install it with `pip install databricks-agents`."
+    "Please install it with `pip install databricks-agents`. "
+    "Warning: `databricks-agents` depends on `databricks-connect`, which pins "
+    "`numpy<2`. Installing it into an environment that already has `numpy>=2` will "
+    "downgrade numpy and can break other packages that require `numpy>=2` (e.g. "
+    "`AttributeError: module 'numpy' has no attribute 'long'`). Consider installing "
+    "`databricks-agents` in a dedicated virtual environment."
 )
 
 _DATABRICKS_CONFIG_PROFILE_ENV_VAR = "DATABRICKS_CONFIG_PROFILE"
@@ -187,6 +192,12 @@ def create_dataset(
     Returns:
         An EvaluationDataset object representing the created dataset.
 
+    Note:
+        On Databricks, this function requires the ``databricks-agents`` package, which
+        depends on ``databricks-connect`` and pins ``numpy<2``. Installing it can
+        downgrade numpy in environments that already have ``numpy>=2``. Consider
+        installing ``databricks-agents`` in a dedicated virtual environment.
+
     Examples:
         .. code-block:: python
 
@@ -273,6 +284,10 @@ def delete_dataset(
     Note:
         - In Databricks environments: Use 'name' to specify the dataset.
         - Outside of Databricks: Use 'dataset_id' to specify the dataset
+        - On Databricks, this function requires the ``databricks-agents`` package, which
+          depends on ``databricks-connect`` and pins ``numpy<2``. Installing it can
+          downgrade numpy in environments that already have ``numpy>=2``. Consider
+          installing ``databricks-agents`` in a dedicated virtual environment.
 
     Examples:
         .. code-block:: python
@@ -346,6 +361,10 @@ def get_dataset(
         - In Databricks environments: Use 'name' to specify the dataset.
         - Outside of Databricks: Use either 'name' or 'dataset_id' to specify the dataset.
           If using 'name', the dataset name must be unique; otherwise use 'dataset_id'.
+        - On Databricks, this function requires the ``databricks-agents`` package, which
+          depends on ``databricks-connect`` and pins ``numpy<2``. Installing it can
+          downgrade numpy in environments that already have ``numpy>=2``. Consider
+          installing ``databricks-agents`` in a dedicated virtual environment.
 
     Examples:
         .. code-block:: python

--- a/tests/genai/test_genai_import_without_agent_sdk.py
+++ b/tests/genai/test_genai_import_without_agent_sdk.py
@@ -63,6 +63,18 @@ def test_delete_dataset_raises_when_agents_not_installed():
             delete_dataset("test_dataset")
 
 
+@pytest.mark.parametrize("func", [create_dataset, get_dataset, delete_dataset])
+def test_dataset_import_error_warns_about_numpy_downgrade_risk(func):
+    # databricks-agents depends on databricks-connect, which pins numpy<2 and can
+    # silently downgrade numpy in the caller's environment (see #24690). The
+    # ImportError raised when databricks-agents isn't installed should warn about
+    # this before the user blindly installs it.
+    with patch("mlflow.genai.datasets.is_databricks_uri", return_value=True):
+        with pytest.raises(ImportError, match="numpy") as exc_info:
+            func("test_dataset")
+    assert "databricks-connect" in str(exc_info.value)
+
+
 class MockScorer(Scorer):
     """Mock scorer for testing purposes."""
 

--- a/tests/genai/test_numpy_compat_warning.py
+++ b/tests/genai/test_numpy_compat_warning.py
@@ -1,0 +1,43 @@
+import warnings
+from unittest import mock
+
+import pytest
+
+import mlflow.genai as mlflow_genai
+
+
+def test_warns_when_numpy_below_2_and_databricks_connect_present(monkeypatch):
+    # databricks-connect pins numpy<2, so its presence alongside an old numpy is a
+    # strong signal that installing databricks-agents downgraded numpy (see #24690).
+    monkeypatch.setattr(mlflow_genai.np, "__version__", "1.26.4")
+    with mock.patch("mlflow.genai.importlib.util.find_spec") as mock_find_spec:
+        with pytest.warns(UserWarning, match="numpy 1.26.4"):
+            mlflow_genai._warn_if_databricks_connect_downgraded_numpy()
+    mock_find_spec.assert_called_once_with("databricks.connect")
+
+
+def test_no_warning_when_numpy_is_2_or_above(monkeypatch):
+    monkeypatch.setattr(mlflow_genai.np, "__version__", "2.1.0")
+    with mock.patch("mlflow.genai.importlib.util.find_spec") as mock_find_spec:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mlflow_genai._warn_if_databricks_connect_downgraded_numpy()
+    mock_find_spec.assert_not_called()
+
+
+def test_no_warning_when_databricks_connect_not_installed(monkeypatch):
+    monkeypatch.setattr(mlflow_genai.np, "__version__", "1.26.4")
+    with mock.patch("mlflow.genai.importlib.util.find_spec", return_value=None):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mlflow_genai._warn_if_databricks_connect_downgraded_numpy()
+
+
+def test_no_warning_when_databricks_namespace_package_missing(monkeypatch):
+    # find_spec("databricks.connect") raises ModuleNotFoundError (rather than
+    # returning None) when the "databricks" parent package isn't installed at all.
+    monkeypatch.setattr(mlflow_genai.np, "__version__", "1.26.4")
+    with mock.patch("mlflow.genai.importlib.util.find_spec", side_effect=ModuleNotFoundError):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mlflow_genai._warn_if_databricks_connect_downgraded_numpy()


### PR DESCRIPTION
### Related Issues/PRs

Closes #24690

### What changes are proposed in this pull request?

Reading a genai eval dataset on Databricks (`mlflow.genai.datasets.get_dataset()`, `create_dataset()`, `delete_dataset()`) lazily imports `databricks.agents.datasets`, which requires the `databricks-agents` package. That package depends on `databricks-connect`, which pins `numpy<2` — installing it in an environment that already has `numpy>=2` silently downgrades numpy and breaks anything depending on numpy 2.x (e.g. `AttributeError: module 'numpy' has no attribute 'long'`).

This PR doesn't change the underlying dependency chain (that pin lives upstream in `databricks-connect`), but addresses the "at minimum" ask from the issue:

- `_ERROR_MSG` in `mlflow/genai/datasets/__init__.py` now explicitly warns about the `numpy<2` pin before suggesting `pip install databricks-agents`, and recommends a dedicated virtual environment.
- Added the same warning as a `Note:` in the docstrings of `get_dataset()`, `create_dataset()`, and `delete_dataset()`.
- Added `_warn_if_databricks_connect_dosilent otherwise, and safe when the `databricks` namespace package is entirely absent).

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Improves the error/warning messages shown when `databricks-agents` is missing or when it has downgraded numpy on a Databricks tracking URI, so users get an actionable diagnosis instead of a cryptic `numpy` `AttributeError`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release