### PR TITLE
fix: initialize tracking store before registry model-version create

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3112,6 +3112,11 @@ def _create_model_version():
         else:
             _validate_source_run(request_message.source, request_message.run_id)
 
+    # create_model_version resolves models:/ URIs via MlflowClient(), which uses
+    # the process-global tracking URI. Registry-only workers never call
+    # _get_tracking_store(), so that URI stays the default ./mlruns path and
+    # get_logged_model 500s (mlflow#17812). Initialize tracking first.
+    _get_tracking_store()
     store = _get_model_registry_store()
     model_version = store.create_model_version(
         name=request_message.name,

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -1043,7 +1043,9 @@ def test_get_latest_versions(mock_get_request_message, mock_model_registry_store
         assert args == {"name": name, "stages": stages}
 
 
-def test_create_model_version(mock_get_request_message, mock_model_registry_store):
+def test_create_model_version(
+    mock_get_request_message, mock_model_registry_store, mock_tracking_store
+):
     run_id = uuid.uuid4().hex
     tags = [
         ModelVersionTag(key="key", value="value"),
@@ -1069,6 +1071,31 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     assert {tag.key: tag.value for tag in args["tags"]} == {tag.key: tag.value for tag in tags}
     assert args["run_link"] == run_link
     assert json.loads(resp.get_data()) == {"model_version": jsonify(mv)}
+
+
+def test_create_model_version_initializes_tracking_store_before_registry(
+    mock_get_request_message, mock_model_registry_store
+):
+    """Registry-only workers must set the tracking URI before create_model_version.
+
+    create_model_version uses MlflowClient() to resolve models:/ sources. If the
+    worker has never handled a tracking request, the default ./mlruns URI 500s
+    (https://github.com/mlflow/mlflow/issues/17812).
+    """
+    mock_get_request_message.return_value = CreateModelVersion(
+        name="model_1",
+        source="models:/m-abc",
+        model_id="m-abc",
+    )
+    mv = ModelVersion(name="model_1", version="1", creation_timestamp=123)
+    mock_model_registry_store.create_model_version.return_value = mv
+    with mock.patch("mlflow.server.handlers._get_tracking_store") as get_tracking_store:
+        get_tracking_store.return_value = mock.MagicMock()
+        with mock.patch("mlflow.server.handlers._validate_source_model"):
+            resp = _create_model_version()
+        get_tracking_store.assert_called()
+        assert get_tracking_store.call_count >= 1
+    assert json.loads(resp.get_data())["model_version"]["name"] == "model_1"
 
 
 @pytest.mark.parametrize(
@@ -2271,7 +2298,9 @@ def test_create_prompt_as_registered_model(mock_get_request_message, mock_model_
     assert json.loads(resp.get_data()) == {"registered_model": jsonify(rm)}
 
 
-def test_create_prompt_as_model_version(mock_get_request_message, mock_model_registry_store):
+def test_create_prompt_as_model_version(
+    mock_get_request_message, mock_model_registry_store, mock_tracking_store
+):
     tags = [
         ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
         ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value="some prompt text"),


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Closes #17812

### What changes are proposed in this pull request?

Initialize the tracking store before registry model-version creation. This makes `models:/` sources use the server's configured tracking backend even when a worker's first request is registry-only.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Previously reported focused server tests: 11 passed. No tests were rerun for this description correction; this is not a full-suite result.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes.

Fixes a user-visible model-version creation failure for `models:/` sources when the worker has not initialized its configured tracking backend. The implementation changes initialization order; that does not make its effect non-user-facing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

The existing small-bugfix release-note category is retained for maintainer review; it is separate from whether the behavior affects users.

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

### AI/LLM disclosure

AI tools assisted with the change and description. ChatGPT assisted with this description correction.
