### PR TITLE
Support UC model services in built-in judges

### DIFF
--- a/mlflow/gateway/providers/databricks.py
+++ b/mlflow/gateway/providers/databricks.py
@@ -10,7 +10,11 @@ from mlflow.gateway.providers.openai_compatible import (
 )
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat
-from mlflow.gateway.utils import normalize_databricks_base_url
+from mlflow.gateway.utils import (
+    _DATABRICKS_AI_GATEWAY_PATH,
+    _is_unity_catalog_model_name,
+    normalize_databricks_base_url,
+)
 
 _SUPPORTED_CONTENT_PART_TYPES = {"text", "image_url", "input_audio"}
 _GEMINI_ACTIONS = {
@@ -113,6 +117,9 @@ class DatabricksProvider(OpenAICompatibleProvider):
     def _api_base(self) -> str:
         client = self._get_workspace_client()
         host = client.config.host.rstrip("/")
+        model_name = self.config.model.name
+        if _is_unity_catalog_model_name(model_name):
+            return f"{host}/{_DATABRICKS_AI_GATEWAY_PATH}"
         return normalize_databricks_base_url(host)
 
     def get_endpoint_url(self, route_type: str) -> str:

--- a/mlflow/gateway/utils.py
+++ b/mlflow/gateway/utils.py
@@ -19,6 +19,20 @@ _logger = logging.getLogger(__name__)
 _gateway_uri: str | None = None
 
 DATABRICKS_SERVING_ENDPOINTS_PATH = "/serving-endpoints"
+_DATABRICKS_AI_GATEWAY_PATH = "ai-gateway/mlflow/v1"
+
+
+def _is_unity_catalog_model_name(model_name: str) -> bool:
+    """Whether a Databricks model name is a Unity Catalog FQN (three-level, served via AI Gateway).
+
+    Unity Catalog names follow ``<catalog>.<schema>.<model>`` (e.g. ``system.ai.claude-haiku-4-5``)
+    and contain at least two dots. Serving endpoint names are restricted to ``[a-zA-Z0-9_-]+`` and
+    cannot contain dots, so this shape check reliably distinguishes the two surfaces.
+
+    Requiring two separators keeps a one-dot name from being silently misrouted; such a name is
+    also invalid as a serving endpoint, so the legacy path will produce a clearer error.
+    """
+    return model_name.count(".") >= 2
 
 
 def normalize_databricks_base_url(base_url: str | None) -> str | None:

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -10,6 +10,7 @@ from mlflow import __version__ as VERSION
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
+from mlflow.gateway.utils import _DATABRICKS_AI_GATEWAY_PATH, _is_unity_catalog_model_name
 from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
     call_chat_completions,
 )
@@ -41,10 +42,9 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-# OpenAI-compatible base paths for the two Databricks model surfaces. See
-# _get_databricks_api_base_key for how a model is routed to one or the other.
+# OpenAI-compatible base path for Databricks model serving endpoints.
 _DATABRICKS_SERVING_ENDPOINTS_PATH = "serving-endpoints"
-_DATABRICKS_AI_GATEWAY_PATH = "ai-gateway/mlflow/v1"
+# _DATABRICKS_AI_GATEWAY_PATH and _is_unity_catalog_model_name imported from mlflow.gateway.utils
 
 
 @contextmanager
@@ -135,25 +135,6 @@ def construct_dspy_lm(model: str):
         if api_base:
             return dspy.LM(model=model_litellm, api_base=api_base, api_key=api_key)
         return dspy.LM(model=model_litellm)
-
-
-def _is_unity_catalog_model_name(model_name: str) -> bool:
-    """
-    Whether a Databricks model name is a Unity Catalog name (and thus served via AI Gateway).
-
-    Unity Catalog model names are three-level (``<catalog>.<schema>.<model>``, e.g.
-    ``system.ai.claude-haiku-4-5``), so they contain at least two ``.`` separators. Databricks
-    serving endpoint names, by contrast, are restricted to ``^[a-zA-Z0-9_-]+$`` and cannot
-    contain ``.`` at all (see the ``name`` field in the create-serving-endpoint API reference:
-    https://docs.databricks.com/api/workspace/servingendpoints/create), so this shape check
-    reliably distinguishes the two surfaces.
-
-    Requiring two separators (rather than just any ``.``) keeps a one-dot name from being
-    misrouted to the AI Gateway. Such a name cannot be a valid serving endpoint either, but
-    leaving it on the legacy path yields a clearer "endpoint not found" error than a malformed
-    gateway URL.
-    """
-    return model_name.count(".") >= 2
 
 
 def _get_api_base_key(model: str) -> tuple[str | None, str | None]:

--- a/tests/gateway/providers/test_databricks.py
+++ b/tests/gateway/providers/test_databricks.py
@@ -22,13 +22,17 @@ def _mock_workspace_client(host="https://my-workspace.databricks.com"):
     return client
 
 
-def _make_provider(*, host: str = "https://my-workspace.databricks.com") -> DatabricksProvider:
+def _make_provider(
+    *,
+    host: str = "https://my-workspace.databricks.com",
+    model_name: str = "databricks-dbrx-instruct",
+) -> DatabricksProvider:
     endpoint_config = EndpointConfig(
         name="databricks-endpoint",
         endpoint_type="llm/v1/chat",
         model={
             "provider": "databricks",
-            "name": "databricks-dbrx-instruct",
+            "name": model_name,
             "config": {"host": host, "token": "dapi-test-key"},
         },
     )
@@ -72,6 +76,37 @@ def _embeddings_response():
 def test_api_base_normalization():
     provider = _make_provider(host="https://my-workspace.databricks.com")
     assert provider._api_base == "https://my-workspace.databricks.com/serving-endpoints"
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_base"),
+    [
+        # Serving endpoint names (simple, no dots) → /serving-endpoints
+        ("databricks-dbrx-instruct", "https://my-workspace.databricks.com/serving-endpoints"),
+        ("my-custom-endpoint", "https://my-workspace.databricks.com/serving-endpoints"),
+        # UC model service FQNs (three-level) → /ai-gateway/mlflow/v1
+        (
+            "catalog_ml.schema_ml.my-opus5",
+            "https://my-workspace.databricks.com/ai-gateway/mlflow/v1",
+        ),
+        ("system.ai.claude-haiku-4-5", "https://my-workspace.databricks.com/ai-gateway/mlflow/v1"),
+        (
+            "my_catalog.my_schema.my_model",
+            "https://my-workspace.databricks.com/ai-gateway/mlflow/v1",
+        ),
+    ],
+)
+def test_api_base_routes_uc_model_to_ai_gateway(model_name, expected_base):
+    provider = _make_provider(model_name=model_name)
+    assert provider._api_base == expected_base
+
+
+def test_get_endpoint_url_uc_model():
+    provider = _make_provider(model_name="catalog.schema.my-model")
+    assert (
+        provider.get_endpoint_url("llm/v1/chat")
+        == "https://my-workspace.databricks.com/ai-gateway/mlflow/v1/chat/completions"
+    )
 
 
 def test_headers_from_sdk():

--- a/tests/gateway/test_utils.py
+++ b/tests/gateway/test_utils.py
@@ -5,6 +5,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.utils import (
     SearchRoutesToken,
+    _is_unity_catalog_model_name,
     _is_valid_uri,
     assemble_uri_path,
     check_configuration_route_name_collisions,
@@ -65,6 +66,25 @@ def test_resolve_route_url_qualified_url_ignores_base(base_url):
 )
 def test_is_valid_endpoint_name(name, expected):
     assert is_valid_endpoint_name(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        # UC FQNs (three-level: catalog.schema.model)
+        ("system.ai.claude-haiku-4-5", True),
+        ("catalog_ml.schema_ml.my-opus5", True),
+        ("my_catalog.my_schema.my_model", True),
+        # Serving endpoint names (no dots allowed by Databricks API)
+        ("databricks-dbrx-instruct", False),
+        ("my-custom-endpoint", False),
+        ("endpoint_name", False),
+        # One-dot names are not valid UC FQNs; route to legacy path for clearer error
+        ("catalog.model", False),
+    ],
+)
+def test_is_unity_catalog_model_name(model_name, expected):
+    assert _is_unity_catalog_model_name(model_name) == expected
 
 
 def test_check_configuration_route_name_collisions():


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://databricks.slack.com/archives/C083A8HQC6N/p1787155165975739

### What changes are proposed in this pull request?

Built-in judges (e.g. `Safety`, `Correctness`) accept a `model=` parameter to override the judge model. Today the `databricks` provider always routes requests to `/serving-endpoints/<name>/invocations`, which only resolves workspace serving endpoint names. Unity Catalog model services use a three-level FQN (`<catalog>.<schema>.<model>`) and must be routed through the AI Gateway at `/ai-gateway/mlflow/v1`.

This PR wires in that routing:

- Add `_is_unity_catalog_model_name` and `_DATABRICKS_AI_GATEWAY_PATH` to `mlflow/gateway/utils.py` as the canonical shared definitions. A model name with two or more dots is a UC FQN; serving endpoint names are restricted to `[a-zA-Z0-9_-]+` and cannot contain dots, so the shape check is reliable.
- Update `DatabricksProvider._api_base` to inspect `self.config.model.name` and select `/ai-gateway/mlflow/v1` for UC FQNs, falling back to `/serving-endpoints` for plain endpoint names. `get_endpoint_url("llm/v1/chat")` therefore returns the correct full URL without any call-site changes.
- Remove the duplicate `_is_unity_catalog_model_name` definition from `dspy_utils.py` (where the same logic already existed for the DSPy optimizer path) and import from `gateway/utils.py` instead.

After this change, the following just works:

```python
from mlflow.genai.judges import Safety

# Routes to https://<host>/ai-gateway/mlflow/v1/chat/completions
result = Safety(model="databricks:/catalog_ml.schema_ml.my-opus5").eval(...)
```

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

New parametrized tests in `tests/gateway/providers/test_databricks.py`:
- `test_api_base_routes_uc_model_to_ai_gateway` — verifies `_api_base` resolves to `/ai-gateway/mlflow/v1` for three-level FQNs and `/serving-endpoints` for plain names.
- `test_get_endpoint_url_uc_model` — verifies the full chat completions URL for a UC model.

New parametrized test in `tests/gateway/test_utils.py`:
- `test_is_unity_catalog_model_name` — covers UC FQNs, serving endpoint names, and the one-dot edge case.

### Does this PR require documentation update?

- [ ] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow built-in judges now accept Unity Catalog model service FQNs (e.g. `databricks:/catalog.schema.my-model`) in the `model=` parameter. Requests are automatically routed to the AI Gateway (`/ai-gateway/mlflow/v1`) instead of the legacy serving-endpoints path.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release