### PR TITLE
[Tracing] Fix metrics provider leak on processor reinitialization

### DIFF
--- a/mlflow/tracing/processor/otel_metrics_mixin.py
+++ b/mlflow/tracing/processor/otel_metrics_mixin.py
@@ -64,10 +64,18 @@ class OtelMetricsMixin:
             )
             return
 
-        metric_exporter = OTLPMetricExporter(endpoint=endpoint)
-        reader = PeriodicExportingMetricReader(metric_exporter)
-        provider = MeterProvider(metric_readers=[reader])
-        metrics.set_meter_provider(provider)
+        provider = metrics.get_meter_provider()
+        if not isinstance(provider, MeterProvider):
+            metric_exporter = OTLPMetricExporter(endpoint=endpoint)
+            reader = PeriodicExportingMetricReader(metric_exporter)
+            provider = MeterProvider(metric_readers=[reader])
+            metrics.set_meter_provider(provider)
+
+            if metrics.get_meter_provider() is not provider:
+                # Registration was refused. Shut down this provider so its
+                # metric reader thread does not leak.
+                provider.shutdown()
+
         meter = metrics.get_meter("mlflow.tracing")
         self._duration_histogram = meter.create_histogram(
             name="mlflow.trace.span.duration",

--- a/mlflow/tracing/processor/otel_metrics_mixin.py
+++ b/mlflow/tracing/processor/otel_metrics_mixin.py
@@ -75,6 +75,12 @@ class OtelMetricsMixin:
                 # Registration was refused. Shut down this provider so its
                 # metric reader thread does not leak.
                 provider.shutdown()
+        else:
+            _logger.debug(
+                "An OpenTelemetry MeterProvider is already configured. MLflow tracing metrics "
+                "will use the existing provider instead of creating a separate exporter for "
+                "the configured OTLP metrics endpoint."
+            )
 
         meter = metrics.get_meter("mlflow.tracing")
         self._duration_histogram = meter.create_histogram(

--- a/tests/tracing/processor/test_otel_metrics.py
+++ b/tests/tracing/processor/test_otel_metrics.py
@@ -1,22 +1,43 @@
+import threading
 import time
 
 import pytest
 from opentelemetry import metrics
+from opentelemetry.metrics import _internal as metrics_internal
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 import mlflow
+from mlflow.entities.trace_location import MlflowExperimentLocation
 from mlflow.tracing.processor.otel_metrics_mixin import OtelMetricsMixin
+
+
+def _uninstall_global_meter_provider() -> None:
+    """Reset OpenTelemetry's process-global meter provider for test isolation."""
+    metrics_internal._METER_PROVIDER_SET_ONCE._done = False
+    metrics_internal._METER_PROVIDER = None
+
+
+def _exporting_reader_threads() -> int:
+    return sum(
+        1 for thread in threading.enumerate() if "PeriodicExportingMetricReader" in thread.name
+    )
 
 
 @pytest.fixture
 def metric_reader() -> InMemoryMetricReader:
     """Create an in-memory metric reader for testing."""
+    _uninstall_global_meter_provider()
+
     reader = InMemoryMetricReader()
     provider = MeterProvider(metric_readers=[reader])
     metrics.set_meter_provider(provider)
-    yield reader
-    provider.shutdown()
+
+    try:
+        yield reader
+    finally:
+        provider.shutdown()
+        _uninstall_global_meter_provider()
 
 
 def test_metrics_export(
@@ -108,45 +129,52 @@ def test_no_metrics_when_disabled(
     assert "mlflow.trace.span.duration" not in metric_names
 
 
-def test_setup_metrics_reuses_existing_meter_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_span_processor_rebuilds_do_not_leak_meter_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv(
         "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
         "http://localhost:9090",
     )
     monkeypatch.setenv(
-        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
         "http/protobuf",
     )
 
-    reader = InMemoryMetricReader()
-    provider = MeterProvider(metric_readers=[reader])
+    _uninstall_global_meter_provider()
+    experiment_id = mlflow.set_experiment("test_meter_provider_rebuild").experiment_id
 
-    set_provider_calls = []
-
-    # Pretend OpenTelemetry already has a configured global MeterProvider.
-    monkeypatch.setattr(metrics, "get_meter_provider", lambda: provider)
-    monkeypatch.setattr(metrics, "get_meter", lambda name: provider.get_meter(name))
-    monkeypatch.setattr(metrics, "set_meter_provider", set_provider_calls.append)
-
-    def unexpected_reader(*args, **kwargs):
-        pytest.fail(
-            "PeriodicExportingMetricReader should not be created "
-            "when a MeterProvider already exists"
-        )
-
-    monkeypatch.setattr(
-        "mlflow.tracing.processor.otel_metrics_mixin.PeriodicExportingMetricReader",
-        unexpected_reader,
-    )
+    def trace_to_destination() -> None:
+        mlflow.tracing.set_destination(MlflowExperimentLocation(experiment_id=experiment_id))
+        with mlflow.start_span(name="span"):
+            pass
 
     try:
-        processor = OtelMetricsMixin()
-        processor._setup_metrics_if_necessary()
+        # The first processor installs MLflow's MeterProvider and reader.
+        trace_to_destination()
 
-        assert processor._duration_histogram is not None
-        assert set_provider_calls == []
+        installed_provider = metrics.get_meter_provider()
+        readers_after_first = _exporting_reader_threads()
+
+        assert isinstance(installed_provider, MeterProvider)
+        assert readers_after_first > 0
+
+        # Rebuilding tracing processors must reuse the same metrics provider
+        # instead of creating additional exporting reader threads.
+        for _ in range(3):
+            trace_to_destination()
+
+        mlflow.tracing.reset()
+        trace_to_destination()
+
+        assert metrics.get_meter_provider() is installed_provider
+        assert _exporting_reader_threads() == readers_after_first
     finally:
-        provider.shutdown()
+        provider = metrics.get_meter_provider()
+        if isinstance(provider, MeterProvider):
+            provider.shutdown()
+
+        _uninstall_global_meter_provider()
 
 
 def test_setup_metrics_shuts_down_rejected_meter_provider(

--- a/tests/tracing/processor/test_otel_metrics.py
+++ b/tests/tracing/processor/test_otel_metrics.py
@@ -6,6 +6,7 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 import mlflow
+from mlflow.tracing.processor.otel_metrics_mixin import OtelMetricsMixin
 
 
 @pytest.fixture
@@ -105,3 +106,95 @@ def test_no_metrics_when_disabled(
                 metric_names.extend(metric.name for metric in scope_metric.metrics)
 
     assert "mlflow.trace.span.duration" not in metric_names
+
+
+def test_setup_metrics_reuses_existing_meter_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "http://localhost:9090",
+    )
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "http/protobuf",
+    )
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+
+    set_provider_calls = []
+
+    # Pretend OpenTelemetry already has a configured global MeterProvider.
+    monkeypatch.setattr(metrics, "get_meter_provider", lambda: provider)
+    monkeypatch.setattr(metrics, "get_meter", lambda name: provider.get_meter(name))
+    monkeypatch.setattr(metrics, "set_meter_provider", set_provider_calls.append)
+
+    def unexpected_reader(*args, **kwargs):
+        pytest.fail(
+            "PeriodicExportingMetricReader should not be created "
+            "when a MeterProvider already exists"
+        )
+
+    monkeypatch.setattr(
+        "mlflow.tracing.processor.otel_metrics_mixin.PeriodicExportingMetricReader",
+        unexpected_reader,
+    )
+
+    try:
+        processor = OtelMetricsMixin()
+        processor._setup_metrics_if_necessary()
+
+        assert processor._duration_histogram is not None
+        assert set_provider_calls == []
+    finally:
+        provider.shutdown()
+
+
+def test_setup_metrics_shuts_down_rejected_meter_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "http://localhost:9090",
+    )
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "http/protobuf",
+    )
+
+    existing_provider = object()
+    created_providers = []
+
+    class FakeMeterProvider:
+        def __init__(self, metric_readers):
+            self.metric_readers = metric_readers
+            self.shutdown_called = False
+            created_providers.append(self)
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    class FakeMeter:
+        def create_histogram(self, **kwargs):
+            return object()
+
+    # Simulate an application-owned provider that OpenTelemetry refuses
+    # to replace with MLflow's newly created provider.
+    monkeypatch.setattr(metrics, "get_meter_provider", lambda: existing_provider)
+    monkeypatch.setattr(metrics, "set_meter_provider", lambda provider: None)
+    monkeypatch.setattr(metrics, "get_meter", lambda name: FakeMeter())
+
+    monkeypatch.setattr(
+        "mlflow.tracing.processor.otel_metrics_mixin.MeterProvider",
+        FakeMeterProvider,
+    )
+    monkeypatch.setattr(
+        "mlflow.tracing.processor.otel_metrics_mixin.PeriodicExportingMetricReader",
+        lambda exporter: object(),
+    )
+
+    processor = OtelMetricsMixin()
+    processor._setup_metrics_if_necessary()
+
+    assert len(created_providers) == 1
+    assert created_providers[0].shutdown_called
+    assert processor._duration_histogram is not None


### PR DESCRIPTION
### Related Issues/PRs

Closes #25206

### What changes are proposed in this pull request?

This PR fixes a resource leak in OpenTelemetry metrics initialization when MLflow tracing span processors are recreated.

`OtelMetricsMixin` previously created a new `MeterProvider` and `PeriodicExportingMetricReader` whenever a new processor initialized metrics. Since OpenTelemetry only allows the global `MeterProvider` to be set once, subsequent providers were rejected while their metric reader threads remained alive.

The change reuses an existing SDK `MeterProvider` when one is already configured. If MLflow creates a new provider but OpenTelemetry refuses to register it, the provider is shut down so its metric reader thread is not leaked.

Regression tests cover both reusing an existing provider and cleaning up a rejected provider.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Testing performed:

- `pytest tests/tracing/processor/test_otel_metrics.py -q` — 4 passed
- `pytest tests/tracing/processor -q` — 42 passed
- `pre-commit run --files mlflow/tracing/processor/otel_metrics_mixin.py tests/tracing/processor/test_otel_metrics.py` — passed
- Manually reproduced repeated `mlflow.tracing.set_destination()` calls and verified that the live `MeterProvider` and `OtelPeriodicExportingMetricReader` counts remain at 1 instead of increasing on each processor recreation.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix a resource leak that could create additional OpenTelemetry metric reader threads when MLflow tracing processors are reinitialized.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release