### PR TITLE
Point coding agents at the MLflow tracing skill on `import mlflow`

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -448,3 +448,11 @@ with contextlib.suppress(Exception):
 from mlflow.telemetry import set_telemetry_client
 
 set_telemetry_client()
+
+# Point coding agents at the MLflow tracing skill. No-op unless a coding agent is
+# driving this process. `mlflow.agent` does not ship in the mlflow-tracing package.
+if not IS_TRACING_SDK_ONLY:
+    with contextlib.suppress(Exception):
+        from mlflow.agent.hint import maybe_hint_tracing_skill
+
+        maybe_hint_tracing_skill()

--- a/mlflow/agent/agents.py
+++ b/mlflow/agent/agents.py
@@ -20,8 +20,6 @@ class AgentTool:
     binary: str
     # Repo-relative directory where this agent reads SKILL.md from.
     skills_dir: str
-    # Home-relative directory where this agent reads user-global SKILL.md from.
-    global_skills_dir: str
     # Args inserted between the binary and the prompt at launch.
     interactive_args: tuple[str, ...] = ()
 
@@ -35,21 +33,18 @@ AGENTS: dict[AgentName, AgentTool] = {
         display_name="Claude Code",
         binary="claude",
         skills_dir=".claude/skills",
-        global_skills_dir=".claude/skills",
     ),
     "codex": AgentTool(
         name="codex",
         display_name="OpenAI Codex",
         binary="codex",
         skills_dir=".agents/skills",
-        global_skills_dir=".codex/skills",
     ),
     "opencode": AgentTool(
         name="opencode",
         display_name="OpenCode",
         binary="opencode",
         skills_dir=".agents/skills",
-        global_skills_dir=".config/opencode/skills",
         interactive_args=("--prompt",),
     ),
 }

--- a/mlflow/agent/agents.py
+++ b/mlflow/agent/agents.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import shutil
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 AgentName = Literal["claude", "codex", "opencode"]
@@ -20,11 +21,19 @@ class AgentTool:
     binary: str
     # Repo-relative directory where this agent reads SKILL.md from.
     skills_dir: str
+    # Home-relative directory where this agent reads user-global SKILL.md from.
+    global_skills_dir: str
     # Args inserted between the binary and the prompt at launch.
     interactive_args: tuple[str, ...] = ()
 
     def is_installed(self) -> bool:
         return shutil.which(self.binary) is not None
+
+    def project_skill_dirs(self, repo_root: Path) -> tuple[Path, ...]:
+        """Project-level directories this agent loads skills from."""
+        # Two layouts: what the agent reads natively, and what `mlflow agent
+        # setup`'s assistant flow writes. They differ for Codex.
+        return (repo_root / self.skills_dir, repo_root / self.global_skills_dir)
 
 
 AGENTS: dict[AgentName, AgentTool] = {
@@ -33,18 +42,21 @@ AGENTS: dict[AgentName, AgentTool] = {
         display_name="Claude Code",
         binary="claude",
         skills_dir=".claude/skills",
+        global_skills_dir=".claude/skills",
     ),
     "codex": AgentTool(
         name="codex",
         display_name="OpenAI Codex",
         binary="codex",
         skills_dir=".agents/skills",
+        global_skills_dir=".codex/skills",
     ),
     "opencode": AgentTool(
         name="opencode",
         display_name="OpenCode",
         binary="opencode",
         skills_dir=".agents/skills",
+        global_skills_dir=".config/opencode/skills",
         interactive_args=("--prompt",),
     ),
 }

--- a/mlflow/agent/agents.py
+++ b/mlflow/agent/agents.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import shutil
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
 
 AgentName = Literal["claude", "codex", "opencode"]
@@ -28,12 +27,6 @@ class AgentTool:
 
     def is_installed(self) -> bool:
         return shutil.which(self.binary) is not None
-
-    def project_skill_dirs(self, repo_root: Path) -> tuple[Path, ...]:
-        """Project-level directories this agent loads skills from."""
-        # Two layouts: what the agent reads natively, and what `mlflow agent
-        # setup`'s assistant flow writes. They differ for Codex.
-        return (repo_root / self.skills_dir, repo_root / self.global_skills_dir)
 
 
 AGENTS: dict[AgentName, AgentTool] = {

--- a/mlflow/agent/hint.py
+++ b/mlflow/agent/hint.py
@@ -1,0 +1,165 @@
+"""An agent-directed pointer to the MLflow tracing skill.
+
+Emitted on ``import mlflow`` when a coding agent is driving and the skill is not
+installed where that agent would find it. Without it, agents design tracing from
+scratch and produce traces with blank tool inputs and outputs.
+
+Fires once per process; ``MLFLOW_DISABLE_AGENT_HINT=1`` silences it for good.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from importlib import resources
+from pathlib import Path
+
+from mlflow.agent.agents import AGENTS
+from mlflow.environment_variables import MLFLOW_DISABLE_AGENT_HINT
+
+_logger = logging.getLogger(__name__)
+
+# Environment variables coding agents export into the processes they spawn.
+# Any one being set means an agent is driving, whatever `mlflow agent setup`
+# happens to support. `AI_AGENT` and `AGENT` are the emerging cross-agent
+# conventions; the rest are agent-specific and confirmed in each tool's source.
+# The marker set below tracks Vercel's cross-agent registry:
+# https://github.com/vercel/detect-agent/blob/3ab1df1e4eaae153cf66f4a5018e4c5854855212/agents.json
+#
+# Deliberately excluded: variables a human exports as configuration rather than
+# ones an agent injects (COPILOT_MODEL, COPILOT_GITHUB_TOKEN, AIDER_*,
+# GOOSE_PROVIDER), and variables set for every shell in an environment whether
+# or not an agent is driving (REPL_ID, CURSOR_TRACE_ID, CI, GITHUB_ACTIONS).
+_AGENT_ENV_MARKERS = (
+    "AGENT",  # Goose, Amp, and other adopters of the convention
+    "AI_AGENT",
+    "AMP_CURRENT_THREAD_ID",
+    "ANTIGRAVITY_AGENT",
+    "AUGMENT_AGENT",
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CLINE_ACTIVE",
+    "CLINE_AGENT",
+    "CODEX_SANDBOX",  # sandboxed runs only
+    "CODEX_THREAD_ID",  # every run, sandboxed or not
+    "CURSOR_AGENT",
+    "GEMINI_CLI",
+    "GROK_PLUGIN_ROOT",
+    "JUNIE_DATA",
+    "KIMI_PLUGIN_ROOT",
+    "OPENCLAW_SHELL",
+    "OPENCODE",
+    "PI_CODING_AGENT",
+    "QWEN_CODE",
+    "ROO_ACTIVE",
+    "TRAE_AI_SHELL_ID",
+)
+
+# Markers that identify an agent only at a particular value.
+_AGENT_ENV_VALUES = {"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}
+
+# Kiro sets this in its own IDE terminal too, so it only means "agent" when
+# nothing is attached to stdout, as a human terminal always is.
+_AGENT_ENV_VALUES_WITHOUT_TTY = {"TERM_PROGRAM": "kiro"}
+
+# The skill that teaches supported autologging and span input/output recording.
+# Lives in https://github.com/mlflow/skills and is installed by `mlflow agent setup`.
+TRACING_SKILL = "instrumenting-with-mlflow-tracing"
+
+# Points at the copy shipped inside this MLflow install: no network, and the
+# revision always matches the installed code.
+#
+# Kept to a single line. Agents habitually append `| tail -3` or `| head -5` to
+# the commands they run, and a multi-line message loses its actionable half to
+# the pipe -- silently, since the surviving fragment still reads like a log line.
+_HINT = (
+    "Load the `{skill}` skill at {path} before writing any tracing code; it ships with this "
+    "MLflow install. Set MLFLOW_DISABLE_AGENT_HINT=1 to silence this."
+)
+
+
+def _bundled_skill_manifest() -> Path | None:
+    """Path to the skill shipped with this install, or ``None`` when absent.
+
+    Released packages bundle it; a source checkout without the
+    ``mlflow/assistant/skills`` submodule does not.
+    """
+    # Imported lazily: `mlflow.assistant` pulls in pydantic config models that
+    # `import mlflow` does not otherwise load, and only a detected agent needs them.
+    from mlflow.assistant.skill_installer import SKILL_MANIFEST_FILE, SKILLS_PACKAGE
+
+    try:
+        # Chained joinpath: importlib's MultiplexedPath takes a single segment.
+        manifest = (
+            resources.files(SKILLS_PACKAGE).joinpath(TRACING_SKILL).joinpath(SKILL_MANIFEST_FILE)
+        )
+        return Path(str(manifest)) if manifest.is_file() else None
+    except (ModuleNotFoundError, OSError):
+        return None
+
+
+def _is_agent_driving() -> bool:
+    """Whether a coding agent is running this process."""
+    if any(os.environ.get(marker) for marker in _AGENT_ENV_MARKERS):
+        return True
+    if any(os.environ.get(name) == value for name, value in _AGENT_ENV_VALUES.items()):
+        return True
+    if sys.stdout.isatty():
+        return False
+    return any(
+        os.environ.get(name) == value for name, value in _AGENT_ENV_VALUES_WITHOUT_TTY.items()
+    )
+
+
+def _custom_skill_dirs() -> tuple[Path, ...]:
+    """Directories `mlflow agent setup` was pointed at via its custom location."""
+    # Lazy for the same reason as the bundled lookup: only a detected agent needs it.
+    from mlflow.assistant.config import AssistantConfig
+
+    try:
+        config = AssistantConfig.load()
+    except Exception:
+        return ()
+    return tuple(
+        Path(provider.skills.custom_path).expanduser()
+        for provider in config.providers.values()
+        if provider.skills.type == "custom" and provider.skills.custom_path
+    )
+
+
+def _is_skill_installed() -> bool:
+    """Whether the skill sits anywhere a coding agent would load it from.
+
+    Every known agent's directories are checked, not just the detected one: the
+    detected agent may not be in :data:`AGENTS` at all, and an already-installed
+    skill should silence the hint regardless of who installed it.
+    """
+    if any(
+        (Path.home() / agent.global_skills_dir / TRACING_SKILL).is_dir()
+        for agent in AGENTS.values()
+    ):
+        return True
+    if any((d / TRACING_SKILL).is_dir() for d in _custom_skill_dirs()):
+        return True
+    # Walk upwards: agents often run from a subdirectory of the repo root.
+    cwd = Path.cwd()
+    return any(
+        (d / TRACING_SKILL).is_dir()
+        for root in (cwd, *cwd.parents)
+        for agent in AGENTS.values()
+        for d in agent.project_skill_dirs(root)
+    )
+
+
+def maybe_hint_tracing_skill() -> None:
+    """Log the tracing-skill hint when a coding agent is driving without it."""
+    if MLFLOW_DISABLE_AGENT_HINT.get():
+        return
+    if not _is_agent_driving():
+        return
+    if _is_skill_installed():
+        return
+    if (path := _bundled_skill_manifest()) is None:
+        return
+    _logger.info(_HINT.format(skill=TRACING_SKILL, path=path))

--- a/mlflow/agent/hint.py
+++ b/mlflow/agent/hint.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Iterator
 from importlib import resources
 from pathlib import Path
 
@@ -55,6 +56,12 @@ _AGENT_ENV_VALUES = {"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}
 # Kiro sets this in its own IDE terminal too, so it only means "agent" when
 # nothing is attached to stdout, as a human terminal always is.
 _AGENT_ENV_VALUES_WITHOUT_TTY = {"TERM_PROGRAM": "kiro"}
+
+# Skill directories, deduplicated across agents that share a layout.
+_HOME_SKILL_DIRS = tuple(sorted({a.global_skills_dir for a in AGENTS.values()}))
+_PROJECT_SKILL_DIRS = tuple(
+    sorted({d for a in AGENTS.values() for d in (a.skills_dir, a.global_skills_dir)})
+)
 
 # The skill that teaches supported autologging and span input/output recording.
 # Lives in https://github.com/mlflow/skills and is installed by `mlflow agent setup`.
@@ -121,28 +128,25 @@ def _custom_skill_dirs() -> tuple[Path, ...]:
     )
 
 
-def _is_skill_installed() -> bool:
-    """Whether the skill sits anywhere a coding agent would load it from.
+def _skill_dir_candidates() -> Iterator[Path]:
+    """Every directory a coding agent might load skills from, cheapest first.
 
-    Every known agent's directories are checked, not just the detected one: the
-    detected agent may not be in :data:`AGENTS` at all, and an already-installed
-    skill should silence the hint regardless of who installed it.
+    All known agents are covered, not just the detected one: the detected agent
+    may have no :data:`AGENTS` entry, and an installed skill should silence the
+    hint whoever installed it. Lazy so the config read is skipped once a
+    directory matches.
     """
-    if any(
-        (Path.home() / agent.global_skills_dir / TRACING_SKILL).is_dir()
-        for agent in AGENTS.values()
-    ):
-        return True
-    if any((d / TRACING_SKILL).is_dir() for d in _custom_skill_dirs()):
-        return True
-    # Walk upwards: agents often run from a subdirectory of the repo root.
+    home = Path.home()
+    yield from (home / rel for rel in _HOME_SKILL_DIRS)
+    # Agents often run from a subdirectory while the skill sits at the repo root.
     cwd = Path.cwd()
-    return any(
-        (d / TRACING_SKILL).is_dir()
-        for root in (cwd, *cwd.parents)
-        for agent in AGENTS.values()
-        for d in agent.project_skill_dirs(root)
-    )
+    yield from (root / rel for root in (cwd, *cwd.parents) for rel in _PROJECT_SKILL_DIRS)
+    # Last: this one reads and parses the assistant config off disk.
+    yield from _custom_skill_dirs()
+
+
+def _is_skill_installed() -> bool:
+    return any((d / TRACING_SKILL).is_dir() for d in _skill_dir_candidates())
 
 
 def maybe_hint_tracing_skill() -> None:

--- a/mlflow/agent/hint.py
+++ b/mlflow/agent/hint.py
@@ -1,8 +1,10 @@
 """An agent-directed pointer to the MLflow tracing skill.
 
-Emitted on ``import mlflow`` when a coding agent is driving and the skill is not
-installed where that agent would find it. Without it, agents design tracing from
-scratch and produce traces with blank tool inputs and outputs.
+Emitted on ``import mlflow`` when a coding agent is driving. Whether the skill
+is already installed is deliberately not probed: skills end up in too many
+places for the check to be accurate, and the pointer stays useful either way.
+Without it, agents design tracing from scratch and produce traces with blank
+tool inputs and outputs.
 
 Fires once per process; ``MLFLOW_DISABLE_AGENT_HINT=1`` silences it for good.
 """
@@ -12,11 +14,9 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from collections.abc import Iterator
 from importlib import resources
 from pathlib import Path
 
-from mlflow.agent.agents import AGENTS
 from mlflow.environment_variables import MLFLOW_DISABLE_AGENT_HINT
 
 _logger = logging.getLogger(__name__)
@@ -56,12 +56,6 @@ _AGENT_ENV_VALUES = {"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"}
 # Kiro sets this in its own IDE terminal too, so it only means "agent" when
 # nothing is attached to stdout, as a human terminal always is.
 _AGENT_ENV_VALUES_WITHOUT_TTY = {"TERM_PROGRAM": "kiro"}
-
-# Skill directories, deduplicated across agents that share a layout.
-_HOME_SKILL_DIRS = tuple(sorted({a.global_skills_dir for a in AGENTS.values()}))
-_PROJECT_SKILL_DIRS = tuple(
-    sorted({d for a in AGENTS.values() for d in (a.skills_dir, a.global_skills_dir)})
-)
 
 # The skill that teaches supported autologging and span input/output recording.
 # Lives in https://github.com/mlflow/skills and is installed by `mlflow agent setup`.
@@ -112,50 +106,11 @@ def _is_agent_driving() -> bool:
     )
 
 
-def _custom_skill_dirs() -> tuple[Path, ...]:
-    """Directories `mlflow agent setup` was pointed at via its custom location."""
-    # Lazy for the same reason as the bundled lookup: only a detected agent needs it.
-    from mlflow.assistant.config import AssistantConfig
-
-    try:
-        config = AssistantConfig.load()
-    except Exception:
-        return ()
-    return tuple(
-        Path(provider.skills.custom_path).expanduser()
-        for provider in config.providers.values()
-        if provider.skills.type == "custom" and provider.skills.custom_path
-    )
-
-
-def _skill_dir_candidates() -> Iterator[Path]:
-    """Every directory a coding agent might load skills from, cheapest first.
-
-    All known agents are covered, not just the detected one: the detected agent
-    may have no :data:`AGENTS` entry, and an installed skill should silence the
-    hint whoever installed it. Lazy so the config read is skipped once a
-    directory matches.
-    """
-    home = Path.home()
-    yield from (home / rel for rel in _HOME_SKILL_DIRS)
-    # Agents often run from a subdirectory while the skill sits at the repo root.
-    cwd = Path.cwd()
-    yield from (root / rel for root in (cwd, *cwd.parents) for rel in _PROJECT_SKILL_DIRS)
-    # Last: this one reads and parses the assistant config off disk.
-    yield from _custom_skill_dirs()
-
-
-def _is_skill_installed() -> bool:
-    return any((d / TRACING_SKILL).is_dir() for d in _skill_dir_candidates())
-
-
 def maybe_hint_tracing_skill() -> None:
-    """Log the tracing-skill hint when a coding agent is driving without it."""
+    """Log the tracing-skill hint when a coding agent is driving."""
     if MLFLOW_DISABLE_AGENT_HINT.get():
         return
     if not _is_agent_driving():
-        return
-    if _is_skill_installed():
         return
     if (path := _bundled_skill_manifest()) is None:
         return

--- a/mlflow/agent/hint.py
+++ b/mlflow/agent/hint.py
@@ -20,17 +20,10 @@ from mlflow.environment_variables import MLFLOW_DISABLE_AGENT_HINT
 
 _logger = logging.getLogger(__name__)
 
-# Environment variables coding agents export into the processes they spawn.
-# Any one being set means an agent is driving, whatever `mlflow agent setup`
-# happens to support. `AI_AGENT` and `AGENT` are the emerging cross-agent
-# conventions; the rest are agent-specific and confirmed in each tool's source.
-# The marker set below tracks Vercel's cross-agent registry:
-# https://github.com/vercel/detect-agent/blob/3ab1df1e4eaae153cf66f4a5018e4c5854855212/agents.json
-#
-# Deliberately excluded: variables a human exports as configuration rather than
-# ones an agent injects (COPILOT_MODEL, COPILOT_GITHUB_TOKEN, AIDER_*,
-# GOOSE_PROVIDER), and variables set for every shell in an environment whether
-# or not an agent is driving (REPL_ID, CURSOR_TRACE_ID, CI, GITHUB_ACTIONS).
+# Variables agents export into the processes they spawn; any one means an agent
+# is driving. Tracks https://github.com/vercel/detect-agent/blob/3ab1df1e4eaae153cf66f4a5018e4c5854855212/agents.json
+# Excludes vars a human also sets: config (COPILOT_MODEL, AIDER_*) and
+# environment-wide ones (REPL_ID, CURSOR_TRACE_ID, CI).
 _AGENT_ENV_MARKERS = (
     "AGENT",  # Goose, Amp, and other adopters of the convention
     "AI_AGENT",

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1420,6 +1420,11 @@ MLFLOW_SERVER_GRAPHQL_MAX_ALIASES = _EnvironmentVariable(
 #: (default: ``False``)
 MLFLOW_DISABLE_SCHEMA_DETAILS = _BooleanEnvironmentVariable("MLFLOW_DISABLE_SCHEMA_DETAILS", False)
 
+#: Disable the hint that points a coding agent at the MLflow tracing skill on
+#: ``import mlflow``. The hint is only ever emitted when a coding agent is detected.
+#: (default: ``False``)
+MLFLOW_DISABLE_AGENT_HINT = _BooleanEnvironmentVariable("MLFLOW_DISABLE_AGENT_HINT", False)
+
 
 def _split_strip(s: str) -> list[str]:
     return [s.strip() for s in s.split(",")]

--- a/tests/agent/test_hint.py
+++ b/tests/agent/test_hint.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mlflow.agent import hint
+from mlflow.agent.agents import AGENTS
+
+# Captured before the autouse fixture stubs it out.
+_REAL_BUNDLED_LOOKUP = hint._bundled_skill_manifest
+
+
+@pytest.fixture
+def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A directory with no agent markers, no skills, and an isolated home."""
+    for marker in (
+        *hint._AGENT_ENV_MARKERS,
+        *hint._AGENT_ENV_VALUES,
+        *hint._AGENT_ENV_VALUES_WITHOUT_TTY,
+    ):
+        monkeypatch.delenv(marker, raising=False)
+    monkeypatch.delenv("MLFLOW_DISABLE_AGENT_HINT", raising=False)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    return cwd
+
+
+@pytest.fixture(autouse=True)
+def bundled_skill(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Stand in for the skill copy that released MLflow packages ship."""
+    manifest = tmp_path / "bundled" / hint.TRACING_SKILL / "SKILL.md"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("---\nname: tracing\n---\n")
+    monkeypatch.setattr(hint, "_bundled_skill_manifest", lambda: manifest)
+    return manifest
+
+
+def hint_message() -> str | None:
+    """Run the hint, returning the logged message or None when it stayed silent."""
+    with mock.patch.object(hint._logger, "info") as info:
+        hint.maybe_hint_tracing_skill()
+    return info.call_args[0][0] if info.call_args else None
+
+
+def test_silent_without_a_coding_agent(clean_env: Path):
+    assert hint_message() is None
+
+
+@pytest.mark.parametrize("marker", hint._AGENT_ENV_MARKERS)
+def test_hints_under_each_supported_agent(
+    clean_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    marker: str,
+    bundled_skill: Path,
+):
+    monkeypatch.setenv(marker, "1")
+    message = hint_message()
+    assert message is not None
+    # The hint points at the skill rather than restating its contents.
+    assert hint.TRACING_SKILL in message
+    assert "before writing any tracing" in message
+    # One line, so any `| tail -N` or `| head -N` an agent appends keeps all of it.
+    assert len(message.splitlines()) == 1
+    assert str(bundled_skill) in message
+
+
+def test_empty_marker_is_not_a_detection(clean_env: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLAUDECODE", "")
+    assert hint_message() is None
+
+
+def test_disable_env_var_silences_the_hint(clean_env: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("MLFLOW_DISABLE_AGENT_HINT", "1")
+    assert hint_message() is None
+
+
+@pytest.mark.parametrize("scope", ["project", "global"])
+def test_silent_once_the_skill_is_installed(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, scope: str
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    root = clean_env if scope == "project" else Path.home()
+    (root / ".claude" / "skills" / hint.TRACING_SKILL).mkdir(parents=True)
+    assert hint_message() is None
+
+
+def test_silent_from_a_subdirectory_of_the_project(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    (clean_env / ".claude" / "skills" / hint.TRACING_SKILL).mkdir(parents=True)
+    # Agents often run from a subdirectory while the skill sits at the repo root.
+    nested = clean_env / "services" / "api"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    assert hint_message() is None
+
+
+def test_silent_for_codex_project_skills_from_the_assistant_flow(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("CODEX_SANDBOX", "seatbelt")
+    # `mlflow agent setup`'s assistant flow writes Codex project skills under
+    # `.codex/skills`, not the `.agents/skills` Codex reads natively.
+    (clean_env / ".codex" / "skills" / hint.TRACING_SKILL).mkdir(parents=True)
+    assert hint_message() is None
+
+
+def test_silent_for_a_custom_skills_location(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    # `mlflow agent setup` can install to an arbitrary path recorded in the config.
+    custom = tmp_path / "somewhere" / "else"
+    (custom / hint.TRACING_SKILL).mkdir(parents=True)
+    monkeypatch.setattr(hint, "_custom_skill_dirs", lambda: (custom,))
+    assert hint_message() is None
+
+
+def test_custom_skill_dirs_survives_an_unreadable_config(monkeypatch: pytest.MonkeyPatch):
+    from mlflow.assistant.config import AssistantConfig
+
+    monkeypatch.setattr(AssistantConfig, "load", mock.Mock(side_effect=OSError("boom")))
+    assert hint._custom_skill_dirs() == ()
+
+
+def test_a_different_skill_does_not_suppress_the_hint(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    (clean_env / ".claude" / "skills" / "some-other-skill").mkdir(parents=True)
+    assert hint_message() is not None
+
+
+def test_points_at_the_bundled_skill_rather_than_the_network(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, bundled_skill: Path
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    message = hint_message()
+    assert str(bundled_skill) in message
+    assert "github.com" not in message
+    assert "http" not in message
+
+
+def test_silent_when_the_install_ships_no_skill(clean_env: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setattr(hint, "_bundled_skill_manifest", lambda: None)
+    # Nothing local to point at, so say nothing rather than send the agent elsewhere.
+    assert hint_message() is None
+
+
+def test_bundled_lookup_survives_a_missing_skills_package(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        hint.resources, "files", mock.Mock(side_effect=ModuleNotFoundError("no skills"))
+    )
+    assert _REAL_BUNDLED_LOOKUP() is None
+
+
+@pytest.mark.parametrize(("name", "value"), sorted(hint._AGENT_ENV_VALUES.items()))
+def test_hints_for_value_specific_markers(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, name: str, value: str, bundled_skill: Path
+):
+    monkeypatch.setenv(name, value)
+    assert hint_message() is not None
+    # A different value for the same variable is an ordinary human environment.
+    monkeypatch.setenv(name, "something-else")
+    assert hint_message() is None
+
+
+@pytest.mark.parametrize(("name", "value"), sorted(hint._AGENT_ENV_VALUES_WITHOUT_TTY.items()))
+def test_tty_gated_markers_only_count_off_a_terminal(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, name: str, value: str, bundled_skill: Path
+):
+    monkeypatch.setenv(name, value)
+    monkeypatch.setattr(hint.sys.stdout, "isatty", lambda: False, raising=False)
+    assert hint_message() is not None
+    # The same variable in a human's terminal is not a detection.
+    monkeypatch.setattr(hint.sys.stdout, "isatty", lambda: True, raising=False)
+    assert hint_message() is None
+
+
+def test_detects_agents_absent_from_the_setup_registry(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, bundled_skill: Path
+):
+    # Cursor has no `mlflow agent setup` entry but still drives MLflow.
+    assert "cursor" not in AGENTS
+    monkeypatch.setenv("CURSOR_AGENT", "1")
+    assert hint_message() is not None

--- a/tests/agent/test_hint.py
+++ b/tests/agent/test_hint.py
@@ -14,7 +14,7 @@ _REAL_BUNDLED_LOOKUP = hint._bundled_skill_manifest
 
 @pytest.fixture
 def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """A directory with no agent markers, no skills, and an isolated home."""
+    """A directory with no agent markers and an isolated home."""
     for marker in (
         *hint._AGENT_ENV_MARKERS,
         *hint._AGENT_ENV_VALUES,
@@ -83,61 +83,11 @@ def test_disable_env_var_silences_the_hint(clean_env: Path, monkeypatch: pytest.
     assert hint_message() is None
 
 
-@pytest.mark.parametrize("scope", ["project", "global"])
-def test_silent_once_the_skill_is_installed(
-    clean_env: Path, monkeypatch: pytest.MonkeyPatch, scope: str
-):
-    monkeypatch.setenv("CLAUDECODE", "1")
-    root = clean_env if scope == "project" else Path.home()
-    (root / ".claude" / "skills" / hint.TRACING_SKILL).mkdir(parents=True)
-    assert hint_message() is None
-
-
-def test_silent_from_a_subdirectory_of_the_project(
-    clean_env: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_hints_even_when_the_skill_is_installed(clean_env: Path, monkeypatch: pytest.MonkeyPatch):
+    # Installation is deliberately not probed: skills end up in too many places
+    # for the check to be accurate, and the pointer stays useful either way.
     monkeypatch.setenv("CLAUDECODE", "1")
     (clean_env / ".claude" / "skills" / hint.TRACING_SKILL).mkdir(parents=True)
-    # Agents often run from a subdirectory while the skill sits at the repo root.
-    nested = clean_env / "services" / "api"
-    nested.mkdir(parents=True)
-    monkeypatch.chdir(nested)
-    assert hint_message() is None
-
-
-def test_silent_for_codex_project_skills_from_the_assistant_flow(
-    clean_env: Path, monkeypatch: pytest.MonkeyPatch
-):
-    monkeypatch.setenv("CODEX_SANDBOX", "seatbelt")
-    # `mlflow agent setup`'s assistant flow writes Codex project skills under
-    # `.codex/skills`, not the `.agents/skills` Codex reads natively.
-    (clean_env / ".codex" / "skills" / hint.TRACING_SKILL).mkdir(parents=True)
-    assert hint_message() is None
-
-
-def test_silent_for_a_custom_skills_location(
-    clean_env: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    monkeypatch.setenv("CLAUDECODE", "1")
-    # `mlflow agent setup` can install to an arbitrary path recorded in the config.
-    custom = tmp_path / "somewhere" / "else"
-    (custom / hint.TRACING_SKILL).mkdir(parents=True)
-    monkeypatch.setattr(hint, "_custom_skill_dirs", lambda: (custom,))
-    assert hint_message() is None
-
-
-def test_custom_skill_dirs_survives_an_unreadable_config(monkeypatch: pytest.MonkeyPatch):
-    from mlflow.assistant.config import AssistantConfig
-
-    monkeypatch.setattr(AssistantConfig, "load", mock.Mock(side_effect=OSError("boom")))
-    assert hint._custom_skill_dirs() == ()
-
-
-def test_a_different_skill_does_not_suppress_the_hint(
-    clean_env: Path, monkeypatch: pytest.MonkeyPatch
-):
-    monkeypatch.setenv("CLAUDECODE", "1")
-    (clean_env / ".claude" / "skills" / "some-other-skill").mkdir(parents=True)
     assert hint_message() is not None
 
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #24963

### What changes are proposed in this pull request?

In a user study, Claude Code and Codex were asked to add MLflow tracing to a LangGraph agent without the [tracing skill](https://github.com/mlflow/skills/tree/main/instrumenting-with-mlflow-tracing) installed. Both designed tracing from scratch: ~40 minutes of setup, and traces with blank tool inputs and outputs. The skill already covers this; the gap is discovery.

So `import mlflow` now logs a one-line pointer when a coding agent is driving:

```
INFO mlflow.agent.hint: Load the `instrumenting-with-mlflow-tracing` skill at
/path/to/site-packages/mlflow/assistant/skills/instrumenting-with-mlflow-tracing/SKILL.md before
writing any tracing code; it ships with this MLflow install. Set MLFLOW_DISABLE_AGENT_HINT=1 to silence this.
```

Design notes:

- **Detection** uses the env vars agents export into spawned processes, tracking [vercel/detect-agent](https://github.com/vercel/detect-agent). A human running MLflow from their own shell never sees it; `MLFLOW_DISABLE_AGENT_HINT=1` silences it.
- **Points at the bundled copy**: no network fetch, and the revision matches the installed code. Installs that ship no skill stay silent.
- **One line on purpose**: agents append `| tail -3` / `| head -5`, and a multi-line message loses its actionable half to the pipe.
- **No installed-skill probe** (per review): skills end up in too many places to check accurately, and the pointer stays useful even when installed.
- **Known limits**: `mlflow-tracing` installs are not covered (gated on `IS_TRACING_SDK_ONLY`), and it fires on any `import mlflow` under an agent. A narrower trigger is a possible follow-up.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

`tests/agent/test_hint.py` covers each detection marker, the human case, the disable flag, the bundled path, and the silent cases. Manually verified with live Claude Code sessions against a toy OpenAI tool-calling agent: tracing tasks loaded the skill and chose `mlflow.openai.autolog()` over hand-rolled spans; unrelated tasks were not derailed. Import time is unchanged.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When a coding agent such as Claude Code or Codex imports MLflow, MLflow now logs a one-line pointer to the copy of the MLflow tracing skill bundled with the installed package. Set `MLFLOW_DISABLE_AGENT_HINT=1` to disable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)