### PR TITLE
Describe `analyze-ci` inputs where the model can read them

### DIFF
--- a/.claude/skills/analyze-ci/SKILL.md
+++ b/.claude/skills/analyze-ci/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: analyze-ci
-description: Analyze failed GitHub Action jobs for a pull request.
+description: Analyze failed GitHub Action jobs. Takes one or more GitHub URLs (job, workflow-run, or PR) and summarizes each failure with root cause and log paths.
+when_to_use: When CI is red or a check failed, when the user pastes a GitHub Actions job or run URL, or when asked why a PR's checks are failing.
 argument-hint: "url(s) of failed GitHub Action jobs, workflow runs, or PRs"
 ---
 
@@ -8,17 +9,20 @@ argument-hint: "url(s) of failed GitHub Action jobs, workflow runs, or PRs"
 
 Fetch logs from failed GitHub Action jobs and produce a focused per-job failure summary.
 
+URLs provided: $ARGUMENTS
+
+If no URLs are listed above, ask for a job, run, or PR URL and stop. `fetch-logs` requires at least one and exits 2 without.
+
 ## Prerequisites
 
 - **GitHub Token**: Auto-detected via `gh auth token`, or set `GH_TOKEN`.
-- Single-quote URLs when invoking to keep the shell from interpreting `?` and other special characters in the URL.
 
 ## Steps
 
-1. **Fetch logs.** Run:
+1. **Fetch logs.** Run, single-quoting each URL so the shell does not interpret `?` or other special characters in it:
 
    ```bash
-   uv run --package skills skills fetch-logs $ARGUMENTS
+   uv run --package skills skills fetch-logs '<url>' ['<url>' ...]
    ```
 
    The command prints one block per failed job containing the workflow/job name, URL, failed step, and paths to the cached raw log, failed-step log, and (optional) package versions file.


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`argument-hint` is not part of the skill listing the model reads, so the URL shapes `fetch-logs` accepts (job, workflow-run, or PR) were invisible at selection time while the description claimed pull requests only. That information moves into `description` and `when_to_use`, the fields the listing is actually built from.

`$ARGUMENTS` is also no longer spliced into the command line. URLs render on their own line and step 1 carries a template with individually quoted placeholders, so multiple URLs still word-split for `nargs="+"` while a `?` in a query string no longer trips zsh globbing. A no-argument guard replaces what previously became a bare `fetch-logs` and an argparse exit 2.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release