### PR TITLE
Truncate the demo experiment badge instead of clipping it

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -268,15 +268,19 @@ const ExperimentListTableCell: ExperimentTableColumnDef['cell'] = ({ row: { orig
   const { theme } = useDesignSystemTheme();
   if (isDemoExperiment(original)) {
     return (
-      <div css={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
         <Link
           componentId="mlflow.experiment_tracking.experiment_list.demo_experiment_link"
           to={Routes.getExperimentPageRoute(original.experimentId)}
           title={original.name}
           data-testid="experiment-list-item-link"
-          css={{ textDecoration: 'none' }}
+          css={{ textDecoration: 'none', minWidth: 0, overflow: 'hidden' }}
         >
-          <Tag componentId="mlflow.experiment_list.demo_badge" color="turquoise">
+          <Tag
+            componentId="mlflow.experiment_list.demo_badge"
+            color="turquoise"
+            css={{ maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
             <FormattedMessage
               defaultMessage="MLflow Demo Experiment"
               description="Badge label for the demo experiment in the experiments list"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

The demo row's Name cell renders a badge inside a flex container that never got
the truncation styles the regular experiment link already has
(`ExperimentListTable.tsx:307`). At the default Name column width the badge is
cut mid-word with no ellipsis, and the tooltip trigger next to it is pushed out
of the cell entirely.

The link is 171px of `nowrap` content inside a 133px `overflow: hidden` cell, so
`text-overflow: ellipsis` never applies: the element with `overflow: hidden` has
`white-space: normal`, and the element with `nowrap` has `overflow: visible`.
Adding `minWidth: 0` lets the flex item shrink, and the badge now ellipsizes.

Before:

![before](https://github.com/user-attachments/assets/a29656d3-1921-4353-b6ef-548ea17f08c0)

After:

![after](https://github.com/user-attachments/assets/9d7d96b0-aee5-4e6d-ba0c-91999a499647)

### How is this PR tested?

- [x] Manual tests

Ran the dev server with demo data seeded and compared the Experiments page
before and after (screenshots above). Verified in the DOM that the badge now
reports `text-overflow: ellipsis` with `scrollWidth 108 > clientWidth 100`,
where previously the link overflowed its cell at 171px against 133px.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
