### PR TITLE
Offload `log_spans()` from the async event loop

### DIFF
--- a/mlflow/server/otel_api.py
+++ b/mlflow/server/otel_api.py
@@ -10,6 +10,7 @@ The actual span ingestion logic would need to properly convert incoming OTel for
 to MLflow spans, which requires more complex conversion logic.
 """
 
+import asyncio
 import base64
 import json
 import logging
@@ -211,7 +212,7 @@ async def export_traces(
         store = _get_tracking_store()
 
         try:
-            store.log_spans(x_mlflow_experiment_id, all_spans)
+            await store.log_spans_async(x_mlflow_experiment_id, all_spans)
         except NotImplementedError:
             store_name = store.__class__.__name__
             raise HTTPException(
@@ -228,7 +229,9 @@ async def export_traces(
 
         if x_mlflow_run_id and completed_trace_ids:
             try:
-                store.link_traces_to_run(list(completed_trace_ids), x_mlflow_run_id)
+                await asyncio.to_thread(
+                    store.link_traces_to_run, list(completed_trace_ids), x_mlflow_run_id
+                )
             except Exception:
                 _logger.exception("Failed to link OpenTelemetry traces to MLflow run")
 

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import bisect
 import json
 from abc import ABCMeta, abstractmethod
@@ -779,6 +780,10 @@ class AbstractStore(MCPServerRegistryMixin, GatewayStoreMixin):
         """
         Asynchronously log multiple span entities to the tracking store.
 
+        The default implementation offloads ``log_spans()`` to a worker thread so
+        async callers do not stall the event loop. Stores that implement
+        ``log_spans()`` inherit this behavior.
+
         Args:
             location: The location to log spans to.
             spans: List of Span entities to log. Spans may belong to different traces.
@@ -786,7 +791,7 @@ class AbstractStore(MCPServerRegistryMixin, GatewayStoreMixin):
         Returns:
             List of logged Span entities.
         """
-        raise NotImplementedError
+        return await asyncio.to_thread(self.log_spans, location, spans)
 
     def log_metric(self, run_id, metric):
         """

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -2480,15 +2480,3 @@ class RestStore(
 
         verify_rest_response(response, OTLP_TRACES_PATH)
         return spans
-
-    async def log_spans_async(self, location: str, spans: list[Span]) -> list[Span]:
-        """Async wrapper for log_spans. Delegates to the synchronous implementation.
-
-        Args:
-            location: Experiment ID of an MLflow experiment.
-            spans: List of Span entities to log.
-
-        Returns:
-            List of logged Span entities.
-        """
-        return self.log_spans(location, spans)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -5810,19 +5810,6 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
         return update_dict
 
-    async def log_spans_async(self, location: str, spans: list[Span]) -> list[Span]:
-        """Async wrapper for log_spans. Delegates to the synchronous implementation.
-
-        Args:
-            location: Experiment ID of an MLflow experiment.
-            spans: List of Span entities to log.
-
-        Returns:
-            List of logged Span entities.
-        """
-        # TODO: Implement proper async support
-        return self.log_spans(location, spans)
-
     def _get_trace_status_from_root_span(self, spans: list[Span]) -> str | None:
         """
         Infer trace status from root span if present.

--- a/tests/server/test_otel_api.py
+++ b/tests/server/test_otel_api.py
@@ -1,5 +1,10 @@
+import asyncio
+import threading
+from abc import ABC
 from unittest import mock
+from unittest.mock import patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
@@ -8,6 +13,7 @@ from mlflow.entities import Workspace
 from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.server.fastapi_app import add_fastapi_workspace_middleware
 from mlflow.server.otel_api import otel_router
+from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH, _set_otel_proto_anyvalue
 from mlflow.utils import workspace_context
 from mlflow.utils.workspace_utils import WORKSPACE_HEADER_NAME
@@ -35,10 +41,17 @@ def _make_test_client():
     return TestClient(app)
 
 
+class _DummyTrackingStore:
+    """Test store that offloads ``log_spans`` the same way production stores do."""
+
+    async def log_spans_async(self, location, spans):
+        return await asyncio.to_thread(self.log_spans, location, spans)
+
+
 def test_workspace_scoped_otlp_endpoint_sets_workspace(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
 
-    class DummyTrackingStore:
+    class DummyTrackingStore(_DummyTrackingStore):
         def __init__(self):
             self.calls = []
 
@@ -82,7 +95,7 @@ def test_workspace_scoped_otlp_endpoint_sets_workspace(monkeypatch):
 def test_default_otlp_endpoint_uses_default_workspace(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
 
-    class DummyTrackingStore:
+    class DummyTrackingStore(_DummyTrackingStore):
         def __init__(self):
             self.calls = []
 
@@ -124,7 +137,7 @@ def test_default_otlp_endpoint_uses_default_workspace(monkeypatch):
 def test_otlp_endpoint_links_trace_to_run(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
 
-    class DummyTrackingStore:
+    class DummyTrackingStore(_DummyTrackingStore):
         def __init__(self):
             self.calls = []
             self.link_calls = []
@@ -171,7 +184,7 @@ def test_otlp_endpoint_without_default_workspace_raises_error(monkeypatch):
 
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
 
-    class DummyWorkspaceAwareStore(WorkspaceAwareMixin):
+    class DummyWorkspaceAwareStore(_DummyTrackingStore, WorkspaceAwareMixin):
         """A dummy store that raises MlflowException when workspace is not set."""
 
         def log_spans(self, experiment_id, spans):
@@ -208,7 +221,7 @@ def test_otlp_endpoint_run_linking_error_is_logged(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
     logged_messages = []
 
-    class DummyTrackingStore:
+    class DummyTrackingStore(_DummyTrackingStore):
         def log_spans(self, experiment_id, spans):
             pass
 
@@ -355,7 +368,7 @@ def test_otlp_conversion_error(monkeypatch):
 def test_otlp_resource_attributes_preserved(monkeypatch):
     monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
 
-    class DummyTrackingStore:
+    class DummyTrackingStore(_DummyTrackingStore):
         def __init__(self):
             self.logged_spans = []
 
@@ -390,3 +403,148 @@ def test_otlp_resource_attributes_preserved(monkeypatch):
     assert res["service.name"] == "my-service"
     assert res["telemetry.sdk.language"] == "python"
     assert res["telemetry.sdk.name"] == "opentelemetry"
+
+
+def _make_asgi_app():
+    app = FastAPI()
+    add_fastapi_workspace_middleware(app)
+    app.include_router(otel_router)
+    return app
+
+
+async def _asgi_post(app, path: str, headers: dict[str, str], body: bytes) -> int:
+    status_code = 500
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        nonlocal status_code
+        if message["type"] == "http.response.start":
+            status_code = message["status"]
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [(key.lower().encode(), value.encode()) for key, value in headers.items()],
+            "client": ("testclient", 500),
+            "server": ("test", 80),
+        },
+        receive,
+        send,
+    )
+    return status_code
+
+
+@pytest.mark.asyncio
+async def test_otlp_export_offloads_store_io_from_event_loop(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+
+    event_loop_ident = threading.get_ident()
+    store_idents = []
+    started = threading.Event()
+    release = threading.Event()
+
+    class DummyTrackingStore(_DummyTrackingStore):
+        def log_spans(self, experiment_id, spans):
+            store_idents.append(threading.get_ident())
+            started.set()
+            assert release.wait(timeout=5)
+
+        def link_traces_to_run(self, trace_ids, run_id):
+            store_idents.append(threading.get_ident())
+
+    monkeypatch.setattr(
+        "mlflow.server.otel_api._get_tracking_store",
+        lambda: DummyTrackingStore(),
+    )
+
+    request_task = asyncio.create_task(
+        _asgi_post(
+            _make_asgi_app(),
+            OTLP_TRACES_PATH,
+            {
+                "Content-Type": "application/x-protobuf",
+                "X-MLflow-Experiment-Id": "42",
+                "X-MLflow-Run-Id": "run-123",
+            },
+            _build_otlp_payload(),
+        )
+    )
+
+    async def _wait_for_store_call():
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+
+    # If log_spans_async ran log_spans on the event loop, this wait would time
+    # out because the loop would be blocked inside DummyTrackingStore.log_spans.
+    await asyncio.wait_for(_wait_for_store_call(), timeout=5)
+    await asyncio.sleep(0.01)
+    release.set()
+    status_code = await request_task
+
+    assert status_code == 200
+    assert store_idents
+    assert all(ident != event_loop_ident for ident in store_idents)
+
+
+@pytest.mark.asyncio
+async def test_otlp_export_handles_concurrent_requests(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+
+    barrier = threading.Barrier(2, timeout=5)
+
+    class DummyTrackingStore(_DummyTrackingStore):
+        def log_spans(self, experiment_id, spans):
+            barrier.wait()
+
+    monkeypatch.setattr(
+        "mlflow.server.otel_api._get_tracking_store",
+        lambda: DummyTrackingStore(),
+    )
+
+    app = _make_asgi_app()
+    headers = {
+        "Content-Type": "application/x-protobuf",
+        "X-MLflow-Experiment-Id": "42",
+    }
+    payload = _build_otlp_payload()
+    status_codes = await asyncio.gather(
+        _asgi_post(app, OTLP_TRACES_PATH, headers, payload),
+        _asgi_post(app, OTLP_TRACES_PATH, headers, payload),
+    )
+
+    assert status_codes == [200, 200]
+
+
+@pytest.mark.asyncio
+async def test_otlp_export_works_for_store_that_only_implements_log_spans(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+
+    class SyncOnlyTrackingStore(AbstractStore, ABC):
+        def log_spans(self, experiment_id, spans, tracking_uri=None):
+            return spans
+
+    with patch.multiple(SyncOnlyTrackingStore, __abstractmethods__=set()):
+        monkeypatch.setattr(
+            "mlflow.server.otel_api._get_tracking_store",
+            lambda: SyncOnlyTrackingStore(),
+        )
+        status_code = await _asgi_post(
+            _make_asgi_app(),
+            OTLP_TRACES_PATH,
+            {
+                "Content-Type": "application/x-protobuf",
+                "X-MLflow-Experiment-Id": "42",
+            },
+            _build_otlp_payload(),
+        )
+
+    assert status_code == 200

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_traces.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import json
 import random
@@ -3609,6 +3610,40 @@ async def test_log_spans(store: SqlAlchemyStore, is_async: bool):
         assert content_dict["attributes"]["mlflow.spanType"] == json.dumps(
             expected_type, cls=TraceJSONEncoder
         )
+
+
+@pytest.mark.asyncio
+async def test_log_spans_async_offloads_to_worker_thread(store: SqlAlchemyStore):
+    event_loop_ident = threading.get_ident()
+    worker_idents = []
+
+    def fake_log_spans(location, spans, tracking_uri=None):
+        worker_idents.append(threading.get_ident())
+        return spans
+
+    with mock.patch.object(store, "log_spans", side_effect=fake_log_spans):
+        result = await store.log_spans_async("1", [])
+
+    assert result == []
+    assert worker_idents
+    assert worker_idents[0] != event_loop_ident
+
+
+@pytest.mark.asyncio
+async def test_log_spans_async_allows_concurrent_store_calls(store: SqlAlchemyStore):
+    barrier = threading.Barrier(2, timeout=5)
+
+    def fake_log_spans(location, spans, tracking_uri=None):
+        barrier.wait()
+        return spans
+
+    with mock.patch.object(store, "log_spans", side_effect=fake_log_spans):
+        results = await asyncio.gather(
+            store.log_spans_async("1", []),
+            store.log_spans_async("1", []),
+        )
+
+    assert results == [[], []]
 
 
 def test_log_spans_multiple_traces(store: SqlAlchemyStore):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -969,7 +969,26 @@ def test_log_spans_locks_and_recomputes_token_usage_in_workspace(workspace_track
         assert trace_info.token_usage["total_tokens"] == 300
 
 
-def test_start_trace_conflict_update_is_workspace_scoped(workspace_tracking_store):
+def test_start_trace_conflict_update_is_workspace_scoped(
+    workspace_tracking_store, monkeypatch, tmp_path
+):
+    archive_path = tmp_path / "archive"
+    archive_path.mkdir()
+    config_path = tmp_path / "trace-archival.yaml"
+    # Enable archival so `get_experiment()` takes its broader-scope retention path,
+    # which adds the extra workspace lookup that made the old call-count assertion brittle.
+    config_path.write_text(
+        "\n".join([
+            "trace_archival:",
+            "  enabled: true",
+            f"  location: {archive_path.as_uri()}",
+            "  retention: 30d",
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, str(config_path))
+
     trace_id = f"tr-{uuid.uuid4().hex}"
     initial_span = create_test_span(
         trace_id=trace_id,
@@ -991,20 +1010,35 @@ def test_start_trace_conflict_update_is_workspace_scoped(workspace_tracking_stor
             trace_metadata={"source": "test"},
         )
 
-        call_state = {"count": 0}
+        original_trace_query = workspace_tracking_store._trace_query
+        conflict_workspace = None
 
-        def workspace_side_effect(*_args, **_kwargs):
-            call_state["count"] += 1
-            return "team-a" if call_state["count"] <= 2 else "team-b"
+        def trace_query_side_effect(session, for_update_or_delete=False, workspace=None):
+            nonlocal conflict_workspace
+            if for_update_or_delete:
+                conflict_workspace = workspace
+                # Simulate the active workspace changing after `start_trace()`
+                # snapshots it for the conflict reread.
+                with WorkspaceContext("team-b"):
+                    return original_trace_query(
+                        session,
+                        for_update_or_delete=for_update_or_delete,
+                        workspace=workspace,
+                    )
+            return original_trace_query(
+                session,
+                for_update_or_delete=for_update_or_delete,
+                workspace=workspace,
+            )
 
         with mock.patch.object(
-            WorkspaceAwareSqlAlchemyStore,
-            "_get_active_workspace",
-            side_effect=workspace_side_effect,
+            workspace_tracking_store,
+            "_trace_query",
+            side_effect=trace_query_side_effect,
         ):
             updated_trace = workspace_tracking_store.start_trace(trace_info)
 
-        assert call_state["count"] == 2
+        assert conflict_workspace == "team-a"
         fetched_trace = workspace_tracking_store.get_trace_info(trace_id)
         assert updated_trace.trace_id == trace_id
         assert fetched_trace.request_time == 1_000

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -913,6 +913,26 @@ def test_get_trace_is_workspace_scoped(workspace_tracking_store):
         assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
 
 
+@pytest.mark.asyncio
+async def test_log_spans_async_is_workspace_scoped(workspace_tracking_store):
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    span = create_test_span(trace_id=trace_id)
+
+    with WorkspaceContext("team-a"):
+        exp_id = workspace_tracking_store.create_experiment("trace-exp-a-async")
+        logged = await workspace_tracking_store.log_spans_async(exp_id, [span])
+        assert logged == [span]
+        trace = workspace_tracking_store.get_trace(trace_id)
+        assert trace.info.trace_id == trace_id
+
+    with WorkspaceContext("team-b"):
+        with pytest.raises(
+            MlflowException, match=f"Trace with ID {trace_id} is not found."
+        ) as excinfo:
+            workspace_tracking_store.get_trace(trace_id)
+        assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+
 def test_log_spans_locks_and_recomputes_token_usage_in_workspace(workspace_tracking_store):
     trace_id = f"tr-{uuid.uuid4().hex}"
 

--- a/tests/store/tracking/test_abstract_store.py
+++ b/tests/store/tracking/test_abstract_store.py
@@ -1,3 +1,4 @@
+import threading
 from abc import ABC
 from unittest import mock
 from unittest.mock import patch
@@ -40,6 +41,33 @@ def test_supports_workspaces_defaults_to_false(store):
 
 def test_supports_trace_archival_defaults_to_false(store):
     assert store.supports_trace_archival is False
+
+
+class _SyncOnlySpanStore(AbstractStore, ABC):
+    """Tracking store that implements ``log_spans`` but not ``log_spans_async``."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+        self.worker_idents = []
+
+    def log_spans(self, location, spans, tracking_uri=None):
+        self.worker_idents.append(threading.get_ident())
+        self.calls.append((location, list(spans)))
+        return spans
+
+
+@pytest.mark.asyncio
+async def test_log_spans_async_defaults_to_offloading_log_spans():
+    with patch.multiple(_SyncOnlySpanStore, __abstractmethods__=set()):
+        store = _SyncOnlySpanStore()
+        event_loop_ident = threading.get_ident()
+        result = await store.log_spans_async("exp-1", [])
+
+    assert result == []
+    assert store.calls == [("exp-1", [])]
+    assert store.worker_idents
+    assert store.worker_idents[0] != event_loop_ident
 
 
 def test_get_metric_history_bulk_interval_empty_run_ids(store):

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import math
+import threading
 import time
 from unittest import mock
 
@@ -3155,6 +3157,42 @@ def test_server_version_check_caching():
             data=mock.ANY,
             extra_headers=mock.ANY,
         )
+
+
+@pytest.mark.asyncio
+async def test_log_spans_async_offloads_to_worker_thread():
+    store = RestStore(lambda: MlflowHostCreds("https://async-host"))
+    event_loop_ident = threading.get_ident()
+    worker_idents = []
+
+    def fake_log_spans(location, spans, tracking_uri=None):
+        worker_idents.append(threading.get_ident())
+        return spans
+
+    with mock.patch.object(store, "log_spans", side_effect=fake_log_spans):
+        result = await store.log_spans_async("exp-123", [])
+
+    assert result == []
+    assert worker_idents
+    assert worker_idents[0] != event_loop_ident
+
+
+@pytest.mark.asyncio
+async def test_log_spans_async_allows_concurrent_store_calls():
+    store = RestStore(lambda: MlflowHostCreds("https://async-host"))
+    barrier = threading.Barrier(2, timeout=5)
+
+    def fake_log_spans(location, spans, tracking_uri=None):
+        barrier.wait()
+        return spans
+
+    with mock.patch.object(store, "log_spans", side_effect=fake_log_spans):
+        results = await asyncio.gather(
+            store.log_spans_async("exp-123", []),
+            store.log_spans_async("exp-123", []),
+        )
+
+    assert results == [[], []]
 
 
 def test_link_prompts_to_trace():


### PR DESCRIPTION
### Related Issues/PRs

Closes #25178

### What changes are proposed in this pull request?

`log_spans_async()` was a synchronous passthrough on `SqlAlchemyStore` and `RestStore`, and the OTLP FastAPI handler called `store.log_spans()` on the event loop. Concurrent tracing could stall the loop during span ingestion.

This keeps the existing `log_spans()` transaction, locking, retry, and aggregation behavior, and offloads that work to a worker thread at async boundaries:

- `AbstractStore.log_spans_async()` now defaults to `asyncio.to_thread(self.log_spans, ...)`, so stores that implement `log_spans()` inherit non-blocking async logging
- The OTLP `export_traces()` handler awaits `log_spans_async()` and offloads `link_traces_to_run()` the same way
- Store-specific `log_spans_async()` passthroughs are removed

This does not introduce a dedicated span-log executor or extra pool limiting. Concurrent OTLP ingest can now contend for the SQLAlchemy connection pool (and the process-wide default executor) the same way other threaded server work already can.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New coverage includes:

- OTLP export stays runnable while `log_spans()` is in progress
- Concurrent OTLP requests can proceed together
- `log_spans_async()` offloads on `SqlAlchemyStore`, `RestStore`, and stores that only implement `log_spans()`
- Workspace-scoped async span logging still isolates traces by workspace

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

OTLP span ingestion and `log_spans_async()` no longer block the server event loop, so concurrent tracing is less likely to stall under load.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release