### PR TITLE
Upload only the media a review actually cites

### DIFF
--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -96,28 +96,45 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
             return None
 
 
+def link_target(name: str) -> str:
+    return rf"\]\((?:\./)?{re.escape(name)}\)"
+
+
+def code_span(name: str) -> str:
+    return rf"`{re.escape(name)}`"
+
+
+def reference_pattern(name: str) -> str:
+    return f"{link_target(name)}|{code_span(name)}"
+
+
+def is_referenced(name: str, text: str) -> bool:
+    return re.search(reference_pattern(name), text) is not None
+
+
 def substitute(text: str, urls: dict[str, str], unavailable: Iterable[str] = ()) -> str:
     for name, url in urls.items():
-        quoted = re.escape(name)
+        link = link_target(name)
+        code = code_span(name)
         if is_video(name):
             # GitHub renders a player only for a bare URL alone in its own paragraph,
             # so promote a reference that already sits on its own line.
-            standalone = rf"(?m)^[ \t]*(?:!?\[[^\]]*\]\((?:\./)?{quoted}\)|`{quoted}`)[ \t]*$"
+            standalone = rf"(?m)^[ \t]*(?:!?\[[^\]]*{link}|{code})[ \t]*$"
             text = re.sub(standalone, f"\n{url}\n", text)
             # Whatever is left is mid-sentence, where ![]() around a video URL renders
             # as a broken image. Drop the bang so it degrades to a link instead.
-            text = re.sub(rf"!(?=\[[^\]]*\]\((?:\./)?{quoted}\))", "", text)
-        text = re.sub(rf"\]\((?:\./)?{quoted}\)", f"]({url})", text)
+            text = re.sub(rf"!(?=\[[^\]]*{link})", "", text)
+        text = re.sub(link, f"]({url})", text)
         # Lookarounds keep a second pass a no-op.
-        text = re.sub(rf"(?<!\[)`{quoted}`(?!\])", f"[`{name}`]({url})", text)
+        text = re.sub(rf"(?<!\[){code}(?!\])", f"[`{name}`]({url})", text)
 
     # A name with no URL (upload failed, or the file was skipped) would otherwise
     # survive as ![desc](shot.png), which GitHub resolves repo-relative and renders
     # as a broken image. Strip the markup so it degrades to prose.
     for name in unavailable:
-        quoted = re.escape(name)
-        text = re.sub(rf"!?\[\]\((?:\./)?{quoted}\)", name, text)
-        text = re.sub(rf"!?\[([^\]]+)\]\((?:\./)?{quoted}\)", r"\1", text)
+        link = link_target(name)
+        text = re.sub(rf"!?\[{link}", name, text)
+        text = re.sub(rf"!?\[([^\]]+){link}", r"\1", text)
     return text
 
 
@@ -174,13 +191,23 @@ def run(args: argparse.Namespace) -> None:
         print(f"No media in {args.dir}")
         return
 
+    # Only what the review actually cites gets published. Captures taken to reason
+    # with and then left uncited are scratch work.
+    target_text = args.target.read_text()
+    referenced = [p for p in files if is_referenced(p.name, target_text)]
+    if unreferenced := [p.name for p in files if p not in referenced]:
+        print(f"  not referenced, skipping: {', '.join(unreferenced)}", file=sys.stderr)
+    if not referenced:
+        print(f"No media referenced by {args.target}")
+        return
+
     # A missing secret must still reach the rewrite below, or every reference ships
     # verbatim and renders as a broken repo-relative image.
     urls = {}
     if token := os.environ.get(TOKEN_ENV):
-        print(f"Uploading {len(files)} file(s) from {args.dir}")
+        print(f"Uploading {len(referenced)} referenced file(s) from {args.dir}")
         try:
-            for path in files:
+            for path in referenced:
                 if url := upload_asset(path, args.repository_id, token):
                     urls[path.name] = url
         except TokenRejected as e:
@@ -190,12 +217,12 @@ def run(args: argparse.Namespace) -> None:
     else:
         print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
 
-    unavailable = [p.name for p in files if p.name not in urls]
+    unavailable = [p.name for p in referenced if p.name not in urls]
 
     if args.target.suffix == ".json":
-        payload = json.loads(args.target.read_text())
+        payload = json.loads(target_text)
         rewritten = rewrite_payload(payload, urls, unavailable)
         args.target.write_text(json.dumps(rewritten, indent=2, ensure_ascii=False))
     else:
-        args.target.write_text(substitute(args.target.read_text(), urls, unavailable))
-    print(f"Embedded {len(urls)} of {len(files)} file(s) into {args.target}")
+        args.target.write_text(substitute(target_text, urls, unavailable))
+    print(f"Embedded {len(urls)} of {len(referenced)} referenced file(s) into {args.target}")

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -337,3 +337,86 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     assert out.count(f"::warning::{upload_media.TOKEN_ENV} was rejected (401)") == 1
     assert uploader.call_count == 1
     assert target.read_text() == "evidence: the bug"
+
+
+def test_cli_uploads_only_media_the_target_references(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path, "cited.png")
+    (media / "scratch.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "body.md"
+    target.write_text("evidence: ![the bug](cited.png)")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "cited.png", "136202695", "t")
+    assert target.read_text() == f"evidence: ![the bug]({URL})"
+
+
+def test_cli_uploads_nothing_when_no_media_is_referenced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path, "scratch.png")
+    target = tmp_path / "body.md"
+    target.write_text("a prose-only finding")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == "a prose-only finding"
+
+
+def test_cli_uploads_media_referenced_by_an_inline_comment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path, "cited.png")
+    (media / "scratch.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "review-payload.json"
+    target.write_text(json.dumps({"body": "b", "comments": [{"body": "see `cited.png`"}]}))
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "cited.png", "136202695", "t")
+    assert json.loads(target.read_text())["comments"][0]["body"] == f"see [`cited.png`]({URL})"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("![x](shot.png)", True),
+        ("![x](./shot.png)", True),
+        ("see `shot.png`", True),
+        # A name that is only a suffix of a cited one is not a reference.
+        ("![x](longshot.png)", False),
+        ("shot.png bare mention", False),
+        ("nothing here", False),
+    ],
+)
+def test_is_referenced_matches_only_real_reference_forms(text: str, expected: bool) -> None:
+    assert upload_media.is_referenced("shot.png", text) is expected
+
+
+def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path, "longshot.png")
+    (media / "shot.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "body.md"
+    target.write_text("![x](longshot.png)")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "longshot.png", "136202695", "t")
+    assert target.read_text() == f"![x]({URL})"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25142

### What changes are proposed in this pull request?

`upload-media` uploaded every file in the media directory, whether or not the
review referenced it. A reviewer that captures a screenshot to reason with and
then decides prose says it better still had that capture uploaded.

Seen on #25150: the reviewer captured two screenshots, verified its finding
against them, wrote a prose-only comment, and both images were uploaded anyway.
Neither appears in the posted review. Those two assets return 404 anonymously,
so nothing was exposed; they are simply uploads that nothing points at.

- Only files whose names appear in the target are uploaded. Uncited captures are
  scratch work and stay local.
- The completion line counted uploads, not substitutions, so that same run
  logged `Embedded 2 of 2` having embedded nothing. It now counts referenced
  files, which is also what gets uploaded.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Three tests cover an uncited file being skipped, a target that references
nothing uploading nothing, and a filename cited only from an inline comment
still being uploaded. Verified against the live endpoint with one cited and one
uncited file: `not referenced, skipping: scratch.png`, then `Embedded 1 of 1
referenced file(s)`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
