### PR TITLE
Fix S3 artifact listing to ignore 0-byte directory-marker objects

### DIFF
--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -327,6 +327,13 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
             # Objects listed directly will be files
             for obj in result.get("Contents", []):
                 file_path = obj.get("Key")
+                # Some S3-compatible backends (e.g. objects created via the AWS
+                # console "folder" feature, or implicitly by Hitachi HCP) expose
+                # 0-byte directory-marker objects whose key ends with "/". These
+                # aren't real artifact files - they duplicate the "directory" that
+                # is already reported via CommonPrefixes above - so skip them here.
+                if file_path.endswith("/"):
+                    continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path
                 )

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -494,6 +494,16 @@ class S3ArtifactRepository(
             # Objects listed directly will be files
             for obj in result.get("Contents", []):
                 file_path = obj.get("Key")
+                # Some S3-compatible backends (e.g. objects created via the AWS
+                # console "folder" feature, or implicitly by Hitachi HCP) expose
+                # 0-byte directory-marker objects whose key ends with "/". These
+                # aren't real artifact files - they duplicate the "directory" that
+                # is already reported via CommonPrefixes above - so skip them here
+                # to avoid listing the same path as both a file and a directory,
+                # and to avoid failures when downloading a "file" that doesn't
+                # actually exist as a regular object on some backends.
+                if file_path.endswith("/"):
+                    continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path
                 )

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -257,6 +257,27 @@ def test_file_and_directories_artifacts_are_logged_and_listed_successfully_in_ba
     assert nested_artifacts_listing == [("nested/c.txt", False, 1)]
 
 
+def test_list_artifacts_ignores_directory_marker_objects(s3_artifact_repo, s3_artifact_root):
+    # Some S3-compatible backends (e.g. objects created via the AWS console "folder"
+    # feature, or implicitly by services like Hitachi HCP) expose 0-byte objects whose
+    # key ends with "/" to represent a "directory". These should not be listed as
+    # regular files - the corresponding directory is already reported via
+    # CommonPrefixes - otherwise the same path shows up as both a file and a directory.
+    bucket, dest_path = s3_artifact_repo.parse_s3_compliant_uri(s3_artifact_repo.artifact_uri)
+    s3_client = s3_artifact_repo._get_s3_client()
+    s3_client.put_object(Bucket=bucket, Key=f"{dest_path}/", Body=b"")
+    s3_client.put_object(Bucket=bucket, Key=f"{dest_path}/subdir/", Body=b"")
+    s3_client.put_object(Bucket=bucket, Key=f"{dest_path}/subdir/a.txt", Body=b"A")
+
+    listing = sorted([(f.path, f.is_dir, f.file_size) for f in s3_artifact_repo.list_artifacts()])
+    assert listing == [("subdir", True, None)]
+
+    nested_listing = sorted([
+        (f.path, f.is_dir, f.file_size) for f in s3_artifact_repo.list_artifacts("subdir")
+    ])
+    assert nested_listing == [("subdir/a.txt", False, 1)]
+
+
 def test_download_directory_artifact_succeeds_when_artifact_root_is_s3_bucket_root(
     s3_artifact_root, tmp_path
 ):


### PR DESCRIPTION
Reopen of #25136 (that PR was auto-closed by a bot after the branch was force-pushed to correct the commit author email; no code changes since).

Some S3-compatible backends (e.g. objects created via the AWS console "folder" feature, or implicitly by services like Hitachi HCP) create 0-byte objects whose key ends with `/` to represent a "directory".

Both `S3ArtifactRepository.list_artifacts` and `OptimizedS3ArtifactRepository.list_artifacts` previously listed these marker objects as regular files in addition to reporting the same path as a directory via `CommonPrefixes`, so the same logical path showed up twice in the listing and downloading the "file" could fail since it isn't a real artifact.

Skips S3 objects whose key ends with `/` when building the file listing, with a regression test covering both artifact repository implementations.