### PR TITLE
[nailaopus] Point orchestrator ref at add-bash-tool branch for testing

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -271,7 +271,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: mlflow/mlflow
-          ref: refs/pull/22962/head
+          ref: refs/pull/24602/head
           path: mlflow
           token: ${{ steps.app_token.outputs.token }}
           persist-credentials: false
@@ -281,7 +281,7 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Run dry-run review (PR 22962)
+      - name: Run dry-run review (PR 24602)
         env:
           ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
@@ -292,4 +292,4 @@ jobs:
           DATABRICKS_CLIENT_ID: ${{ secrets.NAILAOPUS_DATABRICKS_CLIENT_ID }}
           DATABRICKS_CLIENT_SECRET: ${{ secrets.NAILAOPUS_DATABRICKS_CLIENT_SECRET }}
         run: |
-          uv run --directory internal/nailaopus nailaopus 22962 --repo mlflow/mlflow --mlflow-tree "$GITHUB_WORKSPACE/mlflow" --triggered-by "${{ github.actor }}"
+          uv run --directory internal/nailaopus nailaopus 24602 --repo mlflow/mlflow --mlflow-tree "$GITHUB_WORKSPACE/mlflow" --triggered-by "${{ github.actor }}"

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -260,7 +260,7 @@ jobs:
         with:
           repository: mlflow/internal
           # HEAD of mlflow/internal#81 (add Bash tool). Update to main SHA once merged.
-          ref: ${{ vars.NAILAOPUS_INTERNAL_REF || '590949f070b5a26552e168361744c6f2a0e95504' }}
+          ref: ${{ vars.NAILAOPUS_INTERNAL_REF || '67ad4c21d8a1e36d4bc45f7a55f491b0b624e489' }}
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -285,5 +285,11 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          MLFLOW_ENABLE_TRACING: ${{ vars.NAILAOPUS_MLFLOW_ENABLE_TRACING }}
+          MLFLOW_TRACKING_URI: ${{ vars.NAILAOPUS_MLFLOW_TRACKING_URI }}
+          MLFLOW_EXPERIMENT_ID: ${{ secrets.NAILAOPUS_MLFLOW_EXPERIMENT_ID }}
+          DATABRICKS_HOST: ${{ secrets.NAILAOPUS_DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.NAILAOPUS_DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.NAILAOPUS_DATABRICKS_CLIENT_SECRET }}
         run: |
-          uv run --directory internal/nailaopus nailaopus 22962 --repo mlflow/mlflow --mlflow-tree "$GITHUB_WORKSPACE/mlflow"
+          uv run --directory internal/nailaopus nailaopus 22962 --repo mlflow/mlflow --mlflow-tree "$GITHUB_WORKSPACE/mlflow" --triggered-by "${{ github.actor }}"

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -151,7 +151,7 @@ jobs:
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
           # TEST ONLY (mlflow/internal#81): revert to a main SHA before merging.
-          ref: 7f211db2b1656f6b628d00a31c47a7dedde052ec
+          ref: 67ad4c21d8a1e36d4bc45f7a55f491b0b624e489
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -143,7 +143,8 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 5e5f9229e16b97822ea3349b31285370be36b4d1
+          # TEST ONLY (mlflow/internal#81): revert to a main SHA before merging.
+          ref: 7f211db2b1656f6b628d00a31c47a7dedde052ec
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -11,6 +11,13 @@ on:
   # exception or splitting the workflow into LLM-runner + poster jobs.
   issue_comment:
     types: [created]
+  # Dry-run CI gate: runs on PRs that touch this workflow file so that
+  # orchestrator changes can be validated before merging. Runs in dry-run
+  # mode against a fixed sample PR (no comments posted). Only fires on
+  # non-fork PRs because fork PRs don't receive base-repo secrets.
+  pull_request:
+    paths:
+      - .github/workflows/nailaopus.yml
 
 concurrency:
   # Single group per PR. cancel-in-progress is false so each /review-v2
@@ -229,3 +236,61 @@ jobs:
           gh api \
             "repos/$REPO/issues/$PR/comments" \
             -X POST -f body="$body" || true
+
+  # Dry-run validation job: fires on pull_request events to validate
+  # orchestrator changes. Runs against a fixed sample PR in dry-run mode
+  # (no comments posted). Skipped on fork PRs (no secrets available).
+  dry-run:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Generate App installation token
+        id: app_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.NAILAOPUS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NAILAOPUS_APP_KEY }}
+          owner: mlflow
+
+      - name: Checkout PR head of mlflow/mlflow (orchestrator code)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          path: workflow-repo
+          token: ${{ steps.app_token.outputs.token }}
+          persist-credentials: false
+
+      - name: Checkout mlflow/internal (orchestrator code)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: mlflow/internal
+          ref: ${{ vars.NAILAOPUS_INTERNAL_REF || 'main' }}
+          sparse-checkout: |
+            nailaopus
+          path: internal
+          token: ${{ steps.app_token.outputs.token }}
+          persist-credentials: false
+
+      - name: Checkout sample mlflow/mlflow PR for dry-run
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: mlflow/mlflow
+          ref: refs/pull/22962/head
+          path: mlflow
+          token: ${{ steps.app_token.outputs.token }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
+
+      - name: Run dry-run review (PR 22962)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          uv run --directory internal/nailaopus nailaopus 22962 --repo mlflow/mlflow --mlflow-tree "$GITHUB_WORKSPACE/mlflow"

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -267,7 +267,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: mlflow/internal
-          ref: ${{ vars.NAILAOPUS_INTERNAL_REF || 'main' }}
+          # HEAD of mlflow/internal#81 (add Bash tool). Update to main SHA once merged.
+          ref: ${{ vars.NAILAOPUS_INTERNAL_REF || '590949f070b5a26552e168361744c6f2a0e95504' }}
           sparse-checkout: |
             nailaopus
           path: internal

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -255,14 +255,6 @@ jobs:
           private-key: ${{ secrets.NAILAOPUS_APP_KEY }}
           owner: mlflow
 
-      - name: Checkout PR head of mlflow/mlflow (orchestrator code)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.head_ref }}
-          path: workflow-repo
-          token: ${{ steps.app_token.outputs.token }}
-          persist-credentials: false
-
       - name: Checkout mlflow/internal (orchestrator code)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

Test-only PR to validate [mlflow/internal#81](https://github.com/mlflow/internal/pull/81), which adds a `Bash` tool to the spotter and reviewer-opinion agents.

The single change is bumping the pinned `mlflow/internal` SHA in `nailaopus.yml` from `5e5f922` to `7f211db` (HEAD of the `add-bash-tool` branch). Commenting `/review-v2` on any maintainer PR while this is merged will run the bot with the Bash tool available, letting us observe whether agents use it (`git blame`, `git log --follow`, etc.) and confirm the pipeline stays healthy.

**Do not merge as-is** — revert to a `main` SHA once validation is done. The `# TEST ONLY` comment in the workflow marks the line.

## Test Plan

- [ ] Merge this PR
- [ ] Comment `/review-v2` on a small maintainer-authored PR
- [ ] Confirm run completes and check workflow logs for `Bash` tool calls
- [ ] Follow up with a separate PR that reverts to a `main` SHA (or directly to the merged `internal#81` SHA once that lands)

This pull request and its description were written by Isaac.

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._