### PR TITLE
Share the `GH_TOKEN` lookup between `embed-media` and `upload-media`

### DIFF
--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -23,7 +23,7 @@ from skills.github.uploads import (
 
 # Read from the environment, never argv: a PAT in a CLI argument is visible in the
 # process list for the life of the call.
-TOKEN_ENV = "UPLOAD_MEDIA_TOKEN"
+TOKEN_ENV = "GH_TOKEN"
 
 
 def link_target(cited: str) -> str:
@@ -64,7 +64,7 @@ def collect_files(directory: Path) -> tuple[list[Path], list[str]]:
     """Return the uploadable files, and the names rejected for being symlinks.
 
     ``is_file()`` follows symlinks, so a link planted here (say secret.png ->
-    /proc/self/environ) would publish this process's own UPLOAD_MEDIA_TOKEN as an
+    /proc/self/environ) would publish this process's own GH_TOKEN as an
     attachment. Claude writes this directory, and a poisoned diff steers Claude.
     """
     files: list[Path] = []

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 from collections.abc import Iterable, Iterator
@@ -20,10 +19,7 @@ from skills.github.uploads import (
     max_bytes,
     upload_asset,
 )
-
-# Read from the environment, never argv: a PAT in a CLI argument is visible in the
-# process list for the life of the call.
-TOKEN_ENV = "GH_TOKEN"
+from skills.github.utils import resolve_github_token
 
 
 def link_target(cited: str) -> str:
@@ -253,11 +249,11 @@ def run(args: argparse.Namespace) -> None:
         print(f"No media referenced by {args.target}")
         return
 
-    # A missing secret must still reach the rewrite below, or every reference ships
+    # A missing credential must still reach the rewrite below, or every reference ships
     # verbatim and posts a local path.
     urls = {}
-    if not (token := os.environ.get(TOKEN_ENV)):
-        print(f"{TOKEN_ENV} is unset; not uploading", file=sys.stderr)
+    if not (token := resolve_github_token()):
+        print("no GitHub token; not uploading", file=sys.stderr)
     elif referenced:
         print(f"Uploading {len(referenced)} referenced file(s) from {args.dir}")
         for path in referenced:
@@ -269,7 +265,7 @@ def run(args: argparse.Namespace) -> None:
                 # an expired token would silently stop attaching media on every
                 # future review.
                 if e.status == 401:
-                    print(f"::warning::{TOKEN_ENV} was rejected (401); it may have expired")
+                    print("::warning::the GitHub token was rejected (401); it may have expired")
                     break
                 print(f"  failed {e}", file=sys.stderr)
             else:

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -252,7 +252,8 @@ def run(args: argparse.Namespace) -> None:
     # A missing credential must still reach the rewrite below, or every reference ships
     # verbatim and posts a local path.
     urls = {}
-    if not (token := resolve_github_token()):
+    token = resolve_github_token()
+    if not token:
         print("no GitHub token; not uploading", file=sys.stderr)
     elif referenced:
         print(f"Uploading {len(referenced)} referenced file(s) from {args.dir}")

--- a/.claude/skills/src/skills/github/utils.py
+++ b/.claude/skills/src/skills/github/utils.py
@@ -6,11 +6,6 @@ import sys
 
 
 def resolve_github_token() -> str | None:
-    """Return a token, or None for callers that must keep going without one.
-
-    Read from the environment, never argv: a PAT in a CLI argument is visible in the
-    process list for the life of the call.
-    """
     if token := os.environ.get("GH_TOKEN"):
         return token
     try:

--- a/.claude/skills/src/skills/github/utils.py
+++ b/.claude/skills/src/skills/github/utils.py
@@ -5,14 +5,25 @@ import subprocess
 import sys
 
 
-def get_github_token() -> str:
+def resolve_github_token() -> str | None:
+    """Return a token, or None for callers that must keep going without one.
+
+    Read from the environment, never argv: a PAT in a CLI argument is visible in the
+    process list for the life of the call.
+    """
     if token := os.environ.get("GH_TOKEN"):
         return token
     try:
         return subprocess.check_output(["gh", "auth", "token"], text=True).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
-        print("Error: GH_TOKEN not found (set env var or install gh CLI)", file=sys.stderr)
-        sys.exit(1)
+        return None
+
+
+def get_github_token() -> str:
+    if token := resolve_github_token():
+        return token
+    print("Error: GH_TOKEN not found (set env var or install gh CLI)", file=sys.stderr)
+    sys.exit(1)
 
 
 def parse_pr_url(url: str) -> tuple[str, str, int]:

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -207,7 +207,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     media = tmp_path / "media"
     media.mkdir()
     secret = tmp_path / "environ"
-    secret.write_text("UPLOAD_MEDIA_TOKEN=supersecret")
+    secret.write_text("GH_TOKEN=supersecret")
     (media / "shot.png").symlink_to(secret)
     target = tmp_path / "body.md"
     target.write_text(f"![the secret]({media / 'shot.png'})")
@@ -238,7 +238,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
     with mock.patch.object(
         embed_media,
         "upload_asset",
-        side_effect=uploads.UploadFailed("UPLOAD_MEDIA_TOKEN was rejected (401)", status=401),
+        side_effect=uploads.UploadFailed("the credential was rejected (401)", status=401),
     ) as uploader:
         args.func(args)
 
@@ -422,7 +422,7 @@ def test_check_accepts_a_video_on_its_own_line(tmp_path: Path) -> None:
 def test_check_warns_about_a_symlink(tmp_path: Path) -> None:
     media = tmp_path / "media"
     media.mkdir()
-    (tmp_path / "environ").write_text("UPLOAD_MEDIA_TOKEN=supersecret")
+    (tmp_path / "environ").write_text("GH_TOKEN=supersecret")
     (media / "shot.png").symlink_to(tmp_path / "environ")
 
     report = embed_media.check_media(media, ["a prose-only finding"])

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -129,7 +129,7 @@ def test_cli_rewrites_a_json_payload(tmp_path: Path, monkeypatch: pytest.MonkeyP
     target = tmp_path / "review-payload.json"
     target.write_text(json.dumps({"body": f"[the trace]({media / 'shot.png'})", "comments": []}))
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -143,7 +143,7 @@ def test_cli_rewrites_markdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     target = tmp_path / "body.md"
     target.write_text(f"![alt]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -159,7 +159,7 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(
         embed_media, "upload_asset", side_effect=uploads.UploadFailed("shot.png: boom")
@@ -170,18 +170,19 @@ def test_cli_degrades_to_prose_when_every_upload_fails(
     assert target.read_text() == "evidence: the bug"
 
 
-def test_cli_never_posts_a_local_path_when_the_token_env_is_unset(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cli_never_posts_a_local_path_when_no_token_resolves(tmp_path: Path) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shot.png'})")
 
-    monkeypatch.delenv(embed_media.TOKEN_ENV, raising=False)
     args = build_args(media, target)
-    with mock.patch.object(embed_media, "upload_asset") as uploader:
+    with (
+        mock.patch.object(embed_media, "resolve_github_token", return_value=None) as resolver,
+        mock.patch.object(embed_media, "upload_asset") as uploader,
+    ):
         args.func(args)
 
+    resolver.assert_called_once()
     uploader.assert_not_called()
     assert target.read_text() == "evidence: the bug"
 
@@ -194,7 +195,7 @@ def test_cli_is_a_noop_when_there_is_no_media(
     target = tmp_path / "body.md"
     target.write_text("unchanged")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -212,7 +213,7 @@ def test_cli_never_reads_a_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     target = tmp_path / "body.md"
     target.write_text(f"![the secret]({media / 'shot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -233,7 +234,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
         f"evidence: ![the bug]({media / 'shot.png'}) and ![more]({media / 'second.png'})"
     )
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(
         embed_media,
@@ -244,7 +245,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
 
     # One annotation for the run, and the loop stops rather than retrying a dead token.
     out = capsys.readouterr().out
-    assert out.count(f"::warning::{embed_media.TOKEN_ENV} was rejected (401)") == 1
+    assert out.count("::warning::the GitHub token was rejected (401)") == 1
     assert uploader.call_count == 1
     assert target.read_text() == "evidence: the bug and more"
 
@@ -257,7 +258,7 @@ def test_cli_uploads_only_media_the_target_references(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'cited.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -273,7 +274,7 @@ def test_cli_uploads_nothing_when_no_media_is_referenced(
     target = tmp_path / "body.md"
     target.write_text("a prose-only finding")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -292,7 +293,7 @@ def test_cli_uploads_media_referenced_by_an_inline_comment(
         json.dumps({"body": "b", "comments": [{"body": f"see [it]({media / 'cited.png'})"}]})
     )
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -325,7 +326,7 @@ def test_cli_does_not_upload_a_name_that_is_a_suffix_of_a_cited_one(
     target = tmp_path / "body.md"
     target.write_text(f"![x]({media / 'longshot.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -466,7 +467,7 @@ def test_cli_check_exits_zero_and_uploads_nothing(
     body = f"![the bug]({media / 'shot.png'})"
     target.write_text(body)
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_check_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -508,7 +509,7 @@ def test_cli_strips_a_citation_naming_no_capture(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({media / 'shto.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -524,7 +525,7 @@ def test_cli_strips_a_typo_while_still_embedding_the_capture_beside_it(
     target = tmp_path / "body.md"
     target.write_text(f"![ok]({media / 'shot.png'}) and ![typo]({media / 'shto.png'})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset", return_value=URL) as uploader:
         args.func(args)
@@ -542,7 +543,7 @@ def test_cli_strips_a_bare_filename_citation(
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({cite})")
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)
@@ -559,7 +560,7 @@ def test_cli_leaves_a_link_outside_the_media_directory_alone(
     body = "see [the icon](docs/static/img/shot.png)"
     target.write_text(body)
 
-    monkeypatch.setenv(embed_media.TOKEN_ENV, "t")
+    monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
     with mock.patch.object(embed_media, "upload_asset") as uploader:
         args.func(args)

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -105,10 +105,8 @@ def test_a_rejected_credential_stops_the_remaining_uploads(
         args.func(args)
 
     uploader.assert_called_once_with(shot, REPO_ID, "t")
-    # The credential this command resolves, not the one CI carries.
     err = capsys.readouterr().err
     assert "check GH_TOKEN or run `gh auth login`" in err
-    assert "UPLOAD_MEDIA_TOKEN" not in err
 
 
 def test_a_missing_path_is_reported_without_uploading(

--- a/.claude/skills/tests/test_utils.py
+++ b/.claude/skills/tests/test_utils.py
@@ -1,0 +1,50 @@
+import subprocess
+from unittest import mock
+
+import pytest
+from skills.github import utils
+
+
+def test_resolve_prefers_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "from-env")
+
+    with mock.patch("skills.github.utils.subprocess.check_output") as gh:
+        assert utils.resolve_github_token() == "from-env"
+
+    gh.assert_not_called()
+
+
+def test_resolve_falls_back_to_the_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with mock.patch("skills.github.utils.subprocess.check_output", return_value="from-gh\n") as gh:
+        assert utils.resolve_github_token() == "from-gh"
+
+    gh.assert_called_once_with(["gh", "auth", "token"], text=True)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [FileNotFoundError(), subprocess.CalledProcessError(1, "gh")],
+    ids=["gh-not-installed", "gh-not-logged-in"],
+)
+def test_resolve_returns_none_when_the_gh_cli_cannot_answer(
+    monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with mock.patch("skills.github.utils.subprocess.check_output", side_effect=error) as gh:
+        assert utils.resolve_github_token() is None
+
+    gh.assert_called_once()
+
+
+def test_get_github_token_exits_when_nothing_resolves(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        mock.patch.object(utils, "resolve_github_token", return_value=None) as resolver,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        utils.get_github_token()
+
+    resolver.assert_called_once()
+    assert "GH_TOKEN not found" in capsys.readouterr().err

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -256,7 +256,7 @@ jobs:
         # fault here must not take the job down before Post review.
         continue-on-error: true
         env:
-          UPLOAD_MEDIA_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
+          GH_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}
         run: |
           uv run --frozen --package skills skills embed-media \


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25163

### What changes are proposed in this pull request?

`embed-media` read `UPLOAD_MEDIA_TOKEN` while `upload-media` read `GH_TOKEN`, so the two commands disagreed on how to find the same kind of token. Both now go through one helper.

- `resolve_github_token()` returns `None` when nothing resolves, and `get_github_token()` stays the exiting wrapper. `embed-media` needs the non-exiting form: the rewrite below its upload loop is what strips citations to media that never uploaded, so exiting there would post a local path.
- The review workflow hands the secret to the step as `GH_TOKEN`. The GitHub secret keeps the name `UPLOAD_MEDIA_TOKEN`.
- `embed-media` picks up the `gh auth token` fallback as a side effect, so local runs work without exporting anything.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Ran `skills embed-media` against the real `uploads.github.com` endpoint to confirm both degradation paths still rewrite the payload rather than posting a local path:

```
# no GH_TOKEN and no gh on PATH
no GitHub token; not uploading
body -> "evidence: the bug"

# GH_TOKEN set to an invalid value (real 401 from GitHub)
::warning::the GitHub token was rejected (401); it may have expired
body -> "evidence: the bug"
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release