### PR TITLE
Fix `ExperimentSingleChatSessionPage` silently truncating chat sessions past 100 turns

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -109,10 +109,16 @@ const ExperimentSingleChatSessionPageImpl = () => {
 
   const filters = useMemo(() => getChatSessionsFilter({ sessionId }), [sessionId]);
 
+  // A session's conversation view needs every turn up front (the sidebar indexes into the
+  // full array), not incremental scroll-loading. Infinite pagination only fetches its first
+  // page (100 traces) unless something calls fetchNextPage, which this page never does, so
+  // any session past 100 turns was silently truncated. Force the eager-fetch path instead,
+  // which loops through all pages internally (see useSearchMlflowTraces's enablePagination).
   const { data: traceInfos, isLoading: isLoadingTraceInfos } = useSearchMlflowTraces({
     locations: traceSearchLocations,
     filters,
     disabled: false,
+    enablePagination: false,
   });
 
   const sortedTraceInfos = useMemo(() => {


### PR DESCRIPTION
### Related Issues/PRs

Closes #25197

### What changes are proposed in this pull request?

The chat session detail page (`Experiments > <experiment> > Chat Sessions > <session>`)
fetches its traces via `useSearchMlflowTraces` with default options, which resolves
`enablePagination` to `true` and routes into `useSearchMlflowTracesInfinite` — a React Query
`useInfiniteQuery` with a 100-trace page size. `useInfiniteQuery` only auto-fetches its first
page; later pages require an explicit `fetchNextPage()` call, normally wired to a
scroll/`IntersectionObserver` listener.

`ExperimentSingleChatSessionPage` never calls `fetchNextPage`/checks `hasNextPage`, and nothing
downstream (`ExperimentSingleChatSessionSidebar`, `ExperimentSingleChatConversation`) does
either, so the page silently stops after the first 100 traces for every session — no error, no
"load more" affordance. Any real conversation longer than 100 turns has its later turns
disappear from the UI even though they still exist in the backing store.

This page needs the whole conversation up front (the sidebar indexes into the complete traces
array) rather than incremental scroll-loading, so the fix passes `enablePagination: false`,
which routes to the eager-fetch path (`searchMlflowTracesQueryFn`) that already loops through
all pages internally via `next_page_token` (up to `getEvalTabTotalTracesLimit()`, 1000 traces).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Reviewed against the code paths in `useMlflowTraces.tsx` (`useSearchMlflowTraces` /
`useSearchMlflowTracesInfinite` / `searchMlflowTracesQueryFn`) to confirm `enablePagination:
false` takes the eager, fully-paginating path. Repro steps are in the linked issue. The JS
toolchain isn't built in the environment this patch was prepared in, so CI's
`yarn lint`/`yarn type-check`/`yarn test` are the first real run of those checks against this
change — flagging that explicitly rather than claiming local verification that didn't happen.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a bug where the chat session detail view in the UI silently stopped showing turns after
the 100th turn of a conversation, with no indication that anything was missing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
