### PR TITLE
Cite review media by the path it was captured to

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -89,8 +89,8 @@ Node and `agent-browser` are on PATH for docs and UI changes. Render when it set
 change is correct, or when a capture shows a finding more plainly than prose can. Building the
 docs site or the UI is expensive; do it only when the finding justifies it. Capture to an
 absolute path named for what it shows:
-`agent-browser screenshot --full /tmp/review-media/traces-table.png`, and cite that name in a
-finding.
+`agent-browser screenshot --full /tmp/review-media/traces-table.png`, and cite that same path
+in a finding.
 
 Evaluate the changed code across these dimensions:
 
@@ -144,10 +144,11 @@ Authoring rules not captured by the schema:
   indentation.
 - If you have no findings, emit an empty `comments` array.
 - To attach an image or video (a diagram, a chart, a captured repro), write the file into
-  `/tmp/review-media/` and reference it by bare filename: `![desc](name.png)` to embed, or
-  `[desc](name.png)` to link. A later workflow step uploads it and rewrites the reference to
-  a URL. Do not upload anything yourself. Skip this unless a visual genuinely beats prose;
-  most reviews need none.
+  `/tmp/review-media/` and cite it by the absolute path you wrote it to:
+  `![desc](/tmp/review-media/name.png)` to embed, or `[desc](/tmp/review-media/name.png)`
+  to link. A later workflow step uploads it and rewrites the reference to a URL. Do not
+  upload anything yourself. Skip this unless a visual genuinely beats prose; most reviews
+  need none.
 - Put a video reference (`.mp4`, `.mov`, `.webm`) on a line of its own. GitHub renders a
   player only for a bare URL in its own paragraph, so a video cited mid-sentence falls back
   to a plain link.

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -214,8 +214,8 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
                 report.errors.append(f"({raw}): cite the capture as {path}")
             elif raw.startswith(f"{directory}/"):
                 report.errors.append(
-                    f"({raw}): no such file, so the reference ships as-is and renders "
-                    "as a dead link"
+                    f"({raw}): no such file, so the citation is stripped and the finding "
+                    "degrades to prose"
                 )
 
     for name in sorted(cited):
@@ -311,10 +311,12 @@ def run(args: argparse.Namespace) -> None:
     # than posted. --check reports it first, but Claude runs that; this step is the last
     # thing between a typo and the review.
     resolvable = {str(p) for p in referenced}
+    names = {p.name for p in files}
     stray = [
         raw
         for raw in dict.fromkeys(LINK.findall(target_text))
-        if raw.startswith(f"{args.dir}/") and raw not in resolvable
+        if raw not in resolvable
+        and (raw.startswith(f"{args.dir}/") or raw.removeprefix("./") in names)
     ]
     for raw in stray:
         print(f"  no such capture, stripping: {raw}", file=sys.stderr)

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -97,47 +97,36 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
             return None
 
 
-def link_target(name: str) -> str:
-    return rf"\]\((?:\./)?{re.escape(name)}\)"
+def link_target(cited: str) -> str:
+    return rf"\]\({re.escape(cited)}\)"
 
 
-def code_span(name: str) -> str:
-    return rf"`{re.escape(name)}`"
+def is_referenced(cited: str, text: str) -> bool:
+    return re.search(link_target(cited), text) is not None
 
 
-def reference_pattern(name: str) -> str:
-    return f"{link_target(name)}|{code_span(name)}"
-
-
-def is_referenced(name: str, text: str) -> bool:
-    return re.search(reference_pattern(name), text) is not None
-
-
-def standalone_pattern(name: str) -> str:
+def standalone_pattern(cited: str) -> str:
     # GitHub renders a video player only for a bare URL alone in its own paragraph.
-    return rf"(?m)^[ \t]*(?:!?\[[^\]]*{link_target(name)}|{code_span(name)})[ \t]*$"
+    return rf"(?m)^[ \t]*!?\[[^\]]*{link_target(cited)}[ \t]*$"
 
 
 def substitute(text: str, urls: dict[str, str], unavailable: Iterable[str] = ()) -> str:
-    for name, url in urls.items():
-        link = link_target(name)
-        code = code_span(name)
-        if is_video(name):
+    for cited, url in urls.items():
+        link = link_target(cited)
+        if is_video(cited):
             # Promote a reference that already sits on its own line.
-            text = re.sub(standalone_pattern(name), f"\n{url}\n", text)
+            text = re.sub(standalone_pattern(cited), f"\n{url}\n", text)
             # Whatever is left is mid-sentence, where ![]() around a video URL renders
             # as a broken image. Drop the bang so it degrades to a link instead.
             text = re.sub(rf"!(?=\[[^\]]*{link})", "", text)
         text = re.sub(link, f"]({url})", text)
-        # Lookarounds keep a second pass a no-op.
-        text = re.sub(rf"(?<!\[){code}(?!\])", f"[`{name}`]({url})", text)
 
-    # A name with no URL (upload failed, or the file was skipped) would otherwise
-    # survive as ![desc](shot.png), which GitHub resolves repo-relative and renders
-    # as a broken image. Strip the markup so it degrades to prose.
-    for name in unavailable:
-        link = link_target(name)
-        text = re.sub(rf"!?\[{link}", name, text)
+    # A citation with no URL (upload failed, or the file was skipped) would otherwise
+    # post the local path, which resolves to nothing. Strip the markup so it degrades
+    # to prose.
+    for cited in unavailable:
+        link = link_target(cited)
+        text = re.sub(rf"!?\[{link}", Path(cited).name, text)
         text = re.sub(rf"!?\[([^\]]+){link}", r"\1", text)
     return text
 
@@ -211,30 +200,22 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
     by_name = {p.name: p for p in files}
     report.warnings += [f"{name}: a symlink, so it is never uploaded" for name in symlinks]
 
-    cited = {name for name in by_name if any(is_referenced(name, t) for t in texts)}
-
+    cited: set[str] = set()
     for text in texts:
         for raw in LINK.findall(text):
-            if "://" in raw:
-                continue
-            path = raw.removeprefix("./")
-            name = path.rsplit("/", 1)[-1]
-            if name in by_name:
+            name = raw.rsplit("/", 1)[-1]
+            if (path := by_name.get(name)) and raw == str(path):
                 cited.add(name)
-                if path != name:
-                    report.errors.append(
-                        f"({raw}): cite {name} by bare filename, or the path is left alone "
-                        "and GitHub resolves it against the repository"
-                    )
-            # A path still resolves against the repository, so only a bare media filename
-            # that matches no capture is certain to render as a broken image.
-            elif path == name and Path(name).suffix.lower() in MIME_TYPES:
+            elif path:
+                report.errors.append(f"({raw}): cite the capture as {path}")
+            elif raw.startswith(f"{directory}/"):
                 report.errors.append(
-                    f"({raw}): no such file in {directory}, so the reference ships as-is "
-                    "and GitHub renders it as a broken image"
+                    f"({raw}): no such file, so the reference ships as-is and renders "
+                    "as a dead link"
                 )
 
     for name in sorted(cited):
+        cite = str(by_name[name])
         if Path(name).suffix.lower() not in MIME_TYPES:
             report.errors.append(f"{name}: unsupported extension, so the reference is dropped")
         elif (size := by_name[name].stat().st_size) > (limit := max_bytes(name)):
@@ -242,7 +223,7 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
                 f"{name}: {size} bytes exceeds the {limit} byte cap, so the reference is dropped"
             )
         elif is_video(name) and any(
-            is_referenced(name, re.sub(standalone_pattern(name), "", t)) for t in texts
+            is_referenced(cite, re.sub(standalone_pattern(cite), "", t)) for t in texts
         ):
             report.warnings.append(
                 f"{name}: cited mid-paragraph, so GitHub renders a link rather than a player"
@@ -325,7 +306,7 @@ def run(args: argparse.Namespace) -> None:
     # Only what the review actually cites gets published. Captures taken to reason
     # with and then left uncited are scratch work.
     target_text = args.target.read_text()
-    referenced = [p for p in files if is_referenced(p.name, target_text)]
+    referenced = [p for p in files if is_referenced(str(p), target_text)]
     if unreferenced := [p.name for p in files if p not in referenced]:
         print(f"  not referenced, skipping: {', '.join(unreferenced)}", file=sys.stderr)
     if not referenced:
@@ -333,14 +314,14 @@ def run(args: argparse.Namespace) -> None:
         return
 
     # A missing secret must still reach the rewrite below, or every reference ships
-    # verbatim and renders as a broken repo-relative image.
+    # verbatim and posts a local path.
     urls = {}
     if token := os.environ.get(TOKEN_ENV):
         print(f"Uploading {len(referenced)} referenced file(s) from {args.dir}")
         try:
             for path in referenced:
                 if url := upload_asset(path, args.repository_id, token):
-                    urls[path.name] = url
+                    urls[str(path)] = url
         except TokenRejected as e:
             # The step is continue-on-error, so without an annotation an expired
             # token would silently stop attaching media on every future review.
@@ -348,7 +329,7 @@ def run(args: argparse.Namespace) -> None:
     else:
         print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
 
-    unavailable = [p.name for p in referenced if p.name not in urls]
+    unavailable = [str(p) for p in referenced if str(p) not in urls]
 
     if args.target.suffix == ".json":
         payload = json.loads(target_text)

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -204,9 +204,13 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
     for text in texts:
         for raw in LINK.findall(text):
             name = raw.rsplit("/", 1)[-1]
-            if (path := by_name.get(name)) and raw == str(path):
+            path = by_name.get(name)
+            if path and raw == str(path):
                 cited.add(name)
-            elif path:
+            # A basename alone can only be meant as a capture; the same basename under
+            # some other directory is an ordinary link that happens to collide.
+            elif path and "/" not in raw.removeprefix("./"):
+                cited.add(name)
                 report.errors.append(f"({raw}): cite the capture as {path}")
             elif raw.startswith(f"{directory}/"):
                 report.errors.append(
@@ -292,16 +296,9 @@ def run(args: argparse.Namespace) -> None:
     if not args.target.is_file():
         print(f"No target at {args.target}; nothing to rewrite", file=sys.stderr)
         return
-    if not args.dir.is_dir():
-        print(f"No media directory at {args.dir}")
-        return
-
-    files, symlinks = collect_files(args.dir)
+    files, symlinks = collect_files(args.dir) if args.dir.is_dir() else ([], [])
     for name in symlinks:
         print(f"  skip {name}: symlink", file=sys.stderr)
-    if not files:
-        print(f"No media in {args.dir}")
-        return
 
     # Only what the review actually cites gets published. Captures taken to reason
     # with and then left uncited are scratch work.
@@ -309,14 +306,28 @@ def run(args: argparse.Namespace) -> None:
     referenced = [p for p in files if is_referenced(str(p), target_text)]
     if unreferenced := [p.name for p in files if p not in referenced]:
         print(f"  not referenced, skipping: {', '.join(unreferenced)}", file=sys.stderr)
-    if not referenced:
+
+    # A citation naming no capture resolves to nothing, so it has to be stripped rather
+    # than posted. --check reports it first, but Claude runs that; this step is the last
+    # thing between a typo and the review.
+    resolvable = {str(p) for p in referenced}
+    stray = [
+        raw
+        for raw in dict.fromkeys(LINK.findall(target_text))
+        if raw.startswith(f"{args.dir}/") and raw not in resolvable
+    ]
+    for raw in stray:
+        print(f"  no such capture, stripping: {raw}", file=sys.stderr)
+    if not referenced and not stray:
         print(f"No media referenced by {args.target}")
         return
 
     # A missing secret must still reach the rewrite below, or every reference ships
     # verbatim and posts a local path.
     urls = {}
-    if token := os.environ.get(TOKEN_ENV):
+    if not (token := os.environ.get(TOKEN_ENV)):
+        print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
+    elif referenced:
         print(f"Uploading {len(referenced)} referenced file(s) from {args.dir}")
         try:
             for path in referenced:
@@ -326,10 +337,8 @@ def run(args: argparse.Namespace) -> None:
             # The step is continue-on-error, so without an annotation an expired
             # token would silently stop attaching media on every future review.
             print(f"::warning::{e}")
-    else:
-        print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
 
-    unavailable = [str(p) for p in referenced if str(p) not in urls]
+    unavailable = [str(p) for p in referenced if str(p) not in urls] + stray
 
     if args.target.suffix == ".json":
         payload = json.loads(target_text)

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -210,8 +210,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     secret.write_text("UPLOAD_MEDIA_TOKEN=supersecret")
     (media / "shot.png").symlink_to(secret)
     target = tmp_path / "body.md"
-    body = f"![x]({media / 'shot.png'})"
-    target.write_text(body)
+    target.write_text(f"![the secret]({media / 'shot.png'})")
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -219,7 +218,8 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         args.func(args)
 
     uploader.assert_not_called()
-    assert target.read_text() == body
+    # Never uploaded, so the citation resolves to nothing and must not post the path.
+    assert target.read_text() == "the secret"
 
 
 def test_upload_asset_builds_the_request_and_returns_the_url(tmp_path: Path) -> None:
@@ -454,12 +454,13 @@ def test_check_rejects_a_citation_naming_no_captured_file(tmp_path: Path) -> Non
     assert "no such file" in report.errors[0]
 
 
-@pytest.mark.parametrize("body", ["![the bug](shot.png)", "![the bug](media/shot.png)"])
+@pytest.mark.parametrize("body", ["![the bug](shot.png)", "![the bug](./shot.png)"])
 def test_check_rejects_a_citation_that_is_not_the_path_written(tmp_path: Path, body: str) -> None:
     report = check(tmp_path, body)
     assert len(report.errors) == 1
     assert report.errors[0].endswith(f"cite the capture as {tmp_path / 'media' / 'shot.png'}")
-    assert report.warnings == ["shot.png: cited by nothing, so it is not uploaded"]
+    # The capture is plainly meant to be shown, so it is not also reported as uncited.
+    assert report.warnings == []
 
 
 @pytest.mark.parametrize(
@@ -469,13 +470,28 @@ def test_check_rejects_a_citation_that_is_not_the_path_written(tmp_path: Path, b
         "[upstream](https://example.com/diagram.png)",
         "the `logo.png` in the diff",
         "[the module](mlflow/utils.py)",
-        "[a capture from another run](/tmp/other/shot.png)",
     ],
 )
 def test_check_leaves_references_that_are_not_captures_alone(tmp_path: Path, body: str) -> None:
     media = tmp_path / "media"
     media.mkdir()
     assert upload_media.check_media(media, [body]).errors == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "[the docs icon](docs/static/img/shot.png)",
+        "[upstream](https://example.com/shot.png)",
+        "[a capture from another run](/tmp/other/shot.png)",
+    ],
+)
+def test_check_leaves_a_link_whose_basename_collides_with_a_capture_alone(
+    tmp_path: Path, body: str
+) -> None:
+    # The capture is named shot.png, so every one of these shares its basename.
+    report = check(tmp_path, body)
+    assert report.errors == []
 
 
 def test_check_warns_about_a_capture_nothing_cites(tmp_path: Path) -> None:
@@ -589,6 +605,55 @@ def test_cli_check_exits_nonzero_when_the_target_is_missing(tmp_path: Path) -> N
     args = build_check_args(make_media(tmp_path), tmp_path / "absent.md")
     with pytest.raises(SystemExit, match="^1$"):
         args.func(args)
+
+
+def test_cli_strips_a_citation_naming_no_capture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text(f"evidence: ![the bug]({media / 'shto.png'})")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == "evidence: the bug"
+
+
+def test_cli_strips_a_typo_while_still_embedding_the_capture_beside_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text(f"![ok]({media / 'shot.png'}) and ![typo]({media / 'shto.png'})")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
+    assert target.read_text() == f"![ok]({URL}) and typo"
+
+
+def test_cli_leaves_a_link_outside_the_media_directory_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    body = "see [the icon](docs/static/img/shot.png)"
+    target.write_text(body)
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == body
 
 
 def test_cli_check_tolerates_a_missing_media_directory(tmp_path: Path) -> None:

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -12,7 +12,10 @@ from skills.commands import upload_media
 from skills.commands.upload_media import rewrite_payload, substitute
 
 URL = "https://github.com/user-attachments/assets/2f1c0a3e-0000-4000-8000-000000000001"
-URLS = {"shot.png": URL}
+MEDIA = "/tmp/review-media"
+SHOT = f"{MEDIA}/shot.png"
+CLIP = f"{MEDIA}/clip.mp4"
+URLS = {SHOT: URL}
 
 
 def build_args(media: Path, target: Path) -> argparse.Namespace:
@@ -46,18 +49,18 @@ def make_media(tmp_path: Path, name: str = "shot.png") -> Path:
 
 
 def check(tmp_path: Path, body: str, name: str = "shot.png") -> upload_media.CheckReport:
-    return upload_media.check_media(make_media(tmp_path, name), [body])
+    media = make_media(tmp_path, name)
+    return upload_media.check_media(media, [body.format(p=media / name, media=media)])
 
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("![alt](shot.png)", f"![alt]({URL})"),
-        ("![alt](./shot.png)", f"![alt]({URL})"),
-        ("[link](shot.png)", f"[link]({URL})"),
-        ("see `shot.png` here", f"see [`shot.png`]({URL}) here"),
+        (f"![alt]({SHOT})", f"![alt]({URL})"),
+        (f"[link]({SHOT})", f"[link]({URL})"),
         ("nothing to do", "nothing to do"),
-        ("other.png stays", "other.png stays"),
+        ("shot.png stays", "shot.png stays"),
+        (f"`{SHOT}` stays", f"`{SHOT}` stays"),
     ],
 )
 def test_substitute_rewrites_each_reference_form(text: str, expected: str) -> None:
@@ -65,56 +68,53 @@ def test_substitute_rewrites_each_reference_form(text: str, expected: str) -> No
 
 
 def test_substitute_is_idempotent() -> None:
-    once = substitute("see `shot.png`", URLS)
+    once = substitute(f"see ![alt]({SHOT})", URLS)
     assert substitute(once, URLS) == once
 
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("![repro](clip.mp4)", f"\n{URL}\n"),
-        ("`clip.mp4`", f"\n{URL}\n"),
-        ("before\n![repro](clip.mp4)\nafter", f"before\n\n{URL}\n\nafter"),
-        ("see `clip.mp4` inline", f"see [`clip.mp4`]({URL}) inline"),
+        (f"![repro]({CLIP})", f"\n{URL}\n"),
+        (f"before\n![repro]({CLIP})\nafter", f"before\n\n{URL}\n\nafter"),
         # ![]() around a video URL renders as a broken image, so it must become a link.
-        ("see ![repro](clip.mp4) inline", f"see [repro]({URL}) inline"),
+        (f"see ![repro]({CLIP}) inline", f"see [repro]({URL}) inline"),
     ],
 )
 def test_substitute_promotes_a_standalone_video_to_a_bare_url(text: str, expected: str) -> None:
-    assert substitute(text, {"clip.mp4": URL}) == expected
+    assert substitute(text, {CLIP: URL}) == expected
 
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("![a screenshot](shot.png)", "a screenshot"),
-        ("[a screenshot](shot.png)", "a screenshot"),
-        ("![](shot.png)", "shot.png"),
-        ("see `shot.png`", "see `shot.png`"),
+        (f"![a screenshot]({SHOT})", "a screenshot"),
+        (f"[a screenshot]({SHOT})", "a screenshot"),
+        (f"![]({SHOT})", "shot.png"),
     ],
 )
 def test_substitute_strips_markup_for_media_that_never_uploaded(text: str, expected: str) -> None:
-    assert substitute(text, {}, ["shot.png"]) == expected
+    assert substitute(text, {}, [SHOT]) == expected
 
 
 def test_rewrite_payload_covers_body_and_inline_comments() -> None:
     payload = {
         "event": "COMMENT",
-        "body": "Race shown in `shot.png`\n\n🤖 Generated with Claude",
-        "comments": [{"path": "a.py", "body": "🔴 **CRITICAL:** ![x](shot.png)", "line": 1}],
+        "body": f"Race shown in [the trace]({SHOT})\n\n🤖 Generated with Claude",
+        "comments": [{"path": "a.py", "body": f"🔴 **CRITICAL:** ![x]({SHOT})", "line": 1}],
     }
     result = rewrite_payload(payload, URLS)
-    assert result["body"] == f"Race shown in [`shot.png`]({URL})\n\n🤖 Generated with Claude"
+    assert result["body"] == f"Race shown in [the trace]({URL})\n\n🤖 Generated with Claude"
     assert result["comments"][0]["body"] == f"🔴 **CRITICAL:** ![x]({URL})"
 
 
 def test_rewrite_payload_neutralizes_unavailable_media_in_comments() -> None:
-    payload = {"body": "b", "comments": [{"body": "![the bug](shot.png)"}]}
-    assert rewrite_payload(payload, {}, ["shot.png"])["comments"][0]["body"] == "the bug"
+    payload = {"body": "b", "comments": [{"body": f"![the bug]({SHOT})"}]}
+    assert rewrite_payload(payload, {}, [SHOT])["comments"][0]["body"] == "the bug"
 
 
 def test_rewrite_payload_preserves_the_trailing_footer() -> None:
-    payload = {"body": "`shot.png`\n\n🤖 Generated with Claude", "comments": []}
+    payload = {"body": f"![x]({SHOT})\n\n🤖 Generated with Claude", "comments": []}
     assert rewrite_payload(payload, URLS)["body"].endswith("🤖 Generated with Claude")
 
 
@@ -129,7 +129,7 @@ def test_rewrite_payload_tolerates_missing_and_malformed_fields() -> None:
 def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "review-payload.json"
-    target.write_text(json.dumps({"body": "`shot.png`", "comments": []}))
+    target.write_text(json.dumps({"body": f"[the trace]({media / 'shot.png'})", "comments": []}))
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -137,13 +137,13 @@ def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyP
         args.func(args)
 
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
-    assert json.loads(target.read_text())["body"] == f"[`shot.png`]({URL})"
+    assert json.loads(target.read_text())["body"] == f"[the trace]({URL})"
 
 
 def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("![alt](shot.png)")
+    target.write_text(f"![alt]({media / 'shot.png'})")
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -159,7 +159,7 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
 ) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("evidence: ![the bug](shot.png)")
+    target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -170,12 +170,12 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
     assert target.read_text() == "evidence: the bug"
 
 
-def test_cli_degrades_to_prose_when_the_token_env_is_unset(
+def test_cli_never_posts_a_local_path_when_the_token_env_is_unset(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("evidence: ![the bug](shot.png) and `shot.png`")
+    target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
     monkeypatch.delenv(upload_media.TOKEN_ENV, raising=False)
     args = build_args(media, target)
@@ -183,7 +183,7 @@ def test_cli_degrades_to_prose_when_the_token_env_is_unset(
         args.func(args)
 
     uploader.assert_not_called()
-    assert target.read_text() == "evidence: the bug and `shot.png`"
+    assert target.read_text() == "evidence: the bug"
 
 
 def test_cli_is_a_noop_when_there_is_no_media(
@@ -210,7 +210,8 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     secret.write_text("UPLOAD_MEDIA_TOKEN=supersecret")
     (media / "shot.png").symlink_to(secret)
     target = tmp_path / "body.md"
-    target.write_text("`shot.png`")
+    body = f"![x]({media / 'shot.png'})"
+    target.write_text(body)
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -218,7 +219,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         args.func(args)
 
     uploader.assert_not_called()
-    assert target.read_text() == "`shot.png`"
+    assert target.read_text() == body
 
 
 def test_upload_asset_builds_the_request_and_returns_the_url(tmp_path: Path) -> None:
@@ -336,7 +337,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     media = make_media(tmp_path)
     (media / "second.png").write_bytes(b"\x89PNG")
     target = tmp_path / "body.md"
-    target.write_text("evidence: ![the bug](shot.png)")
+    target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -360,7 +361,7 @@ def test_cli_uploads_only_media_the_target_references(
     media = make_media(tmp_path, "cited.png")
     (media / "scratch.png").write_bytes(b"\x89PNG")
     target = tmp_path / "body.md"
-    target.write_text("evidence: ![the bug](cited.png)")
+    target.write_text(f"evidence: ![the bug]({media / 'cited.png'})")
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -393,7 +394,9 @@ def test_cli_uploads_media_referenced_by_an_inline_comment(
     media = make_media(tmp_path, "cited.png")
     (media / "scratch.png").write_bytes(b"\x89PNG")
     target = tmp_path / "review-payload.json"
-    target.write_text(json.dumps({"body": "b", "comments": [{"body": "see `cited.png`"}]}))
+    target.write_text(
+        json.dumps({"body": "b", "comments": [{"body": f"see [it]({media / 'cited.png'})"}]})
+    )
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -401,34 +404,43 @@ def test_cli_uploads_media_referenced_by_an_inline_comment(
         args.func(args)
 
     uploader.assert_called_once_with(media / "cited.png", "136202695", "t")
-    assert json.loads(target.read_text())["comments"][0]["body"] == f"see [`cited.png`]({URL})"
+    assert json.loads(target.read_text())["comments"][0]["body"] == f"see [it]({URL})"
 
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("![x](shot.png)", True),
-        ("![x](./shot.png)", True),
-        ("see `shot.png`", True),
-        # A name that is only a suffix of a cited one is not a reference.
-        ("![x](longshot.png)", False),
-        ("shot.png bare mention", False),
+        (f"![x]({SHOT})", True),
+        (f"[x]({SHOT})", True),
+        # A path that only ends with the cited one is not a reference.
+        (f"![x]({MEDIA}/longshot.png)", False),
+        ("![x](shot.png)", False),
+        (f"`{SHOT}`", False),
         ("nothing here", False),
     ],
 )
-def test_is_referenced_matches_only_real_reference_forms(text: str, expected: bool) -> None:
-    assert upload_media.is_referenced("shot.png", text) is expected
+def test_is_referenced_matches_only_a_link_to_the_full_path(text: str, expected: bool) -> None:
+    assert upload_media.is_referenced(SHOT, text) is expected
 
 
-@pytest.mark.parametrize(
-    "body",
-    [
-        "![the bug](shot.png)",
-        "![the bug](./shot.png)",
-        "[the bug](shot.png)",
-        "see `shot.png`",
-    ],
-)
+def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path, "longshot.png")
+    (media / "shot.png").write_bytes(b"\x89PNG")
+    target = tmp_path / "body.md"
+    target.write_text(f"![x]({media / 'longshot.png'})")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    uploader.assert_called_once_with(media / "longshot.png", "136202695", "t")
+    assert target.read_text() == f"![x]({URL})"
+
+
+@pytest.mark.parametrize("body", ["![the bug]({p})", "[the bug]({p})"])
 def test_check_accepts_every_form_the_rewriter_understands(tmp_path: Path, body: str) -> None:
     report = check(tmp_path, body)
     assert report.errors == []
@@ -436,19 +448,18 @@ def test_check_accepts_every_form_the_rewriter_understands(tmp_path: Path, body:
     assert report.cited == ["shot.png"]
 
 
-@pytest.mark.parametrize("body", ["![the bug](shto.png)", "![the bug](./shto.png)"])
-def test_check_rejects_a_citation_naming_no_captured_file(tmp_path: Path, body: str) -> None:
-    report = check(tmp_path, body)
+def test_check_rejects_a_citation_naming_no_captured_file(tmp_path: Path) -> None:
+    report = check(tmp_path, "![the bug]({media}/shto.png)")
     assert len(report.errors) == 1
     assert "no such file" in report.errors[0]
 
 
-def test_check_rejects_a_citation_carrying_a_path(tmp_path: Path) -> None:
-    report = check(tmp_path, "![the bug](media/shot.png)")
+@pytest.mark.parametrize("body", ["![the bug](shot.png)", "![the bug](media/shot.png)"])
+def test_check_rejects_a_citation_that_is_not_the_path_written(tmp_path: Path, body: str) -> None:
+    report = check(tmp_path, body)
     assert len(report.errors) == 1
-    assert "cite shot.png by bare filename" in report.errors[0]
-    # The capture is plainly meant to be shown, so it is not also reported as uncited.
-    assert report.warnings == []
+    assert report.errors[0].endswith(f"cite the capture as {tmp_path / 'media' / 'shot.png'}")
+    assert report.warnings == ["shot.png: cited by nothing, so it is not uploaded"]
 
 
 @pytest.mark.parametrize(
@@ -458,6 +469,7 @@ def test_check_rejects_a_citation_carrying_a_path(tmp_path: Path) -> None:
         "[upstream](https://example.com/diagram.png)",
         "the `logo.png` in the diff",
         "[the module](mlflow/utils.py)",
+        "[a capture from another run](/tmp/other/shot.png)",
     ],
 )
 def test_check_leaves_references_that_are_not_captures_alone(tmp_path: Path, body: str) -> None:
@@ -473,26 +485,26 @@ def test_check_warns_about_a_capture_nothing_cites(tmp_path: Path) -> None:
 
 
 def test_check_rejects_a_cited_file_with_an_unsupported_extension(tmp_path: Path) -> None:
-    report = check(tmp_path, "see `notes.txt`", "notes.txt")
+    report = check(tmp_path, "[notes]({p})", "notes.txt")
     assert report.errors == ["notes.txt: unsupported extension, so the reference is dropped"]
 
 
 def test_check_rejects_a_cited_file_over_the_size_cap(tmp_path: Path) -> None:
     with mock.patch.object(upload_media, "MAX_IMAGE_BYTES", 2):
-        report = check(tmp_path, "![the bug](shot.png)")
+        report = check(tmp_path, "![the bug]({p})")
     assert len(report.errors) == 1
     assert "exceeds the 2 byte cap" in report.errors[0]
 
 
 def test_check_warns_when_a_video_is_cited_mid_paragraph(tmp_path: Path) -> None:
-    report = check(tmp_path, "the repro is `clip.mp4` here", "clip.mp4")
+    report = check(tmp_path, "the repro is [here]({p}) inline", "clip.mp4")
     assert report.errors == []
     assert len(report.warnings) == 1
     assert "renders a link rather than a player" in report.warnings[0]
 
 
 def test_check_accepts_a_video_on_its_own_line(tmp_path: Path) -> None:
-    report = check(tmp_path, "the repro:\n\n![repro](clip.mp4)\n", "clip.mp4")
+    report = check(tmp_path, "the repro:\n\n![repro]({p})\n", "clip.mp4")
     assert report.errors == []
     assert report.warnings == []
 
@@ -508,30 +520,32 @@ def test_check_warns_about_a_symlink(tmp_path: Path) -> None:
 
 
 def test_check_reads_the_body_and_comments_of_a_json_payload(tmp_path: Path) -> None:
+    media = make_media(tmp_path)
     target = tmp_path / "review-payload.json"
     target.write_text(
         json.dumps({
-            "body": "![overview](shot.png)",
-            "comments": [{"body": "and ![again](missing.png)"}],
+            "body": f"![overview]({media / 'shot.png'})",
+            "comments": [{"body": f"and ![again]({media / 'missing.png'})"}],
         })
     )
-    report = upload_media.check_media(make_media(tmp_path), upload_media.target_bodies(target))
+    report = upload_media.check_media(media, upload_media.target_bodies(target))
     assert report.cited == ["shot.png"]
     assert len(report.errors) == 1
-    assert "(missing.png): no such file" in report.errors[0]
+    assert "missing.png): no such file" in report.errors[0]
 
 
 def test_check_reports_a_repeated_bad_citation_once(tmp_path: Path) -> None:
-    report = upload_media.check_media(
-        make_media(tmp_path), ["![a](missing.png)", "![b](missing.png)"]
-    )
+    media = make_media(tmp_path)
+    cite = f"{media / 'missing.png'}"
+    report = upload_media.check_media(media, [f"![a]({cite})", f"![b]({cite})"])
     assert len(report.errors) == 1
 
 
 def test_check_agrees_with_what_the_upload_would_rewrite(tmp_path: Path) -> None:
-    body = "![the bug](shot.png)"
-    assert check(tmp_path, body).errors == []
-    assert substitute(body, URLS) != body
+    media = make_media(tmp_path)
+    body = f"![the bug]({media / 'shot.png'})"
+    assert upload_media.check_media(media, [body]).errors == []
+    assert substitute(body, {str(media / "shot.png"): URL}) == f"![the bug]({URL})"
 
 
 def test_cli_check_exits_zero_and_uploads_nothing(
@@ -539,7 +553,8 @@ def test_cli_check_exits_zero_and_uploads_nothing(
 ) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("![the bug](shot.png)")
+    body = f"![the bug]({media / 'shot.png'})"
+    target.write_text(body)
 
     monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
     args = build_check_args(media, target)
@@ -547,13 +562,13 @@ def test_cli_check_exits_zero_and_uploads_nothing(
         args.func(args)
 
     uploader.assert_not_called()
-    assert target.read_text() == "![the bug](shot.png)"
+    assert target.read_text() == body
 
 
 def test_cli_check_exits_nonzero_on_an_unresolvable_citation(tmp_path: Path) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("![the bug](shto.png)")
+    target.write_text(f"![the bug]({media / 'shto.png'})")
 
     args = build_check_args(media, target)
     with pytest.raises(SystemExit, match="^1$"):
@@ -586,7 +601,7 @@ def test_cli_check_tolerates_a_missing_media_directory(tmp_path: Path) -> None:
 def test_cli_requires_a_repository_id_without_check(tmp_path: Path) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("![the bug](shot.png)")
+    target.write_text(f"![the bug]({media / 'shot.png'})")
 
     args = build_parser().parse_args([
         "upload-media",
@@ -597,20 +612,3 @@ def test_cli_requires_a_repository_id_without_check(tmp_path: Path) -> None:
     ])
     with pytest.raises(SystemExit, match="^2$"):
         args.func(args)
-
-
-def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    media = make_media(tmp_path, "longshot.png")
-    (media / "shot.png").write_bytes(b"\x89PNG")
-    target = tmp_path / "body.md"
-    target.write_text("![x](longshot.png)")
-
-    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
-    args = build_args(media, target)
-    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
-        args.func(args)
-
-    uploader.assert_called_once_with(media / "longshot.png", "136202695", "t")
-    assert target.read_text() == f"![x]({URL})"

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -639,6 +639,24 @@ def test_cli_strips_a_typo_while_still_embedding_the_capture_beside_it(
     assert target.read_text() == f"![ok]({URL}) and typo"
 
 
+@pytest.mark.parametrize("cite", ["shot.png", "./shot.png"])
+def test_cli_strips_a_bare_filename_citation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cite: str
+) -> None:
+    # The form this PR stopped teaching: nothing resolves it, so it must not post.
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text(f"evidence: ![the bug]({cite})")
+
+    monkeypatch.setenv(upload_media.TOKEN_ENV, "t")
+    args = build_args(media, target)
+    with mock.patch.object(upload_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == "evidence: the bug"
+
+
 def test_cli_leaves_a_link_outside_the_media_directory_alone(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25154

### What changes are proposed in this pull request?

The reviewer is told to capture to an absolute path
(`agent-browser screenshot --full /tmp/review-media/traces-table.png`) and then to cite a
different string, the bare filename. A transformation the reviewer has to remember is
where the typo comes from, and #25154 had to add an error for citing the path it
actually used.

- Citations are the absolute path the capture was written to. Nothing to translate.
- `--check` loses its last guess. A link under the media directory that resolves to no
  file is an error, always; anything else is not a citation. The media-suffix test and
  the "is this a repo-relative link?" judgment both go away, and with them the risk of
  flagging `[the logo](docs/static/img/logo.png)`.
- `substitute` keys on the cited string rather than the bare name, which drops the
  code-span branch and the `./` prefix handling.
- The upload step strips any citation under the media directory that resolved to
  nothing, so a typo degrades to prose rather than posting a local path even when
  `--check` was skipped. A symlinked capture degrades the same way.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

A payload citing a typo'd path, a leftover bare filename, an uncited capture and an
inline video reported all four; corrected, the check counted exactly the two references
the upload step went on to embed. With no token the references still degrade to prose,
so a local path never reaches the review. Repo-relative links, external URLs, a path
outside the media directory and a `logo.png` code span all stay silent.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
