### PR TITLE
docs: add a `Debug Agents with Traces` page to the tracing docs

### DIFF
--- a/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
@@ -8,7 +8,7 @@ This page shows how to go from a wrong or surprising result to the span that cau
 
 ## Start from the trace, not the source code
 
-When an agent returns a wrong answer, the instinct is to open the code and reason about what it should have done. The trace tells you what it *actually* did: which documents the retriever returned, what arguments a tool was called with, what the model saw and produced at each step. Read that first. It turns "somewhere in this pipeline" into a specific span.
+When an agent returns a wrong answer, the instinct is to open the code and reason about what it should have done. The trace tells you what it _actually_ did: which documents the retriever returned, what arguments a tool was called with, what the model saw and produced at each step. Read that first. It turns "somewhere in this pipeline" into a specific span.
 
 A good loop is:
 

--- a/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
@@ -66,40 +66,51 @@ Debugging one bad result often reveals a pattern. Use <APILink fn="mlflow.search
 ```python
 import mlflow
 import time
+from collections import Counter
 
-# Failures in the last hour, most recent first
+# Failures in the last hour, most recent first. return_type="list" gives
+# Trace objects, whose trace.info fields are stable to read.
 cutoff_ms = int(time.time() * 1000) - 60 * 60 * 1000
 failed = mlflow.search_traces(
     filter_string=f"trace.status = 'ERROR' AND trace.timestamp_ms > {cutoff_ms}",
     order_by=["trace.timestamp_ms DESC"],
+    return_type="list",
 )
 
-if len(failed) == 0:
+if not failed:
     print("No errors in the last hour")
 else:
+    by_name = Counter(t.info.tags.get("mlflow.traceName", "unknown") for t in failed)
     print(f"{len(failed)} errors. Grouped by trace name:")
-    print(failed.groupby("tags.mlflow.traceName").size().to_string())
+    for name, count in by_name.most_common():
+        print(f"  {count:4d}  {name}")
 ```
 
 Grouping by trace name (or by any tag you attach, such as a version or a route) turns a pile of failures into a short list of places to look.
 
 ### Slow traces
 
-Latency problems follow the same shape. Pull traces and inspect `execution_time_ms` to find the slow tail, then open the slowest traces and read their spans to see which step dominates.
+Latency problems follow the same shape. Pull traces, sort by `execution_duration` (milliseconds) to find the slow tail, then open the slowest traces and read their spans to see which step dominates.
 
 ```python
-traces = mlflow.search_traces(order_by=["trace.timestamp_ms DESC"])
+traces = mlflow.search_traces(
+    order_by=["trace.execution_time_ms DESC"],
+    max_results=100,
+    return_type="list",
+)
 
-if len(traces) > 0:
-    stats = traces["execution_time_ms"].describe(percentiles=[0.5, 0.95, 0.99])
-    print(f"P50: {stats['50%']:.0f}ms  P95: {stats['95%']:.0f}ms  P99: {stats['99%']:.0f}ms")
+durations = sorted((t.info.execution_duration or 0) for t in traces)
+if durations:
+    def percentile(p):
+        return durations[min(len(durations) - 1, int(len(durations) * p / 100))]
+    print(f"P50: {percentile(50)}ms  P95: {percentile(95)}ms  P99: {percentile(99)}ms")
 
-    slowest = traces.nlargest(3, "execution_time_ms")
-    for _, t in slowest.iterrows():
-        print(f"{t['execution_time_ms']:.0f}ms: {t['request_preview'][:60]}")
+    print("\nSlowest traces:")
+    for t in traces[:3]:
+        print(f"  {t.info.execution_duration}ms  {t.info.trace_id}")
 ```
 
-Once you know which trace is slow, open it and read the span durations to find the step that dominates: a slow tool call, a retrieval over too many documents, or an unnecessary extra model call.
+Once you know which trace is slow, open it with `mlflow.get_trace` and read the span durations to find the step that dominates: a slow tool call, a retrieval over too many documents, or an unnecessary extra model call.
 
 ## Next steps
 

--- a/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
@@ -51,8 +51,10 @@ for span in trace.data.spans:
     is_error = span.status.status_code == SpanStatusCode.ERROR
     is_empty = span.outputs in (None, "", [], {})
     if is_error or is_empty:
-        print(f"Check {span.name} ({span.span_type}): "
-              f"status={span.status.status_code}, outputs={span.outputs}")
+        print(
+            f"Check {span.name} ({span.span_type}): "
+            f"status={span.status.status_code}, outputs={span.outputs}"
+        )
 ```
 
 You can also open the same trace in the MLflow UI and step through the spans visually. See [View Traces](/genai/tracing/observe-with-traces/ui).
@@ -101,8 +103,10 @@ traces = mlflow.search_traces(
 
 durations = sorted((t.info.execution_duration or 0) for t in traces)
 if durations:
+
     def percentile(p):
         return durations[min(len(durations) - 1, int(len(durations) * p / 100))]
+
     print(f"P50: {percentile(50)}ms  P95: {percentile(95)}ms  P99: {percentile(99)}ms")
 
     print("\nSlowest traces:")

--- a/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
+++ b/docs/docs/genai/tracing/observe-with-traces/debug-with-traces.mdx
@@ -1,0 +1,108 @@
+import { APILink } from "@site/src/components/APILink";
+
+# Debug Agents with Traces
+
+Once your agent or LLM application is instrumented, the trace is the first place to look when it behaves in a way you did not expect. A trace records the inputs and outputs of every step, so it shows where the run actually diverged, which is usually faster and more precise than rereading source code and output files.
+
+This page shows how to go from a wrong or surprising result to the span that caused it, and how to spot recurring problems across many traces.
+
+## Start from the trace, not the source code
+
+When an agent returns a wrong answer, the instinct is to open the code and reason about what it should have done. The trace tells you what it *actually* did: which documents the retriever returned, what arguments a tool was called with, what the model saw and produced at each step. Read that first. It turns "somewhere in this pipeline" into a specific span.
+
+A good loop is:
+
+1. Reproduce the behavior, or find the offending trace (see [Search Traces](/genai/tracing/search-traces)).
+2. Open the trace and walk its spans from the top down.
+3. Find the first span whose output is wrong. That span, not the final answer, is where to fix.
+
+## Read a single trace's spans
+
+Use <APILink fn="mlflow.get_trace" /> to fetch a trace by ID, then walk its spans. Each span exposes its `name`, `span_type`, `inputs`, `outputs`, `status`, and `attributes`.
+
+```python
+import mlflow
+
+trace = mlflow.get_trace("<trace_id>")
+
+for span in trace.data.spans:
+    print(f"{span.name} ({span.span_type}) -> {span.status.status_code}")
+    print(f"  inputs:  {span.inputs}")
+    print(f"  outputs: {span.outputs}")
+```
+
+Reading the spans in order shows where the run first went wrong. A few patterns worth checking directly:
+
+- **Retrieval spans**: did the retriever return the documents you expected, in a sensible order? A correct-looking final answer built on the wrong retrieved context is a retrieval bug, not a generation bug.
+- **Tool and function spans**: were the arguments the model passed to a tool correct? A tool called with the wrong input produces a plausible-looking result that is quietly off.
+- **LLM spans**: inspect the exact prompt the model received (`inputs`), not the prompt you think it received. Missing context, a stale system message, or a truncated history usually shows up here.
+- **Span status**: a span can complete with `OK` status and still be the source of the problem, so do not filter on errors alone when the failure is a quality issue rather than a crash.
+
+### Find the failing span programmatically
+
+For a large trace, scan for the spans that errored or that produced an empty or malformed output instead of scrolling the whole tree.
+
+```python
+from mlflow.entities import SpanStatusCode
+
+trace = mlflow.get_trace("<trace_id>")
+
+for span in trace.data.spans:
+    is_error = span.status.status_code == SpanStatusCode.ERROR
+    is_empty = span.outputs in (None, "", [], {})
+    if is_error or is_empty:
+        print(f"Check {span.name} ({span.span_type}): "
+              f"status={span.status.status_code}, outputs={span.outputs}")
+```
+
+You can also open the same trace in the MLflow UI and step through the spans visually. See [View Traces](/genai/tracing/observe-with-traces/ui).
+
+## Find recurring problems across many traces
+
+Debugging one bad result often reveals a pattern. Use <APILink fn="mlflow.search_traces" /> to pull a set of traces and look for the shape of a systematic problem. See [Search Traces](/genai/tracing/search-traces) for the full filter syntax.
+
+### Errors grouped by where they happen
+
+```python
+import mlflow
+import time
+
+# Failures in the last hour, most recent first
+cutoff_ms = int(time.time() * 1000) - 60 * 60 * 1000
+failed = mlflow.search_traces(
+    filter_string=f"trace.status = 'ERROR' AND trace.timestamp_ms > {cutoff_ms}",
+    order_by=["trace.timestamp_ms DESC"],
+)
+
+if len(failed) == 0:
+    print("No errors in the last hour")
+else:
+    print(f"{len(failed)} errors. Grouped by trace name:")
+    print(failed.groupby("tags.mlflow.traceName").size().to_string())
+```
+
+Grouping by trace name (or by any tag you attach, such as a version or a route) turns a pile of failures into a short list of places to look.
+
+### Slow traces
+
+Latency problems follow the same shape. Pull traces and inspect `execution_time_ms` to find the slow tail, then open the slowest traces and read their spans to see which step dominates.
+
+```python
+traces = mlflow.search_traces(order_by=["trace.timestamp_ms DESC"])
+
+if len(traces) > 0:
+    stats = traces["execution_time_ms"].describe(percentiles=[0.5, 0.95, 0.99])
+    print(f"P50: {stats['50%']:.0f}ms  P95: {stats['95%']:.0f}ms  P99: {stats['99%']:.0f}ms")
+
+    slowest = traces.nlargest(3, "execution_time_ms")
+    for _, t in slowest.iterrows():
+        print(f"{t['execution_time_ms']:.0f}ms: {t['request_preview'][:60]}")
+```
+
+Once you know which trace is slow, open it and read the span durations to find the step that dominates: a slow tool call, a retrieval over too many documents, or an unnecessary extra model call.
+
+## Next steps
+
+- [Search Traces](/genai/tracing/search-traces) for the full `search_traces` filter syntax.
+- [View Traces](/genai/tracing/observe-with-traces/ui) to step through spans in the UI.
+- [Collect User Feedback](/genai/tracing/collect-user-feedback) to attach quality signals to traces you can later search on.

--- a/docs/sidebarsGenAI.ts
+++ b/docs/sidebarsGenAI.ts
@@ -114,6 +114,11 @@ const sidebarsGenAI: SidebarsConfig = {
                 },
                 {
                   type: 'doc',
+                  id: 'tracing/observe-with-traces/debug-with-traces',
+                  label: 'Debug Agents with Traces',
+                },
+                {
+                  type: 'doc',
                   id: 'tracing/observe-with-traces/archive-traces',
                   label: 'Archive Traces',
                 },


### PR DESCRIPTION
### Related Issues/PRs

N/A -- documentation improvement, no linked issue.

### What changes are proposed in this pull request?

Adds a new **Debug Agents with Traces** page under the tracing docs (`observe-with-traces/`) and registers it in the GenAI sidebar.

The existing tracing docs cover setting up tracing, navigating the UI, and search syntax, but nothing teaches how to read a trace's spans to diagnose *why* an agent behaved a certain way. The new page walks from a wrong or surprising result to the span that caused it:

- Start from the trace, not the source code.
- Read a single trace's spans with `mlflow.get_trace`, inspecting `inputs`, `outputs`, `status`, and `span_type` per span (retrieval, tool, and LLM span patterns).
- Find the failing span programmatically.
- Find recurring problems across many traces with `mlflow.search_traces` (errors grouped by trace name, slow-trace profiling).

All content is backend-neutral and uses only public MLflow tracing APIs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Documentation-only change. The `mlflow.get_trace` / `mlflow.search_traces` APILinks, the `SpanStatusCode` import, the `return_type="list"` usage, and the fields used (`Trace.data.spans`, span `name`/`span_type`/`inputs`/`outputs`/`status.status_code`, `Trace.info.tags`/`execution_duration`/`trace_id`) were verified against the current source. Internal doc links point to existing pages.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [ ] No.
- [x] Yes. Please link the corresponding PR or explain how you plan to update it.

A complementary skills change, steering agents to debug from traces once tracing is set up, is in mlflow/skills#36.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

New documentation page on debugging agents by reading their MLflow traces.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release