### PR TITLE
docs: fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ MLflow can be used in a variety of environments, including your local environmen
 ## 💭 Support
 
 - For help or questions about MLflow usage (e.g. "how do I do X?") visit the [documentation](https://mlflow.org/docs/latest).
-- In the documentation, you can ask the question to our AI-powered chat bot. Click on the **"Ask AI"** button at the right bottom.
+- In the documentation, you can ask the question to our AI-powered chat bot. Click on the **"Ask AI"** button at the bottom right.
 - Join the [virtual events](https://lu.ma/mlflow?k=c) like office hours and meetups.
 - To report a bug, file a documentation issue, or submit a feature request, please [open a GitHub issue](https://github.com/mlflow/mlflow/issues/new/choose).
 - For release announcements and other discussions, please subscribe to our mailing list (mlflow-users@googlegroups.com)


### PR DESCRIPTION
## What changed

Fixed grammar/typo issues in the README.

## Why

Minor documentation cleanup.

## How verified

Visual inspection of the diff.