### PR TITLE
fix: skip create_all when tables already exist to prevent upgrade failure (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,12 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create initial tables if the database is empty (no user tables exist).
+    # If any user tables are present, skip create_all to avoid "table already exists"
+    # errors on partial or pre-existing schemas, and let Alembic handle the rest.
+    if _is_empty_database(engine):
+        _logger.info("Creating initial MLflow database tables...")
+        InitialBase.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after upgrading to 3.8.x from a previous version, users can encounter `Table 'secrets' already exists` errors. This happens because `_initialize_tables()` unconditionally calls `InitialBase.metadata.create_all(engine)`, which may attempt to recreate tables that already exist (e.g., from a previous partial migration or a pre-existing schema).

## Fix
Modify `_initialize_tables()` to only run `create_all()` when the database is truly empty (no user tables exist). If any tables already exist, we skip `create_all()` and proceed directly to `_upgrade_db()`, allowing Alembic to handle the existing schema without duplicate table creation errors. This preserves the original behavior for fresh databases while preventing failures on upgrades.

Closes #19943