### PR TITLE
[UI] Only render http(s) URLs for git run sources

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.test.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.test.tsx
@@ -994,6 +994,24 @@ test('renderNotebookSource renders plain text for dangerous workspaceUrl', () =>
   /* eslint-enable no-script-url */
 });
 
+test('getGitRepoUrl rejects a non-http(s) source', () => {
+  expect(Utils.getGitRepoUrl('git@github.com:mlflow/mlflow.git')).toEqual('https://github.com/mlflow/mlflow');
+
+  /* eslint-disable no-script-url */
+  expect(Utils.getGitRepoUrl('javascript:alert(document.domain)//git/a')).toBeNull();
+  /* eslint-enable no-script-url */
+});
+
+test('getGitCommitUrl rejects a non-http(s) source', () => {
+  expect(Utils.getGitCommitUrl('git@github.com:mlflow/mlflow.git', 'abc123')).toEqual(
+    'https://github.com/mlflow/mlflow/tree/abc123/',
+  );
+
+  /* eslint-disable no-script-url */
+  expect(Utils.getGitCommitUrl('javascript:alert(document.domain)//git/a', 'abc123')).toBeNull();
+  /* eslint-enable no-script-url */
+});
+
 describe('logErrorAndNotifyUser', () => {
   let mockNotificationsApi: { error: ReturnType<typeof jest.fn> };
 

--- a/mlflow/server/js/src/common/utils/Utils.tsx
+++ b/mlflow/server/js/src/common/utils/Utils.tsx
@@ -321,7 +321,7 @@ class Utils {
         url += `/tree/${branchName}/${fileDir}`;
       }
     }
-    return url;
+    return Utils.isValidHttpUrl(url) ? url : null;
   }
 
   static getGitCommitUrl(sourceName: any, sourceVersion: any) {
@@ -346,7 +346,7 @@ class Utils {
       const [, baseUrl, repoDir, fileDir] = gitMatch;
       url = `${baseUrl.replace(/git@/, 'https://')}/${repoDir.replace(/.git/, '')}/tree/${sourceVersion}/${fileDir}`;
     }
-    return url;
+    return Utils.isValidHttpUrl(url) ? url : null;
   }
 
   static getQueryParams = () => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to a privately reported security advisory (GHSA-wh45-9mhw-v9x3, reported by [turingpoint](https://www.turingpoint.de), unpublished at time of writing).

### What changes are proposed in this pull request?

`Utils.getGitRepoUrl` and `Utils.getGitCommitUrl` (`mlflow/server/js/src/common/utils/Utils.tsx`) build a link from a run's source name. The generic git branch keeps the original scheme (only `git@` is rewritten to `https://`), so a source name whose scheme is not `http` or `https` is returned unchanged and then placed into an `<a href>` by `renderSource` and `renderSourceVersion`. This PR gates both return values through `Utils.isValidHttpUrl`, so a non-http(s) source renders as plain text instead of a link. The notebook and job source URL builders in the same file (`getNotebookSourceUrl`, `getJobSourceUrl`) already apply this guard; this brings the git source builders in line.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New cases in `Utils.test.tsx` cover `getGitRepoUrl` and `getGitCommitUrl`: a normal `git@github.com:...` source still returns its `https://github.com/...` URL, and a non-http(s) source returns `null`. The full CRA/jest suite was not run in this environment; the added cases mirror the existing `getNotebookSourceUrl`/`getJobSourceUrl` guard tests.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Git run source links in the tracking UI are rendered only when the source resolves to an http(s) URL.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release