### PR TITLE
Normalize the GCS artifact root so listings keep full artifact names

### DIFF
--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -149,7 +149,8 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         dest_path = artifact_path
         if path:
             dest_path = posixpath.join(dest_path, path)
-        prefix = dest_path if dest_path.endswith("/") else dest_path + "/"
+        dest_path = dest_path.rstrip("/")
+        prefix = dest_path + "/" if dest_path else ""
 
         bkt = self._get_bucket(bucket)
 
@@ -161,7 +162,7 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             # returns subdirectories as well
             if result.name == prefix:
                 continue
-            blob_path = result.name[len(artifact_path) + 1 :]
+            blob_path = posixpath.relpath(result.name, artifact_path)
             infos.append(FileInfo(blob_path, False, result.size))
 
         return sorted(infos, key=lambda f: f.path)
@@ -172,7 +173,7 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         for page in results.pages:
             dir_paths.update(page.prefixes)
 
-        return [FileInfo(path[len(artifact_path) + 1 : -1], True, None) for path in dir_paths]
+        return [FileInfo(posixpath.relpath(path, artifact_path), True, None) for path in dir_paths]
 
     def _download_file(self, remote_file_path, local_path):
         (bucket, remote_root_path) = self.parse_gcs_uri(self.artifact_uri)

--- a/tests/store/artifact/test_gcs_artifact_repo.py
+++ b/tests/store/artifact/test_gcs_artifact_repo.py
@@ -39,8 +39,10 @@ def test_custom_gcs_client_used():
 
 
 def test_list_artifacts(mock_client):
-    artifact_root_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, client=mock_client)
+    # GCS object names are not prefixed with "/", so neither is the artifact root used to
+    # build the mocked blob names below.
+    artifact_root_path = "experiment_id/run_id/"
+    repo = GCSArtifactRepository("gs://test_bucket/" + artifact_root_path, client=mock_client)
 
     # mocked bucket/blob structure
     # gs://test_bucket/experiment_id/run_id/
@@ -79,8 +81,8 @@ def test_list_artifacts(mock_client):
 
 @pytest.mark.parametrize("dir_name", ["model", "model/"])
 def test_list_artifacts_with_subdir(mock_client, dir_name):
-    artifact_root_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, client=mock_client)
+    artifact_root_path = "experiment_id/run_id/"
+    repo = GCSArtifactRepository("gs://test_bucket/" + artifact_root_path, client=mock_client)
 
     # mocked bucket/blob structure
     # gs://test_bucket/experiment_id/run_id/
@@ -105,7 +107,7 @@ def test_list_artifacts_with_subdir(mock_client, dir_name):
 
     artifacts = repo.list_artifacts(path=dir_name)
     mock_client.bucket().list_blobs.assert_called_with(
-        prefix=posixpath.join(artifact_root_path[1:], "model/"), delimiter="/"
+        prefix=posixpath.join(artifact_root_path, "model/"), delimiter="/"
     )
     assert len(artifacts) == 2
     assert artifacts[0].path == file_path
@@ -114,6 +116,36 @@ def test_list_artifacts_with_subdir(mock_client, dir_name):
     assert artifacts[1].path == subdir_name
     assert artifacts[1].is_dir is True
     assert artifacts[1].file_size is None
+
+
+@pytest.mark.parametrize(
+    ("artifact_uri", "expected_prefix", "blob_name", "dir_prefix"),
+    [
+        ("gs://test_bucket/exp/run", "exp/run/", "exp/run/file.txt", "exp/run/model/"),
+        ("gs://test_bucket/exp/run/", "exp/run/", "exp/run/file.txt", "exp/run/model/"),
+        ("gs://test_bucket", "", "file.txt", "model/"),
+        ("gs://test_bucket/", "", "file.txt", "model/"),
+    ],
+)
+def test_list_artifacts_normalizes_artifact_root(
+    mock_client, artifact_uri, expected_prefix, blob_name, dir_prefix
+):
+    repo = GCSArtifactRepository(artifact_uri, client=mock_client)
+
+    obj_mock = mock.Mock()
+    obj_mock.configure_mock(name=blob_name, size=1)
+    dir_mock = mock.Mock()
+    dir_mock.configure_mock(prefixes=(dir_prefix,))
+
+    mock_results = mock.MagicMock()
+    mock_results.configure_mock(pages=[dir_mock])
+    mock_results.__iter__.return_value = [obj_mock]
+    mock_client.bucket.return_value.list_blobs.return_value = mock_results
+
+    artifacts = repo.list_artifacts()
+
+    mock_client.bucket().list_blobs.assert_called_with(prefix=expected_prefix, delimiter="/")
+    assert [(a.path, a.is_dir) for a in artifacts] == [("file.txt", False), ("model", True)]
 
 
 def test_log_artifact(mock_client, tmp_path):
@@ -233,8 +265,8 @@ def test_get_anonymous_bucket():
 
 
 def test_download_artifacts_downloads_expected_content(mock_client, tmp_path):
-    artifact_root_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, client=mock_client)
+    artifact_root_path = "experiment_id/run_id/"
+    repo = GCSArtifactRepository("gs://test_bucket/" + artifact_root_path, client=mock_client)
 
     obj_mock_1 = mock.Mock()
     file_path_1 = "file1"
@@ -257,8 +289,7 @@ def test_download_artifacts_downloads_expected_content(mock_client, tmp_path):
         directory traversal.
         """
 
-        prefix = os.path.join("/", prefix)
-        if os.path.abspath(prefix) == os.path.abspath(artifact_root_path):
+        if os.path.normpath(prefix) == os.path.normpath(artifact_root_path):
             return mock_populated_results
         else:
             return mock_empty_results


### PR DESCRIPTION
### Related Issues/PRs

None.

### What changes are proposed in this pull request?

`GCSArtifactRepository.list_artifacts` builds the listing prefix and the returned relative paths by slicing at `len(artifact_path) + 1`. That offset is only correct when the artifact root is non-empty and has no trailing slash. Neither is guaranteed: `parse_gcs_uri` returns the URI path verbatim, and nothing upstream normalizes the artifact URI before the repository is constructed.

Listing the same three-object bucket through both backends, with the S3 repository as the reference:

```
case                 backend listing prefix   result
------------------------------------------------------------------------------
no trailing slash    s3    exp/run/         [('file.txt', False), ('model', True)]
                     gs    exp/run/         [('file.txt', False), ('model', True)]

trailing slash       s3    exp/run/         [('file.txt', False), ('model', True)]
                     gs    exp/run/         [('ile.txt', False), ('odel', True)]

bucket root          s3                     [('file.txt', False), ('model', True)]
                     gs    /                [('ile.txt', False), ('odel', True)]
```

Two failures on the GCS side. Every returned name loses its first character, and at the bucket root the prefix becomes `/`, which matches no object because GCS names do not start with a slash.

`S3ArtifactRepository.list_artifacts` already handles both shapes: `dest_path.rstrip("/")`, an empty prefix at the bucket root, and `posixpath.relpath` for the relative path. This applies the same normalization to GCS.

`download_artifacts` walks `list_artifacts`, so the truncated names propagate into a download that names a file nobody logged:

```
'gs://bucket/exp/run'      -> downloaded ['file.txt']
'gs://bucket/exp/run/'     -> MlflowException: The following failures occurred while
                              downloading one or more artifacts from gs://bucket/exp/run/:
                              ##### File ile.txt #####
```

The existing tests did not catch this because they build mocked blob names as `"/experiment_id/run_id/" + name`, and GCS object names never begin with `/`. That extra leading character cancelled the `+ 1` offset, so the fixtures encoded a listing GCS cannot produce. They now use real object names. The prefix assertion in `test_list_artifacts_with_subdir` was already written against the slash-free form (`artifact_root_path[1:]`), which is what made the inconsistency visible.

One note for reviewers: #24161 adds a `continue` a few lines above one of these hunks. The two changes are independent and any conflict is textual.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`test_list_artifacts_normalizes_artifact_root` covers the four artifact-root shapes. With the source change reverted and the tests kept, three of the four fail:

```
FAILED tests/store/artifact/test_gcs_artifact_repo.py::test_list_artifacts_normalizes_artifact_root[gs://test_bucket/exp/run/-exp/run/-exp/run/file.txt-exp/run/model/]
  - AssertionError: assert [('ile.txt', ...'odel', True)] == [('file.txt',...model', True)]
FAILED tests/store/artifact/test_gcs_artifact_repo.py::test_list_artifacts_normalizes_artifact_root[gs://test_bucket--file.txt-model/]
  - AssertionError: expected call not found.
FAILED tests/store/artifact/test_gcs_artifact_repo.py::test_list_artifacts_normalizes_artifact_root[gs://test_bucket/--file.txt-model/]
  - AssertionError: expected call not found.
3 failed, 1 passed, 20 deselected
```

With the change in place the module is green:

```
23 passed
```

(`test_artifact_uri_factory` is excluded above: it constructs a real `google.cloud.storage.Client` and fails identically on an unmodified checkout without GCP credentials.)

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Listing or downloading GCS artifacts no longer drops the first character of every artifact name when the artifact URI ends in `/` or points at a bucket root.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
