### PR TITLE
fix: Avoid creating existing tables during DB initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,17 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create missing tables to avoid failures when some tables already exist
+    # (e.g., when upgrading from an older MLflow version that introduced the
+    # 'secrets' table but left the DB in an inconsistent state).
+    existing_tables = set(sqlalchemy.inspect(engine).get_table_names())
+    missing_tables = [
+        table
+        for table in InitialBase.metadata.sorted_tables
+        if table.name not in existing_tables
+    ]
+    if missing_tables:
+        InitialBase.metadata.create_all(engine, tables=missing_tables)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after upgrading from 3.7.0 to 3.8.x, the command can fail with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` which attempts to create all tables, including those that already exist in the database.

## Fix
Changed `_initialize_tables()` to only create tables that are currently missing. It first inspects the database for existing tables, then filters the tables from `InitialBase.metadata` to only those not already present, and calls `create_all()` with the `tables` argument restricted to that subset. After creating any missing tables, the function still runs `_upgrade_db(engine)` to apply pending migrations.

This preserves the original intent of initializing a fresh database while avoiding conflicts on partially initialized or pre-existing schemas.

Closes #19943