### PR TITLE
Add `unprotect` label to bypass the `Protect` check on stacked PRs

### DIFF
--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -11,7 +11,20 @@ module.exports = async ({ github, context }) => {
   const {
     repo: { owner, repo },
   } = context;
-  const { sha } = context.payload.pull_request.head;
+  const pullRequest = context.payload.pull_request;
+  const { sha } = pullRequest.head;
+
+  // TODO: Remove this once stacked PRs support force-merging.
+  // The `unprotect` label bypasses this check on stacked PRs, which can't be
+  // force-merged like regular PRs (`gh pr merge --admin`). The `stack` property
+  // is only present while the PR belongs to a stack.
+  if (pullRequest.labels.some(({ name }) => name === "unprotect")) {
+    if (pullRequest.stack) {
+      console.log("The `unprotect` label is present on a stacked PR. Skipping this check.");
+      return;
+    }
+    console.log("Ignoring the `unprotect` label: it is only valid on stacked PRs.");
+  }
 
   const STATE = {
     pending: "pending",

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -9,6 +9,8 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
+      - unlabeled
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/protect.yml
+++ b/.github/workflows/protect.yml
@@ -17,7 +17,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't let unrelated label changes (e.g., component/release-note labels) cancel an
+  # in-flight polling run. Only `unprotect` label events restart it.
+  cancel-in-progress: >-
+    ${{
+      github.event.action != 'labeled' && github.event.action != 'unlabeled' ||
+      github.event.label.name == 'unprotect'
+    }}
 
 defaults:
   run:


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/orgs/community/discussions/201439

### What changes are proposed in this pull request?

Add an `unprotect` label that skips the `Protect` check, valid only on stacked PRs.

Stacked PRs [cannot bypass merge requirements](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands) (no `gh pr merge --admin` equivalent), so a flaky or irrelevant conditional job on any PR in a stack blocks the whole stack with no escape hatch. The label restores a maintainer-gated bypass: `protect.js` returns early when the PR has the `unprotect` label and the payload's `pull_request.stack` property (only present while the PR belongs to a stack) exists. On regular PRs the label is ignored since `--admin` merges already work. `labeled`/`unlabeled` triggers re-run the check when the label changes.

The label has been created on the repo. This can be removed once stacked PRs support force-merging.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)