### PR TITLE
Submit Custom View prompt on Enter (Shift+Enter inserts a newline)

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
@@ -559,6 +559,20 @@ describe('ModelTraceExplorerCustomView', () => {
     expect(screen.getByRole('button', { name: /Build with Assistant/ })).toBeInTheDocument();
   });
 
+  it('does not submit on Enter while an IME composition is being confirmed', async () => {
+    const openAssistant = jest.fn();
+    setBridge({ openAssistant });
+    renderCustomView();
+
+    await userEvent.type(screen.getByRole('textbox'), 'Show me the failed spans');
+    // isComposing marks the Enter that confirms an in-progress IME composition
+    // (e.g. CJK input), which must not submit the prompt.
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', isComposing: true });
+
+    expect(openAssistant).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Build with Assistant/ })).toBeInTheDocument();
+  });
+
   it('keeps the building skeleton after streaming ends until a view is created', () => {
     const openAssistant = jest.fn();
     openAssistant.mockImplementation(() => setBridge({ openAssistant, isStreaming: true }));

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.test.tsx
@@ -521,6 +521,44 @@ describe('ModelTraceExplorerCustomView', () => {
     expect(screen.queryByRole('button', { name: /Build with Assistant/ })).not.toBeInTheDocument();
   });
 
+  it('submits the typed prompt to the assistant when pressing Enter', async () => {
+    const openAssistant = jest.fn();
+    openAssistant.mockImplementation(() => setBridge({ openAssistant, isStreaming: true }));
+    setBridge({ openAssistant });
+    renderCustomView();
+
+    await userEvent.type(screen.getByRole('textbox'), 'Show me the failed spans');
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+    expect(openAssistant).toHaveBeenCalledTimes(1);
+    expect(openAssistant).toHaveBeenCalledWith('Show me the failed spans', { newSession: true });
+    expect(screen.getByText('Building this view…')).toBeInTheDocument();
+  });
+
+  it('does not submit on Shift+Enter so the user can insert a newline', async () => {
+    const openAssistant = jest.fn();
+    setBridge({ openAssistant });
+    renderCustomView();
+
+    await userEvent.type(screen.getByRole('textbox'), 'Show me the failed spans');
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', shiftKey: true });
+
+    expect(openAssistant).not.toHaveBeenCalled();
+    // The prompt box stays visible instead of switching to the building skeleton.
+    expect(screen.getByRole('button', { name: /Build with Assistant/ })).toBeInTheDocument();
+  });
+
+  it('does not submit on Enter when the prompt is empty', () => {
+    const openAssistant = jest.fn();
+    setBridge({ openAssistant });
+    renderCustomView();
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+    expect(openAssistant).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Build with Assistant/ })).toBeInTheDocument();
+  });
+
   it('keeps the building skeleton after streaming ends until a view is created', () => {
     const openAssistant = jest.fn();
     openAssistant.mockImplementation(() => setBridge({ openAssistant, isStreaming: true }));

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/custom-view/ModelTraceExplorerCustomView.tsx
@@ -1218,7 +1218,16 @@ export const ModelTraceExplorerCustomView = ({
                   })}
                   value={instruction}
                   autoSize={{ minRows: 3, maxRows: 8 }}
-                  onKeyDown={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => {
+                    event.stopPropagation();
+                    // Enter submits the prompt; Shift+Enter inserts a newline
+                    // (matching the main assistant chat panel). Skip submit while
+                    // an IME composition is being confirmed.
+                    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
+                      event.preventDefault();
+                      handleSubmitPrompt();
+                    }
+                  }}
                   onChange={(event) => setInstruction(event.target.value)}
                 />
                 <div>


### PR DESCRIPTION
### Related Issues/PRs

Relates to: N/A

### What changes are proposed in this pull request?

When building a custom trace view, the empty-state prompt box (in `ModelTraceExplorerCustomView.tsx`) only submitted the prompt to the MLflow Assistant when the user clicked **Build with Assistant** — pressing <kbd>Enter</kbd> just inserted a newline, which is unintuitive for a chat-style prompt.

This PR makes the prompt box submit on <kbd>Enter</kbd>, with <kbd>Shift</kbd>+<kbd>Enter</kbd> reserved for inserting a newline — matching the keyboard behavior of the main MLflow Assistant chat panel (`AssistantChatPanel.tsx`). The `onKeyDown` handler reuses the existing `handleSubmitPrompt` function (whose guards already no-op on an empty prompt or an in-flight build), keeps the existing `stopPropagation()` so the box stays isolated from the trace explorer's global shortcuts, and skips submission while an IME composition is being confirmed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added three tests to `ModelTraceExplorerCustomView.test.tsx`: <kbd>Enter</kbd> submits the prompt, <kbd>Shift</kbd>+<kbd>Enter</kbd> does not submit, and <kbd>Enter</kbd> with an empty prompt is a no-op. `yarn test ModelTraceExplorerCustomView` passes (50 tests), along with `yarn type-check`, `yarn lint`, and `yarn prettier:check`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
