### PR TITLE
Scope artifact tests to `tmp_path` to fix an xdist race

### DIFF
--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -341,7 +341,11 @@ def test_list_artifacts_with_client_and_tracking_uri(tmp_path: pathlib.Path):
     tracking_uri = f"sqlite:///{tmp_path}/mlflow-{uuid.uuid4().hex}.db"
     assert mlflow.get_tracking_uri() != tracking_uri
     client = mlflow.MlflowClient(tracking_uri)
-    experiment_id = client.create_experiment("my_experiment")
+    # Scope artifacts to tmp_path: the default root is a shared `<rootpath>/mlruns`,
+    # which an autouse fixture removes after every test on CI
+    experiment_id = client.create_experiment(
+        "my_experiment", artifact_location=str(tmp_path / "artifacts")
+    )
     run = client.create_run(experiment_id)
     tmp_dir = tmp_path / "subdir"
     tmp_dir.mkdir()
@@ -367,7 +371,11 @@ def test_download_artifacts_with_client_and_tracking_uri(tmp_path: pathlib.Path)
     tracking_uri = f"sqlite:///{tmp_path}/mlflow-{uuid.uuid4().hex}.db"
     assert mlflow.get_tracking_uri() != tracking_uri
     client = mlflow.MlflowClient(tracking_uri)
-    experiment_id = client.create_experiment("my_experiment")
+    # Scope artifacts to tmp_path: the default root is a shared `<rootpath>/mlruns`,
+    # which an autouse fixture removes after every test on CI
+    experiment_id = client.create_experiment(
+        "my_experiment", artifact_location=str(tmp_path / "artifacts")
+    )
     run = client.create_run(experiment_id)
     tmp_dir = tmp_path / "subdir"
     tmp_dir.mkdir()

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -341,8 +341,6 @@ def test_list_artifacts_with_client_and_tracking_uri(tmp_path: pathlib.Path):
     tracking_uri = f"sqlite:///{tmp_path}/mlflow-{uuid.uuid4().hex}.db"
     assert mlflow.get_tracking_uri() != tracking_uri
     client = mlflow.MlflowClient(tracking_uri)
-    # Scope artifacts to tmp_path: the default root is a shared `<rootpath>/mlruns`,
-    # which an autouse fixture removes after every test on CI
     experiment_id = client.create_experiment(
         "my_experiment", artifact_location=str(tmp_path / "artifacts")
     )
@@ -371,8 +369,6 @@ def test_download_artifacts_with_client_and_tracking_uri(tmp_path: pathlib.Path)
     tracking_uri = f"sqlite:///{tmp_path}/mlflow-{uuid.uuid4().hex}.db"
     assert mlflow.get_tracking_uri() != tracking_uri
     client = mlflow.MlflowClient(tracking_uri)
-    # Scope artifacts to tmp_path: the default root is a shared `<rootpath>/mlruns`,
-    # which an autouse fixture removes after every test on CI
     experiment_id = client.create_experiment(
         "my_experiment", artifact_location=str(tmp_path / "artifacts")
     )


### PR DESCRIPTION
### Related Issues/PRs

None — intermittent flake, e.g. `assert [] == ['subdir']` in `python (2)` on #25122.

### What changes are proposed in this pull request?

`test_list_artifacts_with_client_and_tracking_uri` and its download counterpart create an experiment without an `artifact_location`, so artifacts land in the shared `<rootpath>/mlruns` instead of under `tmp_path`. The autouse `clean_up_mlruns_directory` fixture removes that directory after every test, and CI runs `-n auto`, so another xdist worker's teardown can delete the tree between `log_artifacts` and `list_artifacts`. Listing a missing root returns `[]` rather than raising.

Passing an explicit `artifact_location` under `tmp_path` matches what the neighbouring tests in this file already do.

Four occurrences on 2026-08-14, across three different branches, all in `python (2)` — the split that holds `tests/artifacts/`:

| Branch | Job |
| --- | --- |
| `security/authz-02-datasets` | [94707526028](https://github.com/mlflow/mlflow/actions/runs/31781303736/job/94707526028) |
| `probe-python-3.11` | [94715557376](https://github.com/mlflow/mlflow/actions/runs/31783950342/job/94715557376) |
| `security/authz-05-gateway` | [94720386290](https://github.com/mlflow/mlflow/actions/runs/31785500710/job/94720386290) |
| `fix-dspy-330-positional-messages` | [94772587906](https://github.com/mlflow/mlflow/actions/runs/31802187066/job/94772587906) |

Locally: 39 of 40 repetitions fail without this change, 0 of 1170 with it.

### How is this PR tested?

- [x] Existing unit/integration tests

Reproduced with `GITHUB_ACTIONS=1` and `-n 4 --dist loadscope` alongside other modules.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
