### PR TITLE
Fix requirement-locking tests broken by `openai` 3.0.0 dropping `httpx`

### DIFF
--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2653,7 +2653,7 @@ def test_lock_model_requirements_pip_requirements(monkeypatch: pytest.MonkeyPatc
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "jiter==" in contents
+    assert "pydantic==" in contents
 
 
 def test_lock_model_requirements_extra_pip_requirements(
@@ -2671,7 +2671,7 @@ def test_lock_model_requirements_extra_pip_requirements(
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "jiter==" in contents
+    assert "pydantic==" in contents
 
 
 def test_lock_model_requirements_constraints(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -2689,7 +2689,7 @@ def test_lock_model_requirements_constraints(monkeypatch: pytest.MonkeyPatch, tm
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==1.82.0" in contents
-    assert "jiter==" in contents
+    assert "pydantic==" in contents
 
 
 @pytest.mark.parametrize(

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2653,7 +2653,7 @@ def test_lock_model_requirements_pip_requirements(monkeypatch: pytest.MonkeyPatc
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "httpx==" in contents
+    assert "jiter==" in contents
 
 
 def test_lock_model_requirements_extra_pip_requirements(
@@ -2671,7 +2671,7 @@ def test_lock_model_requirements_extra_pip_requirements(
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "httpx==" in contents
+    assert "jiter==" in contents
 
 
 def test_lock_model_requirements_constraints(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -2689,7 +2689,7 @@ def test_lock_model_requirements_constraints(monkeypatch: pytest.MonkeyPatch, tm
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==1.82.0" in contents
-    assert "httpx==" in contents
+    assert "jiter==" in contents
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25225

### What changes are proposed in this pull request?

`test_lock_model_requirements_*` in `test_model_export_with_class_and_artifacts.py` log a model with `openai` as a requirement, lock the environment, and assert that the resulting `requirements.txt` pins the expected transitive dependencies. They asserted `httpx==` appears in the locked output.

`openai` 3.0.0 migrated from `httpx` to `httpx2` and no longer installs `httpx` transitively (see the [HTTPX2 migration guide](https://github.com/openai/openai-python/blob/main/httpx2.md)). Because these tests run `uv pip compile openai` against live PyPI (not `uv.lock`), the resolution now yields `openai==3.0.0` with no `httpx` pin, so the `httpx==` assertion fails.

This surfaced as a CI failure on the automated `uv.lock` bump PR #25225, but it is an environmental failure independent of that PR — any PR running these tests fails identically now.

This PR replaces the `httpx==` assertions with `jiter==`, which remains a transitive (non-direct) dependency of `openai` and preserves the tests' intent of verifying transitive deps get pinned.

### How is this PR tested?

- [x] Existing unit/integration tests

Verified `uv pip compile openai` (the same command the tests invoke) resolves `openai==3.0.0` and `jiter==0.16.0` with no `httpx` line.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
