### PR TITLE
Raise from `upload_asset()` instead of returning `None`

### DIFF
--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -16,7 +16,7 @@ from typing import Any
 from skills.github.uploads import (
     MIME_TYPES,
     TOKEN_ENV,
-    TokenRejected,
+    UploadFailed,
     is_video,
     max_bytes,
     upload_asset,
@@ -257,14 +257,20 @@ def run(args: argparse.Namespace) -> None:
         print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
     elif referenced:
         print(f"Uploading {len(referenced)} referenced file(s) from {args.dir}")
-        try:
-            for path in referenced:
-                if url := upload_asset(path, args.repository_id, token):
-                    urls[str(path)] = url
-        except TokenRejected as e:
-            # The step is continue-on-error, so without an annotation an expired
-            # token would silently stop attaching media on every future review.
-            print(f"::warning::{e}")
+        for path in referenced:
+            try:
+                urls[str(path)] = upload_asset(path, args.repository_id, token)
+            except UploadFailed as e:
+                # A rejected credential fails every remaining upload, so stop rather
+                # than retry. The step is continue-on-error, so without an annotation
+                # an expired token would silently stop attaching media on every
+                # future review.
+                if e.status == 401:
+                    print(f"::warning::{e}")
+                    break
+                print(f"  failed {e}", file=sys.stderr)
+            else:
+                print(f"  uploaded {path.name} -> {urls[str(path)]}")
 
     unavailable = [str(p) for p in referenced if str(p) not in urls] + stray
 

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -1,11 +1,9 @@
-# ruff: noqa: T201
 """Upload a file to GitHub's user-attachments store and return the URL it serves from."""
 
 from __future__ import annotations
 
 import http.client
 import json
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -31,8 +29,16 @@ MIME_TYPES = {
 VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
 
 
-class TokenRejected(Exception):
-    """Raised on 401: the credential is dead, so every remaining upload would fail too."""
+class UploadFailed(Exception):
+    """Raised when one asset does not reach the store; the message says why.
+
+    ``status`` carries the HTTP code when the endpoint answered, so a caller can tell
+    a dead credential (401) from a fault that only affects the file at hand.
+    """
+
+    def __init__(self, message: str, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 MAX_IMAGE_BYTES = 10 * 1024 * 1024
@@ -47,16 +53,14 @@ def max_bytes(name: str) -> int:
     return MAX_VIDEO_BYTES if is_video(name) else MAX_IMAGE_BYTES
 
 
-def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
+def upload_asset(path: Path, repository_id: str, token: str) -> str:
     mime = MIME_TYPES.get(path.suffix.lower())
     if mime is None:
-        print(f"  skip {path.name}: unsupported extension", file=sys.stderr)
-        return None
+        raise UploadFailed(f"{path.name}: unsupported extension")
 
     size = path.stat().st_size
     if size > (limit := max_bytes(path.name)):
-        print(f"  skip {path.name}: {size} bytes exceeds {limit}", file=sys.stderr)
-        return None
+        raise UploadFailed(f"{path.name}: {size} bytes exceeds {limit}")
 
     query = urllib.parse.urlencode({
         "name": path.name,
@@ -74,18 +78,16 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str | None:
             body = json.load(resp)
     # Must precede OSError: HTTPError is a URLError, which is an OSError.
     except urllib.error.HTTPError as e:
-        print(f"  failed {path.name}: {e}", file=sys.stderr)
         if e.code == 401:
-            raise TokenRejected(f"{TOKEN_ENV} was rejected (401); it may have expired") from e
-        return None
+            raise UploadFailed(
+                f"{TOKEN_ENV} was rejected (401); it may have expired", status=401
+            ) from e
+        raise UploadFailed(f"{path.name}: {e}", status=e.code) from e
     except (OSError, http.client.HTTPException, ValueError) as e:
-        print(f"  failed {path.name}: {e}", file=sys.stderr)
-        return None
+        raise UploadFailed(f"{path.name}: {e}") from e
 
     match body:
         case {"url": str(url)} if url:
-            print(f"  uploaded {path.name} -> {url}")
             return url
         case _:
-            print(f"  failed {path.name}: response carried no url", file=sys.stderr)
-            return None
+            raise UploadFailed(f"{path.name}: response carried no url")

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -161,7 +161,9 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
 
     monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
-    with mock.patch.object(embed_media, "upload_asset", return_value=None) as uploader:
+    with mock.patch.object(
+        embed_media, "upload_asset", side_effect=uploads.UploadFailed("shot.png: boom")
+    ) as uploader:
         args.func(args)
 
     uploader.assert_called_once_with(media / "shot.png", "136202695", "t")
@@ -233,7 +235,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     with mock.patch.object(
         embed_media,
         "upload_asset",
-        side_effect=uploads.TokenRejected("UPLOAD_MEDIA_TOKEN was rejected (401)"),
+        side_effect=uploads.UploadFailed("UPLOAD_MEDIA_TOKEN was rejected (401)", status=401),
     ) as uploader:
         args.func(args)
 

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -228,7 +228,10 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     media = make_media(tmp_path)
     (media / "second.png").write_bytes(b"\x89PNG")
     target = tmp_path / "body.md"
-    target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
+    # Both are cited, so a second upload would be attempted if the loop kept going.
+    target.write_text(
+        f"evidence: ![the bug]({media / 'shot.png'}) and ![more]({media / 'second.png'})"
+    )
 
     monkeypatch.setenv(uploads.TOKEN_ENV, "t")
     args = build_args(media, target)
@@ -243,7 +246,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     out = capsys.readouterr().out
     assert out.count(f"::warning::{uploads.TOKEN_ENV} was rejected (401)") == 1
     assert uploader.call_count == 1
-    assert target.read_text() == "evidence: the bug"
+    assert target.read_text() == "evidence: the bug and more"
 
 
 def test_cli_uploads_only_media_the_target_references(

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -38,39 +38,48 @@ def test_upload_asset_builds_the_request_and_returns_the_url(tmp_path: Path) -> 
         json.JSONDecodeError("bad", "", 0),
     ],
 )
-def test_upload_asset_returns_none_when_the_request_fails(
-    tmp_path: Path, outcome: Exception
-) -> None:
+def test_upload_asset_raises_when_the_request_fails(tmp_path: Path, outcome: Exception) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
 
-    with mock.patch("urllib.request.urlopen", side_effect=outcome) as opener:
-        assert uploads.upload_asset(path, "1", "t") is None
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=outcome) as opener,
+        pytest.raises(uploads.UploadFailed, match="shot.png") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    assert excinfo.value.status is None
+    opener.assert_called_once()
+
+
+def test_upload_asset_raises_when_the_response_carries_no_url(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch("urllib.request.urlopen", return_value=io.BytesIO(b"{}")) as opener,
+        pytest.raises(uploads.UploadFailed, match="response carried no url"),
+    ):
+        uploads.upload_asset(path, "1", "t")
 
     opener.assert_called_once()
 
 
-def test_upload_asset_returns_none_when_the_response_carries_no_url(tmp_path: Path) -> None:
-    path = tmp_path / "shot.png"
-    path.write_bytes(b"\x89PNG")
-
-    with mock.patch("urllib.request.urlopen", return_value=io.BytesIO(b"{}")) as opener:
-        assert uploads.upload_asset(path, "1", "t") is None
-
-    opener.assert_called_once()
-
-
-def test_upload_asset_skips_an_unsupported_extension(tmp_path: Path) -> None:
+def test_upload_asset_rejects_an_unsupported_extension(tmp_path: Path) -> None:
     path = tmp_path / "notes.txt"
     path.write_text("x")
-    assert uploads.upload_asset(path, "1", "t") is None
+    with pytest.raises(uploads.UploadFailed, match="unsupported extension"):
+        uploads.upload_asset(path, "1", "t")
 
 
-def test_upload_asset_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
+def test_upload_asset_rejects_a_file_over_the_size_cap(tmp_path: Path) -> None:
     path = tmp_path / "big.png"
     path.write_bytes(b"12345")
-    with mock.patch.object(uploads, "MAX_IMAGE_BYTES", 4):
-        assert uploads.upload_asset(path, "1", "t") is None
+    with (
+        mock.patch.object(uploads, "MAX_IMAGE_BYTES", 4),
+        pytest.raises(uploads.UploadFailed, match="5 bytes exceeds 4"),
+    ):
+        uploads.upload_asset(path, "1", "t")
 
 
 @pytest.mark.parametrize(
@@ -101,20 +110,27 @@ def http_error(code: int) -> urllib.error.HTTPError:
     return urllib.error.HTTPError(uploads.UPLOAD_URL, code, "nope", {}, None)  # type: ignore[arg-type]
 
 
-def test_upload_asset_raises_on_a_rejected_token(tmp_path: Path) -> None:
+def test_upload_asset_flags_a_rejected_token_with_its_status(tmp_path: Path) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
 
     with (
         mock.patch("urllib.request.urlopen", side_effect=http_error(401)),
-        pytest.raises(uploads.TokenRejected, match="rejected \\(401\\)"),
+        pytest.raises(uploads.UploadFailed, match="rejected \\(401\\)") as excinfo,
     ):
         uploads.upload_asset(path, "1", "t")
 
+    assert excinfo.value.status == 401
 
-def test_upload_asset_returns_none_on_other_http_errors(tmp_path: Path) -> None:
+
+def test_upload_asset_carries_the_status_of_other_http_errors(tmp_path: Path) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
 
-    with mock.patch("urllib.request.urlopen", side_effect=http_error(500)):
-        assert uploads.upload_asset(path, "1", "t") is None
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(500)),
+        pytest.raises(uploads.UploadFailed, match="shot.png") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    assert excinfo.value.status == 500


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25160

### What changes are proposed in this pull request?

`upload_asset()` printed its own diagnostics and answered `str | None`, so a caller could neither choose its output format nor say why an upload failed. It now returns the URL or raises `UploadFailed`, and prints nothing. The exception carries `status`, the HTTP code when the endpoint answered, which is how a caller tells a dead credential from a fault affecting only the file at hand.

This matters for the follow-up that adds a bare uploader printing `<path>\t<url>`: with the old contract every upload emitted two lines, one in a format the caller never chose.

`embed-media` keeps its behavior: per-file faults log to stderr and continue, and a 401 emits one `::warning::` annotation and stops rather than retrying a dead token. Two stderr lines do read differently, in a step nothing parses: a rejected file now says `failed` where it said `skip`, and a 401 no longer prints the raw `HTTP Error 401` line ahead of the annotation that names the credential.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
