### PR TITLE
Extract the user-attachments uploader into `skills.github.uploads`

### DIFF
--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -4,97 +4,23 @@
 from __future__ import annotations
 
 import argparse
-import http.client
 import json
 import os
 import re
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
-# Read from the environment, never argv: a PAT in a CLI argument is visible in the
-# process list for the life of the call.
-TOKEN_ENV = "UPLOAD_MEDIA_TOKEN"
-
-# The name's extension must agree with content_type or the endpoint returns 422.
-MIME_TYPES = {
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".mp4": "video/mp4",
-    ".mov": "video/quicktime",
-    ".webm": "video/webm",
-}
-
-VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
-
-
-class TokenRejected(Exception):
-    """Raised on 401: the credential is dead, so every remaining upload would fail too."""
-
-
-MAX_IMAGE_BYTES = 10 * 1024 * 1024
-MAX_VIDEO_BYTES = 100 * 1024 * 1024
-
-
-def is_video(name: str) -> bool:
-    return Path(name).suffix.lower() in VIDEO_SUFFIXES
-
-
-def max_bytes(name: str) -> int:
-    return MAX_VIDEO_BYTES if is_video(name) else MAX_IMAGE_BYTES
-
-
-def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
-    mime = MIME_TYPES.get(path.suffix.lower())
-    if mime is None:
-        print(f"  skip {path.name}: unsupported extension", file=sys.stderr)
-        return None
-
-    size = path.stat().st_size
-    if size > (limit := max_bytes(path.name)):
-        print(f"  skip {path.name}: {size} bytes exceeds {limit}", file=sys.stderr)
-        return None
-
-    query = urllib.parse.urlencode({
-        "name": path.name,
-        "content_type": mime,
-        "repository_id": repository_id,
-    })
-    request = urllib.request.Request(
-        f"{UPLOAD_URL}?{query}",
-        data=path.read_bytes(),
-        method="POST",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=60) as resp:
-            body = json.load(resp)
-    # Must precede OSError: HTTPError is a URLError, which is an OSError.
-    except urllib.error.HTTPError as e:
-        print(f"  failed {path.name}: {e}", file=sys.stderr)
-        if e.code == 401:
-            raise TokenRejected(f"{TOKEN_ENV} was rejected (401); it may have expired") from e
-        return None
-    except (OSError, http.client.HTTPException, ValueError) as e:
-        print(f"  failed {path.name}: {e}", file=sys.stderr)
-        return None
-
-    match body:
-        case {"url": str(url)} if url:
-            print(f"  uploaded {path.name} -> {url}")
-            return url
-        case _:
-            print(f"  failed {path.name}: response carried no url", file=sys.stderr)
-            return None
+from skills.github.uploads import (
+    MIME_TYPES,
+    TOKEN_ENV,
+    TokenRejected,
+    is_video,
+    max_bytes,
+    upload_asset,
+)
 
 
 def link_target(cited: str) -> str:

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -1,0 +1,91 @@
+# ruff: noqa: T201
+"""Upload a file to GitHub's user-attachments store and return the URL it serves from."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
+# Read from the environment, never argv: a PAT in a CLI argument is visible in the
+# process list for the life of the call.
+TOKEN_ENV = "UPLOAD_MEDIA_TOKEN"
+
+# The name's extension must agree with content_type or the endpoint returns 422.
+MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".webm": "video/webm",
+}
+
+VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
+
+
+class TokenRejected(Exception):
+    """Raised on 401: the credential is dead, so every remaining upload would fail too."""
+
+
+MAX_IMAGE_BYTES = 10 * 1024 * 1024
+MAX_VIDEO_BYTES = 100 * 1024 * 1024
+
+
+def is_video(name: str) -> bool:
+    return Path(name).suffix.lower() in VIDEO_SUFFIXES
+
+
+def max_bytes(name: str) -> int:
+    return MAX_VIDEO_BYTES if is_video(name) else MAX_IMAGE_BYTES
+
+
+def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
+    mime = MIME_TYPES.get(path.suffix.lower())
+    if mime is None:
+        print(f"  skip {path.name}: unsupported extension", file=sys.stderr)
+        return None
+
+    size = path.stat().st_size
+    if size > (limit := max_bytes(path.name)):
+        print(f"  skip {path.name}: {size} bytes exceeds {limit}", file=sys.stderr)
+        return None
+
+    query = urllib.parse.urlencode({
+        "name": path.name,
+        "content_type": mime,
+        "repository_id": repository_id,
+    })
+    request = urllib.request.Request(
+        f"{UPLOAD_URL}?{query}",
+        data=path.read_bytes(),
+        method="POST",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as resp:
+            body = json.load(resp)
+    # Must precede OSError: HTTPError is a URLError, which is an OSError.
+    except urllib.error.HTTPError as e:
+        print(f"  failed {path.name}: {e}", file=sys.stderr)
+        if e.code == 401:
+            raise TokenRejected(f"{TOKEN_ENV} was rejected (401); it may have expired") from e
+        return None
+    except (OSError, http.client.HTTPException, ValueError) as e:
+        print(f"  failed {path.name}: {e}", file=sys.stderr)
+        return None
+
+    match body:
+        case {"url": str(url)} if url:
+            print(f"  uploaded {path.name} -> {url}")
+            return url
+        case _:
+            print(f"  failed {path.name}: response carried no url", file=sys.stderr)
+            return None

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -1,8 +1,5 @@
 import argparse
-import http.client
-import io
 import json
-import urllib.error
 from pathlib import Path
 from unittest import mock
 
@@ -10,6 +7,7 @@ import pytest
 from skills.cli import build_parser
 from skills.commands import embed_media
 from skills.commands.embed_media import rewrite_payload, substitute
+from skills.github import uploads
 
 URL = "https://github.com/user-attachments/assets/2f1c0a3e-0000-4000-8000-000000000001"
 MEDIA = "/tmp/review-media"
@@ -131,7 +129,7 @@ def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyP
     target = tmp_path / "review-payload.json"
     target.write_text(json.dumps({"body": f"[the trace]({media / 'shot.png'})", "comments": []}))
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -145,7 +143,7 @@ def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     target = tmp_path / "body.md"
     target.write_text(f"![alt]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -161,7 +159,7 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=None) as uploader:
         args.func(args)
@@ -177,7 +175,7 @@ def test_cli_never_posts_a_local_path_when_the_token_env_is_unset(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.delenv(embed_media.TOKEN_ENV, raising=False)
+    monkeypatch.delenv(uploads.TOKEN_ENV, raising=False)
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -194,7 +192,7 @@ def test_cli_is_a_noop_when_there_is_no_media(
     target = tmp_path / "body.md"
     target.write_text("unchanged")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -212,7 +210,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     target = tmp_path / "body.md"
     target.write_text(f"![the secret]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -220,115 +218,6 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     uploader.assert_not_called()
     # Never uploaded, so the citation resolves to nothing and must not post the path.
     assert target.read_text() == "the secret"
-
-
-def test_upload_asset_builds_the_request_and_returns_the_url(tmp_path: Path) -> None:
-    path = tmp_path / "shot.png"
-    path.write_bytes(b"\x89PNG")
-
-    response = io.BytesIO(json.dumps({"url": URL}).encode())
-    with mock.patch("urllib.request.urlopen", return_value=response) as opener:
-        assert embed_media.upload_asset(path, "136202695", "tok") == URL
-
-    request = opener.call_args.args[0]
-    assert "name=shot.png" in request.full_url
-    assert "content_type=image%2Fpng" in request.full_url
-    assert "repository_id=136202695" in request.full_url
-    assert request.get_header("Authorization") == "Bearer tok"
-    assert request.data == b"\x89PNG"
-
-
-@pytest.mark.parametrize(
-    "outcome",
-    [
-        urllib.error.URLError("boom"),
-        TimeoutError("slow"),
-        # Escapes URLError: urlopen only wraps h.request(), not h.getresponse().
-        http.client.RemoteDisconnected("closed"),
-        http.client.IncompleteRead(b"partial"),
-        json.JSONDecodeError("bad", "", 0),
-    ],
-)
-def test_upload_asset_returns_none_when_the_request_fails(
-    tmp_path: Path, outcome: Exception
-) -> None:
-    path = tmp_path / "shot.png"
-    path.write_bytes(b"\x89PNG")
-
-    with mock.patch("urllib.request.urlopen", side_effect=outcome) as opener:
-        assert embed_media.upload_asset(path, "1", "t") is None
-
-    opener.assert_called_once()
-
-
-def test_upload_asset_returns_none_when_the_response_carries_no_url(tmp_path: Path) -> None:
-    path = tmp_path / "shot.png"
-    path.write_bytes(b"\x89PNG")
-
-    with mock.patch("urllib.request.urlopen", return_value=io.BytesIO(b"{}")) as opener:
-        assert embed_media.upload_asset(path, "1", "t") is None
-
-    opener.assert_called_once()
-
-
-def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
-    path = tmp_path / "notes.txt"
-    path.write_text("x")
-    assert embed_media.upload_asset(path, "1", "t") is None
-
-
-def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
-    path = tmp_path / "big.png"
-    path.write_bytes(b"12345")
-    with mock.patch.object(embed_media, "MAX_IMAGE_BYTES", 4):
-        assert embed_media.upload_asset(path, "1", "t") is None
-
-
-@pytest.mark.parametrize(
-    ("name", "expected"),
-    [
-        ("shot.png", embed_media.MAX_IMAGE_BYTES),
-        ("shot.gif", embed_media.MAX_IMAGE_BYTES),
-        ("clip.mp4", embed_media.MAX_VIDEO_BYTES),
-        ("clip.MOV", embed_media.MAX_VIDEO_BYTES),
-        ("clip.webm", embed_media.MAX_VIDEO_BYTES),
-    ],
-)
-def test_max_bytes_is_larger_for_video(name: str, expected: int) -> None:
-    assert embed_media.max_bytes(name) == expected
-
-
-def test_a_video_between_the_image_and_video_caps_is_not_skipped(tmp_path: Path) -> None:
-    # The old single 10MB cap silently dropped exactly this: a screen recording.
-    path = tmp_path / "clip.mp4"
-    path.write_bytes(b"0" * (embed_media.MAX_IMAGE_BYTES + 1))
-
-    response = io.BytesIO(json.dumps({"url": URL}).encode())
-    with mock.patch("urllib.request.urlopen", return_value=response):
-        assert embed_media.upload_asset(path, "1", "t") == URL
-
-
-def http_error(code: int) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(embed_media.UPLOAD_URL, code, "nope", {}, None)  # type: ignore[arg-type]
-
-
-def test_upload_asset_raises_on_a_rejected_token(tmp_path: Path) -> None:
-    path = tmp_path / "shot.png"
-    path.write_bytes(b"\x89PNG")
-
-    with (
-        mock.patch("urllib.request.urlopen", side_effect=http_error(401)),
-        pytest.raises(embed_media.TokenRejected, match="rejected \\(401\\)"),
-    ):
-        embed_media.upload_asset(path, "1", "t")
-
-
-def test_upload_asset_returns_none_on_other_http_errors(tmp_path: Path) -> None:
-    path = tmp_path / "shot.png"
-    path.write_bytes(b"\x89PNG")
-
-    with mock.patch("urllib.request.urlopen", side_effect=http_error(500)):
-        assert embed_media.upload_asset(path, "1", "t") is None
 
 
 def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
@@ -339,18 +228,18 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(
         embed_media,
         "upload_asset",
-        side_effect=embed_media.TokenRejected("UPLOAD_MEDIA_TOKEN was rejected (401)"),
+        side_effect=uploads.TokenRejected("UPLOAD_MEDIA_TOKEN was rejected (401)"),
     ) as uploader:
         args.func(args)
 
     # One annotation for the run, and the loop stops rather than retrying a dead token.
     out = capsys.readouterr().out
-    assert out.count(f"::warning::{embed_media.TOKEN_ENV} was rejected (401)") == 1
+    assert out.count(f"::warning::{uploads.TOKEN_ENV} was rejected (401)") == 1
     assert uploader.call_count == 1
     assert target.read_text() == "evidence: the bug"
 
@@ -363,7 +252,7 @@ def test_cli_uploads_only_media_the_target_references(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'cited.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -379,7 +268,7 @@ def test_cli_uploads_nothing_when_no_media_is_referenced(
     target = tmp_path / "body.md"
     target.write_text("a prose-only finding")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -398,7 +287,7 @@ def test_cli_uploads_media_referenced_by_an_inline_comment(
         json.dumps({"body": "b", "comments": [{"body": f"see [it]({media / 'cited.png'})"}]})
     )
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -431,7 +320,7 @@ def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(
     target = tmp_path / "body.md"
     target.write_text(f"![x]({media / 'longshot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -506,7 +395,7 @@ def test_check_rejects_a_cited_file_with_an_unsupported_extension(tmp_path: Path
 
 
 def test_check_rejects_a_cited_file_over_the_size_cap(tmp_path: Path) -> None:
-    with mock.patch.object(embed_media, "MAX_IMAGE_BYTES", 2):
+    with mock.patch.object(uploads, "MAX_IMAGE_BYTES", 2):
         report = check(tmp_path, "![the bug]({p})")
     assert len(report.errors) == 1
     assert "exceeds the 2 byte cap" in report.errors[0]
@@ -572,7 +461,7 @@ def test_cli_check_exits_zero_and_uploads_nothing(
     body = f"![the bug]({media / 'shot.png'})"
     target.write_text(body)
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_check_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -614,7 +503,7 @@ def test_cli_strips_a_citation_naming_no_capture(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shto.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -630,7 +519,7 @@ def test_cli_strips_a_typo_while_still_embedding_the_capture_beside_it(
     target = tmp_path / "body.md"
     target.write_text(f"![ok]({media / 'shot.png'}) and ![typo]({media / 'shto.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -648,7 +537,7 @@ def test_cli_strips_a_bare_filename_citation(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({cite})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -665,7 +554,7 @@ def test_cli_leaves_a_link_outside_the_media_directory_alone(
     body = "see [the icon](docs/static/img/shot.png)"
     target.write_text(body)
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -1,0 +1,120 @@
+import http.client
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from skills.github import uploads
+
+URL = "https://github.com/user-attachments/assets/2f1c0a3e-0000-4000-8000-000000000001"
+
+
+def test_upload_asset_builds_the_request_and_returns_the_url(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    response = io.BytesIO(json.dumps({"url": URL}).encode())
+    with mock.patch("urllib.request.urlopen", return_value=response) as opener:
+        assert uploads.upload_asset(path, "136202695", "tok") == URL
+
+    request = opener.call_args.args[0]
+    assert "name=shot.png" in request.full_url
+    assert "content_type=image%2Fpng" in request.full_url
+    assert "repository_id=136202695" in request.full_url
+    assert request.get_header("Authorization") == "Bearer tok"
+    assert request.data == b"\x89PNG"
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        urllib.error.URLError("boom"),
+        TimeoutError("slow"),
+        # Escapes URLError: urlopen only wraps h.request(), not h.getresponse().
+        http.client.RemoteDisconnected("closed"),
+        http.client.IncompleteRead(b"partial"),
+        json.JSONDecodeError("bad", "", 0),
+    ],
+)
+def test_upload_asset_returns_none_when_the_request_fails(
+    tmp_path: Path, outcome: Exception
+) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with mock.patch("urllib.request.urlopen", side_effect=outcome) as opener:
+        assert uploads.upload_asset(path, "1", "t") is None
+
+    opener.assert_called_once()
+
+
+def test_upload_asset_returns_none_when_the_response_carries_no_url(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with mock.patch("urllib.request.urlopen", return_value=io.BytesIO(b"{}")) as opener:
+        assert uploads.upload_asset(path, "1", "t") is None
+
+    opener.assert_called_once()
+
+
+def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    path.write_text("x")
+    assert uploads.upload_asset(path, "1", "t") is None
+
+
+def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
+    path = tmp_path / "big.png"
+    path.write_bytes(b"12345")
+    with mock.patch.object(uploads, "MAX_IMAGE_BYTES", 4):
+        assert uploads.upload_asset(path, "1", "t") is None
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("shot.png", uploads.MAX_IMAGE_BYTES),
+        ("shot.gif", uploads.MAX_IMAGE_BYTES),
+        ("clip.mp4", uploads.MAX_VIDEO_BYTES),
+        ("clip.MOV", uploads.MAX_VIDEO_BYTES),
+        ("clip.webm", uploads.MAX_VIDEO_BYTES),
+    ],
+)
+def test_max_bytes_is_larger_for_video(name: str, expected: int) -> None:
+    assert uploads.max_bytes(name) == expected
+
+
+def test_a_video_between_the_image_and_video_caps_is_not_skipped(tmp_path: Path) -> None:
+    # The old single 10MB cap silently dropped exactly this: a screen recording.
+    path = tmp_path / "clip.mp4"
+    path.write_bytes(b"0" * (uploads.MAX_IMAGE_BYTES + 1))
+
+    response = io.BytesIO(json.dumps({"url": URL}).encode())
+    with mock.patch("urllib.request.urlopen", return_value=response):
+        assert uploads.upload_asset(path, "1", "t") == URL
+
+
+def http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(uploads.UPLOAD_URL, code, "nope", {}, None)  # type: ignore[arg-type]
+
+
+def test_upload_asset_raises_on_a_rejected_token(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(401)),
+        pytest.raises(uploads.TokenRejected, match="rejected \\(401\\)"),
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+
+def test_upload_asset_returns_none_on_other_http_errors(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with mock.patch("urllib.request.urlopen", side_effect=http_error(500)):
+        assert uploads.upload_asset(path, "1", "t") is None


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25159

### What changes are proposed in this pull request?

Moves `upload_asset()` and the endpoint's constants out of the `embed-media` command and into `skills/github/uploads.py`, alongside the other GitHub helpers. Their tests move with them into `tests/test_uploads.py`.

They lived inside a command module, so a second caller would have to import from a sibling command. A follow-up adds a bare `upload-media` command that takes paths and prints URLs; after this move both it and the review flow depend on the module instead of on each other, so the endpoint contract has one home.

Pure move, no behavior change. Test references point at the owning module now, since mypy does not treat re-exports as explicit exports.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release