### PR TITLE
Install ripgrep in the NaiLaOpus workflow

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -156,13 +156,11 @@ jobs:
           enable-cache: false
 
       - name: Install ripgrep
-        # The orchestrator's Read/Grep/Glob tools shell out to `rg`. ripgrep
-        # is NOT preinstalled on the ubuntu-latest runner image, so every
-        # prior production review hit "ripgrep is not installed on this
-        # runner" on its first Grep and fell back to slow sequential file
-        # reads (25-30 reads on a large PR). Installing it restores fast
-        # pattern search and cuts review latency substantially.
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        run: |
+          curl -LsSf https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz -o /tmp/rg.tar.gz
+          tar xzf /tmp/rg.tar.gz -C /tmp
+          sudo mv /tmp/ripgrep-15.2.0-x86_64-unknown-linux-musl/rg /usr/local/bin/rg
+          rg --version
 
       - name: Parse review flags
         id: flags

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -155,6 +155,15 @@ jobs:
         with:
           enable-cache: false
 
+      - name: Install ripgrep
+        # The orchestrator's Read/Grep/Glob tools shell out to `rg`. ripgrep
+        # is NOT preinstalled on the ubuntu-latest runner image, so every
+        # prior production review hit "ripgrep is not installed on this
+        # runner" on its first Grep and fell back to slow sequential file
+        # reads (25-30 reads on a large PR). Installing it restores fast
+        # pattern search and cuts review latency substantially.
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Parse review flags
         id: flags
         env:


### PR DESCRIPTION
### Related Issues/PRs

Fixes a production latency bug in the NaiLaOpus review bot workflow.

### What changes are proposed in this pull request?

The NaiLaOpus orchestrator's `Read`/`Grep`/`Glob` tools shell out to `rg` (ripgrep). ripgrep is **not** preinstalled on the `ubuntu-latest` runner image, so on every production review the first `Grep` call raised `ripgrep (\`rg\`) is not installed on this runner` and the agent fell back to slow sequential file reads (25-30 reads on a large PR, one LLM round-trip each).

Trace analysis of 329 recent runs found **675 of 676** grep failures were this missing-binary error (the one remaining was an unescaped-`{` regex). Adding a ripgrep install step to the workflow restores fast pattern search and cuts review tail latency substantially (traces with working grep finished in ~48-69s vs ~122-262s without).

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Workflow change only (no code). Validation is the next `/review-v2` run: the "Install ripgrep" step succeeds and the orchestrator's Grep calls return matches instead of the not-installed error.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

Internal bot infrastructure; not user-facing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release