### PR TITLE
Fix proto conversion of `DatasetRecordSourceType.UNSPECIFIED` dataset record sources

### DIFF
--- a/mlflow/entities/dataset_record.py
+++ b/mlflow/entities/dataset_record.py
@@ -7,9 +7,13 @@ from typing import Any
 from google.protobuf.json_format import MessageToDict
 
 from mlflow.entities._mlflow_object import _MlflowObject
-from mlflow.entities.dataset_record_source import DatasetRecordSource, DatasetRecordSourceType
+from mlflow.entities.dataset_record_source import (
+    _PROTO_UNSPECIFIED_SOURCE_TYPE_NAME,
+    DatasetRecordSource,
+    DatasetRecordSourceType,
+    _source_type_to_proto,
+)
 from mlflow.protos.datasets_pb2 import DatasetRecord as ProtoDatasetRecord
-from mlflow.protos.datasets_pb2 import DatasetRecordSource as ProtoDatasetRecordSource
 
 # Reserved key for wrapping non-dict outputs when storing in SQL database
 DATASET_RECORD_WRAPPED_OUTPUT_KEY = "mlflow_wrapped"
@@ -73,7 +77,7 @@ class DatasetRecord(_MlflowObject):
         if self.source_id is not None:
             proto.source_id = self.source_id
         if self.source_type is not None:
-            proto.source_type = ProtoDatasetRecordSource.SourceType.Value(self.source_type)
+            proto.source_type = _source_type_to_proto(self.source_type)
         if self.created_by is not None:
             proto.created_by = self.created_by
         if self.last_updated_by is not None:
@@ -125,6 +129,8 @@ class DatasetRecord(_MlflowObject):
             d["tags"] = json.loads(d["tags"])
         if "source" in d:
             d["source"] = json.loads(d["source"])
+        if d.get("source_type") == _PROTO_UNSPECIFIED_SOURCE_TYPE_NAME:
+            d["source_type"] = DatasetRecordSourceType.UNSPECIFIED.value
         d["created_time"] = self.created_time
         d["last_update_time"] = self.last_update_time
         return d

--- a/mlflow/entities/dataset_record_source.py
+++ b/mlflow/entities/dataset_record_source.py
@@ -10,6 +10,11 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.protos.datasets_pb2 import DatasetRecordSource as ProtoDatasetRecordSource
 
+# The zero value of the proto enum is named ``SOURCE_TYPE_UNSPECIFIED``, while the Python
+# enum (and persisted source type strings) use ``UNSPECIFIED``. The two names must be
+# mapped onto each other whenever a source type crosses the proto boundary.
+_PROTO_UNSPECIFIED_SOURCE_TYPE_NAME = "SOURCE_TYPE_UNSPECIFIED"
+
 
 class DatasetRecordSourceType(str, Enum):
     """
@@ -75,7 +80,18 @@ class DatasetRecordSourceType(str, Enum):
 
     @classmethod
     def from_proto(cls, proto_source_type) -> str:
-        return ProtoDatasetRecordSource.SourceType.Name(proto_source_type)
+        name = ProtoDatasetRecordSource.SourceType.Name(proto_source_type)
+        if name == _PROTO_UNSPECIFIED_SOURCE_TYPE_NAME:
+            return cls.UNSPECIFIED.value
+        return name
+
+
+def _source_type_to_proto(source_type: str | DatasetRecordSourceType) -> int:
+    """Convert a source type name to its proto enum value."""
+    name = source_type.value if isinstance(source_type, DatasetRecordSourceType) else source_type
+    if name == DatasetRecordSourceType.UNSPECIFIED.value:
+        name = _PROTO_UNSPECIFIED_SOURCE_TYPE_NAME
+    return ProtoDatasetRecordSource.SourceType.Value(name)
 
 
 @dataclass
@@ -100,7 +116,7 @@ class DatasetRecordSource(_MlflowObject):
 
     def to_proto(self) -> ProtoDatasetRecordSource:
         proto = ProtoDatasetRecordSource()
-        proto.source_type = ProtoDatasetRecordSource.SourceType.Value(self.source_type.value)
+        proto.source_type = _source_type_to_proto(self.source_type)
         if self.source_data:
             proto.source_data = json.dumps(self.source_data)
         return proto
@@ -111,7 +127,7 @@ class DatasetRecordSource(_MlflowObject):
         source_type = (
             DatasetRecordSourceType.from_proto(proto.source_type)
             if proto.HasField("source_type")
-            else None
+            else DatasetRecordSourceType.UNSPECIFIED
         )
 
         return cls(source_type=source_type, source_data=source_data)

--- a/tests/entities/test_dataset_record.py
+++ b/tests/entities/test_dataset_record.py
@@ -214,6 +214,30 @@ def test_dataset_record_to_from_dict():
     assert record2 == record
 
 
+def test_dataset_record_round_trip_with_unspecified_source():
+    record = DatasetRecord(
+        dataset_record_id="rec123",
+        dataset_id="dataset123",
+        inputs={"question": "What is MLflow?"},
+        source=DatasetRecordSource(source_type="UNSPECIFIED", source_data={}),
+        created_time=123456789,
+        last_update_time=987654321,
+    )
+    assert record.source_type == "UNSPECIFIED"
+
+    proto = record.to_proto()
+    assert proto.source_type == ProtoDatasetRecordSource.SourceType.Value("SOURCE_TYPE_UNSPECIFIED")
+    record2 = DatasetRecord.from_proto(proto)
+    assert record2 == record
+    assert record2.source_type == "UNSPECIFIED"
+
+    data = record.to_dict()
+    assert data["source_type"] == "UNSPECIFIED"
+    assert data["source"] == {"source_type": "UNSPECIFIED", "source_data": {}}
+    record3 = DatasetRecord.from_dict(data)
+    assert record3 == record
+
+
 def test_dataset_record_equality():
     source = DatasetRecordSource(source_type="HUMAN", source_data={"user_id": "user1"})
     record1 = DatasetRecord(

--- a/tests/entities/test_dataset_record_source.py
+++ b/tests/entities/test_dataset_record_source.py
@@ -171,6 +171,26 @@ def test_document_source_proto_conversion():
     assert source2.source_data["content"] == "Test content"
 
 
+def test_unspecified_source_proto_conversion():
+    source = DatasetRecordSource(
+        source_type=DatasetRecordSourceType.UNSPECIFIED, source_data={"note": "no source"}
+    )
+
+    proto = source.to_proto()
+    assert proto.source_type == ProtoDatasetRecordSource.SourceType.Value("SOURCE_TYPE_UNSPECIFIED")
+
+    source2 = DatasetRecordSource.from_proto(proto)
+    assert isinstance(source2, DatasetRecordSource)
+    assert source2.source_type == DatasetRecordSourceType.UNSPECIFIED
+    assert source2.source_data == {"note": "no source"}
+
+
+def test_source_from_proto_without_source_type():
+    source = DatasetRecordSource.from_proto(ProtoDatasetRecordSource())
+    assert source.source_type == DatasetRecordSourceType.UNSPECIFIED
+    assert source.source_data == {}
+
+
 def test_dataset_record_source_to_from_dict():
     source = DatasetRecordSource(source_type="CODE", source_data={"file": "example.py", "line": 42})
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #25217

### What changes are proposed in this pull request?

`DatasetRecordSourceType.UNSPECIFIED` — the documented default source type for evaluation dataset records — cannot cross the proto boundary in either direction: the Python enum names the zero value `UNSPECIFIED` while the proto enum names it `SOURCE_TYPE_UNSPECIFIED`, and the converters pass names through verbatim. Consequences: `to_proto()` raises `ValueError`, `from_proto()` raises `MlflowException` (or `AttributeError` for an unset field), and one such record — accepted by the store's own `upsert_dataset_records` API — makes `GET /api/3.0/mlflow/datasets/{id}/records` return HTTP 500 for the whole dataset.

This PR maps the names at the proto boundary only (module helper `_source_type_to_proto()` + `from_proto` mapping the zero value back to `UNSPECIFIED`; unset proto field now yields `UNSPECIFIED` instead of crashing), mirroring how the sibling `AssessmentSourceType` aligns with its proto. The public Python enum member is unchanged, so persisted DB rows and user code holding `"UNSPECIFIED"` keep working, and dicts serialized by unfixed peers still parse.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New tests: `tests/entities/test_dataset_record_source.py::test_unspecified_source_proto_conversion`, `::test_source_from_proto_without_source_type`, `tests/entities/test_dataset_record.py::test_dataset_record_round_trip_with_unspecified_source` — all three fail without the fix (2× `ValueError`, 1× `AttributeError`) and pass with it. Surrounding suites: `tests/entities/test_dataset_record.py` + `test_dataset_record_source.py` + `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_eval_datasets.py` → 71 passed; `tests/entities/test_evaluation_dataset.py` → 22 passed. `ruff check` / `ruff format --check` clean.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed dataset record serialization and the get-dataset-records endpoint failing for records with an UNSPECIFIED source.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A bug fix

#### Should this PR be included in the next patch release?

- [x] No - this PR will be included in the next minor/major release

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.