### PR TITLE
fix: Use JSON as default accept type for SageMaker transform jobs (closes #5474)

### DIFF
--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -51,7 +51,7 @@ def commands():
 @click.option(
     "--accept",
     "-a",
-    default="text/csv",
+    default="application/json",
     help="The multipurpose internet mail extension (MIME) type of the output data",
 )
 @click.option(


### PR DESCRIPTION
## What
When deploying a model to SageMaker with a signature that expects a list of strings (e.g., `[["subject", "body"]]`), the default `--accept` type of `text/csv` causes the model server to attempt CSV parsing, leading to a type error. The model is tested with the same input locally but fails in SageMaker due to mismatched request content type.

## Fix
Change the default `--accept` option from `text/csv` to `application/json`, which is more appropriate for models that accept structured inputs like lists of strings. This ensures the SageMaker transform job sends the input as JSON, aligning with the model's tested signature.

Closes #5474