### PR TITLE
Handle pyspark 4.2 behavior changes in schema inference and genai eval

### DIFF
--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -189,6 +189,10 @@ class EvalItem:
         """Get the expectations as a list of Expectation objects."""
         expectations = []
         for name, value in self.expectations.items():
+            # A Spark DataFrame column of dicts is read back as a struct whose fields are the
+            # union of every row's keys, so rows that omitted an expectation carry it as null
+            if value is None:
+                continue
             source_id = get_context().get_user_name()
             expectations.append(
                 Expectation(

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -191,7 +191,7 @@ class EvalItem:
         for name, value in self.expectations.items():
             # A Spark DataFrame column of dicts is read back as a struct whose fields are the
             # union of every row's keys, so rows that omitted an expectation carry it as null
-            if value is None:
+            if is_none_or_nan(value):
                 continue
             source_id = get_context().get_user_name()
             expectations.append(

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -627,7 +627,10 @@ def _is_spark_df(x) -> bool:
         import pyspark.sql.connect.dataframe
 
         return isinstance(x, pyspark.sql.connect.dataframe.DataFrame)
-    except ImportError:
+    # pyspark >= 4.2 runs `check_dependencies()` on importing `pyspark.sql.connect`, which
+    # calls `sys.exit(0)` when Spark Connect extras are missing and it mistakes the running
+    # interpreter for a doctest session (`__main__` has no `__file__`, as under pytest)
+    except (ImportError, SystemExit):
         return False
 
 

--- a/tests/genai/evaluate/test_entities.py
+++ b/tests/genai/evaluate/test_entities.py
@@ -36,7 +36,7 @@ def test_get_expectation_assessments_skips_null_values():
         request_id="req-1",
         inputs={"question": "test"},
         outputs="answer",
-        expectations={"expected_response": None, "expected_facts": ["a"]},
+        expectations={"expected_response": None, "score": float("nan"), "expected_facts": ["a"]},
     )
 
     with mock.patch("mlflow.genai.evaluation.entities.get_context") as mock_context:

--- a/tests/genai/evaluate/test_entities.py
+++ b/tests/genai/evaluate/test_entities.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import numpy as np
 import pandas as pd
 
@@ -25,6 +27,23 @@ def test_eval_item_from_dataset_row_extracts_source():
     assert eval_item.source.source_data["session_id"] == "session_1"
     assert eval_item.inputs == {"question": "test"}
     assert eval_item.outputs == "answer"
+
+
+def test_get_expectation_assessments_skips_null_values():
+    # Spark reads a column of dicts back as a struct whose fields are the union of every row's
+    # keys, so a row that omitted an expectation carries it as null rather than leaving it out
+    eval_item = EvalItem(
+        request_id="req-1",
+        inputs={"question": "test"},
+        outputs="answer",
+        expectations={"expected_response": None, "expected_facts": ["a"]},
+    )
+
+    with mock.patch("mlflow.genai.evaluation.entities.get_context") as mock_context:
+        mock_context.return_value.get_user_name.return_value = "tester"
+        assessments = eval_item.get_expectation_assessments()
+
+    assert [a.name for a in assessments] == ["expected_facts"]
 
 
 def test_eval_item_from_dataset_row_handles_missing_source():

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1,3 +1,4 @@
+import builtins
 import datetime
 import json
 import math
@@ -35,8 +36,23 @@ from mlflow.types.utils import (
     _infer_colspec_type,
     _infer_param_schema,
     _infer_schema,
+    _is_spark_df,
     _validate_input_dictionary_contains_only_strings_and_lists_of_strings,
 )
+
+
+def test_is_spark_df_when_connect_import_exits(monkeypatch):
+    # pyspark >= 4.2 calls `sys.exit(0)` on importing `pyspark.sql.connect` when the Spark
+    # Connect extras are missing and it mistakes the interpreter for a doctest session
+    real_import = builtins.__import__
+
+    def exiting_import(name, *args, **kwargs):
+        if name.startswith("pyspark.sql.connect"):
+            raise SystemExit(0)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", exiting_import)
+    assert _is_spark_df(object()) is False
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25085, split out of #25120

### What changes are proposed in this pull request?

Two bugs that surface as soon as pyspark 4.2 is installed. Both are real user-facing breaks, not test artifacts, so they are worth fixing independently of when the `pyspark<4.1.0` pin is lifted.

**`_is_spark_df` can terminate the interpreter.** It probes for a Spark Connect DataFrame by importing `pyspark.sql.connect.dataframe`. pyspark >= 4.2 runs `check_dependencies()` on importing `pyspark.sql.connect`, and that function decides it must be running doctests when `__main__` has no `__file__` and there is no `sys.ps1` — which is the case under pytest, `python -c`, and some notebook setups. If the Spark Connect extras are absent it then calls `sys.exit(0)`. Only `ImportError` was caught, so the `SystemExit` escaped `infer_signature` and took the process with it. This accounted for ~20 failures on #25120.

**Null expectations are rejected.** Spark 4.2 enables Arrow by default (`spark.sql.execution.arrow.enabled` flips to `true`), and the Arrow path infers a pandas column of dicts as a `StructType` rather than a `MapType`:

| pyspark | inferred schema | row whose dict was `{}` |
| --- | --- | --- |
| 4.0.4 | `map<string,string>` | `{}` |
| 4.2.0 | `struct<expected_response:string>` | `{'expected_response': None}` |

A struct carries the union of every row's keys, so a record that simply had no expectations now reports each one explicitly as null, and `Expectation` raises `The 'value' field must be specified.` Skipping null values restores the previous meaning: absent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a regression test for each. Both were confirmed to fail without the corresponding fix — the expectation test with the exact production error — and to pass with it. The two suites they live in run green (119 passed).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed two failures on PySpark 4.2: `infer_signature` could exit the interpreter when Spark Connect extras were not installed, and `mlflow.genai.evaluate` rejected Spark datasets in which some rows had no expectations.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release