### PR TITLE
BUG: assert statements in production code raise AssertionError instead of MlflowException

### DIFF
--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -654,7 +654,9 @@ def _gen_classifier_curve(
             xlabel = f"Recall (Positive label: {pos_label})"
             ylabel = f"Precision (Positive label: {pos_label})"
     else:
-        assert False, "illegal curve type"
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid curve_type '{curve_type}'. Must be 'roc' or 'pr'."
+        )
 
     if is_binomial:
         x_data, y_data, line_label, auc = gen_line_x_y_label_auc(y, y_probs, pos_label)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -619,9 +619,11 @@ def set_signature(
         # set the signature for the logged model
         set_signature(model_uri, signature)
     """
-    assert isinstance(signature, ModelSignature), (
-        "The signature argument must be a ModelSignature object"
-    )
+    if not isinstance(signature, ModelSignature):
+        raise MlflowException.invalid_parameter_value(
+            "The signature argument must be a ModelSignature object, "
+            f"got {type(signature).__name__}."
+        )
     resolved_uri = model_uri
     if RunsArtifactRepository.is_runs_uri(model_uri):
         resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -336,7 +336,10 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
         code_key: The key used by the flavor to indicate custom code artifacts.
             By default this is FLAVOR_CONFIG_CODE.
     """
-    assert isinstance(conf, dict), "`conf` argument must be a dict."
+    if not isinstance(conf, dict):
+        raise MlflowException.invalid_parameter_value(
+            f"`conf` argument must be a dict, got {type(conf).__name__}."
+        )
 
     if code_key in conf and conf[code_key]:
         code_path = os.path.join(local_path, conf[code_key])


### PR DESCRIPTION
### Issue Description

Three locations in production MLflow code use bare `assert` statements for 
user-facing validation instead of `MlflowException`, which is the standard 
error type used throughout the codebase:

1. `mlflow/models/evaluation/evaluators/classifier.py:657`
   `assert False, "illegal curve type"` — triggered by invalid `curve_type`
   
2. `mlflow/utils/model_utils.py:339`  
   `assert isinstance(conf, dict), "\`conf\` argument must be a dict."` — triggered by wrong type

3. `mlflow/models/signature.py:622`
   `assert isinstance(signature, ModelSignature), "..."` — triggered by wrong signature type

**Why this matters:**
- `assert` is silently stripped when Python runs with `-O` (optimize flag), making the validation disappear entirely in optimized environments
- Users get `AssertionError` with no MLflow context, instead of a clean `MlflowException` with actionable message
- Inconsistent with every other validation in the same files which use `MlflowException.invalid_parameter_value`

### Code to reproduce

```python
from mlflow.utils.model_utils import _add_code_from_conf_to_system_path
_add_code_from_conf_to_system_path('/tmp', 'not_a_dict')
# AssertionError: `conf` argument must be a dict.
# Should be: MlflowException
```

### Fix

Replace all 3 with `MlflowException.invalid_parameter_value(...)`, consistent with
the pattern used in the same files. I have the fix ready.