### PR TITLE
fix: prevent duplicate table creation during DB upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -93,8 +93,10 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     from mlflow.utils.file_utils import ExclusiveFileLock
 
     if os.name == "nt":
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
+        elif not _all_tables_exist(engine):
+            _upgrade_db(engine)
         return
 
     url_hash = hashlib.md5(
@@ -102,8 +104,10 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
         usedforsecurity=False,
     ).hexdigest()
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
-        if not _all_tables_exist(engine):
+        if _is_empty_database(engine):
             _initialize_tables(engine)
+        elif not _all_tables_exist(engine):
+            _upgrade_db(engine)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What
In MLflow 3.8.x, `mlflow db upgrade` fails with `Table 'secrets' already exists` when upgrading an existing database from 3.7.0. The issue is caused by `_safe_initialize_tables()` using the `_all_tables_exist()` check to decide whether to call `_initialize_tables()`. Since the new secrets table is in `Base.metadata.tables`, the check returns False for existing databases that haven't yet created the secrets table, causing `_initialize_tables()` to attempt to create all initial tables, including those that already exist (like 'secrets'), leading to duplicate table errors.

## Fix
Change `_safe_initialize_tables()` to only call `_initialize_tables()` when the database is completely empty (using `_is_empty_database()`). For existing databases that are missing some tables (e.g., after a partial upgrade), simply call `_upgrade_db()` instead, which will apply the missing Alembic migrations without re-creating existing tables.

Closes #19943