### PR TITLE
BUG: log_param/log_metric/set_tag raise TypeError instead of MlflowException when key is not a string

### DIFF
--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -44,13 +44,13 @@ class RunInfo(_MlflowObject):
         run_name=None,
     ):
         if experiment_id is None:
-            raise Exception("experiment_id cannot be None")
+            raise MlflowException.invalid_parameter_value("experiment_id cannot be None")
         if user_id is None:
-            raise Exception("user_id cannot be None")
+            raise MlflowException.invalid_parameter_value("user_id cannot be None")
         if status is None:
-            raise Exception("status cannot be None")
+            raise MlflowException.invalid_parameter_value("status cannot be None")
         if start_time is None:
-            raise Exception("start_time cannot be None")
+            raise MlflowException.invalid_parameter_value("start_time cannot be None")
         self._run_id = run_id
         self._experiment_id = experiment_id
         self._user_id = user_id

--- a/mlflow/entities/run_status.py
+++ b/mlflow/entities/run_status.py
@@ -1,3 +1,4 @@
+from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import RunStatus as ProtoRunStatus
 
 
@@ -17,7 +18,7 @@ class RunStatus:
     @staticmethod
     def from_string(status_str):
         if status_str not in RunStatus._STRING_TO_STATUS:
-            raise Exception(
+            raise MlflowException(
                 f"Could not get run status corresponding to string {status_str}. Valid run "
                 f"status strings: {list(RunStatus._STRING_TO_STATUS.keys())}"
             )
@@ -26,7 +27,7 @@ class RunStatus:
     @staticmethod
     def to_string(status):
         if status not in RunStatus._STATUS_TO_STRING:
-            raise Exception(
+            raise MlflowException(
                 f"Could not get string corresponding to run status {status}. Valid run "
                 f"statuses: {list(RunStatus._STATUS_TO_STRING.keys())}"
             )

--- a/mlflow/entities/source_type.py
+++ b/mlflow/entities/source_type.py
@@ -1,3 +1,6 @@
+from mlflow.exceptions import MlflowException
+
+
 class SourceType:
     """Enum for originating source of a :py:class:`mlflow.entities.Run`."""
 
@@ -15,7 +18,7 @@ class SourceType:
     @staticmethod
     def from_string(status_str):
         if status_str not in SourceType._STRING_TO_SOURCETYPE:
-            raise Exception(
+            raise MlflowException(
                 f"Could not get run status corresponding to string {status_str}. Valid run "
                 f"status strings: {list(SourceType._STRING_TO_SOURCETYPE.keys())}"
             )
@@ -24,7 +27,7 @@ class SourceType:
     @staticmethod
     def to_string(status):
         if status not in SourceType.SOURCETYPE_TO_STRING:
-            raise Exception(
+            raise MlflowException(
                 f"Could not get string corresponding to run status {status}. Valid run "
                 f"statuses: {list(SourceType.SOURCETYPE_TO_STRING.keys())}"
             )

--- a/mlflow/entities/view_type.py
+++ b/mlflow/entities/view_type.py
@@ -1,3 +1,4 @@
+from mlflow.exceptions import MlflowException
 from mlflow.protos import service_pb2
 
 
@@ -15,7 +16,7 @@ class ViewType:
     @classmethod
     def from_string(cls, view_str):
         if view_str not in cls._STRING_TO_VIEW:
-            raise Exception(
+            raise MlflowException(
                 f"Could not get valid view type corresponding to string {view_str}. "
                 f"Valid view types are {list(cls._STRING_TO_VIEW.keys())}"
             )
@@ -24,7 +25,7 @@ class ViewType:
     @classmethod
     def to_string(cls, view_type):
         if view_type not in cls._VIEW_TO_STRING:
-            raise Exception(
+            raise MlflowException(
                 f"Could not get valid view type corresponding to string {view_type}. "
                 f"Valid view types are {list(cls._VIEW_TO_STRING.keys())}"
             )

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -654,7 +654,9 @@ def _gen_classifier_curve(
             xlabel = f"Recall (Positive label: {pos_label})"
             ylabel = f"Precision (Positive label: {pos_label})"
     else:
-        assert False, "illegal curve type"
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid curve_type '{curve_type}'. Must be 'roc' or 'pr'."
+        )
 
     if is_binomial:
         x_data, y_data, line_label, auc = gen_line_x_y_label_auc(y, y_probs, pos_label)

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -619,9 +619,11 @@ def set_signature(
         # set the signature for the logged model
         set_signature(model_uri, signature)
     """
-    assert isinstance(signature, ModelSignature), (
-        "The signature argument must be a ModelSignature object"
-    )
+    if not isinstance(signature, ModelSignature):
+        raise MlflowException.invalid_parameter_value(
+            "The signature argument must be a ModelSignature object, "
+            f"got {type(signature).__name__}."
+        )
     resolved_uri = model_uri
     if RunsArtifactRepository.is_runs_uri(model_uri):
         resolved_uri = RunsArtifactRepository.get_underlying_uri(model_uri)

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -336,7 +336,10 @@ def _add_code_from_conf_to_system_path(local_path, conf, code_key=FLAVOR_CONFIG_
         code_key: The key used by the flavor to indicate custom code artifacts.
             By default this is FLAVOR_CONFIG_CODE.
     """
-    assert isinstance(conf, dict), "`conf` argument must be a dict."
+    if not isinstance(conf, dict):
+        raise MlflowException.invalid_parameter_value(
+            f"`conf` argument must be a dict, got {type(conf).__name__}."
+        )
 
     if code_key in conf and conf[code_key]:
         code_path = os.path.join(local_path, conf[code_key])

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -344,6 +344,11 @@ def path_not_unique(name):
 
 def _validate_metric_name(name, path="name"):
     """Check that `name` is a valid metric name and raise an exception if it isn't."""
+    if not isinstance(name, str):
+        raise MlflowException(
+            invalid_value(path, name, f"Expected a string, got {type(name).__name__}."),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
     if name is None:
         raise MlflowException(
             invalid_value(path, name, f"Metric name cannot be None. {_MISSING_KEY_NAME_MESSAGE}"),
@@ -502,6 +507,11 @@ def _validate_param_keys_unique(params):
 
 def _validate_param_name(name, path="key"):
     """Check that `name` is a valid parameter name and raise an exception if it isn't."""
+    if not isinstance(name, str):
+        raise MlflowException(
+            invalid_value(path, name, f"Expected a string, got {type(name).__name__}."),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
     if name is None:
         raise MlflowException(
             invalid_value(path, "", _MISSING_KEY_NAME_MESSAGE),
@@ -522,6 +532,11 @@ def _validate_param_name(name, path="key"):
 def _validate_tag_name(name, path="key"):
     """Check that `name` is a valid tag name and raise an exception if it isn't."""
     # Reuse param & metric check.
+    if not isinstance(name, str):
+        raise MlflowException(
+            invalid_value(path, name, f"Expected a string, got {type(name).__name__}."),
+            error_code=INVALID_PARAMETER_VALUE,
+        )
     if name is None:
         raise MlflowException(
             missing_value(path),


### PR DESCRIPTION
### Issue Description

Passing a non-string key/name to `mlflow.log_param`, `mlflow.log_metric`, or 
`mlflow.set_tag` raises an opaque `TypeError` from inside `re.match()` instead 
of a clean `MlflowException`.

### Code to reproduce

```python
import mlflow

with mlflow.start_run():
    mlflow.log_param(123, "value")
    # TypeError: expected string or bytes-like object, got 'int'
    # (raised inside re.match in mlflow/utils/validation.py)
```

### Expected behavior