### PR TITLE
Re-resolve both paths in `validate_path_within_directory` to fix flaky Windows `test_async_log_image_flush`

### DIFF
--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -524,33 +524,46 @@ def validate_path_within_directory(base_dir: str, constructed_path: str) -> str:
     Returns:
         The constructed_path if validation passes.
     """
-    real_base_dir = pathlib.Path(base_dir).resolve()
     target = pathlib.Path(constructed_path)
-    # On Windows, resolve() canonicalizes the existing vs non-existing parts of a path
-    # differently (e.g. 8.3 short-name expansion only for the part that exists). With the
-    # async artifact queue's pool of worker threads sharing one repository, the boundary
-    # between existing/non-existing can shift between these two resolve() calls, making a
-    # valid destination look like it escapes the base dir. Resolve the leaf only when a
-    # real file/dir or a (possibly dangling) symlink exists there; otherwise resolve the
-    # existing parent and append the caller-sanitized leaf verbatim.
-    #
-    # The is_symlink()/exists() check followed by resolve() is not atomic: a racing thread
-    # could plant a symlink at the leaf in that window. This TOCTOU gap is an accepted
-    # limitation. Writing into the artifact directory already requires local write access
-    # to it, and an attacker with that access needs no symlink trick to read or write
-    # files there. The original guard had an equivalent TOCTOU between its two resolve()
-    # calls, and always calling target.resolve() here would reintroduce the Windows
-    # spurious-rejection race this branch exists to avoid.
-    if target.is_symlink() or target.exists():
-        real_constructed_path = target.resolve()
-    else:
-        real_constructed_path = target.parent.resolve() / target.name
+
+    def _resolve_target() -> pathlib.Path:
+        # On Windows, resolve() canonicalizes the existing vs non-existing parts of a path
+        # differently (e.g. 8.3 short-name expansion only for the part that exists). With the
+        # async artifact queue's pool of worker threads sharing one repository, the boundary
+        # between existing/non-existing can shift between the base_dir and target resolve()
+        # calls, making a valid destination look like it escapes the base dir. Resolve the
+        # leaf only when a real file/dir or a (possibly dangling) symlink exists there;
+        # otherwise resolve the existing parent and append the caller-sanitized leaf
+        # verbatim.
+        #
+        # The is_symlink()/exists() check followed by resolve() is not atomic: a racing
+        # thread could plant a symlink at the leaf in that window. This TOCTOU gap is an
+        # accepted limitation. Writing into the artifact directory already requires local
+        # write access to it, and an attacker with that access needs no symlink trick to
+        # read or write files there. The original guard had an equivalent TOCTOU between
+        # its two resolve() calls, and always calling target.resolve() here would
+        # reintroduce the Windows spurious-rejection race this branch exists to avoid.
+        if target.is_symlink() or target.exists():
+            return target.resolve()
+        return target.parent.resolve() / target.name
+
+    real_base_dir = pathlib.Path(base_dir).resolve()
+    real_constructed_path = _resolve_target()
 
     if not real_constructed_path.is_relative_to(real_base_dir):
-        raise MlflowException(
-            "Invalid path: resolved path is outside the artifact directory",
-            error_code=INVALID_PARAMETER_VALUE,
-        )
+        # The base dir and the target were resolved at two different times, so a
+        # directory another worker thread created in between can leave the two forms
+        # mismatched (see the Windows note above). Resolve both again from the same
+        # snapshot and only reject if the target is still outside. A path that
+        # actually escapes the base dir is outside it no matter which snapshot we
+        # resolve in, so this doesn't let anything new through.
+        real_base_dir = pathlib.Path(base_dir).resolve()
+        real_constructed_path = _resolve_target()
+        if not real_constructed_path.is_relative_to(real_base_dir):
+            raise MlflowException(
+                "Invalid path: resolved path is outside the artifact directory",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
     return constructed_path
 

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -1031,3 +1031,74 @@ def test_validate_path_within_directory_blocks_multi_level_dotdot_escape(tmp_pat
     assert not (base_dir / "a").exists()
     with pytest.raises(MlflowException, match="resolved path is outside the artifact directory"):
         validate_path_within_directory(str(base_dir), str(constructed_path))
+
+
+def _patch_resolve_with_stale_base_dir_snapshot(monkeypatch, base_dir):
+    """
+    Mimic the Windows behavior behind the flaky test_async_log_image_flush failures
+    (#24772): resolve() only canonicalizes the part of a path that exists, so the
+    first resolution of base_dir yields a short-name form while later resolutions
+    yield the canonical form.
+    """
+    real_resolve = pathlib.Path.resolve
+    state = {"stale": True}
+
+    def windows_like_resolve(self, *args, **kwargs):
+        resolved = real_resolve(self, *args, **kwargs)
+        if state["stale"] and self == base_dir:
+            state["stale"] = False
+            return resolved.parent / (resolved.name[:6].upper() + "~1")
+        return resolved
+
+    monkeypatch.setattr(pathlib.Path, "resolve", windows_like_resolve)
+    return state
+
+
+def test_validate_path_within_directory_allows_stale_base_dir_resolution(tmp_path, monkeypatch):
+    base_dir = tmp_path / "artifacts"
+    constructed_path = base_dir / "images"
+    constructed_path.mkdir(parents=True)
+    state = _patch_resolve_with_stale_base_dir_snapshot(monkeypatch, base_dir)
+    result = validate_path_within_directory(str(base_dir), str(constructed_path))
+    assert result == str(constructed_path)
+    assert state["stale"] is False
+
+
+def test_validate_path_within_directory_allows_stale_base_dir_resolution_nonexistent_leaf(
+    tmp_path, monkeypatch
+):
+    base_dir = tmp_path / "artifacts"
+    constructed_path = base_dir / "images" / "image_0.png"
+    constructed_path.parent.mkdir(parents=True)
+    assert not constructed_path.exists()
+    state = _patch_resolve_with_stale_base_dir_snapshot(monkeypatch, base_dir)
+    result = validate_path_within_directory(str(base_dir), str(constructed_path))
+    assert result == str(constructed_path)
+    assert state["stale"] is False
+
+
+def test_validate_path_within_directory_blocks_escape_despite_stale_base_dir_resolution(
+    tmp_path, monkeypatch
+):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    constructed_path = base_dir / "a" / ".." / ".." / "evil.txt"
+    state = _patch_resolve_with_stale_base_dir_snapshot(monkeypatch, base_dir)
+    with pytest.raises(MlflowException, match="resolved path is outside the artifact directory"):
+        validate_path_within_directory(str(base_dir), str(constructed_path))
+    assert state["stale"] is False
+
+
+def test_validate_path_within_directory_blocks_symlink_escape_despite_stale_base_dir_resolution(
+    tmp_path, monkeypatch
+):
+    base_dir = tmp_path / "artifacts"
+    base_dir.mkdir()
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    symlink_path = base_dir / "leak"
+    os.symlink(str(external_dir), str(symlink_path))
+    state = _patch_resolve_with_stale_base_dir_snapshot(monkeypatch, base_dir)
+    with pytest.raises(MlflowException, match="resolved path is outside the artifact directory"):
+        validate_path_within_directory(str(base_dir), str(symlink_path))
+    assert state["stale"] is False


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24772

### What changes are proposed in this pull request?

`validate_path_within_directory` resolves the base dir and the target at two different times. When the async artifact queue's worker threads create artifact directories concurrently, a directory can be missing when the base dir is resolved but already exist when the target is resolved a moment later. On Windows, `resolve()` only canonicalizes the part of a path that exists (e.g. 8.3 short-name expansion), so the same directory can resolve to two different strings across that window, and a valid destination gets rejected as escaping the base dir. This shows up as the recurring `test_async_log_image_flush` failure (`assert 199 == 200`) on the Windows shards. #24521 fixed the same race on the target side only.

On the first failed containment check, re-resolve both sides from the same snapshot and reject only if the target is still outside. A path that actually escapes the base dir is outside it in any snapshot, so the guard is not weakened.

### How is this PR tested?

- [x] New unit/integration tests

New tests in `tests/utils/test_uri.py` monkeypatch `resolve()` so the first resolution of the base dir returns a short-name form and later ones return the canonical form. They cover both the existing-leaf and nonexistent-leaf branches, and two more cases check that `..` and symlink escapes are still rejected while the stale form is served. The two "allows" tests fail on current master and pass with the fix. `tests/utils/test_uri.py` (218 passed) and `tests/tracking/test_log_image.py` (51 passed) were run locally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed intermittent `Invalid path: resolved path is outside the artifact directory` errors from async artifact logging on Windows.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release