### PR TITLE
Pass `prompt` and `messages` by keyword in the dspy test LM

### DIFF
--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -166,8 +166,9 @@ def test_autolog_cot():
         "temperature": 0.7,
     }
     if _DSPY_3_3_0_OR_NEWER:
-        # 3.3.0 added `*items` and `request` to `BaseLM.__call__`, and autologging records
-        # every bound argument
+        # 3.3.0 added `*items` and `request` to `BaseLM.__call__`, and the span records every
+        # bound argument. `items` is empty because `DummyLMWithUsage.__call__` above forwards
+        # to `super()` entirely by keyword, so nothing binds to the variadic parameter.
         expected_lm_inputs |= {"items": [], "request": None}
     assert spans[3].inputs == expected_lm_inputs
     assert len(spans[3].outputs) == 3

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -34,6 +34,8 @@ _DSPY_3_0_4_OR_NEWER = _DSPY_VERSION >= Version("3.0.4")
 
 _DSPY_3_2_0_OR_NEWER = _DSPY_VERSION >= Version("3.2.0")
 
+_DSPY_3_3_0_OR_NEWER = _DSPY_VERSION >= Version("3.3.0")
+
 
 # Test module
 class CoT(dspy.Module):
@@ -157,12 +159,17 @@ def test_autolog_cot():
     }
     assert spans[3].name == "DummyLMWithUsage.__call__"
     assert spans[3].span_type == SpanType.CHAT_MODEL
-    assert spans[3].inputs == {
+    expected_lm_inputs = {
         "prompt": None,
         "messages": mock.ANY,
         "n": 3,
         "temperature": 0.7,
     }
+    if _DSPY_3_3_0_OR_NEWER:
+        # 3.3.0 added `*items` and `request` to `BaseLM.__call__`, and autologging records
+        # every bound argument
+        expected_lm_inputs |= {"items": [], "request": None}
+    assert spans[3].inputs == expected_lm_inputs
     assert len(spans[3].outputs) == 3
     assert spans[3].model_name == "dummy"
     # Output parser will run per completion output (n=3)

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -66,7 +66,7 @@ class DummyLMWithUsage(DummyLM):
                     },
                 )
 
-            return super().__call__(prompt, messages, **kwargs)
+            return super().__call__(prompt=prompt, messages=messages, **kwargs)
 
 
 def test_autolog_lm():


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085

### What changes are proposed in this pull request?

`dspy / autologging / 3.3.0` has been red on master, failing four tests with:

```
TypeError: Legacy BaseLM calls accept at most one positional prompt.
Use dspy.context(experimental=True) or pass an LMRequest for typed multi-item LM calls.
```

`DummyLMWithUsage.__call__` forwards both arguments positionally. dspy changed the signature in 3.3.0:

| dspy | `BaseLM.__call__` |
| --- | --- |
| 3.0.4 | `(self, prompt=None, messages=None, **kwargs)` |
| 3.2.0 | `(self, prompt=None, messages=None, **kwargs)` |
| 3.3.0 | `(self, *items, prompt=None, messages=None, request=None, **kwargs)` |

On 3.3.0 the two positional arguments are collected into `items` rather than binding to `prompt` and `messages`, and more than one item takes the legacy-call error path. Forwarding both by keyword binds them correctly on 3.3.0 and is equally valid on 3.0.4 and 3.2.0, which is the full range this override runs on (it is gated behind `_DSPY_3_0_4_OR_NEWER`).

### How is this PR tested?

- [x] Existing unit/integration tests

Not reproduced locally, for a macOS-only reason: `dspy==3.3.0` pulls `litellm==1.95.0`, which publishes only manylinux and win_amd64 wheels, so it builds from source through maturin and needs a Rust toolchain. CI runs Linux and installs the manylinux wheel, so the `dspy / autologging / 3.3.0` cross-version job is the check that matters here.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
