### PR TITLE
Fix lock test for `openai`'s `httpx` -> `httpx2` dependency migration

### DIFF
--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2886,7 +2886,10 @@ def test_lock_model_requirements_pip_requirements(monkeypatch: pytest.MonkeyPatc
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "httpx==" in contents
+    # `openai` migrated its HTTP client from `httpx` (1.x) to `httpx2` (2.x, a
+    # separate distribution), so an unpinned `openai` locks one or the other
+    # depending on the resolved version. Assert the family is locked either way.
+    assert "httpx==" in contents or "httpx2==" in contents
 
 
 def test_lock_model_requirements_extra_pip_requirements(
@@ -2904,7 +2907,7 @@ def test_lock_model_requirements_extra_pip_requirements(
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "httpx==" in contents
+    assert "httpx==" in contents or "httpx2==" in contents
 
 
 def test_lock_model_requirements_constraints(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
### Related Issues/PRs

Relates to the current `master` CI failures in `pyfunc (1)` and `pyfunc (4)` (reproducible on any open PR).

### What changes are proposed in this pull request?

`openai` moved its HTTP client dependency from `httpx` (1.x) to `httpx2` (the 2.x line, published under a separate distribution name, alongside `httpcore2`). An unpinned `openai` now resolves to `openai==3.x`, whose locked closure contains `httpx2==...` and no `httpx==` line:

```
$ uv pip compile --universal <(echo openai)
openai==3.1.0
httpx2==2.10.0        # via openai
httpcore2==2.10.0     # via httpx2
...                   # (no `httpx==`)
```

As a result, `test_lock_model_requirements_pip_requirements` and `test_lock_model_requirements_extra_pip_requirements` fail on `assert "httpx==" in contents`.

This PR relaxes those two assertions to accept either distribution (`httpx==` or `httpx2==`), so the test still verifies that openai's HTTP-client transitive dependency is locked without pinning to a distribution name that changes with the resolved openai version.

`test_lock_model_requirements_constraints` pins `openai==1.82.0`, which still uses plain `httpx`, so its assertion is intentionally left unchanged (it also keeps coverage of the older-openai path).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The three affected tests are `test_lock_model_requirements_pip_requirements`, `test_lock_model_requirements_extra_pip_requirements`, and `test_lock_model_requirements_constraints` in `tests/pyfunc/test_model_export_with_class_and_artifacts.py`. Verified the openai lock closure directly (contains `httpx2==`, not `httpx==`), so the updated assertion passes where the old one failed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.