### PR TITLE
Fix incorrect Bedrock model ID for Claude Sonnet 4 in evaluation quickstart

### DIFF
--- a/docs/docs/genai/eval-monitor/quickstart.mdx
+++ b/docs/docs/genai/eval-monitor/quickstart.mdx
@@ -158,7 +158,7 @@ The default model used for LLM-as-a-Judge scorers such as Correctness and Guidel
 Correctness(model="anthropic:/claude-sonnet-4-20250514")
 
 # Bedrock (Anthropic on Bedrock)
-Correctness(model="bedrock:/anthropic.claude-sonnet-4-20250514")
+Correctness(model="bedrock:/anthropic.claude-sonnet-4-20250514-v1:0")
 
 # Bedrock (Amazon Nova)
 Correctness(model="bedrock:/amazon.nova-pro-v1:0")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25201

### What changes are proposed in this pull request?

Fixes an incorrect Amazon Bedrock model ID in the evaluation quickstart's "different model providers for the judge model" example.

The Bedrock example for Claude Sonnet 4 used:

```python
Correctness(model="bedrock:/anthropic.claude-sonnet-4-20250514")
```

This model ID is missing the required `-v1:0` version suffix and is therefore not a valid Bedrock model identifier. On Amazon Bedrock the ID for Claude Sonnet 4 is `anthropic.claude-sonnet-4-20250514-v1:0` (see AWS's [Claude Sonnet 4 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4.html)). The string after `bedrock:/` is passed straight through as `modelId` to the Bedrock API by MLflow's Bedrock provider (`mlflow/gateway/providers/bedrock.py`), so an ID without the version suffix is rejected by Bedrock with a `ValidationException`, and a user copying this snippet would hit a model-not-found error.

The three Amazon Nova examples in the same code block already include the correct `-v1:0` suffix, so this also fixes an internal inconsistency. The separate direct-Anthropic example (`anthropic:/claude-sonnet-4-20250514`) is left unchanged because the Anthropic API correctly uses the un-suffixed ID.

```diff
- Correctness(model="bedrock:/anthropic.claude-sonnet-4-20250514")
+ Correctness(model="bedrock:/anthropic.claude-sonnet-4-20250514-v1:0")
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Documentation-only change (a single string in a code example). Verified the corrected model ID against AWS's official Claude Sonnet 4 model card, and confirmed it matches the `-v1:0` convention used by the adjacent Amazon Nova examples in the same block.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
