### PR TITLE
Skip the reverse DNS lookup in the `pypi` test server

### DIFF
--- a/dev/pypi/tests/test_client.py
+++ b/dev/pypi/tests/test_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import socketserver
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -117,7 +118,17 @@ def _serve(body: str, content_type: str, requests: list[str] | None = None) -> I
         def log_message(self, *args: Any) -> None:
             pass
 
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    class Server(ThreadingHTTPServer):
+        def server_bind(self) -> None:
+            # http.server reverse-resolves the bind address here just to set
+            # server_name, which nothing reads and which costs ~35s per run on
+            # macOS CI while the resolver times out.
+            socketserver.TCPServer.server_bind(self)
+            host, port = self.server_address[:2]
+            self.server_name = str(host)
+            self.server_port = int(port)
+
+    server = Server(("127.0.0.1", 0), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:


### PR DESCRIPTION
### Related Issues/PRs

None.

### What changes are proposed in this pull request?

`Test pypi` takes ~36s on macOS and ~2s on Linux, consistently across runs. It is not the suite: the CI log timestamps put 35.5s inside a single test, the first one to stand up the local `ThreadingHTTPServer`, while the next test serves three requests in 0.5s.

```
13:27:49.354  test_get_packages_preserves_order_and_fetches_each PASSED
13:28:24.885  test_fetch_json_accepts_non_json_mimetype PASSED             <- 35.5s
13:28:25.391  test_fetch_json_retries_then_rejects_non_json_body PASSED    <- 0.5s
```

`HTTPServer.server_bind()` calls `socket.getfqdn()` on the bind address purely to set `server_name`, an attribute these tests never read. On the macOS runner that reverse lookup stalls until the resolver gives up; the negative result is then cached, which is why only the first server pays it. This binds through `TCPServer` and sets the attributes directly.

The gain is only visible on the runner, since the lookup is fast locally (6ms here). If the diagnosis is wrong the change is inert rather than harmful, so the CI run on this PR is the test.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release