### PR TITLE
Raise `MlflowException` for non-numeric `experiment_id` in `SqlAlchemyStore`

### DIFF
--- a/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
+++ b/mlflow/store/tracking/gateway/sqlalchemy_mixin.py
@@ -100,6 +100,7 @@ from mlflow.utils.mlflow_tags import (
 )
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.time import get_current_time_millis
+from mlflow.utils.validation import _parse_experiment_id
 
 
 def _validate_one_of(
@@ -709,7 +710,7 @@ class SqlAlchemyGatewayStoreMixin:
                     last_updated_by=created_by,
                     routing_strategy=routing_strategy.value if routing_strategy else None,
                     fallback_config_json=fallback_config_json,
-                    experiment_id=int(experiment_id) if experiment_id else None,
+                    experiment_id=_parse_experiment_id(experiment_id) if experiment_id else None,
                     usage_tracking=usage_tracking,
                 )
             )
@@ -821,7 +822,7 @@ class SqlAlchemyGatewayStoreMixin:
                 )
 
             if experiment_id is not None:
-                sql_endpoint.experiment_id = int(experiment_id)
+                sql_endpoint.experiment_id = _parse_experiment_id(experiment_id)
 
             if routing_strategy is not None:
                 sql_endpoint.routing_strategy = routing_strategy.value

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -250,6 +250,8 @@ from mlflow.utils.uri import (
     resolve_uri_if_local,
 )
 from mlflow.utils.validation import (
+    _parse_experiment_id,
+    _parse_experiment_ids,
     _resolve_experiment_ids_and_locations,
     _validate_batch_log_data,
     _validate_batch_log_limits,
@@ -747,13 +749,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         stages = LifecycleStage.view_type_to_stages(view_type)
         query_options = self._get_eager_experiment_query_options() if eager else []
 
-        try:
-            experiment_id_int = int(experiment_id)
-        except (ValueError, TypeError):
-            raise MlflowException(
-                f"Invalid experiment ID '{experiment_id}'. Experiment ID must be a valid integer.",
-                INVALID_PARAMETER_VALUE,
-            )
+        experiment_id_int = _parse_experiment_id(experiment_id)
 
         experiment = (
             self
@@ -1906,7 +1902,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         """
 
         MAX_DATASET_SUMMARIES_RESULTS = 1000
-        experiment_ids = [int(e) for e in experiment_ids]
+        experiment_ids = _parse_experiment_ids(experiment_ids)
         with self.ManagedSessionMaker() as session:
             experiment_ids = self._filter_experiment_ids(session, experiment_ids)
             # Note that the join with the input tag table is a left join. This is required so if an
@@ -2251,7 +2247,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 stmt = stmt.outerjoin(j)
 
             offset = SearchUtils.parse_start_offset_from_page_token(page_token)
-            experiment_ids = [int(e) for e in experiment_ids]
+            experiment_ids = _parse_experiment_ids(experiment_ids)
             experiment_ids = self._filter_experiment_ids(session, experiment_ids)
             stmt = (
                 stmt
@@ -3601,7 +3597,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             )
             models = models.join(subquery)
 
-        experiment_ids = [int(e) for e in experiment_ids]
+        experiment_ids = _parse_experiment_ids(experiment_ids)
         return models.filter(
             SqlLoggedModel.lifecycle_stage != LifecycleStage.DELETED,
             SqlLoggedModel.experiment_id.in_(experiment_ids),
@@ -4096,14 +4092,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             session_id ASC).
         """
         with self.ManagedSessionMaker() as session:
-            try:
-                experiment_id_int = int(experiment_id)
-            except (ValueError, TypeError):
-                raise MlflowException(
-                    f"Invalid experiment ID '{experiment_id}'. Experiment ID must be a valid "
-                    "integer.",
-                    INVALID_PARAMETER_VALUE,
-                )
+            experiment_id_int = _parse_experiment_id(experiment_id)
 
             experiment_ids = self._filter_experiment_ids(session, [experiment_id_int])
             if not experiment_ids:
@@ -4389,7 +4378,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
             # Filter by experiment IDs
             if experiment_ids:
-                experiment_ids_int = [int(exp_id) for exp_id in experiment_ids]
+                experiment_ids_int = _parse_experiment_ids(experiment_ids)
                 query = query.filter(SqlTraceInfo.experiment_id.in_(experiment_ids_int))
 
             # Filter by time range
@@ -4472,7 +4461,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         deleted_db_backed_count = 0
         selected_archived_traces: list[_TraceDeleteSelection] = []
         with self.ManagedSessionMaker(read_only=False) as session:
-            filters = [SqlTraceInfo.experiment_id == int(experiment_id)]
+            filters = [SqlTraceInfo.experiment_id == _parse_experiment_id(experiment_id)]
             if max_timestamp_millis is not None:
                 filters.append(SqlTraceInfo.timestamp_ms <= max_timestamp_millis)
             if trace_ids:
@@ -5071,7 +5060,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         """
 
         with self.ManagedSessionMaker() as session:
-            experiment_ids = self._filter_experiment_ids(session, [int(e) for e in experiment_ids])
+            experiment_ids = self._filter_experiment_ids(
+                session, _parse_experiment_ids(experiment_ids)
+            )
             experiment_ids = [str(e) for e in experiment_ids]
 
             filter1_combined = (
@@ -8217,7 +8208,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 )
 
             if experiment_id:
-                query = query.filter(SqlIssue.experiment_id == int(experiment_id))
+                query = query.filter(SqlIssue.experiment_id == _parse_experiment_id(experiment_id))
 
             if filter_string:
                 parsed_filters = SearchIssuesUtils.parse_search_filter(filter_string)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -573,6 +573,49 @@ def _validate_experiment_id(exp_id):
         )
 
 
+def _parse_experiment_id(experiment_id):
+    """
+    Convert a user-supplied experiment ID to an ``int``.
+
+    SQL-backed stores store ``experiment_id`` as an integer column, so values arriving from
+    request payloads must be converted before they are used in a query. A bare ``int()`` call
+    raises ``ValueError``, which ``catch_mlflow_exception`` does not recognize and therefore
+    surfaces as an opaque 500; raising ``MlflowException`` here yields a 400 instead.
+
+    Args:
+        experiment_id: The experiment ID to convert.
+
+    Returns:
+        The experiment ID as an ``int``.
+
+    Raises:
+        MlflowException: If ``experiment_id`` is not a valid integer.
+    """
+    try:
+        return int(experiment_id)
+    except (ValueError, TypeError):
+        raise MlflowException(
+            f"Invalid experiment ID '{experiment_id}'. Experiment ID must be a valid integer.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+
+def _parse_experiment_ids(experiment_ids):
+    """
+    Convert a collection of user-supplied experiment IDs to ``int``.
+
+    Args:
+        experiment_ids: The experiment IDs to convert.
+
+    Returns:
+        A list of experiment IDs as ``int``.
+
+    Raises:
+        MlflowException: If any of ``experiment_ids`` is not a valid integer.
+    """
+    return [_parse_experiment_id(experiment_id) for experiment_id in experiment_ids]
+
+
 def _validate_batch_limit(entity_name, limit, length):
     if length > limit:
         error_msg = (

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_core.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_core.py
@@ -8,7 +8,13 @@ import sqlalchemy
 
 import mlflow.db
 from mlflow import entities
+from mlflow.entities.trace_metrics import (
+    AggregationType,
+    MetricAggregation,
+    MetricViewType,
+)
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.store.db.db_types import MSSQL, MYSQL
 from mlflow.store.db.utils import (
     _get_latest_schema_revision,
@@ -354,3 +360,69 @@ def test_get_orderby_clauses(tmp_sqlite_uri):
         assert "value IS NULL" in select_clause[0]
         # test that clause name is in parsed
         assert "clause_1" in parsed[0]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "make_args"),
+    [
+        ("_search_datasets", lambda exp_id: ([exp_id],)),
+        ("search_runs", lambda exp_id: ([exp_id], None, entities.ViewType.ALL, 10)),
+        ("search_logged_models", lambda exp_id: ([exp_id],)),
+        ("_delete_traces", lambda exp_id: (exp_id, 1)),
+        (
+            "calculate_trace_filter_correlation",
+            lambda exp_id: ([exp_id], "name = 'a'", "name = 'b'"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("bad_experiment_id", ["not-a-number", "12abc", ""])
+def test_store_methods_reject_non_numeric_experiment_id(
+    store, method_name, make_args, bad_experiment_id
+):
+    # A non-numeric experiment ID must surface as INVALID_PARAMETER_VALUE (HTTP 400) rather
+    # than an unhandled ValueError, which `catch_mlflow_exception` turns into an opaque 500.
+    with pytest.raises(MlflowException, match="Experiment ID must be a valid integer") as exc_info:
+        getattr(store, method_name)(*make_args(bad_experiment_id))
+
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert exc_info.value.get_http_status_code() == 400
+
+
+@pytest.mark.parametrize("bad_experiment_id", ["not-a-number", "12abc"])
+def test_search_issues_rejects_non_numeric_experiment_id(store, bad_experiment_id):
+    with pytest.raises(MlflowException, match="Experiment ID must be a valid integer") as exc_info:
+        store.search_issues(bad_experiment_id)
+
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert exc_info.value.get_http_status_code() == 400
+
+
+@pytest.mark.parametrize("experiment_id", [None, ""])
+def test_search_issues_treats_falsy_experiment_id_as_unfiltered(store, experiment_id):
+    # A falsy experiment_id means "do not filter by experiment" and must stay a no-op rather
+    # than reaching the integer conversion.
+    assert store.search_issues(experiment_id) == []
+
+
+@pytest.mark.parametrize("bad_experiment_id", ["not-a-number", "12abc", ""])
+def test_query_trace_metrics_rejects_non_numeric_experiment_id(store, bad_experiment_id):
+    with pytest.raises(MlflowException, match="Experiment ID must be a valid integer") as exc_info:
+        store.query_trace_metrics(
+            experiment_ids=[bad_experiment_id],
+            view_type=MetricViewType.TRACES,
+            metric_name="trace_count",
+            aggregations=[MetricAggregation(aggregation_type=AggregationType.COUNT)],
+        )
+
+    assert exc_info.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    assert exc_info.value.get_http_status_code() == 400
+
+
+def test_store_methods_accept_valid_experiment_id(store):
+    # The guard must not reject legitimate IDs, including int-typed and default experiment "0".
+    exp_id = store.create_experiment("valid-experiment-id")
+
+    assert store._search_datasets([exp_id]) == []
+    assert store.search_runs([exp_id], None, entities.ViewType.ALL, 10) == []
+    assert store.search_runs([int(exp_id)], None, entities.ViewType.ALL, 10) == []
+    assert store._delete_traces(exp_id, 1) == 0


### PR DESCRIPTION
### Related Issues/PRs

Closes #25204

### What changes are proposed in this pull request?

Several `SqlAlchemyStore` methods convert a user-supplied `experiment_id` with a bare `int()`. On non-numeric input that raises `ValueError`, which `catch_mlflow_exception` does not recognize (it only handles `MlflowException`), so the request surfaces as an opaque **500** instead of a clean **400** `INVALID_PARAMETER_VALUE`.

**Root cause:** the conversion sites listed in #25204 are reachable from `mlflow/server/handlers.py` with request input that is never checked for being numeric — several handlers pass no `schema=` at all, and the rest only check for array/string type.

This PR extracts `_parse_experiment_id` / `_parse_experiment_ids` into `mlflow/utils/validation.py`, mirroring the guard that already exists at `SqlAlchemyStore._get_experiment`, and uses them at the unguarded call sites:

- `mlflow/store/tracking/sqlalchemy_store.py` — `_search_datasets`, `_search_runs`, the `search_logged_models` filter path, `query_trace_metrics`, `_delete_traces`, `calculate_trace_filter_correlation`, `search_issues`
- `mlflow/store/tracking/gateway/sqlalchemy_mixin.py` — `create_gateway_endpoint`, `update_gateway_endpoint`

The two existing hand-rolled guards (`_get_experiment`, `get_trace_session_summaries`) now reuse the helper, so the error message stays identical and the duplication is removed.

The helper lives in `mlflow/utils/validation.py` rather than on `SqlAlchemyStore` because `SqlAlchemyGatewayStoreMixin` is a base class of `SqlAlchemyStore` and cannot import from it without a circular import.

Two notes on deliberate scope:

- **Falsy IDs keep their current meaning.** `search_issues` (`if experiment_id:`) and `create_gateway_endpoint` (`if experiment_id else None`) treat a falsy `experiment_id` as "not filtering / not set", so the guard is applied inside those existing branches rather than in front of them. A test pins this.
- **`handlers.py` request schemas are left alone.** #25204 suggests also tightening them; the store-layer guard already turns every listed path from 500 into 400, and keeping the schema work separate keeps this diff reviewable. Happy to follow up if you'd like it here.

I used `int()` rather than `_validate_experiment_id` because `_EXPERIMENT_ID_REGEX` currently admits non-numeric IDs — that is the subject of #25205, and these call sites can switch over once it is resolved.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_core.py` assert `MlflowException` / `INVALID_PARAMETER_VALUE` / HTTP 400 for `"not-a-number"`, `"12abc"` and `""` across the affected methods, plus a test that valid and int-typed IDs still work and one pinning the falsy-means-unfiltered behavior of `search_issues`.

Verified the tests fail without the source change — with only the tests applied they error with `ValueError: invalid literal for int() with base 10: 'not-a-number'` at `sqlalchemy_store.py:1909` — and pass with it.

```
tests/.../test_sqlalchemy_store_core.py -k experiment_id     46 passed
test_sqlalchemy_store_core.py + _experiments.py             159 passed, 10 skipped
_runs.py + _issues.py + _query_trace_metrics.py             538 passed, 8 skipped
tests/utils/test_validation.py                              219 passed, 2 skipped
tests/store/tracking/test_gateway_sql_store.py              267 passed, 1 skipped
```

`ruff format` and `ruff check` (0.16.0) are clean on all four files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Invalid (non-numeric) experiment IDs now return a `400 INVALID_PARAMETER_VALUE` error with a clear message instead of an opaque `500 INTERNAL_ERROR`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.
