### PR TITLE
Let the PR reviewer check its media citations

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -160,9 +160,5 @@ uv run --package skills skills upload-media --check \
   --dir /tmp/review-media --target /tmp/review-payload.json
 ```
 
-The second checks that every citation names a capture the upload step will actually
-find. A misspelt or path-prefixed name uploads nothing and ships a broken image, and
-neither the schema nor the upload step reports it.
-
 Do not post the review: no `gh pr review`, no review/comment APIs, no other skills. Stop
 after writing and validating `/tmp/review-payload.json`.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -145,8 +145,8 @@ Authoring rules not captured by the schema:
 - If you have no findings, emit an empty `comments` array.
 - To attach an image or video (a diagram, a chart, a captured repro), write the file into
   `/tmp/review-media/` and reference it by bare filename: `![desc](name.png)` to embed, or
-  `` `name.png` `` to cite. A later workflow step uploads it and rewrites the reference to a
-  URL. Do not upload anything yourself. Skip this unless a visual genuinely beats prose;
+  `[desc](name.png)` to link. A later workflow step uploads it and rewrites the reference to
+  a URL. Do not upload anything yourself. Skip this unless a visual genuinely beats prose;
   most reviews need none.
 - Put a video reference (`.mp4`, `.mov`, `.webm`) on a line of its own. GitHub renders a
   player only for a bare URL in its own paragraph, so a video cited mid-sentence falls back

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -156,6 +156,7 @@ Validate before finishing, then fix any errors and re-emit until both of these p
 
 ```bash
 uv run --package skills skills validate-review /tmp/review-payload.json
+# only when you wrote a file into /tmp/review-media/
 uv run --package skills skills upload-media --check \
   --dir /tmp/review-media --target /tmp/review-payload.json
 ```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -152,11 +152,17 @@ Authoring rules not captured by the schema:
   player only for a bare URL in its own paragraph, so a video cited mid-sentence falls back
   to a plain link.
 
-Validate before finishing, then fix any errors and re-emit until this passes:
+Validate before finishing, then fix any errors and re-emit until both of these pass:
 
 ```bash
 uv run --package skills skills validate-review /tmp/review-payload.json
+uv run --package skills skills upload-media --check \
+  --dir /tmp/review-media --target /tmp/review-payload.json
 ```
+
+The second checks that every citation names a capture the upload step will actually
+find. A misspelt or path-prefixed name uploads nothing and ships a broken image, and
+neither the schema nor the upload step reports it.
 
 Do not post the review: no `gh pr review`, no review/comment APIs, no other skills. Stop
 after writing and validating `/tmp/review-payload.json`.

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -12,7 +12,8 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -112,15 +113,18 @@ def is_referenced(name: str, text: str) -> bool:
     return re.search(reference_pattern(name), text) is not None
 
 
+def standalone_pattern(name: str) -> str:
+    # GitHub renders a video player only for a bare URL alone in its own paragraph.
+    return rf"(?m)^[ \t]*(?:!?\[[^\]]*{link_target(name)}|{code_span(name)})[ \t]*$"
+
+
 def substitute(text: str, urls: dict[str, str], unavailable: Iterable[str] = ()) -> str:
     for name, url in urls.items():
         link = link_target(name)
         code = code_span(name)
         if is_video(name):
-            # GitHub renders a player only for a bare URL alone in its own paragraph,
-            # so promote a reference that already sits on its own line.
-            standalone = rf"(?m)^[ \t]*(?:!?\[[^\]]*{link}|{code})[ \t]*$"
-            text = re.sub(standalone, f"\n{url}\n", text)
+            # Promote a reference that already sits on its own line.
+            text = re.sub(standalone_pattern(name), f"\n{url}\n", text)
             # Whatever is left is mid-sentence, where ![]() around a video URL renders
             # as a broken image. Drop the bang so it degrades to a link instead.
             text = re.sub(rf"!(?=\[[^\]]*{link})", "", text)
@@ -136,6 +140,23 @@ def substitute(text: str, urls: dict[str, str], unavailable: Iterable[str] = ())
         text = re.sub(rf"!?\[{link}", name, text)
         text = re.sub(rf"!?\[([^\]]+){link}", r"\1", text)
     return text
+
+
+def collect_files(directory: Path) -> tuple[list[Path], list[str]]:
+    """Return the uploadable files, and the names rejected for being symlinks.
+
+    ``is_file()`` follows symlinks, so a link planted here (say secret.png ->
+    /proc/self/environ) would publish this process's own UPLOAD_MEDIA_TOKEN as an
+    attachment. Claude writes this directory, and a poisoned diff steers Claude.
+    """
+    files: list[Path] = []
+    symlinks: list[str] = []
+    for path in sorted(directory.iterdir()):
+        if path.is_symlink():
+            symlinks.append(path.name)
+        elif path.is_file():
+            files.append(path)
+    return files, symlinks
 
 
 def rewrite_payload(
@@ -154,6 +175,111 @@ def rewrite_payload(
     return payload
 
 
+LINK = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)\)")
+
+
+@dataclass
+class CheckReport:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    cited: list[str] = field(default_factory=list)
+
+
+def iter_bodies(payload: dict[str, Any]) -> Iterator[str]:
+    match payload:
+        case {"body": str(body)}:
+            yield body
+    match payload:
+        case {"comments": [*comments]}:
+            for comment in comments:
+                match comment:
+                    case {"body": str(body)}:
+                        yield body
+
+
+def target_bodies(target: Path) -> list[str]:
+    text = target.read_text()
+    if target.suffix != ".json":
+        return [text]
+    return list(iter_bodies(json.loads(text)))
+
+
+def check_media(directory: Path, texts: list[str]) -> CheckReport:
+    """Report what the upload would silently drop or leave broken in ``texts``."""
+    report = CheckReport()
+    files, symlinks = collect_files(directory) if directory.is_dir() else ([], [])
+    by_name = {p.name: p for p in files}
+    report.warnings += [f"{name}: a symlink, so it is never uploaded" for name in symlinks]
+
+    cited = {name for name in by_name if any(is_referenced(name, t) for t in texts)}
+
+    for text in texts:
+        for raw in LINK.findall(text):
+            if "://" in raw:
+                continue
+            path = raw.removeprefix("./")
+            name = path.rsplit("/", 1)[-1]
+            if name in by_name:
+                cited.add(name)
+                if path != name:
+                    report.errors.append(
+                        f"({raw}): cite {name} by bare filename, or the path is left alone "
+                        "and GitHub resolves it against the repository"
+                    )
+            # A path still resolves against the repository, so only a bare media filename
+            # that matches no capture is certain to render as a broken image.
+            elif path == name and Path(name).suffix.lower() in MIME_TYPES:
+                report.errors.append(
+                    f"({raw}): no such file in {directory}, so the reference ships as-is "
+                    "and GitHub renders it as a broken image"
+                )
+
+    for name in sorted(cited):
+        if Path(name).suffix.lower() not in MIME_TYPES:
+            report.errors.append(f"{name}: unsupported extension, so the reference is dropped")
+        elif (size := by_name[name].stat().st_size) > (limit := max_bytes(name)):
+            report.errors.append(
+                f"{name}: {size} bytes exceeds the {limit} byte cap, so the reference is dropped"
+            )
+        elif is_video(name) and any(
+            is_referenced(name, re.sub(standalone_pattern(name), "", t)) for t in texts
+        ):
+            report.warnings.append(
+                f"{name}: cited mid-paragraph, so GitHub renders a link rather than a player"
+            )
+
+    report.warnings += [
+        f"{name}: cited by nothing, so it is not uploaded"
+        for name in sorted(by_name.keys() - cited)
+    ]
+
+    report.errors = list(dict.fromkeys(report.errors))
+    report.warnings = list(dict.fromkeys(report.warnings))
+    report.cited = sorted(cited)
+    return report
+
+
+def run_check(args: argparse.Namespace) -> None:
+    if not args.target.is_file():
+        print(f"ERROR: no target at {args.target}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        texts = target_bodies(args.target)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: {args.target} is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    report = check_media(args.dir, texts)
+    for warning in report.warnings:
+        print(f"  warning: {warning}", file=sys.stderr)
+    if report.errors:
+        print(f"ERROR: {args.target} cites media that will not render", file=sys.stderr)
+        for error in report.errors:
+            print(f"  {error}", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK: {len(report.cited)} media reference(s) resolve, {len(report.warnings)} warning(s)")
+
+
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     parser = subparsers.add_parser(
         "upload-media",
@@ -166,11 +292,22 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         required=True,
         help="File to rewrite: a .json pr-review payload, or any Markdown file",
     )
-    parser.add_argument("--repository-id", required=True, help="Numeric repository id")
+    parser.add_argument("--repository-id", help="Numeric repository id; required without --check")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report unresolvable references and exit non-zero, without uploading anything",
+    )
     parser.set_defaults(func=run)
 
 
 def run(args: argparse.Namespace) -> None:
+    if args.check:
+        run_check(args)
+        return
+    if not args.repository_id:
+        print("--repository-id is required without --check", file=sys.stderr)
+        sys.exit(2)
     if not args.target.is_file():
         print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
         return
@@ -178,15 +315,9 @@ def run(args: argparse.Namespace) -> None:
         print(f"No media directory at {args.dir}")
         return
 
-    # is_file() follows symlinks, so a link planted here (say secret.png ->
-    # /proc/self/environ) would publish this process's own UPLOAD_MEDIA_TOKEN as an
-    # attachment. Claude writes this directory, and a poisoned diff steers Claude.
-    files: list[Path] = []
-    for path in sorted(args.dir.iterdir()):
-        if path.is_symlink():
-            print(f"  skip {path.name}: symlink", file=sys.stderr)
-        elif path.is_file():
-            files.append(path)
+    files, symlinks = collect_files(args.dir)
+    for name in symlinks:
+        print(f"  skip {name}: symlink", file=sys.stderr)
     if not files:
         print(f"No media in {args.dir}")
         return

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -27,11 +27,26 @@ def build_args(media: Path, target: Path) -> argparse.Namespace:
     ])
 
 
+def build_check_args(media: Path, target: Path) -> argparse.Namespace:
+    return build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+        "--check",
+    ])
+
+
 def make_media(tmp_path: Path, name: str = "shot.png") -> Path:
     media = tmp_path / "media"
     media.mkdir(exist_ok=True)
     (media / name).write_bytes(b"\x89PNG")
     return media
+
+
+def check(tmp_path: Path, body: str, name: str = "shot.png") -> upload_media.CheckReport:
+    return upload_media.check_media(make_media(tmp_path, name), [body])
 
 
 @pytest.mark.parametrize(
@@ -403,6 +418,185 @@ def test_cli_uploads_media_referenced_by_an_inline_comment(
 )
 def test_is_referenced_matches_only_real_reference_forms(text: str, expected: bool) -> None:
     assert upload_media.is_referenced("shot.png", text) is expected
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "![the bug](shot.png)",
+        "![the bug](./shot.png)",
+        "[the bug](shot.png)",
+        "see `shot.png`",
+    ],
+)
+def test_check_accepts_every_form_the_rewriter_understands(tmp_path: Path, body: str) -> None:
+    report = check(tmp_path, body)
+    assert report.errors == []
+    assert report.warnings == []
+    assert report.cited == ["shot.png"]
+
+
+@pytest.mark.parametrize("body", ["![the bug](shto.png)", "![the bug](./shto.png)"])
+def test_check_rejects_a_citation_naming_no_captured_file(tmp_path: Path, body: str) -> None:
+    report = check(tmp_path, body)
+    assert len(report.errors) == 1
+    assert "no such file" in report.errors[0]
+
+
+def test_check_rejects_a_citation_carrying_a_path(tmp_path: Path) -> None:
+    report = check(tmp_path, "![the bug](media/shot.png)")
+    assert len(report.errors) == 1
+    assert "cite shot.png by bare filename" in report.errors[0]
+    # The capture is plainly meant to be shown, so it is not also reported as uncited.
+    assert report.warnings == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "[the docs icon](docs/static/img/logo.png)",
+        "[upstream](https://example.com/diagram.png)",
+        "the `logo.png` in the diff",
+        "[the module](mlflow/utils.py)",
+    ],
+)
+def test_check_leaves_references_that_are_not_captures_alone(tmp_path: Path, body: str) -> None:
+    media = tmp_path / "media"
+    media.mkdir()
+    assert upload_media.check_media(media, [body]).errors == []
+
+
+def test_check_warns_about_a_capture_nothing_cites(tmp_path: Path) -> None:
+    report = check(tmp_path, "a prose-only finding")
+    assert report.errors == []
+    assert report.warnings == ["shot.png: cited by nothing, so it is not uploaded"]
+
+
+def test_check_rejects_a_cited_file_with_an_unsupported_extension(tmp_path: Path) -> None:
+    report = check(tmp_path, "see `notes.txt`", "notes.txt")
+    assert report.errors == ["notes.txt: unsupported extension, so the reference is dropped"]
+
+
+def test_check_rejects_a_cited_file_over_the_size_cap(tmp_path: Path) -> None:
+    with mock.patch.object(upload_media, "MAX_IMAGE_BYTES", 2):
+        report = check(tmp_path, "![the bug](shot.png)")
+    assert len(report.errors) == 1
+    assert "exceeds the 2 byte cap" in report.errors[0]
+
+
+def test_check_warns_when_a_video_is_cited_mid_paragraph(tmp_path: Path) -> None:
+    report = check(tmp_path, "the repro is `clip.mp4` here", "clip.mp4")
+    assert report.errors == []
+    assert len(report.warnings) == 1
+    assert "renders a link rather than a player" in report.warnings[0]
+
+
+def test_check_accepts_a_video_on_its_own_line(tmp_path: Path) -> None:
+    report = check(tmp_path, "the repro:\n\n![repro](clip.mp4)\n", "clip.mp4")
+    assert report.errors == []
+    assert report.warnings == []
+
+
+def test_check_warns_about_a_symlink(tmp_path: Path) -> None:
+    media = tmp_path / "media"
+    media.mkdir()
+    (tmp_path / "environ").write_text("UPLOAD_MEDIA_TOKEN=supersecret")
+    (media / "shot.png").symlink_to(tmp_path / "environ")
+
+    report = upload_media.check_media(media, ["a prose-only finding"])
+    assert report.warnings == ["shot.png: a symlink, so it is never uploaded"]
+
+
+def test_check_reads_the_body_and_comments_of_a_json_payload(tmp_path: Path) -> None:
+    target = tmp_path / "review-payload.json"
+    target.write_text(
+        json.dumps({
+            "body": "![overview](shot.png)",
+            "comments": [{"body": "and ![again](missing.png)"}],
+        })
+    )
+    report = upload_media.check_media(make_media(tmp_path), upload_media.target_bodies(target))
+    assert report.cited == ["shot.png"]
+    assert len(report.errors) == 1
+    assert "(missing.png): no such file" in report.errors[0]
+
+
+def test_check_reports_a_repeated_bad_citation_once(tmp_path: Path) -> None:
+    report = upload_media.check_media(
+        make_media(tmp_path), ["![a](missing.png)", "![b](missing.png)"]
+    )
+    assert len(report.errors) == 1
+
+
+def test_check_agrees_with_what_the_upload_would_rewrite(tmp_path: Path) -> None:
+    body = "![the bug](shot.png)"
+    assert check(tmp_path, body).errors == []
+    assert substitute(body, URLS) != body
+
+
+def test_cli_check_exits_zero_and_uploads_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text("![the bug](shot.png)")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_check_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == "![the bug](shot.png)"
+
+
+def test_cli_check_exits_nonzero_on_an_unresolvable_citation(tmp_path: Path) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text("![the bug](shto.png)")
+
+    args = build_check_args(media, target)
+    with pytest.raises(SystemExit, match="^1$"):
+        args.func(args)
+
+
+@pytest.mark.parametrize("contents", ["not json", '{"body": '])
+def test_cli_check_exits_nonzero_on_a_malformed_json_payload(tmp_path: Path, contents: str) -> None:
+    target = tmp_path / "review-payload.json"
+    target.write_text(contents)
+
+    args = build_check_args(make_media(tmp_path), target)
+    with pytest.raises(SystemExit, match="^1$"):
+        args.func(args)
+
+
+def test_cli_check_exits_nonzero_when_the_target_is_missing(tmp_path: Path) -> None:
+    args = build_check_args(make_media(tmp_path), tmp_path / "absent.md")
+    with pytest.raises(SystemExit, match="^1$"):
+        args.func(args)
+
+
+def test_cli_check_tolerates_a_missing_media_directory(tmp_path: Path) -> None:
+    target = tmp_path / "body.md"
+    target.write_text("a prose-only finding")
+    args = build_check_args(tmp_path / "absent", target)
+    args.func(args)
+
+
+def test_cli_requires_a_repository_id_without_check(tmp_path: Path) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text("![the bug](shot.png)")
+
+    args = build_parser().parse_args([
+        "upload-media",
+        "--dir",
+        str(media),
+        "--target",
+        str(target),
+    ])
+    with pytest.raises(SystemExit, match="^2$"):
+        args.func(args)
 
 
 def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25152

### What changes are proposed in this pull request?

The reviewer captures into `/tmp/review-media/` and cites by bare filename; a
later step uploads what is cited and rewrites the reference to a URL. Nothing
tells the reviewer whether a citation resolves. A misspelt name matches no file,
so it is neither uploaded nor stripped, and `![the bug](shto.png)` reaches the
posted review as a repo-relative link that renders broken. The schema validation
the reviewer already runs says nothing about media.

- `upload-media --check` resolves every citation against the media directory
  with no token and no network, and exits non-zero on one that cannot render: an
  unknown filename, or a path where only a bare name is rewritten. An uncited
  capture and a video cited mid-paragraph warn without failing.
- `pr-review` runs it beside `validate-review` when the review captured
  something, inside the loop that already says to fix and re-emit until it
  passes.
- Citing with a code span is dropped from the contract, since a bare filename in
  backticks is ordinary prose and a typo there cannot be told from a reference to
  a file in the diff. `[desc](name.png)` covers linking without embedding.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Tests cover each accepted citation form, the two failure modes, repo-relative
links and absolute URLs that must not be flagged, and the warnings. Manually: a
payload carrying a typo, a path-prefixed citation, an uncited capture and an
inline video reported all four, and once fixed the check counted exactly the two
references the upload step went on to embed. That same broken payload passes
schema validation today, uploads none of its three captures, and posts both
citations verbatim as broken images.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

