### PR TITLE
fix(ui): keep valid run images when one filename is malformed

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -1015,8 +1015,13 @@ class Utils {
       Utils.displayGlobalErrorNotification(e.renderHttpError(), duration);
     } else if (e instanceof NetworkRequestError) {
       Utils.displayGlobalErrorNotification(e.displayMessage, duration);
-      // eslint-disable-next-line no-empty
     } else {
+      // Unknown error type (e.g. a plain Error like ImagePathParseError):
+      // there is no user-facing message to render, but silently dropping it
+      // hid real failures -- log it so the console shows what happened
+      // (issue #24789).
+      // eslint-disable-next-line no-console
+      console.error(e);
     }
   }
 

--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.test.ts
@@ -107,7 +107,59 @@ describe('ImageReducer', () => {
     });
   });
 
-  it('should handle error and prevent state update on malformed inputs', () => {
+  it("should skip a malformed filename without discarding the run's other images", () => {
+    const initialState = {};
+    const action: AsyncFulfilledAction<ListImagesAction> = {
+      type: 'LIST_IMAGES_API_FULFILLED',
+      payload: {
+        files: [
+          {
+            path: 'images/image1%step%0%timestamp%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            // Missing the timestamp label -- parseImageFile throws on this.
+            path: 'images/broken%step%0%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            path: 'images/image2%step%1%timestamp%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+        ],
+        root_uri: '',
+      },
+      meta: {
+        id: '123',
+        runUuid: '123',
+      },
+    };
+    const newState = imagesByRunUuid(initialState, action);
+    // The valid images survive; only the malformed one is dropped.
+    expect(newState).toEqual({
+      '123': {
+        image1: {
+          'image1%step%0%timestamp%1%UUID': {
+            filepath: 'images/image1%step%0%timestamp%1%UUID.png',
+            step: 0,
+            timestamp: 1,
+          },
+        },
+        image2: {
+          'image2%step%1%timestamp%1%UUID': {
+            filepath: 'images/image2%step%1%timestamp%1%UUID.png',
+            step: 1,
+            timestamp: 1,
+          },
+        },
+      },
+    });
+  });
+
+  it('should record an empty image state for a run whose files are all malformed', () => {
     const initialState = {};
     const action: AsyncFulfilledAction<ListImagesAction> = {
       type: 'LIST_IMAGES_API_FULFILLED',
@@ -127,7 +179,9 @@ describe('ImageReducer', () => {
       },
     };
     const newState = imagesByRunUuid(initialState, action);
-    expect(newState).toEqual({});
+    // The run gets an (empty) image state rather than the reducer aborting
+    // and leaving the previous state untouched.
+    expect(newState).toEqual({ '123': {} });
   });
 
   it('should add image and compressed image to the state', () => {

--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.ts
@@ -68,17 +68,17 @@ export const imagesByRunUuid = (
       // Populate state with image keys
       const { runUuid } = action.meta;
       const { files } = action.payload;
-      try {
-        if (!files) {
-          // There are no images for this run
-          return {
-            ...state,
-            [runUuid]: {},
-          };
-        }
-        // Filter images to only include directories
-        const result = files.reduce(
-          (acc: Record<string, Record<string, ImageEntity>>, file: ArtifactFileInfo) => {
+      if (!files) {
+        // There are no images for this run
+        return {
+          ...state,
+          [runUuid]: {},
+        };
+      }
+      // Filter images to only include directories
+      const result = files.reduce(
+        (acc: Record<string, Record<string, ImageEntity>>, file: ArtifactFileInfo) => {
+          try {
             if (!file.is_dir) {
               if (!file.path) {
                 return acc;
@@ -111,19 +111,20 @@ export const imagesByRunUuid = (
                 }
               }
             }
-            return acc;
-          },
-          {} as Record<string, Record<string, ImageEntity>>,
-        );
-        return {
-          ...state,
-          [runUuid]: result,
-        };
-      } catch (e) {
-        // On malformed inputs we will report alert and continue without updating the state
-        Utils.logErrorAndNotifyUser(e);
-        return state;
-      }
+          } catch (e) {
+            // A single malformed image filename must not discard every other
+            // image in the run (issue #24789): skip this file, keep the ones
+            // that parsed, and surface the error instead of swallowing it.
+            Utils.logErrorAndNotifyUser(e);
+          }
+          return acc;
+        },
+        {} as Record<string, Record<string, ImageEntity>>,
+      );
+      return {
+        ...state,
+        [runUuid]: result,
+      };
     }
     default:
       return state;


### PR DESCRIPTION
### Related Issues/PRs

Closes #24789

### What changes are proposed in this pull request?

A single malformed filename under a run's `images/` directory made the Image grid drop **every** logged image for that run, with no error surfaced anywhere. Two defects in the experiment-tracking UI caused it:

1. **`ImageReducer.ts` was all-or-nothing.** The entire `files.reduce(...)` was wrapped in one `try`/`catch`; `parseImageFile` throws for any name that does not match the `%step%`/`+step+` convention, so one bad file aborted the reduce and the whole run's image state was discarded (previous state returned untouched).

2. **The failure was silent.** `Utils.logErrorAndNotifyUser` renders notifications only for strings, `ErrorWrapper`, and `NetworkRequestError`; a plain `Error` like `ImagePathParseError` fell through the empty `else` — no notification, no console output.

Changes:

- **`ImageReducer.ts`**: move the `try`/`catch` inside the per-file `reduce` callback. A malformed filename now skips that file, keeps every file that parsed, and reports the error — instead of discarding the batch.
- **`Utils.tsx`**: the `else` branch now logs unknown error types with `console.error` instead of dropping them entirely.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New/changed tests in `ImageReducer.test.ts`:
- a list mixing one malformed filename with two valid ones keeps both valid images (previously both were dropped)
- a run whose files are all malformed records an empty image state rather than leaving the previous state untouched

`yarn test src/experiment-tracking/reducers/ImageReducer.test.ts` → 6 pass; `yarn test src/common/utils/Utils.test.tsx` → 37 pass; `yarn eslint` and `yarn prettier --check` clean on the changed files.

The `ImagePathParseError` lines now visible in the test output (via the new `console.error`) confirm the errors are surfaced instead of swallowed.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A malformed image filename in a run's `images/` directory no longer hides all of that run's logged images; the invalid file is skipped and reported instead.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/artifacts`: MLflow artifacts
- [ ] `area/uiux`: Frontend, user experience, JavaScript, React
- [ ] `area/registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/server-infra`: MLflow server infrastructure
- [ ] `area/utils`: MLflow Python utilities

- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
