### PR TITLE
Add an `upload-media` skills command and skill

### DIFF
--- a/.claude/skills/src/skills/cli.py
+++ b/.claude/skills/src/skills/cli.py
@@ -5,6 +5,7 @@ from skills.commands import (
     fetch_diff,
     fetch_logs,
     load_rules,
+    upload_media,
     validate_review,
 )
 
@@ -17,6 +18,7 @@ def build_parser() -> argparse.ArgumentParser:
     fetch_diff.register(subparsers)
     fetch_logs.register(subparsers)
     load_rules.register(subparsers)
+    upload_media.register(subparsers)
     validate_review.register(subparsers)
 
     return parser

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -15,12 +15,15 @@ from typing import Any
 
 from skills.github.uploads import (
     MIME_TYPES,
-    TOKEN_ENV,
     UploadFailed,
     is_video,
     max_bytes,
     upload_asset,
 )
+
+# Read from the environment, never argv: a PAT in a CLI argument is visible in the
+# process list for the life of the call.
+TOKEN_ENV = "UPLOAD_MEDIA_TOKEN"
 
 
 def link_target(cited: str) -> str:
@@ -266,7 +269,7 @@ def run(args: argparse.Namespace) -> None:
                 # an expired token would silently stop attaching media on every
                 # future review.
                 if e.status == 401:
-                    print(f"::warning::{e}")
+                    print(f"::warning::{TOKEN_ENV} was rejected (401); it may have expired")
                     break
                 print(f"  failed {e}", file=sys.stderr)
             else:

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -1,0 +1,65 @@
+# ruff: noqa: T201
+"""Upload media to GitHub's user-attachments store and print the URL for each file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from skills.github.uploads import UploadFailed, upload_asset
+from skills.github.utils import get_github_token
+
+DEFAULT_REPO = "mlflow/mlflow"
+
+
+def resolve_repository_id(repo: str) -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}", "--jq", ".id"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as e:
+        print(f"Could not resolve {repo}: {e}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser(
+        "upload-media",
+        help="Upload images or videos and print their user-attachments URLs",
+    )
+    parser.add_argument("paths", type=Path, nargs="+", help="Media files to upload")
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"Repository the assets are bound to (default: {DEFAULT_REPO})",
+    )
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    token = get_github_token()
+    repository_id = resolve_repository_id(args.repo)
+
+    failed = False
+    for path in args.paths:
+        if not path.is_file():
+            print(f"failed {path}: not a file", file=sys.stderr)
+            failed = True
+            continue
+        try:
+            print(f"{path}\t{upload_asset(path, repository_id, token)}")
+        except UploadFailed as e:
+            print(f"failed {e}", file=sys.stderr)
+            failed = True
+            # A rejected credential fails every remaining upload, so stop asking.
+            if e.status == 401:
+                break
+
+    if failed:
+        sys.exit(1)

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -22,7 +22,12 @@ def resolve_repository_id(repo: str) -> str:
             text=True,
             check=True,
         )
-    except (OSError, subprocess.CalledProcessError) as e:
+    # `gh` writes the actionable part ("Not Found (HTTP 404)", an auth error) to
+    # stderr, which CalledProcessError leaves out of its own message.
+    except subprocess.CalledProcessError as e:
+        print(f"Could not resolve {repo}: {e.stderr.strip() or e}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
         print(f"Could not resolve {repo}: {e}", file=sys.stderr)
         sys.exit(1)
     return result.stdout.strip()
@@ -55,11 +60,13 @@ def run(args: argparse.Namespace) -> None:
         try:
             print(f"{path}\t{upload_asset(path, repository_id, token)}")
         except UploadFailed as e:
-            print(f"failed {e}", file=sys.stderr)
             failed = True
-            # A rejected credential fails every remaining upload, so stop asking.
+            # A rejected credential fails every remaining upload, so stop asking, and
+            # name the credential this command actually resolved.
             if e.status == 401:
+                print(f"failed {path}: {e}; check GH_TOKEN or run `gh auth login`", file=sys.stderr)
                 break
+            print(f"failed {e}", file=sys.stderr)
 
     if failed:
         sys.exit(1)

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -10,9 +10,6 @@ import urllib.request
 from pathlib import Path
 
 UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
-# Read from the environment, never argv: a PAT in a CLI argument is visible in the
-# process list for the life of the call.
-TOKEN_ENV = "UPLOAD_MEDIA_TOKEN"
 
 # The name's extension must agree with content_type or the endpoint returns 422.
 MIME_TYPES = {
@@ -79,9 +76,8 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str:
     # Must precede OSError: HTTPError is a URLError, which is an OSError.
     except urllib.error.HTTPError as e:
         if e.code == 401:
-            raise UploadFailed(
-                f"{TOKEN_ENV} was rejected (401); it may have expired", status=401
-            ) from e
+            # Callers resolve credentials differently, so name none of them here.
+            raise UploadFailed("the credential was rejected (401)", status=401) from e
         raise UploadFailed(f"{path.name}: {e}", status=e.code) from e
     except (OSError, http.client.HTTPException, ValueError) as e:
         raise UploadFailed(f"{path.name}: {e}") from e

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -129,7 +129,7 @@ def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyP
     target = tmp_path / "review-payload.json"
     target.write_text(json.dumps({"body": f"[the trace]({media / 'shot.png'})", "comments": []}))
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -143,7 +143,7 @@ def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     target = tmp_path / "body.md"
     target.write_text(f"![alt]({media / 'shot.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -159,7 +159,7 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(
         embed_media, "upload_asset", side_effect=uploads.UploadFailed("shot.png: boom")
@@ -177,7 +177,7 @@ def test_cli_never_posts_a_local_path_when_the_token_env_is_unset(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.delenv(uploads.TOKEN_ENV, raising=False)
+    monkeypatch.delenv(embed_media.TOKEN_ENV, raising=False)
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -194,7 +194,7 @@ def test_cli_is_a_noop_when_there_is_no_media(
     target = tmp_path / "body.md"
     target.write_text("unchanged")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -212,7 +212,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     target = tmp_path / "body.md"
     target.write_text(f"![the secret]({media / 'shot.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -233,7 +233,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
         f"evidence: ![the bug]({media / 'shot.png'}) and ![more]({media / 'second.png'})"
     )
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(
         embed_media,
@@ -244,7 +244,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
 
     # One annotation for the run, and the loop stops rather than retrying a dead token.
     out = capsys.readouterr().out
-    assert out.count(f"::warning::{uploads.TOKEN_ENV} was rejected (401)") == 1
+    assert out.count(f"::warning::{embed_media.TOKEN_ENV} was rejected (401)") == 1
     assert uploader.call_count == 1
     assert target.read_text() == "evidence: the bug and more"
 
@@ -257,7 +257,7 @@ def test_cli_uploads_only_media_the_target_references(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'cited.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -273,7 +273,7 @@ def test_cli_uploads_nothing_when_no_media_is_referenced(
     target = tmp_path / "body.md"
     target.write_text("a prose-only finding")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -292,7 +292,7 @@ def test_cli_uploads_media_referenced_by_an_inline_comment(
         json.dumps({"body": "b", "comments": [{"body": f"see [it]({media / 'cited.png'})"}]})
     )
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -325,7 +325,7 @@ def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(
     target = tmp_path / "body.md"
     target.write_text(f"![x]({media / 'longshot.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -466,7 +466,7 @@ def test_cli_check_exits_zero_and_uploads_nothing(
     body = f"![the bug]({media / 'shot.png'})"
     target.write_text(body)
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_check_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -508,7 +508,7 @@ def test_cli_strips_a_citation_naming_no_capture(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shto.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -524,7 +524,7 @@ def test_cli_strips_a_typo_while_still_embedding_the_capture_beside_it(
     target = tmp_path / "body.md"
     target.write_text(f"![ok]({media / 'shot.png'}) and ![typo]({media / 'shto.png'})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -542,7 +542,7 @@ def test_cli_strips_a_bare_filename_citation(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({cite})")
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -559,7 +559,7 @@ def test_cli_leaves_a_link_outside_the_media_directory_alone(
     body = "see [the icon](docs/static/img/shot.png)"
     target.write_text(body)
 
-    monkeypatch.setenv(uploads.TOKEN_ENV, "t")
+    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -1,0 +1,152 @@
+import argparse
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from skills.cli import build_parser
+from skills.commands import upload_media
+from skills.github.uploads import UploadFailed
+
+URL = "https://github.com/user-attachments/assets/2f1c0a3e-0000-4000-8000-000000000001"
+REPO_ID = "136202695"
+
+
+def build_args(*argv: str) -> argparse.Namespace:
+    return build_parser().parse_args(["upload-media", *argv])
+
+
+@pytest.fixture
+def shot(tmp_path: Path) -> Path:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+    return path
+
+
+@pytest.fixture
+def credentials() -> Iterator[None]:
+    # The command's own asserts pin REPO_ID and "t" through to upload_asset.
+    with (
+        mock.patch.object(upload_media, "get_github_token", return_value="t"),
+        mock.patch.object(upload_media, "resolve_repository_id", return_value=REPO_ID),
+    ):
+        yield
+
+
+def test_prints_a_url_for_each_file(
+    tmp_path: Path, shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"\x00")
+    args = build_args(str(shot), str(clip))
+
+    with mock.patch.object(upload_media, "upload_asset", return_value=URL) as uploader:
+        args.func(args)
+
+    assert uploader.call_args_list == [
+        mock.call(shot, REPO_ID, "t"),
+        mock.call(clip, REPO_ID, "t"),
+    ]
+    assert capsys.readouterr().out == f"{shot}\t{URL}\n{clip}\t{URL}\n"
+
+
+def test_reports_a_failure_and_exits_nonzero(
+    shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = build_args(str(shot))
+
+    with (
+        mock.patch.object(
+            upload_media, "upload_asset", side_effect=UploadFailed("shot.png: boom")
+        ) as uploader,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        args.func(args)
+
+    uploader.assert_called_once_with(shot, REPO_ID, "t")
+
+    assert "failed shot.png: boom" in capsys.readouterr().err
+
+
+def test_a_failed_file_does_not_stop_the_rest(
+    tmp_path: Path, shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    notes = tmp_path / "notes.txt"
+    notes.write_text("x")
+    args = build_args(str(notes), str(shot))
+
+    outcomes = [UploadFailed("notes.txt: unsupported extension"), URL]
+    with (
+        mock.patch.object(upload_media, "upload_asset", side_effect=outcomes) as uploader,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        args.func(args)
+
+    assert uploader.call_count == 2
+    assert capsys.readouterr().out == f"{shot}\t{URL}\n"
+
+
+def test_a_rejected_credential_stops_the_remaining_uploads(
+    tmp_path: Path, shot: Path, credentials: None
+) -> None:
+    second = tmp_path / "second.png"
+    second.write_bytes(b"\x89PNG")
+    args = build_args(str(shot), str(second))
+
+    with (
+        mock.patch.object(
+            upload_media,
+            "upload_asset",
+            side_effect=UploadFailed("token was rejected (401)", status=401),
+        ) as uploader,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        args.func(args)
+
+    uploader.assert_called_once_with(shot, REPO_ID, "t")
+
+
+def test_a_missing_path_is_reported_without_uploading(
+    tmp_path: Path, credentials: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = build_args(str(tmp_path / "gone.png"), str(tmp_path))
+
+    with (
+        mock.patch.object(upload_media, "upload_asset") as uploader,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert capsys.readouterr().err.count("not a file") == 2
+
+
+def test_repo_defaults_to_mlflow_and_is_overridable(shot: Path) -> None:
+    assert build_args(str(shot)).repo == "mlflow/mlflow"
+    assert build_args(str(shot), "--repo", "harupy/mlflow").repo == "harupy/mlflow"
+
+
+def test_resolve_repository_id_returns_the_id() -> None:
+    completed = subprocess.CompletedProcess([], 0, stdout=f"{REPO_ID}\n", stderr="")
+    with mock.patch("subprocess.run", return_value=completed) as run:
+        assert upload_media.resolve_repository_id("mlflow/mlflow") == REPO_ID
+
+    assert run.call_args.args[0] == ["gh", "api", "repos/mlflow/mlflow", "--jq", ".id"]
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        subprocess.CalledProcessError(1, "gh"),
+        FileNotFoundError("gh"),
+    ],
+)
+def test_resolve_repository_id_exits_when_gh_fails(outcome: Exception) -> None:
+    with (
+        mock.patch("subprocess.run", side_effect=outcome) as run,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        upload_media.resolve_repository_id("mlflow/mlflow")
+
+    run.assert_called_once()

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -88,7 +88,7 @@ def test_a_failed_file_does_not_stop_the_rest(
 
 
 def test_a_rejected_credential_stops_the_remaining_uploads(
-    tmp_path: Path, shot: Path, credentials: None
+    tmp_path: Path, shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
 ) -> None:
     second = tmp_path / "second.png"
     second.write_bytes(b"\x89PNG")
@@ -98,13 +98,17 @@ def test_a_rejected_credential_stops_the_remaining_uploads(
         mock.patch.object(
             upload_media,
             "upload_asset",
-            side_effect=UploadFailed("token was rejected (401)", status=401),
+            side_effect=UploadFailed("the credential was rejected (401)", status=401),
         ) as uploader,
         pytest.raises(SystemExit, match="^1$"),
     ):
         args.func(args)
 
     uploader.assert_called_once_with(shot, REPO_ID, "t")
+    # The credential this command resolves, not the one CI carries.
+    err = capsys.readouterr().err
+    assert "check GH_TOKEN or run `gh auth login`" in err
+    assert "UPLOAD_MEDIA_TOKEN" not in err
 
 
 def test_a_missing_path_is_reported_without_uploading(
@@ -135,10 +139,23 @@ def test_resolve_repository_id_returns_the_id() -> None:
     assert run.call_args.args[0] == ["gh", "api", "repos/mlflow/mlflow", "--jq", ".id"]
 
 
+def test_resolve_repository_id_surfaces_the_gh_error(capsys: pytest.CaptureFixture[str]) -> None:
+    failure = subprocess.CalledProcessError(1, "gh", stderr="gh: Not Found (HTTP 404)\n")
+    with (
+        mock.patch("subprocess.run", side_effect=failure) as run,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        upload_media.resolve_repository_id("mlflow/nope")
+
+    run.assert_called_once()
+    # Without this the user only sees "returned non-zero exit status 1".
+    assert "gh: Not Found (HTTP 404)" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     "outcome",
     [
-        subprocess.CalledProcessError(1, "gh"),
+        subprocess.CalledProcessError(1, "gh", stderr=""),
         FileNotFoundError("gh"),
     ],
 )

--- a/.claude/skills/upload-media/SKILL.md
+++ b/.claude/skills/upload-media/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upload-media
-description: Upload one or more local images or videos to GitHub and get back a `user-attachments` URL for each, to embed in a PR body, issue, or comment. Use when asked to attach screenshots or screen recordings without driving the browser UI.
+description: Upload one or more local images or videos to GitHub and get back a `user-attachments` URL for each, to embed in a PR body, issue, or comment. Use when asked to attach screenshots or screen recordings.
 argument-hint: "path(s) to the image or video to upload"
 ---
 

--- a/.claude/skills/upload-media/SKILL.md
+++ b/.claude/skills/upload-media/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: upload-media
+description: Upload one or more local images or videos to GitHub and get back a `user-attachments` URL for each, to embed in a PR body, issue, or comment. Use when asked to attach screenshots or screen recordings without driving the browser UI.
+argument-hint: "path(s) to the image or video to upload"
+---
+
+# Upload media
+
+Files: $ARGUMENTS (when empty, the paths named in the request).
+
+```bash
+uv run --package skills skills upload-media <path>...  # prints "<path>\t<url>" per file
+```
+
+Embed an image as `![alt](url)`. Embed a video as the bare URL in its own paragraph, blank line above and below; anything else renders as a link rather than a player.
+
+No GitHub documentation covers this endpoint, so it can stop working without notice. Source: <https://x.com/steipete/status/2088486859244741020>.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25161

### What changes are proposed in this pull request?

Adds `skills upload-media <path>...`, which uploads each file to GitHub's user-attachments store and prints `<path>\t<url>`, plus an `upload-media` skill that calls it.

`embed-media` publishes only what a review payload cites and rewrites that payload, so there was no way to ask for the URL of a file at hand: attaching a screenshot or screen recording to a PR body meant driving the browser. The command reuses `upload_asset()` and `get_github_token()`, so nothing about the endpoint is reimplemented, and it exits non-zero if any file fails while still printing the URLs of the ones that succeeded. A 401 stops the run rather than retrying a dead credential.

Verified against the live endpoint: a `.png` returned a `user-attachments` URL, and a `.txt` was reported as an unsupported extension with exit 1.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release