### PR TITLE
Add a report-only flaky-test pipeline for the JS suite

### DIFF
--- a/.github/workflows/flaky-test-detector-js.yml
+++ b/.github/workflows/flaky-test-detector-js.yml
@@ -77,7 +77,7 @@ jobs:
             exit 0
           fi
           python dev/classify_flaky_tests.py --in flakes.json --framework jest \
-            --out classified.json
+            --out classified.json --summary classified.md
 
       - name: Upload report
         if: "!cancelled()"
@@ -88,6 +88,7 @@ jobs:
             flakes.json
             flakes.md
             classified.json
+            classified.md
           if-no-files-found: ignore
           retention-days: 90
 
@@ -105,14 +106,20 @@ jobs:
             echo "No flakes detected; skipping issue."
             exit 0
           fi
+          # Publish the classified report (verdicts + fix guidance). Fall back to the
+          # detector's verdict-less flakes.md only if classify didn't run/produce one.
+          body_file=flakes.md
+          if [ -s classified.md ]; then
+            body_file=classified.md
+          fi
           title="Weekly flaky JS-test report"
           # Scope the dedup search to issues this bot authored so we never comment on
           # an unrelated issue that happens to share the title.
           existing=$(gh issue list --repo "$REPO" --author "@me" \
             --search "in:title \"$title\"" --state open --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$REPO" --body-file flakes.md
+            gh issue comment "$existing" --repo "$REPO" --body-file "$body_file"
           else
             gh issue create --repo "$REPO" \
-              --title "$title" --body-file flakes.md --label "area/build"
+              --title "$title" --body-file "$body_file" --label "area/build"
           fi

--- a/.github/workflows/flaky-test-detector-js.yml
+++ b/.github/workflows/flaky-test-detector-js.yml
@@ -68,6 +68,14 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
         run: |
+          # The detector always writes flakes.json (even `[]`), so the hashFiles guard
+          # above only proves it exists. Skip the classifier when there are zero flakes
+          # so we don't burn Anthropic quota on an empty run, mirroring the jq guard in
+          # the publish step below.
+          if [ "$(jq 'length' flakes.json)" = "0" ]; then
+            echo "No flakes detected; skipping classify."
+            exit 0
+          fi
           python dev/classify_flaky_tests.py --in flakes.json --framework jest \
             --out classified.json
 

--- a/.github/workflows/flaky-test-detector-js.yml
+++ b/.github/workflows/flaky-test-detector-js.yml
@@ -1,0 +1,110 @@
+name: Flaky JS test detector
+
+# Weekly report-only flaky-test pipeline for the JS suite (detect -> classify -> issue):
+#   1. Detect: mine user-triggered CI re-runs of the "JS" workflow for ground-truth
+#      flakes (a shard that failed on one run attempt and passed on the next attempt of
+#      the same commit; the failing test + error are parsed from that attempt's logs).
+#   2. Classify: an LLM judges each flake's likely root cause and points a human at the
+#      fix.
+#
+# Unlike the Python pipeline, this one is REPORT-ONLY: it never edits tests and never
+# opens a PR. The MLflow frontend forbids `jest.retryTimes` ("Tests must pass without
+# retries. If a test is flaky, fix it instead of adding retries."), so a JS flake is
+# always something a human fixes — the weekly issue just tells them where to look.
+on:
+  schedule:
+    # Thursdays at 01:00 UTC — a day before the Python detector (Fridays) so the two
+    # weekly reports don't land at once. The detector scans a trailing 14-day window.
+    - cron: "0 1 * * 4"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "ISO date to scan from (default: 14 days ago)"
+        required: false
+
+# Deny all permissions by default; the single job grants only what it needs.
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  detect:
+    if: github.repository == 'mlflow/mlflow'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      # actions: read is required for the GitHub API calls the detector makes
+      # (workflow runs, per-attempt jobs, and job logs); without it they 403.
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Only the detector/classifier scripts are needed; skip the full tree.
+          sparse-checkout: |
+            dev
+            .github
+      - uses: ./.github/actions/setup-python
+      - name: Detect flaky JS tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SINCE: ${{ inputs.since }}
+        run: |
+          ARGS=(--repo "$REPO" --framework jest --out flakes.json --summary flakes.md)
+          if [ -n "$SINCE" ]; then
+            ARGS+=(--since "$SINCE")
+          fi
+          python dev/detect_flaky_tests.py "${ARGS[@]}"
+          # Mirror the report into the run's step summary for at-a-glance viewing.
+          cat flakes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Classify flaky JS tests
+        if: hashFiles('flakes.json') != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
+        run: |
+          python dev/classify_flaky_tests.py --in flakes.json --framework jest \
+            --out classified.json
+
+      - name: Upload report
+        if: "!cancelled()"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flaky-js-report
+          path: |
+            flakes.json
+            flakes.md
+            classified.json
+          if-no-files-found: ignore
+          retention-days: 90
+
+      # File/update a single rolling GitHub issue with the week's report so JS flakes
+      # have a visible home. Report-only: there is no PR stage.
+      - name: Publish weekly issue
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # flakes.md always carries a header, so gate on the JSON actually
+          # holding flakes — otherwise we'd file a "0 flakes" issue every week.
+          if [ ! -s flakes.json ] || [ "$(jq 'length' flakes.json)" = "0" ]; then
+            echo "No flakes detected; skipping issue."
+            exit 0
+          fi
+          title="Weekly flaky JS-test report"
+          # Scope the dedup search to issues this bot authored so we never comment on
+          # an unrelated issue that happens to share the title.
+          existing=$(gh issue list --repo "$REPO" --author "@me" \
+            --search "in:title \"$title\"" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body-file flakes.md
+          else
+            gh issue create --repo "$REPO" \
+              --title "$title" --body-file flakes.md --label "area/build"
+          fi

--- a/dev/classify_flaky_tests.py
+++ b/dev/classify_flaky_tests.py
@@ -240,10 +240,45 @@ def _aggregate(flakes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(tests, key=lambda t: t["count"], reverse=True)
 
 
+def render_summary(results: list[dict[str, Any]], framework: str) -> str:
+    """Markdown report of the classified flakes, ranked by flake count.
+
+    The detector's own summary (flakes.md) carries no verdicts, so this is what the
+    weekly issue should publish: each flake's LLM action, category, confidence, and
+    rationale — the fix guidance a human actually acts on.
+    """
+    lines = [
+        f"# Classified flaky {framework} tests",
+        "",
+        f"**{len(results)}** distinct flaky tests/shards, ranked by flake count. Each "
+        "carries an LLM triage verdict (root cause + recommended action).",
+        "",
+    ]
+    for r in results:
+        v = r["verdict"]
+        label = r["test"] or f"{r['shard']} (whole shard — no test line in log)"
+        lines.append(f"### `{label}`")
+        lines.append(
+            f"- **action: {v['action']}** · category: {v['category']} · "
+            f"confidence: {v['confidence']} · flaked {r['count']}×"
+        )
+        if attempts := v.get("attempts"):
+            lines.append(f"- suggested retry attempts: {attempts}")
+        lines.append(f"- shard: `{r['shard']}`")
+        if r.get("error"):
+            lines.append(f"- error: `{r['error']}`")
+        lines.append(f"- _rationale:_ {v['rationale']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--in", dest="infile", required=True, help="flakes.json from the detector")
     p.add_argument("--out", help="Write classified JSON here")
+    p.add_argument(
+        "--summary", help="Write a Markdown report (with verdicts) here for the issue body."
+    )
     p.add_argument(
         "--framework",
         default="pytest",
@@ -286,6 +321,9 @@ def main() -> None:
     if args.out:
         with open(args.out, "w") as f:
             json.dump(results, f, indent=2)
+    if args.summary:
+        with open(args.summary, "w") as f:
+            f.write(render_summary(results, args.framework) + "\n")
 
 
 if __name__ == "__main__":

--- a/dev/classify_flaky_tests.py
+++ b/dev/classify_flaky_tests.py
@@ -1,14 +1,19 @@
-"""Classify detected flaky tests and decide which to annotate @pytest.mark.flaky.
+"""Classify detected flaky tests and recommend how to handle each one.
 
 Second stage of the flaky-test pipeline. `detect_flaky_tests.py` produces the
 *deterministic* signal (a test that failed on one run attempt and passed on the next
 attempt of the same commit). This stage adds *judgment*: given each test's failure
-count and error message, an LLM classifies the root cause and recommends whether to
-retry the test (annotate @pytest.mark.flaky) or leave it for a human to fix — because
-a retry masks a genuine product bug and should not be applied blindly.
+count and error message, an LLM classifies the root cause and recommends an action.
 
-The verdict is advisory: it is written into the report / PR body so a human reviewer
-sees the rationale, and the annotate step only ever acts on `action == "annotate"`.
+The allowed actions depend on the framework (`--framework`, default pytest):
+  - pytest: `annotate` (safe to retry via @pytest.mark.flaky), `fix`, or `investigate`.
+    A retry masks a genuine product bug, so the annotate step only acts on `annotate`.
+  - jest: report-only — `fix` or `investigate` only. The MLflow frontend forbids
+    `jest.retryTimes`, so a JS flake is never auto-retried; the verdict just tells a
+    human where to look.
+
+The verdict is advisory: it is written into the report so a human reviewer sees the
+rationale (and, for pytest, gates the annotate step).
 
 Auth uses an `ANTHROPIC_API_KEY` secret and a direct call to the Anthropic Messages
 API. `ANTHROPIC_BASE_URL` / `FLAKY_CLASSIFIER_MODEL` may override the endpoint and
@@ -16,12 +21,14 @@ model (e.g. to route through an internal gateway).
 
 Usage:
   python dev/classify_flaky_tests.py --in flakes.json --out classified.json
+  python dev/classify_flaky_tests.py --in flakes.json --framework jest --out classified.json
 """
 
 from __future__ import annotations
 
 import argparse
 import collections
+import dataclasses
 import json
 import os
 import sys
@@ -33,15 +40,17 @@ from detect_flaky_tests import FRAMEWORKS
 DEFAULT_MODEL = os.environ.get("FLAKY_CLASSIFIER_MODEL", "claude-sonnet-4-6")
 BASE_URL = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com").rstrip("/")
 
-# The prompt is identical across frameworks except for how a retry is expressed;
-# `{retry_mechanism}` is filled per framework (see RETRY_MECHANISMS below) so the
-# classifier's `annotate` verdict names the mechanism a human would actually apply.
-PROMPT_TEMPLATE = """\
+# pytest's pipeline can auto-retry a flake (via @pytest.mark.flaky), so its classifier
+# decides annotate-vs-fix. The JS pipeline cannot: the frontend ESLint config forbids
+# `jest.retryTimes` ("Tests must pass without retries. If a test is flaky, fix it"), so
+# the jest classifier is report-only — every flake is a fix/investigate for a human, and
+# `annotate` is not an option it can pick.
+_PYTEST_PROMPT = """\
 You are triaging a flaky test in the MLflow CI suite. A "flake" here is a test that \
 FAILED on one CI run attempt and PASSED on a re-run of the exact same commit — so the \
 code did not change between the two outcomes.
 
-Your job: decide whether this test should be annotated with `{retry_mechanism}` \
+Your job: decide whether this test should be annotated with `@pytest.mark.flaky` \
 (which makes CI automatically retry it), or whether the flake likely reflects a real \
 bug that a human should FIX instead.
 
@@ -65,7 +74,7 @@ failure that only "passed on retry" by luck.
 Return a JSON object:
 - `category`: one of "timeout", "resource-contention", "network", "test-harness-race", \
 "product-race", "logic-bug", "unknown".
-- `action`: one of "annotate" (safe to retry via {retry_mechanism}), "fix" (likely a \
+- `action`: one of "annotate" (safe to retry via @pytest.mark.flaky), "fix" (likely a \
 real bug — do not retry, a human should fix it), "investigate" (not enough signal to \
 decide).
 - `attempts`: suggested retry count (2 or 3) if action is "annotate", else null.
@@ -76,23 +85,42 @@ Weigh the failure count: a test that flaked repeatedly across many commits is mo
 likely a genuine flake safe to retry; a single occurrence with a logic-bug-shaped error \
 should lean toward "investigate" or "fix"."""
 
-# How each framework expresses an automatic retry, injected into the prompt above.
-# Keyed by the same framework names as detect's FRAMEWORKS registry: every framework the
-# detector can mine must have a retry mechanism here, or `--framework X` would pass
-# argparse in detect and then KeyError here. The assert below enforces that at import so
-# the two registries can't silently drift out of sync.
-RETRY_MECHANISMS: dict[str, str] = {
-    "pytest": "@pytest.mark.flaky",
-}
+_JEST_PROMPT = """\
+You are triaging a flaky test in the MLflow JS CI suite. A "flake" here is a test that \
+FAILED on one CI run attempt and PASSED on a re-run of the exact same commit — so the \
+code did not change between the two outcomes.
 
-assert RETRY_MECHANISMS.keys() == FRAMEWORKS.keys(), (
-    "RETRY_MECHANISMS and detect_flaky_tests.FRAMEWORKS must cover the same frameworks; "
-    f"got {sorted(RETRY_MECHANISMS)} vs {sorted(FRAMEWORKS)}"
-)
+Retrying is NOT an option: the MLflow frontend forbids `jest.retryTimes` as a matter of \
+policy ("Tests must pass without retries. If a test is flaky, fix it instead of adding \
+retries."). Your job is therefore purely diagnostic — classify the likely root cause \
+and point a human at the fix. Every flake here must be FIXED or INVESTIGATED, never \
+masked with a retry.
 
-_SCHEMA = {
-    "type": "object",
-    "properties": {
+## Test
+{nodeid}
+
+## How often it flaked (distinct commits, in the window)
+{count}
+
+## Representative error message
+{error}
+
+## Instructions
+Return a JSON object:
+- `category`: one of "timeout", "resource-contention", "network", "test-harness-race", \
+"product-race", "logic-bug", "unknown". For JS flakes, common causes are unawaited \
+state updates (missing `await`/`waitFor`, React "not wrapped in act(...)" warnings), \
+fake-timer/real-timer races, and unmocked network — most map to "test-harness-race".
+- `action`: one of "fix" (a concrete root cause is identifiable and a human should fix \
+the test/product) or "investigate" (not enough signal to pinpoint the cause yet).
+- `confidence`: "high", "medium", or "low".
+- `rationale`: one or two sentences explaining the decision, for the human reviewer — \
+lead with the most likely root cause and the fix direction."""
+
+
+def _schema(actions: list[str], *, with_attempts: bool) -> dict[str, Any]:
+    """Verdict JSON schema. `attempts` only exists for frameworks that can retry."""
+    properties: dict[str, Any] = {
         "category": {
             "type": "string",
             "enum": [
@@ -105,14 +133,45 @@ _SCHEMA = {
                 "unknown",
             ],
         },
-        "action": {"type": "string", "enum": ["annotate", "fix", "investigate"]},
-        "attempts": {"type": ["integer", "null"]},
+        "action": {"type": "string", "enum": actions},
         "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
         "rationale": {"type": "string"},
-    },
-    "required": ["category", "action", "attempts", "confidence", "rationale"],
-    "additionalProperties": False,
+    }
+    if with_attempts:
+        properties["attempts"] = {"type": ["integer", "null"]}
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties),
+        "additionalProperties": False,
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class FrameworkClassifier:
+    """Per-framework prompt + verdict schema. pytest can `annotate` (auto-retry); jest is
+    report-only (fix/investigate) because retries are banned in the JS suite.
+    """
+
+    prompt: str
+    schema: dict[str, Any]
+
+
+CLASSIFIERS: dict[str, FrameworkClassifier] = {
+    "pytest": FrameworkClassifier(
+        _PYTEST_PROMPT, _schema(["annotate", "fix", "investigate"], with_attempts=True)
+    ),
+    "jest": FrameworkClassifier(_JEST_PROMPT, _schema(["fix", "investigate"], with_attempts=False)),
 }
+
+# Keyed by the same framework names as detect's FRAMEWORKS registry: every framework the
+# detector can mine must have a classifier here, or `--framework X` would pass argparse in
+# detect and then KeyError here. The assert enforces that at import so the two registries
+# can't silently drift out of sync.
+assert CLASSIFIERS.keys() == FRAMEWORKS.keys(), (
+    "CLASSIFIERS and detect_flaky_tests.FRAMEWORKS must cover the same frameworks; "
+    f"got {sorted(CLASSIFIERS)} vs {sorted(FRAMEWORKS)}"
+)
 
 
 def _auth_headers() -> dict[str, str]:
@@ -129,10 +188,10 @@ def _auth_headers() -> dict[str, str]:
     return headers
 
 
-def classify(nodeid: str, count: int, error: str, retry_mechanism: str) -> dict[str, Any]:
-    prompt = PROMPT_TEMPLATE.format(
-        nodeid=nodeid, count=count, error=error or "(none)", retry_mechanism=retry_mechanism
-    )
+def classify(
+    nodeid: str, count: int, error: str, classifier: FrameworkClassifier
+) -> dict[str, Any]:
+    prompt = classifier.prompt.format(nodeid=nodeid, count=count, error=error or "(none)")
     request_body = {
         "model": DEFAULT_MODEL,
         "max_tokens": 1024,
@@ -140,10 +199,10 @@ def classify(nodeid: str, count: int, error: str, retry_mechanism: str) -> dict[
         # should classify the same way run-to-run so the report/PR stays stable.
         "temperature": 0,
         "messages": [{"role": "user", "content": prompt}],
-        # Constrain the reply to `_SCHEMA` so the model emits exactly the fields the
-        # downstream stages read — no prose to parse, and an off-schema reply is rejected
-        # by the API rather than reaching us.
-        "output_config": {"format": {"type": "json_schema", "schema": _SCHEMA}},
+        # Constrain the reply to the framework's schema so the model emits exactly the
+        # fields the downstream stages read — no prose to parse, and an off-schema reply
+        # (e.g. jest picking the disallowed `annotate`) is rejected by the API.
+        "output_config": {"format": {"type": "json_schema", "schema": classifier.schema}},
     }
     req = urllib.request.Request(
         f"{BASE_URL}/v1/messages",
@@ -188,30 +247,29 @@ def main() -> None:
     p.add_argument(
         "--framework",
         default="pytest",
-        choices=sorted(RETRY_MECHANISMS),
-        help="Test framework the flakes came from (selects the retry mechanism named in "
-        "the prompt). Default: pytest.",
+        choices=sorted(CLASSIFIERS),
+        help="Test framework the flakes came from (selects the prompt and allowed "
+        "verdicts; jest is report-only since retries are banned). Default: pytest.",
     )
     args = p.parse_args()
 
-    retry_mechanism = RETRY_MECHANISMS[args.framework]
+    classifier = CLASSIFIERS[args.framework]
 
     with open(args.infile) as f:
         flakes = json.load(f)
 
     results = []
     for t in _aggregate(flakes):
-        # Only test-level entries can be annotated; shard-level ones lack a nodeid.
+        # Only test-level entries carry a nodeid; shard-level ones can't be classified.
         if not t["test"]:
             verdict = {
                 "category": "unknown",
                 "action": "investigate",
-                "attempts": None,
                 "confidence": "low",
                 "rationale": "No test-level nodeid recovered (shard/infra flake).",
             }
         else:
-            verdict = classify(t["test"], t["count"], t["error"] or "", retry_mechanism)
+            verdict = classify(t["test"], t["count"], t["error"] or "", classifier)
         results.append({**t, "verdict": verdict})
         label = t["test"] or t["shard"]
         v = verdict

--- a/dev/classify_flaky_tests.py
+++ b/dev/classify_flaky_tests.py
@@ -262,12 +262,17 @@ def main() -> None:
     for t in _aggregate(flakes):
         # Only test-level entries carry a nodeid; shard-level ones can't be classified.
         if not t["test"]:
-            verdict = {
+            verdict: dict[str, Any] = {
                 "category": "unknown",
                 "action": "investigate",
                 "confidence": "low",
                 "rationale": "No test-level nodeid recovered (shard/infra flake).",
             }
+            # Keep the fallback conformant with the framework's verdict schema: pytest
+            # lists `attempts` as required, so include it (null) there; jest's schema
+            # omits it entirely.
+            if "attempts" in classifier.schema["properties"]:
+                verdict["attempts"] = None
         else:
             verdict = classify(t["test"], t["count"], t["error"] or "", classifier)
         results.append({**t, "verdict": verdict})

--- a/dev/detect_flaky_tests.py
+++ b/dev/detect_flaky_tests.py
@@ -49,6 +49,16 @@ _TIMESTAMP_RE = re.compile(r"^[0-9T:.Z\-]+\s+")
 # colorizes FAILED / the test name); both must be stripped before the nodeid regex.
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
+# Jest's default reporter prints, per failing file: a `FAIL <path>` header, then one
+# bullet (`  ● <suite chain> <test name>`) block per failing test whose first body line
+# is the assertion message. The file path is only on the FAIL line, so the parser threads
+# it onto each following bullet to build a "<file> <sep> <suite chain> <sep> <test>" id.
+# Both regexes tolerate leading whitespace since the reporter indents the bullet two
+# spaces (the timestamp strip already removes the Actions prefix). `(?: \(.*\))?` drops
+# the trailing `(1.2 s)` timing.
+_JEST_FAIL_FILE_RE = re.compile(r"^\s*FAIL\s+(\S+\.test\.[jt]sx?)")
+_JEST_FAIL_TEST_RE = re.compile(r"^\s*●\s+(.+?)(?:\s+\(\d[\d.]*\s*m?s\))?\s*$")
+
 
 @dataclasses.dataclass
 class FlakyTest:
@@ -160,6 +170,41 @@ def parse_pytest_failures(log: str) -> dict[str, str]:
     return failures
 
 
+def parse_jest_failures(log: str) -> dict[str, str]:
+    """{test id: first-line error} parsed from a raw jest Actions log. Empty if none found.
+
+    A jest test id is "<file> <sep> <describe chain> <sep> <test name>" (matching how
+    jest's reporter renders it, joined by the same separator), so a reader can jump
+    straight to the failing test from the report. Pure function (no I/O) so it can be
+    unit-tested against captured log snippets, guarding the format-fragile regexes
+    against reporter/Actions log-format drift.
+    """
+    failures: dict[str, str] = {}
+    current_file: str | None = None
+    lines = log.splitlines()
+    for i, raw in enumerate(lines):
+        line = _TIMESTAMP_RE.sub("", _ANSI_RE.sub("", raw))
+        if m := _JEST_FAIL_FILE_RE.match(line):
+            # A new `FAIL <path>` header rebinds the file every subsequent ● attaches to.
+            current_file = m.group(1)
+            continue
+        if not current_file:
+            continue
+        if m := _JEST_FAIL_TEST_RE.match(line):
+            title = m.group(1).strip()
+            # The assertion message is the first non-blank body line after the ● header.
+            error = next(
+                (
+                    stripped
+                    for nxt in lines[i + 1 :]
+                    if (stripped := _TIMESTAMP_RE.sub("", _ANSI_RE.sub("", nxt)).strip())
+                ),
+                "",
+            )
+            failures.setdefault(f"{current_file} › {title}", error[:300])
+    return failures
+
+
 @dataclasses.dataclass(frozen=True)
 class Framework:
     """A test framework the detector can mine, decoupling the shared CI-history mining
@@ -175,6 +220,7 @@ class Framework:
 
 FRAMEWORKS: dict[str, Framework] = {
     "pytest": Framework("MLflow tests", parse_pytest_failures),
+    "jest": Framework("JS", parse_jest_failures),
 }
 
 

--- a/dev/detect_flaky_tests.py
+++ b/dev/detect_flaky_tests.py
@@ -55,8 +55,9 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 # it onto each following bullet to build a "<file> <sep> <suite chain> <sep> <test>" id.
 # Both regexes tolerate leading whitespace since the reporter indents the bullet two
 # spaces (the timestamp strip already removes the Actions prefix). `(?: \(.*\))?` drops
-# the trailing `(1.2 s)` timing.
-_JEST_FAIL_FILE_RE = re.compile(r"^\s*FAIL\s+(\S+\.test\.[jt]sx?)")
+# the trailing `(1.2 s)` timing. The file pattern accepts both jest naming conventions,
+# `.test.` and `.spec.`, so a suffix change never silently drops a file's failures.
+_JEST_FAIL_FILE_RE = re.compile(r"^\s*FAIL\s+(\S+\.(?:test|spec)\.[jt]sx?)")
 _JEST_FAIL_TEST_RE = re.compile(r"^\s*●\s+(.+?)(?:\s+\(\d[\d.]*\s*m?s\))?\s*$")
 
 

--- a/tests/dev/test_classify_flaky_tests.py
+++ b/tests/dev/test_classify_flaky_tests.py
@@ -6,7 +6,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "dev"))
 
 import classify_flaky_tests
-from classify_flaky_tests import CLASSIFIERS, _aggregate, classify
+from classify_flaky_tests import CLASSIFIERS, _aggregate, classify, render_summary
 from detect_flaky_tests import FRAMEWORKS
 
 
@@ -159,3 +159,27 @@ def test_shard_fallback_verdict_conforms_to_pytest_schema(tmp_path, monkeypatch)
     verdict = _run_main_on_shard_flake(tmp_path, monkeypatch, "pytest")
     assert verdict["attempts"] is None
     _assert_conforms(verdict, CLASSIFIERS["pytest"].schema)
+
+
+def test_render_summary_surfaces_the_verdict_fields():
+    # The weekly issue publishes this, so the LLM's action + rationale (its fix guidance)
+    # must appear in the rendered markdown — not just the raw flake.
+    results = [
+        {
+            "test": "src/foo/Bar.test.tsx › Bar › renders",
+            "shard": "js (rest)",
+            "count": 3,
+            "error": "Unable to find element",
+            "verdict": {
+                "category": "test-harness-race",
+                "action": "fix",
+                "confidence": "high",
+                "rationale": "Missing await on findBy*; wrap in waitFor.",
+            },
+        }
+    ]
+    md = render_summary(results, "jest")
+    assert "src/foo/Bar.test.tsx › Bar › renders" in md
+    assert "action: fix" in md
+    assert "Missing await on findBy*; wrap in waitFor." in md
+    assert "flaked 3×" in md

--- a/tests/dev/test_classify_flaky_tests.py
+++ b/tests/dev/test_classify_flaky_tests.py
@@ -1,9 +1,11 @@
+import json
 import sys
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "dev"))
 
-from classify_flaky_tests import CLASSIFIERS, _aggregate
+from classify_flaky_tests import CLASSIFIERS, _aggregate, classify
 from detect_flaky_tests import FRAMEWORKS
 
 
@@ -61,3 +63,59 @@ def test_jest_classifier_is_report_only():
     schema = CLASSIFIERS["jest"].schema
     assert set(schema["properties"]["action"]["enum"]) == {"fix", "investigate"}
     assert "attempts" not in schema["properties"]
+
+
+def _fake_response(verdict: dict[str, object]):
+    """A stub urlopen context manager returning the Messages API envelope for `verdict`."""
+    envelope = {"content": [{"text": json.dumps(verdict)}]}
+    resp = mock.MagicMock()
+    resp.read.return_value = json.dumps(envelope).encode()
+    resp.__enter__.return_value = resp
+    return resp
+
+
+def test_classify_sends_jest_report_only_schema_and_formatted_prompt(monkeypatch):
+    # End-to-end wiring for the JS path: the jest flake's test id is formatted into the
+    # prompt, the request carries the report-only schema (so the model cannot return
+    # `annotate`), and the parsed verdict flows back.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    verdict = {
+        "category": "test-harness-race",
+        "action": "investigate",
+        "confidence": "medium",
+        "rationale": "Likely a missing await on findBy*; wrap in waitFor.",
+    }
+    with mock.patch("urllib.request.urlopen", return_value=_fake_response(verdict)) as urlopen:
+        result = classify(
+            "src/foo/Bar.test.tsx › Bar › renders rows",
+            2,
+            "Unable to find element",
+            CLASSIFIERS["jest"],
+        )
+
+    assert result == verdict
+    urlopen.assert_called_once()
+    sent = json.loads(urlopen.call_args[0][0].data)
+    schema = sent["output_config"]["format"]["schema"]
+    assert set(schema["properties"]["action"]["enum"]) == {"fix", "investigate"}
+    assert "attempts" not in schema["properties"]
+    assert "src/foo/Bar.test.tsx › Bar › renders rows" in sent["messages"][0]["content"]
+
+
+def test_classify_sends_pytest_schema_allowing_annotate(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    verdict = {
+        "category": "timeout",
+        "action": "annotate",
+        "attempts": 3,
+        "confidence": "high",
+        "rationale": "Load-induced timeout, safe to retry.",
+    }
+    with mock.patch("urllib.request.urlopen", return_value=_fake_response(verdict)) as urlopen:
+        result = classify("tests/a.py::t1", 5, "TimeoutError", CLASSIFIERS["pytest"])
+
+    assert result == verdict
+    sent = json.loads(urlopen.call_args[0][0].data)
+    schema = sent["output_config"]["format"]["schema"]
+    assert "annotate" in schema["properties"]["action"]["enum"]
+    assert "attempts" in schema["properties"]

--- a/tests/dev/test_classify_flaky_tests.py
+++ b/tests/dev/test_classify_flaky_tests.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "dev"))
 
+import classify_flaky_tests
 from classify_flaky_tests import CLASSIFIERS, _aggregate, classify
 from detect_flaky_tests import FRAMEWORKS
 
@@ -119,3 +120,42 @@ def test_classify_sends_pytest_schema_allowing_annotate(monkeypatch):
     schema = sent["output_config"]["format"]["schema"]
     assert "annotate" in schema["properties"]["action"]["enum"]
     assert "attempts" in schema["properties"]
+
+
+def _run_main_on_shard_flake(tmp_path, monkeypatch, framework: str):
+    """Run classify main() on a single shard-level (test=None) flake for `framework`,
+    returning the one verdict it wrote. Shard flakes take the fallback path (no API call).
+    """
+    infile = tmp_path / "flakes.json"
+    outfile = tmp_path / "classified.json"
+    infile.write_text(json.dumps([{"shard": "js (rest)", "test": None, "error": None}]))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--in", str(infile), "--out", str(outfile), "--framework", framework],
+    )
+    classify_flaky_tests.main()
+    (entry,) = json.loads(outfile.read_text())
+    return entry["verdict"]
+
+
+def _assert_conforms(verdict: dict[str, object], schema: dict[str, object]):
+    props = schema["properties"]
+    # Every required field is present, and no field outside the schema leaked in.
+    assert set(schema["required"]) <= set(verdict)
+    assert set(verdict) <= set(props)
+    assert verdict["action"] in props["action"]["enum"]
+
+
+def test_shard_fallback_verdict_conforms_to_jest_schema(tmp_path, monkeypatch):
+    # jest's schema omits `attempts`, so the fallback must not include it.
+    verdict = _run_main_on_shard_flake(tmp_path, monkeypatch, "jest")
+    assert "attempts" not in verdict
+    _assert_conforms(verdict, CLASSIFIERS["jest"].schema)
+
+
+def test_shard_fallback_verdict_conforms_to_pytest_schema(tmp_path, monkeypatch):
+    # pytest's schema lists `attempts` as required, so the fallback must carry it (null).
+    verdict = _run_main_on_shard_flake(tmp_path, monkeypatch, "pytest")
+    assert verdict["attempts"] is None
+    _assert_conforms(verdict, CLASSIFIERS["pytest"].schema)

--- a/tests/dev/test_classify_flaky_tests.py
+++ b/tests/dev/test_classify_flaky_tests.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "dev"))
 
-from classify_flaky_tests import RETRY_MECHANISMS, _aggregate
+from classify_flaky_tests import CLASSIFIERS, _aggregate
 from detect_flaky_tests import FRAMEWORKS
 
 
-def test_retry_mechanisms_cover_exactly_the_detect_frameworks():
+def test_classifiers_cover_exactly_the_detect_frameworks():
     # The two registries live in different modules; a mismatch would let `--framework X`
     # pass argparse in detect and then KeyError in classify. Keep them locked together.
     #
@@ -16,7 +16,7 @@ def test_retry_mechanisms_cover_exactly_the_detect_frameworks():
     # loads), while this test exists to give a readable pytest diff of the offending keys.
     # If the assert ever fires on drift, importing classify here raises and this test
     # errors too — which is the intended signal, just surfaced through the test runner.
-    assert RETRY_MECHANISMS.keys() == FRAMEWORKS.keys()
+    assert CLASSIFIERS.keys() == FRAMEWORKS.keys()
 
 
 def test_aggregate_collapses_events_per_test_and_counts():
@@ -47,3 +47,17 @@ def test_aggregate_keys_shard_level_flakes_without_a_nodeid():
     assert result[0]["test"] is None
     assert result[0]["shard"] == "windows (3)"
     assert result[0]["count"] == 2
+
+
+def test_pytest_classifier_can_annotate_and_suggest_attempts():
+    schema = CLASSIFIERS["pytest"].schema
+    assert set(schema["properties"]["action"]["enum"]) == {"annotate", "fix", "investigate"}
+    assert "attempts" in schema["properties"]
+
+
+def test_jest_classifier_is_report_only():
+    # Retries are banned in the JS suite, so the jest verdict schema must not offer
+    # `annotate` (nor an `attempts` count) — every flake is fix/investigate for a human.
+    schema = CLASSIFIERS["jest"].schema
+    assert set(schema["properties"]["action"]["enum"]) == {"fix", "investigate"}
+    assert "attempts" not in schema["properties"]

--- a/tests/dev/test_detect_flaky_tests.py
+++ b/tests/dev/test_detect_flaky_tests.py
@@ -9,6 +9,7 @@ from detect_flaky_tests import (
     Framework,
     failing_tests_from_log,
     gh_api_objects,
+    parse_jest_failures,
     parse_pytest_failures,
 )
 
@@ -67,6 +68,49 @@ def test_error_message_is_truncated():
 
 def test_empty_log_yields_no_failures():
     assert parse_pytest_failures("") == {}
+
+
+# A captured jest failure block as its default reporter renders it: a `FAIL <path>`
+# header (with a trailing `(7.812 s)` timing), then one bullet block per failing test
+# (`  <bullet> <suite chain> <test>`) whose first body line is the assertion message.
+# ANSI SGR codes and the Actions ISO-timestamp prefix wrap the real lines and must be
+# stripped first.
+_JEST_TIMESTAMP = "2026-07-20T10:00:00.1234567Z "
+_JEST_LOG = (
+    f"{_JEST_TIMESTAMP}\x1b[1m\x1b[31m FAIL \x1b[0m src/\x1b[1m__flaky_probe__.test.tsx\x1b[0m "
+    "(7.812 s)\n"
+    f"{_JEST_TIMESTAMP}  \x1b[31m✕\x1b[0m top level failing test (1 ms)\n"
+    f"{_JEST_TIMESTAMP}\n"
+    f"{_JEST_TIMESTAMP}\x1b[1m\x1b[31m  ● \x1b[1mFlaky probe suite › renders the widget\x1b[0m\n"
+    f"{_JEST_TIMESTAMP}\n"
+    f"{_JEST_TIMESTAMP}    expect(received).toBe(expected) // Object.is equality\n"
+    f"{_JEST_TIMESTAMP}    Expected: 3\n"
+    f"{_JEST_TIMESTAMP}    Received: 2\n"
+    f"{_JEST_TIMESTAMP}\x1b[1m\x1b[31m  ● \x1b[1mtop level failing test\x1b[0m\n"
+    f"{_JEST_TIMESTAMP}\n"
+    f"{_JEST_TIMESTAMP}    expect(received).toBe(expected) // Object.is equality\n"
+)
+
+
+def test_parses_jest_file_suite_and_test_into_id_with_error():
+    assert parse_jest_failures(_JEST_LOG) == {
+        "src/__flaky_probe__.test.tsx › Flaky probe suite › renders the widget": (
+            "expect(received).toBe(expected) // Object.is equality"
+        ),
+        "src/__flaky_probe__.test.tsx › top level failing test": (
+            "expect(received).toBe(expected) // Object.is equality"
+        ),
+    }
+
+
+def test_jest_test_without_a_preceding_fail_file_is_ignored():
+    # A bare ● with no `FAIL <path>` header before it has no file to attach to; the
+    # detector must not emit a fileless id.
+    assert parse_jest_failures("2026-07-20T10:00:00Z   ● Some suite › a test\n") == {}
+
+
+def test_jest_empty_log_yields_no_failures():
+    assert parse_jest_failures("") == {}
 
 
 def test_gh_api_objects_parses_concatenated_pages(monkeypatch):

--- a/tests/dev/test_detect_flaky_tests.py
+++ b/tests/dev/test_detect_flaky_tests.py
@@ -113,6 +113,12 @@ def test_jest_empty_log_yields_no_failures():
     assert parse_jest_failures("") == {}
 
 
+def test_jest_framework_is_registered_scanning_the_js_workflow():
+    fw = FRAMEWORKS["jest"]
+    assert fw.workflow_name == "JS"
+    assert fw.parse_log is parse_jest_failures
+
+
 def test_gh_api_objects_parses_concatenated_pages(monkeypatch):
     # `gh api --paginate` concatenates each page's JSON body back-to-back; the decoder
     # must recover every object, not just the first.

--- a/tests/dev/test_detect_flaky_tests.py
+++ b/tests/dev/test_detect_flaky_tests.py
@@ -109,6 +109,33 @@ def test_jest_test_without_a_preceding_fail_file_is_ignored():
     assert parse_jest_failures("2026-07-20T10:00:00Z   ● Some suite › a test\n") == {}
 
 
+def test_jest_second_fail_header_rebinds_the_file_for_following_bullets():
+    # Two FAIL blocks in one log: each bullet must attach to the FAIL header directly
+    # above it, so the second file's failure is not misattributed to the first file.
+    log = (
+        "2026-07-20T10:00:00Z FAIL src/a.test.tsx (1 s)\n"
+        "2026-07-20T10:00:00Z   ● Suite A › first\n"
+        "2026-07-20T10:00:00Z     Error: boom-a\n"
+        "2026-07-20T10:00:00Z FAIL src/b.test.tsx (2 s)\n"
+        "2026-07-20T10:00:00Z   ● Suite B › second\n"
+        "2026-07-20T10:00:00Z     Error: boom-b\n"
+    )
+    assert parse_jest_failures(log) == {
+        "src/a.test.tsx › Suite A › first": "Error: boom-a",
+        "src/b.test.tsx › Suite B › second": "Error: boom-b",
+    }
+
+
+def test_jest_accepts_spec_suffix_files():
+    # `.spec.` is also valid jest naming; failures in such files must not be dropped.
+    log = (
+        "2026-07-20T10:00:00Z FAIL src/widget.spec.ts (1 s)\n"
+        "2026-07-20T10:00:00Z   ● Widget › renders\n"
+        "2026-07-20T10:00:00Z     Error: nope\n"
+    )
+    assert parse_jest_failures(log) == {"src/widget.spec.ts › Widget › renders": "Error: nope"}
+
+
 def test_jest_empty_log_yields_no_failures():
     assert parse_jest_failures("") == {}
 


### PR DESCRIPTION
> Builds on the framework-agnostic refactor in #25249 (now merged).

### Related Issues/PRs

Relates to #24510

### What changes are proposed in this pull request?

This attempts to automate the squashing of failing tests. 

Extends the weekly flaky-test detector (#24510) to the JS suite (the `JS` workflow). **Unlike the Python pipeline, this is report-only: it never edits tests and never opens a PR.**

The MLflow frontend forbids `jest.retryTimes` via ESLint (`config-eslint/presets/createConfigFactory.js`: _"Tests must pass without retries. If a test is flaky, fix it instead of adding retries."_). So the Python pipeline's headline move — auto-inserting a retry marker — is deliberately off the table for JS. A JS flake is always something a human fixes; the weekly issue just tells them where to look.

- **detect** (`dev/detect_flaky_tests.py`): add a `jest` framework whose log parser turns jest's reporter output (`FAIL <file>` headers + `● <suite> › <test>` blocks) into `<file> › <suite> › <test>` ids. The regexes were written against **captured live jest output**, not guessed.
- **classify** (`dev/classify_flaky_tests.py`): split the framework-specific prompt/schema into a `FrameworkClassifier`. The jest classifier is **report-only** — its schema offers only `fix`/`investigate` (no `annotate`, no `attempts`), so the model literally cannot recommend a retry — and its prompt is JS-flavored (`act()`/`waitFor`/fake-timer causes).
- **workflow** (`.github/workflows/flaky-test-detector-js.yml`): weekly detect → classify → rolling GitHub issue, scheduled a day before the Python detector so the two reports don't land together.

There is intentionally **no JS annotator stage**: retries are banned, so there is nothing to auto-apply.

I may follow up with a workflow PR to attempt to autofix failing tests. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

- New `parse_jest_failures` tests assert against a captured real jest failure log (ANSI + Actions-timestamp wrapping and all).
- New classifier tests assert the jest schema is report-only (`fix`/`investigate` only, no `attempts`) and pytest retains `annotate`.
- Manually verified end-to-end (API mocked): a `flakes.json` flows through the jest classifier, the report-only schema is sent to the model, and the verdict flows back.
- Separately confirmed the discovery that motivated report-only: a working `jest.retryTimes` annotation _does_ make a flaky test pass, but `yarn lint` (which JS CI runs before tests) rejects it — so an auto-annotate PR would be dead on arrival.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] Yes, this PR is a critical bugfix/security fix.
