### PR TITLE
feat: serve trace analytics reads from opt-in SQL daily rollups

### DIFF
--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -137,7 +137,7 @@ Enabling this variable does not populate the rollup tables by itself; a separate
 :::note[Backend-specific behavior]
 
 - **Percentiles** (p50/p90/p99) are served from rollups for trace metrics such as latency and token usage, and only on PostgreSQL. On other backends, and for assessment percentiles, percentile aggregations fall back to the raw path.
-- **Grouping** is limited to whole-experiment daily aggregates. Requests that group by a dimension, such as a per-status breakdown, use the raw path.
+- **Grouping** supports whole-experiment daily aggregates and trace-count breakdowns by trace status. Other dimension groupings use the raw path.
 - **Span cost** metrics are intentionally excluded from rollups and always use the raw path, because their day bucketing cannot be made row-identical to the raw query. All other ungrouped trace-metric and assessment aggregations are eligible.
 
 :::

--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -107,6 +107,41 @@ You can inject some [SQLAlchemy connection pooling options](https://docs.sqlalch
   </tbody>
 </Table>
 
+## Trace Analytics Daily Rollups
+
+Trace analytics queries (used by the traces dashboards) aggregate metrics such as trace counts, latency, token usage, and assessment values over a time range. On large trace tables these queries scan a lot of rows. MLflow can serve the whole-day portions of such queries from precomputed daily rollup tables, which is much faster than scanning raw traces and spans.
+
+Rollups are an **opt-in read acceleration**. They never change query results: any day that is not yet rolled up, and any partial day at the edges of a requested range, is served from the raw path, so enabling rollups only changes query speed. This feature requires a database backend (it is not available for the file store).
+
+To let the query planner serve eligible whole days from the rollup tables, set the following environment variable on the tracking server:
+
+<Table>
+  <thead>
+    <tr>
+      <th>MLflow Environment Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`MLFLOW_SQL_TRACE_ROLLUPS_ENABLED`</td>
+      <td>When `true`, trace analytics queries serve eligible whole days from precomputed rollup tables and fall back to the raw path for any day that is not covered. When `false`, all queries use the raw path.</td>
+      <td>`false`</td>
+    </tr>
+  </tbody>
+</Table>
+
+Enabling this variable does not populate the rollup tables by itself; a separate maintenance job builds and refreshes them. Until a day has been rolled up, queries for that day transparently use the raw path, so the feature is safe to turn on before any rollups exist.
+
+:::note[Backend-specific behavior]
+
+- **Percentiles** (p50/p90/p99) are served from rollups for trace metrics such as latency and token usage, and only on PostgreSQL. On other backends, and for assessment percentiles, percentile aggregations fall back to the raw path.
+- **Grouping** is limited to whole-experiment daily aggregates. Requests that group by a dimension, such as a per-status breakdown, use the raw path.
+- **Span cost** metrics are intentionally excluded from rollups and always use the raw path, because their day bucketing cannot be made row-identical to the raw query. All other ungrouped trace-metric and assessment aggregations are eligible.
+
+:::
+
 ## MySQL SSL Options
 
 When connecting to a MySQL database that requires SSL certificates, you can set the following environment variables:

--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -137,8 +137,9 @@ Enabling this variable does not populate the rollup tables by itself; a separate
 :::note[Backend-specific behavior]
 
 - **Percentiles** (p50/p90/p99) are served from rollups for trace metrics such as latency and token usage, and only on PostgreSQL. On other backends, and for assessment percentiles, percentile aggregations fall back to the raw path.
-- **Grouping** supports whole-experiment daily aggregates and trace-count breakdowns by trace status. Other dimension groupings use the raw path.
-- **Span cost** metrics are intentionally excluded from rollups and always use the raw path, because their day bucketing cannot be made row-identical to the raw query. All other ungrouped trace-metric and assessment aggregations are eligible.
+- **Grouping** supports whole-experiment daily aggregates, trace-count breakdowns by trace status, and span-cost breakdowns by model and provider. Other dimension groupings use the raw path.
+- **Span cost** metrics use rollups for global, model, provider, and model/provider grouping sets. Both raw and rollup span-cost ranges use the span start timestamp so results remain identical.
+- **Unbucketed aggregates** such as whole-range trace counts and span-cost breakdowns combine daily rollup counts and sums with any raw partial-day contributions. Unbucketed percentiles remain on the exact raw path because daily percentiles are not composable.
 
 :::
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1549,6 +1549,15 @@ MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY = _EnvironmentVariable(
 #: (default: ``None``)
 MLFLOW_TRACE_ARCHIVAL_CONFIG = _EnvironmentVariable("MLFLOW_TRACE_ARCHIVAL_CONFIG", str, None)
 
+#: Enables opt-in SQL daily rollups for trace analytics. When ``true``, the query planner serves
+#: eligible daily aggregate requests from precomputed rollup tables, falling back to the raw path
+#: for any day that is not covered. When ``false`` (the default), all trace analytics queries use
+#: the raw path.
+#: (default: ``False``)
+MLFLOW_SQL_TRACE_ROLLUPS_ENABLED = _BooleanEnvironmentVariable(
+    "MLFLOW_SQL_TRACE_ROLLUPS_ENABLED", False
+)
+
 #: Specifies the maximum number of workers for async judge invocation jobs.
 #: (default: ``10``)
 MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS = _EnvironmentVariable(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4407,6 +4407,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     time_interval_seconds=time_interval_seconds,
                     max_results=max_results,
                     time_ranges_ms=ranges,
+                    accessible_experiment_ids=experiment_ids_int,
                 )
 
             full_raw_range = [(start_time_ms, end_time_ms)]
@@ -4437,6 +4438,13 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     else []
                 )
                 if not rollup_read_is_current(session, plan, served.served_day_starts_ms):
+                    _logger.debug(
+                        "SQL trace rollup routing selected the full raw path for view=%s "
+                        "metric=%s: "
+                        "a served day was invalidated during the read",
+                        view_type.value,
+                        metric_name,
+                    )
                     data_points = raw_range_points(full_raw_range)
                 elif plan.bucketed:
                     # Match the single-query raw path: order by time bucket (then grouping

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -129,6 +129,7 @@ from mlflow.store.tracking import (
 )
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
     SqlAssessments,
     SqlDataset,
     SqlEntityAssociation,
@@ -160,9 +161,12 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlScorer,
     SqlScorerVersion,
     SqlSpan,
+    SqlSpanCostDailyRollup,
     SqlTag,
     SqlTraceInfo,
     SqlTraceMetadata,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
     SqlTraceTag,
     _input_to_dict,
 )
@@ -175,8 +179,12 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     validate_query_trace_metrics_params,
 )
 from mlflow.store.tracking.utils.sql_trace_rollups import (
+    configure_rollup_read_snapshot,
+    merge_unbucketed_data_points,
     order_and_limit_data_points,
+    raw_aggregations_for_plan,
     resolve_rollup_read,
+    rollup_read_is_current,
     serve_rollup_read,
 )
 from mlflow.store.tracking.utils.trace_analytics import (
@@ -914,6 +922,18 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session=session,
                 view_type=ViewType.DELETED_ONLY,
             )
+            # Rollup tables deliberately have no experiment foreign key. Remove their rows in the
+            # same transaction so backends that reuse integer experiment ids (notably SQLite)
+            # cannot expose aggregates or rebuild state from the deleted experiment.
+            for model in (
+                SqlTraceMetricDailyRollup,
+                SqlSpanCostDailyRollup,
+                SqlAssessmentDailyRollup,
+                SqlTraceRollupRebuild,
+            ):
+                session.query(model).filter(model.experiment_id == int(experiment_id)).delete(
+                    synchronize_session=False
+                )
             session.delete(experiment)
 
     def _mark_run_deleted(self, session, run):
@@ -4354,39 +4374,42 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             )
 
         with self.ManagedSessionMaker() as session:
+            # Rollup routing reads coverage, rebuild state, rollup rows, and raw gaps in separate
+            # statements. Establish their shared snapshot before the first database read.
+            configure_rollup_read_snapshot(session, self.db_type)
             experiment_ids_int = self._filter_experiment_ids(
                 session, [int(exp_id) for exp_id in experiment_ids]
             )
 
-            def raw_range_query(range_start_ms: int | None, range_end_ms: int | None):
+            def raw_query():
                 if view_type == MetricViewType.ASSESSMENTS:
-                    query = session.query(SqlAssessments).filter(
+                    return session.query(SqlAssessments).filter(
                         SqlAssessments.experiment_id.in_(experiment_ids_int)
                     )
-                    timestamp_column = SqlAssessments.trace_timestamp_ms
-                else:
-                    query = self._trace_query(session).filter(
-                        SqlTraceInfo.experiment_id.in_(experiment_ids_int)
-                    )
-                    timestamp_column = SqlTraceInfo.timestamp_ms
-                if range_start_ms is not None:
-                    query = query.filter(timestamp_column >= range_start_ms)
-                if range_end_ms is not None:
-                    query = query.filter(timestamp_column <= range_end_ms)
-                return query
+                return self._trace_query(session).filter(
+                    SqlTraceInfo.experiment_id.in_(experiment_ids_int)
+                )
 
-            def raw_range_points(range_start_ms: int | None, range_end_ms: int | None):
+            def raw_range_points(
+                ranges: list[tuple[int | None, int | None]],
+                range_aggregations: list[MetricAggregation] | None = None,
+            ):
                 return query_metrics(
                     view_type=view_type,
                     db_type=self.db_type,
-                    query=raw_range_query(range_start_ms, range_end_ms),
+                    query=raw_query(),
                     metric_name=metric_name,
-                    aggregations=aggregations,
+                    aggregations=(
+                        range_aggregations if range_aggregations is not None else aggregations
+                    ),
                     dimensions=dimensions,
                     filters=filters,
                     time_interval_seconds=time_interval_seconds,
                     max_results=max_results,
+                    time_ranges_ms=ranges,
                 )
+
+            full_raw_range = [(start_time_ms, end_time_ms)]
 
             # Opt-in fast path: serve whole covered UTC days from precomputed rollups and query only
             # the partial-day edges (and any not-yet-built days) raw. resolve_rollup_read returns
@@ -4407,15 +4430,27 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             served = serve_rollup_read(session, plan) if plan is not None else None
 
             if served is not None:
-                rollup_points, raw_ranges = served
-                data_points = list(rollup_points)
-                for range_start_ms, range_end_ms in raw_ranges:
-                    data_points.extend(raw_range_points(range_start_ms, range_end_ms))
-                # Match the single-query raw path: order by time bucket (then grouping dimensions)
-                # and apply the global max_results after merging rollup and raw sub-range results.
-                data_points = order_and_limit_data_points(data_points, max_results)
+                range_aggregations = raw_aggregations_for_plan(plan)
+                raw_points = (
+                    raw_range_points(served.raw_ranges, range_aggregations)
+                    if served.raw_ranges
+                    else []
+                )
+                if not rollup_read_is_current(session, plan, served.served_day_starts_ms):
+                    data_points = raw_range_points(full_raw_range)
+                elif plan.bucketed:
+                    # Match the single-query raw path: order by time bucket (then grouping
+                    # dimensions) and apply the global max_results after merging rollup and raw
+                    # contributions.
+                    data_points = order_and_limit_data_points(
+                        [*served.data_points, *raw_points], max_results
+                    )
+                else:
+                    data_points = merge_unbucketed_data_points(
+                        plan, served.data_points, raw_points, max_results
+                    )
             else:
-                data_points = raw_range_points(start_time_ms, end_time_ms)
+                data_points = raw_range_points(full_raw_range)
 
             # TODO: Implement pagination with page_token
             return PagedList(data_points, None)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -183,9 +183,11 @@ from mlflow.store.tracking.utils.sql_trace_rollups import (
     merge_unbucketed_data_points,
     order_and_limit_data_points,
     raw_aggregations_for_plan,
+    requires_sql_grouped_merge,
     resolve_rollup_read,
     rollup_read_is_current,
     serve_rollup_read,
+    serve_sql_grouped_span_cost_read,
 )
 from mlflow.store.tracking.utils.trace_analytics import (
     COST_COLUMN_BY_KEY,
@@ -4428,15 +4430,13 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 experiment_ids=experiment_ids_int,
                 db_type=self.db_type,
             )
-            served = serve_rollup_read(session, plan) if plan is not None else None
+            sql_grouped_merge = plan is not None and requires_sql_grouped_merge(plan)
+            if sql_grouped_merge:
+                served = serve_sql_grouped_span_cost_read(session, plan, self.db_type, max_results)
+            else:
+                served = serve_rollup_read(session, plan) if plan is not None else None
 
             if served is not None:
-                range_aggregations = raw_aggregations_for_plan(plan)
-                raw_points = (
-                    raw_range_points(served.raw_ranges, range_aggregations)
-                    if served.raw_ranges
-                    else []
-                )
                 if not rollup_read_is_current(session, plan, served.served_day_starts_ms):
                     _logger.debug(
                         "SQL trace rollup routing selected the full raw path for view=%s "
@@ -4446,7 +4446,17 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         metric_name,
                     )
                     data_points = raw_range_points(full_raw_range)
+                elif sql_grouped_merge:
+                    # This path already combined rollup and raw-gap contributions under the
+                    # database's string collation, including global ordering and limiting.
+                    data_points = served.data_points
                 elif plan.bucketed:
+                    range_aggregations = raw_aggregations_for_plan(plan)
+                    raw_points = (
+                        raw_range_points(served.raw_ranges, range_aggregations)
+                        if served.raw_ranges
+                        else []
+                    )
                     # Match the single-query raw path: order by time bucket (then grouping
                     # dimensions) and apply the global max_results after merging rollup and raw
                     # contributions.
@@ -4454,6 +4464,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         [*served.data_points, *raw_points], max_results
                     )
                 else:
+                    range_aggregations = raw_aggregations_for_plan(plan)
+                    raw_points = (
+                        raw_range_points(served.raw_ranges, range_aggregations)
+                        if served.raw_ranges
+                        else []
+                    )
                     data_points = merge_unbucketed_data_points(
                         plan, served.data_points, raw_points, max_results
                     )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -174,6 +174,11 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     query_metrics,
     validate_query_trace_metrics_params,
 )
+from mlflow.store.tracking.utils.sql_trace_rollups import (
+    order_and_limit_data_points,
+    resolve_rollup_read,
+    serve_rollup_read,
+)
 from mlflow.store.tracking.utils.trace_analytics import (
     COST_COLUMN_BY_KEY,
     PROMOTED_TRACE_METADATA_KEYS,
@@ -4352,33 +4357,65 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             experiment_ids_int = self._filter_experiment_ids(
                 session, [int(exp_id) for exp_id in experiment_ids]
             )
-            if view_type == MetricViewType.ASSESSMENTS:
-                query = session.query(SqlAssessments).filter(
-                    SqlAssessments.experiment_id.in_(experiment_ids_int)
-                )
-                timestamp_column = SqlAssessments.trace_timestamp_ms
-            else:
-                query = self._trace_query(session).filter(
-                    SqlTraceInfo.experiment_id.in_(experiment_ids_int)
-                )
-                timestamp_column = SqlTraceInfo.timestamp_ms
 
-            if start_time_ms is not None:
-                query = query.filter(timestamp_column >= start_time_ms)
-            if end_time_ms is not None:
-                query = query.filter(timestamp_column <= end_time_ms)
+            def raw_range_query(range_start_ms: int | None, range_end_ms: int | None):
+                if view_type == MetricViewType.ASSESSMENTS:
+                    query = session.query(SqlAssessments).filter(
+                        SqlAssessments.experiment_id.in_(experiment_ids_int)
+                    )
+                    timestamp_column = SqlAssessments.trace_timestamp_ms
+                else:
+                    query = self._trace_query(session).filter(
+                        SqlTraceInfo.experiment_id.in_(experiment_ids_int)
+                    )
+                    timestamp_column = SqlTraceInfo.timestamp_ms
+                if range_start_ms is not None:
+                    query = query.filter(timestamp_column >= range_start_ms)
+                if range_end_ms is not None:
+                    query = query.filter(timestamp_column <= range_end_ms)
+                return query
 
-            data_points = query_metrics(
+            def raw_range_points(range_start_ms: int | None, range_end_ms: int | None):
+                return query_metrics(
+                    view_type=view_type,
+                    db_type=self.db_type,
+                    query=raw_range_query(range_start_ms, range_end_ms),
+                    metric_name=metric_name,
+                    aggregations=aggregations,
+                    dimensions=dimensions,
+                    filters=filters,
+                    time_interval_seconds=time_interval_seconds,
+                    max_results=max_results,
+                )
+
+            # Opt-in fast path: serve whole covered UTC days from precomputed rollups and query only
+            # the partial-day edges (and any not-yet-built days) raw. resolve_rollup_read returns
+            # None whenever rollups are disabled or the request is not exactly rollup-servable, so
+            # the raw path below stays authoritative and results match the rollups-disabled case.
+            plan = resolve_rollup_read(
                 view_type=view_type,
-                db_type=self.db_type,
-                query=query,
                 metric_name=metric_name,
                 aggregations=aggregations,
                 dimensions=dimensions,
                 filters=filters,
                 time_interval_seconds=time_interval_seconds,
-                max_results=max_results,
+                start_time_ms=start_time_ms,
+                end_time_ms=end_time_ms,
+                experiment_ids=experiment_ids_int,
+                db_type=self.db_type,
             )
+            served = serve_rollup_read(session, plan) if plan is not None else None
+
+            if served is not None:
+                rollup_points, raw_ranges = served
+                data_points = list(rollup_points)
+                for range_start_ms, range_end_ms in raw_ranges:
+                    data_points.extend(raw_range_points(range_start_ms, range_end_ms))
+                # Match the single-query raw path: order by time bucket (then grouping dimensions)
+                # and apply the global max_results after merging rollup and raw sub-range results.
+                data_points = order_and_limit_data_points(data_points, max_results)
+            else:
+                data_points = raw_range_points(start_time_ms, end_time_ms)
 
             # TODO: Implement pagination with page_token
             return PagedList(data_points, None)

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -666,6 +666,46 @@ def _build_query_with_percentile_subquery(
     return outer_query, select_columns
 
 
+def _build_time_range_predicate(
+    timestamp_column: Column,
+    time_ranges_ms: list[tuple[int | None, int | None]],
+    *,
+    nanosecond_column: bool = False,
+):
+    range_predicates = []
+    for range_start_ms, range_end_ms in time_ranges_ms:
+        predicates = []
+        if nanosecond_column:
+            # Include every nanosecond in the caller's inclusive end millisecond while keeping the
+            # indexed span timestamp column bare. Bounds outside BIGINT become constant predicates
+            # instead of overflowing a DBAPI integer bind.
+            if range_start_ms is not None:
+                start_ns = range_start_ms * _NANOSECONDS_PER_MILLISECOND
+                if start_ns > _SQL_BIGINT_MAX:
+                    predicates.append(false())
+                elif start_ns > _SQL_BIGINT_MIN:
+                    predicates.append(timestamp_column >= start_ns)
+            if range_end_ms is not None:
+                end_ns_exclusive = (range_end_ms + 1) * _NANOSECONDS_PER_MILLISECOND
+                if end_ns_exclusive <= _SQL_BIGINT_MIN:
+                    predicates.append(false())
+                elif end_ns_exclusive <= _SQL_BIGINT_MAX:
+                    predicates.append(timestamp_column < end_ns_exclusive)
+        else:
+            if range_start_ms is not None:
+                if range_start_ms > _SQL_BIGINT_MAX:
+                    predicates.append(false())
+                elif range_start_ms > _SQL_BIGINT_MIN:
+                    predicates.append(timestamp_column >= range_start_ms)
+            if range_end_ms is not None:
+                if range_end_ms < _SQL_BIGINT_MIN:
+                    predicates.append(false())
+                elif range_end_ms < _SQL_BIGINT_MAX:
+                    predicates.append(timestamp_column <= range_end_ms)
+        range_predicates.append(and_(*predicates) if predicates else true())
+    return or_(*range_predicates) if range_predicates else false()
+
+
 def query_metrics(
     view_type: MetricViewType,
     db_type: str,
@@ -677,6 +717,7 @@ def query_metrics(
     time_interval_seconds: int | None,
     max_results: int,
     time_ranges_ms: list[tuple[int | None, int | None]] | None = None,
+    accessible_experiment_ids: list[int] | None = None,
 ) -> list[MetricDataPoint]:
     """Unified query metrics function for all view types.
 
@@ -691,63 +732,65 @@ def query_metrics(
         time_interval_seconds: Time interval in seconds for time bucketing
         max_results: Maximum number of results to return
         time_ranges_ms: Optional inclusive timestamp ranges to query. Multiple ranges are combined
-            into one SQL predicate. Span ranges are applied to span start time; trace and
-            assessment ranges use their respective trace timestamps.
+            into one SQL predicate. Span-cost ranges use span start time, preserving their rollup
+            day assignment. Span count and latency preserve the existing parent-trace timestamp
+            behavior. Trace and assessment ranges use their respective trace timestamps.
+        accessible_experiment_ids: Experiment IDs already filtered through the store's workspace
+            access checks. PostgreSQL span-cost queries without trace-level filters use these IDs
+            to query the denormalized span columns directly.
 
     Returns:
         List of MetricDataPoint objects
     """
+    span_uses_trace_time = (
+        view_type == MetricViewType.SPANS and metric_name not in _SPAN_COST_COLUMNS
+    )
+    if time_ranges_ms is not None and span_uses_trace_time:
+        # Apply trace-time bounds before PostgreSQL materializes trace IDs. This preserves the
+        # pre-rollup span count/latency behavior without adding trace_info back to the span query.
+        query = query.filter(_build_time_range_predicate(SqlTraceInfo.timestamp_ms, time_ranges_ms))
+
     if view_type == MetricViewType.SPANS and db_type == db_types.POSTGRES:
         trace_filters, span_filters = _partition_span_metric_filters(filters)
-        query = _apply_filters(query, trace_filters, view_type)
-        query = _apply_postgres_trace_first_span_query(query)
-        query = _apply_filters(query, span_filters, view_type)
+        if (
+            metric_name in _SPAN_COST_COLUMNS
+            and not trace_filters
+            and accessible_experiment_ids is not None
+        ):
+            # Span cost, model, provider, experiment, and start time are denormalized and indexed
+            # on SqlSpan. Avoid materializing every trace ID when no trace-level predicate needs
+            # trace_info; the caller supplies only workspace-authorized experiment IDs.
+            query = query.session.query(SqlSpan).filter(
+                SqlSpan.experiment_id.in_(accessible_experiment_ids)
+            )
+            query = _apply_filters(query, span_filters, view_type)
+        else:
+            query = _apply_filters(query, trace_filters, view_type)
+            query = _apply_postgres_trace_first_span_query(query)
+            query = _apply_filters(query, span_filters, view_type)
     else:
         # Apply view-specific initial join
         query = _apply_view_initial_join(query, view_type)
         query = _apply_filters(query, filters, view_type)
 
-    if time_ranges_ms is not None:
+    if time_ranges_ms is not None and not span_uses_trace_time:
         match view_type:
             case MetricViewType.TRACES:
                 timestamp_column = SqlTraceInfo.timestamp_ms
+                nanosecond_column = False
             case MetricViewType.SPANS:
                 timestamp_column = SqlSpan.start_time_unix_nano
+                nanosecond_column = True
             case MetricViewType.ASSESSMENTS:
                 timestamp_column = SqlAssessments.trace_timestamp_ms
-
-        range_predicates = []
-        for range_start_ms, range_end_ms in time_ranges_ms:
-            predicates = []
-            if view_type == MetricViewType.SPANS:
-                # Include every nanosecond in the caller's inclusive end millisecond while keeping
-                # the indexed span timestamp column bare. Bounds outside BIGINT become constant
-                # predicates instead of overflowing a DBAPI integer bind.
-                if range_start_ms is not None:
-                    start_ns = range_start_ms * _NANOSECONDS_PER_MILLISECOND
-                    if start_ns > _SQL_BIGINT_MAX:
-                        predicates.append(false())
-                    elif start_ns > _SQL_BIGINT_MIN:
-                        predicates.append(timestamp_column >= start_ns)
-                if range_end_ms is not None:
-                    end_ns_exclusive = (range_end_ms + 1) * _NANOSECONDS_PER_MILLISECOND
-                    if end_ns_exclusive <= _SQL_BIGINT_MIN:
-                        predicates.append(false())
-                    elif end_ns_exclusive <= _SQL_BIGINT_MAX:
-                        predicates.append(timestamp_column < end_ns_exclusive)
-            else:
-                if range_start_ms is not None:
-                    if range_start_ms > _SQL_BIGINT_MAX:
-                        predicates.append(false())
-                    elif range_start_ms > _SQL_BIGINT_MIN:
-                        predicates.append(timestamp_column >= range_start_ms)
-                if range_end_ms is not None:
-                    if range_end_ms < _SQL_BIGINT_MIN:
-                        predicates.append(false())
-                    elif range_end_ms < _SQL_BIGINT_MAX:
-                        predicates.append(timestamp_column <= range_end_ms)
-            range_predicates.append(and_(*predicates) if predicates else true())
-        query = query.filter(or_(*range_predicates) if range_predicates else false())
+                nanosecond_column = False
+        query = query.filter(
+            _build_time_range_predicate(
+                timestamp_column,
+                time_ranges_ms,
+                nanosecond_column=nanosecond_column,
+            )
+        )
 
     if view_type == MetricViewType.TRACES and metric_name == TraceMetricKey.SESSION_COUNT:
         query = query.filter(SqlTraceInfo.session_id.isnot(None))

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, and_, case, distinct, exists, func, literal_column, true
+from sqlalchemy import Column, and_, case, distinct, exists, false, func, literal_column, or_, true
 from sqlalchemy.orm.query import Query
 
 from mlflow.entities.entity_type import EntityAssociationType
@@ -150,6 +150,9 @@ VIEW_TYPE_CONFIGS: dict[MetricViewType, dict[str, TraceMetricsConfig]] = {
 }
 
 TIME_BUCKET_LABEL = "time_bucket"
+_SQL_BIGINT_MIN = -(2**63)
+_SQL_BIGINT_MAX = 2**63 - 1
+_NANOSECONDS_PER_MILLISECOND = 1_000_000
 
 _TRACE_METRIC_COLUMNS = {
     TraceMetricKey.INPUT_TOKENS: SqlTraceInfo.input_tokens,
@@ -673,6 +676,7 @@ def query_metrics(
     filters: list[str] | None,
     time_interval_seconds: int | None,
     max_results: int,
+    time_ranges_ms: list[tuple[int | None, int | None]] | None = None,
 ) -> list[MetricDataPoint]:
     """Unified query metrics function for all view types.
 
@@ -686,6 +690,9 @@ def query_metrics(
         filters: List of filter strings (each parsed by SearchTraceUtils), combined with AND
         time_interval_seconds: Time interval in seconds for time bucketing
         max_results: Maximum number of results to return
+        time_ranges_ms: Optional inclusive timestamp ranges to query. Multiple ranges are combined
+            into one SQL predicate. Span ranges are applied to span start time; trace and
+            assessment ranges use their respective trace timestamps.
 
     Returns:
         List of MetricDataPoint objects
@@ -700,11 +707,57 @@ def query_metrics(
         query = _apply_view_initial_join(query, view_type)
         query = _apply_filters(query, filters, view_type)
 
+    if time_ranges_ms is not None:
+        match view_type:
+            case MetricViewType.TRACES:
+                timestamp_column = SqlTraceInfo.timestamp_ms
+            case MetricViewType.SPANS:
+                timestamp_column = SqlSpan.start_time_unix_nano
+            case MetricViewType.ASSESSMENTS:
+                timestamp_column = SqlAssessments.trace_timestamp_ms
+
+        range_predicates = []
+        for range_start_ms, range_end_ms in time_ranges_ms:
+            predicates = []
+            if view_type == MetricViewType.SPANS:
+                # Include every nanosecond in the caller's inclusive end millisecond while keeping
+                # the indexed span timestamp column bare. Bounds outside BIGINT become constant
+                # predicates instead of overflowing a DBAPI integer bind.
+                if range_start_ms is not None:
+                    start_ns = range_start_ms * _NANOSECONDS_PER_MILLISECOND
+                    if start_ns > _SQL_BIGINT_MAX:
+                        predicates.append(false())
+                    elif start_ns > _SQL_BIGINT_MIN:
+                        predicates.append(timestamp_column >= start_ns)
+                if range_end_ms is not None:
+                    end_ns_exclusive = (range_end_ms + 1) * _NANOSECONDS_PER_MILLISECOND
+                    if end_ns_exclusive <= _SQL_BIGINT_MIN:
+                        predicates.append(false())
+                    elif end_ns_exclusive <= _SQL_BIGINT_MAX:
+                        predicates.append(timestamp_column < end_ns_exclusive)
+            else:
+                if range_start_ms is not None:
+                    if range_start_ms > _SQL_BIGINT_MAX:
+                        predicates.append(false())
+                    elif range_start_ms > _SQL_BIGINT_MIN:
+                        predicates.append(timestamp_column >= range_start_ms)
+                if range_end_ms is not None:
+                    if range_end_ms < _SQL_BIGINT_MIN:
+                        predicates.append(false())
+                    elif range_end_ms < _SQL_BIGINT_MAX:
+                        predicates.append(timestamp_column <= range_end_ms)
+            range_predicates.append(and_(*predicates) if predicates else true())
+        query = query.filter(or_(*range_predicates) if range_predicates else false())
+
     if view_type == MetricViewType.TRACES and metric_name == TraceMetricKey.SESSION_COUNT:
         query = query.filter(SqlTraceInfo.session_id.isnot(None))
 
     agg_column = _get_column_to_aggregate(view_type, metric_name)
-    if view_type == MetricViewType.SPANS and metric_name in _SPAN_COST_COLUMNS:
+    # SQL aggregate functions ignore null inputs. Filtering them before grouping is equivalent for
+    # aggregate values, but prevents an all-null group from consuming SQL LIMIT and then being
+    # discarded by conversion. This keeps max_results semantics stable when raw and rollup rows
+    # are merged.
+    if not (view_type == MetricViewType.TRACES and metric_name == TraceMetricKey.SESSION_COUNT):
         query = query.filter(agg_column.isnot(None))
 
     # Group by dimension columns, labeled for SELECT

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -32,6 +32,17 @@ from datetime import date, datetime, timezone
 from enum import Enum
 from typing import Any
 
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    cast,
+    extract,
+    func,
+    literal,
+    literal_column,
+    or_,
+    select,
+)
 from sqlalchemy.orm import Session
 
 from mlflow.entities.trace_metrics import (
@@ -44,11 +55,17 @@ from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
 from mlflow.store.db import db_types
 from mlflow.store.tracking.dbmodels.models import (
     SqlAssessmentDailyRollup,
+    SqlSpan,
     SqlSpanCostDailyRollup,
     SqlTraceMetricDailyRollup,
     SqlTraceRollupRebuild,
 )
-from mlflow.store.tracking.utils.sql_trace_metrics_utils import TIME_BUCKET_LABEL
+from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
+    TIME_BUCKET_LABEL,
+    _build_time_range_predicate,
+    convert_results_to_metric_data_points,
+    get_time_bucket_expression,
+)
 from mlflow.tracing.constant import (
     AssessmentMetricKey,
     SpanMetricDimensionKey,
@@ -163,11 +180,10 @@ SERVABLE_FAMILIES = frozenset(RollupFamily)
 # readable. Trace status additionally has a cheap global-count completeness check.
 SERVABLE_GROUPING_SETS = frozenset(GroupingSet)
 
-# Model/provider dimensions are user-controlled strings. Python equality and ordering cannot
-# reproduce an arbitrary database collation, which can change both grouping and the max_results
-# boundary. These shapes stay in SQL until merging, ordering, and limiting can all be performed
-# under the backend's own collation.
-COLLATION_SENSITIVE_GROUPING_SETS = frozenset({
+# Model/provider dimensions are user-controlled strings. Their rollup and raw-gap contributions
+# must be combined, grouped, ordered, and limited in SQL so the configured database collation is
+# preserved across the entire result.
+SQL_MERGED_GROUPING_SETS = frozenset({
     GroupingSet.MODEL,
     GroupingSet.PROVIDER,
     GroupingSet.MODEL_PROVIDER,
@@ -332,6 +348,11 @@ class RollupReadPlan:
     uses_percentiles: bool
 
 
+def requires_sql_grouped_merge(plan: RollupReadPlan) -> bool:
+    """Whether this plan must keep contribution merging under database collation semantics."""
+    return plan.family == RollupFamily.SPAN_COST and plan.grouping_set in SQL_MERGED_GROUPING_SETS
+
+
 def _aggregation_servable(
     aggregation: MetricAggregation, family: RollupFamily, db_type: str, bucketed: bool
 ) -> bool:
@@ -399,13 +420,6 @@ def resolve_rollup_read(
     if time_interval_seconds is not None and time_interval_seconds != DAILY_INTERVAL_SECONDS:
         return _raw_fallback(view_type, metric_name, "the time bucket is not one UTC day")
     bucketed = time_interval_seconds == DAILY_INTERVAL_SECONDS
-    if grouping_set in COLLATION_SENSITIVE_GROUPING_SETS:
-        return _raw_fallback(
-            view_type,
-            metric_name,
-            "string grouping and ordering require database collation semantics",
-        )
-
     if start_time_ms is None or end_time_ms is None:
         return _raw_fallback(view_type, metric_name, "the request has no bounded time range")
 
@@ -705,6 +719,238 @@ class RollupReadResult:
     data_points: list[MetricDataPoint]
     raw_ranges: list[tuple[int, int]]
     served_day_starts_ms: list[int]
+
+
+def _valid_sql_grouped_day_starts(
+    session: Session, plan: RollupReadPlan, covered_day_starts: list[int]
+) -> list[int]:
+    """Exclude covered days whose rows cannot supply every requested aggregation."""
+    nullable_columns = set()
+    for aggregation in plan.aggregations:
+        match aggregation.aggregation_type:
+            case AggregationType.SUM | AggregationType.AVG:
+                nullable_columns.add(SqlSpanCostDailyRollup.sum_value)
+            case AggregationType.MIN:
+                nullable_columns.add(SqlSpanCostDailyRollup.min_value)
+            case AggregationType.MAX:
+                nullable_columns.add(SqlSpanCostDailyRollup.max_value)
+
+    if not nullable_columns:
+        return covered_day_starts
+
+    date_to_ms = {_day_start_ms_to_date(ms): ms for ms in covered_day_starts}
+    invalid_dates = {
+        rollup_day
+        for (rollup_day,) in session.query(SqlSpanCostDailyRollup.rollup_day).filter(
+            SqlSpanCostDailyRollup.experiment_id == plan.experiment_id,
+            SqlSpanCostDailyRollup.metric_name == plan.metric_name,
+            SqlSpanCostDailyRollup.grouping_set == plan.grouping_set.value,
+            SqlSpanCostDailyRollup.rollup_day.in_(list(date_to_ms)),
+            or_(*(column.is_(None) for column in nullable_columns)),
+        )
+    }
+    return sorted(ms for rollup_day, ms in date_to_ms.items() if rollup_day not in invalid_dates)
+
+
+def _rollup_day_bucket_expression(db_type: str):
+    """Convert a SQL DATE rollup key to its UTC-midnight epoch-millisecond bucket."""
+    rollup_day = SqlSpanCostDailyRollup.rollup_day
+    epoch_day = literal(date(1970, 1, 1))
+    match db_type:
+        case db_types.POSTGRES:
+            return cast(extract("epoch", cast(rollup_day, DateTime)), BigInteger) * 1000
+        case db_types.MYSQL:
+            return cast(func.datediff(rollup_day, epoch_day), BigInteger) * MS_PER_DAY
+        case db_types.MSSQL:
+            return (
+                cast(func.datediff(literal_column("day"), epoch_day, rollup_day), BigInteger)
+                * MS_PER_DAY
+            )
+        case db_types.SQLITE:
+            return cast(func.strftime("%s", rollup_day), BigInteger) * 1000
+        case _:
+            raise ValueError(f"Unsupported database type: {db_type}")
+
+
+def _span_cost_columns(metric_name: str):
+    match metric_name:
+        case SpanMetricKey.INPUT_COST:
+            return SqlSpan.input_cost
+        case SpanMetricKey.OUTPUT_COST:
+            return SqlSpan.output_cost
+        case SpanMetricKey.TOTAL_COST:
+            return SqlSpan.total_cost
+        case _:
+            raise ValueError(f"Unsupported span cost metric: {metric_name}")
+
+
+def _sql_grouping_columns(plan: RollupReadPlan):
+    raw_columns = {
+        SpanMetricDimensionKey.SPAN_MODEL_NAME: SqlSpan.model_name,
+        SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: SqlSpan.model_provider,
+    }
+    rollup_columns = {
+        SpanMetricDimensionKey.SPAN_MODEL_NAME: SqlSpanCostDailyRollup.model_name,
+        SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: SqlSpanCostDailyRollup.model_provider,
+    }
+    return (
+        [raw_columns[dimension] for dimension in plan.dimensions],
+        [rollup_columns[dimension] for dimension in plan.dimensions],
+    )
+
+
+def _build_sql_grouped_span_cost_query(
+    session: Session,
+    plan: RollupReadPlan,
+    db_type: str,
+    raw_ranges: list[tuple[int, int]],
+    served_day_starts: list[int],
+    max_results: int,
+):
+    """Build a database-collated aggregate over raw-gap and daily-rollup contributions."""
+    metric_column = _span_cost_columns(plan.metric_name)
+    raw_string_columns, rollup_group_columns = _sql_grouping_columns(plan)
+    raw_group_columns = list(raw_string_columns)
+    raw_dimension_columns = []
+    rollup_dimension_columns = []
+
+    if plan.bucketed:
+        raw_bucket = get_time_bucket_expression(
+            MetricViewType.SPANS, DAILY_INTERVAL_SECONDS, db_type
+        )
+        rollup_bucket = _rollup_day_bucket_expression(db_type)
+        raw_dimension_columns.append(raw_bucket.label(TIME_BUCKET_LABEL))
+        rollup_dimension_columns.append(rollup_bucket.label(TIME_BUCKET_LABEL))
+        raw_group_columns.insert(0, raw_bucket)
+
+    raw_dimension_columns.extend(
+        column.label(dimension) for column, dimension in zip(raw_string_columns, plan.dimensions)
+    )
+    rollup_dimension_columns.extend(
+        column.label(dimension) for column, dimension in zip(rollup_group_columns, plan.dimensions)
+    )
+
+    raw_contributions = (
+        select(
+            *raw_dimension_columns,
+            func.count(metric_column).label("_sample_count"),
+            func.sum(metric_column).label("_sum_value"),
+            func.min(metric_column).label("_min_value"),
+            func.max(metric_column).label("_max_value"),
+        )
+        .select_from(SqlSpan)
+        .where(
+            SqlSpan.experiment_id == plan.experiment_id,
+            metric_column.isnot(None),
+            _build_time_range_predicate(
+                SqlSpan.start_time_unix_nano,
+                raw_ranges,
+                nanosecond_column=True,
+            ),
+        )
+        .group_by(*raw_group_columns)
+    )
+
+    served_dates = [_day_start_ms_to_date(ms) for ms in served_day_starts]
+    rollup_contributions = select(
+        *rollup_dimension_columns,
+        SqlSpanCostDailyRollup.sample_count.label("_sample_count"),
+        SqlSpanCostDailyRollup.sum_value.label("_sum_value"),
+        SqlSpanCostDailyRollup.min_value.label("_min_value"),
+        SqlSpanCostDailyRollup.max_value.label("_max_value"),
+    ).where(
+        SqlSpanCostDailyRollup.experiment_id == plan.experiment_id,
+        SqlSpanCostDailyRollup.metric_name == plan.metric_name,
+        SqlSpanCostDailyRollup.grouping_set == plan.grouping_set.value,
+        SqlSpanCostDailyRollup.rollup_day.in_(served_dates),
+    )
+
+    # Put authoritative raw columns first so the UNION output uses their configured collation.
+    contributions = raw_contributions.union_all(rollup_contributions).subquery(
+        "span_cost_contributions"
+    )
+    dimension_names = ([TIME_BUCKET_LABEL] if plan.bucketed else []) + plan.dimensions
+    dimension_columns = [contributions.c[name] for name in dimension_names]
+
+    aggregate_columns = []
+    for aggregation in plan.aggregations:
+        match aggregation.aggregation_type:
+            case AggregationType.COUNT:
+                expression = func.sum(contributions.c["_sample_count"])
+            case AggregationType.SUM:
+                expression = func.sum(contributions.c["_sum_value"])
+            case AggregationType.AVG:
+                expression = func.sum(contributions.c["_sum_value"]) / func.nullif(
+                    func.sum(contributions.c["_sample_count"]), 0
+                )
+            case AggregationType.MIN:
+                expression = func.min(contributions.c["_min_value"])
+            case AggregationType.MAX:
+                expression = func.max(contributions.c["_max_value"])
+            case _:
+                raise ValueError(f"Unsupported grouped rollup aggregation: {aggregation}")
+        aggregate_columns.append(expression.label(str(aggregation)))
+
+    query = session.query(*dimension_columns, *aggregate_columns).select_from(contributions)
+    if dimension_columns:
+        query = query.group_by(*dimension_columns).order_by(*dimension_columns)
+    select_columns = [*dimension_columns, *aggregate_columns]
+    return query.limit(max_results), select_columns
+
+
+def serve_sql_grouped_span_cost_read(
+    session: Session, plan: RollupReadPlan, db_type: str, max_results: int
+) -> RollupReadResult | None:
+    """Serve grouped span cost with all collation-sensitive operations performed in SQL."""
+    if not requires_sql_grouped_merge(plan):
+        raise ValueError("SQL grouped rollup serving requires a grouped span-cost plan")
+
+    covered = compute_covered_day_starts(session, plan)
+    if not covered:
+        _logger.debug(
+            "SQL trace rollup routing selected the full raw path for grouped span cost: none of "
+            "%d candidate days has valid coverage",
+            len(plan.covered_day_starts_ms),
+        )
+        return None
+
+    served_day_starts = _valid_sql_grouped_day_starts(session, plan, covered)
+    if not served_day_starts:
+        _logger.debug(
+            "SQL trace rollup routing selected the full raw path for grouped span cost: covered "
+            "rows were incomplete for the requested aggregations"
+        )
+        return None
+
+    raw_ranges = remaining_raw_ranges(plan, served_day_starts)
+    if len(raw_ranges) > MAX_RAW_RANGES:
+        _logger.debug(
+            "SQL trace rollup routing selected the full raw path for grouped span cost: %d raw "
+            "ranges exceed the routing limit of %d",
+            len(raw_ranges),
+            MAX_RAW_RANGES,
+        )
+        return None
+
+    query, select_columns = _build_sql_grouped_span_cost_query(
+        session,
+        plan,
+        db_type,
+        raw_ranges,
+        served_day_starts,
+        max_results,
+    )
+    dimension_count = len(plan.dimensions) + int(plan.bucketed)
+    data_points = convert_results_to_metric_data_points(
+        query.all(), select_columns, dimension_count, plan.metric_name
+    )
+    _logger.debug(
+        "SQL trace rollup routing served grouped span cost using %d rollup days and %d raw ranges "
+        "with database-side grouping and ordering",
+        len(served_day_starts),
+        len(raw_ranges),
+    )
+    return RollupReadResult(data_points, raw_ranges, served_day_starts)
 
 
 def serve_rollup_read(session: Session, plan: RollupReadPlan) -> RollupReadResult | None:

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -1,0 +1,555 @@
+"""Opt-in SQL daily rollup planning for trace analytics.
+
+Daily rollups precompute per-day aggregates (``sample_count``, ``sum``, ``min``, ``max``, and, for
+trace metrics on PostgreSQL, daily ``p50``/``p90``/``p99``) keyed by
+``(experiment_id, rollup_day, metric_name, grouping_set, <dimension columns>)``. Eligible dashboard
+queries then read a handful of daily summary rows instead of scanning millions of raw rows. Rollups
+are opt-in via :data:`MLFLOW_SQL_TRACE_ROLLUPS_ENABLED` and always fall back to the raw query path,
+so an absent, stale, or partially built rollup can never change a query result, only its speed.
+
+This module holds the backend-agnostic planning layer plus the read-serving helpers: the
+family/grouping/metric taxonomy, the runtime-config gate, the read-eligibility decision, the
+UTC-midnight range split, and reading rollup rows to assemble a response. Populating the rollup
+tables lives in the separate rollup maintenance job.
+
+The reader trusts a full UTC day only when a matching rollup row exists for the metric and grouping
+set and no rebuild is queued for that day and family; it also demotes a covered day back to the raw
+path when the row is missing a column the request needs (a null aggregate value). Whole-day
+completeness of a grouping set is a maintenance-job guarantee, so the reader serves only the
+single-row ``global`` grouping set, whose one row per experiment-day is self-verifying. Multi-row
+grouping sets (for example per-status breakdowns) are served once the maintenance job that writes
+and invalidates them can guarantee that every group's row for a day is present before the day is
+treated as built.
+
+The rollup tables carry no ``workspace`` column (the shipped analytics schema scopes purely on
+``experiment_id``, which is globally unique), so workspace isolation is preserved by the caller only
+routing experiment ids the requester may access.
+"""
+
+import math
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+
+from sqlalchemy.orm import Session
+
+from mlflow.entities.trace_metrics import (
+    AggregationType,
+    MetricAggregation,
+    MetricDataPoint,
+    MetricViewType,
+)
+from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
+from mlflow.store.db import db_types
+from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
+    SqlSpanCostDailyRollup,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
+)
+from mlflow.store.tracking.utils.sql_trace_metrics_utils import TIME_BUCKET_LABEL
+from mlflow.tracing.constant import (
+    AssessmentMetricKey,
+    SpanMetricDimensionKey,
+    SpanMetricKey,
+    TraceMetricDimensionKey,
+    TraceMetricKey,
+)
+
+MS_PER_DAY = 86_400_000
+DAILY_INTERVAL_SECONDS = 86_400
+
+# Daily percentiles are not composable into coarser buckets, so rollups only serve these three exact
+# daily percentile values, and only for single-experiment complete-UTC-day requests.
+SUPPORTED_PERCENTILE_VALUES = frozenset({50.0, 90.0, 99.0})
+
+
+class RollupFamily(str, Enum):
+    """Rollup table family, persisted in ``sql_trace_rollup_rebuild_queue.rollup_family``."""
+
+    TRACE_METRIC = "trace_metric"
+    SPAN_COST = "span_cost"
+    ASSESSMENT = "assessment"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class GroupingSet(str, Enum):
+    """Dimension set a rollup row aggregates. Persisted in ``grouping_set`` columns.
+
+    ``global`` aggregates across all rows for the experiment and day without an optional dimension;
+    global rows are identified by this value, not by null dimension columns.
+    """
+
+    GLOBAL = "global"
+    STATUS = "status"
+    MODEL = "model"
+    PROVIDER = "provider"
+    MODEL_PROVIDER = "model_provider"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+VIEW_TYPE_TO_FAMILY: dict[MetricViewType, RollupFamily] = {
+    MetricViewType.TRACES: RollupFamily.TRACE_METRIC,
+    MetricViewType.SPANS: RollupFamily.SPAN_COST,
+    MetricViewType.ASSESSMENTS: RollupFamily.ASSESSMENT,
+}
+
+# Metrics each family materializes into rollups. Metrics outside these sets always use the raw path:
+# session counts (not composable across days/experiments), span counts and span latency (the span
+# rollup table is cost-only), and any assessment metric grouped by name or value.
+ROLLUP_METRICS: dict[RollupFamily, frozenset[str]] = {
+    RollupFamily.TRACE_METRIC: frozenset({
+        TraceMetricKey.TRACE_COUNT,
+        TraceMetricKey.LATENCY,
+        TraceMetricKey.INPUT_TOKENS,
+        TraceMetricKey.OUTPUT_TOKENS,
+        TraceMetricKey.TOTAL_TOKENS,
+        TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+    }),
+    RollupFamily.SPAN_COST: frozenset({
+        SpanMetricKey.INPUT_COST,
+        SpanMetricKey.OUTPUT_COST,
+        SpanMetricKey.TOTAL_COST,
+    }),
+    RollupFamily.ASSESSMENT: frozenset({
+        AssessmentMetricKey.ASSESSMENT_COUNT,
+        AssessmentMetricKey.ASSESSMENT_VALUE,
+    }),
+}
+
+# Only trace-metric rollups store daily percentile columns, and only PostgreSQL computes them.
+PERCENTILE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC})
+PERCENTILE_BACKENDS = frozenset({db_types.POSTGRES})
+
+# Families the reader may serve from rollups. Span cost is intentionally excluded: the raw span
+# query filters by the parent trace's timestamp (``trace_info.timestamp_ms``) but buckets by span
+# start time (``spans.start_time_unix_nano``), so a span-day rollup cannot be guaranteed row-for-row
+# identical to raw when a span and its trace fall on different UTC days (e.g. delayed or
+# long-running OTLP spans). Serving it would violate the invariant that rollups never change
+# results, only speed.
+# Span-cost rollups are therefore neither built nor read until the span read path filters by span
+# time; trace-metric and assessment queries filter and bucket on the same timestamp, so they are
+# always exactly reproducible from daily rollups.
+SERVABLE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC, RollupFamily.ASSESSMENT})
+
+# Grouping sets the reader may serve. Restricted to ``global`` because that grouping set has exactly
+# one row per experiment-day, so "a row exists and is not queued" already proves the day complete.
+# Multi-row grouping sets (status, model, provider) need the maintenance job to guarantee that every
+# group's row for a day is written before the day is treated as built; until that job lands, serving
+# them could under-report a day whose sibling rows are missing, so they stay on the raw path.
+SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL})
+
+
+def rollups_enabled() -> bool:
+    """Whether opt-in SQL trace rollups are enabled for this deployment."""
+    return MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.get()
+
+
+@dataclass
+class UtcDaySplit:
+    """Result of splitting an inclusive ``[start, end]`` ms range at UTC-midnight boundaries.
+
+    Args:
+        covered_day_starts_ms: Epoch-ms UTC-midnight starts of full days entirely inside the range.
+            These are candidates that a reader may serve from rollups if matching rows exist and no
+            rebuild is queued; any that are not covered fall back to their own raw day range.
+        raw_ranges: Inclusive ``(start_ms, end_ms)`` sub-ranges for the partial first/last days that
+            can never be served by whole-day rollups.
+    """
+
+    covered_day_starts_ms: list[int]
+    raw_ranges: list[tuple[int, int]]
+
+
+def split_range_into_utc_days(start_time_ms: int | None, end_time_ms: int | None) -> UtcDaySplit:
+    """Split an inclusive ``[start_time_ms, end_time_ms]`` range into full UTC days and raw edges.
+
+    A full UTC day ``[D, D + MS_PER_DAY)`` is a covered candidate only when the request range fully
+    contains it, i.e. ``start_time_ms <= D`` and ``end_time_ms >= D + MS_PER_DAY - 1``. This matches
+    the raw query filter (``timestamp >= start AND timestamp <= end``) so a rollup-served day is
+    exactly equivalent to the raw aggregate for that day. Partial first/last days become raw ranges.
+    """
+    if start_time_ms is None or end_time_ms is None or start_time_ms > end_time_ms:
+        has_range = start_time_ms is not None and end_time_ms is not None
+        raw = [(start_time_ms, end_time_ms)] if has_range else []
+        return UtcDaySplit(covered_day_starts_ms=[], raw_ranges=raw)
+
+    first_full_day_start = math.ceil(start_time_ms / MS_PER_DAY) * MS_PER_DAY
+    # Greatest UTC midnight D such that the whole day [D, D + MS_PER_DAY) fits inside the range,
+    # i.e. D + MS_PER_DAY - 1 <= end_time_ms.
+    last_full_day_start = ((end_time_ms + 1) // MS_PER_DAY) * MS_PER_DAY - MS_PER_DAY
+
+    covered = list(range(first_full_day_start, last_full_day_start + MS_PER_DAY, MS_PER_DAY))
+
+    raw_ranges: list[tuple[int, int]] = []
+    if not covered:
+        raw_ranges.append((start_time_ms, end_time_ms))
+    else:
+        if start_time_ms < first_full_day_start:
+            raw_ranges.append((start_time_ms, first_full_day_start - 1))
+        covered_end_exclusive = last_full_day_start + MS_PER_DAY
+        if covered_end_exclusive <= end_time_ms:
+            raw_ranges.append((covered_end_exclusive, end_time_ms))
+
+    return UtcDaySplit(covered_day_starts_ms=covered, raw_ranges=raw_ranges)
+
+
+def resolve_grouping_set(
+    view_type: MetricViewType, dimensions: list[str] | None
+) -> GroupingSet | None:
+    """Map requested grouping dimensions to a materialized grouping set, or ``None`` if unsupported.
+
+    User-controlled high-cardinality dimensions (trace name, assessment name/value, span name/type/
+    status) have no rollup grouping set and always return ``None`` so the request stays raw.
+    """
+    dims = set(dimensions or [])
+    match view_type:
+        case MetricViewType.TRACES:
+            if not dims:
+                return GroupingSet.GLOBAL
+            if dims == {TraceMetricDimensionKey.TRACE_STATUS}:
+                return GroupingSet.STATUS
+        case MetricViewType.SPANS:
+            if not dims:
+                return GroupingSet.GLOBAL
+            if dims == {SpanMetricDimensionKey.SPAN_MODEL_NAME}:
+                return GroupingSet.MODEL
+            if dims == {SpanMetricDimensionKey.SPAN_MODEL_PROVIDER}:
+                return GroupingSet.PROVIDER
+            if dims == {
+                SpanMetricDimensionKey.SPAN_MODEL_NAME,
+                SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            }:
+                return GroupingSet.MODEL_PROVIDER
+        case MetricViewType.ASSESSMENTS:
+            if not dims:
+                return GroupingSet.GLOBAL
+    return None
+
+
+@dataclass
+class RollupReadPlan:
+    """A validated plan describing how to serve a query from rollups.
+
+    Args:
+        family: The rollup table family to read.
+        metric_name: The metric whose rollup rows to read (matches the request metric name).
+        grouping_set: The materialized grouping set to read.
+        aggregations: The requested aggregations, all confirmed rollup-servable.
+        bucketed: ``True`` for one data point per UTC day (daily interval); ``False`` for a single
+            aggregate over the whole range.
+        experiment_id: The single experiment id to read (rollup serving is single-experiment only).
+        covered_day_starts_ms: Candidate full UTC days that may be served from rollups.
+        raw_ranges: Inclusive ``(start_ms, end_ms)`` partial-day ranges that must be served raw.
+        uses_percentiles: Whether any requested aggregation is a percentile.
+    """
+
+    family: RollupFamily
+    metric_name: str
+    grouping_set: GroupingSet
+    aggregations: list[MetricAggregation]
+    bucketed: bool
+    experiment_id: int
+    covered_day_starts_ms: list[int]
+    raw_ranges: list[tuple[int, int]]
+    uses_percentiles: bool
+
+
+def _aggregation_servable(
+    aggregation: MetricAggregation, family: RollupFamily, db_type: str, bucketed: bool
+) -> bool:
+    if aggregation.aggregation_type != AggregationType.PERCENTILE:
+        # COUNT/SUM/AVG/MIN/MAX derive from sample_count/sum_value/min_value/max_value in every
+        # family.
+        return True
+    # Percentiles are only materialized for trace metrics on supported backends, only for the three
+    # exact daily percentile values, and only when bucketed by day (a daily percentile is not
+    # composable across days into a single range aggregate).
+    return (
+        bucketed
+        and family in PERCENTILE_FAMILIES
+        and db_type in PERCENTILE_BACKENDS
+        and aggregation.percentile_value in SUPPORTED_PERCENTILE_VALUES
+    )
+
+
+def resolve_rollup_read(
+    view_type: MetricViewType,
+    metric_name: str,
+    aggregations: list[MetricAggregation],
+    dimensions: list[str] | None,
+    filters: list[str] | None,
+    time_interval_seconds: int | None,
+    start_time_ms: int | None,
+    end_time_ms: int | None,
+    experiment_ids: list[int],
+    db_type: str,
+) -> RollupReadPlan | None:
+    """Decide whether a trace metrics query can be served from rollups.
+
+    Returns a :class:`RollupReadPlan` when at least one full UTC day of the request is rollup
+    eligible, or ``None`` to signal the caller to use the raw path. Returning ``None`` is always a
+    safe, correct choice; this function never changes results, only whether rollups are consulted.
+
+    Requests fall back to raw for any of: rollups disabled, an unsupported view/metric/dimension/
+    aggregation, a grouping set not yet servable from rollups, any filter (rollups are unfiltered
+    aggregates), a non-daily bucket width, a missing time range, more than one experiment, or a
+    range containing no full UTC day.
+    """
+    if not rollups_enabled():
+        return None
+
+    family = VIEW_TYPE_TO_FAMILY.get(view_type)
+    if family is None or family not in SERVABLE_FAMILIES:
+        return None
+    if metric_name not in ROLLUP_METRICS[family]:
+        return None
+
+    # Rollups are unfiltered daily aggregates; any request-level filter must use the raw path.
+    if filters:
+        return None
+
+    grouping_set = resolve_grouping_set(view_type, dimensions)
+    if grouping_set is None or grouping_set not in SERVABLE_GROUPING_SETS:
+        return None
+
+    # Rollups are UTC-day aligned: serve only single-day buckets or a single whole-range aggregate.
+    if time_interval_seconds is not None and time_interval_seconds != DAILY_INTERVAL_SECONDS:
+        return None
+    bucketed = time_interval_seconds == DAILY_INTERVAL_SECONDS
+
+    if start_time_ms is None or end_time_ms is None:
+        return None
+
+    # Rollup serving is single-experiment: multi-experiment coverage cannot distinguish "no data
+    # that day" from "not built yet", and daily percentiles are single-experiment by definition.
+    if len(experiment_ids) != 1:
+        return None
+
+    if not all(_aggregation_servable(agg, family, db_type, bucketed) for agg in aggregations):
+        return None
+
+    split = split_range_into_utc_days(start_time_ms, end_time_ms)
+    if not split.covered_day_starts_ms:
+        return None
+
+    return RollupReadPlan(
+        family=family,
+        metric_name=metric_name,
+        grouping_set=grouping_set,
+        aggregations=aggregations,
+        bucketed=bucketed,
+        experiment_id=experiment_ids[0],
+        covered_day_starts_ms=split.covered_day_starts_ms,
+        raw_ranges=split.raw_ranges,
+        uses_percentiles=any(
+            agg.aggregation_type == AggregationType.PERCENTILE for agg in aggregations
+        ),
+    )
+
+
+FAMILY_MODEL = {
+    RollupFamily.TRACE_METRIC: SqlTraceMetricDailyRollup,
+    RollupFamily.SPAN_COST: SqlSpanCostDailyRollup,
+    RollupFamily.ASSESSMENT: SqlAssessmentDailyRollup,
+}
+
+
+def _day_start_ms_to_date(day_start_ms: int) -> date:
+    return datetime.fromtimestamp(day_start_ms / 1000, tz=timezone.utc).date()
+
+
+def _day_start_ms_to_iso(day_start_ms: int) -> str:
+    # Matches the raw path's time_bucket rendering in convert_results_to_metric_data_points.
+    return datetime.fromtimestamp(day_start_ms / 1000, tz=timezone.utc).isoformat()
+
+
+def _rollup_row_dimensions(plan: RollupReadPlan, row) -> dict[str, str]:
+    match plan.grouping_set:
+        case GroupingSet.STATUS:
+            return {TraceMetricDimensionKey.TRACE_STATUS: row.trace_status}
+        case GroupingSet.MODEL:
+            return {SpanMetricDimensionKey.SPAN_MODEL_NAME: row.model_name}
+        case GroupingSet.PROVIDER:
+            return {SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: row.model_provider}
+        case GroupingSet.MODEL_PROVIDER:
+            return {
+                SpanMetricDimensionKey.SPAN_MODEL_NAME: row.model_name,
+                SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: row.model_provider,
+            }
+        case _:
+            return {}
+
+
+def _rollup_row_value(aggregation: MetricAggregation, row) -> float | None:
+    match aggregation.aggregation_type:
+        case AggregationType.COUNT:
+            return row.sample_count
+        case AggregationType.SUM:
+            return row.sum_value
+        case AggregationType.AVG:
+            if row.sample_count and row.sum_value is not None:
+                return row.sum_value / row.sample_count
+            return None
+        case AggregationType.MIN:
+            return row.min_value
+        case AggregationType.MAX:
+            return row.max_value
+        case AggregationType.PERCENTILE:
+            match aggregation.percentile_value:
+                case 50.0:
+                    return row.p50_value
+                case 90.0:
+                    return row.p90_value
+                case 99.0:
+                    return row.p99_value
+    return None
+
+
+def compute_covered_day_starts(session: Session, plan: RollupReadPlan) -> list[int]:
+    """Return the candidate days actually servable from rollups.
+
+    A day is covered when a matching rollup row exists for the metric and grouping set and no
+    rebuild entry is queued for the family and day. Missing or queued days fall back to the raw
+    path.
+    """
+    date_to_ms = {_day_start_ms_to_date(ms): ms for ms in plan.covered_day_starts_ms}
+    candidate_dates = list(date_to_ms.keys())
+    model = FAMILY_MODEL[plan.family]
+
+    built = {
+        row_day
+        for (row_day,) in session
+        .query(model.rollup_day)
+        .filter(
+            model.experiment_id == plan.experiment_id,
+            model.metric_name == plan.metric_name,
+            model.grouping_set == plan.grouping_set.value,
+            model.rollup_day.in_(candidate_dates),
+        )
+        .distinct()
+    }
+    queued = {
+        row_day
+        for (row_day,) in session.query(SqlTraceRollupRebuild.rollup_day).filter(
+            SqlTraceRollupRebuild.experiment_id == plan.experiment_id,
+            SqlTraceRollupRebuild.rollup_family == plan.family.value,
+            SqlTraceRollupRebuild.rollup_day.in_(candidate_dates),
+        )
+    }
+    covered = [ms for d, ms in date_to_ms.items() if d in built and d not in queued]
+    return sorted(covered)
+
+
+def read_rollup_data_points(
+    session: Session, plan: RollupReadPlan, covered_day_starts: list[int]
+) -> tuple[list[MetricDataPoint], list[int]]:
+    """Assemble daily data points from rollup rows, with the day starts actually served.
+
+    A covered day is served only when its rollup row yields a non-null value for every requested
+    aggregation. A day whose row is missing a needed column (a null aggregate) is left out of the
+    served set so the caller re-queries it raw rather than returning a crashing or short response,
+    keeping a served result identical to the rollups-disabled result.
+    """
+    date_to_ms = {_day_start_ms_to_date(ms): ms for ms in covered_day_starts}
+    model = FAMILY_MODEL[plan.family]
+    rows = session.query(model).filter(
+        model.experiment_id == plan.experiment_id,
+        model.metric_name == plan.metric_name,
+        model.grouping_set == plan.grouping_set.value,
+        model.rollup_day.in_(list(date_to_ms.keys())),
+    )
+
+    data_points = []
+    served_day_starts: set[int] = set()
+    for row in rows:
+        group_dims = _rollup_row_dimensions(plan, row)
+        # Mirror the raw path, which drops rows whose grouping dimension is null.
+        if any(v is None for v in group_dims.values()):
+            continue
+
+        values = {}
+        for agg in plan.aggregations:
+            value = _rollup_row_value(agg, row)
+            if value is None:
+                # A requested aggregation has no value for this day; demote the day to raw.
+                break
+            values[str(agg)] = value
+        else:
+            day_start_ms = date_to_ms[row.rollup_day]
+            served_day_starts.add(day_start_ms)
+            dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
+            dimensions.update(group_dims)
+            data_points.append(
+                MetricDataPoint(metric_name=plan.metric_name, dimensions=dimensions, values=values)
+            )
+    return data_points, sorted(served_day_starts)
+
+
+def _coalesce_day_starts_to_ranges(day_starts: list[int]) -> list[tuple[int, int]]:
+    """Merge consecutive UTC-day starts into inclusive ``(start_ms, end_ms)`` ranges."""
+    ranges: list[tuple[int, int]] = []
+    for day_start in sorted(day_starts):
+        day_end = day_start + MS_PER_DAY - 1
+        if ranges and day_start == ranges[-1][1] + 1:
+            ranges[-1] = (ranges[-1][0], day_end)
+        else:
+            ranges.append((day_start, day_end))
+    return ranges
+
+
+def remaining_raw_ranges(
+    plan: RollupReadPlan, covered_day_starts: list[int]
+) -> list[tuple[int, int]]:
+    """Inclusive ms ranges still requiring the raw path: partial edges plus uncovered full days."""
+    covered = set(covered_day_starts)
+    uncovered_days = [ms for ms in plan.covered_day_starts_ms if ms not in covered]
+    return plan.raw_ranges + _coalesce_day_starts_to_ranges(uncovered_days)
+
+
+def serve_rollup_read(
+    session: Session, plan: RollupReadPlan
+) -> tuple[list[MetricDataPoint], list[tuple[int, int]]] | None:
+    """Serve the rollup-eligible portion of a query.
+
+    Returns ``(rollup_data_points, raw_ranges)`` where ``raw_ranges`` are the inclusive ms ranges
+    the caller must still query raw and concatenate, or ``None`` to signal a full raw fallback
+    (nothing is servable from rollups). Non-bucketed single-range aggregates currently fall back to
+    raw; only daily time-series buckets are accelerated.
+
+    Days whose rollup row is missing a requested aggregation are demoted back into ``raw_ranges``,
+    so a served response always matches the raw one.
+    """
+    if not plan.bucketed:
+        return None
+    covered = compute_covered_day_starts(session, plan)
+    if not covered:
+        return None
+    data_points, served_day_starts = read_rollup_data_points(session, plan, covered)
+    if not served_day_starts:
+        return None
+    return data_points, remaining_raw_ranges(plan, served_day_starts)
+
+
+def _data_point_ordering(point: MetricDataPoint) -> tuple[str, tuple[str, ...]]:
+    dims = point.dimensions
+    time_bucket = dims.get(TIME_BUCKET_LABEL) or ""
+    grouping = tuple(v or "" for k, v in dims.items() if k != TIME_BUCKET_LABEL)
+    return (time_bucket, grouping)
+
+
+def order_and_limit_data_points(
+    data_points: list[MetricDataPoint], max_results: int
+) -> list[MetricDataPoint]:
+    """Order merged rollup and raw data points, then cap to ``max_results``.
+
+    Reproduces the single-query raw path's ``ORDER BY <time_bucket>, <dimensions>`` then
+    ``LIMIT max_results`` so a rollup-served response is row-for-row identical to the
+    rollups-disabled response.
+    """
+    return sorted(data_points, key=_data_point_ordering)[:max_results]

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -26,9 +26,11 @@ the requester may access. Hard experiment deletion removes these non-FK rows bef
 can be reused.
 """
 
+import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from enum import Enum
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -54,6 +56,8 @@ from mlflow.tracing.constant import (
     TraceMetricDimensionKey,
     TraceMetricKey,
 )
+
+_logger = logging.getLogger(__name__)
 
 MS_PER_DAY = 86_400_000
 DAILY_INTERVAL_SECONDS = 86_400
@@ -131,6 +135,22 @@ ROLLUP_METRICS: dict[RollupFamily, frozenset[str]] = {
     }),
 }
 
+# Token counts are stored as exact BIGINT values in the authoritative trace table, while the
+# current rollup schema stores ``sum_value`` as a double-precision float. Serving SUM or AVG from
+# that column could change results above 2^53, so those shapes remain on the exact raw path.
+EXACT_INTEGER_SUM_METRICS = frozenset({
+    TraceMetricKey.INPUT_TOKENS,
+    TraceMetricKey.OUTPUT_TOKENS,
+    TraceMetricKey.TOTAL_TOKENS,
+    TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+    TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+})
+
+# Trace latency also originates from a BIGINT column, but a daily latency sum must exceed
+# 2**53 milliseconds (roughly 285,000 years of aggregate latency) before the rollup FLOAT
+# can lose integer precision. Keep latency AVG eligible because it is a core rollup use case;
+# supporting exact arbitrary-magnitude latency sums would require a future schema change.
+
 # Only trace-metric rollups store daily percentile columns, and only PostgreSQL computes them.
 PERCENTILE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC})
 PERCENTILE_BACKENDS = frozenset({db_types.POSTGRES})
@@ -142,6 +162,16 @@ SERVABLE_FAMILIES = frozenset(RollupFamily)
 # Publication is atomic with rebuild-queue removal, making every materialized grouping set
 # readable. Trace status additionally has a cheap global-count completeness check.
 SERVABLE_GROUPING_SETS = frozenset(GroupingSet)
+
+# Model/provider dimensions are user-controlled strings. Python equality and ordering cannot
+# reproduce an arbitrary database collation, which can change both grouping and the max_results
+# boundary. These shapes stay in SQL until merging, ordering, and limiting can all be performed
+# under the backend's own collation.
+COLLATION_SENSITIVE_GROUPING_SETS = frozenset({
+    GroupingSet.MODEL,
+    GroupingSet.PROVIDER,
+    GroupingSet.MODEL_PROVIDER,
+})
 
 _ROLLUP_READ_ISOLATION_LEVEL = {
     db_types.POSTGRES: "REPEATABLE READ",
@@ -155,14 +185,32 @@ def rollups_enabled() -> bool:
     return MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.get()
 
 
+def _raw_fallback(view_type: MetricViewType, metric_name: str, reason: str) -> None:
+    _logger.debug(
+        "SQL trace rollup routing selected the raw path for view=%s metric=%s: %s",
+        view_type.value,
+        metric_name,
+        reason,
+    )
+
+
 def configure_rollup_read_snapshot(session: Session, db_type: str) -> None:
     """Start eligible multi-statement reads at a stable backend isolation level.
 
     PostgreSQL and MySQL use a repeatable snapshot. MSSQL repeatable-read locks stable rows; a
-    final rebuild-queue check catches queue-row phantoms. SQLite's managed session already starts
-    reads in its serializable transaction mode, so it needs no per-connection override.
+    final rebuild-queue check catches queue-row phantoms. SQLite's legacy driver mode does not emit
+    BEGIN for SELECT, so issue it explicitly before the first planning query to keep coverage,
+    rollup rows, raw gaps, and the final queue check in one read snapshot.
     """
-    if rollups_enabled() and (isolation_level := _ROLLUP_READ_ISOLATION_LEVEL.get(db_type)):
+    if not rollups_enabled():
+        return
+
+    if db_type == db_types.SQLITE:
+        connection = session.connection()
+        driver_connection = connection.connection.driver_connection
+        if not driver_connection.in_transaction:
+            connection.exec_driver_sql("BEGIN")
+    elif isolation_level := _ROLLUP_READ_ISOLATION_LEVEL.get(db_type):
         session.connection(execution_options={"isolation_level": isolation_level})
 
 
@@ -330,42 +378,57 @@ def resolve_rollup_read(
 
     family = VIEW_TYPE_TO_FAMILY.get(view_type)
     if family is None or family not in SERVABLE_FAMILIES:
-        return None
+        return _raw_fallback(view_type, metric_name, "the metric view is not rollup-servable")
     if metric_name not in ROLLUP_METRICS[family]:
-        return None
+        return _raw_fallback(view_type, metric_name, "the metric is not materialized")
 
     # ``all([])`` is true, but an empty aggregation request produces no raw data points and must
     # not be turned into rollup points with empty value maps.
     if not aggregations:
-        return None
+        return _raw_fallback(view_type, metric_name, "the aggregation list is empty")
 
     # Rollups are unfiltered daily aggregates; any request-level filter must use the raw path.
     if filters:
-        return None
+        return _raw_fallback(view_type, metric_name, "request filters are not materialized")
 
     grouping_set = resolve_grouping_set(view_type, dimensions)
     if grouping_set is None or grouping_set not in SERVABLE_GROUPING_SETS:
-        return None
+        return _raw_fallback(view_type, metric_name, "the requested grouping is not materialized")
 
     # Rollups are UTC-day aligned: serve only single-day buckets or a single whole-range aggregate.
     if time_interval_seconds is not None and time_interval_seconds != DAILY_INTERVAL_SECONDS:
-        return None
+        return _raw_fallback(view_type, metric_name, "the time bucket is not one UTC day")
     bucketed = time_interval_seconds == DAILY_INTERVAL_SECONDS
+    if grouping_set in COLLATION_SENSITIVE_GROUPING_SETS:
+        return _raw_fallback(
+            view_type,
+            metric_name,
+            "string grouping and ordering require database collation semantics",
+        )
 
     if start_time_ms is None or end_time_ms is None:
-        return None
+        return _raw_fallback(view_type, metric_name, "the request has no bounded time range")
 
     # Rollup serving is single-experiment: multi-experiment coverage cannot distinguish "no data
     # that day" from "not built yet", and daily percentiles are single-experiment by definition.
     if len(experiment_ids) != 1:
-        return None
+        return _raw_fallback(view_type, metric_name, "the request is not single-experiment")
+
+    if metric_name in EXACT_INTEGER_SUM_METRICS and any(
+        agg.aggregation_type in {AggregationType.SUM, AggregationType.AVG} for agg in aggregations
+    ):
+        return _raw_fallback(
+            view_type,
+            metric_name,
+            "token SUM and AVG require the authoritative BIGINT values",
+        )
 
     if not all(_aggregation_servable(agg, family, db_type, bucketed) for agg in aggregations):
-        return None
+        return _raw_fallback(view_type, metric_name, "an aggregation is not rollup-servable")
 
     split = split_range_into_utc_days(start_time_ms, end_time_ms)
     if not split.covered_day_starts_ms:
-        return None
+        return _raw_fallback(view_type, metric_name, "the range contains no eligible full UTC day")
 
     # Date columns cannot represent arbitrary integer epochs. Out-of-range requests remain valid
     # raw SQL predicates, but must never fail while the optional planner converts day starts.
@@ -373,9 +436,9 @@ def resolve_rollup_read(
         _day_start_ms_to_date(split.covered_day_starts_ms[0])
         _day_start_ms_to_date(split.covered_day_starts_ms[-1])
     except (OverflowError, OSError, ValueError):
-        return None
+        return _raw_fallback(view_type, metric_name, "the time range is outside SQL DATE bounds")
 
-    return RollupReadPlan(
+    plan = RollupReadPlan(
         family=family,
         metric_name=metric_name,
         grouping_set=grouping_set,
@@ -389,6 +452,15 @@ def resolve_rollup_read(
             agg.aggregation_type == AggregationType.PERCENTILE for agg in aggregations
         ),
     )
+    _logger.debug(
+        "SQL trace rollup planner accepted view=%s metric=%s with %d candidate days and %d "
+        "partial raw ranges",
+        view_type.value,
+        metric_name,
+        len(plan.covered_day_starts_ms),
+        len(plan.raw_ranges),
+    )
+    return plan
 
 
 FAMILY_MODEL = {
@@ -527,11 +599,11 @@ def read_rollup_data_points(
         model.rollup_day.in_(list(date_to_ms.keys())),
     )
 
-    rows_by_day: dict[date, list] = {}
+    rows_by_day: dict[date, list[Any]] = {}
     for row in rows:
         rows_by_day.setdefault(row.rollup_day, []).append(row)
 
-    global_rows_by_day: dict[date, list] = {}
+    global_rows_by_day: dict[date, list[Any]] = {}
     if plan.grouping_set == GroupingSet.STATUS:
         global_rows = session.query(model).filter(
             model.experiment_id == plan.experiment_id,
@@ -647,13 +719,43 @@ def serve_rollup_read(session: Session, plan: RollupReadPlan) -> RollupReadResul
     """
     covered = compute_covered_day_starts(session, plan)
     if not covered:
+        _logger.debug(
+            "SQL trace rollup routing selected the full raw path for family=%s metric=%s: none "
+            "of %d candidate days has valid coverage",
+            plan.family.value,
+            plan.metric_name,
+            len(plan.covered_day_starts_ms),
+        )
         return None
     data_points, served_day_starts = read_rollup_data_points(session, plan, covered)
     if not served_day_starts:
+        _logger.debug(
+            "SQL trace rollup routing selected the full raw path for family=%s metric=%s: "
+            "covered rows were incomplete for the requested aggregations",
+            plan.family.value,
+            plan.metric_name,
+        )
         return None
     raw_ranges = remaining_raw_ranges(plan, served_day_starts)
     if len(raw_ranges) > MAX_RAW_RANGES:
+        _logger.debug(
+            "SQL trace rollup routing selected the full raw path for family=%s metric=%s: %d raw "
+            "ranges exceed the routing limit of %d",
+            plan.family.value,
+            plan.metric_name,
+            len(raw_ranges),
+            MAX_RAW_RANGES,
+        )
         return None
+    _logger.debug(
+        "SQL trace rollup routing will serve %d of %d candidate days from family=%s metric=%s "
+        "and query %d raw ranges",
+        len(served_day_starts),
+        len(plan.covered_day_starts_ms),
+        plan.family.value,
+        plan.metric_name,
+        len(raw_ranges),
+    )
     return RollupReadResult(data_points, raw_ranges, served_day_starts)
 
 

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -14,12 +14,11 @@ tables lives in the separate rollup maintenance job.
 
 The reader trusts a full UTC day only when a matching rollup row exists for the metric and grouping
 set and no rebuild is queued for that day and family; it also demotes a covered day back to the raw
-path when the row is missing a column the request needs (a null aggregate value). Whole-day
-completeness of a grouping set is a maintenance-job guarantee, so the reader serves only the
-single-row ``global`` grouping set, whose one row per experiment-day is self-verifying. Multi-row
-grouping sets (for example per-status breakdowns) are served once the maintenance job that writes
-and invalidates them can guarantee that every group's row for a day is present before the day is
-treated as built.
+path when the row is missing a column the request needs (a null aggregate value). The single-row
+``global`` grouping set is self-verifying. Trace-status rows are served only when their distinct
+status counts add up to the corresponding global count, which proves the materialized breakdown is
+complete. Other multi-row grouping sets remain raw-only until they have an equivalent completeness
+proof.
 
 The rollup tables carry no ``workspace`` column (the shipped analytics schema scopes purely on
 ``experiment_id``, which is globally unique), so workspace isolation is preserved by the caller only
@@ -137,12 +136,10 @@ PERCENTILE_BACKENDS = frozenset({db_types.POSTGRES})
 # always exactly reproducible from daily rollups.
 SERVABLE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC, RollupFamily.ASSESSMENT})
 
-# Grouping sets the reader may serve. Restricted to ``global`` because that grouping set has exactly
-# one row per experiment-day, so "a row exists and is not queued" already proves the day complete.
-# Multi-row grouping sets (status, model, provider) need the maintenance job to guarantee that every
-# group's row for a day is written before the day is treated as built; until that job lands, serving
-# them could under-report a day whose sibling rows are missing, so they stay on the raw path.
-SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL})
+# Trace-status rollups can be verified against their companion global count row: a day is served
+# only when the status rows' sample counts add up to that global count. Other multi-row grouping
+# sets have no equivalent completeness proof in the read schema and remain raw-only.
+SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL, GroupingSet.STATUS})
 
 
 def rollups_enabled() -> bool:
@@ -465,29 +462,72 @@ def read_rollup_data_points(
         model.rollup_day.in_(list(date_to_ms.keys())),
     )
 
+    rows_by_day: dict[date, list] = {}
+    for row in rows:
+        rows_by_day.setdefault(row.rollup_day, []).append(row)
+
+    global_rows_by_day: dict[date, list] = {}
+    if plan.grouping_set == GroupingSet.STATUS:
+        global_rows = session.query(model).filter(
+            model.experiment_id == plan.experiment_id,
+            model.metric_name == plan.metric_name,
+            model.grouping_set == GroupingSet.GLOBAL.value,
+            model.rollup_day.in_(list(date_to_ms.keys())),
+        )
+        for row in global_rows:
+            global_rows_by_day.setdefault(row.rollup_day, []).append(row)
+
     data_points = []
     served_day_starts: set[int] = set()
-    for row in rows:
-        group_dims = _rollup_row_dimensions(plan, row)
-        # Mirror the raw path, which drops rows whose grouping dimension is null.
-        if any(v is None for v in group_dims.values()):
+    for rollup_day, day_rows in rows_by_day.items():
+        # A global aggregate has exactly one row. Duplicate rows can occur while an external
+        # publisher is replacing a day's rollup, so treat them as incomplete rather than risking
+        # a duplicate data point.
+        if plan.grouping_set == GroupingSet.GLOBAL and len(day_rows) != 1:
             continue
 
-        values = {}
-        for agg in plan.aggregations:
-            value = _rollup_row_value(agg, row)
-            if value is None:
-                # A requested aggregation has no value for this day; demote the day to raw.
+        if plan.grouping_set == GroupingSet.STATUS:
+            global_rows = global_rows_by_day.get(rollup_day, [])
+            statuses = [row.trace_status for row in day_rows]
+            # The global row is the publication/completeness marker for a materialized status
+            # breakdown. It must be unique and equal to the sum of the distinct status rows.
+            if (
+                len(global_rows) != 1
+                or any(status is None for status in statuses)
+                or len(set(statuses)) != len(statuses)
+                or sum(row.sample_count for row in day_rows) != global_rows[0].sample_count
+            ):
+                continue
+
+        day_points = []
+        for row in day_rows:
+            group_dims = _rollup_row_dimensions(plan, row)
+            # Mirror the raw path, which drops rows whose grouping dimension is null.
+            if any(v is None for v in group_dims.values()):
                 break
-            values[str(agg)] = value
+
+            values = {}
+            for agg in plan.aggregations:
+                value = _rollup_row_value(agg, row)
+                if value is None:
+                    # A requested aggregation has no value for this day; demote the whole day to
+                    # raw so a grouped result cannot be only partially served.
+                    break
+                values[str(agg)] = value
+            else:
+                day_start_ms = date_to_ms[rollup_day]
+                dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
+                dimensions.update(group_dims)
+                day_points.append(
+                    MetricDataPoint(
+                        metric_name=plan.metric_name, dimensions=dimensions, values=values
+                    )
+                )
+                continue
+            break
         else:
-            day_start_ms = date_to_ms[row.rollup_day]
-            served_day_starts.add(day_start_ms)
-            dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
-            dimensions.update(group_dims)
-            data_points.append(
-                MetricDataPoint(metric_name=plan.metric_name, dimensions=dimensions, values=values)
-            )
+            served_day_starts.add(date_to_ms[rollup_day])
+            data_points.extend(day_points)
     return data_points, sorted(served_day_starts)
 
 

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -17,15 +17,15 @@ set and no rebuild is queued for that day and family; it also demotes a covered 
 path when the row is missing a column the request needs (a null aggregate value). The single-row
 ``global`` grouping set is self-verifying. Trace-status rows are served only when their distinct
 status counts add up to the corresponding global count, which proves the materialized breakdown is
-complete. Other multi-row grouping sets remain raw-only until they have an equivalent completeness
-proof.
+complete. Span model/provider grouping sets rely on the maintenance contract that replacement and
+rebuild-queue removal publish a complete partition atomically.
 
 The rollup tables carry no ``workspace`` column (the shipped analytics schema scopes purely on
-``experiment_id``, which is globally unique), so workspace isolation is preserved by the caller only
-routing experiment ids the requester may access.
+``experiment_id``), so workspace isolation is preserved by the caller only routing experiment ids
+the requester may access. Hard experiment deletion removes these non-FK rows before an integer id
+can be reused.
 """
 
-import math
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from enum import Enum
@@ -57,6 +57,16 @@ from mlflow.tracing.constant import (
 
 MS_PER_DAY = 86_400_000
 DAILY_INTERVAL_SECONDS = 86_400
+
+# Keep every date ``IN`` predicate comfortably below MSSQL's 2,100-parameter statement limit and
+# bound planner memory for caller-controlled timestamp ranges. A larger request remains valid; it
+# simply uses the authoritative raw query.
+MAX_ROLLUP_DAYS = 1_000
+
+# Scattered missing or invalidated days can otherwise produce a very large OR expression even
+# though the raw portions are executed in one statement. Above this threshold the single full raw
+# query is both simpler and predictably cheaper.
+MAX_RAW_RANGES = 8
 
 # Daily percentiles are not composable into coarser buckets, so rollups only serve these three exact
 # daily percentile values, and only for single-experiment complete-UTC-day requests.
@@ -125,26 +135,35 @@ ROLLUP_METRICS: dict[RollupFamily, frozenset[str]] = {
 PERCENTILE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC})
 PERCENTILE_BACKENDS = frozenset({db_types.POSTGRES})
 
-# Families the reader may serve from rollups. Span cost is intentionally excluded: the raw span
-# query filters by the parent trace's timestamp (``trace_info.timestamp_ms``) but buckets by span
-# start time (``spans.start_time_unix_nano``), so a span-day rollup cannot be guaranteed row-for-row
-# identical to raw when a span and its trace fall on different UTC days (e.g. delayed or
-# long-running OTLP spans). Serving it would violate the invariant that rollups never change
-# results, only speed.
-# Span-cost rollups are therefore neither built nor read until the span read path filters by span
-# time; trace-metric and assessment queries filter and bucket on the same timestamp, so they are
-# always exactly reproducible from daily rollups.
-SERVABLE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC, RollupFamily.ASSESSMENT})
+# Raw span ranges and buckets use span start time, the same timestamp used to assign span-cost
+# rollup days. All three materialized families can therefore be reproduced exactly.
+SERVABLE_FAMILIES = frozenset(RollupFamily)
 
-# Trace-status rollups can be verified against their companion global count row: a day is served
-# only when the status rows' sample counts add up to that global count. Other multi-row grouping
-# sets have no equivalent completeness proof in the read schema and remain raw-only.
-SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL, GroupingSet.STATUS})
+# Publication is atomic with rebuild-queue removal, making every materialized grouping set
+# readable. Trace status additionally has a cheap global-count completeness check.
+SERVABLE_GROUPING_SETS = frozenset(GroupingSet)
+
+_ROLLUP_READ_ISOLATION_LEVEL = {
+    db_types.POSTGRES: "REPEATABLE READ",
+    db_types.MYSQL: "REPEATABLE READ",
+    db_types.MSSQL: "REPEATABLE READ",
+}
 
 
 def rollups_enabled() -> bool:
     """Whether opt-in SQL trace rollups are enabled for this deployment."""
     return MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.get()
+
+
+def configure_rollup_read_snapshot(session: Session, db_type: str) -> None:
+    """Start eligible multi-statement reads at a stable backend isolation level.
+
+    PostgreSQL and MySQL use a repeatable snapshot. MSSQL repeatable-read locks stable rows; a
+    final rebuild-queue check catches queue-row phantoms. SQLite's managed session already starts
+    reads in its serializable transaction mode, so it needs no per-connection override.
+    """
+    if rollups_enabled() and (isolation_level := _ROLLUP_READ_ISOLATION_LEVEL.get(db_type)):
+        session.connection(execution_options={"isolation_level": isolation_level})
 
 
 @dataclass
@@ -176,10 +195,16 @@ def split_range_into_utc_days(start_time_ms: int | None, end_time_ms: int | None
         raw = [(start_time_ms, end_time_ms)] if has_range else []
         return UtcDaySplit(covered_day_starts_ms=[], raw_ranges=raw)
 
-    first_full_day_start = math.ceil(start_time_ms / MS_PER_DAY) * MS_PER_DAY
+    # Integer ceiling division avoids float overflow and precision loss for caller-controlled epoch
+    # values.
+    first_full_day_start = -(-start_time_ms // MS_PER_DAY) * MS_PER_DAY
     # Greatest UTC midnight D such that the whole day [D, D + MS_PER_DAY) fits inside the range,
     # i.e. D + MS_PER_DAY - 1 <= end_time_ms.
     last_full_day_start = ((end_time_ms + 1) // MS_PER_DAY) * MS_PER_DAY - MS_PER_DAY
+
+    full_day_count = max(0, (last_full_day_start - first_full_day_start) // MS_PER_DAY + 1)
+    if full_day_count > MAX_ROLLUP_DAYS:
+        return UtcDaySplit(covered_day_starts_ms=[], raw_ranges=[(start_time_ms, end_time_ms)])
 
     covered = list(range(first_full_day_start, last_full_day_start + MS_PER_DAY, MS_PER_DAY))
 
@@ -237,6 +262,7 @@ class RollupReadPlan:
         family: The rollup table family to read.
         metric_name: The metric whose rollup rows to read (matches the request metric name).
         grouping_set: The materialized grouping set to read.
+        dimensions: Requested grouping dimensions in API order.
         aggregations: The requested aggregations, all confirmed rollup-servable.
         bucketed: ``True`` for one data point per UTC day (daily interval); ``False`` for a single
             aggregate over the whole range.
@@ -249,6 +275,7 @@ class RollupReadPlan:
     family: RollupFamily
     metric_name: str
     grouping_set: GroupingSet
+    dimensions: list[str]
     aggregations: list[MetricAggregation]
     bucketed: bool
     experiment_id: int
@@ -307,6 +334,11 @@ def resolve_rollup_read(
     if metric_name not in ROLLUP_METRICS[family]:
         return None
 
+    # ``all([])`` is true, but an empty aggregation request produces no raw data points and must
+    # not be turned into rollup points with empty value maps.
+    if not aggregations:
+        return None
+
     # Rollups are unfiltered daily aggregates; any request-level filter must use the raw path.
     if filters:
         return None
@@ -335,10 +367,19 @@ def resolve_rollup_read(
     if not split.covered_day_starts_ms:
         return None
 
+    # Date columns cannot represent arbitrary integer epochs. Out-of-range requests remain valid
+    # raw SQL predicates, but must never fail while the optional planner converts day starts.
+    try:
+        _day_start_ms_to_date(split.covered_day_starts_ms[0])
+        _day_start_ms_to_date(split.covered_day_starts_ms[-1])
+    except (OverflowError, OSError, ValueError):
+        return None
+
     return RollupReadPlan(
         family=family,
         metric_name=metric_name,
         grouping_set=grouping_set,
+        dimensions=list(dimensions or []),
         aggregations=aggregations,
         bucketed=bucketed,
         experiment_id=experiment_ids[0],
@@ -375,10 +416,11 @@ def _rollup_row_dimensions(plan: RollupReadPlan, row) -> dict[str, str]:
         case GroupingSet.PROVIDER:
             return {SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: row.model_provider}
         case GroupingSet.MODEL_PROVIDER:
-            return {
+            values = {
                 SpanMetricDimensionKey.SPAN_MODEL_NAME: row.model_name,
                 SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: row.model_provider,
             }
+            return {dimension: values[dimension] for dimension in plan.dimensions}
         case _:
             return {}
 
@@ -406,6 +448,29 @@ def _rollup_row_value(aggregation: MetricAggregation, row) -> float | None:
                 case 99.0:
                     return row.p99_value
     return None
+
+
+def raw_aggregations_for_plan(plan: RollupReadPlan) -> list[MetricAggregation]:
+    """Return raw aggregations needed to merge an unbucketed result exactly.
+
+    Daily averages are not composable, so an unbucketed AVG is represented by SUM and COUNT
+    contributions from both rollup rows and the combined raw-range query.
+    """
+    if plan.bucketed:
+        return plan.aggregations
+
+    aggregation_types = []
+    for aggregation in plan.aggregations:
+        match aggregation.aggregation_type:
+            case AggregationType.AVG:
+                aggregation_types.extend([AggregationType.SUM, AggregationType.COUNT])
+            case aggregation_type:
+                aggregation_types.append(aggregation_type)
+
+    unique_types = dict.fromkeys(aggregation_types)
+    return [
+        MetricAggregation(aggregation_type=aggregation_type) for aggregation_type in unique_types
+    ]
 
 
 def compute_covered_day_starts(session: Session, plan: RollupReadPlan) -> list[int]:
@@ -477,6 +542,7 @@ def read_rollup_data_points(
         for row in global_rows:
             global_rows_by_day.setdefault(row.rollup_day, []).append(row)
 
+    contribution_aggregations = raw_aggregations_for_plan(plan)
     data_points = []
     served_day_starts: set[int] = set()
     for rollup_day, day_rows in rows_by_day.items():
@@ -499,6 +565,12 @@ def read_rollup_data_points(
             ):
                 continue
 
+        if plan.grouping_set != GroupingSet.GLOBAL:
+            dimension_keys = [tuple(_rollup_row_dimensions(plan, row).values()) for row in day_rows]
+            if len(set(dimension_keys)) != len(dimension_keys):
+                # Duplicate dimension rows mean publication is not a complete atomic replacement.
+                continue
+
         day_points = []
         for row in day_rows:
             group_dims = _rollup_row_dimensions(plan, row)
@@ -507,7 +579,7 @@ def read_rollup_data_points(
                 break
 
             values = {}
-            for agg in plan.aggregations:
+            for agg in contribution_aggregations:
                 value = _rollup_row_value(agg, row)
                 if value is None:
                     # A requested aggregation has no value for this day; demote the whole day to
@@ -516,7 +588,9 @@ def read_rollup_data_points(
                 values[str(agg)] = value
             else:
                 day_start_ms = date_to_ms[rollup_day]
-                dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
+                dimensions = (
+                    {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)} if plan.bucketed else {}
+                )
                 dimensions.update(group_dims)
                 day_points.append(
                     MetricDataPoint(
@@ -552,28 +626,112 @@ def remaining_raw_ranges(
     return plan.raw_ranges + _coalesce_day_starts_to_ranges(uncovered_days)
 
 
-def serve_rollup_read(
-    session: Session, plan: RollupReadPlan
-) -> tuple[list[MetricDataPoint], list[tuple[int, int]]] | None:
+@dataclass
+class RollupReadResult:
+    """Rollup contributions plus the raw ranges needed to complete a response."""
+
+    data_points: list[MetricDataPoint]
+    raw_ranges: list[tuple[int, int]]
+    served_day_starts_ms: list[int]
+
+
+def serve_rollup_read(session: Session, plan: RollupReadPlan) -> RollupReadResult | None:
     """Serve the rollup-eligible portion of a query.
 
-    Returns ``(rollup_data_points, raw_ranges)`` where ``raw_ranges`` are the inclusive ms ranges
-    the caller must still query raw and concatenate, or ``None`` to signal a full raw fallback
-    (nothing is servable from rollups). Non-bucketed single-range aggregates currently fall back to
-    raw; only daily time-series buckets are accelerated.
+    Returns rollup contributions and inclusive raw ranges, or ``None`` to signal a full raw
+    fallback. Unbucketed contributions use composable backing aggregates (for example SUM and
+    COUNT for AVG), which the caller merges after querying all raw gaps in one statement.
 
     Days whose rollup row is missing a requested aggregation are demoted back into ``raw_ranges``,
     so a served response always matches the raw one.
     """
-    if not plan.bucketed:
-        return None
     covered = compute_covered_day_starts(session, plan)
     if not covered:
         return None
     data_points, served_day_starts = read_rollup_data_points(session, plan, covered)
     if not served_day_starts:
         return None
-    return data_points, remaining_raw_ranges(plan, served_day_starts)
+    raw_ranges = remaining_raw_ranges(plan, served_day_starts)
+    if len(raw_ranges) > MAX_RAW_RANGES:
+        return None
+    return RollupReadResult(data_points, raw_ranges, served_day_starts)
+
+
+def rollup_read_is_current(
+    session: Session, plan: RollupReadPlan, served_day_starts_ms: list[int]
+) -> bool:
+    """Recheck invalidation after raw-gap reads for backends without snapshot phantoms.
+
+    Repeatable snapshots make this a stable re-read on PostgreSQL/MySQL. On MSSQL, a rebuild row
+    inserted after the initial absence check is a permitted repeatable-read phantom; seeing it here
+    makes the caller abandon the mixed result and execute one authoritative raw query.
+    """
+    served_dates = [_day_start_ms_to_date(ms) for ms in served_day_starts_ms]
+    return (
+        session
+        .query(SqlTraceRollupRebuild.experiment_id)
+        .filter(
+            SqlTraceRollupRebuild.experiment_id == plan.experiment_id,
+            SqlTraceRollupRebuild.rollup_family == plan.family.value,
+            SqlTraceRollupRebuild.rollup_day.in_(served_dates),
+        )
+        .first()
+        is None
+    )
+
+
+def merge_unbucketed_data_points(
+    plan: RollupReadPlan,
+    rollup_points: list[MetricDataPoint],
+    raw_points: list[MetricDataPoint],
+    max_results: int,
+) -> list[MetricDataPoint]:
+    """Merge composable unbucketed rollup and raw contributions by grouping dimensions."""
+    support_aggregations = raw_aggregations_for_plan(plan)
+    grouped: dict[tuple[tuple[str, str], ...], dict[str, float]] = {}
+    dimensions_by_key: dict[tuple[tuple[str, str], ...], dict[str, str]] = {}
+
+    for point in [*rollup_points, *raw_points]:
+        dimensions = point.dimensions or {}
+        key = tuple(dimensions.items())
+        dimensions_by_key[key] = dimensions
+        accumulated = grouped.setdefault(key, {})
+        for aggregation in support_aggregations:
+            label = str(aggregation)
+            if label not in point.values:
+                continue
+            value = point.values[label]
+            match aggregation.aggregation_type:
+                case AggregationType.COUNT | AggregationType.SUM:
+                    accumulated[label] = accumulated.get(label, 0) + value
+                case AggregationType.MIN:
+                    accumulated[label] = min(accumulated.get(label, value), value)
+                case AggregationType.MAX:
+                    accumulated[label] = max(accumulated.get(label, value), value)
+
+    data_points = []
+    for key, support_values in grouped.items():
+        values = {}
+        for aggregation in plan.aggregations:
+            label = str(aggregation)
+            if aggregation.aggregation_type == AggregationType.AVG:
+                count_label = str(MetricAggregation(aggregation_type=AggregationType.COUNT))
+                sum_label = str(MetricAggregation(aggregation_type=AggregationType.SUM))
+                sample_count = support_values.get(count_label, 0)
+                sum_value = support_values.get(sum_label)
+                if sample_count and sum_value is not None:
+                    values[label] = sum_value / sample_count
+            elif label in support_values:
+                values[label] = support_values[label]
+        if values:
+            data_points.append(
+                MetricDataPoint(
+                    metric_name=plan.metric_name,
+                    dimensions=dimensions_by_key[key],
+                    values=values,
+                )
+            )
+    return order_and_limit_data_points(data_points, max_results)
 
 
 def _data_point_ordering(point: MetricDataPoint) -> tuple[str, tuple[str, ...]]:

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_experiments.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_experiments.py
@@ -1,6 +1,7 @@
 import json
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.store.tracking.dbmodels import models
 from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
     SqlAssessments,
     SqlExperiment,
     SqlExperimentTag,
@@ -28,10 +30,13 @@ from mlflow.store.tracking.dbmodels.models import (
     SqlLoggedModelTag,
     SqlRun,
     SqlSpan,
+    SqlSpanCostDailyRollup,
     SqlSpanMetrics,
     SqlTraceInfo,
     SqlTraceMetadata,
+    SqlTraceMetricDailyRollup,
     SqlTraceMetrics,
+    SqlTraceRollupRebuild,
     SqlTraceTag,
     TraceState,
 )
@@ -585,6 +590,36 @@ def test_hard_delete_experiment_cascades_to_child_tables(
                 tag_value="v",
             )
         )
+        rollup_day = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).date()
+        session.add_all([
+            SqlTraceMetricDailyRollup(
+                experiment_id=target_exp_id,
+                rollup_day=rollup_day,
+                metric_name="trace_count",
+                grouping_set="global",
+                sample_count=1,
+            ),
+            SqlSpanCostDailyRollup(
+                experiment_id=target_exp_id,
+                rollup_day=rollup_day,
+                metric_name="total_cost",
+                grouping_set="global",
+                sample_count=1,
+                sum_value=1.0,
+            ),
+            SqlAssessmentDailyRollup(
+                experiment_id=target_exp_id,
+                rollup_day=rollup_day,
+                metric_name="assessment_count",
+                grouping_set="global",
+                sample_count=1,
+            ),
+            SqlTraceRollupRebuild(
+                experiment_id=target_exp_id,
+                rollup_day=rollup_day,
+                rollup_family="trace_metric",
+            ),
+        ])
 
     # _hard_delete_experiment requires the experiment to be soft-deleted first.
     store.delete_experiment(str(target_exp_id))
@@ -598,6 +633,10 @@ def test_hard_delete_experiment_cascades_to_child_tables(
             SqlLoggedModelMetric,
             SqlLoggedModelParam,
             SqlLoggedModelTag,
+            SqlTraceMetricDailyRollup,
+            SqlSpanCostDailyRollup,
+            SqlAssessmentDailyRollup,
+            SqlTraceRollupRebuild,
         ):
             remaining = session.query(model).filter_by(experiment_id=target_exp_id).count()
             assert remaining == 0

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_query_trace_metrics.py
@@ -28,6 +28,7 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges import CategoricalRating
 from mlflow.store.db import db_types
+from mlflow.store.tracking.dbmodels.models import SqlTraceInfo
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.tracking.utils.sql_trace_metrics_postgres import (
     _apply_postgres_trace_first_span_query,
@@ -75,6 +76,110 @@ def test_postgres_span_query_materializes_trace_filters_before_span_join(
 
 
 @pytest.mark.parametrize(
+    ("metric_name", "aggregations", "filter_fragment", "uses_trace_cte"),
+    [
+        (
+            SpanMetricKey.SPAN_COUNT,
+            [MetricAggregation(aggregation_type=AggregationType.COUNT)],
+            "trace_info.timestamp_ms >= 1000",
+            True,
+        ),
+        (
+            SpanMetricKey.TOTAL_COST,
+            [MetricAggregation(aggregation_type=AggregationType.SUM)],
+            "spans.start_time_unix_nano >= 1000000000",
+            False,
+        ),
+    ],
+)
+def test_postgres_span_time_range_uses_metric_authoritative_timestamp(
+    store: SqlAlchemyStore,
+    monkeypatch: pytest.MonkeyPatch,
+    metric_name: str,
+    aggregations: list[MetricAggregation],
+    filter_fragment: str,
+    uses_trace_cte: bool,
+):
+    statements = []
+
+    def capture_statement(query):
+        statements.append(
+            str(
+                query.statement.compile(
+                    dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+                )
+            )
+        )
+        return []
+
+    monkeypatch.setattr(Query, "all", capture_statement)
+    with store.ManagedSessionMaker() as session:
+        query_metrics(
+            view_type=MetricViewType.SPANS,
+            db_type=db_types.POSTGRES,
+            query=store._trace_query(session).filter(SqlTraceInfo.experiment_id == 7),
+            metric_name=metric_name,
+            aggregations=aggregations,
+            dimensions=None,
+            filters=None if uses_trace_cte else ["span.status = 'ERROR'"],
+            time_interval_seconds=None,
+            max_results=1000,
+            time_ranges_ms=[(1000, 2000)],
+            accessible_experiment_ids=[7],
+        )
+
+    statement = statements[0]
+    filter_position = statement.index(filter_fragment)
+    if uses_trace_cte:
+        join_position = statement.index("FROM spans JOIN metric_trace_ids")
+        assert filter_position < join_position
+    else:
+        assert "metric_trace_ids" not in statement
+        assert "FROM spans" in statement
+        assert "spans.experiment_id IN (7)" in statement
+        assert "spans.status = 'ERROR'" in statement
+
+
+def test_postgres_span_cost_trace_filter_keeps_materialized_trace_ids(
+    store: SqlAlchemyStore, monkeypatch: pytest.MonkeyPatch
+):
+    statements = []
+
+    def capture_statement(query):
+        statements.append(
+            str(
+                query.statement.compile(
+                    dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+                )
+            )
+        )
+        return []
+
+    monkeypatch.setattr(Query, "all", capture_statement)
+    with store.ManagedSessionMaker() as session:
+        query_metrics(
+            view_type=MetricViewType.SPANS,
+            db_type=db_types.POSTGRES,
+            query=store._trace_query(session).filter(SqlTraceInfo.experiment_id == 7),
+            metric_name=SpanMetricKey.TOTAL_COST,
+            aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
+            dimensions=None,
+            filters=["trace.status = 'OK'"],
+            time_interval_seconds=None,
+            max_results=1000,
+            time_ranges_ms=[(1000, 2000)],
+            accessible_experiment_ids=[7],
+        )
+
+    statement = statements[0]
+    join_position = statement.index("FROM spans JOIN metric_trace_ids")
+    assert "WITH metric_trace_ids AS MATERIALIZED" in statement
+    assert statement.index("trace_info.experiment_id = 7") < join_position
+    assert statement.index("trace_info.status = 'OK'") < join_position
+    assert statement.index("spans.start_time_unix_nano >= 1000000000") > join_position
+
+
+@pytest.mark.parametrize(
     ("metric_name", "column_name"),
     [
         (SpanMetricKey.INPUT_COST, "input_cost"),
@@ -106,6 +211,7 @@ def test_postgres_span_cost_query_filters_null_metric_values(
             filters=None,
             time_interval_seconds=None,
             max_results=100,
+            accessible_experiment_ids=[7],
         )
 
     assert len(statements) == 1

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -19,21 +19,33 @@ from mlflow.entities.trace_state import TraceState
 from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
 from mlflow.store.tracking.dbmodels.models import (
     SqlAssessmentDailyRollup,
+    SqlSpanCostDailyRollup,
     SqlTraceMetricDailyRollup,
     SqlTraceRollupRebuild,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.tracking.utils.sql_trace_rollups import (
     DAILY_INTERVAL_SECONDS,
+    MAX_RAW_RANGES,
+    MAX_ROLLUP_DAYS,
     GroupingSet,
     RollupFamily,
+    configure_rollup_read_snapshot,
+    resolve_rollup_read,
+    rollup_read_is_current,
+    serve_rollup_read,
 )
 from mlflow.tracing.constant import (
     AssessmentMetricKey,
+    SpanAttributeKey,
+    SpanMetricDimensionKey,
+    SpanMetricKey,
     TraceMetricDimensionKey,
     TraceMetricKey,
     TraceTagKey,
 )
+
+from tests.store.tracking.sqlalchemy_store.conftest import create_test_span
 
 pytestmark = pytest.mark.notrackingurimock
 
@@ -51,6 +63,11 @@ SOURCE = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="tes
 _COUNT = [MetricAggregation(aggregation_type=AggregationType.COUNT)]
 _AVG = [MetricAggregation(aggregation_type=AggregationType.AVG)]
 _P50 = [MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=50)]
+_P50_P90_P99 = [
+    MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=value)
+    for value in (50, 90, 99)
+]
+_SUM = [MetricAggregation(aggregation_type=AggregationType.SUM)]
 
 
 def _day_of(timestamp_ms: int):
@@ -76,6 +93,36 @@ def _add_feedback(store, trace_id, value=0.5, name="quality"):
     return store.create_assessment(
         Feedback(trace_id=trace_id, name=name, value=value, source=SOURCE)
     )
+
+
+def _new_span_cost_trace(
+    store,
+    exp_id,
+    *,
+    trace_time_ms,
+    span_time_ms,
+    total_cost,
+    model_name="gpt-test",
+    model_provider="test-provider",
+):
+    trace_id = _new_trace(store, exp_id, trace_time_ms)
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=1,
+                start_ns=span_time_ms * 1_000_000,
+                end_ns=(span_time_ms + 1) * 1_000_000,
+                attributes={
+                    SpanAttributeKey.LLM_COST: {"total_cost": total_cost},
+                    SpanAttributeKey.MODEL: model_name,
+                    SpanAttributeKey.MODEL_PROVIDER: model_provider,
+                },
+            )
+        ],
+    )
+    return trace_id
 
 
 def _seed(store) -> str:
@@ -104,6 +151,8 @@ def _insert_trace_metric_rollup(
     sum_value=None,
     trace_status=None,
     p50_value=None,
+    p90_value=None,
+    p99_value=None,
 ):
     with store.ManagedSessionMaker(read_only=False) as session:
         session.add(
@@ -116,6 +165,36 @@ def _insert_trace_metric_rollup(
                 sample_count=sample_count,
                 sum_value=sum_value,
                 p50_value=p50_value,
+                p90_value=p90_value,
+                p99_value=p99_value,
+            )
+        )
+        session.commit()
+
+
+def _insert_span_cost_rollup(
+    store,
+    exp_id,
+    day_start_ms,
+    metric_name,
+    grouping_set,
+    *,
+    sample_count,
+    sum_value=None,
+    model_name=None,
+    model_provider=None,
+):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlSpanCostDailyRollup(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                metric_name=metric_name,
+                grouping_set=grouping_set,
+                model_name=model_name,
+                model_provider=model_provider,
+                sample_count=sample_count,
+                sum_value=sum_value,
             )
         )
         session.commit()
@@ -173,6 +252,7 @@ def _query(
     time_interval=DAILY_INTERVAL_SECONDS,
     filters=None,
     experiment_ids=None,
+    max_results=1000,
 ):
     return _normalize(
         store.query_trace_metrics(
@@ -185,6 +265,7 @@ def _query(
             time_interval_seconds=time_interval,
             start_time_ms=start,
             end_time_ms=end,
+            max_results=max_results,
         )
     )
 
@@ -666,3 +747,398 @@ def test_percentiles_fall_back_to_raw_off_postgres(store: SqlAlchemyStore, monke
     _assert_enabled_equals_raw(
         store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _P50, None
     )
+
+
+def test_postgres_percentiles_are_served_with_expected_labels(store: SqlAlchemyStore, monkeypatch):
+    if store.engine.dialect.name != "postgresql":
+        pytest.skip("positive percentile serving is PostgreSQL-specific")
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        p50_value=50.5,
+        p90_value=90.5,
+        p99_value=99.5,
+    )
+    _set_enabled(monkeypatch, True)
+
+    served = _query(
+        store,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.LATENCY,
+        _P50_P90_P99,
+        None,
+    )
+
+    assert dict(served[0][1]) == {"P50": 50.5, "P90": 90.5, "P99": 99.5}
+
+
+def test_empty_aggregation_list_stays_on_raw_path(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _set_enabled(monkeypatch, True)
+
+    assert _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, [], None) == []
+
+
+def test_large_and_out_of_range_epochs_fall_back_before_materializing_days(
+    store: SqlAlchemyStore, monkeypatch
+):
+    _set_enabled(monkeypatch, True)
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    common = {
+        "view_type": MetricViewType.TRACES,
+        "metric_name": TraceMetricKey.TRACE_COUNT,
+        "aggregations": _COUNT,
+        "dimensions": None,
+        "filters": None,
+        "time_interval_seconds": DAILY_INTERVAL_SECONDS,
+        "experiment_ids": [int(exp_id)],
+        "db_type": store.db_type,
+    }
+
+    assert (
+        resolve_rollup_read(
+            **common,
+            start_time_ms=0,
+            end_time_ms=(MAX_ROLLUP_DAYS + 1) * MS_PER_DAY - 1,
+        )
+        is None
+    )
+    assert (
+        _query(
+            store,
+            exp_id,
+            MetricViewType.TRACES,
+            TraceMetricKey.TRACE_COUNT,
+            _COUNT,
+            None,
+            start=10**30,
+            end=10**30 + MS_PER_DAY - 1,
+        )
+        == []
+    )
+    assert (
+        resolve_rollup_read(
+            **common,
+            start_time_ms=10**30,
+            end_time_ms=10**30 + MS_PER_DAY - 1,
+        )
+        is None
+    )
+
+
+def test_unbucketed_count_merges_rollup_day_and_raw_edge(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=2,
+    )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        end=DAY_B_START + 10_000,
+        time_interval=None,
+    )
+
+
+def test_unbucketed_avg_uses_sum_and_count_contributions(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=2,
+        sum_value=400.0,
+    )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.LATENCY,
+        _AVG,
+        None,
+        end=DAY_B_START + 10_000,
+        time_interval=None,
+    )
+
+
+def test_null_only_early_bucket_does_not_consume_max_results(store: SqlAlchemyStore, monkeypatch):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_START + 5_000, duration_ms=None)
+    _new_trace(store, exp_id, DAY_B_START + 5_000, duration_ms=500)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_B_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=1,
+        sum_value=500.0,
+    )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.LATENCY,
+        _AVG,
+        None,
+        start=DAY_A_START,
+        end=DAY_B_START + MS_PER_DAY - 1,
+        max_results=1,
+    )
+
+
+def test_span_cost_raw_ranges_use_span_start_time(store: SqlAlchemyStore, monkeypatch):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_span_cost_trace(
+        store,
+        exp_id,
+        trace_time_ms=DAY_A_START + 5_000,
+        span_time_ms=DAY_B_START + 5_000,
+        total_cost=0.75,
+    )
+    _set_enabled(monkeypatch, False)
+
+    day_a = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        None,
+        start=DAY_A_START,
+        end=DAY_A_START + MS_PER_DAY - 1,
+    )
+    day_b = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        None,
+        start=DAY_B_START,
+        end=DAY_B_START + MS_PER_DAY - 1,
+    )
+
+    assert day_a == []
+    assert dict(day_b[0][1]) == {"SUM": 0.75}
+
+
+def test_span_raw_range_includes_fractional_nanoseconds_in_end_millisecond(
+    store: SqlAlchemyStore, monkeypatch
+):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_START + 5_000)
+    day_end_ms = DAY_A_START + MS_PER_DAY - 1
+    span_start_ns = day_end_ms * 1_000_000 + 999_999
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id,
+                span_id=1,
+                start_ns=span_start_ns,
+                end_ns=span_start_ns + 1,
+                attributes={SpanAttributeKey.LLM_COST: {"total_cost": 0.5}},
+            )
+        ],
+    )
+    _set_enabled(monkeypatch, False)
+
+    result = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        None,
+    )
+
+    assert dict(result[0][1]) == {"SUM": 0.5}
+
+
+def test_span_cost_model_grouping_is_served_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_span_cost_trace(
+        store,
+        exp_id,
+        trace_time_ms=DAY_A_START + 5_000,
+        span_time_ms=DAY_A_START + 5_000,
+        total_cost=0.75,
+    )
+    _insert_span_cost_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        SpanMetricKey.TOTAL_COST,
+        GroupingSet.MODEL.value,
+        sample_count=1,
+        sum_value=float(SENTINEL_COUNT),
+        model_name="gpt-test",
+    )
+    _set_enabled(monkeypatch, True)
+
+    served = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        [SpanMetricDimensionKey.SPAN_MODEL_NAME],
+    )
+
+    assert dict(served[0][0])[SpanMetricDimensionKey.SPAN_MODEL_NAME] == "gpt-test"
+    assert dict(served[0][1]) == {"SUM": float(SENTINEL_COUNT)}
+
+
+def test_scattered_raw_gaps_are_queried_once(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    for day_start in (DAY_A_START, DAY_A_START + 2 * MS_PER_DAY, DAY_A_START + 4 * MS_PER_DAY):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            day_start,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.GLOBAL.value,
+            sample_count=1,
+        )
+
+    from mlflow.store.tracking import sqlalchemy_store as store_module
+
+    original = store_module.query_metrics
+    queried_ranges = []
+
+    def capture_ranges(*args, **kwargs):
+        queried_ranges.append(kwargs["time_ranges_ms"])
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(store_module, "query_metrics", capture_ranges)
+    _set_enabled(monkeypatch, True)
+    _query(
+        store,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        start=DAY_A_START,
+        end=DAY_A_START + 5 * MS_PER_DAY - 1,
+    )
+
+    assert len(queried_ranges) == 1
+    assert len(queried_ranges[0]) == 2
+
+
+def test_too_many_raw_gaps_abandons_rollup_plan(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    day_count = 2 * (MAX_RAW_RANGES + 1)
+    for day_offset in range(0, day_count, 2):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START + day_offset * MS_PER_DAY,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.GLOBAL.value,
+            sample_count=1,
+        )
+
+    from mlflow.store.tracking import sqlalchemy_store as store_module
+
+    original = store_module.query_metrics
+    queried_ranges = []
+
+    def capture_ranges(*args, **kwargs):
+        queried_ranges.append(kwargs["time_ranges_ms"])
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(store_module, "query_metrics", capture_ranges)
+    _set_enabled(monkeypatch, True)
+    _query(
+        store,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        start=DAY_A_START,
+        end=DAY_A_START + day_count * MS_PER_DAY - 1,
+    )
+
+    assert queried_ranges == [[(DAY_A_START, DAY_A_START + day_count * MS_PER_DAY - 1)]]
+
+
+def test_rebuild_queued_after_rollup_read_invalidates_mixed_result(
+    store: SqlAlchemyStore, monkeypatch
+):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=2,
+    )
+    _set_enabled(monkeypatch, True)
+    plan = resolve_rollup_read(
+        view_type=MetricViewType.TRACES,
+        metric_name=TraceMetricKey.TRACE_COUNT,
+        aggregations=_COUNT,
+        dimensions=None,
+        filters=None,
+        time_interval_seconds=DAILY_INTERVAL_SECONDS,
+        start_time_ms=DAY_A_START,
+        end_time_ms=DAY_A_START + MS_PER_DAY - 1,
+        experiment_ids=[int(exp_id)],
+        db_type=store.db_type,
+    )
+    assert plan is not None
+    with store.ManagedSessionMaker() as session:
+        served = serve_rollup_read(session, plan)
+    assert served is not None
+
+    _invalidate_day(store, RollupFamily.TRACE_METRIC, exp_id, DAY_A_START)
+    with store.ManagedSessionMaker() as session:
+        assert not rollup_read_is_current(session, plan, served.served_day_starts_ms)
+
+
+def test_rollup_snapshot_configures_repeatable_read(monkeypatch):
+    _set_enabled(monkeypatch, True)
+    calls = []
+
+    class SessionSpy:
+        def connection(self, **kwargs):
+            calls.append(kwargs)
+
+    configure_rollup_read_snapshot(SessionSpy(), "postgresql")
+
+    assert calls == [{"execution_options": {"isolation_level": "REPEATABLE READ"}}]

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -12,6 +12,8 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.dialects import mssql, mysql, postgresql
 
 from mlflow.entities import AssessmentSource, AssessmentSourceType, Feedback, trace_location
 from mlflow.entities.trace_info import TraceInfo
@@ -31,6 +33,7 @@ from mlflow.store.tracking.utils.sql_trace_rollups import (
     MAX_ROLLUP_DAYS,
     GroupingSet,
     RollupFamily,
+    _build_sql_grouped_span_cost_query,
     configure_rollup_read_snapshot,
     resolve_rollup_read,
     rollup_read_is_current,
@@ -139,6 +142,17 @@ def _seed(store) -> str:
 
 def _set_enabled(monkeypatch, enabled: bool):
     monkeypatch.setenv(MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "true" if enabled else "false")
+
+
+def _install_case_insensitive_binary_collation(store: SqlAlchemyStore):
+    def case_insensitive(left: str, right: str) -> int:
+        return (left.casefold() > right.casefold()) - (left.casefold() < right.casefold())
+
+    def install_case_insensitive_collation(dbapi_connection, _):
+        dbapi_connection.create_collation("BINARY", case_insensitive)
+
+    event.listen(store.engine, "connect", install_case_insensitive_collation)
+    store.engine.dispose()
 
 
 def _insert_trace_metric_rollup(
@@ -1125,7 +1139,7 @@ def test_span_raw_range_includes_fractional_nanoseconds_in_end_millisecond(
     ],
 )
 @pytest.mark.parametrize("time_interval", [DAILY_INTERVAL_SECONDS, None])
-def test_span_string_groupings_stay_on_raw_path(
+def test_span_string_groupings_are_served_from_rollups(
     store: SqlAlchemyStore, monkeypatch, grouping_set, dimensions, time_interval
 ):
     exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
@@ -1148,11 +1162,9 @@ def test_span_string_groupings_stay_on_raw_path(
         model_provider="test-provider" if grouping_set != GroupingSet.MODEL else None,
     )
 
-    # Python cannot reproduce the database's string grouping or ordering semantics. A rollup read
-    # could therefore split one raw SQL group or select a different max_results boundary.
-    _assert_enabled_equals_raw(
+    _set_enabled(monkeypatch, True)
+    served = _query(
         store,
-        monkeypatch,
         exp_id,
         MetricViewType.SPANS,
         SpanMetricKey.TOTAL_COST,
@@ -1160,6 +1172,230 @@ def test_span_string_groupings_stay_on_raw_path(
         dimensions,
         time_interval=time_interval,
     )
+
+    assert len(served) == 1
+    assert dict(served[0][1]) == {"SUM": float(SENTINEL_COUNT)}
+
+
+@pytest.mark.parametrize("time_interval", [DAILY_INTERVAL_SECONDS, None])
+def test_span_string_grouping_merges_rollup_and_raw_gap_in_sql(
+    store: SqlAlchemyStore, monkeypatch, time_interval
+):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    for day_start, cost in ((DAY_A_START, 0.75), (DAY_B_START, 1.25)):
+        _new_span_cost_trace(
+            store,
+            exp_id,
+            trace_time_ms=day_start + 5_000,
+            span_time_ms=day_start + 5_000,
+            total_cost=cost,
+        )
+    _insert_span_cost_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        SpanMetricKey.TOTAL_COST,
+        GroupingSet.MODEL_PROVIDER.value,
+        sample_count=1,
+        sum_value=0.75,
+        model_name="gpt-test",
+        model_provider="test-provider",
+    )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        [*_SUM, *_AVG],
+        [
+            SpanMetricDimensionKey.SPAN_MODEL_NAME,
+            SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+        ],
+        end=DAY_B_START + 10_000,
+        time_interval=time_interval,
+    )
+
+
+def test_span_string_grouping_uses_database_collation_across_contributions(
+    store: SqlAlchemyStore, monkeypatch
+):
+    if store.engine.dialect.name != "sqlite":
+        pytest.skip("The test installs a SQLite collation to emulate a case-insensitive backend")
+
+    # SQLite normally uses binary string comparison. Override it on every new connection to
+    # reproduce the case-insensitive grouping behavior common on MySQL and MSSQL.
+    _install_case_insensitive_binary_collation(store)
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    for day_start, model_name in ((DAY_A_START, "OpenAI"), (DAY_B_START, "openai")):
+        _new_span_cost_trace(
+            store,
+            exp_id,
+            trace_time_ms=day_start + 5_000,
+            span_time_ms=day_start + 5_000,
+            total_cost=1.0,
+            model_name=model_name,
+        )
+    _insert_span_cost_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        SpanMetricKey.TOTAL_COST,
+        GroupingSet.MODEL.value,
+        sample_count=1,
+        sum_value=1.0,
+        model_name="OpenAI",
+    )
+
+    _set_enabled(monkeypatch, False)
+    raw = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        [SpanMetricDimensionKey.SPAN_MODEL_NAME],
+        end=DAY_B_START + 10_000,
+        time_interval=None,
+    )
+    _set_enabled(monkeypatch, True)
+    served = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        [SpanMetricDimensionKey.SPAN_MODEL_NAME],
+        end=DAY_B_START + 10_000,
+        time_interval=None,
+    )
+
+    assert served == raw
+    assert len(served) == 1
+    assert dict(served[0][1]) == {"SUM": 2.0}
+
+
+def test_span_string_grouping_orders_and_limits_under_database_collation(
+    store: SqlAlchemyStore, monkeypatch
+):
+    if store.engine.dialect.name != "sqlite":
+        pytest.skip("The test installs a SQLite collation to emulate a case-insensitive backend")
+
+    _install_case_insensitive_binary_collation(store)
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    for model_name in ("alpha", "Zed"):
+        _new_span_cost_trace(
+            store,
+            exp_id,
+            trace_time_ms=DAY_A_START + 5_000,
+            span_time_ms=DAY_A_START + 5_000,
+            total_cost=1.0,
+            model_name=model_name,
+        )
+        _insert_span_cost_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            SpanMetricKey.TOTAL_COST,
+            GroupingSet.MODEL.value,
+            sample_count=1,
+            sum_value=1.0,
+            model_name=model_name,
+        )
+
+    query_args = (
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        [SpanMetricDimensionKey.SPAN_MODEL_NAME],
+    )
+    _set_enabled(monkeypatch, False)
+    raw = _query(*query_args, time_interval=None, max_results=1)
+    _set_enabled(monkeypatch, True)
+    served = _query(*query_args, time_interval=None, max_results=1)
+
+    assert served == raw
+    assert len(served) == 1
+
+
+def test_incomplete_span_string_rollup_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_span_cost_trace(
+        store,
+        exp_id,
+        trace_time_ms=DAY_A_START + 5_000,
+        span_time_ms=DAY_A_START + 5_000,
+        total_cost=0.75,
+    )
+    _insert_span_cost_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        SpanMetricKey.TOTAL_COST,
+        GroupingSet.MODEL.value,
+        sample_count=1,
+        sum_value=None,
+        model_name="gpt-test",
+    )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.SPANS,
+        SpanMetricKey.TOTAL_COST,
+        _SUM,
+        [SpanMetricDimensionKey.SPAN_MODEL_NAME],
+    )
+
+
+@pytest.mark.parametrize(
+    ("db_type", "dialect"),
+    [
+        ("postgresql", postgresql.dialect()),
+        ("mysql", mysql.dialect()),
+        ("mssql", mssql.dialect()),
+    ],
+)
+def test_span_string_grouping_sql_merges_before_order_and_limit(
+    store: SqlAlchemyStore, monkeypatch, db_type, dialect
+):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _set_enabled(monkeypatch, True)
+    plan = resolve_rollup_read(
+        view_type=MetricViewType.SPANS,
+        metric_name=SpanMetricKey.TOTAL_COST,
+        aggregations=_SUM,
+        dimensions=[SpanMetricDimensionKey.SPAN_MODEL_NAME],
+        filters=None,
+        time_interval_seconds=None,
+        start_time_ms=DAY_A_START,
+        end_time_ms=DAY_A_START + MS_PER_DAY - 1,
+        experiment_ids=[int(exp_id)],
+        db_type=db_type,
+    )
+
+    with store.ManagedSessionMaker() as session:
+        query, _ = _build_sql_grouped_span_cost_query(
+            session,
+            plan,
+            db_type,
+            raw_ranges=[],
+            served_day_starts=[DAY_A_START],
+            max_results=1,
+        )
+        statement = str(
+            query.statement.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+        )
+
+    assert "UNION ALL" in statement
+    outer_query = statement.rsplit(") AS span_cost_contributions", maxsplit=1)[1]
+    assert "GROUP BY" in outer_query
+    assert "ORDER BY" in outer_query
+    assert "span_model_name" in outer_query
 
 
 def test_scattered_raw_gaps_are_queried_once(store: SqlAlchemyStore, monkeypatch):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -232,11 +232,9 @@ def test_covered_bucketed_day_is_served_from_rollup(store: SqlAlchemyStore, monk
     assert served == [(raw[0][0], (("COUNT", float(SENTINEL_COUNT)),))]
 
 
-def test_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+def test_incomplete_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
     exp_id = _seed(store)
-    # Per-status breakdowns are not served from rollups yet: whole-day completeness of a multi-row
-    # grouping set is a maintenance-job guarantee, so a status request stays on the raw path and the
-    # seeded sentinel rows are ignored.
+    # A status breakdown without its global publication row is incomplete and must stay raw.
     for status in ("OK", "ERROR"):
         _insert_trace_metric_rollup(
             store,
@@ -255,6 +253,60 @@ def test_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
         TraceMetricKey.TRACE_COUNT,
         _COUNT,
         [TraceMetricDimensionKey.TRACE_STATUS],
+    )
+
+
+def test_complete_status_grouping_is_served_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT * 2,
+    )
+    for status in ("OK", "ERROR"):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.STATUS.value,
+            sample_count=SENTINEL_COUNT,
+            trace_status=status,
+        )
+
+    _set_enabled(monkeypatch, True)
+    served = _query(
+        store,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        [TraceMetricDimensionKey.TRACE_STATUS],
+    )
+
+    counts_by_status = {
+        dict(dimensions)[TraceMetricDimensionKey.TRACE_STATUS]: dict(values)["COUNT"]
+        for dimensions, values in served
+    }
+    assert counts_by_status == {"OK": float(SENTINEL_COUNT), "ERROR": float(SENTINEL_COUNT)}
+
+
+def test_duplicate_global_rollup_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    for _ in range(2):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.GLOBAL.value,
+            sample_count=SENTINEL_COUNT,
+        )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
     )
 
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -7,6 +7,7 @@
 # the sentinel, while a served query returns the sentinel, pinning down exactly when rollups are
 # consulted.
 
+import logging
 import uuid
 from datetime import datetime, timezone
 
@@ -712,6 +713,79 @@ def test_multi_experiment_request_falls_back_to_raw(store: SqlAlchemyStore, monk
     )
 
 
+@pytest.mark.parametrize(
+    "metric_name",
+    [
+        TraceMetricKey.INPUT_TOKENS,
+        TraceMetricKey.OUTPUT_TOKENS,
+        TraceMetricKey.TOTAL_TOKENS,
+        TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+    ],
+)
+@pytest.mark.parametrize("aggregations", [_SUM, _AVG])
+def test_token_sum_and_avg_stay_on_raw_path(
+    store: SqlAlchemyStore, monkeypatch, metric_name, aggregations
+):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        metric_name,
+        GroupingSet.GLOBAL.value,
+        sample_count=2,
+        sum_value=float(SENTINEL_COUNT),
+    )
+
+    # Token values are authoritative BIGINTs, but the current rollup sum is a float. The raw rows
+    # in this fixture are null, so consulting the sentinel rollup would incorrectly emit a point.
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        metric_name,
+        aggregations,
+        None,
+    )
+
+
+def test_debug_log_explains_planner_fallback(store: SqlAlchemyStore, monkeypatch, caplog):
+    exp_id = _seed(store)
+    _set_enabled(monkeypatch, True)
+
+    with caplog.at_level(logging.DEBUG, logger="mlflow.store.tracking.utils.sql_trace_rollups"):
+        _query(
+            store,
+            exp_id,
+            MetricViewType.TRACES,
+            TraceMetricKey.INPUT_TOKENS,
+            _SUM,
+            None,
+        )
+
+    assert "token SUM and AVG require the authoritative BIGINT values" in caplog.text
+
+
+def test_debug_log_summarizes_missing_coverage(store: SqlAlchemyStore, monkeypatch, caplog):
+    exp_id = _seed(store)
+    _set_enabled(monkeypatch, True)
+
+    with caplog.at_level(logging.DEBUG, logger="mlflow.store.tracking.utils.sql_trace_rollups"):
+        _query(
+            store,
+            exp_id,
+            MetricViewType.TRACES,
+            TraceMetricKey.TRACE_COUNT,
+            _COUNT,
+            None,
+        )
+
+    assert "1 candidate days" in caplog.text
+    assert "none of 1 candidate days has valid coverage" in caplog.text
+
+
 def test_rollup_for_other_experiment_is_ignored(store: SqlAlchemyStore, monkeypatch):
     exp_id = _seed(store)
     other_exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
@@ -953,6 +1027,56 @@ def test_span_cost_raw_ranges_use_span_start_time(store: SqlAlchemyStore, monkey
     assert dict(day_b[0][1]) == {"SUM": 0.75}
 
 
+@pytest.mark.parametrize(
+    ("metric_name", "aggregations", "value_label", "expected_value"),
+    [
+        (SpanMetricKey.SPAN_COUNT, _COUNT, "COUNT", 1.0),
+        (SpanMetricKey.LATENCY, _AVG, "AVG", 1.0),
+    ],
+)
+def test_span_count_and_latency_ranges_preserve_parent_trace_time(
+    store: SqlAlchemyStore,
+    monkeypatch,
+    metric_name,
+    aggregations,
+    value_label,
+    expected_value,
+):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_span_cost_trace(
+        store,
+        exp_id,
+        trace_time_ms=DAY_A_START + 5_000,
+        span_time_ms=DAY_B_START + 5_000,
+        total_cost=0.75,
+    )
+    _set_enabled(monkeypatch, False)
+
+    day_a = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        metric_name,
+        aggregations,
+        None,
+        start=DAY_A_START,
+        end=DAY_A_START + MS_PER_DAY - 1,
+    )
+    day_b = _query(
+        store,
+        exp_id,
+        MetricViewType.SPANS,
+        metric_name,
+        aggregations,
+        None,
+        start=DAY_B_START,
+        end=DAY_B_START + MS_PER_DAY - 1,
+    )
+
+    assert dict(day_a[0][1]) == {value_label: expected_value}
+    assert day_b == []
+
+
 def test_span_raw_range_includes_fractional_nanoseconds_in_end_millisecond(
     store: SqlAlchemyStore, monkeypatch
 ):
@@ -986,7 +1110,24 @@ def test_span_raw_range_includes_fractional_nanoseconds_in_end_millisecond(
     assert dict(result[0][1]) == {"SUM": 0.5}
 
 
-def test_span_cost_model_grouping_is_served_from_rollup(store: SqlAlchemyStore, monkeypatch):
+@pytest.mark.parametrize(
+    ("grouping_set", "dimensions"),
+    [
+        (GroupingSet.MODEL, [SpanMetricDimensionKey.SPAN_MODEL_NAME]),
+        (GroupingSet.PROVIDER, [SpanMetricDimensionKey.SPAN_MODEL_PROVIDER]),
+        (
+            GroupingSet.MODEL_PROVIDER,
+            [
+                SpanMetricDimensionKey.SPAN_MODEL_NAME,
+                SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            ],
+        ),
+    ],
+)
+@pytest.mark.parametrize("time_interval", [DAILY_INTERVAL_SECONDS, None])
+def test_span_string_groupings_stay_on_raw_path(
+    store: SqlAlchemyStore, monkeypatch, grouping_set, dimensions, time_interval
+):
     exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
     _new_span_cost_trace(
         store,
@@ -1000,24 +1141,25 @@ def test_span_cost_model_grouping_is_served_from_rollup(store: SqlAlchemyStore, 
         exp_id,
         DAY_A_START,
         SpanMetricKey.TOTAL_COST,
-        GroupingSet.MODEL.value,
+        grouping_set.value,
         sample_count=1,
         sum_value=float(SENTINEL_COUNT),
-        model_name="gpt-test",
+        model_name="gpt-test" if grouping_set != GroupingSet.PROVIDER else None,
+        model_provider="test-provider" if grouping_set != GroupingSet.MODEL else None,
     )
-    _set_enabled(monkeypatch, True)
 
-    served = _query(
+    # Python cannot reproduce the database's string grouping or ordering semantics. A rollup read
+    # could therefore split one raw SQL group or select a different max_results boundary.
+    _assert_enabled_equals_raw(
         store,
+        monkeypatch,
         exp_id,
         MetricViewType.SPANS,
         SpanMetricKey.TOTAL_COST,
         _SUM,
-        [SpanMetricDimensionKey.SPAN_MODEL_NAME],
+        dimensions,
+        time_interval=time_interval,
     )
-
-    assert dict(served[0][0])[SpanMetricDimensionKey.SPAN_MODEL_NAME] == "gpt-test"
-    assert dict(served[0][1]) == {"SUM": float(SENTINEL_COUNT)}
 
 
 def test_scattered_raw_gaps_are_queried_once(store: SqlAlchemyStore, monkeypatch):
@@ -1142,3 +1284,79 @@ def test_rollup_snapshot_configures_repeatable_read(monkeypatch):
     configure_rollup_read_snapshot(SessionSpy(), "postgresql")
 
     assert calls == [{"execution_options": {"isolation_level": "REPEATABLE READ"}}]
+
+
+def test_sqlite_rollup_snapshot_stays_stable_through_completed_rebuild(
+    store: SqlAlchemyStore, monkeypatch
+):
+    if store.engine.dialect.name != "sqlite":
+        pytest.skip("SQLite snapshot behavior is backend-specific")
+
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=2,
+    )
+    _set_enabled(monkeypatch, True)
+
+    # WAL allows the rebuild transaction to publish while the reader remains open, making this a
+    # deterministic reproduction of the invalidate/rebuild/queue-removal race.
+    with store.engine.connect() as connection:
+        journal_mode = connection.exec_driver_sql("PRAGMA journal_mode=WAL").scalar_one()
+    if journal_mode.lower() != "wal":
+        pytest.skip("SQLite WAL mode is unavailable")
+
+    rollup_filter = (
+        SqlTraceMetricDailyRollup.experiment_id == int(exp_id),
+        SqlTraceMetricDailyRollup.rollup_day == _day_of(DAY_A_START),
+        SqlTraceMetricDailyRollup.metric_name == TraceMetricKey.TRACE_COUNT,
+        SqlTraceMetricDailyRollup.grouping_set == GroupingSet.GLOBAL.value,
+    )
+    queue_filter = (
+        SqlTraceRollupRebuild.experiment_id == int(exp_id),
+        SqlTraceRollupRebuild.rollup_day == _day_of(DAY_A_START),
+        SqlTraceRollupRebuild.rollup_family == RollupFamily.TRACE_METRIC.value,
+    )
+
+    with store.ManagedSessionMaker() as reader:
+        configure_rollup_read_snapshot(reader, store.db_type)
+        assert reader.query(SqlTraceRollupRebuild).filter(*queue_filter).first() is None
+        assert (
+            reader.query(SqlTraceMetricDailyRollup).filter(*rollup_filter).one().sample_count == 2
+        )
+
+        with store.ManagedSessionMaker(read_only=False) as writer:
+            writer.add(
+                SqlTraceRollupRebuild(
+                    experiment_id=int(exp_id),
+                    rollup_day=_day_of(DAY_A_START),
+                    rollup_family=RollupFamily.TRACE_METRIC.value,
+                )
+            )
+            writer.flush()
+            writer.query(SqlTraceMetricDailyRollup).filter(*rollup_filter).update({
+                SqlTraceMetricDailyRollup.sample_count: SENTINEL_COUNT
+            })
+            writer.query(SqlTraceRollupRebuild).filter(*queue_filter).delete()
+            writer.commit()
+
+        # The queue is absent both before and after publication, but the rollup and any raw-gap
+        # reads remain on the same old snapshot rather than mixing old and newly committed state.
+        assert reader.query(SqlTraceRollupRebuild).filter(*queue_filter).first() is None
+        assert (
+            reader.query(SqlTraceMetricDailyRollup).filter(*rollup_filter).one().sample_count == 2
+        )
+
+    with store.ManagedSessionMaker() as current_reader:
+        assert (
+            current_reader
+            .query(SqlTraceMetricDailyRollup)
+            .filter(*rollup_filter)
+            .one()
+            .sample_count
+            == SENTINEL_COUNT
+        )

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -1,0 +1,616 @@
+# Read-path routing tests for opt-in SQL daily trace analytics rollups.
+#
+# Rollup rows are seeded directly through the ORM (the rollup build job lives elsewhere), so these
+# tests cover only what the query planner owns: routing an eligible request to the rollup tables and
+# falling back to the raw path for every ineligible case. Seeding by hand also lets a test store a
+# deliberately wrong ("sentinel") value: a query that falls back returns the raw result and ignores
+# the sentinel, while a served query returns the sentinel, pinning down exactly when rollups are
+# consulted.
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from mlflow.entities import AssessmentSource, AssessmentSourceType, Feedback, trace_location
+from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_metrics import AggregationType, MetricAggregation, MetricViewType
+from mlflow.entities.trace_state import TraceState
+from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
+from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
+)
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.store.tracking.utils.sql_trace_rollups import (
+    DAILY_INTERVAL_SECONDS,
+    GroupingSet,
+    RollupFamily,
+)
+from mlflow.tracing.constant import (
+    AssessmentMetricKey,
+    TraceMetricDimensionKey,
+    TraceMetricKey,
+    TraceTagKey,
+)
+
+pytestmark = pytest.mark.notrackingurimock
+
+MS_PER_DAY = 86_400_000
+# Two full UTC days, aligned to midnight so a whole-day request is exactly rollup-servable.
+DAY_A_START = 20_000 * MS_PER_DAY
+DAY_B_START = DAY_A_START + MS_PER_DAY
+DAY_A_RANGE = (DAY_A_START, DAY_A_START + MS_PER_DAY - 1)
+
+# A value no raw aggregate in these tests can produce, so it reveals whether a rollup was consulted.
+SENTINEL_COUNT = 987_654
+
+SOURCE = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="tester")
+
+_COUNT = [MetricAggregation(aggregation_type=AggregationType.COUNT)]
+_AVG = [MetricAggregation(aggregation_type=AggregationType.AVG)]
+_P50 = [MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=50)]
+
+
+def _day_of(timestamp_ms: int):
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).date()
+
+
+def _new_trace(store, exp_id, timestamp_ms, duration_ms=100, state=TraceState.OK):
+    trace_id = f"tr-{uuid.uuid4()}"
+    store.start_trace(
+        TraceInfo(
+            trace_id=trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=duration_ms,
+            state=state,
+            tags={TraceTagKey.TRACE_NAME: "rollup-test"},
+        )
+    )
+    return trace_id
+
+
+def _add_feedback(store, trace_id, value=0.5, name="quality"):
+    return store.create_assessment(
+        Feedback(trace_id=trace_id, name=name, value=value, source=SOURCE)
+    )
+
+
+def _seed(store) -> str:
+    """Two OK/ERROR traces on day A, plus one trace and feedback on day B, in a new experiment."""
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    t1 = _new_trace(store, exp_id, DAY_A_START + 5_000, duration_ms=100, state=TraceState.OK)
+    _new_trace(store, exp_id, DAY_A_START + 6_000, duration_ms=300, state=TraceState.ERROR)
+    t3 = _new_trace(store, exp_id, DAY_B_START + 7_000, duration_ms=500, state=TraceState.OK)
+    _add_feedback(store, t1, value=0.4)
+    _add_feedback(store, t3, value=0.9)
+    return exp_id
+
+
+def _set_enabled(monkeypatch, enabled: bool):
+    monkeypatch.setenv(MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "true" if enabled else "false")
+
+
+def _insert_trace_metric_rollup(
+    store,
+    exp_id,
+    day_start_ms,
+    metric_name,
+    grouping_set,
+    *,
+    sample_count,
+    sum_value=None,
+    trace_status=None,
+    p50_value=None,
+):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlTraceMetricDailyRollup(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                metric_name=metric_name,
+                grouping_set=grouping_set,
+                trace_status=trace_status,
+                sample_count=sample_count,
+                sum_value=sum_value,
+                p50_value=p50_value,
+            )
+        )
+        session.commit()
+
+
+def _insert_assessment_rollup(
+    store, exp_id, day_start_ms, metric_name, grouping_set, *, sample_count, sum_value=None
+):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlAssessmentDailyRollup(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                metric_name=metric_name,
+                grouping_set=grouping_set,
+                sample_count=sample_count,
+                sum_value=sum_value,
+            )
+        )
+        session.commit()
+
+
+def _invalidate_day(store, family, exp_id, day_start_ms):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlTraceRollupRebuild(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                rollup_family=family.value,
+            )
+        )
+        session.commit()
+
+
+def _normalize(points):
+    return sorted(
+        (
+            tuple(sorted((p.dimensions or {}).items())),
+            tuple(sorted((k, round(float(v), 6)) for k, v in p.values.items())),
+        )
+        for p in points
+    )
+
+
+def _query(
+    store,
+    exp_id,
+    view,
+    metric,
+    aggs,
+    dims,
+    *,
+    start=DAY_A_RANGE[0],
+    end=DAY_A_RANGE[1],
+    time_interval=DAILY_INTERVAL_SECONDS,
+    filters=None,
+    experiment_ids=None,
+):
+    return _normalize(
+        store.query_trace_metrics(
+            experiment_ids=experiment_ids or [exp_id],
+            view_type=view,
+            metric_name=metric,
+            aggregations=aggs,
+            dimensions=dims,
+            filters=filters,
+            time_interval_seconds=time_interval,
+            start_time_ms=start,
+            end_time_ms=end,
+        )
+    )
+
+
+def _raw_day_points(store, exp_id, view, metric, dims, day_start_ms):
+    """Raw single-day aggregate (no bucketing) used to seed correct rollup sample counts."""
+    return store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=view,
+        metric_name=metric,
+        aggregations=_COUNT,
+        dimensions=dims,
+        start_time_ms=day_start_ms,
+        end_time_ms=day_start_ms + MS_PER_DAY - 1,
+    )
+
+
+def _assert_enabled_equals_raw(
+    store, monkeypatch, exp_id, view, metric, aggs, dims, **query_kwargs
+):
+    _set_enabled(monkeypatch, False)
+    raw = _query(store, exp_id, view, metric, aggs, dims, **query_kwargs)
+    _set_enabled(monkeypatch, True)
+    fast = _query(store, exp_id, view, metric, aggs, dims, **query_kwargs)
+    assert raw == fast
+
+
+def test_covered_bucketed_day_is_served_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _set_enabled(monkeypatch, False)
+    raw = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None)
+    _set_enabled(monkeypatch, True)
+    served = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None)
+
+    # Same day bucket as raw, but the count comes from the rollup row rather than the raw scan.
+    assert [dims for dims, _ in served] == [dims for dims, _ in raw]
+    assert served == [(raw[0][0], (("COUNT", float(SENTINEL_COUNT)),))]
+
+
+def test_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # Per-status breakdowns are not served from rollups yet: whole-day completeness of a multi-row
+    # grouping set is a maintenance-job guarantee, so a status request stays on the raw path and the
+    # seeded sentinel rows are ignored.
+    for status in ("OK", "ERROR"):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.STATUS.value,
+            sample_count=SENTINEL_COUNT,
+            trace_status=status,
+        )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        [TraceMetricDimensionKey.TRACE_STATUS],
+    )
+
+
+def test_latency_avg_is_computed_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        sum_value=1000.0,
+    )
+    _set_enabled(monkeypatch, True)
+    served = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _AVG, None)
+
+    # AVG is derived from the stored sum and sample count: 1000 / 4.
+    assert served == [(served[0][0], (("AVG", 250.0),))]
+
+
+def test_assessment_value_avg_is_computed_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_assessment_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        AssessmentMetricKey.ASSESSMENT_VALUE,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        sum_value=2.0,
+    )
+    _set_enabled(monkeypatch, True)
+    served = _query(
+        store, exp_id, MetricViewType.ASSESSMENTS, AssessmentMetricKey.ASSESSMENT_VALUE, _AVG, None
+    )
+
+    # AVG is derived from the stored sum and sample count: 2.0 / 4.
+    assert served == [(served[0][0], (("AVG", 0.5),))]
+
+
+def test_latency_avg_falls_back_when_rollup_sum_is_null(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # A covered day whose AVG backing column is null must demote to the raw path, not divide by the
+    # sample count and raise.
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        sum_value=None,
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _AVG, None
+    )
+
+
+@pytest.mark.parametrize(
+    ("view", "metric"),
+    [
+        (MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT),
+        (MetricViewType.ASSESSMENTS, AssessmentMetricKey.ASSESSMENT_COUNT),
+    ],
+    ids=["trace_count global", "assessment_count global"],
+)
+def test_enabled_matches_raw_for_correct_count_rollups(
+    store: SqlAlchemyStore, monkeypatch, view, metric
+):
+    exp_id = _seed(store)
+    for day_start in (DAY_A_START, DAY_B_START):
+        for point in _raw_day_points(store, exp_id, view, metric, None, day_start):
+            sample_count = int(point.values["COUNT"])
+            if view == MetricViewType.ASSESSMENTS:
+                _insert_assessment_rollup(
+                    store,
+                    exp_id,
+                    day_start,
+                    metric,
+                    GroupingSet.GLOBAL.value,
+                    sample_count=sample_count,
+                )
+            else:
+                _insert_trace_metric_rollup(
+                    store,
+                    exp_id,
+                    day_start,
+                    metric,
+                    GroupingSet.GLOBAL.value,
+                    sample_count=sample_count,
+                )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        view,
+        metric,
+        _COUNT,
+        None,
+        start=DAY_A_START,
+        end=DAY_B_START + MS_PER_DAY - 1,
+    )
+
+
+def test_partial_edges_query_raw_around_covered_day(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    # Whole day A is covered; day B is only partially in range, so its edge stays on the raw path.
+    end = DAY_B_START + 10_000
+    _set_enabled(monkeypatch, False)
+    raw = _query(
+        store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None, end=end
+    )
+    _set_enabled(monkeypatch, True)
+    merged = _query(
+        store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None, end=end
+    )
+
+    raw_by_bucket = {dims: dict(vals)["COUNT"] for dims, vals in raw}
+    merged_by_bucket = {dims: dict(vals)["COUNT"] for dims, vals in merged}
+    assert set(merged_by_bucket) == set(raw_by_bucket)
+    day_a_bucket = min(raw_by_bucket)
+    day_b_bucket = max(raw_by_bucket)
+    assert merged_by_bucket[day_a_bucket] == float(SENTINEL_COUNT)
+    assert merged_by_bucket[day_b_bucket] == raw_by_bucket[day_b_bucket]
+
+
+def test_merged_result_matches_raw_with_correct_rollup_values(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # Seed day A's real count, then request a range covering day A fully and only part of day B so a
+    # rollup-served day and a raw edge must merge into a result identical to the raw path.
+    for point in _raw_day_points(
+        store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, None, DAY_A_START
+    ):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.GLOBAL.value,
+            sample_count=int(point.values["COUNT"]),
+        )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        end=DAY_B_START + 10_000,
+    )
+
+
+def test_disabled_ignores_rollups(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _set_enabled(monkeypatch, False)
+    result = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None)
+
+    assert dict(result[0][1])["COUNT"] == 2.0
+
+
+def test_invalidated_day_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _invalidate_day(store, RollupFamily.TRACE_METRIC, exp_id, DAY_A_START)
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
+    )
+
+
+def test_uncovered_day_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # A rollup exists for day B, but the request targets day A, which has none.
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_B_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
+    )
+
+
+def test_partial_day_only_range_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    # A range that never spans a full UTC day cannot use whole-day rollups.
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        start=DAY_A_START + 100,
+        end=DAY_A_START + MS_PER_DAY - 200,
+    )
+
+
+def test_non_daily_interval_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        time_interval=3_600,
+    )
+
+
+def test_filtered_request_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        filters=["trace.status = 'OK'"],
+    )
+
+
+def test_high_cardinality_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    # trace_name is not a materialized grouping set, so the request stays raw.
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        [TraceMetricDimensionKey.TRACE_NAME],
+    )
+
+
+def test_multi_experiment_request_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    other_exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        experiment_ids=[exp_id, other_exp_id],
+    )
+
+
+def test_rollup_for_other_experiment_is_ignored(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    other_exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    # Rollup rows are keyed by experiment id, so another experiment's row must never satisfy this
+    # experiment's request. This is what keeps rollups workspace-isolated: the caller only ever
+    # routes accessible experiment ids into the planner.
+    _insert_trace_metric_rollup(
+        store,
+        other_exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
+    )
+
+
+def test_percentiles_fall_back_to_raw_off_postgres(store: SqlAlchemyStore, monkeypatch):
+    if store.engine.dialect.name == "postgresql":
+        pytest.skip("percentiles are served from rollups on postgres")
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        p50_value=float(SENTINEL_COUNT),
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _P50, None
+    )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24877 (part of the RFC 0006 trace analytics series). This adds the read path on top of the schema, authoritative columns, and prepopulation utility already merged into `rfc-0006`.

### What changes are proposed in this pull request?

This PR adds the opt-in read path that serves eligible trace analytics queries from precomputed daily rollup tables while preserving the authoritative raw-query behavior.

- Adds the runtime gate `MLFLOW_SQL_TRACE_ROLLUPS_ENABLED` (default `false`). When disabled, every request uses the raw path.
- Routes supported single-experiment requests between rollup data for valid full UTC days and raw data for partial, uncovered, incomplete, or invalidated days.
- Supports daily and composable unbucketed aggregates for materialized trace, span-cost, and assessment shapes. This includes trace-status breakdowns and span-cost breakdowns by model, provider, or model/provider.
- Combines grouped span-cost rollup and raw-gap contributions in SQL, with the final `GROUP BY`, `ORDER BY`, and `LIMIT` applied by the database so backend collation semantics are preserved. Unbucketed averages are reconstructed from `SUM` and `COUNT` contributions.
- Falls back to the full raw path when the feature is disabled, the request is unsupported, no valid rollup coverage exists, coverage is too fragmented, or a concurrent invalidation makes a mixed read unsafe.
- Keeps filtered, multi-experiment, non-daily-bucket, unsupported-dimension, unsupported-percentile, and unbounded requests on the raw path. Token `SUM` and `AVG` also remain raw because their authoritative `BIGINT` values cannot be represented exactly by the current floating-point rollup sum column.
- Uses a stable read snapshot across coverage, rebuild-queue, rollup, and raw-gap statements, with SQLite and MSSQL safeguards for their transaction behavior.
- Removes non-foreign-keyed rollup and rebuild rows during permanent experiment deletion so a reused experiment ID cannot expose stale aggregates.

Populating or rebuilding rollup tables, enqueueing invalidations, registering a periodic task, implementing a scheduler, and handling `MLFLOW_TRACE_ROLLUPS_SCHEDULE` are intentionally out of scope and remain in the separate maintenance/scheduler ticket.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

The rollup routing tests cover:

- Feature-disabled behavior and supported-shape routing.
- Partial, uncovered, invalidated, incomplete, fragmented, and concurrently invalidated coverage.
- Daily and unbucketed merging, including average reconstruction.
- Trace status and span model/provider grouping completeness.
- Database-collated grouped SQL merging, global ordering, and limiting.
- Raw/rollup timestamp parity, inclusive nanosecond boundaries, and exact token fallback.
- Workspace isolation, cross-experiment isolation, hard-delete cleanup, and stable read snapshots.
- PostgreSQL/MySQL/MSSQL SQL compilation plus SQLite execution.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

Documented the feature and `MLFLOW_SQL_TRACE_ROLLUPS_ENABLED` in the backend store guide.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds an opt-in setting (`MLFLOW_SQL_TRACE_ROLLUPS_ENABLED`) that accelerates supported trace analytics queries with precomputed SQL daily rollups and safely uses authoritative raw data wherever valid rollup coverage is unavailable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
