### PR TITLE
Give the PR reviewer Node and `agent-browser`

### DIFF
--- a/.claude/scripts/install-agent-browser.sh
+++ b/.claude/scripts/install-agent-browser.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Installs the agent-browser binary from its GitHub release. The npm package only wraps
+# these same per-platform binaries, so downloading one directly avoids needing Node.
+# Upstream publishes no checksum manifest, so the digest below is pinned here and must
+# be recomputed when VERSION changes.
+set -euo pipefail
+
+if [ "${CI:-}" != "true" ]; then
+  echo "Error: This script is intended for CI only." >&2
+  exit 1
+fi
+
+VERSION="0.34.0"
+PLATFORM="linux-x64"
+CHECKSUM="69eadf5d8d6003a06a5cd2f914ebb261c7754fe1335a9190122c334e91909789"
+
+URL="https://github.com/vercel-labs/agent-browser/releases/download/v$VERSION/agent-browser-$PLATFORM"
+
+tmp_bin="$(mktemp)"
+trap 'rm -f "$tmp_bin"' EXIT
+
+curl -fsSL --retry 3 --retry-delay 2 "$URL" -o "$tmp_bin"
+echo "${CHECKSUM}  $tmp_bin" | sha256sum -c -
+mkdir -p ~/.local/bin
+chmod +x "$tmp_bin"
+mv "$tmp_bin" ~/.local/bin/agent-browser
+trap - EXIT
+echo "Installed agent-browser $VERSION"

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -85,6 +85,13 @@ Verify rather than infer. A `grep` through the installed package, a `uv run pyth
 quick search and fetch of the upstream docs will settle most questions in seconds, and an unverified
 finding should be dropped rather than hedged.
 
+Node and `agent-browser` are on PATH for docs and UI changes. Render when it settles whether the
+change is correct, or when a capture shows a finding more plainly than prose can. Building the
+docs site or the UI is expensive; do it only when the finding justifies it. Capture to an
+absolute path named for what it shows:
+`agent-browser screenshot --full /tmp/review-media/traces-table.png`, and cite that name in a
+finding.
+
 Evaluate the changed code across these dimensions:
 
 - **Correctness**: logic errors, off-by-one, incorrect API usage, broken invariants, regressions in behavior

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/review.yml"
-      - ".claude/scripts/anthropic-proxy.mjs"
+      - ".claude/scripts/**"
       - ".claude/skills/pr-review/**"
 
 concurrency:
@@ -89,7 +89,7 @@ jobs:
     # minted below. Grant nothing so any future accidental use of GITHUB_TOKEN
     # fails closed.
     permissions: {}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -135,12 +135,19 @@ jobs:
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
+      - uses: ./.github/actions/setup-node
       - name: Install Claude CLI
         run: |
           .claude/scripts/install-claude.sh
       - name: Verify Claude CLI
         run: |
           claude --version
+      - name: Install agent-browser
+        run: |
+          .claude/scripts/install-agent-browser.sh
+      - name: Verify agent-browser
+        run: |
+          agent-browser --version
 
       - name: Parse review arguments
         id: prompt
@@ -207,6 +214,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
+          AGENT_BROWSER_SCREENSHOT_DIR: /tmp/review-shots
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
           mkdir -p /tmp/review-media
@@ -214,10 +222,10 @@ jobs:
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
           EXIT_CODE=0
-          timeout 20m claude \
+          timeout 30m claude \
             --model "$MODEL" \
             --effort "$EFFORT" \
-            --max-budget-usd 5 \
+            --max-budget-usd 8 \
             --permission-mode auto \
             --allowed-tools "Bash(uv run --package skills skills:*)" \
             --print \
@@ -226,7 +234,7 @@ jobs:
             "/pr-review $PR_URL" \
             | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
-            echo "Warning: Claude command timed out after 20 minutes"
+            echo "Warning: Claude command timed out after 30 minutes"
           elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
             echo "Error: Claude command failed with exit code $EXIT_CODE"
             cat "$OUTPUT_FILE"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25142

### What changes are proposed in this pull request?

Gives the PR reviewer Node and `agent-browser`, so it can render a docs or UI change
and capture it. #25142 made review media embeddable; this produces the media.

- `agent-browser` is installed from its GitHub release, not npm. The npm package only
  wraps these same per-platform binaries, so the binary alone needs no Node and no
  `node_modules`. Upstream ships no checksum manifest, so the digest is pinned in the
  script, following `install-claude.sh`.
- Chrome is not downloaded. The runner already has Google Chrome and `agent-browser`
  finds it, so `agent-browser install` would add 391MB for nothing.
- `AGENT_BROWSER_SCREENSHOT_DIR` points at a scratch dir, not the upload dir, because
  `upload-media` publishes every file it finds. Deliberate captures go to an absolute
  path under `/tmp/review-media`, which the skill specifies.
- Timeout and budget move to 30m/$8 with a 45m job, matching `ui-review.yml`, which
  already sizes for a browser plus a build. Rendering does not fit the old 20m/$5.

### How is this PR tested?

- [x] Manual tests

The install script ran end to end in a clean `ubuntu:24.04` container with no Node
present: checksum verified, `agent-browser 0.34.0` on PATH.

Chrome availability was settled by a temporary probe on this PR (since removed, run
31893180655), which captured a screenshot with no `agent-browser install` against a
post-install control that also passed. Docker cannot answer that question: Chrome fails
in a container for sandbox and shared-library reasons even when `agent-browser`
downloads it itself, so the control fails alongside the test.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
