### PR TITLE
Auto-select the seeded custom view on demo experiments

### DIFF
--- a/mlflow/demo/README.md
+++ b/mlflow/demo/README.md
@@ -18,13 +18,14 @@ mlflow/demo/
     ├── __init__.py          # Registers generators (order matters!)
     ├── prompts.py           # Prompt versions and aliases
     ├── traces.py            # Sample traces with various patterns
+    ├── custom_view.py       # Saved custom view (span I/O cards + accuracy form)
     ├── evaluation.py        # Evaluation runs and datasets
     ├── judges.py            # Registered LLM judges
     ├── issues.py            # Detected issues linked to failing traces
     └── review_queues.py     # Review queues, label schemas, and queued items
 ```
 
-**Generator order matters** - some generators depend on others (e.g., traces depend on prompts, evaluation depends on traces).
+**Generator order matters** - some generators depend on others (e.g., traces depend on prompts, the custom view and evaluation depend on traces).
 
 ## API Endpoints
 

--- a/mlflow/demo/base.py
+++ b/mlflow/demo/base.py
@@ -20,6 +20,7 @@ class DemoFeature(str, Enum):
     JUDGES = "judges"
     ISSUES = "issues"
     REVIEW_QUEUES = "review_queues"
+    CUSTOM_VIEW = "custom_view"
 
 
 @dataclass

--- a/mlflow/demo/generators/__init__.py
+++ b/mlflow/demo/generators/__init__.py
@@ -1,3 +1,4 @@
+from mlflow.demo.generators.custom_view import CustomViewDemoGenerator
 from mlflow.demo.generators.evaluation import EvaluationDemoGenerator
 from mlflow.demo.generators.issues import IssuesDemoGenerator
 from mlflow.demo.generators.judges import JudgesDemoGenerator
@@ -8,17 +9,20 @@ from mlflow.demo.registry import demo_registry
 
 # NB: Order matters here. Prompts must be created before traces (for linking),
 # and traces must exist before evaluation (which references them).
-# Judges are independent and can be registered last.
+# The custom view is an experiment tag and needs the demo experiment (created
+# by traces). Judges are independent and can be registered last.
 # Issues should be registered after traces exist (since they reference trace problems).
 # Review queues should be registered after traces exist (since they attach traces).
 demo_registry.register(PromptsDemoGenerator)
 demo_registry.register(TracesDemoGenerator)
+demo_registry.register(CustomViewDemoGenerator)
 demo_registry.register(EvaluationDemoGenerator)
 demo_registry.register(JudgesDemoGenerator)
 demo_registry.register(IssuesDemoGenerator)
 demo_registry.register(ReviewQueuesDemoGenerator)
 
 __all__ = [
+    "CustomViewDemoGenerator",
     "EvaluationDemoGenerator",
     "IssuesDemoGenerator",
     "JudgesDemoGenerator",

--- a/mlflow/demo/generators/custom_view.py
+++ b/mlflow/demo/generators/custom_view.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from mlflow.demo.base import (
+    DEMO_EXPERIMENT_NAME,
+    BaseDemoGenerator,
+    DemoFeature,
+    DemoResult,
+)
+from mlflow.tracking._tracking_service.utils import _get_store
+from mlflow.tracking.client import MlflowClient
+from mlflow.utils.mlflow_tags import MLFLOW_CUSTOM_VIEW_TAG_PREFIX
+from mlflow.utils.validation import MAX_EXPERIMENT_TAG_VAL_LENGTH
+
+_logger = logging.getLogger(__name__)
+
+DEMO_CUSTOM_VIEW_ID = "mlflow-demo-span-review"
+DEMO_CUSTOM_VIEW_TAG_KEY = f"{MLFLOW_CUSTOM_VIEW_TAG_PREFIX}.v1.{DEMO_CUSTOM_VIEW_ID}"
+DEMO_CUSTOM_VIEW_NAME = "Span review"
+DEMO_CUSTOM_VIEW_LABEL = "Span inputs, outputs, and accuracy"
+DEMO_CUSTOM_VIEW_INSTRUCTION = (
+    "Show each span's input and output as cards and collect a per-span Accuracy "
+    "rating from Super accurate to Not accurate, submitted together."
+)
+DEMO_CUSTOM_VIEW_CREATED_AT_MS = 1
+
+_ACCURACY_OPTIONS = [
+    {"label": "Super accurate", "value": "Super accurate"},
+    {"label": "Accurate", "value": "Accurate"},
+    {"label": "Somewhat accurate", "value": "Somewhat accurate"},
+    {"label": "Not very accurate", "value": "Not very accurate"},
+    {"label": "Not accurate", "value": "Not accurate"},
+]
+
+# Role selectors covering the demo traces. A2UI templates cannot loop over
+# spans, so each card is authored up front and hidden via renderIfSpan when
+# that role is absent. CHAIN nth=0 is usually the root (RAG / prompt), so
+# only nth=1 is included to avoid a duplicate of the root card.
+_CHILD_SPAN_CARDS: list[tuple[str, dict[str, object]]] = [
+    ("embed", {"type": "EMBEDDING", "nth": 0}),
+    ("retrieve", {"type": "RETRIEVER", "nth": 0}),
+    ("chain1", {"type": "CHAIN", "nth": 1}),
+    ("llm0", {"type": "LLM", "nth": 0}),
+    ("llm1", {"type": "LLM", "nth": 1}),
+    ("llm2", {"type": "LLM", "nth": 2}),
+    ("tool0", {"type": "TOOL", "nth": 0}),
+    ("tool1", {"type": "TOOL", "nth": 1}),
+]
+
+
+def _span_field(span_ref: str | dict[str, object], field: str) -> dict[str, object]:
+    return {"$source": "spanField", "spanRef": span_ref, "field": field}
+
+
+def _span_ref_marker(span_ref: str | dict[str, object]) -> dict[str, object]:
+    return {"$spanRef": span_ref}
+
+
+def _span_io_card(
+    prefix: str, span_ref: str | dict[str, object]
+) -> tuple[str, list[dict[str, object]]]:
+    card_id = f"{prefix}-card"
+    col_id = f"{prefix}-col"
+    title_id = f"{prefix}-title"
+    in_id = f"{prefix}-in"
+    out_id = f"{prefix}-out"
+    accuracy_id = f"{prefix}-accuracy"
+    why_id = f"{prefix}-why"
+    span_id = _span_ref_marker(span_ref)
+    return card_id, [
+        {"id": card_id, "component": "Card", "child": col_id, "renderIfSpan": span_ref},
+        {
+            "id": col_id,
+            "component": "Column",
+            "children": [title_id, in_id, out_id, accuracy_id, why_id],
+        },
+        {
+            "id": title_id,
+            "component": "Text",
+            "variant": "h4",
+            "text": _span_field(span_ref, "name"),
+        },
+        {
+            "id": in_id,
+            "component": "KeyValueViewer",
+            "label": "Input",
+            "value": _span_field(span_ref, "inputs"),
+            "initialFormat": "json",
+        },
+        {
+            "id": out_id,
+            "component": "KeyValueViewer",
+            "label": "Output",
+            "value": _span_field(span_ref, "outputs"),
+            "initialFormat": "json",
+        },
+        {
+            "id": accuracy_id,
+            "component": "RadioGroup",
+            "label": "Accuracy",
+            "name": "Accuracy",
+            "formId": "feedback",
+            "spanId": span_id,
+            "options": _ACCURACY_OPTIONS,
+        },
+        {
+            "id": why_id,
+            "component": "FeedbackInputText",
+            "label": "Why?",
+            "name": "Accuracy",
+            "field": "rationale",
+            "formId": "feedback",
+            "spanId": span_id,
+            "placeholder": "Optional rationale",
+        },
+    ]
+
+
+def build_demo_custom_view() -> dict[str, object]:
+    """Return the stored CustomView payload for the seeded demo view."""
+    root_card_id, root_components = _span_io_card("root", "root")
+    child_card_ids: list[str] = []
+    child_components: list[dict[str, object]] = []
+    for prefix, selector in _CHILD_SPAN_CARDS:
+        card_id, components = _span_io_card(prefix, selector)
+        child_card_ids.append(card_id)
+        child_components.extend(components)
+
+    components = [
+        {
+            "id": "root",
+            "component": "Column",
+            "children": ["metrics", root_card_id, *child_card_ids, "submit"],
+        },
+        {
+            "id": "metrics",
+            "component": "Row",
+            "align": "stretch",
+            "children": ["stat-status", "stat-latency", "stat-tokens"],
+        },
+        {
+            "id": "stat-status",
+            "component": "StatCard",
+            "value": {"$source": "metrics.status"},
+            "label": "Status",
+            "icon": "checklist",
+            "tone": "info",
+        },
+        {
+            "id": "stat-latency",
+            "component": "StatCard",
+            "value": {"$source": "metrics.latency"},
+            "label": "Latency",
+            "icon": "clock",
+            "tone": "info",
+        },
+        {
+            "id": "stat-tokens",
+            "component": "StatCard",
+            "value": {"$source": "metrics.totalTokens"},
+            "label": "Tokens",
+            "icon": "hash",
+            "tone": "info",
+        },
+        *root_components,
+        *child_components,
+        {
+            "id": "submit",
+            "component": "FeedbackSubmit",
+            "label": "Submit feedback",
+            "formId": "feedback",
+        },
+    ]
+    return {
+        "id": DEMO_CUSTOM_VIEW_ID,
+        "name": DEMO_CUSTOM_VIEW_NAME,
+        "label": DEMO_CUSTOM_VIEW_LABEL,
+        "instruction": DEMO_CUSTOM_VIEW_INSTRUCTION,
+        "template": [
+            {
+                "version": "v0.9",
+                "updateComponents": {
+                    "surfaceId": "main",
+                    "components": components,
+                },
+            }
+        ],
+        "createdAtMs": DEMO_CUSTOM_VIEW_CREATED_AT_MS,
+    }
+
+
+def serialize_demo_custom_view() -> str:
+    payload = json.dumps(build_demo_custom_view(), separators=(",", ":"))
+    if len(payload) > MAX_EXPERIMENT_TAG_VAL_LENGTH:
+        raise ValueError(
+            f"Demo custom view exceeds experiment tag limit "
+            f"({len(payload)} > {MAX_EXPERIMENT_TAG_VAL_LENGTH})"
+        )
+    return payload
+
+
+class CustomViewDemoGenerator(BaseDemoGenerator):
+    """Seeds a saved custom view on the demo experiment.
+
+    Writes one experiment tag (`mlflow.customView.view.v1.<id>`) whose template
+    binds per-span input/output cards and an Accuracy feedback form. The host
+    re-resolves the bindings for whichever demo trace is open.
+    """
+
+    name = DemoFeature.CUSTOM_VIEW
+    version = 1
+
+    def generate(self) -> DemoResult:
+        store = _get_store()
+        experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+        if experiment is None:
+            raise ValueError(f"Demo experiment '{DEMO_EXPERIMENT_NAME}' not found")
+
+        experiment_id = experiment.experiment_id
+        MlflowClient().set_experiment_tag(
+            experiment_id, DEMO_CUSTOM_VIEW_TAG_KEY, serialize_demo_custom_view()
+        )
+        return DemoResult(
+            feature=self.name,
+            entity_ids=[DEMO_CUSTOM_VIEW_ID],
+            navigation_url=f"#/experiments/{experiment_id}",
+        )
+
+    def _data_exists(self) -> bool:
+        try:
+            experiment = _get_store().get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+            if experiment is None or experiment.lifecycle_stage != "active":
+                return False
+            return bool(experiment.tags.get(DEMO_CUSTOM_VIEW_TAG_KEY))
+        except Exception:
+            _logger.debug("Failed to check if custom view demo exists", exc_info=True)
+            return False
+
+    def delete_demo(self) -> None:
+        try:
+            experiment = _get_store().get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+            if experiment is None:
+                return
+            MlflowClient().delete_experiment_tag(experiment.experiment_id, DEMO_CUSTOM_VIEW_TAG_KEY)
+        except Exception:
+            _logger.debug("Failed to delete demo custom view", exc_info=True)

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.test.tsx
@@ -67,6 +67,7 @@ let capturedDefinitionProviderProps:
       onPersistView?: unknown;
       onDeleteView?: unknown;
       canModifyPersistedViews?: boolean;
+      autoSelectFirstView?: boolean;
     }
   | undefined;
 
@@ -117,7 +118,11 @@ describe('ExperimentCustomViewProvider', () => {
     capturedContextProvider = undefined;
     capturedConnectorProviderProps = undefined;
     capturedDefinitionProviderProps = undefined;
-    mockUseExperimentCustomViewDefinition.mockReturnValue({ views: [], isLoaded: true });
+    mockUseExperimentCustomViewDefinition.mockReturnValue({
+      views: [],
+      isLoaded: true,
+      isDemoExperiment: false,
+    });
     mockCanEdit = { canEdit: true, isLoading: false };
     mockGetCurrentApplierSessionId.mockReturnValue('session-1');
     mockGetCustomViewAuthoringContext.mockReturnValue(null);
@@ -135,6 +140,7 @@ describe('ExperimentCustomViewProvider', () => {
     mockUseExperimentCustomViewDefinition.mockReturnValue({
       views: [],
       isLoaded: true,
+      isDemoExperiment: false,
       persistView,
       deleteView,
     });
@@ -146,6 +152,19 @@ describe('ExperimentCustomViewProvider', () => {
     expect(capturedDefinitionProviderProps?.onPersistView).toBe(persistView);
     expect(capturedDefinitionProviderProps?.onDeleteView).toBe(deleteView);
     expect(capturedDefinitionProviderProps?.canModifyPersistedViews).toBe(false);
+    expect(capturedDefinitionProviderProps?.autoSelectFirstView).toBe(false);
+  });
+
+  it('auto-selects the first saved view on a demo experiment', () => {
+    mockUseExperimentCustomViewDefinition.mockReturnValue({
+      views: [],
+      isLoaded: true,
+      isDemoExperiment: true,
+    });
+    makeAssistant();
+    renderProvider();
+
+    expect(capturedDefinitionProviderProps?.autoSelectFirstView).toBe(true);
   });
 
   describe('connector.openAssistant', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/ExperimentCustomViewProvider.tsx
@@ -46,7 +46,8 @@ export const ExperimentCustomViewProvider = ({
   experimentId?: string;
   children: ReactNode;
 }) => {
-  const { views, isLoaded, persistView, deleteView } = useExperimentCustomViewDefinition(experimentId);
+  const { views, isLoaded, isDemoExperiment, persistView, deleteView } =
+    useExperimentCustomViewDefinition(experimentId);
   const { canEdit: canModifyPersistedViews } = useCanEditExperimentCustomViews(experimentId);
   const {
     openPanel,
@@ -134,6 +135,7 @@ export const ExperimentCustomViewProvider = ({
         onPersistView={persistView}
         onDeleteView={deleteView}
         canModifyPersistedViews={canModifyPersistedViews}
+        autoSelectFirstView={isDemoExperiment}
       >
         {children}
       </CustomViewDefinitionProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.test.ts
@@ -166,6 +166,18 @@ describe('useExperimentCustomViewDefinition', () => {
       // Valid views are untouched (not flagged unreadable).
       expect(byId('older')?.unreadable).toBeUndefined();
       expect(byId('newer')?.unreadable).toBeUndefined();
+      expect(result.current.isDemoExperiment).toBe(false);
+    });
+
+    it('flags the experiment as a demo when a demo version tag is present', async () => {
+      mockGetExperiment.mockResolvedValue(
+        getExperimentResponse([{ key: 'mlflow.demo.version.traces', value: '3' }]),
+      );
+
+      const { result } = renderDefinition(queryClient, EXPERIMENT_ID);
+      await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+      expect(result.current.isDemoExperiment).toBe(true);
     });
 
     it('keeps a valid-shape view whose template fails validation as a normal (not unreadable) view', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/hooks/custom-view/useExperimentCustomViewDefinition.ts
@@ -18,6 +18,7 @@ import {
   textCompressDeflate,
   textDecompressDeflate,
 } from '../../../../../../../common/utils/StringUtils';
+import { hasDemoVersionTag } from '../../../../../../utils/isDemoExperiment';
 
 type ExperimentTag = { key: string; value: string };
 
@@ -81,6 +82,9 @@ const serializeViewForTag = async (view: CustomView): Promise<string> => {
 export type ExperimentCustomViewDefinition = {
   views: CustomView[];
   isLoaded: boolean;
+  // True when this experiment was created by the demo seeder. The host uses it
+  // to auto-select the first saved view so the seeded sample is visible.
+  isDemoExperiment: boolean;
   // Undefined (no experiment scope) → the host falls back to a session-local,
   // non-persisting engine.
   persistView?: (view: CustomView) => Promise<void>;
@@ -97,10 +101,10 @@ export const useExperimentCustomViewDefinition = (experimentId?: string): Experi
   const queryClient = useQueryClient();
   const queryKey = useMemo(() => ['experiment-custom-views', experimentId], [experimentId]);
 
-  const { data: views, isLoading } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey,
     enabled: Boolean(experimentId),
-    queryFn: async (): Promise<CustomView[]> => {
+    queryFn: async (): Promise<{ views: CustomView[]; isDemoExperiment: boolean }> => {
       const response = await MlflowService.getExperiment({ experiment_id: experimentId });
       const tags: ExperimentTag[] = response?.experiment?.tags ?? [];
       const customViewTags = tags.filter((tag) => tag.key.startsWith(CUSTOM_VIEW_TAG_PREFIX));
@@ -110,7 +114,10 @@ export const useExperimentCustomViewDefinition = (experimentId?: string): Experi
       const parsed = await Promise.all(
         customViewTags.map((tag) => deserializeView(tag.key.slice(CUSTOM_VIEW_PREFIX_V1.length), tag.value)),
       );
-      return parsed.sort((a, b) => a.createdAtMs - b.createdAtMs);
+      return {
+        views: parsed.sort((a, b) => a.createdAtMs - b.createdAtMs),
+        isDemoExperiment: hasDemoVersionTag(tags),
+      };
     },
   });
 
@@ -144,8 +151,9 @@ export const useExperimentCustomViewDefinition = (experimentId?: string): Experi
   );
 
   return {
-    views: views ?? [],
+    views: data?.views ?? [],
     isLoaded: experimentId ? !isLoading : true,
+    isDemoExperiment: data?.isDemoExperiment ?? false,
     persistView: experimentId ? persistView : undefined,
     deleteView: experimentId ? deleteView : undefined,
   };

--- a/mlflow/server/js/src/experiment-tracking/utils/isDemoExperiment.ts
+++ b/mlflow/server/js/src/experiment-tracking/utils/isDemoExperiment.ts
@@ -2,5 +2,8 @@ import type { ExperimentEntity } from '../types';
 
 const DEMO_VERSION_TAG_PREFIX = 'mlflow.demo.version.';
 
+export const hasDemoVersionTag = (tags?: Array<{ key: string }>): boolean =>
+  tags?.some(({ key }) => key.startsWith(DEMO_VERSION_TAG_PREFIX)) ?? false;
+
 export const isDemoExperiment = (experiment: ExperimentEntity): boolean =>
-  experiment.tags?.some(({ key }) => key.startsWith(DEMO_VERSION_TAG_PREFIX)) ?? false;
+  hasDemoVersionTag(experiment.tags);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.test.tsx
@@ -743,4 +743,63 @@ describe('useCustomViewDefinitionState', () => {
     rerender({ views: refetched, isLoaded: true });
     expect(result.current.views.map((view) => view.id)).toEqual(['a', 'c']);
   });
+
+  describe('autoSelectFirstView', () => {
+    it('selects the first persisted view on load', () => {
+      const { result } = renderHook(() =>
+        useCustomViewDefinitionState(SINGLE_VIEW, true, noopPersistView, true, undefined, true),
+      );
+
+      expect(result.current.activeViewId).toBe('a');
+      expect(result.current.activeView).toEqual(makeView('a'));
+    });
+
+    it('does not select a view when the flag is off', () => {
+      const { result } = renderHook(() => useCustomViewDefinitionState(SINGLE_VIEW, true, noopPersistView, true));
+
+      expect(result.current.activeViewId).toBeUndefined();
+    });
+
+    it('selects the first view after async load', () => {
+      const loaded = [makeView('a'), makeView('b')];
+      const { result, rerender } = renderHook(
+        ({ views, isLoaded }: { views: CustomView[]; isLoaded: boolean }) =>
+          useCustomViewDefinitionState(views, isLoaded, noopPersistView, true, undefined, true),
+        { initialProps: { views: NO_VIEWS, isLoaded: false } },
+      );
+
+      expect(result.current.activeViewId).toBeUndefined();
+
+      rerender({ views: loaded, isLoaded: true });
+      expect(result.current.activeViewId).toBe('a');
+    });
+
+    it('does not steal the empty state after the user starts a new draft', () => {
+      const { result } = renderHook(() =>
+        useCustomViewDefinitionState(SINGLE_VIEW, true, noopPersistView, true, undefined, true),
+      );
+
+      expect(result.current.activeViewId).toBe('a');
+
+      act(() => result.current.startNewView('My new view'));
+      expect(result.current.isDraft).toBe(true);
+      expect(result.current.activeViewId).toBeUndefined();
+    });
+
+    it('does not re-select after the user deletes the auto-selected view', async () => {
+      const onDeleteView = jest.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined);
+      const initialViews = [makeView('a'), makeView('b')];
+      const { result } = renderHook(() =>
+        useCustomViewDefinitionState(initialViews, true, noopPersistView, true, onDeleteView, true),
+      );
+
+      expect(result.current.activeViewId).toBe('a');
+
+      await act(async () => {
+        await result.current.deleteView('a');
+      });
+
+      expect(result.current.activeViewId).toBeUndefined();
+    });
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext.tsx
@@ -126,6 +126,7 @@ export const useCustomViewDefinitionState = (
   onPersistView?: (view: CustomView) => Promise<void>,
   canModifyPersistedViews?: boolean,
   onDeleteView?: (id: string) => Promise<void>,
+  autoSelectFirstView?: boolean,
 ): CustomViewDefinitionContextValue => {
   const canPersist = Boolean(onPersistView) && Boolean(canModifyPersistedViews);
   const canDelete = Boolean(onDeleteView) && Boolean(canModifyPersistedViews);
@@ -160,7 +161,7 @@ export const useCustomViewDefinitionState = (
   // `initialViews` reference after mount, even if `isLoaded` was already true).
   // Once the user diverges (creates / saves / deletes a view) we stop, so a later refetch
   // can't clobber unsaved local edits. The active selection is left untouched
-  // (no default) so the host shows the placeholder until the user picks a view.
+  // unless `autoSelectFirstView` is set (demo experiment: show the seeded view).
   //
   // We only re-adopt when `initialViews` is a genuinely new reference (callers
   // must pass a stable/memoized array): setting state on every render would loop.
@@ -180,6 +181,25 @@ export const useCustomViewDefinitionState = (
   useEffect(() => {
     activeViewIdRef.current = activeViewId;
   }, [activeViewId]);
+
+  // Demo experiments auto-select the first persisted view on first load so the
+  // seeded sample renders immediately. Skip once the user has diverged (draft,
+  // delete, explicit selection) so we never steal a later empty state.
+  useEffect(() => {
+    if (
+      !autoSelectFirstView ||
+      !isLoaded ||
+      hasLocalEditsRef.current ||
+      isDraft ||
+      activeViewIdRef.current !== undefined
+    ) {
+      return;
+    }
+    const firstId = views[0]?.id;
+    if (firstId) {
+      setActiveViewId(firstId);
+    }
+  }, [autoSelectFirstView, isLoaded, views, isDraft]);
 
   const isDirty = useMemo(() => {
     if (!activeView) {
@@ -417,6 +437,7 @@ export const CustomViewDefinitionProvider = ({
   onPersistView,
   onDeleteView,
   canModifyPersistedViews,
+  autoSelectFirstView,
   children,
 }: {
   views: CustomView[];
@@ -424,9 +445,17 @@ export const CustomViewDefinitionProvider = ({
   onPersistView?: (view: CustomView) => Promise<void>;
   onDeleteView?: (id: string) => Promise<void>;
   canModifyPersistedViews?: boolean;
+  autoSelectFirstView?: boolean;
   children: ReactNode;
 }): JSX.Element => {
-  const value = useCustomViewDefinitionState(views, isLoaded, onPersistView, canModifyPersistedViews, onDeleteView);
+  const value = useCustomViewDefinitionState(
+    views,
+    isLoaded,
+    onPersistView,
+    canModifyPersistedViews,
+    onDeleteView,
+    autoSelectFirstView,
+  );
   return <CustomViewDefinitionContext.Provider value={value}>{children}</CustomViewDefinitionContext.Provider>;
 };
 

--- a/tests/demo/test_base.py
+++ b/tests/demo/test_base.py
@@ -12,6 +12,7 @@ from mlflow.demo.base import (
 def test_demo_feature_enum():
     assert DemoFeature.TRACES == "traces"
     assert DemoFeature.EVALUATION == "evaluation"
+    assert DemoFeature.CUSTOM_VIEW == "custom_view"
     assert isinstance(DemoFeature.TRACES, str)
 
 

--- a/tests/demo/test_custom_view_generator.py
+++ b/tests/demo/test_custom_view_generator.py
@@ -1,0 +1,168 @@
+import json
+
+import pytest
+
+from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
+from mlflow.demo.generators.custom_view import (
+    DEMO_CUSTOM_VIEW_CREATED_AT_MS,
+    DEMO_CUSTOM_VIEW_ID,
+    DEMO_CUSTOM_VIEW_INSTRUCTION,
+    DEMO_CUSTOM_VIEW_LABEL,
+    DEMO_CUSTOM_VIEW_NAME,
+    DEMO_CUSTOM_VIEW_TAG_KEY,
+    CustomViewDemoGenerator,
+    serialize_demo_custom_view,
+)
+from mlflow.utils.mlflow_tags import MLFLOW_CUSTOM_VIEW_TAG_PREFIX
+from mlflow.utils.validation import MAX_EXPERIMENT_TAG_VAL_LENGTH
+
+
+@pytest.fixture
+def custom_view_generator():
+    generator = CustomViewDemoGenerator()
+    original_version = generator.version
+    yield generator
+    CustomViewDemoGenerator.version = original_version
+
+
+def _create_demo_experiment():
+    import mlflow
+
+    return mlflow.set_experiment(DEMO_EXPERIMENT_NAME)
+
+
+def test_generator_attributes():
+    generator = CustomViewDemoGenerator()
+    assert generator.name == DemoFeature.CUSTOM_VIEW
+    assert generator.version == 1
+    assert DEMO_CUSTOM_VIEW_TAG_KEY == f"{MLFLOW_CUSTOM_VIEW_TAG_PREFIX}.v1.{DEMO_CUSTOM_VIEW_ID}"
+
+
+def test_serialized_view_fits_experiment_tag_limit():
+    payload = serialize_demo_custom_view()
+    assert len(payload) <= MAX_EXPERIMENT_TAG_VAL_LENGTH
+
+
+def test_serialized_view_shape():
+    view = json.loads(serialize_demo_custom_view())
+    assert view["id"] == DEMO_CUSTOM_VIEW_ID
+    assert view["name"] == DEMO_CUSTOM_VIEW_NAME
+    assert view["label"] == DEMO_CUSTOM_VIEW_LABEL
+    assert view["instruction"] == DEMO_CUSTOM_VIEW_INSTRUCTION
+    assert view["createdAtMs"] == DEMO_CUSTOM_VIEW_CREATED_AT_MS
+
+    template = view["template"]
+    assert isinstance(template, list)
+    assert template[0]["version"] == "v0.9"
+    components = template[0]["updateComponents"]["components"]
+    by_id = {component["id"]: component for component in components}
+
+    assert by_id["root"]["component"] == "Column"
+    assert by_id["stat-status"]["value"] == {"$source": "metrics.status"}
+    assert "assessments" not in by_id
+    assert "accuracy" not in by_id
+
+    assert by_id["submit"]["component"] == "FeedbackSubmit"
+    assert by_id["submit"]["formId"] == "feedback"
+    assert sum(1 for component in components if component.get("component") == "FeedbackSubmit") == 1
+
+    radios = [component for component in components if component.get("component") == "RadioGroup"]
+    rationales = [
+        component for component in components if component.get("component") == "FeedbackInputText"
+    ]
+    assert radios
+    assert len(radios) == len(rationales)
+    assert all(radio["name"] == "Accuracy" for radio in radios)
+    assert all(radio["formId"] == "feedback" for radio in radios)
+    assert all(radio["spanId"]["$spanRef"] for radio in radios)
+    assert [option["value"] for option in radios[0]["options"]] == [
+        "Super accurate",
+        "Accurate",
+        "Somewhat accurate",
+        "Not very accurate",
+        "Not accurate",
+    ]
+    assert by_id["root-accuracy"]["spanId"] == {"$spanRef": "root"}
+    assert by_id["root-why"]["spanId"] == {"$spanRef": "root"}
+    assert by_id["llm0-accuracy"]["spanId"] == {"$spanRef": {"type": "LLM", "nth": 0}}
+    assert by_id["llm0-why"]["spanId"] == {"$spanRef": {"type": "LLM", "nth": 0}}
+
+    child_cards = [
+        component
+        for component in components
+        if component.get("component") == "Card" and component["id"] != "root-card"
+    ]
+    assert child_cards
+    assert all("renderIfSpan" in card for card in child_cards)
+    assert by_id["root-card"]["renderIfSpan"] == "root"
+    assert by_id["llm0-card"]["renderIfSpan"] == {"type": "LLM", "nth": 0}
+    assert by_id["tool1-card"]["renderIfSpan"] == {"type": "TOOL", "nth": 1}
+    assert "chain0-card" not in by_id
+    assert by_id["chain1-card"]["renderIfSpan"] == {"type": "CHAIN", "nth": 1}
+
+
+def test_data_exists_false_when_no_experiment():
+    generator = CustomViewDemoGenerator()
+    assert generator._data_exists() is False
+
+
+def test_generate_requires_demo_experiment():
+    generator = CustomViewDemoGenerator()
+    with pytest.raises(ValueError, match="not found"):
+        generator.generate()
+
+
+def test_generate_writes_experiment_tag():
+    _create_demo_experiment()
+    generator = CustomViewDemoGenerator()
+    result = generator.generate()
+
+    assert isinstance(result, DemoResult)
+    assert result.feature == DemoFeature.CUSTOM_VIEW
+    assert result.entity_ids == [DEMO_CUSTOM_VIEW_ID]
+    assert "/experiments/" in result.navigation_url
+
+    import mlflow
+
+    experiment = mlflow.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    stored = json.loads(experiment.tags[DEMO_CUSTOM_VIEW_TAG_KEY])
+    assert stored["id"] == DEMO_CUSTOM_VIEW_ID
+    assert stored["id"] == DEMO_CUSTOM_VIEW_TAG_KEY.rsplit(".", 1)[-1]
+
+
+def test_data_exists_true_after_generate():
+    _create_demo_experiment()
+    generator = CustomViewDemoGenerator()
+    assert generator._data_exists() is False
+
+    generator.generate()
+
+    assert generator._data_exists() is True
+
+
+def test_delete_demo_removes_tag():
+    _create_demo_experiment()
+    generator = CustomViewDemoGenerator()
+    generator.generate()
+    assert generator._data_exists() is True
+
+    generator.delete_demo()
+
+    assert generator._data_exists() is False
+    import mlflow
+
+    experiment = mlflow.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    assert DEMO_CUSTOM_VIEW_TAG_KEY not in experiment.tags
+
+
+def test_is_generated_checks_version(custom_view_generator):
+    _create_demo_experiment()
+    custom_view_generator.generate()
+    custom_view_generator.store_version()
+
+    assert custom_view_generator.is_generated() is True
+
+    CustomViewDemoGenerator.version = 99
+    fresh_generator = CustomViewDemoGenerator()
+    assert fresh_generator.is_generated() is False
+    assert fresh_generator._data_exists() is False

--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -6,6 +7,10 @@ from mlflow import MlflowClient, set_tracking_uri
 from mlflow.demo import generate_all_demos
 from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DEMO_PROMPT_PREFIX
 from mlflow.demo.data import DEMO_PROMPTS
+from mlflow.demo.generators.custom_view import (
+    DEMO_CUSTOM_VIEW_ID,
+    DEMO_CUSTOM_VIEW_TAG_KEY,
+)
 from mlflow.demo.generators.evaluation import (
     DEMO_DATASET_BASELINE_SESSION_NAME,
     DEMO_DATASET_IMPROVED_SESSION_NAME,
@@ -120,6 +125,15 @@ def test_generate_all_demos_creates_experiment(client):
     experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
     assert experiment is not None
     assert experiment.lifecycle_stage == "active"
+
+
+def test_generate_all_demos_seeds_custom_view(client):
+    generate_all_demos()
+
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    stored = json.loads(experiment.tags[DEMO_CUSTOM_VIEW_TAG_KEY])
+    assert stored["id"] == DEMO_CUSTOM_VIEW_ID
+    assert stored["template"][0]["version"] == "v0.9"
 
 
 def test_version_mismatch_triggers_cleanup_and_regeneration(client, traces_generator):


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

Relates to #25208 (merge that PR first).

This is the follow-up layer on top of #25208. GitHub does not support cross-fork stacked PRs, so this PR targets `master` from `seed-demo-custom-view-auto-select`. Until #25208 merges, the Files changed tab also includes that PR's demo-generator commit. The incremental change is the frontend auto-select work (`ee5b876`).

### What changes are proposed in this pull request?

On demo experiments only, auto-select the first saved custom view when the Custom view tab opens so Start Demo shows **Span review** immediately instead of an empty switcher.

Non-demo experiments are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Demo-only UI behavior.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release