### PR TITLE
fix(ui): make quality chart tooltip link reachable

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
 import { renderWithIntl } from '../../../../common/utils/TestUtils.react18';
 import { TraceAssessmentChart, type TraceAssessmentChartProps } from './TraceAssessmentChart';
@@ -6,6 +6,18 @@ import { DesignSystemProvider } from '@databricks/design-system';
 import { OverviewChartProvider } from '../OverviewChartContext';
 import { MemoryRouter } from '../../../../common/utils/RoutingUtils';
 import type { AssessmentChartDataPoint, DistributionChartDataPoint } from '../hooks/useAssessmentChartsSectionData';
+
+jest.mock('recharts', () => {
+  const baseMock = jest.requireActual<typeof import('../../../../../__mocks__/recharts')>(
+    '../../../../../__mocks__/recharts',
+  );
+  return {
+    ...baseMock,
+    Tooltip: ({ content }: { content?: unknown }) => (
+      <div data-testid="tooltip" data-content-type={typeof content} />
+    ),
+  };
+});
 
 describe('TraceAssessmentChart', () => {
   const testAssessmentName = 'Correctness';
@@ -238,6 +250,17 @@ describe('TraceAssessmentChart', () => {
 
       expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
       expect(screen.queryByTestId('line-chart')).not.toBeInTheDocument();
+    });
+
+    it('should pass distribution tooltip content as a render function', () => {
+      renderComponent({
+        distributionChartData: createDistributionData([
+          { name: 'pass', count: 10 },
+          { name: 'fail', count: 5 },
+        ]),
+      });
+
+      expect(screen.getByTestId('tooltip')).toHaveAttribute('data-content-type', 'function');
     });
 
     it('should display "Total aggregate scores" label for bar chart', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-overview/components/TraceAssessmentChart.tsx
@@ -51,6 +51,12 @@ const ChartPanel: React.FC<{ label: React.ReactNode; children: React.ReactElemen
   );
 };
 
+type DistributionTooltipRenderProps = {
+  active?: boolean;
+  payload?: React.ComponentProps<typeof ScrollableTooltip>['payload'];
+  label?: string | number;
+};
+
 export interface TraceAssessmentChartProps {
   assessmentName: string;
   lineColor?: string;
@@ -136,24 +142,30 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({
     />
   );
 
-  const distributionTooltipContent = (
-    <ScrollableTooltip
-      formatter={distributionTooltipFormatter}
-      componentId="mlflow.overview.quality.assessment.view_traces_link"
-      linkConfig={
-        enableTraceNavigation
-          ? {
-              linkText: (
-                <FormattedMessage
-                  defaultMessage="View traces with this score"
-                  description="Link text to navigate to traces filtered by assessment score"
-                />
-              ),
-              onLinkClick: handleViewTraces,
-            }
-          : undefined
-      }
-    />
+  const distributionTooltipRenderer = useCallback(
+    ({ active, payload, label }: DistributionTooltipRenderProps) => (
+      <ScrollableTooltip
+        active={active}
+        payload={payload}
+        label={String(label ?? '')}
+        formatter={distributionTooltipFormatter}
+        componentId="mlflow.overview.quality.assessment.view_traces_link"
+        linkConfig={
+          enableTraceNavigation
+            ? {
+                linkText: (
+                  <FormattedMessage
+                    defaultMessage="View traces with this score"
+                    description="Link text to navigate to traces filtered by assessment score"
+                  />
+                ),
+                onLinkClick: handleViewTraces,
+              }
+            : undefined
+        }
+      />
+    ),
+    [distributionTooltipFormatter, enableTraceNavigation, handleViewTraces],
   );
 
   const hasData = timeSeriesChartData.length > 0 || distributionChartData.length > 0;
@@ -204,7 +216,7 @@ export const TraceAssessmentChart: React.FC<TraceAssessmentChartProps> = ({
               width={80}
             />
             <Tooltip
-              content={distributionTooltipContent}
+              content={distributionTooltipRenderer}
               cursor={{ fill: theme.colors.actionTertiaryBackgroundHover }}
               wrapperStyle={{ pointerEvents: 'auto' }}
             />


### PR DESCRIPTION
### Related Issues/PRs

Closes #23479

### What changes are proposed in this pull request?

The quality insights bar chart tooltip link was unreachable for bars above another bar. Moving the pointer from a hovered bar into the tooltip caused Recharts to activate the adjacent bar and replace the tooltip before the link could be clicked.

This change passes the distribution tooltip content as a render function instead of a static React element. This allows the tooltip's mouse event handling to keep the active tooltip stable while the pointer moves onto the "View traces with this score" link.

It also adds a regression test confirming that the distribution tooltip is provided to Recharts as a render function.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Ran:

`corepack yarn test TraceAssessmentChart.test.tsx --runInBand --globalSetup=`

Result: 21 tests passed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The quality insights chart tooltip now remains accessible when users move the pointer from a chart bar to the trace-filter link.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
