### PR TITLE
Support `.pbtxt` artifact previews

### DIFF
--- a/mlflow/server/js/src/common/utils/FileUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.test.ts
@@ -15,4 +15,8 @@ describe('FileUtils', () => {
   test('supports jsonl text previews', () => {
     expect(TEXT_EXTENSIONS.has('jsonl')).toBe(true);
   });
+
+  test('supports pbtxt text previews', () => {
+    expect(TEXT_EXTENSIONS.has('pbtxt')).toBe(true);
+  });
 });

--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -28,6 +28,7 @@ const MLFLOW_FILE_LANGUAGES = {
 export const IMAGE_EXTENSIONS = new Set(['jpg', 'bmp', 'jpeg', 'png', 'gif', 'svg']);
 export const TEXT_EXTENSIONS = new Set([
   'txt',
+  'pbtxt',
   'log',
   'err',
   'cfg',


### PR DESCRIPTION
### Related Issues/PRs

Closes #25179

### What changes are proposed in this pull request?

Add `pbtxt` to the artifact viewer's text extension allowlist so that human-readable Protocol Buffer text files, including Triton `config.pbtxt` files, can be previewed directly in the MLflow UI.

Add a focused unit test that preserves `.pbtxt` preview support. The existing artifact page test verifies that every extension in the text allowlist is routed to `ShowArtifactTextView`.

#### Before

Selecting a `.pbtxt` artifact does not display a preview.

<img width="1280" height="720" alt="mlflow-pbtxt-before" src="https://github.com/user-attachments/assets/02787b99-c8a1-48f4-bf25-4ef6be63c9ca" />

#### After

The same `.pbtxt` artifact is rendered in the text preview.

<img width="1280" height="720" alt="mlflow-pbtxt-after" src="https://github.com/user-attachments/assets/806a75c4-0728-45c5-bf77-eeedba6c68c0" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Commands run:

```text
yarn test FileUtils.test.ts ShowArtifactPage.enzyme.test.tsx --runInBand
yarn lint
yarn prettier:check
yarn i18n:check
yarn type-check
uv run --frozen pre-commit run --files mlflow/server/js/src/common/utils/FileUtils.ts mlflow/server/js/src/common/utils/FileUtils.test.ts
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow's artifact browser can now preview `.pbtxt` files as text.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes and improvements. Non-critical bug fixes and documentation updates can be included as well. By default, this PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically reserved for critical regressions and fixes.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
