### PR TITLE
feat: job lock acquisition logic (RHOAIENG-56602 3/3)

### DIFF
--- a/mlflow/server/jobs/lock_manager.py
+++ b/mlflow/server/jobs/lock_manager.py
@@ -316,9 +316,16 @@ class JobLockManager:
 
         Returns False if a valid lock already exists.
 
+        NOTE:
+            This method cleans up stale locks only when a new acquisition
+            targets the same lock_key. It does not remove stale rows for
+            other keys. Each lock_key persists as a unique row in the
+            ``job_locks`` table until it is manually deleted.
+
         Args:
             lock_key: Framework-computed key
-            job_id: The job ID trying to acquire this lock
+            job_id: The job ID trying to acquire this lock. Must belong
+                to an existing ``SqlJob``
 
         Returns:
             True if lock acquired, False if held by another live job.
@@ -363,15 +370,10 @@ class JobLockManager:
                     session.delete(existing_lock)
                     session.flush()
 
-                requesting_job = session.query(SqlJob).filter(SqlJob.id == job_id).one_or_none()
-                if requesting_job is None:
-                    _logger.debug("Job lock acquisition denied. Requesting job not found.")
-                    return False
-
                 session.add(
                     SqlJobLock(
                         lock_key=lock_key,
-                        job_id=requesting_job.id,
+                        job_id=job_id,
                         acquired_at=get_current_time_millis(),
                     )
                 )
@@ -437,4 +439,4 @@ class JobLockManager:
             if now > expiration_time:
                 return False
 
-        return not (holding_job.lease_expires_at is not None and now > holding_job.lease_expires_at)
+        return True

--- a/mlflow/server/jobs/lock_manager.py
+++ b/mlflow/server/jobs/lock_manager.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import ParamSpec, TypeVar
 
-from sqlalchemy import Update, and_, insert, join, or_, select, update
+from sqlalchemy import Update, and_, delete, insert, join, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from mlflow.entities._job_status import JobStatus
@@ -490,3 +490,35 @@ class JobLockManager:
             lock_key=lock_key,
             job_id=job_id,
         )
+
+    def release_exclusive_lock(self, job_lock: JobLock) -> None:
+        """
+        Delete the lock row that matches all fields of ``job_lock``.
+
+        The method matches ``lock_key``, ``job_id``, and ``acquired_at`` against the database row.
+        If all three fields match, the row is deleted. If any field does not match, or the row
+        does not exist, the method does nothing.
+
+        This makes the operation safe against concurrent re-acquisition: if another job acquired
+        the lock before this call, the DELETE does not affect the new lock.
+
+        Args:
+            job_lock: The lock to release. Must be a ``JobLock`` that was returned by
+            ``acquire_exclusive_lock``.
+        """
+
+        with self._session_maker(read_only=False) as session:
+            filter_args = (
+                SqlJobLock.lock_key == job_lock.lock_key,
+                SqlJobLock.job_id == job_lock.job_id,
+                SqlJobLock.acquired_at == job_lock.acquired_at,
+            )
+
+            statement = delete(SqlJobLock).filter(*filter_args)
+            result = session.execute(statement)
+
+            if result.rowcount == 0:
+                _logger.debug(
+                    "Lock release was a no-op. The lock may have been released "
+                    "or acquired by another job."
+                )

--- a/mlflow/server/jobs/lock_manager.py
+++ b/mlflow/server/jobs/lock_manager.py
@@ -411,6 +411,12 @@ class JobLockManager:
         app_now_millis = get_current_time_millis()
 
         with self._session_maker(read_only=False) as session:
+            calling_job: SqlJob = session.query(SqlJob).filter(SqlJob.id == job_id).one()
+            if calling_job.timeout is None:
+                raise MlflowException.invalid_parameter_value(
+                    "Exclusive job locks require non-null timeout."
+                )
+
             statement = self._stale_lock_update_statement(lock_key, job_id)
             result = session.execute(statement)
 
@@ -483,6 +489,7 @@ class JobLockManager:
 
         Raises:
             MlflowException: A valid lock already exists for the job_id.
+            MlflowException: Calling job has null timeout.
         """
 
         return self._guard_insert_race(

--- a/mlflow/server/jobs/lock_manager.py
+++ b/mlflow/server/jobs/lock_manager.py
@@ -7,12 +7,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import ParamSpec, TypeVar
 
-from sqlalchemy import insert
+from sqlalchemy import Update, and_, insert, join, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE, ErrorCode
+from mlflow.store.db.db_types import MSSQL, MYSQL, POSTGRES, SQLITE
 from mlflow.store.db.utils import get_current_time_millis_expression
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.tracking.dbmodels.models import SqlJob, SqlJobLock, SqlSchedulerLease
@@ -48,6 +49,13 @@ class SchedulerLease:
     ttl_seconds: int
 
 
+@dataclass(frozen=True)
+class JobLock:
+    lock_key: str
+    job_id: str
+    acquired_at: int
+
+
 class JobLockManager:
     """
     Manages scheduler lease and job lock coordination for multi-replica
@@ -73,7 +81,8 @@ class JobLockManager:
                 ...
 
         # Acquire exclusive lock
-        if lock_mgr.acquire_exclusive_lock("exp-123:hash", "job-456"):
+        exclusive_lock = lock_mgr.acquire_exclusive_lock("exp-123:hash", "job-456")
+        if exclusive_lock:
             try:
                 # ... do work ...
     """
@@ -112,7 +121,7 @@ class JobLockManager:
                 # existing row and race to insert the same lease key.
                 if isinstance(e.__cause__, IntegrityError):
                     _logger.debug(
-                        "Lease acquisition denied. A concurrent insert conflict occurred."
+                        "Lease/Lock acquisition denied. A concurrent insert conflict occurred."
                     )
                     return None
 
@@ -308,13 +317,155 @@ class JobLockManager:
             ttl_seconds=ttl_seconds,
         )
 
-    def acquire_exclusive_lock(self, lock_key: str, job_id: str) -> bool:
+    def _stale_lock_update_statement(self, lock_key: str, job_id: str) -> Update:
+        """
+        Build an UPDATE statement that replaces a stale lock with a new one.
+
+        The statement joins ``job_locks`` to ``jobs`` and updates the lock row only if the lock
+        matches ``lock_key`` AND one of these conditions is true:
+
+        - The job status is terminal or pending (not RUNNING or NEEDS_RECOVERY).
+        - The job has a timeout and the lock age exceeds 115% of that timeout.
+
+        If neither condition is true, the statement updates zero rows.
+
+        Each database dialect uses a different UPDATE syntax:
+
+        - PostgreSQL / MSSQL: ``UPDATE ... FROM`` (single atomic statement).
+        - MySQL: ``UPDATE ... JOIN`` (single atomic statement).
+        - SQLite: ``UPDATE ... WHERE IN (subquery)`` (not atomic; test use only).
+
+        Args:
+            lock_key: The lock row to target.
+            job_id: The new job ID to write into the lock row.
+
+        Returns:
+            A SQLAlchemy ``Update`` statement. The caller must execute it in a session and inspect
+            ``result.rowcount``.
+
+        Raises:
+            MlflowException: If ``self.db_type`` is not a supported dialect.
+        """
+
+        now = get_current_time_millis_expression(self.db_type)
+
+        job_has_timed_out = and_(
+            SqlJob.timeout.is_not(None),
+            SqlJobLock.acquired_at + (SqlJob.timeout * 1000 * 1.15) < now,
+        )
+        eligible_status = [
+            JobStatus.PENDING.to_int(),
+            JobStatus.SUCCEEDED.to_int(),
+            JobStatus.FAILED.to_int(),
+            JobStatus.TIMEOUT.to_int(),
+            JobStatus.CANCELED.to_int(),
+        ]
+        job_has_timed_out_or_status_is_eligible = or_(
+            job_has_timed_out, SqlJob.status.in_(eligible_status)
+        )
+
+        filter_args = (
+            SqlJobLock.lock_key == lock_key,
+            job_has_timed_out_or_status_is_eligible,
+        )
+
+        update_values = {
+            SqlJobLock.acquired_at: now,
+            SqlJobLock.job_id: job_id,
+        }
+
+        if self.db_type in {POSTGRES, MSSQL}:
+            return (
+                update(SqlJobLock)
+                .where(SqlJobLock.job_id == SqlJob.id)
+                .filter(*filter_args)
+                .values(update_values)
+            )
+
+        if self.db_type == MYSQL:
+            return (
+                update(join(SqlJobLock, SqlJob, SqlJobLock.job_id == SqlJob.id))
+                .filter(*filter_args)
+                .values(update_values)
+            )
+
+        if self.db_type == SQLITE:
+            # Use subquery for sqlite even though it is not atomic.
+            # This branch is used for unit tests and does not need to support
+            # atomic updates
+            eligible_lock_subquery = (
+                select(SqlJobLock.lock_key)
+                .join(SqlJob, SqlJobLock.job_id == SqlJob.id)
+                .filter(*filter_args)
+            ).scalar_subquery()
+
+            lock_key_matches_and_is_eligible = and_(
+                SqlJobLock.lock_key == lock_key, SqlJobLock.lock_key.in_(eligible_lock_subquery)
+            )
+
+            return update(SqlJobLock).filter(lock_key_matches_and_is_eligible).values(update_values)
+
+        raise MlflowException.invalid_parameter_value(f"Unsupported db type: {self.db_type}")
+
+    def _acquire_exclusive_lock(self, lock_key: str, job_id: str) -> JobLock | None:
+        app_now_millis = get_current_time_millis()
+
+        with self._session_maker(read_only=False) as session:
+            statement = self._stale_lock_update_statement(lock_key, job_id)
+            result = session.execute(statement)
+
+            if result.rowcount > 0:
+                reacquired_lock = (
+                    session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one()
+                )
+                _check_time_drift_and_log(app_now_millis, reacquired_lock.acquired_at)
+
+                return JobLock(
+                    lock_key=reacquired_lock.lock_key,
+                    job_id=reacquired_lock.job_id,
+                    acquired_at=reacquired_lock.acquired_at,
+                )
+
+            existing_lock = (
+                session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one_or_none()
+            )
+            if existing_lock is None:
+                insert_values = {
+                    SqlJobLock.lock_key: lock_key,
+                    SqlJobLock.acquired_at: get_current_time_millis_expression(self.db_type),
+                    SqlJobLock.job_id: job_id,
+                }
+                session.execute(insert(SqlJobLock).values(insert_values))
+
+                new_lock = session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one()
+                _check_time_drift_and_log(app_now_millis, new_lock.acquired_at)
+
+                return JobLock(
+                    lock_key=new_lock.lock_key,
+                    job_id=new_lock.job_id,
+                    acquired_at=new_lock.acquired_at,
+                )
+
+            # If the provided job_id matches an existing valid lock, a simple refusal could
+            # cause the caller to mark a running job terminal. This scenario is unlikely as
+            # the job claim logic should prevent multi replica ownership. More likely is the
+            # single owner of the job may attempt to acquire the lock twice for the same job_id
+            # before it is expired or in an eligible state. This is unlikely but the check is cheap.
+            if existing_lock.job_id == job_id:
+                raise MlflowException.invalid_parameter_value(
+                    "A valid lock already exists for this job_id"
+                )
+
+            _logger.debug("Job lock acquisition denied. A valid lock exists.")
+            return None
+
+    def acquire_exclusive_lock(self, lock_key: str, job_id: str) -> JobLock | None:
         """
         Creates an exclusive job lock from ``lock_key`` and ``job_id``.
 
-        Returns True if no lock exists or the existing lock is stale.
+        Returns ``JobLock`` if no lock exists or the existing lock is stale.
 
-        Returns False if a valid lock already exists.
+        Returns ``None`` if a valid lock already exists.
 
         NOTE:
             This method cleans up stale locks only when a new acquisition
@@ -328,115 +479,14 @@ class JobLockManager:
                 to an existing ``SqlJob``
 
         Returns:
-            True if lock acquired, False if held by another live job.
+            JobLock if lock acquired, None if held by another live job.
 
         Raises:
             MlflowException: A valid lock already exists for the job_id.
         """
-        try:
-            with self._session_maker(read_only=False) as session:
-                existing_lock = (
-                    session
-                    .query(SqlJobLock)
-                    .filter(SqlJobLock.lock_key == lock_key)
-                    .with_for_update()
-                    .one_or_none()
-                )
 
-                if existing_lock is not None:
-                    holding_job = (
-                        session
-                        .query(SqlJob)
-                        .filter(SqlJob.id == existing_lock.job_id)
-                        .one_or_none()
-                    )
-
-                    job_lock_is_valid = self._is_job_lock_valid(existing_lock, holding_job)
-
-                    # Raise an exception when the requesting job_id already holds a valid lock.
-                    # A False return could cause the caller to mark the active job as CANCELED.
-                    # The job row claim logic prevents duplicate ownership, but a replica could
-                    # still retry a lock it already holds. A stale lock held by the same job_id
-                    # can still be evicted and re-acquired.
-                    if job_lock_is_valid and job_id == existing_lock.job_id:
-                        raise MlflowException.invalid_parameter_value(
-                            "A valid lock already exists for this job_id"
-                        )
-
-                    if job_lock_is_valid:
-                        _logger.debug("Job lock acquisition denied. A valid lock exists.")
-                        return False
-
-                    session.delete(existing_lock)
-                    session.flush()
-
-                session.add(
-                    SqlJobLock(
-                        lock_key=lock_key,
-                        job_id=job_id,
-                        acquired_at=get_current_time_millis(),
-                    )
-                )
-
-            return True
-
-        except MlflowException as e:
-            holding_job_id = None
-            with self._session_maker(read_only=True) as session:
-                existing_lock = (
-                    session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one_or_none()
-                )
-
-                if existing_lock is not None:
-                    holding_job_id = existing_lock.job_id
-
-            # Check that the IntegrityError is from two different jobs that tried to
-            # acquire the same lock.
-            valid_integrity_error = (
-                isinstance(e.__cause__, IntegrityError)
-                and holding_job_id is not None
-                and holding_job_id != job_id
-            )
-            if valid_integrity_error:
-                _logger.debug("Job lock acquisition denied. A concurrent insert conflict occurred.")
-                return False
-
-            if isinstance(e.__cause__, IntegrityError):
-                _logger.error("An unexpected IntegrityError occurred during job lock acquisition")
-
-            raise
-
-    @staticmethod
-    def _is_job_lock_valid(lock: SqlJobLock, holding_job: SqlJob | None) -> bool:
-        """
-        Check if a lock is still valid.
-
-        Args:
-            lock: The ``SqlJobLock`` to validate
-            holding_job: The job currently holding the lock
-
-        Returns:
-            True if the job lock is still valid. False otherwise.
-
-        Raises:
-            MlflowException: ``lock.job_id`` must match ``holding_job.id``
-        """
-
-        if holding_job is None:
-            return False
-
-        if holding_job.id != lock.job_id:
-            raise MlflowException.invalid_parameter_value(
-                f"Lock is not held by SqlJob {lock.job_id=} != {holding_job.id=}"
-            )
-
-        if JobStatus.is_finalized(JobStatus.from_int(holding_job.status)):
-            return False
-
-        now = get_current_time_millis()
-        if holding_job.timeout is not None:
-            expiration_time = lock.acquired_at + int(holding_job.timeout * 1.15 * 1000)
-            if now > expiration_time:
-                return False
-
-        return True
+        return self._guard_insert_race(
+            fn=self._acquire_exclusive_lock,
+            lock_key=lock_key,
+            job_id=job_id,
+        )

--- a/mlflow/server/jobs/lock_manager.py
+++ b/mlflow/server/jobs/lock_manager.py
@@ -10,11 +10,12 @@ from typing import ParamSpec, TypeVar
 from sqlalchemy import insert
 from sqlalchemy.exc import IntegrityError
 
+from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE, ErrorCode
 from mlflow.store.db.utils import get_current_time_millis_expression
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
-from mlflow.store.tracking.dbmodels.models import SqlSchedulerLease
+from mlflow.store.tracking.dbmodels.models import SqlJob, SqlJobLock, SqlSchedulerLease
 from mlflow.utils.time import get_current_time_millis
 
 _logger = logging.getLogger(__name__)
@@ -52,7 +53,7 @@ class JobLockManager:
     Manages scheduler lease and job lock coordination for multi-replica
     MLflow deployments.
 
-    Uses the ``scheduler_leases`` and ``job_locks`` tables through a
+    Uses the ``scheduler_leases`` and ``job_locks`` tables with a
     SQLAlchemy session factory from a ``SqlAlchemyJobStore``.
 
     Example usage::
@@ -70,6 +71,11 @@ class JobLockManager:
             if renewed_lease is not None:
                 # This replica still holds the scheduler lease.
                 ...
+
+        # Acquire exclusive lock
+        if lock_mgr.acquire_exclusive_lock("exp-123:hash", "job-456"):
+            try:
+                # ... do work ...
     """
 
     def __init__(self, job_store: SqlAlchemyJobStore):
@@ -301,3 +307,134 @@ class JobLockManager:
             lease_key=lease_key,
             ttl_seconds=ttl_seconds,
         )
+
+    def acquire_exclusive_lock(self, lock_key: str, job_id: str) -> bool:
+        """
+        Creates an exclusive job lock from ``lock_key`` and ``job_id``.
+
+        Returns True if no lock exists or the existing lock is stale.
+
+        Returns False if a valid lock already exists.
+
+        Args:
+            lock_key: Framework-computed key
+            job_id: The job ID trying to acquire this lock
+
+        Returns:
+            True if lock acquired, False if held by another live job.
+
+        Raises:
+            MlflowException: A valid lock already exists for the job_id.
+        """
+        try:
+            with self._session_maker(read_only=False) as session:
+                existing_lock = (
+                    session
+                    .query(SqlJobLock)
+                    .filter(SqlJobLock.lock_key == lock_key)
+                    .with_for_update()
+                    .one_or_none()
+                )
+
+                if existing_lock is not None:
+                    holding_job = (
+                        session
+                        .query(SqlJob)
+                        .filter(SqlJob.id == existing_lock.job_id)
+                        .one_or_none()
+                    )
+
+                    job_lock_is_valid = self._is_job_lock_valid(existing_lock, holding_job)
+
+                    # Raise an exception when the requesting job_id already holds a valid lock.
+                    # A False return could cause the caller to mark the active job as CANCELED.
+                    # The job row claim logic prevents duplicate ownership, but a replica could
+                    # still retry a lock it already holds. A stale lock held by the same job_id
+                    # can still be evicted and re-acquired.
+                    if job_lock_is_valid and job_id == existing_lock.job_id:
+                        raise MlflowException.invalid_parameter_value(
+                            "A valid lock already exists for this job_id"
+                        )
+
+                    if job_lock_is_valid:
+                        _logger.debug("Job lock acquisition denied. A valid lock exists.")
+                        return False
+
+                    session.delete(existing_lock)
+                    session.flush()
+
+                requesting_job = session.query(SqlJob).filter(SqlJob.id == job_id).one_or_none()
+                if requesting_job is None:
+                    _logger.debug("Job lock acquisition denied. Requesting job not found.")
+                    return False
+
+                session.add(
+                    SqlJobLock(
+                        lock_key=lock_key,
+                        job_id=requesting_job.id,
+                        acquired_at=get_current_time_millis(),
+                    )
+                )
+
+            return True
+
+        except MlflowException as e:
+            holding_job_id = None
+            with self._session_maker(read_only=True) as session:
+                existing_lock = (
+                    session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one_or_none()
+                )
+
+                if existing_lock is not None:
+                    holding_job_id = existing_lock.job_id
+
+            # Check that the IntegrityError is from two different jobs that tried to
+            # acquire the same lock.
+            valid_integrity_error = (
+                isinstance(e.__cause__, IntegrityError)
+                and holding_job_id is not None
+                and holding_job_id != job_id
+            )
+            if valid_integrity_error:
+                _logger.debug("Job lock acquisition denied. A concurrent insert conflict occurred.")
+                return False
+
+            if isinstance(e.__cause__, IntegrityError):
+                _logger.error("An unexpected IntegrityError occurred during job lock acquisition")
+
+            raise
+
+    @staticmethod
+    def _is_job_lock_valid(lock: SqlJobLock, holding_job: SqlJob | None) -> bool:
+        """
+        Check if a lock is still valid.
+
+        Args:
+            lock: The ``SqlJobLock`` to validate
+            holding_job: The job currently holding the lock
+
+        Returns:
+            True if the job lock is still valid. False otherwise.
+
+        Raises:
+            MlflowException: ``lock.job_id`` must match ``holding_job.id``
+        """
+
+        if holding_job is None:
+            return False
+
+        if holding_job.id != lock.job_id:
+            raise MlflowException.invalid_parameter_value(
+                f"Lock is not held by SqlJob {lock.job_id=} != {holding_job.id=}"
+            )
+
+        if JobStatus.is_finalized(JobStatus.from_int(holding_job.status)):
+            return False
+
+        now = get_current_time_millis()
+        if holding_job.timeout is not None:
+            expiration_time = lock.acquired_at + int(holding_job.timeout * 1.15 * 1000)
+            if now > expiration_time:
+                return False
+
+        return not (holding_job.lease_expires_at is not None and now > holding_job.lease_expires_at)

--- a/tests/server/jobs/test_lock_manager.py
+++ b/tests/server/jobs/test_lock_manager.py
@@ -586,11 +586,12 @@ def test_acquire_exclusive_lock_not_evicted_for_needs_recovery_job(
     assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
 
 
-def test_acquire_exclusive_lock_evicts_lock_held_by_deleted_job_refuses_requesting_job_doesnt_exist(
+def test_acquire_exclusive_lock_held_by_deleted_job_raises_if_requesting_job_doesnt_exist(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
-    """Evicts the lock when the holding job row was deleted but the lock row
-    remains. Refuses acquisition when the requesting job does not exist.
+    """The logic in the lock acquisition method assumes the job_id belongs
+    to an existion job. If the job does not exist the method will fail
+    to remove an orphaned lock and an mlflow exception will be raised.
     """
 
     lock_key = "orphan-key"
@@ -607,11 +608,23 @@ def test_acquire_exclusive_lock_evicts_lock_held_by_deleted_job_refuses_requesti
         )
         conn.commit()
 
-    assert lock_mgr.acquire_exclusive_lock(lock_key, job_id) is False
+    # Check exception message
+    def check_exception(e: MlflowException) -> bool:
 
+        if not isinstance(e.__cause__, IntegrityError):
+            return False
+
+        return "FOREIGN KEY constraint failed" in e.message
+
+    # Call with missing job_id
+    with pytest.raises(MlflowException, check=check_exception):
+        _ = lock_mgr.acquire_exclusive_lock(lock_key, job_id)
+
+    # Validate the orphaned lock still exists
     with lock_mgr._session_maker() as session:
-        new_lock = session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one_or_none()
-        assert new_lock is None
+        orphaned_lock = session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one()
+        assert orphaned_lock.lock_key == "orphan-key"
+        assert orphaned_lock.job_id == "nonexistent-job-id"
 
 
 def test_acquire_exclusive_lock_evicts_lock_held_by_deleted_job_and_issues_new_lock(
@@ -720,7 +733,7 @@ def test_acquire_exclusive_lock_integrity_error_unique_job_ids_returns_false(
         Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
     ) as mock_one_or_none:
         assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
-        assert mock_one_or_none.call_count == 3
+        assert mock_one_or_none.call_count == 2
 
 
 def test_acquire_exclusive_lock_caught_integrity_error_raises_when_no_holding_job(
@@ -754,7 +767,7 @@ def test_acquire_exclusive_lock_caught_integrity_error_raises_when_no_holding_jo
         with pytest.raises(MlflowException, match="re-raise"):
             _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
         mock_add.assert_called_once()
-        assert mock_one_or_none.call_count == 3
+        assert mock_one_or_none.call_count == 2
 
 
 def test_acquire_exclusive_lock_caught_integrity_error_raises_when_job_ids_match(
@@ -797,7 +810,7 @@ def test_acquire_exclusive_lock_caught_integrity_error_raises_when_job_ids_match
         with pytest.raises(MlflowException, check=check_exception):
             _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
 
-        assert mock_one_or_none.call_count == 3
+        assert mock_one_or_none.call_count == 2
         mock_logger_error.assert_called_once_with(
             "An unexpected IntegrityError occurred during job lock acquisition"
         )
@@ -853,7 +866,7 @@ def test_acquire_exclusive_lock_evicts_stale_lock_timeout_exceeded(
         assert new_lock.job_id == job2.job_id
 
 
-def test_acquire_exclusive_lock_evicts_lock_when_job_not_timed_out_but_lease_has_expired(
+def test_acquire_exclusive_lock_fails_when_job_not_timed_out_but_lease_has_expired(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
     base_time = 1_000_000_000_000
@@ -875,7 +888,7 @@ def test_acquire_exclusive_lock_evicts_lock_when_job_not_timed_out_but_lease_has
         assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=after_lease):
-        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
 
 
 @pytest.mark.parametrize(
@@ -885,10 +898,10 @@ def test_acquire_exclusive_lock_evicts_lock_when_job_not_timed_out_but_lease_has
         (11.5, None, 11_500, True),
         (None, 10.0, 11_500, True),
         (11.5, 10.0, 11_500, True),
-        (11.5, None, 12_000, False),
+        (11.5, None, 12_000, True),
         (None, 10.0, 12_000, False),
         (11.5, 10.0, 12_000, False),
-        (11.5, 20.0, 12_000, False),
+        (11.5, 20.0, 12_000, True),
         (20.0, 10.0, 12_000, False),
     ],
     ids=[
@@ -896,10 +909,10 @@ def test_acquire_exclusive_lock_evicts_lock_when_job_not_timed_out_but_lease_has
         "valid_lease_no_timeout_is_valid",
         "no_lease_valid_timeout_is_valid",
         "valid_lease_valid_timeout_is_valid",
-        "expired_lease_no_timeout_is_not_valid",
+        "expired_lease_no_timeout_is_valid",
         "no_lease_expired_timeout_is_not_valid",
         "expired_lease_expired_timeout_is_not_valid",
-        "expired_lease_valid_timeout_is_not_valid",
+        "expired_lease_valid_timeout_is_valid",
         "valid_lease_expired_timeout_is_not_valid",
     ],
 )

--- a/tests/server/jobs/test_lock_manager.py
+++ b/tests/server/jobs/test_lock_manager.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 import sqlalchemy
+from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import Session
@@ -12,6 +13,7 @@ from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, TEMPORARILY_UNAVAILABLE
 from mlflow.server.jobs.lock_manager import (
+    JobLock,
     JobLockManager,
     SchedulerLease,
     _check_time_drift_and_log,
@@ -494,7 +496,7 @@ def test_acquire_exclusive_lock_succeeds_when_no_lock_exists(
     update_status = job_store.claim_job(job.job_id)
     assert update_status == JobUpdateStatus.APPLIED
 
-    assert lock_mgr.acquire_exclusive_lock("test-lock-key", job.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("test-lock-key", job.job_id), JobLock)
 
 
 def test_acquire_exclusive_lock_fails_when_live_job_holds_lock(
@@ -507,8 +509,8 @@ def test_acquire_exclusive_lock_fails_when_live_job_holds_lock(
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
 
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
 def test_acquire_exclusive_lock_evicts_stale_lock_terminal_job(
@@ -517,12 +519,12 @@ def test_acquire_exclusive_lock_evicts_stale_lock_terminal_job(
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
     job_store.report_job_result(job1.job_id, status=JobStatus.SUCCEEDED, result="done")
 
     job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
 
 
 def test_acquire_exclusive_lock_is_not_reentrant(
@@ -537,7 +539,7 @@ def test_acquire_exclusive_lock_is_not_reentrant(
     job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
     job_store.claim_job(job.job_id)
 
-    assert lock_mgr.acquire_exclusive_lock("test-key", job.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("test-key", job.job_id), JobLock)
     with pytest.raises(MlflowException, match="A valid lock already exists for this job_id"):
         _ = lock_mgr.acquire_exclusive_lock("test-key", job.job_id)
 
@@ -548,10 +550,10 @@ def test_acquire_exclusive_lock_evicts_stale_lock_terminal_job_for_same_job(
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
     job_store.report_job_result(job1.job_id, status=JobStatus.TIMEOUT, result=None)
 
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
 
 def test_multiple_unique_locks_can_coexist(
@@ -564,11 +566,11 @@ def test_multiple_unique_locks_can_coexist(
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
 
-    assert lock_mgr.acquire_exclusive_lock("key-1", job1.job_id) is True
-    assert lock_mgr.acquire_exclusive_lock("key-2", job2.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("key-1", job1.job_id), JobLock)
+    assert isinstance(lock_mgr.acquire_exclusive_lock("key-2", job2.job_id), JobLock)
 
-    assert lock_mgr.acquire_exclusive_lock("key-1", job2.job_id) is False
-    assert lock_mgr.acquire_exclusive_lock("key-2", job1.job_id) is False
+    assert lock_mgr.acquire_exclusive_lock("key-1", job2.job_id) is None
+    assert lock_mgr.acquire_exclusive_lock("key-2", job1.job_id) is None
 
 
 def test_acquire_exclusive_lock_not_evicted_for_needs_recovery_job(
@@ -578,24 +580,26 @@ def test_acquire_exclusive_lock_not_evicted_for_needs_recovery_job(
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
 
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
     job_store.mark_job_needs_recovery(job1.job_id)
 
     job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
-def test_acquire_exclusive_lock_held_by_deleted_job_raises_if_requesting_job_doesnt_exist(
+def test_acquire_exclusive_lock_held_by_deleted_job_if_cascade_failure(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
-    """The logic in the lock acquisition method assumes the job_id belongs
-    to an existion job. If the job does not exist the method will fail
-    to remove an orphaned lock and an mlflow exception will be raised.
+    """The logic in the lock acquisition method assumes the job_id belongs to an existing
+    job and does not account for cascade failures. If the job_id for referenced by the lock
+    doesnt exist, the method will raise if the the same job_id as the deleted job is used
+    and it will silently refuse a request for a different job_id. This test is included to
+    document this behavior.
     """
 
     lock_key = "orphan-key"
-    job_id = "nonexistent-job-id"
+    job_id = "job-that-got-deleted"
 
     # Insert an orphaned lock row with FK enforcement off to simulate a cascade failure
     with job_store.engine.connect() as conn:
@@ -608,58 +612,12 @@ def test_acquire_exclusive_lock_held_by_deleted_job_raises_if_requesting_job_doe
         )
         conn.commit()
 
-    # Check exception message
-    def check_exception(e: MlflowException) -> bool:
-
-        if not isinstance(e.__cause__, IntegrityError):
-            return False
-
-        return "FOREIGN KEY constraint failed" in e.message
-
-    # Call with missing job_id
-    with pytest.raises(MlflowException, check=check_exception):
+    # Call with same job_id
+    with pytest.raises(MlflowException, match="A valid lock already exists for this job_id"):
         _ = lock_mgr.acquire_exclusive_lock(lock_key, job_id)
 
-    # Validate the orphaned lock still exists
-    with lock_mgr._session_maker() as session:
-        orphaned_lock = session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one()
-        assert orphaned_lock.lock_key == "orphan-key"
-        assert orphaned_lock.job_id == "nonexistent-job-id"
-
-
-def test_acquire_exclusive_lock_evicts_lock_held_by_deleted_job_and_issues_new_lock(
-    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
-) -> None:
-    """Evicts the lock when the holding job row was deleted but the lock row
-    remains. Issues a new lock to the requesting job.
-    """
-
-    shared_job_lock = "shared-job-lock"
-
-    # Insert an orphaned lock row with FK enforcement off to simulate a cascade failure
-    with job_store.engine.connect() as conn:
-        conn.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
-        conn.execute(
-            sqlalchemy.text(
-                "INSERT INTO job_locks (lock_key, job_id, acquired_at) VALUES (:key, :id, :at)"
-            ),
-            {"key": shared_job_lock, "id": "nonexistent-job-id", "at": get_current_time_millis()},
-        )
-        conn.commit()
-
-    job = job_store.create_job(job_name="new-job", params="{}", timeout=60.0)
-    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
-
-    assert lock_mgr.acquire_exclusive_lock(shared_job_lock, job.job_id) is True
-
-    with lock_mgr._session_maker() as session:
-        new_lock = (
-            session.query(SqlJobLock).filter(SqlJobLock.lock_key == shared_job_lock).one_or_none()
-        )
-
-        assert new_lock is not None
-        assert new_lock.lock_key == shared_job_lock
-        assert new_lock.job_id == job.job_id
+    # Call with different job_id
+    assert lock_mgr.acquire_exclusive_lock(lock_key, "different-job-id") is None
 
 
 def test_acquire_exclusive_lock_with_no_timeout_and_active_lease_fails(
@@ -668,11 +626,11 @@ def test_acquire_exclusive_lock_with_no_timeout_and_active_lease_fails(
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
     assert job_store.claim_job(job1.job_id, lease_duration=3600.0) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
 def test_acquire_exclusive_lock_fails_when_no_timeout_and_no_lease_and_non_terminal_job(
@@ -681,11 +639,11 @@ def test_acquire_exclusive_lock_fails_when_no_timeout_and_no_lease_and_non_termi
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
 def test_acquire_exclusive_lock_granted_when_no_timeout_and_no_lease_and_holding_job_terminal(
@@ -694,13 +652,13 @@ def test_acquire_exclusive_lock_granted_when_no_timeout_and_no_lease_and_holding
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     job_store.finish_job(job1.job_id, "Job 1 finished")
 
     job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
 
 
 def test_acquire_exclusive_lock_integrity_error_unique_job_ids_returns_false(
@@ -713,7 +671,7 @@ def test_acquire_exclusive_lock_integrity_error_unique_job_ids_returns_false(
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
@@ -732,88 +690,8 @@ def test_acquire_exclusive_lock_integrity_error_unique_job_ids_returns_false(
     with mock.patch.object(
         Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
     ) as mock_one_or_none:
-        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
-        assert mock_one_or_none.call_count == 2
-
-
-def test_acquire_exclusive_lock_caught_integrity_error_raises_when_no_holding_job(
-    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
-) -> None:
-    """
-    The method re-raises the IntegrityError when the recovery path cannot
-    find the lock row or the holding job's ID.
-    """
-
-    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
-    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-
-    integrity_error = IntegrityError("re-raise", None, None)
-    original_one_or_none = Query.one_or_none
-    call_count = 0
-
-    def patched_one_or_none(self, *args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            return original_one_or_none(self, *args, **kwargs)
-        return None
-
-    with (
-        mock.patch.object(
-            Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
-        ) as mock_one_or_none,
-        mock.patch.object(Session, "add", side_effect=integrity_error) as mock_add,
-    ):
-        with pytest.raises(MlflowException, match="re-raise"):
-            _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
-        mock_add.assert_called_once()
-        assert mock_one_or_none.call_count == 2
-
-
-def test_acquire_exclusive_lock_caught_integrity_error_raises_when_job_ids_match(
-    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
-) -> None:
-    """
-    Simulates a race condition that must not occur in production. Two replicas
-    try to acquire a lock for the same job row. The job store prevents this.
-    If it occurs, the method must raise an exception, not return False.
-    """
-
-    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
-    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
-
-    original_one_or_none = Query.one_or_none
-    call_count = 0
-
-    def patched_one_or_none(self, *args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return None
-        return original_one_or_none(self, *args, **kwargs)
-
-    def check_exception(e: MlflowException) -> bool:
-
-        if not isinstance(e.__cause__, IntegrityError):
-            return False
-
-        return "UNIQUE constraint failed: job_locks.lock_key" in e.message
-
-    # Patch one_or_none so the first call returns None to simulate a race condition
-    with (
-        mock.patch.object(
-            Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
-        ) as mock_one_or_none,
-        mock.patch.object(Logger, "error") as mock_logger_error,
-    ):
-        with pytest.raises(MlflowException, check=check_exception):
-            _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
-
-        assert mock_one_or_none.call_count == 2
-        mock_logger_error.assert_called_once_with(
-            "An unexpected IntegrityError occurred during job lock acquisition"
-        )
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
+        mock_one_or_none.assert_called_once()
 
 
 def test_acquire_exclusive_lock_reraises_non_integrity_mlflow_exception(
@@ -824,10 +702,13 @@ def test_acquire_exclusive_lock_reraises_non_integrity_mlflow_exception(
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
 
     non_integrity_error = RuntimeError("not integrity")
-    with mock.patch.object(Session, "add", side_effect=non_integrity_error) as mock_add:
+
+    with mock.patch.object(
+        Query, "one_or_none", side_effect=non_integrity_error
+    ) as mock_one_or_none:
         with pytest.raises(MlflowException, match="not integrity"):
             lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
-        mock_add.assert_called_once()
+        mock_one_or_none.assert_called_once()
 
 
 def test_acquire_exclusive_lock_evicts_stale_lock_timeout_exceeded(
@@ -835,7 +716,7 @@ def test_acquire_exclusive_lock_evicts_stale_lock_timeout_exceeded(
 ) -> None:
     base_time = 1_000_000_000_000
     patch_time_jobstore = "mlflow.store.jobs.sqlalchemy_store.get_current_time_millis"
-    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis"
+    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis_expression"
     timeout = 60.0
     shared_job_lock = "shared-key"
 
@@ -844,7 +725,7 @@ def test_acquire_exclusive_lock_evicts_stale_lock_timeout_exceeded(
         assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=base_time):
-        assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+        assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     # 115% of timeout + 1 ms
     time_after_timeout = base_time + int(timeout * 1.15 * 1_000) + 1
@@ -854,7 +735,7 @@ def test_acquire_exclusive_lock_evicts_stale_lock_timeout_exceeded(
         assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=time_after_timeout):
-        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+        assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
 
     with lock_mgr._session_maker() as session:
         new_lock = (
@@ -878,7 +759,7 @@ def test_acquire_exclusive_lock_fails_when_job_not_timed_out_but_lease_has_expir
         assert job_store.claim_job(job1.job_id, lease_duration=10.0) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=base_time):
-        assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+        assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     # Advance past lease expiry but still within timeout
     after_lease = base_time + 11_000
@@ -888,21 +769,21 @@ def test_acquire_exclusive_lock_fails_when_job_not_timed_out_but_lease_has_expir
         assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=after_lease):
-        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
 @pytest.mark.parametrize(
-    ("lease_duration", "timeout", "time_delta", "expected"),
+    ("lease_duration", "timeout", "time_delta", "acquisition_expected"),
     [
-        (None, None, 0, True),
-        (11.5, None, 11_500, True),
-        (None, 10.0, 11_500, True),
-        (11.5, 10.0, 11_500, True),
-        (11.5, None, 12_000, True),
-        (None, 10.0, 12_000, False),
-        (11.5, 10.0, 12_000, False),
-        (11.5, 20.0, 12_000, True),
-        (20.0, 10.0, 12_000, False),
+        (None, None, 0, False),
+        (11.5, None, 11_500, False),
+        (None, 10.0, 11_500, False),
+        (11.5, 10.0, 11_500, False),
+        (11.5, None, 12_000, False),
+        (None, 10.0, 12_000, True),
+        (11.5, 10.0, 12_000, True),
+        (11.5, 20.0, 12_000, False),
+        (20.0, 10.0, 12_000, True),
     ],
     ids=[
         "no_lease_or_timeout_is_valid",
@@ -916,68 +797,69 @@ def test_acquire_exclusive_lock_fails_when_job_not_timed_out_but_lease_has_expir
         "valid_lease_expired_timeout_is_not_valid",
     ],
 )
-def test_is_job_lock_valid_lease_and_timeout_interleaving(
-    sql_job: SqlJob,
-    sql_job_lock: SqlJobLock,
+def test_acquire_exclusive_lock_lease_and_timeout_interleaving(
+    job_store: SqlAlchemyJobStore,
+    lock_mgr: JobLockManager,
     lease_duration: float | None,
     timeout: float | None,
     time_delta: int,
-    expected: bool,
+    acquisition_expected: bool,
 ) -> None:
 
     base_time = 1_000_000_000_000
-    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis"
+    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis_expression"
+    patch_time_jobstore = "mlflow.store.jobs.sqlalchemy_store.get_current_time_millis"
 
-    sql_job_lock.acquired_at = base_time
-    sql_job.creation_time = base_time
-    sql_job.timeout = timeout
-    sql_job.lease_expires_at = lease_duration
-    if lease_duration is not None:
-        sql_job.lease_expires_at = base_time + int(lease_duration * 1_000)
+    with mock.patch(patch_time_jobstore, return_value=base_time):
+        job1 = job_store.create_job(job_name="job-name-1", params="{}", timeout=timeout)
+        assert job_store.claim_job(job1.job_id, lease_duration) == JobUpdateStatus.APPLIED
+
+    with mock.patch(patch_time_lock_mgr, return_value=base_time):
+        assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     check_time = base_time + time_delta
+    with mock.patch(patch_time_jobstore, return_value=check_time):
+        job2 = job_store.create_job(job_name="job-name-2", params="{}", timeout=timeout)
+        assert job_store.claim_job(job2.job_id, lease_duration) == JobUpdateStatus.APPLIED
+
     with mock.patch(patch_time_lock_mgr, return_value=check_time):
-        assert JobLockManager._is_job_lock_valid(sql_job_lock, sql_job) is expected
-
-
-def test_is_job_lock_valid_false_when_holding_job_none(sql_job_lock: SqlJobLock) -> None:
-    assert JobLockManager._is_job_lock_valid(sql_job_lock, None) is False
-
-
-def test_is_job_lock_valid_raises_when_lock_and_holding_dont_match(
-    sql_job: SqlJob,
-    sql_job_lock: SqlJobLock,
-) -> None:
-
-    sql_job.id = str(uuid.uuid4())
-    match = (
-        f"Lock is not held by SqlJob lock.job_id='{sql_job_lock.job_id}'"
-        f" != holding_job.id='{sql_job.id}'"
-    )
-    with pytest.raises(MlflowException, match=match):
-        _ = JobLockManager._is_job_lock_valid(sql_job_lock, sql_job)
+        if acquisition_expected:
+            assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
+        else:
+            assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
 @pytest.mark.parametrize(
-    "job_status",
+    ("job_status", "acquisition_expected"),
     [
-        JobStatus.PENDING,
-        JobStatus.RUNNING,
-        JobStatus.SUCCEEDED,
-        JobStatus.FAILED,
-        JobStatus.TIMEOUT,
-        JobStatus.CANCELED,
-        JobStatus.NEEDS_RECOVERY,
+        (JobStatus.PENDING, True),
+        (JobStatus.RUNNING, False),
+        (JobStatus.SUCCEEDED, True),
+        (JobStatus.FAILED, True),
+        (JobStatus.TIMEOUT, True),
+        (JobStatus.CANCELED, True),
+        (JobStatus.NEEDS_RECOVERY, False),
     ],
 )
-def test_is_job_lock_valid_status_values(
-    sql_job: SqlJob, sql_job_lock: SqlJobLock, job_status: JobStatus
+def test_acquire_exclusive_lock_valid_status_values(
+    job_store: SqlAlchemyJobStore,
+    lock_mgr: JobLockManager,
+    job_status: JobStatus,
+    acquisition_expected: bool,
 ) -> None:
 
-    # Verify unmodified fixtures are valid
-    assert JobLockManager._is_job_lock_valid(sql_job_lock, sql_job) is True
+    job1 = job_store.create_job(job_name="job-name-1", params="{}", timeout=1000)
+    assert job_store.claim_job(job1.job_id, 1000) == JobUpdateStatus.APPLIED
+    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
-    # Update status
-    sql_job.status = JobStatus.to_int(job_status)
-    is_finalized = JobStatus.is_finalized(job_status)
-    assert JobLockManager._is_job_lock_valid(sql_job_lock, sql_job) is not is_finalized
+    job2 = job_store.create_job(job_name="job-name-2", params="{}", timeout=1000)
+    with lock_mgr._session_maker(read_only=False) as session:
+        result = session.execute(
+            update(SqlJob).filter(SqlJob.id == job1.job_id).values(status=job_status.to_int())
+        )
+        assert result.rowcount != 0
+
+    if acquisition_expected:
+        assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
+    else:
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None

--- a/tests/server/jobs/test_lock_manager.py
+++ b/tests/server/jobs/test_lock_manager.py
@@ -1,11 +1,14 @@
+import uuid
 from logging import Logger
 from unittest import mock
 
 import pytest
+import sqlalchemy
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import Session
 
+from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import BAD_REQUEST, TEMPORARILY_UNAVAILABLE
 from mlflow.server.jobs.lock_manager import (
@@ -13,8 +16,10 @@ from mlflow.server.jobs.lock_manager import (
     SchedulerLease,
     _check_time_drift_and_log,
 )
+from mlflow.store.jobs.abstract_store import JobUpdateStatus
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
-from mlflow.store.tracking.dbmodels.models import SqlSchedulerLease
+from mlflow.store.tracking.dbmodels.models import SqlJob, SqlJobLock, SqlSchedulerLease
+from mlflow.utils.time import get_current_time_millis
 
 
 @pytest.fixture
@@ -25,6 +30,26 @@ def job_store() -> SqlAlchemyJobStore:
 @pytest.fixture
 def lock_mgr(job_store: SqlAlchemyJobStore) -> JobLockManager:
     return JobLockManager(job_store)
+
+
+@pytest.fixture
+def sql_job() -> SqlJob:
+
+    job_id = str(uuid.uuid4())
+    creation_time = get_current_time_millis()
+    return SqlJob(
+        id=job_id,
+        creation_time=creation_time,
+        job_name="job-name",
+        params="params",
+        status=JobStatus.PENDING.to_int(),
+        last_update_time=creation_time,
+    )
+
+
+@pytest.fixture
+def sql_job_lock(sql_job: SqlJob) -> SqlJobLock:
+    return SqlJobLock(lock_key="lock-key", job_id=sql_job.id, acquired_at=get_current_time_millis())
 
 
 @pytest.mark.parametrize("invalid_ttl", [-1, 0], ids=["negative", "zero"])
@@ -459,3 +484,487 @@ def test_acquire_scheduler_lease_returns_none_on_concurrent_insert_race_mock(
     with mock.patch.object(Query, "one_or_none", return_value=None) as mock_one_or_none:
         assert lock_mgr.acquire_scheduler_lease("scheduler", ttl_seconds=60) is None
         mock_one_or_none.assert_called_once()
+
+
+def test_acquire_exclusive_lock_succeeds_when_no_lock_exists(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job = job_store.create_job(job_name="test_job", params="{}", timeout=60.0)
+    update_status = job_store.claim_job(job.job_id)
+    assert update_status == JobUpdateStatus.APPLIED
+
+    assert lock_mgr.acquire_exclusive_lock("test-lock-key", job.job_id) is True
+
+
+def test_acquire_exclusive_lock_fails_when_live_job_holds_lock(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+
+
+def test_acquire_exclusive_lock_evicts_stale_lock_terminal_job(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    job_store.report_job_result(job1.job_id, status=JobStatus.SUCCEEDED, result="done")
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+
+
+def test_acquire_exclusive_lock_is_not_reentrant(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    """A second attempt to acquire a valid exclusive lock raises an exception.
+    A simple refusal could cause the caller to mark the active job as CANCELED.
+    The same job_id can acquire the lock after the lock becomes stale.
+    See: test_acquire_exclusive_lock_evicts_stale_lock_terminal_job_for_same_job
+    """
+
+    job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
+    job_store.claim_job(job.job_id)
+
+    assert lock_mgr.acquire_exclusive_lock("test-key", job.job_id) is True
+    with pytest.raises(MlflowException, match="A valid lock already exists for this job_id"):
+        _ = lock_mgr.acquire_exclusive_lock("test-key", job.job_id)
+
+
+def test_acquire_exclusive_lock_evicts_stale_lock_terminal_job_for_same_job(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    job_store.report_job_result(job1.job_id, status=JobStatus.TIMEOUT, result=None)
+
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+
+def test_multiple_unique_locks_can_coexist(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    assert lock_mgr.acquire_exclusive_lock("key-1", job1.job_id) is True
+    assert lock_mgr.acquire_exclusive_lock("key-2", job2.job_id) is True
+
+    assert lock_mgr.acquire_exclusive_lock("key-1", job2.job_id) is False
+    assert lock_mgr.acquire_exclusive_lock("key-2", job1.job_id) is False
+
+
+def test_acquire_exclusive_lock_not_evicted_for_needs_recovery_job(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+    job_store.mark_job_needs_recovery(job1.job_id)
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+
+
+def test_acquire_exclusive_lock_evicts_lock_held_by_deleted_job_refuses_requesting_job_doesnt_exist(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    """Evicts the lock when the holding job row was deleted but the lock row
+    remains. Refuses acquisition when the requesting job does not exist.
+    """
+
+    lock_key = "orphan-key"
+    job_id = "nonexistent-job-id"
+
+    # Insert an orphaned lock row with FK enforcement off to simulate a cascade failure
+    with job_store.engine.connect() as conn:
+        conn.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
+        conn.execute(
+            sqlalchemy.text(
+                "INSERT INTO job_locks (lock_key, job_id, acquired_at) VALUES (:key, :id, :at)"
+            ),
+            {"key": lock_key, "id": job_id, "at": get_current_time_millis()},
+        )
+        conn.commit()
+
+    assert lock_mgr.acquire_exclusive_lock(lock_key, job_id) is False
+
+    with lock_mgr._session_maker() as session:
+        new_lock = session.query(SqlJobLock).filter(SqlJobLock.lock_key == lock_key).one_or_none()
+        assert new_lock is None
+
+
+def test_acquire_exclusive_lock_evicts_lock_held_by_deleted_job_and_issues_new_lock(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    """Evicts the lock when the holding job row was deleted but the lock row
+    remains. Issues a new lock to the requesting job.
+    """
+
+    shared_job_lock = "shared-job-lock"
+
+    # Insert an orphaned lock row with FK enforcement off to simulate a cascade failure
+    with job_store.engine.connect() as conn:
+        conn.execute(sqlalchemy.text("PRAGMA foreign_keys = OFF"))
+        conn.execute(
+            sqlalchemy.text(
+                "INSERT INTO job_locks (lock_key, job_id, acquired_at) VALUES (:key, :id, :at)"
+            ),
+            {"key": shared_job_lock, "id": "nonexistent-job-id", "at": get_current_time_millis()},
+        )
+        conn.commit()
+
+    job = job_store.create_job(job_name="new-job", params="{}", timeout=60.0)
+    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    assert lock_mgr.acquire_exclusive_lock(shared_job_lock, job.job_id) is True
+
+    with lock_mgr._session_maker() as session:
+        new_lock = (
+            session.query(SqlJobLock).filter(SqlJobLock.lock_key == shared_job_lock).one_or_none()
+        )
+
+        assert new_lock is not None
+        assert new_lock.lock_key == shared_job_lock
+        assert new_lock.job_id == job.job_id
+
+
+def test_acquire_exclusive_lock_with_no_timeout_and_active_lease_fails(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id, lease_duration=3600.0) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+
+
+def test_acquire_exclusive_lock_fails_when_no_timeout_and_no_lease_and_non_terminal_job(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+
+
+def test_acquire_exclusive_lock_granted_when_no_timeout_and_no_lease_and_holding_job_terminal(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    job_store.finish_job(job1.job_id, "Job 1 finished")
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+
+
+def test_acquire_exclusive_lock_integrity_error_unique_job_ids_returns_false(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    """
+    Two different jobs race to acquire the same lock. The loser receives
+    False so it can mark the job as CANCELED.
+    """
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    original_one_or_none = Query.one_or_none
+    call_count = 0
+
+    def patched_one_or_none(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return None
+        return original_one_or_none(self, *args, **kwargs)
+
+    # Patch one_or_none so the first call returns None to simulate a race condition
+    with mock.patch.object(
+        Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
+    ) as mock_one_or_none:
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is False
+        assert mock_one_or_none.call_count == 3
+
+
+def test_acquire_exclusive_lock_caught_integrity_error_raises_when_no_holding_job(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    """
+    The method re-raises the IntegrityError when the recovery path cannot
+    find the lock row or the holding job's ID.
+    """
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+
+    integrity_error = IntegrityError("re-raise", None, None)
+    original_one_or_none = Query.one_or_none
+    call_count = 0
+
+    def patched_one_or_none(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            return original_one_or_none(self, *args, **kwargs)
+        return None
+
+    with (
+        mock.patch.object(
+            Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
+        ) as mock_one_or_none,
+        mock.patch.object(Session, "add", side_effect=integrity_error) as mock_add,
+    ):
+        with pytest.raises(MlflowException, match="re-raise"):
+            _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
+        mock_add.assert_called_once()
+        assert mock_one_or_none.call_count == 3
+
+
+def test_acquire_exclusive_lock_caught_integrity_error_raises_when_job_ids_match(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    """
+    Simulates a race condition that must not occur in production. Two replicas
+    try to acquire a lock for the same job row. The job store prevents this.
+    If it occurs, the method must raise an exception, not return False.
+    """
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    original_one_or_none = Query.one_or_none
+    call_count = 0
+
+    def patched_one_or_none(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return None
+        return original_one_or_none(self, *args, **kwargs)
+
+    def check_exception(e: MlflowException) -> bool:
+
+        if not isinstance(e.__cause__, IntegrityError):
+            return False
+
+        return "UNIQUE constraint failed: job_locks.lock_key" in e.message
+
+    # Patch one_or_none so the first call returns None to simulate a race condition
+    with (
+        mock.patch.object(
+            Query, "one_or_none", side_effect=patched_one_or_none, autospec=True
+        ) as mock_one_or_none,
+        mock.patch.object(Logger, "error") as mock_logger_error,
+    ):
+        with pytest.raises(MlflowException, check=check_exception):
+            _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
+
+        assert mock_one_or_none.call_count == 3
+        mock_logger_error.assert_called_once_with(
+            "An unexpected IntegrityError occurred during job lock acquisition"
+        )
+
+
+def test_acquire_exclusive_lock_reraises_non_integrity_mlflow_exception(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+
+    non_integrity_error = RuntimeError("not integrity")
+    with mock.patch.object(Session, "add", side_effect=non_integrity_error) as mock_add:
+        with pytest.raises(MlflowException, match="not integrity"):
+            lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
+        mock_add.assert_called_once()
+
+
+def test_acquire_exclusive_lock_evicts_stale_lock_timeout_exceeded(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    base_time = 1_000_000_000_000
+    patch_time_jobstore = "mlflow.store.jobs.sqlalchemy_store.get_current_time_millis"
+    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis"
+    timeout = 60.0
+    shared_job_lock = "shared-key"
+
+    with mock.patch(patch_time_jobstore, return_value=base_time):
+        job1 = job_store.create_job(job_name="job1", params="{}", timeout=timeout)
+        assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+
+    with mock.patch(patch_time_lock_mgr, return_value=base_time):
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    # 115% of timeout + 1 ms
+    time_after_timeout = base_time + int(timeout * 1.15 * 1_000) + 1
+
+    with mock.patch(patch_time_jobstore, return_value=time_after_timeout):
+        job2 = job_store.create_job(job_name="job2", params="{}", timeout=timeout)
+        assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    with mock.patch(patch_time_lock_mgr, return_value=time_after_timeout):
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+
+    with lock_mgr._session_maker() as session:
+        new_lock = (
+            session.query(SqlJobLock).filter(SqlJobLock.lock_key == shared_job_lock).one_or_none()
+        )
+
+        assert new_lock is not None
+        assert new_lock.lock_key == shared_job_lock
+        assert new_lock.job_id == job2.job_id
+
+
+def test_acquire_exclusive_lock_evicts_lock_when_job_not_timed_out_but_lease_has_expired(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+    base_time = 1_000_000_000_000
+    patch_time_jobstore = "mlflow.store.jobs.sqlalchemy_store.get_current_time_millis"
+    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis"
+
+    with mock.patch(patch_time_jobstore, return_value=base_time):
+        job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+        assert job_store.claim_job(job1.job_id, lease_duration=10.0) == JobUpdateStatus.APPLIED
+
+    with mock.patch(patch_time_lock_mgr, return_value=base_time):
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id) is True
+
+    # Advance past lease expiry but still within timeout
+    after_lease = base_time + 11_000
+
+    with mock.patch(patch_time_jobstore, return_value=after_lease):
+        job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+        assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    with mock.patch(patch_time_lock_mgr, return_value=after_lease):
+        assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is True
+
+
+@pytest.mark.parametrize(
+    ("lease_duration", "timeout", "time_delta", "expected"),
+    [
+        (None, None, 0, True),
+        (11.5, None, 11_500, True),
+        (None, 10.0, 11_500, True),
+        (11.5, 10.0, 11_500, True),
+        (11.5, None, 12_000, False),
+        (None, 10.0, 12_000, False),
+        (11.5, 10.0, 12_000, False),
+        (11.5, 20.0, 12_000, False),
+        (20.0, 10.0, 12_000, False),
+    ],
+    ids=[
+        "no_lease_or_timeout_is_valid",
+        "valid_lease_no_timeout_is_valid",
+        "no_lease_valid_timeout_is_valid",
+        "valid_lease_valid_timeout_is_valid",
+        "expired_lease_no_timeout_is_not_valid",
+        "no_lease_expired_timeout_is_not_valid",
+        "expired_lease_expired_timeout_is_not_valid",
+        "expired_lease_valid_timeout_is_not_valid",
+        "valid_lease_expired_timeout_is_not_valid",
+    ],
+)
+def test_is_job_lock_valid_lease_and_timeout_interleaving(
+    sql_job: SqlJob,
+    sql_job_lock: SqlJobLock,
+    lease_duration: float | None,
+    timeout: float | None,
+    time_delta: int,
+    expected: bool,
+) -> None:
+
+    base_time = 1_000_000_000_000
+    patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis"
+
+    sql_job_lock.acquired_at = base_time
+    sql_job.creation_time = base_time
+    sql_job.timeout = timeout
+    sql_job.lease_expires_at = lease_duration
+    if lease_duration is not None:
+        sql_job.lease_expires_at = base_time + int(lease_duration * 1_000)
+
+    check_time = base_time + time_delta
+    with mock.patch(patch_time_lock_mgr, return_value=check_time):
+        assert JobLockManager._is_job_lock_valid(sql_job_lock, sql_job) is expected
+
+
+def test_is_job_lock_valid_false_when_holding_job_none(sql_job_lock: SqlJobLock) -> None:
+    assert JobLockManager._is_job_lock_valid(sql_job_lock, None) is False
+
+
+def test_is_job_lock_valid_raises_when_lock_and_holding_dont_match(
+    sql_job: SqlJob,
+    sql_job_lock: SqlJobLock,
+) -> None:
+
+    sql_job.id = str(uuid.uuid4())
+    match = (
+        f"Lock is not held by SqlJob lock.job_id='{sql_job_lock.job_id}'"
+        f" != holding_job.id='{sql_job.id}'"
+    )
+    with pytest.raises(MlflowException, match=match):
+        _ = JobLockManager._is_job_lock_valid(sql_job_lock, sql_job)
+
+
+@pytest.mark.parametrize(
+    "job_status",
+    [
+        JobStatus.PENDING,
+        JobStatus.RUNNING,
+        JobStatus.SUCCEEDED,
+        JobStatus.FAILED,
+        JobStatus.TIMEOUT,
+        JobStatus.CANCELED,
+        JobStatus.NEEDS_RECOVERY,
+    ],
+)
+def test_is_job_lock_valid_status_values(
+    sql_job: SqlJob, sql_job_lock: SqlJobLock, job_status: JobStatus
+) -> None:
+
+    # Verify unmodified fixtures are valid
+    assert JobLockManager._is_job_lock_valid(sql_job_lock, sql_job) is True
+
+    # Update status
+    sql_job.status = JobStatus.to_int(job_status)
+    is_finalized = JobStatus.is_finalized(job_status)
+    assert JobLockManager._is_job_lock_valid(sql_job_lock, sql_job) is not is_finalized

--- a/tests/server/jobs/test_lock_manager.py
+++ b/tests/server/jobs/test_lock_manager.py
@@ -863,3 +863,163 @@ def test_acquire_exclusive_lock_valid_status_values(
         assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
     else:
         assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
+
+
+def test_release_exclusive_lock_deletes_lock_row(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
+    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    job_lock = lock_mgr.acquire_exclusive_lock("test-key", job.job_id)
+    assert isinstance(job_lock, JobLock)
+
+    lock_mgr.release_exclusive_lock(job_lock)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "test-key").one_or_none()
+        assert row is None
+
+
+def test_release_exclusive_lock_is_idempotent(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
+    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    job_lock = lock_mgr.acquire_exclusive_lock("test-key", job.job_id)
+    assert isinstance(job_lock, JobLock)
+
+    lock_mgr.release_exclusive_lock(job_lock)
+    lock_mgr.release_exclusive_lock(job_lock)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "test-key").one_or_none()
+        assert row is None
+
+
+def test_release_exclusive_lock_allows_reacquisition(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+
+    lock1 = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
+    assert isinstance(lock1, JobLock)
+
+    lock_mgr.release_exclusive_lock(lock1)
+
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    lock2 = lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id)
+    assert isinstance(lock2, JobLock)
+    assert lock2.job_id == job2.job_id
+
+
+def test_release_exclusive_lock_does_not_delete_other_jobs_lock(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    lock1 = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
+    assert isinstance(lock1, JobLock)
+
+    job_store.report_job_result(job1.job_id, status=JobStatus.SUCCEEDED, result="done")
+    lock2 = lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id)
+    assert isinstance(lock2, JobLock)
+
+    # Job1 tries to release with its stale JobLock — should not affect job2's lock
+    lock_mgr.release_exclusive_lock(lock1)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "shared-key").one()
+        assert row.job_id == job2.job_id
+
+
+def test_release_exclusive_lock_no_op_with_wrong_lock_key(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
+    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    job_lock = lock_mgr.acquire_exclusive_lock("real-key", job.job_id)
+    assert isinstance(job_lock, JobLock)
+
+    fake_lock = JobLock(
+        lock_key="wrong-key", job_id=job_lock.job_id, acquired_at=job_lock.acquired_at
+    )
+    lock_mgr.release_exclusive_lock(fake_lock)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "real-key").one_or_none()
+        assert row is not None
+
+
+def test_release_exclusive_lock_no_op_with_wrong_job_id(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
+    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    job_lock = lock_mgr.acquire_exclusive_lock("test-key", job.job_id)
+    assert isinstance(job_lock, JobLock)
+
+    fake_lock = JobLock(
+        lock_key=job_lock.lock_key, job_id="wrong-id", acquired_at=job_lock.acquired_at
+    )
+    lock_mgr.release_exclusive_lock(fake_lock)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "test-key").one_or_none()
+        assert row is not None
+
+
+def test_release_exclusive_lock_no_op_with_wrong_acquired_at(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job = job_store.create_job(job_name="job", params="{}", timeout=60.0)
+    assert job_store.claim_job(job.job_id) == JobUpdateStatus.APPLIED
+
+    job_lock = lock_mgr.acquire_exclusive_lock("test-key", job.job_id)
+    assert isinstance(job_lock, JobLock)
+
+    fake_lock = JobLock(lock_key=job_lock.lock_key, job_id=job_lock.job_id, acquired_at=0)
+    lock_mgr.release_exclusive_lock(fake_lock)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "test-key").one_or_none()
+        assert row is not None
+
+
+def test_release_exclusive_lock_does_not_affect_other_lock_keys(
+    job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
+) -> None:
+
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=60.0)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=60.0)
+    assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
+    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
+
+    lock1 = lock_mgr.acquire_exclusive_lock("key-1", job1.job_id)
+    lock2 = lock_mgr.acquire_exclusive_lock("key-2", job2.job_id)
+    assert isinstance(lock1, JobLock)
+    assert isinstance(lock2, JobLock)
+
+    lock_mgr.release_exclusive_lock(lock1)
+
+    with lock_mgr._session_maker(read_only=True) as session:
+        row1 = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "key-1").one_or_none()
+        row2 = session.query(SqlJobLock).filter(SqlJobLock.lock_key == "key-2").one_or_none()
+        assert row1 is None
+        assert row2 is not None

--- a/tests/server/jobs/test_lock_manager.py
+++ b/tests/server/jobs/test_lock_manager.py
@@ -588,14 +588,12 @@ def test_acquire_exclusive_lock_not_evicted_for_needs_recovery_job(
     assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
-def test_acquire_exclusive_lock_held_by_deleted_job_if_cascade_failure(
+def test_acquire_exclusive_lock_held_by_deleted_job_cascade_failure_raises(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
     """The logic in the lock acquisition method assumes the job_id belongs to an existing
     job and does not account for cascade failures. If the job_id for referenced by the lock
-    doesnt exist, the method will raise if the the same job_id as the deleted job is used
-    and it will silently refuse a request for a different job_id. This test is included to
-    document this behavior.
+    doesnt exist, the method will raise when the job is not found.
     """
 
     lock_key = "orphan-key"
@@ -613,11 +611,12 @@ def test_acquire_exclusive_lock_held_by_deleted_job_if_cascade_failure(
         conn.commit()
 
     # Call with same job_id
-    with pytest.raises(MlflowException, match="A valid lock already exists for this job_id"):
+    with pytest.raises(MlflowException, match="No row was found when one was required"):
         _ = lock_mgr.acquire_exclusive_lock(lock_key, job_id)
 
     # Call with different job_id
-    assert lock_mgr.acquire_exclusive_lock(lock_key, "different-job-id") is None
+    with pytest.raises(MlflowException, match="No row was found when one was required"):
+        _ = lock_mgr.acquire_exclusive_lock(lock_key, "different-job-id")
 
 
 def test_acquire_exclusive_lock_with_no_timeout_and_active_lease_fails(
@@ -626,37 +625,34 @@ def test_acquire_exclusive_lock_with_no_timeout_and_active_lease_fails(
 
     job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
     assert job_store.claim_job(job1.job_id, lease_duration=3600.0) == JobUpdateStatus.APPLIED
-    assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
-
-    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
-    assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
-    assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
+    with pytest.raises(MlflowException, match="Exclusive job locks require non-null timeout."):
+        _ = lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id)
 
 
-def test_acquire_exclusive_lock_fails_when_no_timeout_and_no_lease_and_non_terminal_job(
+def test_acquire_exclusive_lock_fails_when_no_lease_and_non_terminal_job(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
 
-    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=1000)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
     assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
-    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=1000)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
     assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
 
 
-def test_acquire_exclusive_lock_granted_when_no_timeout_and_no_lease_and_holding_job_terminal(
+def test_acquire_exclusive_lock_granted_when_no_lease_and_holding_job_terminal(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
 
-    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=1000)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
     assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
     job_store.finish_job(job1.job_id, "Job 1 finished")
 
-    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=1000)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
     assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
 
@@ -669,11 +665,11 @@ def test_acquire_exclusive_lock_integrity_error_unique_job_ids_returns_false(
     False so it can mark the job as CANCELED.
     """
 
-    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=1000)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
     assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job1.job_id), JobLock)
 
-    job2 = job_store.create_job(job_name="job2", params="{}", timeout=None)
+    job2 = job_store.create_job(job_name="job2", params="{}", timeout=1000)
     assert job_store.claim_job(job2.job_id) == JobUpdateStatus.APPLIED
 
     original_one_or_none = Query.one_or_none
@@ -698,7 +694,7 @@ def test_acquire_exclusive_lock_reraises_non_integrity_mlflow_exception(
     job_store: SqlAlchemyJobStore, lock_mgr: JobLockManager
 ) -> None:
 
-    job1 = job_store.create_job(job_name="job1", params="{}", timeout=None)
+    job1 = job_store.create_job(job_name="job1", params="{}", timeout=1000)
     assert job_store.claim_job(job1.job_id) == JobUpdateStatus.APPLIED
 
     non_integrity_error = RuntimeError("not integrity")
@@ -810,8 +806,12 @@ def test_acquire_exclusive_lock_lease_and_timeout_interleaving(
     patch_time_lock_mgr = "mlflow.server.jobs.lock_manager.get_current_time_millis_expression"
     patch_time_jobstore = "mlflow.store.jobs.sqlalchemy_store.get_current_time_millis"
 
+    job1_timeout = 1000
+    if timeout is not None:
+        job1_timeout = timeout
+
     with mock.patch(patch_time_jobstore, return_value=base_time):
-        job1 = job_store.create_job(job_name="job-name-1", params="{}", timeout=timeout)
+        job1 = job_store.create_job(job_name="job-name-1", params="{}", timeout=job1_timeout)
         assert job_store.claim_job(job1.job_id, lease_duration) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=base_time):
@@ -823,7 +823,11 @@ def test_acquire_exclusive_lock_lease_and_timeout_interleaving(
         assert job_store.claim_job(job2.job_id, lease_duration) == JobUpdateStatus.APPLIED
 
     with mock.patch(patch_time_lock_mgr, return_value=check_time):
-        if acquisition_expected:
+        if timeout is None:
+            match = "Exclusive job locks require non-null timeout."
+            with pytest.raises(MlflowException, match=match):
+                _ = lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id)
+        elif acquisition_expected:
             assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
         else:
             assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
@@ -863,6 +867,18 @@ def test_acquire_exclusive_lock_valid_status_values(
         assert isinstance(lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id), JobLock)
     else:
         assert lock_mgr.acquire_exclusive_lock("shared-key", job2.job_id) is None
+
+
+def test_acquire_exclusive_lock_valid_null_timeout_raises(
+    job_store: SqlAlchemyJobStore,
+    lock_mgr: JobLockManager,
+) -> None:
+
+    job = job_store.create_job(job_name="job-name-1", params="{}", timeout=None)
+    assert job_store.claim_job(job.job_id, 1000) == JobUpdateStatus.APPLIED
+
+    with pytest.raises(MlflowException, match="Exclusive job locks require non-null timeout."):
+        _ = lock_mgr.acquire_exclusive_lock("shared-key", job.job_id)
 
 
 def test_release_exclusive_lock_deletes_lock_row(


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Relates to https://github.com/mlflow/rfcs/pull/2

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR introduces the `JobLockManager.acquire_exclusive_lock` and `JobLockManager._is_job_lock_valid` methods.

`acquire_exclusive_lock` inserts a row into the job_locks table. The method uses SELECT ... FOR UPDATE and an IntegrityError fallback to stay safe across replicas.

When a lock is stale, the next acquisition evicts it and inserts a new row. There is no explicit release method. The terminal status of the holding job lets the next acquirer evict the lock.

The method raises an exception when a job tries to acquire a lock it already holds. A silent refusal could cause the caller to mark the active job as CANCELED.

When two different jobs race to insert the same lock, the loser receives False. The IntegrityError recovery path opens a second read-only session to identify the winner. If the recovery path finds that the same job caused the conflict, the method re-raises the exception

`_is_job_lock_valid` is a helper function used to validate an existing lock.

  A lock is valid when all of these conditions are true:
  - The holding job exists and is not in a terminal status.
  - The job timeout (with 15% grace) has not elapsed.
  - The job lease has not expired.

**NOTE**: The implementation does not provide a means to "release" or remove locks from the `job_locks` table. Stale locks are only removed when there is a requesting lock key collision. In the event of a collision, locks are replaced so once a row is created in the table it will persist. Over time, job locks will accumulate in the table. A future optimization could be added to periodically sweep and prune old locks.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

### PR Stack
- https://github.com/mlflow/mlflow/pull/24942
- https://github.com/mlflow/mlflow/pull/25199
- https://github.com/mlflow/mlflow/pull/25200 **<- This PR**

---
*Part of a stacked PR sequence. Please review layers sequentially.*

