### PR TITLE
[ui] Open v4 traces from legacy trace links

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.test.tsx
@@ -61,6 +61,16 @@ describe('useTracesV4UrlState', () => {
     expect(result.current.traceId).toBe('tr-1');
   });
 
+  test('reads legacy selectedEvaluationId as the active trace for old deep links', async () => {
+    const { result } = await mountHook('/p?selectedEvaluationId=trace%3A%2Fcat.sch%2Fabc123');
+    expect(result.current.traceId).toBe('trace:/cat.sch/abc123');
+  });
+
+  test('reads selectedTraceId as the active trace for session links', async () => {
+    const { result } = await mountHook('/p?selectedTraceId=tr-session');
+    expect(result.current.traceId).toBe('tr-session');
+  });
+
   test('defaults: page 1, pageSize 25, start_time DESC, no traceId', async () => {
     const { result } = await mountHook('/p');
     expect(result.current.pageIndex).toBe(1);
@@ -113,10 +123,12 @@ describe('useTracesV4UrlState', () => {
     expect(param('dir')).toBeNull();
   });
 
-  test('setTraceId writes and clears the traceId param without touching page', async () => {
-    const { result } = await mountHook('/p?page=3');
+  test('setTraceId writes traceId, clears legacy trace params, and does not touch page', async () => {
+    const { result } = await mountHook('/p?page=3&selectedEvaluationId=tr-old&selectedTraceId=tr-session');
     act(() => result.current.setTraceId('tr-abc'));
     expect(param('traceId')).toBe('tr-abc');
+    expect(param('selectedEvaluationId')).toBeNull();
+    expect(param('selectedTraceId')).toBeNull();
     expect(param('page')).toBe('3'); // opening the drawer must not reset pagination
 
     act(() => result.current.setTraceId(undefined));

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.ts
@@ -19,6 +19,8 @@ const PAGE_SIZE_PARAM = 'pageSize';
 const SORT_PARAM = 'sort';
 const DIR_PARAM = 'dir';
 const TRACE_ID_PARAM = 'traceId';
+const SELECTED_TRACE_ID_PARAM = 'selectedTraceId';
+const LEGACY_SELECTED_EVALUATION_ID_PARAM = 'selectedEvaluationId';
 // Repeatable param (like v3's `filter`): each value is `encodeURIComponent(key)=encodeURIComponent(value)`.
 const TAG_PARAM = 'tag';
 
@@ -99,7 +101,11 @@ export const useTracesV4UrlState = (): TracesV4UrlState => {
   const pageSizeRaw = searchParams.get(PAGE_SIZE_PARAM);
   const sortRaw = searchParams.get(SORT_PARAM);
   const dirRaw = searchParams.get(DIR_PARAM);
-  const traceId = searchParams.get(TRACE_ID_PARAM) ?? undefined;
+  const traceId =
+    searchParams.get(TRACE_ID_PARAM) ??
+    searchParams.get(SELECTED_TRACE_ID_PARAM) ??
+    searchParams.get(LEGACY_SELECTED_EVALUATION_ID_PARAM) ??
+    undefined;
   // getAll → the repeatable `tag` values.
   const tagFilters = searchParams
     .getAll(TAG_PARAM)
@@ -166,6 +172,8 @@ export const useTracesV4UrlState = (): TracesV4UrlState => {
         } else {
           params.delete(TRACE_ID_PARAM);
         }
+        params.delete(SELECTED_TRACE_ID_PARAM);
+        params.delete(LEGACY_SELECTED_EVALUATION_ID_PARAM);
         return params;
       });
     },

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
@@ -37,7 +37,9 @@ describe('tracesV4SavedViewState tag-key helpers', () => {
 describe('captureV4ViewState', () => {
   test('captures the whitelisted URL view params and drops the transient ones', () => {
     const state = captureV4ViewState(
-      params('q=refund&sort=duration&dir=asc&pageSize=50&page=3&traceId=abc123&startTimeLabel=LAST_7_DAYS'),
+      params(
+        'q=refund&sort=duration&dir=asc&pageSize=50&page=3&traceId=abc123&selectedTraceId=def456&selectedEvaluationId=ghi789&startTimeLabel=LAST_7_DAYS',
+      ),
       ['start_time', 'input', 'duration'],
     );
     const query = buildV4ViewQuery(state, 'view-1');
@@ -51,6 +53,8 @@ describe('captureV4ViewState', () => {
     // Transient state is never part of a saved view.
     expect(out.get('page')).toBeNull();
     expect(out.get('traceId')).toBeNull();
+    expect(out.get('selectedTraceId')).toBeNull();
+    expect(out.get('selectedEvaluationId')).toBeNull();
   });
 
   test('preserves repeatable tag filters in order', () => {
@@ -97,7 +101,9 @@ describe('urlHasCapturedV4ViewState', () => {
     expect(urlHasCapturedV4ViewState(params(`${TRACE_V4_SHARE_URL_PARAM_KEY}=x`))).toBe(false);
     expect(urlHasCapturedV4ViewState(params(''))).toBe(false);
     // Transient params alone are not view state.
-    expect(urlHasCapturedV4ViewState(params('page=2&traceId=abc'))).toBe(false);
+    expect(urlHasCapturedV4ViewState(params('page=2&traceId=abc&selectedTraceId=def&selectedEvaluationId=ghi'))).toBe(
+      false,
+    );
   });
 });
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to evaluation-runs v4 traces table navigation regression.

### What changes are proposed in this pull request?

The v4 traces tab only treated `traceId` as the URL parameter that opens the trace drawer. Some existing entry points still deep-link with older parameters: evaluation/review flows use `selectedEvaluationId`, and session links use `selectedTraceId`. On v4, those URLs navigated to the Traces tab but left the drawer closed, so users coming from evaluation runs could not open the trace they selected.

This PR updates the v4 traces URL state to treat `traceId`, `selectedTraceId`, and legacy `selectedEvaluationId` as equivalent read sources for the active trace. New v4 interactions continue writing `traceId`, and those writes clear the legacy params so stale selected traces do not persist after the user closes or changes the drawer.

It also extends regression coverage for:

- legacy `selectedEvaluationId` deep links opening a v4 trace
- `selectedTraceId` session links opening a v4 trace
- clearing legacy params when v4 writes the selected trace
- saved-view capture not treating trace-selection params as persistent view state

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Manual/static verification performed locally:

- `git diff --check`
- pre-commit `check-mlflow-ui` passed during commit
- pre-commit `check-component-ids` passed during commit

I could not run the targeted Jest file or start the local JS dev server in this worktree because the environment cannot reach `https://registry.yarnpkg.com` and the fresh worktree has no existing `node_modules` install state. `curl -I --connect-timeout 5 https://registry.yarnpkg.com/react` fails with `Couldn’t connect to server`; `yarn test ...useTracesV4UrlState.test.tsx --runInBand` initially failed before install with missing Yarn node_modules state. Local commit skipped only `pyproject` (it rewrote unrelated `uv.lock` churn) and `js-fmt` (`npx >= 11.10.0` required, local `npx` is 11.9.0).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes v4 traces tab deep links from evaluation and session flows so the selected trace opens instead of only navigating to the Traces tab.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
