### PR TITLE
Skip `entry_point.getLogger()` when unavailable in dynamic token config provider

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1473,7 +1473,15 @@ def _init_databricks_dynamic_token_config_provider(entry_point):
 
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):
-                logger = entry_point.getLogger()
+                # `entry_point.getLogger()` is only used to emit best-effort usage telemetry
+                # below. It is unavailable on some runtimes (e.g. serverless, where the Py4J
+                # entry point is disabled), so resolve it defensively and skip logging if it
+                # cannot be obtained rather than failing credential resolution.
+                try:
+                    logger = entry_point.getLogger()
+                except Exception as e:
+                    logger = None
+                    _logger.debug(f"Failed to get Databricks entry point logger: {e}")
                 try:
                     from dbruntime.databricks_repl_context import get_context
 
@@ -1502,11 +1510,12 @@ def _init_databricks_dynamic_token_config_provider(entry_point):
                     # Using apiToken from command context would return back the token which is not
                     # refreshed.
                     fallback_api_token_option = notebook_utils.getContext().apiToken()
-                    logger.logUsage(
-                        "refreshableTokenNotFound",
-                        {"api_url": api_url},
-                        None,
-                    )
+                    if logger is not None:
+                        logger.logUsage(
+                            "refreshableTokenNotFound",
+                            {"api_url": api_url},
+                            None,
+                        )
                     if fallback_api_token_option.isDefined():
                         api_token = fallback_api_token_option.get()
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1468,20 +1468,22 @@ def _init_databricks_dynamic_token_config_provider(entry_point):
     dbr_version = get_databricks_runtime_major_minor_version()
     dbr_major_minor_version = (dbr_version.major, dbr_version.minor)
 
+    # `entry_point.getLogger()` is only used to emit best-effort usage telemetry below. It is
+    # unavailable on some runtimes (e.g. serverless, where the Py4J entry point is disabled), so
+    # resolve it once at construction time and skip logging if it cannot be obtained rather than
+    # failing credential resolution. Resolving here (instead of in `get_config()`) avoids emitting
+    # the debug log on every credential refresh.
+    try:
+        entry_point_logger = entry_point.getLogger()
+    except Exception as e:
+        entry_point_logger = None
+        _logger.debug(f"Failed to get Databricks entry point logger: {e}")
+
     # the CLI code in client-branch-1.0 is the same as in the 15.0 runtime branch
     if dbr_version.is_client_image or dbr_major_minor_version >= (13, 2):
 
         class DynamicConfigProvider(DatabricksConfigProvider):
             def get_config(self):
-                # `entry_point.getLogger()` is only used to emit best-effort usage telemetry
-                # below. It is unavailable on some runtimes (e.g. serverless, where the Py4J
-                # entry point is disabled), so resolve it defensively and skip logging if it
-                # cannot be obtained rather than failing credential resolution.
-                try:
-                    logger = entry_point.getLogger()
-                except Exception as e:
-                    logger = None
-                    _logger.debug(f"Failed to get Databricks entry point logger: {e}")
                 try:
                     from dbruntime.databricks_repl_context import get_context
 
@@ -1510,8 +1512,8 @@ def _init_databricks_dynamic_token_config_provider(entry_point):
                     # Using apiToken from command context would return back the token which is not
                     # refreshed.
                     fallback_api_token_option = notebook_utils.getContext().apiToken()
-                    if logger is not None:
-                        logger.logUsage(
+                    if entry_point_logger is not None:
+                        entry_point_logger.logUsage(
                             "refreshableTokenNotFound",
                             {"api_url": api_url},
                             None,

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1513,11 +1513,16 @@ def _init_databricks_dynamic_token_config_provider(entry_point):
                     # refreshed.
                     fallback_api_token_option = notebook_utils.getContext().apiToken()
                     if entry_point_logger is not None:
-                        entry_point_logger.logUsage(
-                            "refreshableTokenNotFound",
-                            {"api_url": api_url},
-                            None,
-                        )
+                        # Best-effort telemetry: never let a logging failure prevent the fallback
+                        # token retrieval below.
+                        try:
+                            entry_point_logger.logUsage(
+                                "refreshableTokenNotFound",
+                                {"api_url": api_url},
+                                None,
+                            )
+                        except Exception as e:
+                            _logger.debug(f"Failed to emit `refreshableTokenNotFound` usage: {e}")
                     if fallback_api_token_option.isDefined():
                         api_token = fallback_api_token_option.get()
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -387,6 +387,47 @@ def test_model_serving_config_provider_errors_caught():
         assert provider.get_config() is None
 
 
+def _make_dynamic_token_entry_point(get_logger_raises):
+    """
+    Build a mock ``entry_point`` for ``_init_databricks_dynamic_token_config_provider`` whose
+    notebook context returns a host/token and whose token-refresh path falls back to the command
+    context (exercising the branch that would emit usage telemetry).
+    """
+    entry_point = mock.MagicMock()
+    if get_logger_raises:
+        entry_point.getLogger.side_effect = AttributeError(
+            "dbutils.entry_point.getLogger is not supported on this cluster."
+        )
+    context = entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value
+    context.apiUrl.return_value.isDefined.return_value = True
+    context.apiUrl.return_value.get.return_value = "https://databricks.com"
+    context.apiToken.return_value.isDefined.return_value = True
+    context.apiToken.return_value.get.return_value = "token"
+    # Force the token-refresh fallback path, which is the only place the logger is used.
+    entry_point.getNonUcApiToken.side_effect = Exception("no refreshable token")
+    entry_point.getDriverConf.return_value.workflowSslTrustAll.return_value = False
+    return entry_point
+
+
+@pytest.mark.parametrize("get_logger_raises", [True, False])
+def test_dynamic_token_config_provider_get_config_when_logger_unavailable(
+    monkeypatch, get_logger_raises
+):
+    monkeypatch.setattr(
+        databricks_utils,
+        "get_databricks_runtime_major_minor_version",
+        lambda: DatabricksRuntimeVersion(
+            is_client_image=False, major=15, minor=0, is_gpu_image=False
+        ),
+    )
+    entry_point = _make_dynamic_token_entry_point(get_logger_raises)
+    databricks_utils._init_databricks_dynamic_token_config_provider(entry_point)
+    config = databricks_utils._dynamic_token_config_provider.get_config()
+
+    assert config.host == "https://databricks.com"
+    assert config.token == "token"
+
+
 def test_get_workspace_info_from_databricks_secrets():
     mock_dbutils = mock.MagicMock()
     mock_dbutils.secrets.get.return_value = "workspace-placeholder-info"

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -427,6 +427,15 @@ def test_dynamic_token_config_provider_get_config_when_logger_unavailable(
     assert config.host == "https://databricks.com"
     assert config.token == "token"
 
+    if get_logger_raises:
+        # No logger is available, so no usage telemetry should be emitted.
+        entry_point.getLogger.return_value.logUsage.assert_not_called()
+    else:
+        # The logger resolved successfully, so the fallback path should emit usage telemetry.
+        entry_point.getLogger.return_value.logUsage.assert_called_once_with(
+            "refreshableTokenNotFound", {"api_url": "https://databricks.com"}, None
+        )
+
 
 def test_get_workspace_info_from_databricks_secrets():
     mock_dbutils = mock.MagicMock()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

On serverless runtimes, the Py4J-backed `dbutils.entry_point.getLogger()` is not supported (Py4J is disabled). Because `DynamicConfigProvider.get_config()` called `entry_point.getLogger()` as its very first statement, `mlflow.start_run()` failed with:

```
AttributeError: dbutils.entry_point.getLogger is not supported on this cluster.
```

during Databricks credential resolution.

The `getLogger()` result is only used to emit a best-effort `logUsage("refreshableTokenNotFound", ...)` telemetry ping in the token-refresh fallback path — it is not needed for credential resolution. This PR resolves the logger defensively: if `getLogger()` raises, we log a debug message and set the logger to `None`, and the later `logUsage` call is skipped when the logger is unavailable. This lets `start_run()` proceed instead of raising.

This is an intermediate fix. The same `get_config()` still calls other `entry_point` methods (`getNonUcApiToken()`, `getDriverConf()`) that may also be unsupported on serverless; migrating those to the runtime integration client can be a follow-up.

### How is this PR tested?

- [x] Manual tests

Verified on a serverless (AI v6) cluster that the `RuntimeIntegrationGrpcClient` does not expose a logging surface, and that skipping the telemetry ping allows credential resolution to continue.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an `AttributeError` from `dbutils.entry_point.getLogger` that could cause `mlflow.start_run()` to fail on Databricks serverless runtimes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.