### PR TITLE
Gate the presigned-upload-url route in basic-auth (parity with presigned-download-url)

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -133,6 +133,7 @@ from mlflow.protos.service_pb2 import (
     CreateGatewaySecret,
     CreateLoggedModel,
     CreatePresignedDownloadUrl,
+    CreatePresignedUploadUrl,
     CreatePromptOptimizationJob,
     CreateRun,
     CreateWorkspace,
@@ -2671,6 +2672,10 @@ BEFORE_REQUEST_HANDLERS = {
     # artifacts, so it requires the same per-run READ permission as the
     # proxied artifact download paths.
     CreatePresignedDownloadUrl: validate_can_read_run,
+    # Minting a presigned upload URL grants direct write access to a run's
+    # artifacts, so it requires per-run UPDATE permission (the write-side
+    # counterpart of CreatePresignedDownloadUrl above).
+    CreatePresignedUploadUrl: validate_can_update_run,
     # Routes for model registry (shared with prompts — dispatch via
     # `_get_permission_from_registered_model_or_prompt_name`).
     CreateRegisteredModel: validate_can_create_registered_model,
@@ -3376,7 +3381,6 @@ _KNOWN_UNGATED_ROUTE_MARKERS = (
     "/gateway/supported-models",
     "/gateway/endpoints/list",
     "/gateway/model-definitions/list",
-    "/mlflow/artifacts/presigned-upload-url",
     "/mlflow/demo/",
     "/mlflow/genai/evaluate/invoke",
     "/api/2.0/mlflow/metrics/get-history-bulk-interval",

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -777,6 +777,55 @@ def test_presigned_download_url_authorization_required(client, monkeypatch):
 
 
 @pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+def test_presigned_upload_url_authorization_required(client, monkeypatch):
+    # Minting a presigned upload URL grants direct write access to a run's artifacts,
+    # so it must enforce per-run UPDATE permission — the write-side counterpart of the
+    # READ requirement on CreatePresignedDownloadUrl. READ alone must not be enough.
+    username1, password1 = create_user(client.tracking_uri)
+    username2, password2 = create_user(client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        experiment_id = client.create_experiment("presigned-upload-authz-test")
+        run = client.create_run(experiment_id)
+        run_id = run.info.run_id
+
+    # Grant user2 only READ on user1's experiment. READ permits reading the run but not
+    # updating it, so the write-granting upload route must still reject with 403 at the
+    # auth layer — before the handler runs.
+    grant_role_permission(client.tracking_uri, username2, "experiment", experiment_id, "READ")
+
+    response = requests.post(
+        url=client.tracking_uri + "/api/2.0/mlflow/artifacts/presigned-upload-url",
+        json={"run_id": run_id, "path": "model.pkl"},
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+
+    # Same READ-only user reaches the download handler (READ satisfies its validator),
+    # which rejects the local (file://) artifact repo with 501. This confirms the READ
+    # grant is genuine and that the 403 above is specifically the UPDATE requirement.
+    response = requests.post(
+        url=client.tracking_uri + "/api/2.0/mlflow/artifacts/presigned-download-url",
+        json={"run_id": run_id, "path": "model.pkl"},
+        auth=(username2, password2),
+    )
+    assert response.status_code == 501
+
+    # user1 (creator, MANAGE on the experiment) can update the run, so the request passes
+    # the auth layer and reaches the handler, which rejects the local artifact repo with 501.
+    response = requests.post(
+        url=client.tracking_uri + "/api/2.0/mlflow/artifacts/presigned-upload-url",
+        json={"run_id": run_id, "path": "model.pkl"},
+        auth=(username1, password1),
+    )
+    assert response.status_code == 501
+
+
+@pytest.mark.parametrize(
     "fastapi_client",
     [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
     indirect=True,


### PR DESCRIPTION
### Related Issues/PRs

Relates to the ongoing per-endpoint authorization gating of routes tracked in `_KNOWN_UNGATED_ROUTE_MARKERS`.

### What changes are proposed in this pull request?

The basic-auth layer (`mlflow/server/auth/__init__.py`) gates `POST /api/2.0/mlflow/artifacts/presigned-download-url` (`CreatePresignedDownloadUrl`) with `validate_can_read_run`, but its upload counterpart `POST /api/2.0/mlflow/artifacts/presigned-upload-url` (`CreatePresignedUploadUrl`) had no validator and was carried in `_KNOWN_UNGATED_ROUTE_MARKERS` — the debt list of routes "temporarily exempt from fail-closed until each is gated." Under the default fail-open posture a user without update permission on a run could reach the upload handler (which mints a presigned URL granting direct write access to the run's artifacts), even though the same user is correctly rejected on the presigned-download route.

This PR finishes that acknowledged hardening for the upload route:

- Registers `CreatePresignedUploadUrl: validate_can_update_run` in `BEFORE_REQUEST_HANDLERS`. It requires `UPDATE` (not `READ`) because minting an upload URL grants write access — the write-side counterpart of the download route's read requirement.
- Removes `/mlflow/artifacts/presigned-upload-url` from `_KNOWN_UNGATED_ROUTE_MARKERS`.

This follows the same per-endpoint gating pattern applied recently to other previously ungated routes (e.g. `LogInputs`, `CreateModelVersion`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Adds `test_presigned_upload_url_authorization_required` in `tests/server/auth/test_auth.py`, mirroring the existing `test_presigned_download_url_authorization_required`:

- A user with only `READ` on the run is rejected with **403** at the auth layer on presigned-upload.
- That same READ-only user still reaches the presigned-download handler (**501** for the local file:// repo), confirming the 403 is specifically the `UPDATE` requirement and not a missing READ grant.
- A user with `UPDATE` (the run's owner) passes the auth layer and reaches the upload handler (**501** for the local file:// repo).

Verification: with the fix reverted the new test fails with `assert 501 == 403` (the READ-only user reaches the upload handler); with the fix it passes. The authorization coverage tests (`test_no_new_ungated_routes`, `test_known_ungated_markers_are_not_stale`) also pass. `ruff check` and `ruff format --check` pass on the changed files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The basic-auth server now enforces per-run `UPDATE` permission on the presigned artifact upload route, matching the read-permission enforcement already applied to the presigned download route.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
