### PR TITLE
Fix basic auth overriding Kubernetes auth in Python SDK

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -252,7 +252,8 @@ def http_request(
 
     timeout = MLFLOW_HTTP_REQUEST_TIMEOUT.get() if timeout is None else timeout
     auth_str = None
-    if host_creds.username and host_creds.password:
+    is_kubernetes_auth = host_creds.auth in {"kubernetes", "kubernetes-namespaced"}
+    if host_creds.username and host_creds.password and not is_kubernetes_auth:
         basic_auth_str = f"{host_creds.username}:{host_creds.password}".encode()
         auth_str = "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
     elif host_creds.token:

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -163,6 +163,36 @@ def test_http_request_with_basic_auth():
         )
 
 
+@pytest.mark.parametrize("auth", ["kubernetes", "kubernetes-namespaced"])
+@pytest.mark.parametrize(
+    ("token", "expected_authorization"),
+    [(None, None), ("my-token", "Bearer my-token")],
+)
+def test_http_request_with_kubernetes_auth_ignores_basic_auth(auth, token, expected_authorization):
+    host_creds = MlflowHostCreds(
+        "http://my-host",
+        username="user",
+        password="pass",
+        token=token,
+        auth=auth,
+    )
+    response = mock.MagicMock(status_code=200)
+    request_auth = mock.MagicMock()
+
+    with (
+        mock.patch("requests.Session.request", return_value=response) as mock_request,
+        mock.patch(
+            "mlflow.tracking.request_auth.registry.fetch_auth", return_value=request_auth
+        ) as mock_fetch_auth,
+    ):
+        http_request(host_creds, "/my/endpoint", "GET")
+
+    mock_fetch_auth.assert_called_once_with(auth)
+    headers = mock_request.call_args.kwargs["headers"]
+    assert headers.get("Authorization") == expected_authorization
+    assert mock_request.call_args.kwargs["auth"] is request_auth
+
+
 def test_http_request_with_aws_sigv4(monkeypatch):
     from requests_auth_aws_sigv4 import AWSSigV4
 


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #25082 | Related to #24243
### What changes are proposed in this pull request?


Ignore username/password Basic authentication when `MLFLOW_TRACKING_AUTH`
is set to `kubernetes` or `kubernetes-namespaced`.

An explicitly configured `MLFLOW_TRACKING_TOKEN` continues to be used as
a bearer token. Without an explicit token, the Kubernetes request auth
provider resolves credentials from the ServiceAccount mount or kubeconfig.

This matches the TypeScript SDK behavior implemented in #24243.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added regression tests covering both `kubernetes` and
`kubernetes-namespaced`, with and without an explicit bearer token.

Validation performed:

- `pytest -q tests/utils/test_rest_utils.py`: 57 passed, 2 skipped
- `pytest -q tests/tracking/request_auth/test_kubernetes_request_auth_provider.py`: 41 passed
- Ruff formatting and lint checks passed

### Does this PR require documentation update?

- [x] No.

This fixes existing documented authentication behavior and does not add
or modify a public API.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. When Kubernetes authentication is explicitly selected, MLflow
  now ignores username/password Basic credentials while continuing to honor
  an explicit tracking bearer token.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release