### PR TITLE
Prevent oversized UI state from breaking local storage

### DIFF
--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
@@ -93,6 +93,28 @@ test('Non-quota storage errors are re-thrown', () => {
   expect(() => setStorageItem(storage, 'chartUIState', 'new state')).toThrow('Access denied.');
 });
 
+test('Firefox quota errors are ignored', () => {
+  const storage = {
+    setItem: () => {
+      throw new DOMException('The quota has been exceeded.', 'NS_ERROR_DOM_QUOTA_REACHED');
+    },
+  } as unknown as Storage;
+
+  expect(() => setStorageItem(storage, 'chartUIState', 'new state')).not.toThrow();
+});
+
+test('Legacy Firefox quota error codes are ignored', () => {
+  const quotaError = new DOMException('The quota has been exceeded.', 'UnknownError');
+  Object.defineProperty(quotaError, 'code', { value: 1014 });
+  const storage = {
+    setItem: () => {
+      throw quotaError;
+    },
+  } as unknown as Storage;
+
+  expect(() => setStorageItem(storage, 'chartUIState', 'new state')).not.toThrow();
+});
+
 test('Quota exhaustion preserves the last cached state without crashing', () => {
   const store = LocalStorageUtils.getStoreForComponent('QuotaTest', 1);
   store.setItem('chartUIState', 'stale state');

--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.test.ts
@@ -1,6 +1,10 @@
-import { test, expect, jest } from '@jest/globals';
-import LocalStorageUtils from './LocalStorageUtils';
+import { afterEach, test, expect, jest } from '@jest/globals';
+import LocalStorageUtils, { setStorageItem } from './LocalStorageUtils';
 import { ExperimentPagePersistedState } from '../../experiment-tracking/sdk/MlflowLocalStorageMessages';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 test('Setting key-value pairs in one scope does not affect the other', () => {
   const store0 = LocalStorageUtils.getStoreForComponent('SomeTestComponent', 1);
@@ -59,4 +63,43 @@ test('Session scoped storage works', () => {
     expect(store.loadComponentState().searchInput).toEqual('params.ollKorrect');
     expect(otherStore.loadComponentState().searchInput).toEqual('metrics.ok');
   });
+});
+
+test('Oversized cached state is discarded before loading', () => {
+  const store = LocalStorageUtils.getStoreForComponent('OversizedStateTest', 1);
+  const storageKey = store.withScopePrefix('chartUIState');
+  window.localStorage.setItem(storageKey, 'x'.repeat(1_000_001));
+
+  expect(store.getItem('chartUIState')).toBeNull();
+  expect(window.localStorage.getItem(storageKey)).toBeNull();
+});
+
+test('Oversized writes preserve the last cached state', () => {
+  const store = LocalStorageUtils.getStoreForComponent('OversizedWriteTest', 1);
+  store.setItem('chartUIState', 'stale state');
+
+  store.setItem('chartUIState', 'x'.repeat(1_000_001));
+
+  expect(store.getItem('chartUIState')).toBe('stale state');
+});
+
+test('Non-quota storage errors are re-thrown', () => {
+  const storage = {
+    setItem: () => {
+      throw new DOMException('Access denied.', 'SecurityError');
+    },
+  } as unknown as Storage;
+
+  expect(() => setStorageItem(storage, 'chartUIState', 'new state')).toThrow('Access denied.');
+});
+
+test('Quota exhaustion preserves the last cached state without crashing', () => {
+  const store = LocalStorageUtils.getStoreForComponent('QuotaTest', 1);
+  store.setItem('chartUIState', 'stale state');
+  jest.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+    throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+  });
+
+  expect(() => store.setItem('chartUIState', 'new state')).not.toThrow();
+  expect(store.getItem('chartUIState')).toBe('stale state');
 });

--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.ts
@@ -12,7 +12,11 @@
 const MAX_STORAGE_ITEM_SIZE = 1_000_000;
 
 const isQuotaExceededError = (error: unknown) =>
-  error instanceof DOMException && (error.name === 'QuotaExceededError' || error.code === 22);
+  error instanceof DOMException &&
+  (error.name === 'QuotaExceededError' ||
+    error.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    error.code === 22 ||
+    error.code === 1014);
 
 export const getStorageItem = (storage: Storage, key: string) => {
   const value = storage.getItem(key);

--- a/mlflow/server/js/src/common/utils/LocalStorageUtils.ts
+++ b/mlflow/server/js/src/common/utils/LocalStorageUtils.ts
@@ -8,6 +8,35 @@
 /**
  * Utils for working with local storage.
  */
+// Keep one UI-state entry from consuming most common 5 MiB per-origin quotas.
+const MAX_STORAGE_ITEM_SIZE = 1_000_000;
+
+const isQuotaExceededError = (error: unknown) =>
+  error instanceof DOMException && (error.name === 'QuotaExceededError' || error.code === 22);
+
+export const getStorageItem = (storage: Storage, key: string) => {
+  const value = storage.getItem(key);
+  if (value !== null && value.length > MAX_STORAGE_ITEM_SIZE) {
+    storage.removeItem(key);
+    return null;
+  }
+  return value;
+};
+
+export const setStorageItem = (storage: Storage, key: string, value: string) => {
+  if (value.length > MAX_STORAGE_ITEM_SIZE) {
+    return;
+  }
+
+  try {
+    storage.setItem(key, value);
+  } catch (error) {
+    if (!isQuotaExceededError(error)) {
+      throw error;
+    }
+  }
+};
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class -- TODO(FEINF-4274)
 export default class LocalStorageUtils {
   /**
@@ -79,11 +108,11 @@ class LocalStorageStore {
 
   /** Save the specified key-value pair in local storage. */
   setItem(key: any, value: any) {
-    this.storageObj.setItem(this.withScopePrefix(key), value);
+    setStorageItem(this.storageObj, this.withScopePrefix(key), value);
   }
 
   /** Fetch the value corresponding to the passed-in key from local storage. */
-  getItem(key: any) {
-    return this.storageObj.getItem(this.withScopePrefix(key));
+  getItem(key: any): any {
+    return getStorageItem(this.storageObj, this.withScopePrefix(key));
   }
 }

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.tsx
@@ -9,6 +9,7 @@ import type {
 import { RunsChartType } from '../../runs-charts/runs-charts.types';
 import { isEmpty, uniq } from 'lodash';
 import type { RunsChartsUIConfigurationSetter } from '../../runs-charts/hooks/useRunsChartsUIConfiguration';
+import { getStorageItem, setStorageItem } from '../../../../common/utils/LocalStorageUtils';
 
 type UpdateChartStateAction = { type: 'UPDATE'; stateSetter: RunsChartsUIConfigurationSetter };
 type InitializeChartStateAction = { type: 'INITIALIZE'; initialConfig?: LoggedModelsChartsUIConfiguration };
@@ -137,8 +138,7 @@ const chartsUIStateReducer = (state: LoggedModelsChartsUIConfiguration, action: 
 
 const loadPersistedDataFromStorage = async (storeIdentifier: string) => {
   // This function is async on purpose to accommodate potential asynchoronous storage mechanisms (e.g. IndexedDB) in the future
-  // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-  const serializedData = localStorage.getItem(createLocalStorageKey(storeIdentifier));
+  const serializedData = getStorageItem(localStorage, createLocalStorageKey(storeIdentifier));
   if (!serializedData) {
     return undefined;
   }
@@ -150,8 +150,7 @@ const loadPersistedDataFromStorage = async (storeIdentifier: string) => {
 };
 
 const saveDataToStorage = async (storeIdentifier: string, dataToPersist: LoggedModelsChartsUIConfiguration) => {
-  // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-  localStorage.setItem(createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
+  setStorageItem(localStorage, createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
 };
 
 export const useExperimentLoggedModelsChartsUIState = (

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentRunColor.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentRunColor.tsx
@@ -8,14 +8,14 @@ import {
   RUN_COLOR_ACTION_INITIALIZE_RUN_COLORS,
   RUN_COLOR_ACTION_SET_RUN_COLOR,
 } from '../../../reducers/RunColorReducer';
+import { getStorageItem, setStorageItem } from '../../../../common/utils/LocalStorageUtils';
 
 const STORAGE_KEY = 'experimentRunColors';
 
 export type SaveExperimentRunColorFn = (args: { runUuid?: string; groupUuid?: string; colorValue: string }) => void;
 
 const loadSavedColors = () => {
-  // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-  const savedColorsRaw = window.localStorage.getItem(STORAGE_KEY);
+  const savedColorsRaw = getStorageItem(window.localStorage, STORAGE_KEY);
   try {
     return savedColorsRaw ? JSON.parse(savedColorsRaw) : {};
   } catch {
@@ -53,8 +53,7 @@ export const useSaveExperimentRunColor = () => {
       if (groupUuid) {
         const colors = loadSavedColors();
         colors[groupUuid] = colorValue;
-        // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(colors));
+        setStorageItem(window.localStorage, STORAGE_KEY, JSON.stringify(colors));
       }
     },
     [dispatch],

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsChartsUIState.tsx
@@ -7,6 +7,7 @@ import type { RunsChartsUIConfigurationSetter } from '../../../components/runs-c
 import type { RunsChartsBarCardConfig, RunsChartsCardConfig } from '../../../components/runs-charts/runs-charts.types';
 import { RunsChartType } from '../../../components/runs-charts/runs-charts.types';
 import type { ExperimentRunsChartsUIConfiguration } from '../../../components/experiment-page/models/ExperimentPageUIState';
+import { getStorageItem, setStorageItem } from '../../../../common/utils/LocalStorageUtils';
 
 type UpdateChartStateAction = { type: 'UPDATE'; stateSetter: RunsChartsUIConfigurationSetter };
 type InitializeChartStateAction = { type: 'INITIALIZE'; initialConfig?: ExperimentEvaluationRunsChartsUIConfiguration };
@@ -135,8 +136,7 @@ const chartsUIStateReducer = (state: ExperimentEvaluationRunsChartsUIConfigurati
 
 // This function is async on purpose to accommodate potential asynchoronous storage mechanisms (e.g. IndexedDB) in the future
 const loadPersistedDataFromStorage = async (storeIdentifier: string) => {
-  // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-  const serializedData = localStorage.getItem(createLocalStorageKey(storeIdentifier));
+  const serializedData = getStorageItem(localStorage, createLocalStorageKey(storeIdentifier));
   if (!serializedData) {
     return undefined;
   }
@@ -152,8 +152,7 @@ const saveDataToStorage = async (
   storeIdentifier: string,
   dataToPersist: ExperimentEvaluationRunsChartsUIConfiguration,
 ) => {
-  // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-  localStorage.setItem(createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
+  setStorageItem(localStorage, createLocalStorageKey(storeIdentifier), JSON.stringify(dataToPersist));
 };
 
 /**


### PR DESCRIPTION
### Related Issues/PRs

Relates to #20516, #22489, and #22640.

### What changes are proposed in this pull request?

MLflow persists full experiment and run chart configuration as JSON. Large metric sets can grow one cached value past 1,000,000 characters or exhaust browser storage. Existing oversized values are parsed again on reload, and unguarded writes throw `QuotaExceededError`. This matches reports that affected pages recover only after large site-data entries are deleted.

This PR adds one bounded storage path for cached UI state:

- discard existing cached values over 1,000,000 characters before parsing them
- skip oversized writes while preserving last valid cached state
- ignore only browser quota-exhaustion errors, including Firefox's legacy variant, while preserving last valid state and rethrowing unrelated storage errors
- use same behavior for experiment/run state, logged-model charts, evaluation charts, and run colors

Quota detection and direct-write consolidation were inspired by #22640. Its proposed 1 MB chart-state guard also motivated bounded-value handling here. This PR adds read-side recovery for already-oversized JSON, so users with poisoned browser state recover without clearing all site data.

No storage migration, LRU, TTL, or state-model refactor.

Reproduction on `795b4da2c0f72a5e36b476d6535ae5067739c684`:

1. Persist a 1,000,001-character component-state value and read it.
2. Mock browser `localStorage.setItem` to throw `DOMException(..., "QuotaExceededError")`, then update component state.
3. Before production changes, focused suite failed twice: oversized value was returned and quota exception escaped.
4. After changes, oversized legacy value is removed before loading and quota write no longer crashes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```text
corepack yarn test --runTestsByPath \
  src/common/utils/LocalStorageUtils.test.ts \
  src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelsChartsUIState.test.tsx \
  src/experiment-tracking/components/experiment-page/hooks/useExperimentRunColor.intg.test.tsx \
  --runInBand

Test Suites: 3 passed, 3 total
Tests:       13 passed, 13 total
```

Also passed:

- `corepack yarn type-check`
- targeted ESLint for all five changed files
- targeted Prettier check for all five changed files

Visual media is not applicable because rendered UI does not change; regression is browser storage failure and recovery behavior.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow UI now recovers from oversized cached chart state and remains usable when browser local storage is full.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
