### PR TITLE
Probe whether CI tokens can upload `user-attachments` assets

### DIFF
--- a/.github/workflows/attachment-token-probe.yml
+++ b/.github/workflows/attachment-token-probe.yml
@@ -75,6 +75,9 @@ jobs:
           TOKEN_ACTIONS: ${{ secrets.GITHUB_TOKEN }}
           TOKEN_APP_WRITE: ${{ steps.app-token-write.outputs.token }}
           TOKEN_APP_READ: ${{ steps.app-token-read.outputs.token }}
+          # Fine-grained PAT scoped to this repo with metadata-only access. Proven
+          # to work locally; this checks it also works from a runner.
+          TOKEN_PAT: ${{ secrets.USER_ATTACHMENTS_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}
           RUN_ID: ${{ github.run_id }}
         run: |
@@ -113,6 +116,13 @@ jobs:
           resolve "App installation token (write)" "$TOKEN_APP_WRITE"
           resolve "App installation token (read)" "$TOKEN_APP_READ"
           cat "$SANITY"
+
+          # An absent secret would arrive as an empty string and 401, which reads
+          # like a token-kind result rather than a config mistake. Fail loudly.
+          if [ -z "$TOKEN_PAT" ]; then
+            echo "::error::USER_ATTACHMENTS_TOKEN is empty; the secret is missing or not exposed to this run"
+            exit 1
+          fi
 
           SUMMARY=/tmp/summary.md
           {
@@ -158,10 +168,14 @@ jobs:
             image image/png "$PNG" "probe-app-write-$RUN_ID.png"
           probe "App installation token" "contents: write" "$TOKEN_APP_WRITE" \
             video video/mp4 "$MP4" "probe-app-write-$RUN_ID.mp4"
-          # Control only needs one media type: the write gate is checked before
+          # Control only needs one media type: the token check happens before
           # anything content-specific.
           probe "App installation token (control)" "contents: read" "$TOKEN_APP_READ" \
             image image/png "$PNG" "probe-app-read-$RUN_ID.png"
+          probe "Fine-grained PAT (secret)" "metadata: read" "$TOKEN_PAT" \
+            image image/png "$PNG" "probe-pat-$RUN_ID.png"
+          probe "Fine-grained PAT (secret)" "metadata: read" "$TOKEN_PAT" \
+            video video/mp4 "$MP4" "probe-pat-$RUN_ID.mp4"
 
           {
             echo "Token can resolve \`repository_id=$REPO_ID\` on the regular API:"

--- a/.github/workflows/attachment-token-probe.yml
+++ b/.github/workflows/attachment-token-probe.yml
@@ -1,0 +1,185 @@
+name: attachment-token-probe
+
+# Throwaway probe: does the undocumented user-attachments upload endpoint
+#
+#   POST https://uploads.github.com/user-attachments/assets
+#        ?name=<file>&content_type=<mime>&repository_id=<id>
+#
+# accept CI credentials? It is known to work with a `gho_` OAuth user token, but
+# the two `ghs_` token kinds (the Actions GITHUB_TOKEN and an App installation
+# token) are minted and scoped differently, and neither has been tested. The
+# endpoint is absent from GitHub's OpenAPI spec, so a real run is the only
+# source of truth.
+#
+# Answering this decides whether a workflow can turn a generated image or video
+# into an embeddable https://github.com/user-attachments/assets/<uuid> URL, or
+# whether that stays limited to a human's OAuth token.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/attachment-token-probe.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  probe:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      # The endpoint gates on push/write access to the repo named by
+      # repository_id, so GITHUB_TOKEN is given the strongest form of that.
+      # A 404 under this grant means the token kind is rejected outright.
+      contents: write
+      # Used only to post the result comment, not part of the probe.
+      pull-requests: write
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token-write
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+      # Negative control: read-only is known from manual testing to 404. If this
+      # case does NOT 404, the harness is measuring the wrong thing and the
+      # other results mean nothing.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token-read
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+
+      # A real 90KB video already in the repo, so the video case exercises bytes
+      # a player can actually decode. The endpoint never inspects bytes, so a
+      # synthetic file would return 201 and still fail to render.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            docs/static/images/genai/select-traces.mp4
+          sparse-checkout-cone-mode: false
+
+      - name: Probe upload endpoint
+        env:
+          # Not named GITHUB_TOKEN: policy.rego reserves that name.
+          TOKEN_ACTIONS: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN_APP_WRITE: ${{ steps.app-token-write.outputs.token }}
+          TOKEN_APP_READ: ${{ steps.app-token-read.outputs.token }}
+          REPO_ID: ${{ github.event.repository.id }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          PNG=/tmp/probe.png
+          base64 -d > "$PNG" <<'B64'
+          iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAABvklEQVR42u3Yy3HEMAwDUDSwh5xS
+          RmrcqnNNOqBX4g8gZ+QbgcMbjywLP+/fg/X6+h6ycAY0x+gcaIjRFdAEo1sgeSMHIG0jHyBhIzcg
+          VSNPIEkjZyA9I38gMaMQICWjKCAZo0AgDaNYIAGjcCB2owwgaqMkIF4j/D9rZACtkQ20RjbQGtlA
+          a2QDrZENtEY20BrZQGtkA62RDbRGeDI02QgP58Ya4fnoTCN8ND3QCJ8GphnhIDPKCGexOUY4Tg4x
+          wk14ghEu8/JGuK/QNoJLi7ARvIpUjeDYJWkE3zo9I7g3ihkholTJCEG9MkaIq9YwQmi7gBGiX1F2
+          IyTsc9RGyPlY8hoh7cRFaoTMYzujEZL//eiMkH+BwGWEklsoIqMaICKjMiAWo0ogCqNioP5G9UDN
+          jVoAdTbqAtTWqBFQT6NeQA2N2gF1M+oI1MqoKVAfo75ATYxaA3Uw6g5UbkQAVGvEAVRoRANUZcQE
+          VGJEBpRvxAeUbEQJlGnECpRmRAyUY8QNlGBEDxRtpAAUaiQCFGekAxRkJAUUYaQG5G4kCORrpAnk
+          aCQL5GWkDORiJA50b6QPdGk0AujGaArQsdEfHZuzZSxpQOkAAAAASUVORK5CYII=
+          B64
+          MP4=docs/static/images/genai/select-traces.mp4
+          echo "png: $(wc -c < "$PNG") bytes, mp4: $(wc -c < "$MP4") bytes"
+
+          SUMMARY=/tmp/summary.md
+          {
+            echo "| Token | Requested scope | Media | Prefix | HTTP | Asset URL |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+          } > "$SUMMARY"
+          : > /tmp/uploaded.txt
+
+          probe() {
+            local label=$1 scope=$2 token=$3 kind=$4 mime=$5 file=$6 name=$7
+            local body status prefix url cell
+            body=$(mktemp)
+            prefix=${token:0:4}
+            status=$(curl -sS -o "$body" -w '%{http_code}' -X POST \
+              "https://uploads.github.com/user-attachments/assets?name=$name&content_type=$mime&repository_id=$REPO_ID" \
+              -H "Authorization: Bearer $token" \
+              -H "Accept: application/json" \
+              --data-binary "@$file") || status="curl-failed"
+
+            # A non-201 can return HTML rather than JSON, so tolerate a parse failure.
+            url=$(jq -r '.url // empty' "$body" 2>/dev/null) || url=""
+
+            echo "::group::$label / $kind -> HTTP $status"
+            echo "token prefix: ${prefix}"
+            jq . "$body" 2>/dev/null || cat "$body"
+            echo
+            echo "::endgroup::"
+
+            if [ -n "$url" ]; then
+              cell="[\`${url##*/}\`]($url)"
+              echo "$kind|$label|$url" >> /tmp/uploaded.txt
+            else
+              cell="-"
+            fi
+            echo "| $label | \`$scope\` | $kind | \`$prefix\` | $status | $cell |" >> "$SUMMARY"
+          }
+
+          probe "Actions \`GITHUB_TOKEN\`" "contents: write" "$TOKEN_ACTIONS" \
+            image image/png "$PNG" "probe-actions-$RUN_ID.png"
+          probe "Actions \`GITHUB_TOKEN\`" "contents: write" "$TOKEN_ACTIONS" \
+            video video/mp4 "$MP4" "probe-actions-$RUN_ID.mp4"
+          probe "App installation token" "contents: write" "$TOKEN_APP_WRITE" \
+            image image/png "$PNG" "probe-app-write-$RUN_ID.png"
+          probe "App installation token" "contents: write" "$TOKEN_APP_WRITE" \
+            video video/mp4 "$MP4" "probe-app-write-$RUN_ID.mp4"
+          # Control only needs one media type: the write gate is checked before
+          # anything content-specific.
+          probe "App installation token (control)" "contents: read" "$TOKEN_APP_READ" \
+            image image/png "$PNG" "probe-app-read-$RUN_ID.png"
+
+          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          cat "$SUMMARY"
+
+      # Referencing an asset in repo content is what flips it world-readable, so
+      # this doubles as the render check: any asset below that displays is both
+      # minted and publicly resolvable. Video needs the bare URL alone in its own
+      # paragraph to get a player; wrapping it in ![]() renders a dead link.
+      - name: Comment results on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY=/tmp/comment.md
+          {
+            echo "### user-attachments upload probe"
+            echo
+            cat /tmp/summary.md
+            echo
+            if [ -s /tmp/uploaded.txt ]; then
+              echo "#### Rendered"
+              echo
+              while IFS='|' read -r kind label url; do
+                echo "$label ($kind):"
+                echo
+                if [ "$kind" = "video" ]; then
+                  echo "$url"
+                else
+                  echo "![$label]($url)"
+                fi
+                echo
+              done < /tmp/uploaded.txt
+            else
+              echo "No asset URL was returned by any token."
+              echo
+            fi
+            echo "[Run log]($JOB_RUN_URL)"
+          } > "$BODY"
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@"$BODY"

--- a/.github/workflows/attachment-token-probe.yml
+++ b/.github/workflows/attachment-token-probe.yml
@@ -92,6 +92,27 @@ jobs:
           B64
           MP4=docs/static/images/genai/select-traces.mp4
           echo "png: $(wc -c < "$PNG") bytes, mp4: $(wc -c < "$MP4") bytes"
+          echo "repository_id: $REPO_ID"
+
+          # A wrong repository_id returns a 404 byte-identical to an access
+          # denial, so the upload result alone cannot tell the two apart. Prove
+          # each token resolves this exact id on the regular API first: a token
+          # that gets 200 here and 404 on the upload is being refused by the
+          # upload endpoint specifically, not failing to see the repo.
+          SANITY=/tmp/sanity.md
+          : > "$SANITY"
+          resolve() {
+            local label=$1 token=$2 status
+            status=$(curl -sS -o /dev/null -w '%{http_code}' \
+              "https://api.github.com/repositories/$REPO_ID" \
+              -H "Authorization: Bearer $token" \
+              -H "Accept: application/vnd.github+json") || status="curl-failed"
+            echo "- $label: \`GET /repositories/$REPO_ID\` -> $status" >> "$SANITY"
+          }
+          resolve "Actions \`GITHUB_TOKEN\`" "$TOKEN_ACTIONS"
+          resolve "App installation token (write)" "$TOKEN_APP_WRITE"
+          resolve "App installation token (read)" "$TOKEN_APP_READ"
+          cat "$SANITY"
 
           SUMMARY=/tmp/summary.md
           {
@@ -142,8 +163,13 @@ jobs:
           probe "App installation token (control)" "contents: read" "$TOKEN_APP_READ" \
             image image/png "$PNG" "probe-app-read-$RUN_ID.png"
 
-          cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
-          cat "$SUMMARY"
+          {
+            echo "Token can resolve \`repository_id=$REPO_ID\` on the regular API:"
+            echo
+            cat "$SANITY"
+            echo
+            cat "$SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       # Referencing an asset in repo content is what flips it world-readable, so
       # this doubles as the render check: any asset below that displays is both
@@ -160,6 +186,8 @@ jobs:
           BODY=/tmp/comment.md
           {
             echo "### user-attachments upload probe"
+            echo
+            cat /tmp/sanity.md
             echo
             cat /tmp/summary.md
             echo


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

**Throwaway experiment — not for merge.**

`POST https://uploads.github.com/user-attachments/assets` mints the
`https://github.com/user-attachments/assets/<uuid>` URLs that GitHub renders
inline in PR bodies. It is undocumented (absent from GitHub's OpenAPI spec) and
verified only with a `gho_` OAuth user token. Whether CI credentials work is
unknown, and the two `ghs_` kinds are not interchangeable — the Actions
`GITHUB_TOKEN` and a GitHub App installation token are minted and scoped
differently, so neither result implies the other.

This workflow uploads a PNG and a real 90KB `.mp4` from `docs/static/` with each
token and reports the HTTP status. A read-only app token is included as a
negative control: the endpoint gates on push access and is expected to 404, so
if that case succeeds the harness is measuring the wrong thing.

Results are posted as a PR comment. Referencing an asset in repo content is what
makes it world-readable, so the comment doubles as the render check.

If CI tokens are accepted, workflows can attach generated media to PRs directly
instead of that being limited to a human's OAuth token.

### How is this PR tested?

- [x] Manual tests

The probe script was run locally against the real endpoint before pushing: a
`gho_` token returned 201 for both the PNG and the mp4, and a deliberately
invalid token returned 401, confirming both the success-parse and failure paths.
The CI run is the actual experiment.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
