### PR TITLE
Add TrustedRouter as a gateway provider

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -62,6 +62,7 @@ class Provider(str, Enum):
     DEEPSEEK = "deepseek"
     XAI = "xai"
     OPENROUTER = "openrouter"
+    TRUSTEDROUTER = "trustedrouter"
     OLLAMA = "ollama"
     VERTEX_AI = "vertex_ai"
     PORTKEY = "portkey"

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -55,6 +55,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.ollama import OllamaProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.openrouter import OpenRouterProvider
+    from mlflow.gateway.providers.trustedrouter import TrustedRouterProvider
     from mlflow.gateway.providers.palm import PaLMProvider
     from mlflow.gateway.providers.portkey import PortkeyProvider
     from mlflow.gateway.providers.sap_ai_core import SapAiCoreProvider
@@ -83,6 +84,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.OLLAMA, OllamaProvider)
     registry.register(Provider.OPENAI, OpenAIProvider)
     registry.register(Provider.OPENROUTER, OpenRouterProvider)
+    registry.register(Provider.TRUSTEDROUTER, TrustedRouterProvider)
     registry.register(Provider.PALM, PaLMProvider)
     registry.register(Provider.PORTKEY, PortkeyProvider)
     registry.register(Provider.SAP_AI_CORE, SapAiCoreProvider)

--- a/mlflow/gateway/providers/trustedrouter.py
+++ b/mlflow/gateway/providers/trustedrouter.py
@@ -1,0 +1,8 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class TrustedRouterProvider(OpenAICompatibleProvider):
+    DISPLAY_NAME = "TrustedRouter"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://api.trustedrouter.com/v1"

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -12,6 +12,7 @@ export const COMMON_PROVIDERS = [
   'deepseek',
   'portkey',
   'openrouter',
+  'trustedrouter',
   'ollama',
   'together_ai',
 ] as const;
@@ -40,6 +41,7 @@ const PROVIDER_DISPLAY_NAMES = {
   cerebras: 'Cerebras',
   deepseek: 'DeepSeek',
   openrouter: 'OpenRouter',
+  trustedrouter: 'TrustedRouter',
   ollama: 'Ollama',
 } satisfies Record<string, string>;
 

--- a/mlflow/utils/model_catalog/trustedrouter.json
+++ b/mlflow/utils/model_catalog/trustedrouter.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "1.0",
+  "models": {
+    "trustedrouter/auto": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096,
+        "max_tokens": 4096
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.0735,
+        "output_per_million_tokens": 0.147
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-15"
+    },
+    "trustedrouter/fast": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096,
+        "max_tokens": 4096
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.3675,
+        "output_per_million_tokens": 0.7875
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-15"
+    },
+    "trustedrouter/cheap": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096,
+        "max_tokens": 4096
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.01,
+        "output_per_million_tokens": 0.01
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-15"
+    },
+    "trustedrouter/zdr": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096,
+        "max_tokens": 4096
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.0389,
+        "output_per_million_tokens": 0.1575
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-15"
+    },
+    "trustedrouter/e2e": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 128000,
+        "max_output": 4096,
+        "max_tokens": 4096
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.0257,
+        "output_per_million_tokens": 0.1027
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-15"
+    },
+    "trustedrouter/eu": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 200000,
+        "max_output": 4096,
+        "max_tokens": 4096
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.01,
+        "output_per_million_tokens": 0.01
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": false,
+        "prompt_caching": false,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-15"
+    }
+  }
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

<!-- No existing issue; opening this as a provider addition alongside the existing OpenRouter gateway provider. -->

### What changes are proposed in this pull request?

Adds TrustedRouter as an AI Gateway provider. TrustedRouter is an OpenAI-compatible router — one API key reaches models from OpenAI, Anthropic, Google, DeepSeek and others, with per-request routing and failover.

This mirrors the existing OpenRouter wiring:

- `mlflow/gateway/providers/trustedrouter.py` — an `OpenAICompatibleProvider` subclass with `DEFAULT_API_BASE = https://api.trustedrouter.com/v1`
- `mlflow/gateway/config.py` — `Provider.TRUSTEDROUTER`
- `mlflow/gateway/provider_registry.py` — import + `registry.register(...)`
- `mlflow/utils/model_catalog/trustedrouter.json` — bundled catalog (auto-discovered by the existing `*.json` glob)
- `mlflow/server/js/src/gateway/utils/providerUtils.ts` — provider list + display name

On the catalog contents: it lists only TrustedRouter's own routing policies (`auto`, `fast`, `cheap`, `zdr`, `e2e`, `eu`) rather than pinned third-party models. I generated a larger version first and checked it against the source, which revealed that TrustedRouter's `architecture.input_modalities` under-reports — it lists `anthropic/claude-opus-4-7` as text-only although Opus supports vision. Shipping that would put `supports_vision: false` in the catalog and cause the gateway to reject image inputs that would work. Users can still route to any model id; the catalog only supplies metadata hints.

Prices and context lengths were read from the live `/v1/models` response with `last_updated_at` stamped. These are blended rates for a routing policy rather than a single model's price.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified through the real code paths rather than by inspection:

```
Provider.TRUSTEDROUTER      -> "trustedrouter"
provider_registry.get(...)  -> TrustedRouterProvider, base https://api.trustedrouter.com/v1
_list_provider_names()      -> catalog auto-discovered by the glob
_parse_catalog_models(...)  -> 6 routes parsed, costs flattened correctly
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. TrustedRouter is now supported as an MLflow AI Gateway provider.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
