### PR TITLE
fix(gateway): drop inbound Authorization from passthrough headers

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -577,6 +577,14 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
                 # Preserve the client's own credentials for subscription-based tools
                 # (e.g. Claude Code, Codex, Gemini CLI) instead of using the server key.
                 result_headers.pop("x-api-key", None)
+            else:
+                # The inbound Authorization authenticates the client to the gateway,
+                # not to the upstream provider. Forwarding it would shadow the
+                # provider's own credentials (e.g. the Vertex AI OAuth Bearer) and
+                # get the upstream call rejected, so drop it here.
+                client_headers = {
+                    k: v for k, v in client_headers.items() if k.lower() != "authorization"
+                }
             result_headers = client_headers | result_headers
 
         return result_headers

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -727,6 +727,14 @@ class GeminiProvider(BaseProvider):
                 # Preserve the client's own credentials for subscription-based tools
                 # (e.g. Claude Code, Codex, Gemini CLI) instead of using the server key.
                 result_headers.pop("x-goog-api-key", None)
+            else:
+                # The inbound Authorization authenticates the client to the gateway,
+                # not to the upstream provider. Forwarding it would shadow the
+                # provider's own credentials (e.g. the Vertex AI OAuth Bearer) and
+                # get the upstream call rejected, so drop it here.
+                client_headers = {
+                    k: v for k, v in client_headers.items() if k.lower() != "authorization"
+                }
             result_headers = client_headers | result_headers
 
         return result_headers

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -120,6 +120,16 @@ def test_get_headers_uses_server_key_by_default():
     assert merged["X-Custom"] == "value"
 
 
+def test_get_headers_strips_client_authorization():
+    provider = AnthropicProvider(EndpointConfig(**completions_config()))
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer client-key", "X-Custom": "value"}
+    )
+    assert merged["x-api-key"] == "key"
+    assert "authorization" not in {k.lower() for k in merged}
+    assert merged["X-Custom"] == "value"
+
+
 @pytest.mark.parametrize(
     "user_agent",
     [

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -113,6 +113,16 @@ def test_get_headers_uses_server_key_by_default():
     assert merged["X-Custom"] == "value"
 
 
+def test_get_headers_strips_client_authorization():
+    provider = GeminiProvider(EndpointConfig(**chat_config()))
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer client-key", "X-Custom": "value"}
+    )
+    assert merged["x-goog-api-key"] == "key"
+    assert "authorization" not in {k.lower() for k in merged}
+    assert merged["X-Custom"] == "value"
+
+
 @pytest.mark.parametrize(
     "user_agent",
     [

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -74,6 +74,18 @@ def test_headers_use_bearer_token():
     assert provider.headers == {"Authorization": "Bearer mock-access-token"}
 
 
+def test_get_headers_strips_client_authorization():
+    provider = _make_provider()
+    merged = provider._get_headers(
+        headers={"authorization": "Bearer inbound-token", "X-Custom": "value"}
+    )
+    # The forwarded client Authorization must not shadow the Vertex OAuth Bearer,
+    # otherwise Google rejects the passthrough request with a 401.
+    assert merged["X-Custom"] == "value"
+    auth_headers = [v for k, v in merged.items() if k.lower() == "authorization"]
+    assert auth_headers == ["Bearer mock-access-token"]
+
+
 def test_name():
     provider = _make_provider()
     assert provider.DISPLAY_NAME == "Vertex AI"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25108

### What changes are proposed in this pull request?

The AI Gateway passthrough routes (`/gateway/gemini/...`, `/gateway/anthropic/...` and the raw proxy endpoint) forwarded the client's inbound `Authorization` header to the upstream provider. When the provider authenticates with its own `Authorization` header — notably the Vertex AI OAuth Bearer — the forwarded header shadows the provider credential and Google rejects the request with a 401, which blocks the Gemini and Anthropic passthrough routes for Vertex-backed endpoints.

This change mirrors the existing `openai_compatible` provider behavior: when an endpoint uses server-side auth, the client's `authorization` header is dropped (case-insensitively) before merging, so the provider's own credential is the only one sent upstream. The carve-out that preserves client credentials for known CLI agents (Claude Code, Codex, Gemini CLI) is unchanged.

Files changed:
- `mlflow/gateway/providers/gemini.py` — `_get_headers`
- `mlflow/gateway/providers/anthropic.py` — `_get_headers`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added regression tests in `tests/gateway/providers/test_gemini.py`, `test_anthropic.py` and `test_vertex_ai.py` asserting the client `Authorization` is no longer forwarded while the provider credential is preserved. The full Gemini, Anthropic and Vertex AI provider suites pass:

```
161 passed in 4.48s
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

AI Gateway passthrough requests to Vertex AI-backed endpoints no longer forward the client's `Authorization` header upstream, so they no longer fail with HTTP 401 when the provider authenticates with its own OAuth Bearer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/examples`: Example code
- [x] `area/gateway`: AI Gateway service, routes, client APIs and third-party integrations
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment, scoring server, and server hooks
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/store`: Tracking server, artifact store, and client-side model registry
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interfaces
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Models and MLflow Model servers
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Languages
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages
- [ ] `language/python`: Python APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
