### PR TITLE
Add `coding_agent` to SDK telemetry

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -34,6 +34,7 @@ from mlflow.telemetry.schemas import Record, TelemetryConfig, TelemetryInfo, get
 from mlflow.telemetry.utils import (
     _IS_IN_DATABRICKS,
     _IS_MLFLOW_DEV_VERSION,
+    _detect_agent,
     _detect_environment,
     _get_config_url,
     _log_error,
@@ -131,6 +132,7 @@ class TelemetryClient:
             TelemetryInfo(
                 session_id=_MLFLOW_TELEMETRY_SESSION_ID.get() or uuid.uuid4().hex,
                 environment=_detect_environment(),
+                coding_agent=_detect_agent(),
                 installation_id=get_or_create_installation_id(),
             )
         )

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -56,15 +56,10 @@ class Environment(str, Enum):
 
 
 class CodingAgent(str, Enum):
-    AMP = "amp"
-    ANDROID_STUDIO = "android-studio"
-    ANTIGRAVITY = "antigravity"
-    AUGMENT_CLI = "augment-cli"
     CLAUDE_CODE = "claude-code"
     CLINE = "cline"
     CODEX = "codex"
     COPILOT_CLI = "copilot-cli"
-    COWORK = "cowork"
     CURSOR = "cursor"
     CURSOR_CLI = "cursor-cli"
     GEMINI_CLI = "gemini-cli"

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -55,6 +55,24 @@ class Environment(str, Enum):
     DEMO = "demo"
 
 
+class CodingAgent(str, Enum):
+    AMP = "amp"
+    ANDROID_STUDIO = "android-studio"
+    ANTIGRAVITY = "antigravity"
+    AUGMENT_CLI = "augment-cli"
+    CLAUDE_CODE = "claude-code"
+    CLINE = "cline"
+    CODEX = "codex"
+    COPILOT_CLI = "copilot-cli"
+    COWORK = "cowork"
+    CURSOR = "cursor"
+    CURSOR_CLI = "cursor-cli"
+    GEMINI_CLI = "gemini-cli"
+    KIRO = "kiro"
+    OPENCODE = "opencode"
+    PI = "pi"
+
+
 # The following env vars were found by manually inspecting
 # env vars in the specified environments and avoiding potentially
 # PII-containing variables.
@@ -98,6 +116,7 @@ class TelemetryInfo:
     )
     operating_system: str = platform.platform()
     environment: str | None = None
+    coding_agent: str | None = None
     tracking_uri_scheme: str | None = None
     is_localhost: bool | None = None
     installation_id: str | None = None

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -93,7 +93,7 @@ def _detect_environment() -> str | None:
 
 def _detect_agent() -> str | None:
     """Return the coding agent driving this process, if one can be identified."""
-    # Keep these heuristics aligned with https://github.com/cli/cli/tree/trunk/internal/agents.
+    # https://www.npmjs.com/package/std-env#agent-detection
     if agent := os.environ.get("AI_AGENT", "").strip():
         if _AGENT_NAME_PATTERN.fullmatch(agent):
             return agent.lower()

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -18,10 +19,12 @@ from mlflow.telemetry.constant import (
     UI_CONFIG_STAGING_URL,
     UI_CONFIG_URL,
 )
-from mlflow.telemetry.schemas import ENV_VAR_TO_ENVIRONMENT_MAP, Environment
+from mlflow.telemetry.schemas import ENV_VAR_TO_ENVIRONMENT_MAP, CodingAgent, Environment
 from mlflow.version import VERSION
 
 _logger = logging.getLogger(__name__)
+
+_AGENT_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 
 def _is_ci_env_or_testing() -> bool:
@@ -85,6 +88,50 @@ def _detect_environment() -> str | None:
     # unofficial heuristic to detect docker environment
     if Path("/.dockerenv").exists():
         return Environment.DOCKER.value
+    return None
+
+
+def _detect_agent() -> str | None:
+    """Return the coding agent driving this process, if one can be identified."""
+    # Keep these heuristics aligned with https://github.com/cli/cli/tree/trunk/internal/agents.
+    if agent := os.environ.get("AI_AGENT", "").strip():
+        if _AGENT_NAME_PATTERN.fullmatch(agent):
+            return agent.lower()
+
+    def is_set(*names: str) -> bool:
+        return any(os.environ.get(name) for name in names)
+
+    # Amp and Cowork also set Claude Code markers, so check their specific signals first.
+    if os.environ.get("AGENT") == "amp" or is_set("AMP_CURRENT_THREAD_ID"):
+        return CodingAgent.AMP.value
+    if is_set("CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"):
+        return CodingAgent.CODEX.value
+    if is_set("GEMINI_CLI"):
+        return CodingAgent.GEMINI_CLI.value
+    if is_set("COPILOT_CLI", "COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"):
+        return CodingAgent.COPILOT_CLI.value
+    if is_set("OPENCODE"):
+        return CodingAgent.OPENCODE.value
+    if is_set("ANTIGRAVITY_AGENT"):
+        return CodingAgent.ANTIGRAVITY.value
+    if is_set("AUGMENT_AGENT"):
+        return CodingAgent.AUGMENT_CLI.value
+    if is_set("CLINE_ACTIVE", "CLINE_AGENT"):
+        return CodingAgent.CLINE.value
+    if is_set("CLAUDECODE", "CLAUDE_CODE"):
+        if is_set("CLAUDE_CODE_IS_COWORK"):
+            return CodingAgent.COWORK.value
+        return CodingAgent.CLAUDE_CODE.value
+    if is_set("CURSOR_TRACE_ID"):
+        return CodingAgent.CURSOR.value
+    if is_set("CURSOR_AGENT") or os.environ.get("CURSOR_EXTENSION_HOST_ROLE") == "agent-exec":
+        return CodingAgent.CURSOR_CLI.value
+    if is_set("KIRO_AGENT_PATH") or os.environ.get("TERM_PROGRAM") == "kiro":
+        return CodingAgent.KIRO.value
+    if is_set("PI_CODING_AGENT"):
+        return CodingAgent.PI.value
+    if is_set("ANDROID_STUDIO_AGENT"):
+        return CodingAgent.ANDROID_STUDIO.value
     return None
 
 

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -96,7 +96,11 @@ def _detect_agent() -> str | None:
     # https://www.npmjs.com/package/std-env#agent-detection
     if agent := os.environ.get("AI_AGENT", "").strip():
         if _AGENT_NAME_PATTERN.fullmatch(agent):
-            return agent.lower()
+            agent = agent.lower()
+            for known in sorted(CodingAgent, key=lambda a: len(a.value), reverse=True):
+                if agent.startswith(known.value):
+                    return known.value
+            return agent
 
     def is_set(*names: str) -> bool:
         return any(os.environ.get(name) for name in names)
@@ -108,7 +112,7 @@ def _detect_agent() -> str | None:
         return CodingAgent.CODEX.value
     if is_set("GEMINI_CLI"):
         return CodingAgent.GEMINI_CLI.value
-    if is_set("COPILOT_CLI", "COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"):
+    if is_set("COPILOT_CLI"):
         return CodingAgent.COPILOT_CLI.value
     if is_set("OPENCODE"):
         return CodingAgent.OPENCODE.value
@@ -122,7 +126,7 @@ def _detect_agent() -> str | None:
         return CodingAgent.CURSOR.value
     if is_set("CURSOR_AGENT") or os.environ.get("CURSOR_EXTENSION_HOST_ROLE") == "agent-exec":
         return CodingAgent.CURSOR_CLI.value
-    if is_set("KIRO_AGENT_PATH") or os.environ.get("TERM_PROGRAM") == "kiro":
+    if is_set("KIRO_AGENT_PATH"):
         return CodingAgent.KIRO.value
     if is_set("PI_CODING_AGENT"):
         return CodingAgent.PI.value

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -101,9 +101,9 @@ def _detect_agent() -> str | None:
     def is_set(*names: str) -> bool:
         return any(os.environ.get(name) for name in names)
 
-    # Amp and Cowork also set Claude Code markers, so check their specific signals first.
+    # Amp also sets Claude Code markers, but it is not included in telemetry detection.
     if os.environ.get("AGENT") == "amp" or is_set("AMP_CURRENT_THREAD_ID"):
-        return CodingAgent.AMP.value
+        return None
     if is_set("CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"):
         return CodingAgent.CODEX.value
     if is_set("GEMINI_CLI"):
@@ -112,15 +112,11 @@ def _detect_agent() -> str | None:
         return CodingAgent.COPILOT_CLI.value
     if is_set("OPENCODE"):
         return CodingAgent.OPENCODE.value
-    if is_set("ANTIGRAVITY_AGENT"):
-        return CodingAgent.ANTIGRAVITY.value
-    if is_set("AUGMENT_AGENT"):
-        return CodingAgent.AUGMENT_CLI.value
     if is_set("CLINE_ACTIVE", "CLINE_AGENT"):
         return CodingAgent.CLINE.value
     if is_set("CLAUDECODE", "CLAUDE_CODE"):
         if is_set("CLAUDE_CODE_IS_COWORK"):
-            return CodingAgent.COWORK.value
+            return None
         return CodingAgent.CLAUDE_CODE.value
     if is_set("CURSOR_TRACE_ID"):
         return CodingAgent.CURSOR.value
@@ -130,8 +126,6 @@ def _detect_agent() -> str | None:
         return CodingAgent.KIRO.value
     if is_set("PI_CODING_AGENT"):
         return CodingAgent.PI.value
-    if is_set("ANDROID_STUDIO_AGENT"):
-        return CodingAgent.ANDROID_STUDIO.value
     return None
 
 

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -98,7 +98,9 @@ def _detect_agent() -> str | None:
         if _AGENT_NAME_PATTERN.fullmatch(agent):
             agent = agent.lower()
             for known in sorted(CodingAgent, key=lambda a: len(a.value), reverse=True):
-                if agent.startswith(known.value):
+                if agent == known.value or (
+                    agent.startswith(f"{known.value}_") and agent.endswith("_agent")
+                ):
                     return known.value
             return agent
 

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,6 +12,13 @@ from mlflow.telemetry.client import (
 )
 from mlflow.utils.server_info import _clear_server_info_cache
 from mlflow.version import VERSION
+
+
+@pytest.fixture
+def clear_os_environ(monkeypatch):
+    for name in tuple(os.environ):
+        monkeypatch.delenv(name)
+    return monkeypatch
 
 
 @pytest.fixture(autouse=True)

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -58,10 +58,10 @@ def test_telemetry_client_session_id(
         assert telemetry_client.info["session_id"] != "test_session_id"
 
 
-def test_telemetry_client_coding_agent():
-    with mock.patch.dict("os.environ", {"CLAUDECODE": "1"}, clear=True):
-        with TelemetryClient() as telemetry_client:
-            assert telemetry_client.info["coding_agent"] == "claude-code"
+def test_telemetry_client_coding_agent(clear_os_environ):
+    clear_os_environ.setenv("CLAUDECODE", "1")
+    with TelemetryClient() as telemetry_client:
+        assert telemetry_client.info["coding_agent"] == "claude-code"
 
 
 def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_requests):

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -58,6 +58,12 @@ def test_telemetry_client_session_id(
         assert telemetry_client.info["session_id"] != "test_session_id"
 
 
+def test_telemetry_client_coding_agent():
+    with mock.patch.dict("os.environ", {"CLAUDECODE": "1"}, clear=True):
+        with TelemetryClient() as telemetry_client:
+            assert telemetry_client.info["coding_agent"] == "claude-code"
+
+
 def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_requests):
     # Create a test record
     record = Record(
@@ -430,6 +436,7 @@ def test_telemetry_info_inclusion(mock_telemetry_client: TelemetryClient, mock_r
 
     # Check that telemetry info fields are present
     assert mock_telemetry_client.info.items() <= data.items()
+    assert "coding_agent" in data
 
     # Check that record fields are present
     assert data["event_name"] == "test_event"

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -83,6 +83,7 @@ def test_detect_environment_none():
     ("environment", "expected"),
     [
         ({"AI_AGENT": "custom-agent"}, "custom-agent"),
+        ({"AI_AGENT": "codex-custom"}, "codex-custom"),
         ({"AI_AGENT": "claude-code_2-1-232_agent"}, "claude-code"),
         ({"CODEX_THREAD_ID": "thread-id"}, "codex"),
         ({"GEMINI_CLI": "1"}, "gemini-cli"),

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -97,20 +97,20 @@ def test_detect_environment_none():
         ({"PI_CODING_AGENT": "1"}, "pi"),
     ],
 )
-def test_detect_agent(environment, expected):
-    with patch.dict("os.environ", environment, clear=True):
-        assert _detect_agent() == expected
+def test_detect_agent(clear_os_environ, environment, expected):
+    for name, value in environment.items():
+        clear_os_environ.setenv(name, value)
+    assert _detect_agent() == expected
 
 
 @pytest.mark.parametrize("agent", ["", "contains spaces", "agent@1", "x" * 65])
-def test_detect_agent_ignores_invalid_ai_agent(agent):
-    with patch.dict("os.environ", {"AI_AGENT": agent}, clear=True):
-        assert _detect_agent() is None
+def test_detect_agent_ignores_invalid_ai_agent(clear_os_environ, agent):
+    clear_os_environ.setenv("AI_AGENT", agent)
+    assert _detect_agent() is None
 
 
-def test_detect_agent_none():
-    with patch.dict("os.environ", {}, clear=True):
-        assert _detect_agent() is None
+def test_detect_agent_none(clear_os_environ):
+    assert _detect_agent() is None
 
 
 @pytest.mark.parametrize(
@@ -122,9 +122,10 @@ def test_detect_agent_none():
         {"TERM_PROGRAM": "kiro"},
     ],
 )
-def test_detect_agent_ignores_non_agent_markers(environment):
-    with patch.dict("os.environ", environment, clear=True):
-        assert _detect_agent() is None
+def test_detect_agent_ignores_non_agent_markers(clear_os_environ, environment):
+    for name, value in environment.items():
+        clear_os_environ.setenv(name, value)
+    assert _detect_agent() is None
 
 
 @pytest.mark.parametrize(
@@ -134,9 +135,10 @@ def test_detect_agent_ignores_non_agent_markers(environment):
         {"CLAUDE_CODE": "1", "CLAUDE_CODE_IS_COWORK": "1"},
     ],
 )
-def test_detect_agent_ignores_unsupported_claude_variants(environment):
-    with patch.dict("os.environ", environment, clear=True):
-        assert _detect_agent() is None
+def test_detect_agent_ignores_unsupported_claude_variants(clear_os_environ, environment):
+    for name, value in environment.items():
+        clear_os_environ.setenv(name, value)
+    assert _detect_agent() is None
 
 
 def test_is_telemetry_disabled(monkeypatch, bypass_env_check):

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -83,6 +83,7 @@ def test_detect_environment_none():
     ("environment", "expected"),
     [
         ({"AI_AGENT": "custom-agent"}, "custom-agent"),
+        ({"AI_AGENT": "claude-code_2-1-232_agent"}, "claude-code"),
         ({"CODEX_THREAD_ID": "thread-id"}, "codex"),
         ({"GEMINI_CLI": "1"}, "gemini-cli"),
         ({"COPILOT_CLI": "1"}, "copilot-cli"),
@@ -108,6 +109,20 @@ def test_detect_agent_ignores_invalid_ai_agent(agent):
 
 def test_detect_agent_none():
     with patch.dict("os.environ", {}, clear=True):
+        assert _detect_agent() is None
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {"COPILOT_MODEL": "gpt-5"},
+        {"COPILOT_ALLOW_ALL": "1"},
+        {"COPILOT_GITHUB_TOKEN": "token"},
+        {"TERM_PROGRAM": "kiro"},
+    ],
+)
+def test_detect_agent_ignores_non_agent_markers(environment):
+    with patch.dict("os.environ", environment, clear=True):
         assert _detect_agent() is None
 
 

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -83,21 +83,16 @@ def test_detect_environment_none():
     ("environment", "expected"),
     [
         ({"AI_AGENT": "custom-agent"}, "custom-agent"),
-        ({"AGENT": "amp", "CLAUDECODE": "1"}, "amp"),
         ({"CODEX_THREAD_ID": "thread-id"}, "codex"),
         ({"GEMINI_CLI": "1"}, "gemini-cli"),
         ({"COPILOT_CLI": "1"}, "copilot-cli"),
         ({"OPENCODE": "1"}, "opencode"),
-        ({"ANTIGRAVITY_AGENT": "1"}, "antigravity"),
-        ({"AUGMENT_AGENT": "1"}, "augment-cli"),
         ({"CLINE_ACTIVE": "true"}, "cline"),
         ({"CLAUDECODE": "1"}, "claude-code"),
-        ({"CLAUDE_CODE": "1", "CLAUDE_CODE_IS_COWORK": "1"}, "cowork"),
         ({"CURSOR_TRACE_ID": "trace-id"}, "cursor"),
         ({"CURSOR_AGENT": "1"}, "cursor-cli"),
         ({"KIRO_AGENT_PATH": "/path/to/kiro"}, "kiro"),
         ({"PI_CODING_AGENT": "1"}, "pi"),
-        ({"ANDROID_STUDIO_AGENT": "1"}, "android-studio"),
     ],
 )
 def test_detect_agent(environment, expected):
@@ -113,6 +108,18 @@ def test_detect_agent_ignores_invalid_ai_agent(agent):
 
 def test_detect_agent_none():
     with patch.dict("os.environ", {}, clear=True):
+        assert _detect_agent() is None
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {"AGENT": "amp", "CLAUDECODE": "1"},
+        {"CLAUDE_CODE": "1", "CLAUDE_CODE_IS_COWORK": "1"},
+    ],
+)
+def test_detect_agent_ignores_unsupported_claude_variants(environment):
+    with patch.dict("os.environ", environment, clear=True):
         assert _detect_agent() is None
 
 

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -13,6 +13,7 @@ from mlflow.telemetry.constant import (
 )
 from mlflow.telemetry.schemas import Environment
 from mlflow.telemetry.utils import (
+    _detect_agent,
     _detect_environment,
     _get_config_url,
     fetch_ui_telemetry_config,
@@ -76,6 +77,43 @@ def test_detect_environment_docker(tmp_path, monkeypatch):
 
 def test_detect_environment_none():
     assert _detect_environment() is None
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ({"AI_AGENT": "custom-agent"}, "custom-agent"),
+        ({"AGENT": "amp", "CLAUDECODE": "1"}, "amp"),
+        ({"CODEX_THREAD_ID": "thread-id"}, "codex"),
+        ({"GEMINI_CLI": "1"}, "gemini-cli"),
+        ({"COPILOT_CLI": "1"}, "copilot-cli"),
+        ({"OPENCODE": "1"}, "opencode"),
+        ({"ANTIGRAVITY_AGENT": "1"}, "antigravity"),
+        ({"AUGMENT_AGENT": "1"}, "augment-cli"),
+        ({"CLINE_ACTIVE": "true"}, "cline"),
+        ({"CLAUDECODE": "1"}, "claude-code"),
+        ({"CLAUDE_CODE": "1", "CLAUDE_CODE_IS_COWORK": "1"}, "cowork"),
+        ({"CURSOR_TRACE_ID": "trace-id"}, "cursor"),
+        ({"CURSOR_AGENT": "1"}, "cursor-cli"),
+        ({"KIRO_AGENT_PATH": "/path/to/kiro"}, "kiro"),
+        ({"PI_CODING_AGENT": "1"}, "pi"),
+        ({"ANDROID_STUDIO_AGENT": "1"}, "android-studio"),
+    ],
+)
+def test_detect_agent(environment, expected):
+    with patch.dict("os.environ", environment, clear=True):
+        assert _detect_agent() == expected
+
+
+@pytest.mark.parametrize("agent", ["", "contains spaces", "agent@1", "x" * 65])
+def test_detect_agent_ignores_invalid_ai_agent(agent):
+    with patch.dict("os.environ", {"AI_AGENT": agent}, clear=True):
+        assert _detect_agent() is None
+
+
+def test_detect_agent_none():
+    with patch.dict("os.environ", {}, clear=True):
+        assert _detect_agent() is None
 
 
 def test_is_telemetry_disabled(monkeypatch, bypass_env_check):


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a nullable `coding_agent` field to every OSS SDK telemetry event. The field is populated once per telemetry session from the emerging `AI_AGENT` convention or known environment markers for 10 coding-agent identities and variants, including Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, Cline, and Kiro.

Agent detection follows the established GitHub CLI and Vercel detection approaches. Explicit `AI_AGENT` values are validated before they are included in telemetry, and broad signals that can also identify human-driven environments are omitted.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```
uv run --frozen pytest tests/telemetry/test_utils.py tests/telemetry/test_client.py -q
uv run --frozen ruff check mlflow/telemetry/client.py mlflow/telemetry/schemas.py mlflow/telemetry/utils.py tests/telemetry/test_client.py tests/telemetry/test_utils.py
uv run --frozen ruff format --check mlflow/telemetry/client.py mlflow/telemetry/schemas.py mlflow/telemetry/utils.py tests/telemetry/test_client.py tests/telemetry/test_utils.py
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
