### PR TITLE
feat(typescript): add `logFeedback` and typed trace assessments

### DIFF
--- a/libs/typescript/README.md
+++ b/libs/typescript/README.md
@@ -19,7 +19,7 @@
 MLflow Typescript SDK is a variant of the [MLflow Python SDK](https://github.com/mlflow/mlflow) that provides a TypeScript API for MLflow.
 
 > [!IMPORTANT]
-> MLflow Typescript SDK is catching up with the Python SDK. Currently only support [Tracing]() and [Feedback Collection]() features. Please raise an issue in Github if you need a feature that is not supported.
+> MLflow Typescript SDK is catching up with the Python SDK. Currently only support [Tracing](<>) and [Feedback Collection](<>) features. Please raise an issue in Github if you need a feature that is not supported.
 
 ## Packages
 
@@ -137,6 +137,31 @@ getWeather('San Francisco');
 const span = mlflow.startSpan({ name: 'my-span' });
 span.end();
 ```
+
+Log feedback on a persisted trace (Python `mlflow.log_feedback` parity):
+
+```typescript
+import { AssessmentSourceType, MlflowClient, createAuthProvider } from '@mlflow/core';
+
+const trackingUri = 'http://localhost:5000';
+const client = new MlflowClient({
+  trackingUri,
+  authProvider: createAuthProvider({ trackingUri }),
+});
+
+await client.logFeedback({
+  traceId: '<trace-id>',
+  name: 'correctness',
+  value: true,
+  source: { sourceType: AssessmentSourceType.HUMAN, sourceId: 'reviewer@example.com' },
+  rationale: 'The answer matches the expected fact.',
+});
+
+const info = await client.getTraceInfo('<trace-id>');
+console.log(info.assessments);
+```
+
+Databricks Unity Catalog V4 assessment posting is not included in this first slice.
 
 Tag spans with a severity level so users (or you) can filter by **Minimum log level** in the trace UI:
 

--- a/libs/typescript/README.md
+++ b/libs/typescript/README.md
@@ -19,7 +19,9 @@
 MLflow Typescript SDK is a variant of the [MLflow Python SDK](https://github.com/mlflow/mlflow) that provides a TypeScript API for MLflow.
 
 > [!IMPORTANT]
-> MLflow Typescript SDK is catching up with the Python SDK. Currently only support [Tracing](<>) and [Feedback Collection](<>) features. Please raise an issue in Github if you need a feature that is not supported.
+> MLflow Typescript SDK is catching up with the Python SDK. Currently only support Tracing and
+> Feedback Collection features. Please raise an issue in Github if you need a feature that is not
+> supported.
 
 ## Packages
 

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -1,6 +1,7 @@
 import { TraceInfo } from '../core/entities/trace_info';
 import { Trace } from '../core/entities/trace';
 import {
+  CreateAssessment,
   CreateExperiment,
   CreateTraceInfoV4,
   DeleteExperiment,
@@ -12,6 +13,16 @@ import {
   SearchTracesV3,
   StartTraceV3,
 } from './spec';
+import {
+  AssessmentSourceType,
+  assertFeedbackPayload,
+  assertMetadataStringMap,
+  Feedback,
+  standardizeSourceType,
+  type AssessmentError,
+  type AssessmentSource,
+  type FeedbackValueType,
+} from '../core/entities/assessment';
 import { makeRawRequest, makeRequest, MlflowHttpError } from './utils';
 import { TraceData } from '../core/entities/trace_data';
 import { ArtifactsClient, getArtifactsClient } from './artifacts';
@@ -321,6 +332,53 @@ export class MlflowClient {
    */
   async uploadTraceData(traceInfo: TraceInfo, traceData: TraceData): Promise<void> {
     await this.artifactsClient.uploadTraceData(traceInfo, traceData);
+  }
+
+  /**
+   * Log feedback on a persisted trace via the V3 assessments API.
+   * Corresponds to Python `mlflow.log_feedback`.
+   *
+   * Databricks Unity Catalog V4 assessment posting is not included in this method.
+   */
+  async logFeedback(params: {
+    traceId: string;
+    name?: string;
+    value?: FeedbackValueType;
+    error?: AssessmentError | string;
+    source?: AssessmentSource;
+    rationale?: string;
+    metadata?: Record<string, string>;
+    spanId?: string;
+  }): Promise<Feedback> {
+    assertFeedbackPayload({ value: params.value, error: params.error });
+    const metadata = assertMetadataStringMap(params.metadata);
+    const source = params.source
+      ? {
+          sourceType: standardizeSourceType(params.source.sourceType),
+          sourceId: params.source.sourceId || 'default',
+        }
+      : { sourceType: AssessmentSourceType.CODE, sourceId: 'default' };
+
+    const feedback = new Feedback({
+      name: params.name,
+      value: params.value,
+      error: params.error,
+      source,
+      rationale: params.rationale,
+      metadata,
+      spanId: params.spanId,
+      traceId: params.traceId,
+    });
+
+    const url = CreateAssessment.getEndpoint(this.hostUrl, params.traceId);
+    const payload: CreateAssessment.Request = { assessment: feedback.toJson() };
+    const response = await makeRequest<CreateAssessment.Response>(
+      'POST',
+      url,
+      this.headersProvider,
+      payload,
+    );
+    return Feedback.fromJson(response.assessment);
   }
 
   // === EXPERIMENT METHODS  ===

--- a/libs/typescript/core/src/clients/spec.ts
+++ b/libs/typescript/core/src/clients/spec.ts
@@ -6,6 +6,7 @@
  */
 
 import type { TraceInfo } from '../core/entities/trace_info';
+import type { SerializedAssessment } from '../core/entities/assessment';
 import type { SerializedTraceLocation } from '../core/entities/trace_location';
 import { ArtifactCredentialType } from './artifacts/databricks';
 
@@ -147,6 +148,23 @@ export namespace CreateTraceInfoV4 {
  */
 export namespace ExportOtlpTraces {
   export const getEndpoint = (host: string) => `${host}/api/2.0/otel/v1/traces`;
+}
+
+/**
+ * Create an assessment on a trace using the V3 traces API.
+ * Endpoint: POST /api/3.0/mlflow/traces/{trace_id}/assessments
+ */
+export namespace CreateAssessment {
+  export const getEndpoint = (host: string, traceId: string) =>
+    `${host}/api/3.0/mlflow/traces/${encodeURIComponent(traceId)}/assessments`;
+
+  export interface Request {
+    assessment: SerializedAssessment;
+  }
+
+  export interface Response {
+    assessment: SerializedAssessment;
+  }
 }
 
 /**

--- a/libs/typescript/core/src/core/entities/assessment.ts
+++ b/libs/typescript/core/src/core/entities/assessment.ts
@@ -21,6 +21,10 @@ export type FeedbackValueType =
   | FeedbackPrimitive[]
   | { [key: string]: FeedbackPrimitive | FeedbackValueType };
 
+/** Matches Python `mlflow.entities.assessment_error` truncation. */
+export const STACK_TRACE_TRUNCATION_PREFIX = '[Stack trace is truncated]\n...\n';
+export const STACK_TRACE_TRUNCATION_LENGTH = 10000;
+
 export interface AssessmentError {
   errorCode?: string;
   errorMessage?: string;
@@ -104,7 +108,10 @@ export class Feedback {
         }
       : { sourceType: AssessmentSourceType.CODE, sourceId: 'default' };
     this.value = params.value;
-    this.error = typeof params.error === 'string' ? { errorMessage: params.error } : params.error;
+    this.error =
+      typeof params.error === 'string'
+        ? { errorCode: 'ASSESSMENT_ERROR', errorMessage: params.error }
+        : params.error;
     this.traceId = params.traceId;
     this.spanId = params.spanId;
     this.rationale = params.rationale;
@@ -156,11 +163,7 @@ export class Feedback {
       json.feedback.value = this.value;
     }
     if (this.error != null) {
-      json.feedback.error = {
-        error_code: this.error.errorCode,
-        error_message: this.error.errorMessage,
-        stack_trace: this.error.stackTrace,
-      };
+      json.feedback.error = assessmentErrorToJson(this.error);
     }
     return json;
   }
@@ -202,6 +205,29 @@ export type Assessment = Feedback | SerializedAssessment;
 
 export function isFeedback(assessment: Assessment): assessment is Feedback {
   return assessment instanceof Feedback;
+}
+
+/** Truncate stack traces the same way as Python `AssessmentError.to_proto`. */
+export function truncateStackTrace(stackTrace: string): string {
+  if (stackTrace.length <= STACK_TRACE_TRUNCATION_LENGTH) {
+    return stackTrace;
+  }
+  const truncLen = STACK_TRACE_TRUNCATION_LENGTH - STACK_TRACE_TRUNCATION_PREFIX.length;
+  return STACK_TRACE_TRUNCATION_PREFIX + stackTrace.slice(-truncLen);
+}
+
+export function assessmentErrorToJson(error: AssessmentError): SerializedAssessmentError {
+  const json: SerializedAssessmentError = {};
+  if (error.errorCode != null) {
+    json.error_code = error.errorCode;
+  }
+  if (error.errorMessage != null) {
+    json.error_message = error.errorMessage;
+  }
+  if (error.stackTrace != null) {
+    json.stack_trace = truncateStackTrace(error.stackTrace);
+  }
+  return json;
 }
 
 export function assessmentFromJson(json: SerializedAssessment): Assessment {

--- a/libs/typescript/core/src/core/entities/assessment.ts
+++ b/libs/typescript/core/src/core/entities/assessment.ts
@@ -1,0 +1,261 @@
+/**
+ * TypeScript counterparts of Python `mlflow.entities.assessment` for the
+ * V3 assessments REST API. Field names on the wire are proto JSON (snake_case).
+ */
+
+export const AssessmentSourceType = {
+  SOURCE_TYPE_UNSPECIFIED: 'SOURCE_TYPE_UNSPECIFIED',
+  HUMAN: 'HUMAN',
+  LLM_JUDGE: 'LLM_JUDGE',
+  CODE: 'CODE',
+} as const;
+
+export type AssessmentSourceTypeName =
+  (typeof AssessmentSourceType)[keyof typeof AssessmentSourceType];
+
+const VALID_SOURCE_TYPES = new Set<string>(Object.values(AssessmentSourceType));
+
+export type FeedbackPrimitive = number | string | boolean;
+export type FeedbackValueType =
+  | FeedbackPrimitive
+  | FeedbackPrimitive[]
+  | { [key: string]: FeedbackPrimitive | FeedbackValueType };
+
+export interface AssessmentError {
+  errorCode?: string;
+  errorMessage?: string;
+  stackTrace?: string;
+}
+
+export interface AssessmentSource {
+  sourceType: AssessmentSourceTypeName;
+  sourceId: string;
+}
+
+export interface SerializedAssessmentSource {
+  source_type: string;
+  source_id?: string;
+}
+
+export interface SerializedAssessmentError {
+  error_code?: string;
+  error_message?: string;
+  stack_trace?: string;
+}
+
+export interface SerializedFeedbackValue {
+  value?: unknown;
+  error?: SerializedAssessmentError;
+}
+
+export interface SerializedAssessment {
+  assessment_id?: string;
+  assessment_name: string;
+  trace_id?: string;
+  span_id?: string;
+  source?: SerializedAssessmentSource;
+  create_time?: string;
+  last_update_time?: string;
+  feedback?: SerializedFeedbackValue;
+  expectation?: unknown;
+  issue?: unknown;
+  rationale?: string;
+  error?: SerializedAssessmentError;
+  metadata?: Record<string, string>;
+  overrides?: string;
+  valid?: boolean;
+}
+
+export class Feedback {
+  name: string;
+  source: AssessmentSource;
+  value?: FeedbackValueType;
+  error?: AssessmentError;
+  traceId?: string;
+  spanId?: string;
+  rationale?: string;
+  metadata?: Record<string, string>;
+  assessmentId?: string;
+  createTime?: string;
+  lastUpdateTime?: string;
+  overrides?: string;
+  valid?: boolean;
+
+  constructor(params: {
+    name?: string;
+    source?: AssessmentSource;
+    value?: FeedbackValueType;
+    error?: AssessmentError | string;
+    traceId?: string;
+    spanId?: string;
+    rationale?: string;
+    metadata?: Record<string, string>;
+    assessmentId?: string;
+    createTime?: string;
+    lastUpdateTime?: string;
+    overrides?: string;
+    valid?: boolean;
+  }) {
+    this.name = params.name ?? 'feedback';
+    this.source = params.source
+      ? {
+          sourceType: standardizeSourceType(params.source.sourceType),
+          sourceId: params.source.sourceId || 'default',
+        }
+      : { sourceType: AssessmentSourceType.CODE, sourceId: 'default' };
+    this.value = params.value;
+    this.error = typeof params.error === 'string' ? { errorMessage: params.error } : params.error;
+    this.traceId = params.traceId;
+    this.spanId = params.spanId;
+    this.rationale = params.rationale;
+    this.metadata = params.metadata;
+    this.assessmentId = params.assessmentId;
+    this.createTime = params.createTime;
+    this.lastUpdateTime = params.lastUpdateTime;
+    this.overrides = params.overrides;
+    this.valid = params.valid;
+  }
+
+  toJson(): SerializedAssessment {
+    const json: SerializedAssessment = {
+      assessment_name: this.name,
+      source: {
+        source_type: this.source.sourceType,
+        source_id: this.source.sourceId,
+      },
+    };
+    if (this.assessmentId != null) {
+      json.assessment_id = this.assessmentId;
+    }
+    if (this.traceId != null) {
+      json.trace_id = this.traceId;
+    }
+    if (this.spanId != null) {
+      json.span_id = this.spanId;
+    }
+    if (this.createTime != null) {
+      json.create_time = this.createTime;
+    }
+    if (this.lastUpdateTime != null) {
+      json.last_update_time = this.lastUpdateTime;
+    }
+    if (this.rationale != null) {
+      json.rationale = this.rationale;
+    }
+    if (this.metadata != null) {
+      json.metadata = this.metadata;
+    }
+    if (this.overrides != null) {
+      json.overrides = this.overrides;
+    }
+    if (this.valid != null) {
+      json.valid = this.valid;
+    }
+    json.feedback = {};
+    if (this.value !== undefined) {
+      json.feedback.value = this.value;
+    }
+    if (this.error != null) {
+      json.feedback.error = {
+        error_code: this.error.errorCode,
+        error_message: this.error.errorMessage,
+        stack_trace: this.error.stackTrace,
+      };
+    }
+    return json;
+  }
+
+  static fromJson(json: SerializedAssessment): Feedback {
+    const feedbackValue = json.feedback;
+    const topLevelError = json.error;
+    const errorJson = feedbackValue?.error ?? topLevelError;
+    return new Feedback({
+      name: json.assessment_name,
+      source: json.source
+        ? {
+            sourceType: standardizeSourceType(json.source.source_type),
+            sourceId: json.source.source_id || 'default',
+          }
+        : undefined,
+      value: feedbackValue?.value as FeedbackValueType | undefined,
+      error: errorJson
+        ? {
+            errorCode: errorJson.error_code,
+            errorMessage: errorJson.error_message,
+            stackTrace: errorJson.stack_trace,
+          }
+        : undefined,
+      traceId: json.trace_id,
+      spanId: json.span_id,
+      rationale: json.rationale,
+      metadata: json.metadata,
+      assessmentId: json.assessment_id,
+      createTime: json.create_time,
+      lastUpdateTime: json.last_update_time,
+      overrides: json.overrides,
+      valid: json.valid,
+    });
+  }
+}
+
+export type Assessment = Feedback | SerializedAssessment;
+
+export function isFeedback(assessment: Assessment): assessment is Feedback {
+  return assessment instanceof Feedback;
+}
+
+export function assessmentFromJson(json: SerializedAssessment): Assessment {
+  if (json.feedback) {
+    return Feedback.fromJson(json);
+  }
+  return json;
+}
+
+export function assessmentToJson(assessment: Assessment): SerializedAssessment {
+  if (assessment instanceof Feedback) {
+    return assessment.toJson();
+  }
+  return assessment;
+}
+
+export function standardizeSourceType(sourceType: string): AssessmentSourceTypeName {
+  const normalized =
+    sourceType.toUpperCase() === 'AI_JUDGE' ? 'LLM_JUDGE' : sourceType.toUpperCase();
+  if (!VALID_SOURCE_TYPES.has(normalized)) {
+    throw new Error(
+      `Invalid assessment source type: ${sourceType}. Valid source types: ${[
+        ...VALID_SOURCE_TYPES,
+      ].join(', ')}`,
+    );
+  }
+  return normalized as AssessmentSourceTypeName;
+}
+
+export function assertMetadataStringMap(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, string> | undefined {
+  if (metadata == null) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value !== 'string') {
+      throw new Error(
+        `Assessment metadata values must be strings. Got ${typeof value} for key "${key}".`,
+      );
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+export function assertFeedbackPayload(params: {
+  value?: FeedbackValueType;
+  error?: AssessmentError | string;
+}): void {
+  const hasValue = params.value !== undefined;
+  const hasError = params.error != null && params.error !== '';
+  if (!hasValue && !hasError) {
+    throw new Error('logFeedback requires `value` or `error`.');
+  }
+}

--- a/libs/typescript/core/src/core/entities/trace_info.ts
+++ b/libs/typescript/core/src/core/entities/trace_info.ts
@@ -6,6 +6,13 @@ import {
 } from './trace_location';
 import type { TraceState } from './trace_state';
 import { TraceMetadataKey } from '../constants';
+import {
+  assessmentFromJson,
+  assessmentToJson,
+  isFeedback,
+  type Assessment,
+  type SerializedAssessment,
+} from './assessment';
 
 /**
  * Interface for token usage information
@@ -74,9 +81,8 @@ export class TraceInfo {
 
   /**
    * List of assessments associated with the trace.
-   * TODO: Assessments are not yet supported in the TypeScript SDK.
    */
-  assessments: any[];
+  assessments: Assessment[];
 
   /**
    * Create a new TraceInfo instance
@@ -93,7 +99,7 @@ export class TraceInfo {
     executionDuration?: number;
     traceMetadata?: Record<string, string>;
     tags?: Record<string, string>;
-    assessments?: any[];
+    assessments?: Assessment[] | SerializedAssessment[];
   }) {
     this.traceId = params.traceId;
     this.traceLocation = params.traceLocation;
@@ -105,8 +111,7 @@ export class TraceInfo {
     this.executionDuration = params.executionDuration;
     this.traceMetadata = params.traceMetadata || {};
     this.tags = params.tags || {};
-    // TODO: Assessments are not yet supported in the TypeScript SDK.
-    this.assessments = [];
+    this.assessments = (params.assessments || []).map(normalizeAssessment);
   }
 
   /**
@@ -126,7 +131,7 @@ export class TraceInfo {
       state: this.state,
       trace_metadata: this.traceMetadata,
       tags: this.tags,
-      assessments: this.assessments,
+      assessments: this.assessments.map(assessmentToJson),
     };
   }
 
@@ -182,6 +187,13 @@ export class TraceInfo {
   }
 }
 
+function normalizeAssessment(assessment: Assessment | SerializedAssessment): Assessment {
+  if (isFeedback(assessment)) {
+    return assessment;
+  }
+  return assessmentFromJson(assessment);
+}
+
 export interface SerializedTraceInfo {
   trace_id: string;
   client_request_id?: string;
@@ -194,6 +206,5 @@ export interface SerializedTraceInfo {
   state: TraceState;
   trace_metadata: Record<string, string>;
   tags: Record<string, string>;
-  // TODO: Define proper type for assessments once supported
-  assessments: any[];
+  assessments: SerializedAssessment[];
 }

--- a/libs/typescript/core/src/index.ts
+++ b/libs/typescript/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   Feedback,
   assessmentFromJson,
   assessmentToJson,
+  isFeedback,
 } from './core/entities/assessment';
 export type {
   Assessment,

--- a/libs/typescript/core/src/index.ts
+++ b/libs/typescript/core/src/index.ts
@@ -34,6 +34,20 @@ export * from './core/constants';
 export type { LiveSpan, Span } from './core/entities/span';
 export type { Trace } from './core/entities/trace';
 export type { TraceInfo, TokenUsage } from './core/entities/trace_info';
+export {
+  AssessmentSourceType,
+  Feedback,
+  assessmentFromJson,
+  assessmentToJson,
+} from './core/entities/assessment';
+export type {
+  Assessment,
+  AssessmentError,
+  AssessmentSource,
+  AssessmentSourceTypeName,
+  FeedbackValueType,
+  SerializedAssessment,
+} from './core/entities/assessment';
 export type { TraceData } from './core/entities/trace_data';
 export type { TraceLocation, UnityCatalogLocation } from './core/entities/trace_location';
 export type { SearchTracesOptions, SearchTracesResult } from './clients';

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import * as mlflow from '../../src';
 import { MlflowClient, type SearchTracesOptions } from '../../src/clients/client';
 import type { ArtifactsClient } from '../../src/clients/artifacts';
+import { Feedback } from '../../src/core/entities/assessment';
 import { Trace } from '../../src/core/entities/trace';
 import { TraceData } from '../../src/core/entities/trace_data';
 import { TraceInfo } from '../../src/core/entities/trace_info';
@@ -122,6 +123,67 @@ describe('MlflowClient', () => {
       expect(retrievedTraceInfo.traceId).toBe(traceId);
       expect(retrievedTraceInfo.state).toBe(TraceState.OK);
       expect(retrievedTraceInfo.requestTime).toBe(1000);
+    });
+  });
+
+  describe('logFeedback', () => {
+    const experimentLocation = () => ({
+      type: TraceLocationType.MLFLOW_EXPERIMENT,
+      mlflowExperiment: {
+        experimentId: experimentId,
+      },
+    });
+
+    it('logs feedback and preserves it on getTraceInfo', async () => {
+      const traceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId,
+          traceLocation: experimentLocation(),
+          state: TraceState.OK,
+          requestTime: 1000,
+        }),
+      );
+
+      const created = await client.logFeedback({
+        traceId,
+        name: 'correctness',
+        value: true,
+        source: { sourceType: 'HUMAN', sourceId: 'reviewer@example.com' },
+        rationale: 'Matches the expected fact',
+        metadata: { suite: 'typescript' },
+      });
+
+      expect(created).toBeInstanceOf(Feedback);
+      expect(created.name).toBe('correctness');
+      expect(created.value).toBe(true);
+      expect(created.assessmentId).toBeDefined();
+
+      const retrieved = await client.getTraceInfo(traceId);
+      expect(retrieved.assessments.length).toBeGreaterThanOrEqual(1);
+      const feedback = retrieved.assessments.find(
+        (assessment) => assessment instanceof Feedback && assessment.name === 'correctness',
+      ) as Feedback | undefined;
+      expect(feedback).toBeDefined();
+      expect(feedback?.value).toBe(true);
+      expect(feedback?.source.sourceType).toBe('HUMAN');
+    });
+
+    it('rejects missing value and error', async () => {
+      await expect(client.logFeedback({ traceId: randomUUID(), name: 'empty' })).rejects.toThrow(
+        /logFeedback requires/,
+      );
+    });
+
+    it('rejects invalid source type', async () => {
+      await expect(
+        client.logFeedback({
+          traceId: randomUUID(),
+          name: 'bad-source',
+          value: true,
+          source: { sourceType: 'ROBOT' as 'HUMAN', sourceId: 'bot' },
+        }),
+      ).rejects.toThrow(/Invalid assessment source type/);
     });
   });
 

--- a/libs/typescript/core/tests/core/entities/assessment.test.ts
+++ b/libs/typescript/core/tests/core/entities/assessment.test.ts
@@ -1,0 +1,73 @@
+import {
+  AssessmentSourceType,
+  Feedback,
+  assessmentFromJson,
+  assessmentToJson,
+  assertFeedbackPayload,
+  standardizeSourceType,
+} from '../../../src/core/entities/assessment';
+
+describe('assessment entities', () => {
+  it('serializes feedback to proto JSON snake_case', () => {
+    const feedback = new Feedback({
+      name: 'correctness',
+      value: true,
+      source: { sourceType: AssessmentSourceType.HUMAN, sourceId: 'reviewer@example.com' },
+      rationale: 'Looks right',
+      metadata: { project: 'demo' },
+      traceId: 'tr-1',
+    });
+
+    expect(feedback.toJson()).toEqual({
+      assessment_name: 'correctness',
+      source: { source_type: 'HUMAN', source_id: 'reviewer@example.com' },
+      trace_id: 'tr-1',
+      rationale: 'Looks right',
+      metadata: { project: 'demo' },
+      feedback: { value: true },
+    });
+  });
+
+  it('round-trips proto JSON including nested feedback error', () => {
+    const parsed = Feedback.fromJson({
+      assessment_id: 'a-1',
+      assessment_name: 'faithfulness',
+      trace_id: 'tr-2',
+      source: { source_type: 'LLM_JUDGE', source_id: 'gpt-4' },
+      feedback: {
+        value: 0.9,
+        error: { error_code: 'TIMEOUT', error_message: 'judge timed out' },
+      },
+      valid: true,
+    });
+
+    expect(parsed).toBeInstanceOf(Feedback);
+    expect(parsed.value).toBe(0.9);
+    expect(parsed.error?.errorCode).toBe('TIMEOUT');
+    expect(assessmentToJson(parsed).feedback?.error?.error_code).toBe('TIMEOUT');
+  });
+
+  it('maps deprecated AI_JUDGE to LLM_JUDGE', () => {
+    expect(standardizeSourceType('AI_JUDGE')).toBe(AssessmentSourceType.LLM_JUDGE);
+  });
+
+  it('rejects invalid source types', () => {
+    expect(() => standardizeSourceType('ROBOT')).toThrow(/Invalid assessment source type/);
+  });
+
+  it('requires value or error for logFeedback payloads', () => {
+    expect(() => assertFeedbackPayload({})).toThrow(/logFeedback requires/);
+    expect(() => assertFeedbackPayload({ value: false })).not.toThrow();
+    expect(() => assertFeedbackPayload({ error: 'failed' })).not.toThrow();
+  });
+
+  it('leaves expectation assessments opaque so TraceInfo does not drop them', () => {
+    const raw = {
+      assessment_name: 'expected_response',
+      expectation: { value: 'Paris' },
+    };
+    const parsed = assessmentFromJson(raw);
+    expect(parsed).toEqual(raw);
+    expect(assessmentToJson(parsed)).toEqual(raw);
+  });
+});

--- a/libs/typescript/core/tests/core/entities/assessment.test.ts
+++ b/libs/typescript/core/tests/core/entities/assessment.test.ts
@@ -1,10 +1,14 @@
 import {
   AssessmentSourceType,
   Feedback,
+  STACK_TRACE_TRUNCATION_LENGTH,
+  STACK_TRACE_TRUNCATION_PREFIX,
   assessmentFromJson,
   assessmentToJson,
   assertFeedbackPayload,
+  isFeedback,
   standardizeSourceType,
+  truncateStackTrace,
 } from '../../../src/core/entities/assessment';
 
 describe('assessment entities', () => {
@@ -69,5 +73,37 @@ describe('assessment entities', () => {
     const parsed = assessmentFromJson(raw);
     expect(parsed).toEqual(raw);
     expect(assessmentToJson(parsed)).toEqual(raw);
+  });
+
+  it('exports isFeedback for public Assessment narrowing', () => {
+    const feedback = new Feedback({ name: 'correctness', value: true });
+    const opaque = { assessment_name: 'expected_response', expectation: { value: 'Paris' } };
+    expect(isFeedback(feedback)).toBe(true);
+    expect(isFeedback(opaque)).toBe(false);
+  });
+
+  it('maps string error overload to ASSESSMENT_ERROR like Python Feedback', () => {
+    const feedback = new Feedback({ name: 'correctness', error: 'judge failed' });
+    expect(feedback.error).toEqual({
+      errorCode: 'ASSESSMENT_ERROR',
+      errorMessage: 'judge failed',
+    });
+    expect(feedback.toJson().feedback?.error).toEqual({
+      error_code: 'ASSESSMENT_ERROR',
+      error_message: 'judge failed',
+    });
+  });
+
+  it('truncates stackTrace before serialization like Python AssessmentError.to_proto', () => {
+    const longTrace = 'x'.repeat(STACK_TRACE_TRUNCATION_LENGTH + 50);
+    const feedback = new Feedback({
+      name: 'correctness',
+      error: { errorCode: 'TIMEOUT', errorMessage: 'boom', stackTrace: longTrace },
+    });
+    const serialized = feedback.toJson().feedback?.error?.stack_trace;
+    expect(serialized).toBeDefined();
+    expect(serialized!.length).toBe(STACK_TRACE_TRUNCATION_LENGTH);
+    expect(serialized!.startsWith(STACK_TRACE_TRUNCATION_PREFIX)).toBe(true);
+    expect(truncateStackTrace('short')).toBe('short');
   });
 });

--- a/libs/typescript/core/tests/core/entities/trace_info.test.ts
+++ b/libs/typescript/core/tests/core/entities/trace_info.test.ts
@@ -1,3 +1,4 @@
+import { Feedback } from '../../../src/core/entities/assessment';
 import { TraceInfo } from '../../../src/core/entities/trace_info';
 import { TraceLocationType } from '../../../src/core/entities/trace_location';
 import { TraceState } from '../../../src/core/entities/trace_state';
@@ -40,6 +41,50 @@ describe('TraceInfo', () => {
       expect(traceInfo.traceMetadata['meta-key']).toBe('meta-value');
       expect(traceInfo.tags['tag-key']).toBe('tag-value');
       expect(traceInfo.assessments).toEqual([]);
+    });
+  });
+
+  describe('assessments', () => {
+    it('preserves assessments from the constructor and fromJson', () => {
+      const feedback = new Feedback({
+        name: 'correctness',
+        value: true,
+        source: { sourceType: 'HUMAN', sourceId: 'alice' },
+      });
+      const traceInfo = new TraceInfo({
+        traceId: 'test-trace-id',
+        traceLocation: {
+          type: TraceLocationType.MLFLOW_EXPERIMENT,
+          mlflowExperiment: { experimentId: 'test-experiment-id' },
+        },
+        requestTime: 1000,
+        state: TraceState.OK,
+        assessments: [feedback],
+      });
+
+      expect(traceInfo.assessments).toHaveLength(1);
+      expect(traceInfo.assessments[0]).toBeInstanceOf(Feedback);
+      expect((traceInfo.assessments[0] as Feedback).value).toBe(true);
+
+      const json = traceInfo.toJson();
+      expect(json.assessments[0]).toMatchObject({
+        assessment_name: 'correctness',
+        feedback: { value: true },
+        source: { source_type: 'HUMAN', source_id: 'alice' },
+      });
+
+      const restored = TraceInfo.fromJson({
+        ...json,
+        assessments: [
+          {
+            assessment_name: 'correctness',
+            source: { source_type: 'HUMAN', source_id: 'alice' },
+            feedback: { value: true },
+          },
+        ],
+      });
+      expect(restored.assessments[0]).toBeInstanceOf(Feedback);
+      expect((restored.assessments[0] as Feedback).value).toBe(true);
     });
   });
 });


### PR DESCRIPTION
### Related Issues/PRs

Closes #25051

### What changes are proposed in this pull request?

Implements **Option A** from #25051 for `@mlflow/core`:

1. Typed assessment/feedback entities (`Feedback`, `AssessmentSource`, exported `AssessmentSourceType`).
2. `MlflowClient.logFeedback(...)` posting to the existing V3 endpoint `POST /api/3.0/mlflow/traces/{trace_id}/assessments` (Python `mlflow.log_feedback` parity for OSS).
3. Fix `TraceInfo` so assessments returned by `GET /api/3.0/mlflow/traces/{id}` are preserved (constructor no longer forces `assessments = []`), with typed `toJson`/`fromJson` round-trip.
4. TypeScript README example for `logFeedback` + reading assessments back from a retrieved trace.

Explicit non-goals for this PR (follow-ups):
- Databricks UC V4 assessment posting
- `logAssessment` / `logExpectation` convenience helpers
- New REST endpoints or store/Python/UI changes

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Focused validation under `libs/typescript`:
- `npm run build:core`
- `npm run test:core` (full core suite green locally; assessment/trace_info/client coverage included)
- New tests in `assessment.test.ts`, `trace_info.test.ts`, and `client.test.ts` for serialization, TraceInfo preservation, `logFeedback` success path, and missing `value`/`error` rejection

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

Updated `libs/typescript/README.md` with a working `logFeedback` example.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds TypeScript `@mlflow/core` support for logging feedback on persisted traces and reading typed assessments from `TraceInfo`, aligning with Python `log_feedback` for OSS tracking servers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/security` - A security-related change that users must be aware of
- [ ] `rn/deprecation` - A deprecation announcement worth mentioning in the release notes

#### Selected classification

`rn/feature`

### Additional notes

Maintainer guidance from #25051 (@PattaraS): author implements first slice; Prakhar’s wire-format notes incorporated (snake_case payload, `metadata` as `Record<string, string>`, nested feedback error). Happy to split UC V4 / generic assessment helpers into follow-up PRs.

#### Is this PR a critical bug fix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
