### PR TITLE
Return 400 instead of 500 for a non-UTF-8 scoring request body

### DIFF
--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -118,7 +118,9 @@ def _decode_json_input(json_input):
 
     try:
         decoded_input = json.loads(json_input)
-    except json.decoder.JSONDecodeError as ex:
+    except (json.decoder.JSONDecodeError, UnicodeDecodeError) as ex:
+        # json.loads() decodes bytes before parsing them, so a payload that is
+        # not valid UTF-8 raises UnicodeDecodeError rather than JSONDecodeError.
         raise MlflowInvalidInputException(
             "Ensure that input is a valid JSON formatted string. "
             f"Error: '{ex!r}'\nInput: \n{json_input}\n"
@@ -308,7 +310,12 @@ def invocations(data, content_type, model, input_schema):
     if mime_type == CONTENT_TYPE_CSV:
         # Convert from CSV to pandas
         if isinstance(data, bytes):
-            data = data.decode("utf-8")
+            try:
+                data = data.decode("utf-8")
+            except UnicodeDecodeError as ex:
+                raise MlflowInvalidInputException(
+                    f"Ensure that input is a valid UTF-8 encoded string. Error: '{ex!r}'"
+                ) from ex
         csv_input = StringIO(data)
         data = parse_csv_input(csv_input=csv_input, schema=input_schema)
         params = None

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -4,6 +4,7 @@ import os
 import random
 import signal
 from io import BytesIO, StringIO
+from unittest import mock
 from typing import Any, NamedTuple
 
 import keras
@@ -22,6 +23,7 @@ from mlflow.models import ModelSignature, infer_signature
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, ErrorCode
 from mlflow.pyfunc import PythonModel
 from mlflow.pyfunc.scoring_server import _get_jsonable_obj, get_cmd
+from mlflow.utils.proto_json_utils import MlflowInvalidInputException
 from mlflow.types import ColSpec, DataType, ParamSchema, ParamSpec, Schema
 from mlflow.types.schema import Array, Object, Property
 from mlflow.utils import env_manager as _EnvManager
@@ -1130,3 +1132,30 @@ def test_split_data_and_params_for_llm_input(dict_input, param_schema, expected)
     expected_data, expected_params = expected
     assert data == expected_data
     assert params == expected_params
+
+
+def test_decode_json_input_rejects_non_utf8_body():
+    """A body that is not valid UTF-8 is bad input, not a server error.
+
+    json.loads() decodes bytes before parsing them, so an invalid byte sequence
+    raises UnicodeDecodeError rather than JSONDecodeError. That escaped the
+    handler and surfaced as an unhandled exception instead of a 400.
+    """
+    with pytest.raises(MlflowInvalidInputException, match="valid JSON formatted string"):
+        pyfunc_scoring_server._decode_json_input(b"\x80\x81")
+
+
+def test_decode_json_input_still_rejects_malformed_json():
+    with pytest.raises(MlflowInvalidInputException, match="valid JSON formatted string"):
+        pyfunc_scoring_server._decode_json_input(b"{not json")
+
+
+def test_invocations_rejects_non_utf8_csv_body():
+    """The CSV branch decoded the request body with no guard at all."""
+    with pytest.raises(MlflowInvalidInputException, match="valid UTF-8 encoded string"):
+        pyfunc_scoring_server.invocations(
+            b"\x80\x81",
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_CSV,
+            model=mock.MagicMock(),
+            input_schema=None,
+        )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #none

### What changes are proposed in this pull request?

A scoring request whose body is not valid UTF-8 comes back as a `500` with a traceback,
rather than the `400` that every other malformed-input case returns.

`_decode_json_input` guards the parse:

```python
try:
    decoded_input = json.loads(json_input)
except json.decoder.JSONDecodeError as ex:
    raise MlflowInvalidInputException(...)
```

but `json.loads()` decodes bytes before parsing them, so an invalid byte sequence raises
`UnicodeDecodeError`. That is a `ValueError`, and **not** a `json.JSONDecodeError`:

```
issubclass(UnicodeDecodeError, json.JSONDecodeError)  ->  False
```

so the handler does not catch it. `_async_catch_mlflow_exception` only converts
`MlflowException`, so the error escapes to the framework:

| body | before | after |
|---|---|---|
| `{"dataframe_split": ...}` | 200 | 200 |
| `{not json` (valid UTF-8) | 400 | 400 |
| `\x80\x81` (invalid UTF-8) | **500 + traceback** | 400 |

The two malformed cases disagreed, even though both are the client sending something the
server cannot parse.

The CSV branch of `invocations` had the same gap with no guard at all:

```python
if isinstance(data, bytes):
    data = data.decode("utf-8")
```

`/invocations` is the public model-serving data plane and takes untrusted input, so any
latin-1 or cp1252 encoded payload, or a truncated multi-byte character, turns a client error
into an unhandled server exception. That inflates the server error rate, breaks client retry
logic that distinguishes 4xx from 5xx, and writes a stack trace for a bad request.

One request reproduces it:

```
curl -X POST http://host/invocations -H 'Content-Type: application/json' --data-binary $'\x80\x81'
```

This catches `UnicodeDecodeError` alongside `JSONDecodeError`, and guards the CSV decode the
same way. Both raise `MlflowInvalidInputException`, which already carries `BAD_REQUEST`, so
both answer 400. Valid input and already-handled malformed JSON are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Three cases added to `tests/pyfunc/test_scoring_server.py`: a non-UTF-8 JSON body, a
malformed but valid-UTF-8 JSON body (to show existing behaviour is preserved), and a
non-UTF-8 CSV body.

I was not able to run the suite locally, as MLflow's dependencies are not installed in my
environment. Both changed files pass `py_compile`, and the before/after table above comes
from exercising the exact `except` clause with the same payloads.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

A scoring request with a body that is not valid UTF-8 now returns `400 Bad Request` instead
of `500 Internal Server Error`, for both the JSON and CSV content types.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
