### PR TITLE
Raise frontend experiment tag limits to 20000

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.test.tsx
@@ -187,10 +187,10 @@ describe('ExperimentGetShareLinkModal', () => {
 
   test('surfaces a clear error and writes no tag when the view exceeds the tag size limit', async () => {
     // Turn compression off so the serialized state stays large, and give it a payload that blows
-    // past the 5000-char experiment-tag ceiling.
+    // past the 20000-char experiment-tag ceiling.
     jest.mocked(shouldUseCompressedExperimentViewSharedState).mockImplementation(() => false);
     const errorSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
-    const hugeSearchState = { ...createExperimentPageSearchFacetsState(), searchFilter: 'x'.repeat(6000) };
+    const hugeSearchState = { ...createExperimentPageSearchFacetsState(), searchFilter: 'x'.repeat(21000) };
     renderModal({ searchFacetsState: hugeSearchState });
 
     await userEvent.click(screen.getByText('open modal'));

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.tsx
@@ -40,11 +40,11 @@ type GetShareLinkModalProps = {
 
 type ShareableViewState = ExperimentPageSearchFacetsState & ExperimentPageUIState;
 
-// Experiment-tag values are capped at MAX_EXPERIMENT_TAG_VAL_LENGTH (5000 chars) server-side
+// Experiment-tag values are capped at MAX_EXPERIMENT_TAG_VAL_LENGTH (20000 chars) server-side
 // (mlflow/utils/validation.py); a write above the ceiling HARD-THROWS in the tracking store rather
 // than truncating, so we preflight the encoded envelope length and surface a clear error instead of
 // the generic "failed to save" that a rejected write would produce.
-const MAX_TAG_VALUE_LENGTH = 5000;
+const MAX_TAG_VALUE_LENGTH = 20000;
 
 // Client-side cap: each view is a tag and `get-experiment` returns every tag value, so the count
 // is bounded to keep that payload small. Best-effort; tags have no server-side count constraint.
@@ -177,7 +177,7 @@ export const ExperimentGetShareLinkModal = ({
       const compressedState = await serializePersistedState(state);
       const id = getUUID();
       const envelope = encodeSavedViewEnvelope(trimmed, compressedState, Date.now());
-      // Preflight the tag-value size: the backend rejects values over the 5000-char ceiling with a
+      // Preflight the tag-value size: the backend rejects values over the 20000-char ceiling with a
       // hard error, so catch it here and tell the user why rather than showing a generic failure.
       if (envelope.length > MAX_TAG_VALUE_LENGTH) {
         Utils.displayGlobalErrorNotification(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
@@ -46,10 +46,10 @@ import { SavedViewsMenu, type SavedViewMenuItem } from '../saved-views/SavedView
 const TRACE_SAVED_VIEW_TAG_PREFIX = 'mlflow.traceViewState.';
 export const TRACE_SHARE_URL_PARAM_KEY = 'traceViewShareKey';
 
-// Experiment-tag values are capped at MAX_EXPERIMENT_TAG_VAL_LENGTH (5000 chars) server-side; a
+// Experiment-tag values are capped at MAX_EXPERIMENT_TAG_VAL_LENGTH (20000 chars) server-side; a
 // write above the ceiling HARD-THROWS in the tracking store rather than truncating, so we preflight
 // the encoded envelope length before dispatching.
-const MAX_TAG_VALUE_LENGTH = 5000;
+const MAX_TAG_VALUE_LENGTH = 20000;
 
 // Client-side cap (mirrors the runs MAX_SAVED_VIEWS): each view is a tag and `get-experiment`
 // returns every tag value, so the count is bounded to keep that payload small. Best-effort; tags

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts
@@ -328,7 +328,7 @@ describe('useExperimentCustomViewDefinition', () => {
     });
 
     it('uses UTF-8 bytes to decide whether to compress', async () => {
-      const view = makeView({ id: 'unicode', instruction: '🙂'.repeat(2000) });
+      const view = makeView({ id: 'unicode', instruction: '🙂'.repeat(6000) });
       const raw = serializeCustomView(view);
       expect(raw.length).toBeLessThan(CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES);
       expect(getUtf8ByteLength(raw)).toBeGreaterThan(CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES);
@@ -346,8 +346,8 @@ describe('useExperimentCustomViewDefinition', () => {
       expect(isTextCompressedDeflate(call.value)).toBe(true);
     });
 
-    it('stores raw JSON at the 5,000-byte safe client limit', async () => {
-      expect(CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES).toBe(5000);
+    it('stores raw JSON at the 20,000-byte safe client limit', async () => {
+      expect(CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES).toBe(20000);
       const baseView = makeView({ id: 'raw-boundary', instruction: '' });
       const instructionLength = CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES - getUtf8ByteLength(serializeCustomView(baseView));
       expect(instructionLength).toBeGreaterThanOrEqual(0);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -52,9 +52,9 @@ import {
  * drops it.
  */
 
-// Experiment-tag values are capped server-side (MAX_EXPERIMENT_TAG_VAL_LENGTH, 5000 chars); a write
+// Experiment-tag values are capped server-side (MAX_EXPERIMENT_TAG_VAL_LENGTH, 20000 chars); a write
 // above the ceiling hard-throws rather than truncating, so preflight the encoded length.
-const MAX_TAG_VALUE_LENGTH = 5000;
+const MAX_TAG_VALUE_LENGTH = 20000;
 
 // Client-side cap (mirrors the V3 / runs MAX_SAVED_VIEWS): each view is a tag and `get-experiment`
 // returns every tag value, so the count is bounded to keep that payload small.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewDefinition.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewDefinition.ts
@@ -12,10 +12,10 @@ export const viewTagKey = (id: string): string => `${CUSTOM_VIEW_PREFIX_V1}${id}
 // The OSS backend caps an experiment tag value at MAX_EXPERIMENT_TAG_VAL_LENGTH
 // (20,000 CHARACTERS, mlflow/utils/validation.py) and rejects anything longer
 // outright — `_validate_experiment_tag` passes no `truncate`, so an oversized
-// view fails the save rather than being silently cut. Budgeting the same number
-// in UTF-8 BYTES is deliberately conservative: a string's byte length is never
-// below its character count, so nothing that passes here can exceed the
-// server's limit.
+// view fails the save rather than being silently cut. This client-side limit is
+// deliberately conservative: it budgets UTF-8 BYTES using the same numeric
+// value as the server's CHARACTER limit. A string's byte length is never below
+// its character count, so nothing that passes here can exceed the server's limit.
 export const CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES = 20000;
 
 // Each saved view costs one experiment tag, so cap creation before the user authors a view that

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewDefinition.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/customViewDefinition.ts
@@ -10,13 +10,13 @@ export const CUSTOM_VIEW_PREFIX_V1 = `${CUSTOM_VIEW_TAG_PREFIX}.v1.`;
 export const viewTagKey = (id: string): string => `${CUSTOM_VIEW_PREFIX_V1}${id}`;
 
 // The OSS backend caps an experiment tag value at MAX_EXPERIMENT_TAG_VAL_LENGTH
-// (5,000 CHARACTERS, mlflow/utils/validation.py) and rejects anything longer
+// (20,000 CHARACTERS, mlflow/utils/validation.py) and rejects anything longer
 // outright — `_validate_experiment_tag` passes no `truncate`, so an oversized
 // view fails the save rather than being silently cut. Budgeting the same number
 // in UTF-8 BYTES is deliberately conservative: a string's byte length is never
 // below its character count, so nothing that passes here can exceed the
 // server's limit.
-export const CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES = 5000;
+export const CUSTOM_VIEW_TAG_VALUE_SAFE_MAX_BYTES = 20000;
 
 // Each saved view costs one experiment tag, so cap creation before the user authors a view that
 // the backend will reject. The server is authoritative; this constant only drives the UI hint.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/25186/files) to review incremental changes.
- [stack/update-experiment-tag-size-fe-changes-cv](https://github.com/mlflow/mlflow/pull/25186) [[Files changed](https://github.com/mlflow/mlflow/pull/25186/files)]

---------
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Follow-up to #25062.

### What changes are proposed in this pull request?

- Increase the custom-view serialized tag budget from 5,000 to 20,000 UTF-8 bytes.
- Increase the experiment-tag preflight limits for V3/V4 saved trace views and shared run views from 5,000 to 20,000 characters.
- Update boundary, multibyte UTF-8, compression, and oversized-payload test fixtures for the expanded limit.

### How is this PR tested?

- [x] Existing unit/integration tests

```bash
node mlflow/server/js/yarn/releases/yarn-4.12.0.cjs --cwd mlflow/server/js test --runTestsByPath \
  src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts \
  src/experiment-tracking/components/experiment-page/components/header/ExperimentGetShareLinkModal.test.tsx \
  --runInBand
```

All 23 focused tests passed. ESLint, Prettier, TypeScript, and i18n checks also passed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Custom views, saved trace views, and shared run views can now persist larger experiment-tag payloads up to the expanded backend limit.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release