### PR TITLE
[MLflow Assistant] Fix trace drawer closing when opening the Assistant provider picker

### DIFF
--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.test.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.test.tsx
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+
 import { shouldPreventDrawerDismiss } from './AssistantAwareDrawer';
 
 // These tests exercise the pure guard directly against real DOM nodes so they are fully

--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.test.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.test.tsx
@@ -1,0 +1,43 @@
+import { shouldPreventDrawerDismiss } from './AssistantAwareDrawer';
+
+// These tests exercise the pure guard directly against real DOM nodes so they are fully
+// deterministic: no component rendering, no Radix DismissableLayer event simulation, and no
+// timers/async that could make the assertions flaky.
+describe('shouldPreventDrawerDismiss', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  const renderTarget = (html: string): HTMLElement => {
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    document.body.appendChild(container);
+    return container.querySelector<HTMLElement>('[data-target]')!;
+  };
+
+  it('prevents dismissal for a portaled Radix popover/menu (e.g. the provider picker)', () => {
+    const target = renderTarget(
+      '<div data-radix-popper-content-wrapper><div role="menu"><span data-target>Claude</span></div></div>',
+    );
+    expect(shouldPreventDrawerDismiss(target)).toBe(true);
+  });
+
+  it('prevents dismissal for assistant UI', () => {
+    const target = renderTarget('<div data-assistant-ui="true"><button data-target>Ask</button></div>');
+    expect(shouldPreventDrawerDismiss(target)).toBe(true);
+  });
+
+  it('prevents dismissal for the drawer resize handle', () => {
+    const target = renderTarget('<div data-drawer-resize-handle="true" data-target></div>');
+    expect(shouldPreventDrawerDismiss(target)).toBe(true);
+  });
+
+  it('allows dismissal for an unrelated element outside the drawer', () => {
+    const target = renderTarget('<div><span data-target>elsewhere</span></div>');
+    expect(shouldPreventDrawerDismiss(target)).toBe(false);
+  });
+
+  it('allows dismissal when there is no target', () => {
+    expect(shouldPreventDrawerDismiss(null)).toBe(false);
+  });
+});

--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
@@ -39,8 +39,8 @@ function resolveWidthToPixels(w: number | string): number {
 export const shouldPreventDrawerDismiss = (target: HTMLElement | null): boolean =>
   Boolean(
     target?.closest('[data-assistant-ui="true"]') ||
-      target?.closest('[data-drawer-resize-handle="true"]') ||
-      target?.closest('[data-radix-popper-content-wrapper]'),
+    target?.closest('[data-drawer-resize-handle="true"]') ||
+    target?.closest('[data-radix-popper-content-wrapper]'),
   );
 
 // Keeping modal prop for compatibility with Drawer.Root props.

--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
@@ -171,7 +171,10 @@ function Content({
           const target = event.target as HTMLElement;
           const isAssistantClick = target?.closest('[data-assistant-ui="true"]');
           const isResizeHandle = target?.closest('[data-drawer-resize-handle="true"]');
-          if (isAssistantClick || isResizeHandle) {
+          // Portaled Radix menus/popovers (e.g. the provider picker) render outside the drawer,
+          // so opening one would otherwise dismiss it. Don't count them as outside interactions.
+          const isPopperContent = target?.closest('[data-radix-popper-content-wrapper]');
+          if (isAssistantClick || isResizeHandle || isPopperContent) {
             event.preventDefault();
           }
         }}

--- a/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
+++ b/mlflow/server/js/src/common/components/AssistantAwareDrawer.tsx
@@ -35,6 +35,14 @@ function resolveWidthToPixels(w: number | string): number {
   return 320;
 }
 
+// Keep the drawer open for assistant UI, the resize handle, and portaled Radix popovers (which live outside the drawer's DOM).
+export const shouldPreventDrawerDismiss = (target: HTMLElement | null): boolean =>
+  Boolean(
+    target?.closest('[data-assistant-ui="true"]') ||
+      target?.closest('[data-drawer-resize-handle="true"]') ||
+      target?.closest('[data-radix-popper-content-wrapper]'),
+  );
+
 // Keeping modal prop for compatibility with Drawer.Root props.
 function Root({
   open,
@@ -162,19 +170,11 @@ function Content({
         size={size}
         css={mergedCss}
         onInteractOutside={(event) => {
-          // Prevent drawer from closing when clicking on assistant UI elements.
-          // We use a data attribute selector instead of React patterns (e.g., stopPropagation)
-          // because Radix's DismissableLayer uses document-level listeners that bypass
-          // React's event propagation. The onInteractOutside handler is the correct
-          // interception point, and we identify assistant elements via data-assistant-ui
-          // attribute set on AssistantIconButton and RootAssistantLayout.
-          const target = event.target as HTMLElement;
-          const isAssistantClick = target?.closest('[data-assistant-ui="true"]');
-          const isResizeHandle = target?.closest('[data-drawer-resize-handle="true"]');
-          // Portaled Radix menus/popovers (e.g. the provider picker) render outside the drawer,
-          // so opening one would otherwise dismiss it. Don't count them as outside interactions.
-          const isPopperContent = target?.closest('[data-radix-popper-content-wrapper]');
-          if (isAssistantClick || isResizeHandle || isPopperContent) {
+          // We inspect the DOM target instead of using React patterns (e.g. stopPropagation)
+          // because Radix's DismissableLayer uses document-level listeners that bypass React's
+          // event propagation. onInteractOutside is the correct interception point; see
+          // shouldPreventDrawerDismiss for which interactions are treated as "not outside".
+          if (shouldPreventDrawerDismiss(event.target as HTMLElement)) {
             event.preventDefault();
           }
         }}


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

When the MLflow Assistant panel is open, the trace drawer docks to the left (`AssistantAwareDrawer` renders with `position="left"`). Opening the Assistant's model provider picker dismissed the drawer: the picker's Radix `DropdownMenu` content is portaled outside the drawer (under `document.body`, so outside `[data-assistant-ui]`), and opening it moved focus into that portaled content. That fired a `focusOutside` interaction on the drawer's Radix `DismissableLayer`, which its `onInteractOutside` guard did not exempt, so the drawer closed via `onOpenChange(false)`.

This PR exempts Radix popper content (`[data-radix-popper-content-wrapper]`) in the drawer's `onInteractOutside` guard, so portaled menus/popovers (the provider picker, its gateway submenu, and the model picker) no longer dismiss the drawer. This mirrors the existing exemptions for `[data-assistant-ui]` and the resize handle.

### How is this PR tested?

- [x] Manual tests

With the Assistant open and a trace drawer left-snapped, opening the provider picker (and selecting a provider/model) no longer dismisses the drawer, while clicking truly outside still closes it as before.

Before changes:

https://github.com/user-attachments/assets/441c8678-a0a9-4f21-8e72-365189a90c1d

After changes:

https://github.com/user-attachments/assets/51a9f7de-175b-4dca-8a36-5725ddd40aa6

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed the trace drawer being dismissed when opening the MLflow Assistant's model provider picker while the drawer is docked next to the Assistant.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release