### PR TITLE
fix: prevent async trace queue deadlock during flush

### DIFF
--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -41,6 +41,9 @@ class AsyncTraceExportQueue:
     def __init__(self):
         self._queue: Queue[Task] = Queue(maxsize=MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE.get())
         self._lock = threading.RLock()
+        # Serialize flush() without holding self._lock across thread joins, which could
+        # deadlock with a concurrent put().
+        self._flush_lock = threading.Lock()
         self._max_workers = MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS.get()
 
         # Thread event that indicates the queue should stop processing tasks
@@ -53,33 +56,31 @@ class AsyncTraceExportQueue:
 
     def put(self, task: Task):
         """Put a new task to the queue for processing."""
-        if not self.is_active():
-            if self._stop_event.is_set():
-                # Queue was terminated via flush(terminate=True); _stop_event will never be
-                # cleared, so activating and then waiting would deadlock. Execute synchronously.
-                task.handle()
+        with self._lock:
+            if not self.is_active():
+                if not self._stop_event.is_set():
+                    self.activate()
+
+            if self.is_active():
+                try:
+                    # Do not block if the queue is full, it will block the main application
+                    self._queue.put(task, block=False)
+                except queue_Full:
+                    if self._last_full_queue_warning_time is None or (
+                        time.time() - self._last_full_queue_warning_time > 30
+                    ):
+                        _logger.warning(
+                            "Trace export queue is full, trace will be discarded. "
+                            "Consider increasing the queue size through "
+                            "`MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE` environment variable or "
+                            "number of workers through `MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS`"
+                            " environment variable."
+                        )
+                        self._last_full_queue_warning_time = time.time()
                 return
-            self.activate()
 
-        # If stop event is set, wait for the queue to be drained before putting the task
-        if self._stop_event.is_set():
-            self._stop_event.wait()
-
-        try:
-            # Do not block if the queue is full, it will block the main application
-            self._queue.put(task, block=False)
-        except queue_Full:
-            if self._last_full_queue_warning_time is None or (
-                time.time() - self._last_full_queue_warning_time > 30
-            ):
-                _logger.warning(
-                    "Trace export queue is full, trace will be discarded. "
-                    "Consider increasing the queue size through "
-                    "`MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE` environment variable or "
-                    "number of workers through `MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS`"
-                    " environment variable."
-                )
-                self._last_full_queue_warning_time = time.time()
+        # Queue is flushing or was terminated; execute synchronously.
+        task.handle()
 
     def _consumer_loop(self) -> None:
         while not self._stop_event.is_set():
@@ -170,18 +171,24 @@ class AsyncTraceExportQueue:
         Args:
             terminate: If True, shut down the logging threads after flushing.
         """
-        if not self.is_active():
-            return
+        with self._flush_lock:
+            with self._lock:
+                if not self.is_active():
+                    return
 
-        self._stop_event.set()
-        self._consumer_thread.join()
+                # Mark the queue inactive before stopping the consumer so concurrent
+                # put() calls cannot enqueue work that no consumer will process.
+                self._is_active = False
+                self._stop_event.set()
 
-        # Wait for all tasks to be processed
-        self._queue.join()
+            self._consumer_thread.join()
 
-        self._worker_threadpool.shutdown(wait=True)
-        self._is_active = False
-        # Restart threads to listen to incoming requests after flushing, if not terminating
-        if not terminate:
-            self._stop_event.clear()
-            self.activate()
+            # Wait for all tasks to be processed
+            self._queue.join()
+
+            self._worker_threadpool.shutdown(wait=True)
+
+            # Restart threads to listen to incoming requests after flushing, if not terminating
+            if not terminate:
+                self._stop_event.clear()
+                self.activate()

--- a/tests/tracing/export/test_async_export_queue.py
+++ b/tests/tracing/export/test_async_export_queue.py
@@ -4,6 +4,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
+import pytest
+
 from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
 
 from tests.tracing.helper import skip_when_testing_trace_sdk
@@ -129,3 +131,97 @@ def test_async_queue_drop_task_when_full(monkeypatch):
     # One more task than the queue size might be processed, because the first task
     # can be drained from the queue immediately, which creates a slot for another task
     assert processed_tasks <= 4
+
+
+@pytest.mark.parametrize("terminate", [False, True])
+def test_concurrent_put_during_flush_does_not_deadlock(terminate):
+    queue = AsyncTraceExportQueue()
+
+    calls = []
+    consumer_joined = threading.Event()
+    allow_flush_to_continue = threading.Event()
+
+    queue.activate()
+
+    original_join = queue._consumer_thread.join
+
+    def controlled_join(*args, **kwargs):
+        result = original_join(*args, **kwargs)
+        consumer_joined.set()
+        allow_flush_to_continue.wait(timeout=5)
+        return result
+
+    queue._consumer_thread.join = controlled_join
+
+    flush_thread = threading.Thread(
+        target=queue.flush,
+        kwargs={"terminate": terminate},
+        name="test-concurrent-put-flush",
+        daemon=True,
+    )
+    flush_thread.start()
+
+    assert consumer_joined.wait(timeout=5)
+
+    # The consumer has stopped while flush() is still in progress.
+    # A concurrent put() must not enqueue work that no consumer can process.
+    queue.put(Task(handler=calls.append, args=(1,)))
+
+    allow_flush_to_continue.set()
+    flush_thread.join(timeout=5)
+
+    assert not flush_thread.is_alive()
+    assert calls == [1]
+    assert queue.is_active() is not terminate
+
+    if not terminate:
+        queue.flush(terminate=True)
+
+
+def test_flush_waits_for_in_progress_flush():
+    queue = AsyncTraceExportQueue()
+    release = threading.Event()
+    completed = []
+
+    def handler(value):
+        assert release.wait(timeout=10)
+        completed.append(value)
+
+    for value in range(3):
+        queue.put(Task(handler=handler, args=(value,)))
+
+    first_flush_thread = threading.Thread(
+        target=queue.flush,
+        kwargs={"terminate": True},
+        name="test-first-concurrent-flush",
+        daemon=True,
+    )
+    first_flush_thread.start()
+
+    deadline = time.monotonic() + 5
+    while queue.is_active() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not queue.is_active()
+
+    completed_when_second_flush_returns = []
+
+    def second_flush():
+        queue.flush(terminate=True)
+        completed_when_second_flush_returns.append(len(completed))
+
+    second_flush_thread = threading.Thread(
+        target=second_flush,
+        name="test-second-concurrent-flush",
+        daemon=True,
+    )
+    second_flush_thread.start()
+
+    second_flush_thread.join(timeout=0.1)
+
+    release.set()
+    first_flush_thread.join(timeout=5)
+    second_flush_thread.join(timeout=5)
+
+    assert not first_flush_thread.is_alive()
+    assert not second_flush_thread.is_alive()
+    assert completed_when_second_flush_returns == [3]


### PR DESCRIPTION
### Related Issues/PRs

Closes #25237

### What changes are proposed in this pull request?

Fixes a race between `AsyncTraceExportQueue.put()` and `flush()` where a task could be enqueued after the consumer thread had already exited.

During `flush()`, the queue previously remained active while the consumer was stopping. A concurrent `put()` could therefore enqueue a task after the consumer's drain loop had already observed an empty queue and exited.

That late task increments `queue.unfinished_tasks`, but no consumer remains to process it and call `task_done()`. As a result, `flush()` can block indefinitely in `self._queue.join()`.

This affects both `terminate=False` and `terminate=True`, including the shutdown path used by the tracing queue's `atexit` handler.

This change:

* synchronizes the `put()` enqueue decision with the `flush()` lifecycle transition using the existing `RLock`
* marks the queue inactive before stopping the consumer so new tasks cannot be enqueued after the consumer has exited
* executes tasks synchronously when they arrive while the queue is flushing or has been terminated
* removes the ineffective `Event.wait()` path, since `threading.Event.wait()` returns immediately when the event is already set
* adds a dedicated plain `_flush_lock` to serialize concurrent `flush()` calls without holding the queue lifecycle lock across thread joins
* preserves the existing `flush()` contract so a second concurrent flush waits for the in-progress flush instead of returning while tasks are still pending
* adds regression coverage for both terminating and non-terminating flushes and for concurrent `flush()` callers

### How is this PR tested?

* [x] Existing unit/integration tests
* [x] New unit/integration tests

Ran:

```text
uv run python -m pytest tests/tracing/export/test_async_export_queue.py -v
```

Result:

```text
8 passed
```

Also ran:

```text
uv run ruff check mlflow/tracing/export/async_export_queue.py tests/tracing/export/test_async_export_queue.py
uv run ruff format --check mlflow/tracing/export/async_export_queue.py tests/tracing/export/test_async_export_queue.py
uv run clint mlflow/tracing/export/async_export_queue.py tests/tracing/export/test_async_export_queue.py
git diff --check
```

Results:

```text
Ruff check: All checks passed
Ruff format: 2 files already formatted
Clint: No errors found
git diff --check: no errors
```

### Does this PR require documentation update?

* [x] No.

### Does this PR require updating the [[MLflow Skills](https://github.com/mlflow/skills)](https://github.com/mlflow/skills) repository?

* [x] No.

### Release Notes

#### Is this a user-facing change?

* [x] Yes. Fixes a tracing deadlock where asynchronous trace export could hang during `flush()` if a concurrent `put()` arrived after the consumer had already exited.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

* [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

* [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release