### PR TITLE
[BUG] Cast experiment IDs to int in `WorkspaceAwareSqlAlchemyStore` filters

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -233,6 +233,10 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
 
     def _filter_experiment_ids(self, session, experiment_ids):
         workspace = self._get_active_workspace()
+        # `SqlExperiment.experiment_id` is an Integer column, so callers passing string IDs
+        # break strict backends such as PostgreSQL ("operator does not exist: integer = varchar").
+        # Normalize to int to match the base store, which does the same before comparing.
+        experiment_ids = [int(e) for e in experiment_ids]
         rows = (
             session
             .query(SqlExperiment.experiment_id)
@@ -255,11 +259,13 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
             return [str(row[0]) for row in rows]
 
         if entity_type == EntityAssociationType.EXPERIMENT:
+            # `experiment_id` is an Integer column; cast so string IDs don't break strict
+            # backends such as PostgreSQL (see `_filter_experiment_ids`).
             rows = (
                 session
                 .query(SqlExperiment.experiment_id)
                 .filter(
-                    SqlExperiment.experiment_id.in_(entity_ids),
+                    SqlExperiment.experiment_id.in_([int(e) for e in entity_ids]),
                     SqlExperiment.workspace == workspace,
                 )
                 .all()

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -280,6 +280,33 @@ def test_search_datasets_is_workspace_scoped(workspace_tracking_store):
         assert workspace_tracking_store._search_datasets([exp_b_id]) == []
 
 
+def test_filter_experiment_ids_accepts_string_ids(workspace_tracking_store):
+    # Regression test for #25188: `experiment_id` is an Integer column, so passing the
+    # string IDs that callers hand these hooks raised "operator does not exist:
+    # integer = character varying" on PostgreSQL. Exercised against real backends by the
+    # `database` CI job.
+    exp_a_id = _create_run(workspace_tracking_store, "team-a", "filter-exp-a", "run-a")[0]
+    exp_b_id = _create_run(workspace_tracking_store, "team-b", "filter-exp-b", "run-b")[0]
+
+    with WorkspaceContext("team-a"):
+        with workspace_tracking_store.ManagedSessionMaker() as session:
+            assert workspace_tracking_store._filter_experiment_ids(
+                session, [exp_a_id, exp_b_id]
+            ) == [int(exp_a_id)]
+            assert workspace_tracking_store._filter_entity_ids(
+                session, EntityAssociationType.EXPERIMENT, [exp_a_id, exp_b_id]
+            ) == [exp_a_id]
+
+    with WorkspaceContext("team-b"):
+        with workspace_tracking_store.ManagedSessionMaker() as session:
+            assert workspace_tracking_store._filter_experiment_ids(
+                session, [exp_a_id, exp_b_id]
+            ) == [int(exp_b_id)]
+            assert workspace_tracking_store._filter_entity_ids(
+                session, EntityAssociationType.EXPERIMENT, [exp_a_id, exp_b_id]
+            ) == [exp_b_id]
+
+
 def test_search_runs_datasets_in_clause_is_workspace_scoped(workspace_tracking_store):
     exp_a_id, run_a = _create_run(workspace_tracking_store, "team-a", "exp-ds-a", "run-ds-a")
     exp_b_id, run_b = _create_run(workspace_tracking_store, "team-b", "exp-ds-b", "run-ds-b")


### PR DESCRIPTION
### Related Issues/PRs

Closes #25188

### What changes are proposed in this pull request?

When workspaces are enabled with a PostgreSQL backend, `WorkspaceAwareSqlAlchemyStore` passed string experiment IDs straight into `.in_()` against `SqlExperiment.experiment_id`, which is an `Integer` column. PostgreSQL (unlike SQLite) rejects the mismatch:

```
operator does not exist: integer = character varying
LINE 1: ...WHERE experiments.experiment_id IN ($1::VARCHAR) ...
```

This fixes it by casting the incoming IDs to `int` in the two workspace hooks that compare against that column:

- `_filter_experiment_ids`
- the `EXPERIMENT` branch of `_filter_entity_ids`

This mirrors the base `SqlAlchemyStore`, which already normalizes with `[int(e) for e in experiment_ids]` before comparing (the same class of bug was fixed for the base store in #17035, issue #17013). The `RUN`, `TRACE`, and `EVALUATION_DATASET` branches compare against `VARCHAR` columns and are intentionally left unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Adds `test_filter_experiment_ids_accepts_string_ids`, which passes string experiment IDs through both hooks and asserts workspace-correct results. It runs against real PostgreSQL/MySQL/MSSQL via the `database` CI job (`tests/store/tracking/sqlalchemy_store`), where the pre-fix code raises the error above; SQLite silently coerces the type, which is why existing coverage missed it.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where experiment-scoped operations (e.g. `search_datasets`) failed on a PostgreSQL backend when workspaces were enabled, due to an integer/varchar type mismatch on `experiment_id`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
