### PR TITLE
Let the PR reviewer attach images and video

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -141,6 +141,9 @@ Authoring rules not captured by the schema:
   `` `name.png` `` to cite. A later workflow step uploads it and rewrites the reference to a
   URL. Do not upload anything yourself. Skip this unless a visual genuinely beats prose;
   most reviews need none.
+- Put a video reference (`.mp4`, `.mov`, `.webm`) on a line of its own. GitHub renders a
+  player only for a bare URL in its own paragraph, so a video cited mid-sentence falls back
+  to a plain link.
 
 Validate before finishing, then fix any errors and re-emit until this passes:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -136,6 +136,11 @@ Authoring rules not captured by the schema:
 - Use suggestion blocks for simple fixes: fence with ` ```suggestion ` and preserve original
   indentation.
 - If you have no findings, emit an empty `comments` array.
+- To attach an image or video (a diagram, a chart, a captured repro), write the file into
+  `/tmp/review-media/` and reference it by bare filename: `![desc](name.png)` to embed, or
+  `` `name.png` `` to cite. A later workflow step uploads it and rewrites the reference to a
+  URL. Do not upload anything yourself. Skip this unless a visual genuinely beats prose;
+  most reviews need none.
 
 Validate before finishing, then fix any errors and re-emit until this passes:
 

--- a/.claude/skills/src/skills/cli.py
+++ b/.claude/skills/src/skills/cli.py
@@ -4,6 +4,7 @@ from skills.commands import (
     fetch_diff,
     fetch_logs,
     load_rules,
+    upload_media,
     validate_review,
 )
 
@@ -15,6 +16,7 @@ def build_parser() -> argparse.ArgumentParser:
     fetch_diff.register(subparsers)
     fetch_logs.register(subparsers)
     load_rules.register(subparsers)
+    upload_media.register(subparsers)
     validate_review.register(subparsers)
 
     return parser

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -14,6 +15,9 @@ from pathlib import Path
 from typing import Any
 
 UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
+# Read from the environment, never argv: a PAT in a CLI argument is visible in the
+# process list for the life of the call.
+TOKEN_ENV = "MEDIA_TOKEN"
 
 # The name's extension must agree with content_type or the endpoint returns 422.
 MIME_TYPES = {
@@ -105,11 +109,13 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="File to rewrite: a .json pr-review payload, or any Markdown file",
     )
     parser.add_argument("--repository-id", required=True, help="Numeric repository id")
-    parser.add_argument("--token", required=True, help="User token accepted by the endpoint")
     parser.set_defaults(func=run)
 
 
 def run(args: argparse.Namespace) -> None:
+    if not (token := os.environ.get(TOKEN_ENV)):
+        print(f"{TOKEN_ENV} is unset; skipping media upload", file=sys.stderr)
+        return
     if not args.target.is_file():
         print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
         return
@@ -125,7 +131,7 @@ def run(args: argparse.Namespace) -> None:
     print(f"Uploading {len(files)} file(s) from {args.dir}")
     urls = {}
     for path in files:
-        if url := upload_asset(path, args.repository_id, args.token):
+        if url := upload_asset(path, args.repository_id, token):
             urls[path.name] = url
 
     if not urls:

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Iterable
@@ -33,6 +34,11 @@ MIME_TYPES = {
 }
 
 VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
+
+
+class TokenRejected(Exception):
+    """Raised on 401: the credential is dead, so every remaining upload would fail too."""
+
 
 # 10MB covers images and video on free plans; the smaller bound is the safe one.
 MAX_BYTES = 10 * 1024 * 1024
@@ -67,6 +73,12 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
     try:
         with urllib.request.urlopen(request, timeout=60) as resp:
             body = json.load(resp)
+    # Must precede OSError: HTTPError is a URLError, which is an OSError.
+    except urllib.error.HTTPError as e:
+        print(f"  failed {path.name}: {e}", file=sys.stderr)
+        if e.code == 401:
+            raise TokenRejected(f"{TOKEN_ENV} was rejected (401); it may have expired") from e
+        return None
     except (OSError, http.client.HTTPException, ValueError) as e:
         print(f"  failed {path.name}: {e}", file=sys.stderr)
         return None
@@ -163,9 +175,14 @@ def run(args: argparse.Namespace) -> None:
     urls = {}
     if token := os.environ.get(TOKEN_ENV):
         print(f"Uploading {len(files)} file(s) from {args.dir}")
-        for path in files:
-            if url := upload_asset(path, args.repository_id, token):
-                urls[path.name] = url
+        try:
+            for path in files:
+                if url := upload_asset(path, args.repository_id, token):
+                    urls[path.name] = url
+        except TokenRejected as e:
+            # The step is continue-on-error, so without an annotation an expired
+            # token would silently stop attaching media on every future review.
+            print(f"::warning::{e}")
     else:
         print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
 

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -1,0 +1,141 @@
+# ruff: noqa: T201
+"""Upload review media to GitHub's user-attachments store and swap filenames for URLs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
+
+# The name's extension must agree with content_type or the endpoint returns 422.
+MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".webm": "video/webm",
+}
+
+# 10MB covers images and video on free plans; the smaller bound is the safe one.
+MAX_BYTES = 10 * 1024 * 1024
+
+
+def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
+    mime = MIME_TYPES.get(path.suffix.lower())
+    if mime is None:
+        print(f"  skip {path.name}: unsupported extension", file=sys.stderr)
+        return None
+
+    size = path.stat().st_size
+    if size > MAX_BYTES:
+        print(f"  skip {path.name}: {size} bytes exceeds {MAX_BYTES}", file=sys.stderr)
+        return None
+
+    query = urllib.parse.urlencode({
+        "name": path.name,
+        "content_type": mime,
+        "repository_id": repository_id,
+    })
+    request = urllib.request.Request(
+        f"{UPLOAD_URL}?{query}",
+        data=path.read_bytes(),
+        method="POST",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as resp:
+            body = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, ValueError) as e:
+        print(f"  failed {path.name}: {e}", file=sys.stderr)
+        return None
+
+    match body:
+        case {"url": str(url)} if url:
+            print(f"  uploaded {path.name} -> {url}")
+            return url
+        case _:
+            print(f"  failed {path.name}: response carried no url", file=sys.stderr)
+            return None
+
+
+def substitute(text: str, urls: dict[str, str]) -> str:
+    for name, url in urls.items():
+        quoted = re.escape(name)
+        text = re.sub(rf"\]\((?:\./)?{quoted}\)", f"]({url})", text)
+        # Lookarounds keep a second pass a no-op.
+        text = re.sub(rf"(?<!\[)`{quoted}`(?!\])", f"[`{name}`]({url})", text)
+    return text
+
+
+def rewrite_payload(payload: dict[str, Any], urls: dict[str, str]) -> dict[str, Any]:
+    # The schema pins body to end with the Claude footer, so only substitute, never append.
+    match payload:
+        case {"body": str(body)}:
+            payload["body"] = substitute(body, urls)
+    match payload:
+        case {"comments": [*comments]}:
+            for comment in comments:
+                match comment:
+                    case {"body": str(body)}:
+                        comment["body"] = substitute(body, urls)
+    return payload
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser(
+        "upload-media",
+        help="Upload media to GitHub user-attachments and point a review at the URLs",
+    )
+    parser.add_argument("--dir", type=Path, required=True, help="Directory holding the media")
+    parser.add_argument(
+        "--target",
+        type=Path,
+        required=True,
+        help="File to rewrite: a .json pr-review payload, or any Markdown file",
+    )
+    parser.add_argument("--repository-id", required=True, help="Numeric repository id")
+    parser.add_argument("--token", required=True, help="User token accepted by the endpoint")
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    if not args.target.is_file():
+        print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
+        return
+    if not args.dir.is_dir():
+        print(f"No media directory at {args.dir}")
+        return
+
+    files = sorted(p for p in args.dir.iterdir() if p.is_file())
+    if not files:
+        print(f"No media in {args.dir}")
+        return
+
+    print(f"Uploading {len(files)} file(s) from {args.dir}")
+    urls = {}
+    for path in files:
+        if url := upload_asset(path, args.repository_id, args.token):
+            urls[path.name] = url
+
+    if not urls:
+        print("No uploads succeeded; leaving the target unchanged", file=sys.stderr)
+        return
+
+    if args.target.suffix == ".json":
+        payload = json.loads(args.target.read_text())
+        rewritten = rewrite_payload(payload, urls)
+        args.target.write_text(json.dumps(rewritten, indent=2, ensure_ascii=False))
+    else:
+        args.target.write_text(substitute(args.target.read_text(), urls))
+    print(f"Embedded {len(urls)} of {len(files)} file(s) into {args.target}")

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -11,6 +11,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -79,32 +80,44 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
             return None
 
 
-def substitute(text: str, urls: dict[str, str]) -> str:
+def substitute(text: str, urls: dict[str, str], unavailable: Iterable[str] = ()) -> str:
     for name, url in urls.items():
         quoted = re.escape(name)
         if is_video(name):
-            # GitHub only renders a player for a bare URL alone in its own paragraph;
-            # inside ![]() or a link it degrades to text. Promote a reference that
-            # already sits on its own line, and leave anything mid-sentence as a link.
+            # GitHub renders a player only for a bare URL alone in its own paragraph,
+            # so promote a reference that already sits on its own line.
             standalone = rf"(?m)^[ \t]*(?:!?\[[^\]]*\]\((?:\./)?{quoted}\)|`{quoted}`)[ \t]*$"
             text = re.sub(standalone, f"\n{url}\n", text)
+            # Whatever is left is mid-sentence, where ![]() around a video URL renders
+            # as a broken image. Drop the bang so it degrades to a link instead.
+            text = re.sub(rf"!(?=\[[^\]]*\]\((?:\./)?{quoted}\))", "", text)
         text = re.sub(rf"\]\((?:\./)?{quoted}\)", f"]({url})", text)
         # Lookarounds keep a second pass a no-op.
         text = re.sub(rf"(?<!\[)`{quoted}`(?!\])", f"[`{name}`]({url})", text)
+
+    # A name with no URL (upload failed, or the file was skipped) would otherwise
+    # survive as ![desc](shot.png), which GitHub resolves repo-relative and renders
+    # as a broken image. Strip the markup so it degrades to prose.
+    for name in unavailable:
+        quoted = re.escape(name)
+        text = re.sub(rf"!?\[\]\((?:\./)?{quoted}\)", name, text)
+        text = re.sub(rf"!?\[([^\]]+)\]\((?:\./)?{quoted}\)", r"\1", text)
     return text
 
 
-def rewrite_payload(payload: dict[str, Any], urls: dict[str, str]) -> dict[str, Any]:
+def rewrite_payload(
+    payload: dict[str, Any], urls: dict[str, str], unavailable: Iterable[str] = ()
+) -> dict[str, Any]:
     # The schema pins body to end with the Claude footer, so only substitute, never append.
     match payload:
         case {"body": str(body)}:
-            payload["body"] = substitute(body, urls)
+            payload["body"] = substitute(body, urls, unavailable)
     match payload:
         case {"comments": [*comments]}:
             for comment in comments:
                 match comment:
                     case {"body": str(body)}:
-                        comment["body"] = substitute(body, urls)
+                        comment["body"] = substitute(body, urls, unavailable)
     return payload
 
 
@@ -154,14 +167,14 @@ def run(args: argparse.Namespace) -> None:
         if url := upload_asset(path, args.repository_id, token):
             urls[path.name] = url
 
-    if not urls:
-        print("No uploads succeeded; leaving the target unchanged", file=sys.stderr)
-        return
+    # Rewrite even when nothing uploaded: the neutralizing pass is what keeps a
+    # failed upload from shipping a broken embed.
+    unavailable = [p.name for p in files if p.name not in urls]
 
     if args.target.suffix == ".json":
         payload = json.loads(args.target.read_text())
-        rewritten = rewrite_payload(payload, urls)
+        rewritten = rewrite_payload(payload, urls, unavailable)
         args.target.write_text(json.dumps(rewritten, indent=2, ensure_ascii=False))
     else:
-        args.target.write_text(substitute(args.target.read_text(), urls))
+        args.target.write_text(substitute(args.target.read_text(), urls, unavailable))
     print(f"Embedded {len(urls)} of {len(files)} file(s) into {args.target}")

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -11,7 +11,7 @@ import re
 import sys
 import urllib.parse
 import urllib.request
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -42,21 +42,15 @@ def is_video(name: str) -> bool:
     return Path(name).suffix.lower() in VIDEO_SUFFIXES
 
 
-def upload_asset(
-    path: Path,
-    repository_id: str,
-    token: str,
-    opener: Callable[..., Any] = urllib.request.urlopen,
-    max_bytes: int = MAX_BYTES,
-) -> str | None:
+def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
     mime = MIME_TYPES.get(path.suffix.lower())
     if mime is None:
         print(f"  skip {path.name}: unsupported extension", file=sys.stderr)
         return None
 
     size = path.stat().st_size
-    if size > max_bytes:
-        print(f"  skip {path.name}: {size} bytes exceeds {max_bytes}", file=sys.stderr)
+    if size > MAX_BYTES:
+        print(f"  skip {path.name}: {size} bytes exceeds {MAX_BYTES}", file=sys.stderr)
         return None
 
     query = urllib.parse.urlencode({
@@ -71,7 +65,7 @@ def upload_asset(
         headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
     )
     try:
-        with opener(request, timeout=60) as resp:
+        with urllib.request.urlopen(request, timeout=60) as resp:
             body = json.load(resp)
     except (OSError, http.client.HTTPException, ValueError) as e:
         print(f"  failed {path.name}: {e}", file=sys.stderr)
@@ -143,10 +137,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     parser.set_defaults(func=run)
 
 
-def run(
-    args: argparse.Namespace,
-    upload: Callable[..., str | None] = upload_asset,
-) -> None:
+def run(args: argparse.Namespace) -> None:
     if not args.target.is_file():
         print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
         return
@@ -173,7 +164,7 @@ def run(
     if token := os.environ.get(TOKEN_ENV):
         print(f"Uploading {len(files)} file(s) from {args.dir}")
         for path in files:
-            if url := upload(path, args.repository_id, token):
+            if url := upload_asset(path, args.repository_id, token):
                 urls[path.name] = url
     else:
         print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -40,12 +40,16 @@ class TokenRejected(Exception):
     """Raised on 401: the credential is dead, so every remaining upload would fail too."""
 
 
-# 10MB covers images and video on free plans; the smaller bound is the safe one.
-MAX_BYTES = 10 * 1024 * 1024
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+MAX_VIDEO_BYTES = 100 * 1024 * 1024
 
 
 def is_video(name: str) -> bool:
     return Path(name).suffix.lower() in VIDEO_SUFFIXES
+
+
+def max_bytes(name: str) -> int:
+    return MAX_VIDEO_BYTES if is_video(name) else MAX_IMAGE_BYTES
 
 
 def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
@@ -55,8 +59,8 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
         return None
 
     size = path.stat().st_size
-    if size > MAX_BYTES:
-        print(f"  skip {path.name}: {size} bytes exceeds {MAX_BYTES}", file=sys.stderr)
+    if size > (limit := max_bytes(path.name)):
+        print(f"  skip {path.name}: {size} bytes exceeds {limit}", file=sys.stderr)
         return None
 
     query = urllib.parse.urlencode({

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -151,7 +151,7 @@ def run(args: argparse.Namespace) -> None:
     # is_file() follows symlinks, so a link planted here (say secret.png ->
     # /proc/self/environ) would publish this process's own UPLOAD_MEDIA_TOKEN as an
     # attachment. Claude writes this directory, and a poisoned diff steers Claude.
-    files = []
+    files: list[Path] = []
     for path in sorted(args.dir.iterdir()):
         if path.is_symlink():
             print(f"  skip {path.name}: symlink", file=sys.stderr)

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -31,8 +31,14 @@ MIME_TYPES = {
     ".webm": "video/webm",
 }
 
+VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
+
 # 10MB covers images and video on free plans; the smaller bound is the safe one.
 MAX_BYTES = 10 * 1024 * 1024
+
+
+def is_video(name: str) -> bool:
+    return Path(name).suffix.lower() in VIDEO_SUFFIXES
 
 
 def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
@@ -76,6 +82,12 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
 def substitute(text: str, urls: dict[str, str]) -> str:
     for name, url in urls.items():
         quoted = re.escape(name)
+        if is_video(name):
+            # GitHub only renders a player for a bare URL alone in its own paragraph;
+            # inside ![]() or a link it degrades to text. Promote a reference that
+            # already sits on its own line, and leave anything mid-sentence as a link.
+            standalone = rf"(?m)^[ \t]*(?:!?\[[^\]]*\]\((?:\./)?{quoted}\)|`{quoted}`)[ \t]*$"
+            text = re.sub(standalone, f"\n{url}\n", text)
         text = re.sub(rf"\]\((?:\./)?{quoted}\)", f"]({url})", text)
         # Lookarounds keep a second pass a no-op.
         text = re.sub(rf"(?<!\[)`{quoted}`(?!\])", f"[`{name}`]({url})", text)
@@ -123,7 +135,15 @@ def run(args: argparse.Namespace) -> None:
         print(f"No media directory at {args.dir}")
         return
 
-    files = sorted(p for p in args.dir.iterdir() if p.is_file())
+    # is_file() follows symlinks, so a link planted here (say secret.png ->
+    # /proc/self/environ) would publish this process's own MEDIA_TOKEN as an
+    # attachment. Claude writes this directory, and a poisoned diff steers Claude.
+    files = []
+    for path in sorted(args.dir.iterdir()):
+        if path.is_symlink():
+            print(f"  skip {path.name}: symlink", file=sys.stderr)
+        elif path.is_file():
+            files.append(path)
     if not files:
         print(f"No media in {args.dir}")
         return

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -138,9 +138,6 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
 
 
 def run(args: argparse.Namespace) -> None:
-    if not (token := os.environ.get(TOKEN_ENV)):
-        print(f"{TOKEN_ENV} is unset; skipping media upload", file=sys.stderr)
-        return
     if not args.target.is_file():
         print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
         return
@@ -161,14 +158,17 @@ def run(args: argparse.Namespace) -> None:
         print(f"No media in {args.dir}")
         return
 
-    print(f"Uploading {len(files)} file(s) from {args.dir}")
+    # A missing secret must still reach the rewrite below, or every reference ships
+    # verbatim and renders as a broken repo-relative image.
     urls = {}
-    for path in files:
-        if url := upload_asset(path, args.repository_id, token):
-            urls[path.name] = url
+    if token := os.environ.get(TOKEN_ENV):
+        print(f"Uploading {len(files)} file(s) from {args.dir}")
+        for path in files:
+            if url := upload_asset(path, args.repository_id, token):
+                urls[path.name] = url
+    else:
+        print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
 
-    # Rewrite even when nothing uploaded: the neutralizing pass is what keeps a
-    # failed upload from shipping a broken embed.
     unavailable = [p.name for p in files if p.name not in urls]
 
     if args.target.suffix == ".json":

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -4,14 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import re
 import sys
-import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -42,15 +42,21 @@ def is_video(name: str) -> bool:
     return Path(name).suffix.lower() in VIDEO_SUFFIXES
 
 
-def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
+def upload_asset(
+    path: Path,
+    repository_id: str,
+    token: str,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+    max_bytes: int = MAX_BYTES,
+) -> str | None:
     mime = MIME_TYPES.get(path.suffix.lower())
     if mime is None:
         print(f"  skip {path.name}: unsupported extension", file=sys.stderr)
         return None
 
     size = path.stat().st_size
-    if size > MAX_BYTES:
-        print(f"  skip {path.name}: {size} bytes exceeds {MAX_BYTES}", file=sys.stderr)
+    if size > max_bytes:
+        print(f"  skip {path.name}: {size} bytes exceeds {max_bytes}", file=sys.stderr)
         return None
 
     query = urllib.parse.urlencode({
@@ -65,9 +71,9 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
         headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
     )
     try:
-        with urllib.request.urlopen(request, timeout=60) as resp:
+        with opener(request, timeout=60) as resp:
             body = json.load(resp)
-    except (urllib.error.URLError, TimeoutError, ValueError) as e:
+    except (OSError, http.client.HTTPException, ValueError) as e:
         print(f"  failed {path.name}: {e}", file=sys.stderr)
         return None
 
@@ -137,7 +143,10 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     parser.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> None:
+def run(
+    args: argparse.Namespace,
+    upload: Callable[..., str | None] = upload_asset,
+) -> None:
     if not args.target.is_file():
         print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
         return
@@ -164,7 +173,7 @@ def run(args: argparse.Namespace) -> None:
     if token := os.environ.get(TOKEN_ENV):
         print(f"Uploading {len(files)} file(s) from {args.dir}")
         for path in files:
-            if url := upload_asset(path, args.repository_id, token):
+            if url := upload(path, args.repository_id, token):
                 urls[path.name] = url
     else:
         print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -18,7 +18,7 @@ from typing import Any
 UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
 # Read from the environment, never argv: a PAT in a CLI argument is visible in the
 # process list for the life of the call.
-TOKEN_ENV = "MEDIA_TOKEN"
+TOKEN_ENV = "UPLOAD_MEDIA_TOKEN"
 
 # The name's extension must agree with content_type or the endpoint returns 422.
 MIME_TYPES = {
@@ -149,7 +149,7 @@ def run(args: argparse.Namespace) -> None:
         return
 
     # is_file() follows symlinks, so a link planted here (say secret.png ->
-    # /proc/self/environ) would publish this process's own MEDIA_TOKEN as an
+    # /proc/self/environ) would publish this process's own UPLOAD_MEDIA_TOKEN as an
     # attachment. Claude writes this directory, and a poisoned diff steers Claude.
     files = []
     for path in sorted(args.dir.iterdir()):

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from skills.cli import build_parser
@@ -59,7 +60,8 @@ def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> No
     media = tmp_path / "media"
     media.mkdir(exist_ok=True)
     (media / "shot.png").write_bytes(b"\x89PNG")
-    monkeypatch.setattr(upload_media, "upload_asset", lambda *a, **k: URL)
+    uploader = mock.Mock(return_value=URL)
+    monkeypatch.setattr(upload_media, "upload_asset", uploader)
     args = build_parser().parse_args([
         "upload-media",
         "--dir",
@@ -70,6 +72,7 @@ def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> No
         "136202695",
     ])
     args.func(args)
+    uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
 
 
 def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -97,7 +100,8 @@ def test_cli_leaves_the_target_alone_when_every_upload_fails(
     target.write_text(original)
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
-    monkeypatch.setattr(upload_media, "upload_asset", lambda *a, **k: None)
+    uploader = mock.Mock(return_value=None)
+    monkeypatch.setattr(upload_media, "upload_asset", uploader)
     args = build_parser().parse_args([
         "upload-media",
         "--dir",
@@ -108,6 +112,7 @@ def test_cli_leaves_the_target_alone_when_every_upload_fails(
         "136202695",
     ])
     args.func(args)
+    uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
     assert target.read_text() == original
 
 
@@ -167,3 +172,42 @@ def test_cli_skips_everything_when_the_token_env_is_unset(
     ])
     args.func(args)
     assert target.read_text() == "`shot.png`"
+
+
+def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    media = tmp_path / "media"
+    media.mkdir()
+    secret = tmp_path / "environ"
+    secret.write_text("MEDIA_TOKEN=supersecret")
+    (media / "shot.png").symlink_to(secret)
+    target = tmp_path / "body.md"
+    target.write_text("`shot.png`")
+
+    uploader = mock.Mock(return_value=URL)
+    monkeypatch.setattr(upload_media, "upload_asset", uploader)
+    args = build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--repository-id",
+        "136202695",
+    ])
+    args.func(args)
+    uploader.assert_not_called()
+    assert target.read_text() == "`shot.png`"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("![repro](clip.mp4)", f"\n{URL}\n"),
+        ("`clip.mp4`", f"\n{URL}\n"),
+        ("before\n![repro](clip.mp4)\nafter", f"before\n\n{URL}\n\nafter"),
+        ("see `clip.mp4` inline", f"see [`clip.mp4`]({URL}) inline"),
+    ],
+)
+def test_substitute_promotes_a_standalone_video_to_a_bare_url(text: str, expected: str) -> None:
+    assert substitute(text, {"clip.mp4": URL}) == expected

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -1,4 +1,8 @@
+import argparse
+import io
 import json
+import urllib.error
+import urllib.request
 from pathlib import Path
 from unittest import mock
 
@@ -9,6 +13,18 @@ from skills.commands.upload_media import rewrite_payload, substitute
 
 URL = "https://github.com/user-attachments/assets/2f1c0a3e-0000-4000-8000-000000000001"
 URLS = {"shot.png": URL}
+
+
+def build_args(media: Path, target: Path) -> argparse.Namespace:
+    return build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--repository-id",
+        "136202695",
+    ])
 
 
 @pytest.mark.parametrize(
@@ -31,6 +47,34 @@ def test_substitute_is_idempotent() -> None:
     assert substitute(once, URLS) == once
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("![repro](clip.mp4)", f"\n{URL}\n"),
+        ("`clip.mp4`", f"\n{URL}\n"),
+        ("before\n![repro](clip.mp4)\nafter", f"before\n\n{URL}\n\nafter"),
+        ("see `clip.mp4` inline", f"see [`clip.mp4`]({URL}) inline"),
+        # ![]() around a video URL renders as a broken image, so it must become a link.
+        ("see ![repro](clip.mp4) inline", f"see [repro]({URL}) inline"),
+    ],
+)
+def test_substitute_promotes_a_standalone_video_to_a_bare_url(text: str, expected: str) -> None:
+    assert substitute(text, {"clip.mp4": URL}) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("![a screenshot](shot.png)", "a screenshot"),
+        ("[a screenshot](shot.png)", "a screenshot"),
+        ("![](shot.png)", "shot.png"),
+        ("see `shot.png`", "see `shot.png`"),
+    ],
+)
+def test_substitute_strips_markup_for_media_that_never_uploaded(text: str, expected: str) -> None:
+    assert substitute(text, {}, ["shot.png"]) == expected
+
+
 def test_rewrite_payload_covers_body_and_inline_comments() -> None:
     payload = {
         "event": "COMMENT",
@@ -40,6 +84,11 @@ def test_rewrite_payload_covers_body_and_inline_comments() -> None:
     result = rewrite_payload(payload, URLS)
     assert result["body"] == f"Race shown in [`shot.png`]({URL})\n\n🤖 Generated with Claude"
     assert result["comments"][0]["body"] == f"🔴 **CRITICAL:** ![x]({URL})"
+
+
+def test_rewrite_payload_neutralizes_unavailable_media_in_comments() -> None:
+    payload = {"body": "b", "comments": [{"body": "![the bug](shot.png)"}]}
+    assert rewrite_payload(payload, {}, ["shot.png"])["comments"][0]["body"] == "the bug"
 
 
 def test_rewrite_payload_preserves_the_trailing_footer() -> None:
@@ -62,15 +111,7 @@ def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> No
     (media / "shot.png").write_bytes(b"\x89PNG")
     uploader = mock.Mock(return_value=URL)
     monkeypatch.setattr(upload_media, "upload_asset", uploader)
-    args = build_parser().parse_args([
-        "upload-media",
-        "--dir",
-        str(media),
-        "--target",
-        str(target),
-        "--repository-id",
-        "136202695",
-    ])
+    args = build_args(media, target)
     args.func(args)
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
 
@@ -89,31 +130,22 @@ def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert target.read_text() == f"![alt]({URL})"
 
 
-def test_cli_leaves_the_target_alone_when_every_upload_fails(
+def test_cli_degrades_to_prose_when_every_upload_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     media = tmp_path / "media"
     media.mkdir()
     (media / "shot.png").write_bytes(b"\x89PNG")
-    target = tmp_path / "review-payload.json"
-    original = json.dumps({"body": "`shot.png`", "comments": []})
-    target.write_text(original)
+    target = tmp_path / "body.md"
+    target.write_text("evidence: ![the bug](shot.png)")
 
-    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     uploader = mock.Mock(return_value=None)
     monkeypatch.setattr(upload_media, "upload_asset", uploader)
-    args = build_parser().parse_args([
-        "upload-media",
-        "--dir",
-        str(media),
-        "--target",
-        str(target),
-        "--repository-id",
-        "136202695",
-    ])
+    args = build_args(media, target)
     args.func(args)
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
-    assert target.read_text() == original
+    assert target.read_text() == "evidence: the bug"
 
 
 def test_cli_is_a_noop_when_there_is_no_media(
@@ -124,32 +156,9 @@ def test_cli_is_a_noop_when_there_is_no_media(
     media.mkdir()
     target = tmp_path / "body.md"
     target.write_text("unchanged")
-    args = build_parser().parse_args([
-        "upload-media",
-        "--dir",
-        str(media),
-        "--target",
-        str(target),
-        "--repository-id",
-        "136202695",
-    ])
+    args = build_args(media, target)
     args.func(args)
     assert target.read_text() == "unchanged"
-
-
-def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
-    path = tmp_path / "notes.txt"
-    path.write_text("x")
-    assert upload_media.upload_asset(path, "1", "t") is None
-
-
-def test_upload_asset_skips_a_file_over_the_size_cap(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(upload_media, "MAX_BYTES", 4)
-    path = tmp_path / "big.png"
-    path.write_bytes(b"12345")
-    assert upload_media.upload_asset(path, "1", "t") is None
 
 
 def test_cli_skips_everything_when_the_token_env_is_unset(
@@ -161,15 +170,7 @@ def test_cli_skips_everything_when_the_token_env_is_unset(
     (media / "shot.png").write_bytes(b"\x89PNG")
     target = tmp_path / "body.md"
     target.write_text("`shot.png`")
-    args = build_parser().parse_args([
-        "upload-media",
-        "--dir",
-        str(media),
-        "--target",
-        str(target),
-        "--repository-id",
-        "136202695",
-    ])
+    args = build_args(media, target)
     args.func(args)
     assert target.read_text() == "`shot.png`"
 
@@ -186,28 +187,63 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
     uploader = mock.Mock(return_value=URL)
     monkeypatch.setattr(upload_media, "upload_asset", uploader)
-    args = build_parser().parse_args([
-        "upload-media",
-        "--dir",
-        str(media),
-        "--target",
-        str(target),
-        "--repository-id",
-        "136202695",
-    ])
+    args = build_args(media, target)
     args.func(args)
     uploader.assert_not_called()
     assert target.read_text() == "`shot.png`"
 
 
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
-        ("![repro](clip.mp4)", f"\n{URL}\n"),
-        ("`clip.mp4`", f"\n{URL}\n"),
-        ("before\n![repro](clip.mp4)\nafter", f"before\n\n{URL}\n\nafter"),
-        ("see `clip.mp4` inline", f"see [`clip.mp4`]({URL}) inline"),
-    ],
-)
-def test_substitute_promotes_a_standalone_video_to_a_bare_url(text: str, expected: str) -> None:
-    assert substitute(text, {"clip.mp4": URL}) == expected
+def test_upload_asset_builds_the_request_and_returns_the_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+    opener = mock.Mock(return_value=io.BytesIO(json.dumps({"url": URL}).encode()))
+    monkeypatch.setattr(urllib.request, "urlopen", opener)
+
+    assert upload_media.upload_asset(path, "136202695", "tok") == URL
+
+    request = opener.call_args.args[0]
+    assert "name=shot.png" in request.full_url
+    assert "content_type=image%2Fpng" in request.full_url
+    assert "repository_id=136202695" in request.full_url
+    assert request.get_header("Authorization") == "Bearer tok"
+    assert request.data == b"\x89PNG"
+
+
+@pytest.mark.parametrize("outcome", [urllib.error.URLError("boom"), TimeoutError("slow")])
+def test_upload_asset_returns_none_when_the_request_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: Exception
+) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+    opener = mock.Mock(side_effect=outcome)
+    monkeypatch.setattr(urllib.request, "urlopen", opener)
+    assert upload_media.upload_asset(path, "1", "t") is None
+    opener.assert_called_once()
+
+
+def test_upload_asset_returns_none_when_the_response_carries_no_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+    opener = mock.Mock(return_value=io.BytesIO(b"{}"))
+    monkeypatch.setattr(urllib.request, "urlopen", opener)
+    assert upload_media.upload_asset(path, "1", "t") is None
+    opener.assert_called_once()
+
+
+def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    path.write_text("x")
+    assert upload_media.upload_asset(path, "1", "t") is None
+
+
+def test_upload_asset_skips_a_file_over_the_size_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(upload_media, "MAX_BYTES", 4)
+    path = tmp_path / "big.png"
+    path.write_bytes(b"12345")
+    assert upload_media.upload_asset(path, "1", "t") is None

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -55,6 +55,7 @@ def test_rewrite_payload_tolerates_missing_and_malformed_fields() -> None:
 
 
 def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     media = tmp_path / "media"
     media.mkdir(exist_ok=True)
     (media / "shot.png").write_bytes(b"\x89PNG")
@@ -67,8 +68,6 @@ def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> No
         str(target),
         "--repository-id",
         "136202695",
-        "--token",
-        "t",
     ])
     args.func(args)
 
@@ -97,6 +96,7 @@ def test_cli_leaves_the_target_alone_when_every_upload_fails(
     original = json.dumps({"body": "`shot.png`", "comments": []})
     target.write_text(original)
 
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     monkeypatch.setattr(upload_media, "upload_asset", lambda *a, **k: None)
     args = build_parser().parse_args([
         "upload-media",
@@ -106,8 +106,6 @@ def test_cli_leaves_the_target_alone_when_every_upload_fails(
         str(target),
         "--repository-id",
         "136202695",
-        "--token",
-        "t",
     ])
     args.func(args)
     assert target.read_text() == original
@@ -116,6 +114,7 @@ def test_cli_leaves_the_target_alone_when_every_upload_fails(
 def test_cli_is_a_noop_when_there_is_no_media(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     media = tmp_path / "empty"
     media.mkdir()
     target = tmp_path / "body.md"
@@ -128,8 +127,6 @@ def test_cli_is_a_noop_when_there_is_no_media(
         str(target),
         "--repository-id",
         "136202695",
-        "--token",
-        "t",
     ])
     args.func(args)
     assert target.read_text() == "unchanged"
@@ -148,3 +145,25 @@ def test_upload_asset_skips_a_file_over_the_size_cap(
     path = tmp_path / "big.png"
     path.write_bytes(b"12345")
     assert upload_media.upload_asset(path, "1", "t") is None
+
+
+def test_cli_skips_everything_when_the_token_env_is_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(upload_media.TOKEN_ENV, raising=False)
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "shot.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "body.md"
+    target.write_text("`shot.png`")
+    args = build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--repository-id",
+        "136202695",
+    ])
+    args.func(args)
+    assert target.read_text() == "`shot.png`"

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -264,8 +264,32 @@ def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
 def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
     path = tmp_path / "big.png"
     path.write_bytes(b"12345")
-    with mock.patch.object(upload_media, "MAX_BYTES", 4):
+    with mock.patch.object(upload_media, "MAX_IMAGE_BYTES", 4):
         assert upload_media.upload_asset(path, "1", "t") is None
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("shot.png", upload_media.MAX_IMAGE_BYTES),
+        ("shot.gif", upload_media.MAX_IMAGE_BYTES),
+        ("clip.mp4", upload_media.MAX_VIDEO_BYTES),
+        ("clip.MOV", upload_media.MAX_VIDEO_BYTES),
+        ("clip.webm", upload_media.MAX_VIDEO_BYTES),
+    ],
+)
+def test_max_bytes_is_larger_for_video(name: str, expected: int) -> None:
+    assert upload_media.max_bytes(name) == expected
+
+
+def test_a_video_between_the_image_and_video_caps_is_not_skipped(tmp_path: Path) -> None:
+    # The old single 10MB cap silently dropped exactly this: a screen recording.
+    path = tmp_path / "clip.mp4"
+    path.write_bytes(b"0" * (upload_media.MAX_IMAGE_BYTES + 1))
+
+    response = io.BytesIO(json.dumps({"url": URL}).encode())
+    with mock.patch("urllib.request.urlopen", return_value=response):
+        assert upload_media.upload_asset(path, "1", "t") == URL
 
 
 def http_error(code: int) -> urllib.error.HTTPError:

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -180,7 +180,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     media = tmp_path / "media"
     media.mkdir()
     secret = tmp_path / "environ"
-    secret.write_text("MEDIA_TOKEN=supersecret")
+    secret.write_text("UPLOAD_MEDIA_TOKEN=supersecret")
     (media / "shot.png").symlink_to(secret)
     target = tmp_path / "body.md"
     target.write_text("`shot.png`")

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -27,6 +27,13 @@ def build_args(media: Path, target: Path) -> argparse.Namespace:
     ])
 
 
+def make_media(tmp_path: Path, name: str = "shot.png") -> Path:
+    media = tmp_path / "media"
+    media.mkdir(exist_ok=True)
+    (media / name).write_bytes(b"\x89PNG")
+    return media
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
@@ -104,75 +111,84 @@ def test_rewrite_payload_tolerates_missing_and_malformed_fields() -> None:
     }
 
 
-def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
-    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
-    media = tmp_path / "media"
-    media.mkdir(exist_ok=True)
-    (media / "shot.png").write_bytes(b"\x89PNG")
-    uploader = mock.Mock(return_value=URL)
-    upload_media.run(build_args(media, target), upload=uploader)
-    uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
-
-
 def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    media = make_media(tmp_path)
     target = tmp_path / "review-payload.json"
     target.write_text(json.dumps({"body": "`shot.png`", "comments": []}))
-    run_cli(tmp_path, monkeypatch, target)
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
     assert json.loads(target.read_text())["body"] == f"[`shot.png`]({URL})"
 
 
 def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    media = make_media(tmp_path)
     target = tmp_path / "body.md"
     target.write_text("![alt](shot.png)")
-    run_cli(tmp_path, monkeypatch, target)
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
     assert target.read_text() == f"![alt]({URL})"
 
 
 def test_cli_degrades_to_prose_when_every_upload_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
-    media = tmp_path / "media"
-    media.mkdir()
-    (media / "shot.png").write_bytes(b"\x89PNG")
+    media = make_media(tmp_path)
     target = tmp_path / "body.md"
     target.write_text("evidence: ![the bug](shot.png)")
 
-    uploader = mock.Mock(return_value=None)
-    upload_media.run(build_args(media, target), upload=uploader)
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=None) as uploader:
+        args.func(args)
+
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
     assert target.read_text() == "evidence: the bug"
-
-
-def test_cli_is_a_noop_when_there_is_no_media(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
-    media = tmp_path / "empty"
-    media.mkdir()
-    target = tmp_path / "body.md"
-    target.write_text("unchanged")
-    args = build_args(media, target)
-    args.func(args)
-    assert target.read_text() == "unchanged"
 
 
 def test_cli_degrades_to_prose_when_the_token_env_is_unset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.delenv(upload_media.TOKEN_ENV, raising=False)
-    media = tmp_path / "media"
-    media.mkdir()
-    (media / "shot.png").write_bytes(b"\x89PNG")
+    media = make_media(tmp_path)
     target = tmp_path / "body.md"
     target.write_text("evidence: ![the bug](shot.png) and `shot.png`")
+
+    monkeypatch.delenv(upload_media.TOKEN_ENV, raising=False)
     args = build_args(media, target)
-    args.func(args)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
     assert target.read_text() == "evidence: the bug and `shot.png`"
 
 
-def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_is_a_noop_when_there_is_no_media(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = tmp_path / "empty"
+    media.mkdir()
+    target = tmp_path / "body.md"
+    target.write_text("unchanged")
+
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == "unchanged"
+
+
+def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     media = tmp_path / "media"
     media.mkdir()
     secret = tmp_path / "environ"
@@ -181,20 +197,22 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     target = tmp_path / "body.md"
     target.write_text("`shot.png`")
 
-    uploader = mock.Mock(return_value=URL)
-    upload_media.run(build_args(media, target), upload=uploader)
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
     uploader.assert_not_called()
     assert target.read_text() == "`shot.png`"
 
 
-def test_upload_asset_builds_the_request_and_returns_the_url(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_upload_asset_builds_the_request_and_returns_the_url(tmp_path: Path) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
-    opener = mock.Mock(return_value=io.BytesIO(json.dumps({"url": URL}).encode()))
 
-    assert upload_media.upload_asset(path, "136202695", "tok", opener=opener) == URL
+    response = io.BytesIO(json.dumps({"url": URL}).encode())
+    with mock.patch("urllib.request.urlopen", return_value=response) as opener:
+        assert upload_media.upload_asset(path, "136202695", "tok") == URL
 
     request = opener.call_args.args[0]
     assert "name=shot.png" in request.full_url
@@ -216,22 +234,24 @@ def test_upload_asset_builds_the_request_and_returns_the_url(
     ],
 )
 def test_upload_asset_returns_none_when_the_request_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: Exception
+    tmp_path: Path, outcome: Exception
 ) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
-    opener = mock.Mock(side_effect=outcome)
-    assert upload_media.upload_asset(path, "1", "t", opener=opener) is None
+
+    with mock.patch("urllib.request.urlopen", side_effect=outcome) as opener:
+        assert upload_media.upload_asset(path, "1", "t") is None
+
     opener.assert_called_once()
 
 
-def test_upload_asset_returns_none_when_the_response_carries_no_url(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_upload_asset_returns_none_when_the_response_carries_no_url(tmp_path: Path) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
-    opener = mock.Mock(return_value=io.BytesIO(b"{}"))
-    assert upload_media.upload_asset(path, "1", "t", opener=opener) is None
+
+    with mock.patch("urllib.request.urlopen", return_value=io.BytesIO(b"{}")) as opener:
+        assert upload_media.upload_asset(path, "1", "t") is None
+
     opener.assert_called_once()
 
 
@@ -244,4 +264,5 @@ def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
 def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
     path = tmp_path / "big.png"
     path.write_bytes(b"12345")
-    assert upload_media.upload_asset(path, "1", "t", max_bytes=4) is None
+    with mock.patch.object(upload_media, "MAX_BYTES", 4):
+        assert upload_media.upload_asset(path, "1", "t") is None

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -266,3 +266,50 @@ def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
     path.write_bytes(b"12345")
     with mock.patch.object(upload_media, "MAX_BYTES", 4):
         assert upload_media.upload_asset(path, "1", "t") is None
+
+
+def http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(upload_media.UPLOAD_URL, code, "nope", {}, None)  # type: ignore[arg-type]
+
+
+def test_upload_asset_raises_on_a_rejected_token(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(401)),
+        pytest.raises(upload_media.TokenRejected, match="rejected \\(401\\)"),
+    ):
+        upload_media.upload_asset(path, "1", "t")
+
+
+def test_upload_asset_returns_none_on_other_http_errors(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with mock.patch("urllib.request.urlopen", side_effect=http_error(500)):
+        assert upload_media.upload_asset(path, "1", "t") is None
+
+
+def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    media = make_media(tmp_path)
+    (media / "second.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "body.md"
+    target.write_text("evidence: ![the bug](shot.png)")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(
+        upload_media,
+        "upload_asset",
+        side_effect=upload_media.TokenRejected("UPLOAD_MEDIA_TOKEN was rejected (401)"),
+    ) as uploader:
+        args.func(args)
+
+    # One annotation for the run, and the loop stops rather than retrying a dead token.
+    out = capsys.readouterr().out
+    assert out.count(f"::warning::{upload_media.TOKEN_ENV} was rejected (401)") == 1
+    assert uploader.call_count == 1
+    assert target.read_text() == "evidence: the bug"

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -1,8 +1,8 @@
 import argparse
+import http.client
 import io
 import json
 import urllib.error
-import urllib.request
 from pathlib import Path
 from unittest import mock
 
@@ -110,9 +110,7 @@ def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> No
     media.mkdir(exist_ok=True)
     (media / "shot.png").write_bytes(b"\x89PNG")
     uploader = mock.Mock(return_value=URL)
-    monkeypatch.setattr(upload_media, "upload_asset", uploader)
-    args = build_args(media, target)
-    args.func(args)
+    upload_media.run(build_args(media, target), upload=uploader)
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
 
 
@@ -141,9 +139,7 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
     target.write_text("evidence: ![the bug](shot.png)")
 
     uploader = mock.Mock(return_value=None)
-    monkeypatch.setattr(upload_media, "upload_asset", uploader)
-    args = build_args(media, target)
-    args.func(args)
+    upload_media.run(build_args(media, target), upload=uploader)
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
     assert target.read_text() == "evidence: the bug"
 
@@ -186,9 +182,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     target.write_text("`shot.png`")
 
     uploader = mock.Mock(return_value=URL)
-    monkeypatch.setattr(upload_media, "upload_asset", uploader)
-    args = build_args(media, target)
-    args.func(args)
+    upload_media.run(build_args(media, target), upload=uploader)
     uploader.assert_not_called()
     assert target.read_text() == "`shot.png`"
 
@@ -199,9 +193,8 @@ def test_upload_asset_builds_the_request_and_returns_the_url(
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
     opener = mock.Mock(return_value=io.BytesIO(json.dumps({"url": URL}).encode()))
-    monkeypatch.setattr(urllib.request, "urlopen", opener)
 
-    assert upload_media.upload_asset(path, "136202695", "tok") == URL
+    assert upload_media.upload_asset(path, "136202695", "tok", opener=opener) == URL
 
     request = opener.call_args.args[0]
     assert "name=shot.png" in request.full_url
@@ -211,15 +204,24 @@ def test_upload_asset_builds_the_request_and_returns_the_url(
     assert request.data == b"\x89PNG"
 
 
-@pytest.mark.parametrize("outcome", [urllib.error.URLError("boom"), TimeoutError("slow")])
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        urllib.error.URLError("boom"),
+        TimeoutError("slow"),
+        # Escapes URLError: urlopen only wraps h.request(), not h.getresponse().
+        http.client.RemoteDisconnected("closed"),
+        http.client.IncompleteRead(b"partial"),
+        json.JSONDecodeError("bad", "", 0),
+    ],
+)
 def test_upload_asset_returns_none_when_the_request_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, outcome: Exception
 ) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
     opener = mock.Mock(side_effect=outcome)
-    monkeypatch.setattr(urllib.request, "urlopen", opener)
-    assert upload_media.upload_asset(path, "1", "t") is None
+    assert upload_media.upload_asset(path, "1", "t", opener=opener) is None
     opener.assert_called_once()
 
 
@@ -229,8 +231,7 @@ def test_upload_asset_returns_none_when_the_response_carries_no_url(
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
     opener = mock.Mock(return_value=io.BytesIO(b"{}"))
-    monkeypatch.setattr(urllib.request, "urlopen", opener)
-    assert upload_media.upload_asset(path, "1", "t") is None
+    assert upload_media.upload_asset(path, "1", "t", opener=opener) is None
     opener.assert_called_once()
 
 
@@ -240,10 +241,7 @@ def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
     assert upload_media.upload_asset(path, "1", "t") is None
 
 
-def test_upload_asset_skips_a_file_over_the_size_cap(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(upload_media, "MAX_BYTES", 4)
+def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
     path = tmp_path / "big.png"
     path.write_bytes(b"12345")
-    assert upload_media.upload_asset(path, "1", "t") is None
+    assert upload_media.upload_asset(path, "1", "t", max_bytes=4) is None

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -1,0 +1,150 @@
+import json
+from pathlib import Path
+
+import pytest
+from skills.cli import build_parser
+from skills.commands import upload_media
+from skills.commands.upload_media import rewrite_payload, substitute
+
+URL = "https://github.com/user-attachments/assets/2f1c0a3e-0000-4000-8000-000000000001"
+URLS = {"shot.png": URL}
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("![alt](shot.png)", f"![alt]({URL})"),
+        ("![alt](./shot.png)", f"![alt]({URL})"),
+        ("[link](shot.png)", f"[link]({URL})"),
+        ("see `shot.png` here", f"see [`shot.png`]({URL}) here"),
+        ("nothing to do", "nothing to do"),
+        ("other.png stays", "other.png stays"),
+    ],
+)
+def test_substitute_rewrites_each_reference_form(text: str, expected: str) -> None:
+    assert substitute(text, URLS) == expected
+
+
+def test_substitute_is_idempotent() -> None:
+    once = substitute("see `shot.png`", URLS)
+    assert substitute(once, URLS) == once
+
+
+def test_rewrite_payload_covers_body_and_inline_comments() -> None:
+    payload = {
+        "event": "COMMENT",
+        "body": "Race shown in `shot.png`\n\n🤖 Generated with Claude",
+        "comments": [{"path": "a.py", "body": "🔴 **CRITICAL:** ![x](shot.png)", "line": 1}],
+    }
+    result = rewrite_payload(payload, URLS)
+    assert result["body"] == f"Race shown in [`shot.png`]({URL})\n\n🤖 Generated with Claude"
+    assert result["comments"][0]["body"] == f"🔴 **CRITICAL:** ![x]({URL})"
+
+
+def test_rewrite_payload_preserves_the_trailing_footer() -> None:
+    payload = {"body": "`shot.png`\n\n🤖 Generated with Claude", "comments": []}
+    assert rewrite_payload(payload, URLS)["body"].endswith("🤖 Generated with Claude")
+
+
+def test_rewrite_payload_tolerates_missing_and_malformed_fields() -> None:
+    assert rewrite_payload({}, URLS) == {}
+    assert rewrite_payload({"body": None, "comments": None}, URLS) == {
+        "body": None,
+        "comments": None,
+    }
+
+
+def run_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    media = tmp_path / "media"
+    media.mkdir(exist_ok=True)
+    (media / "shot.png").write_bytes(b"\x89PNG")
+    monkeypatch.setattr(upload_media, "upload_asset", lambda *a, **k: URL)
+    args = build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--repository-id",
+        "136202695",
+        "--token",
+        "t",
+    ])
+    args.func(args)
+
+
+def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "review-payload.json"
+    target.write_text(json.dumps({"body": "`shot.png`", "comments": []}))
+    run_cli(tmp_path, monkeypatch, target)
+    assert json.loads(target.read_text())["body"] == f"[`shot.png`]({URL})"
+
+
+def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "body.md"
+    target.write_text("![alt](shot.png)")
+    run_cli(tmp_path, monkeypatch, target)
+    assert target.read_text() == f"![alt]({URL})"
+
+
+def test_cli_leaves_the_target_alone_when_every_upload_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = tmp_path / "media"
+    media.mkdir()
+    (media / "shot.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "review-payload.json"
+    original = json.dumps({"body": "`shot.png`", "comments": []})
+    target.write_text(original)
+
+    monkeypatch.setattr(upload_media, "upload_asset", lambda *a, **k: None)
+    args = build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--repository-id",
+        "136202695",
+        "--token",
+        "t",
+    ])
+    args.func(args)
+    assert target.read_text() == original
+
+
+def test_cli_is_a_noop_when_there_is_no_media(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = tmp_path / "empty"
+    media.mkdir()
+    target = tmp_path / "body.md"
+    target.write_text("unchanged")
+    args = build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--repository-id",
+        "136202695",
+        "--token",
+        "t",
+    ])
+    args.func(args)
+    assert target.read_text() == "unchanged"
+
+
+def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    path.write_text("x")
+    assert upload_media.upload_asset(path, "1", "t") is None
+
+
+def test_upload_asset_skips_a_file_over_the_size_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(upload_media, "MAX_BYTES", 4)
+    path = tmp_path / "big.png"
+    path.write_bytes(b"12345")
+    assert upload_media.upload_asset(path, "1", "t") is None

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -161,7 +161,7 @@ def test_cli_is_a_noop_when_there_is_no_media(
     assert target.read_text() == "unchanged"
 
 
-def test_cli_skips_everything_when_the_token_env_is_unset(
+def test_cli_degrades_to_prose_when_the_token_env_is_unset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv(upload_media.TOKEN_ENV, raising=False)
@@ -169,10 +169,10 @@ def test_cli_skips_everything_when_the_token_env_is_unset(
     media.mkdir()
     (media / "shot.png").write_bytes(b"\x89PNG")
     target = tmp_path / "body.md"
-    target.write_text("`shot.png`")
+    target.write_text("evidence: ![the bug](shot.png) and `shot.png`")
     args = build_args(media, target)
     args.func(args)
-    assert target.read_text() == "`shot.png`"
+    assert target.read_text() == "evidence: the bug and `shot.png`"
 
 
 def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -209,6 +209,7 @@ jobs:
           EFFORT: ${{ steps.prompt.outputs.effort }}
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
+          mkdir -p /tmp/review-media
 
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
@@ -237,6 +238,24 @@ jobs:
       - name: Show proxy log
         if: always()
         run: cat /tmp/anthropic-proxy.log || true
+
+      # Separate from the Claude step by design: this PAT is a user credential, and
+      # the Claude step holds only the read-only app token so a poisoned diff can't
+      # reach it. Runs before validation so the posted payload is the validated one.
+      - name: Upload review media
+        env:
+          MEDIA_TOKEN: ${{ secrets.USER_ATTACHMENTS_TOKEN }}
+          REPO_ID: ${{ github.event.repository.id }}
+        run: |
+          if [ -z "$MEDIA_TOKEN" ]; then
+            echo "USER_ATTACHMENTS_TOKEN not configured; skipping media upload"
+            exit 0
+          fi
+          uv run --frozen --package skills skills upload-media \
+            --dir /tmp/review-media \
+            --target /tmp/review-payload.json \
+            --repository-id "$REPO_ID" \
+            --token "$MEDIA_TOKEN"
 
       - name: Validate review payload
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -244,6 +244,9 @@ jobs:
       # smoke path stays non-mutating.
       - name: Upload review media
         if: github.event_name == 'issue_comment'
+        # Attaching media is a nicety; losing the whole review over it is not. Any
+        # fault here must not take the job down before Post review.
+        continue-on-error: true
         env:
           UPLOAD_MEDIA_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -242,7 +242,10 @@ jobs:
       # Separate from the Claude step by design: this PAT is a user credential, and
       # the Claude step holds only the read-only app token so a poisoned diff can't
       # reach it. Runs before validation so the posted payload is the validated one.
+      # Gated like Post: uploading mints real attachments, so the pull_request
+      # smoke path stays non-mutating.
       - name: Upload review media
+        if: github.event_name == 'issue_comment'
         env:
           MEDIA_TOKEN: ${{ secrets.USER_ATTACHMENTS_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -247,15 +247,14 @@ jobs:
           MEDIA_TOKEN: ${{ secrets.USER_ATTACHMENTS_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}
         run: |
-          if [ -z "$MEDIA_TOKEN" ]; then
-            echo "USER_ATTACHMENTS_TOKEN not configured; skipping media upload"
-            exit 0
-          fi
+          # MEDIA_TOKEN reaches the script through the environment, not argv, so the
+          # PAT never shows up in the process list. Same reasoning as the proxy step
+          # above, which pipes the Anthropic key over stdin. The script no-ops when
+          # the secret is unset.
           uv run --frozen --package skills skills upload-media \
             --dir /tmp/review-media \
             --target /tmp/review-payload.json \
-            --repository-id "$REPO_ID" \
-            --token "$MEDIA_TOKEN"
+            --repository-id "$REPO_ID"
 
       - name: Validate review payload
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Upload review media
         if: github.event_name == 'issue_comment'
         env:
-          MEDIA_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
+          UPLOAD_MEDIA_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}
         run: |
           uv run --frozen --package skills skills upload-media \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -239,21 +239,15 @@ jobs:
         if: always()
         run: cat /tmp/anthropic-proxy.log || true
 
-      # Separate from the Claude step by design: this PAT is a user credential, and
-      # the Claude step holds only the read-only app token so a poisoned diff can't
-      # reach it. Runs before validation so the posted payload is the validated one.
-      # Gated like Post: uploading mints real attachments, so the pull_request
+      # Kept out of the Claude step, which holds only the read-only app token, so a
+      # poisoned diff can't reach this PAT. Gated like Post so the pull_request
       # smoke path stays non-mutating.
       - name: Upload review media
         if: github.event_name == 'issue_comment'
         env:
-          MEDIA_TOKEN: ${{ secrets.USER_ATTACHMENTS_TOKEN }}
+          MEDIA_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}
         run: |
-          # MEDIA_TOKEN reaches the script through the environment, not argv, so the
-          # PAT never shows up in the process list. Same reasoning as the proxy step
-          # above, which pipes the Anthropic key over stdin. The script no-ops when
-          # the secret is unset.
           uv run --frozen --package skills skills upload-media \
             --dir /tmp/review-media \
             --target /tmp/review-payload.json \


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Lets the PR reviewer attach images and video to a review. Claude writes files
into `/tmp/review-media/` and refers to each by bare filename (`![desc](x.png)`
or `` `x.png` ``); a new `skills upload-media` step uploads them and rewrites
those references to `user-attachments` URLs, which GitHub renders inline.

Two placement decisions carry the weight:

- **Outside the Claude step.** The upload needs a user token, and the Claude
  step deliberately holds only a read-only app token so prompt injection in a
  diff can't reach anything mutable. The PAT stays in a step we control.
- **Before validation**, so the payload that gets posted is the payload that
  was validated. The pr-review schema pins `body` to end with the Claude
  footer, so the rewrite only ever substitutes in place and never appends.

Uploads fail soft: a missing secret, an oversized file, or a dead endpoint
degrades the review rather than failing it.

Needs the `UPLOAD_MEDIA_TOKEN` secret (configured: a fine-grained PAT scoped to
this repo with metadata-only access, which is the minimum that works). A missing
or misnamed secret degrades references to prose rather than shipping broken
markup.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

32 unit tests cover both reference forms, video promotion, symlink rejection,
idempotency, footer preservation, malformed payloads, `upload_asset`'s request
and response handling, and every fail-soft path. Verified end-to-end against the
live endpoint for image and video: references came back as real URLs and the
payload still passed `skills validate-review`.

Not covered by CI before merge. `issue_comment` runs the workflow definition
from the default branch, so the comment path uses master's `review.yml` (no such
step), while the `pull_request` smoke path has the step gated off. The step
therefore first executes on a real `/review` after this merges.

Token support was established empirically first (throwaway workflow, since the
endpoint is absent from GitHub's OpenAPI spec). The Actions `GITHUB_TOKEN` and
an App installation token both 404 no matter what permissions they carry, while
a fine-grained PAT scoped to this repo with metadata-only access returns 201 for
image and video, from a runner as well as locally. That result is what forced
the split-step design.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
