### PR TITLE
Fix integer/varchar type mismatch in WorkspaceAwareSqlAlchemyStore experiment_id filters

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_workspace_store.py
+++ b/mlflow/store/tracking/sqlalchemy_workspace_store.py
@@ -233,6 +233,7 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
 
     def _filter_experiment_ids(self, session, experiment_ids):
         workspace = self._get_active_workspace()
+        experiment_ids = [int(e) for e in experiment_ids]
         rows = (
             session
             .query(SqlExperiment.experiment_id)
@@ -259,7 +260,7 @@ class WorkspaceAwareSqlAlchemyStore(WorkspaceAwareMixin, SqlAlchemyStore):
                 session
                 .query(SqlExperiment.experiment_id)
                 .filter(
-                    SqlExperiment.experiment_id.in_(entity_ids),
+                    SqlExperiment.experiment_id.in_([int(e) for e in entity_ids]),
                     SqlExperiment.workspace == workspace,
                 )
                 .all()

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -418,6 +418,34 @@ def test_entity_associations_are_workspace_scoped(workspace_tracking_store):
         assert reverse.to_list() == []
 
 
+def test_filter_entity_ids_and_experiment_ids_use_integer_bind_params(workspace_tracking_store):
+    # Regression test for https://github.com/mlflow/mlflow/issues/25188: experiment_id
+    # must be bound as an integer (matching the INTEGER column type), not a string, or
+    # backends like PostgreSQL reject the comparison with "operator does not exist:
+    # integer = character varying".
+    with WorkspaceContext("team-a"):
+        exp_id = workspace_tracking_store.create_experiment("filter-entity-ids-exp")
+
+        with workspace_tracking_store.ManagedSessionMaker() as session:
+            filtered_experiment_ids = workspace_tracking_store._filter_experiment_ids(
+                session, [exp_id]
+            )
+            assert filtered_experiment_ids == [int(exp_id)]
+
+            filtered_entity_ids = workspace_tracking_store._filter_entity_ids(
+                session, EntityAssociationType.EXPERIMENT, [exp_id]
+            )
+            assert filtered_entity_ids == [exp_id]
+
+            compiled = (
+                session
+                .query(SqlExperiment.experiment_id)
+                .filter(SqlExperiment.experiment_id.in_([int(exp_id)]))
+                .statement.compile(compile_kwargs={"literal_binds": True})
+            )
+            assert f"experiments.experiment_id IN ({exp_id})" in str(compiled)
+
+
 def test_artifact_locations_are_scoped_to_workspace(workspace_tracking_store):
     with WorkspaceContext("team-alpha"):
         exp_id = workspace_tracking_store.create_experiment("alpha-exp")


### PR DESCRIPTION
### Related Issues/PRs

Closes #25188

### What changes are proposed in this pull request?

`experiments.experiment_id` is an Integer column, but `WorkspaceAwareSqlAlchemyStore._filter_experiment_ids` and `_filter_entity_ids` (EXPERIMENT branch) passed string experiment IDs straight into `SqlExperiment.experiment_id.in_(...)`, causing PostgreSQL/psycopg to bind them as VARCHAR and fail with `operator does not exist: integer = character varying`. This PR coerces the ids to `int` before building the IN clause, mirroring the fix already applied to the non-workspace-aware `SqlAlchemyStore` in #17035.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where filtering experiments/runs by `experiment_id` in `WorkspaceAwareSqlAlchemyStore` could raise a PostgreSQL type-mismatch error (`operator does not exist: integer = character varying`) instead of coercing ids to the column's integer type.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
