### PR TITLE
Fix stale expectations and record counts on dataset export

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.test.tsx
@@ -1,0 +1,227 @@
+import { describe, expect, jest, test, beforeEach } from '@jest/globals';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithDesignSystem } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import Utils from '@mlflow/mlflow/src/common/utils/Utils';
+import { ExportTracesToDatasetModal } from './ExportTracesToDatasetModal';
+import { useFetchTraces } from '../hooks/useFetchTraces';
+import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatasets';
+import { useCheckMultiturnDatasets } from '../hooks/useCheckMultiturnDatasets';
+import { useUpsertDatasetRecordsMutation } from '../hooks/useUpsertDatasetRecordsMutation';
+import type { EvaluationDataset } from '../types';
+
+jest.mock('../hooks/useFetchTraces', () => ({
+  useFetchTraces: jest.fn(),
+}));
+
+jest.mock('../hooks/useSearchEvaluationDatasets', () => ({
+  useSearchEvaluationDatasets: jest.fn(),
+}));
+
+jest.mock('../hooks/useCheckMultiturnDatasets', () => ({
+  useCheckMultiturnDatasets: jest.fn(),
+}));
+
+jest.mock('../hooks/useUpsertDatasetRecordsMutation', () => ({
+  useUpsertDatasetRecordsMutation: jest.fn(),
+}));
+
+jest.mock('../hooks/useInfiniteScrollFetch', () => ({
+  useInfiniteScrollFetch: () => () => {},
+}));
+
+jest.mock('./CreateEvaluationDatasetButton', () => ({
+  CreateEvaluationDatasetButton: () => null,
+}));
+
+jest.mock('../utils/datasetUtils', () => ({
+  extractDatasetInfoFromTraces: jest.fn((traces: unknown[]) => traces),
+}));
+
+const dataset: EvaluationDataset = {
+  dataset_id: 'ds-1',
+  name: 'eval',
+  created_time: 0,
+  last_update_time: 0,
+  created_by: 'user',
+  last_updated_by: 'user',
+  experiment_ids: ['exp-1'],
+};
+
+const secondDataset: EvaluationDataset = {
+  ...dataset,
+  dataset_id: 'ds-2',
+  name: 'eval-2',
+};
+
+describe('ExportTracesToDatasetModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useSearchEvaluationDatasets).mockReturnValue({
+      data: [dataset],
+      isLoading: false,
+      isFetching: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    } as unknown as ReturnType<typeof useSearchEvaluationDatasets>);
+    jest.mocked(useCheckMultiturnDatasets).mockReturnValue({
+      data: false,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCheckMultiturnDatasets>);
+  });
+
+  test('upserts records built from the refetch result, not the cached traces', async () => {
+    const user = userEvent.setup();
+    const cachedRows = [{ inputs: { q: 'stale' }, expectations: {} }];
+    const freshRows = [{ inputs: { q: 'fresh' }, expectations: { length: 50 } }];
+    const refetch = jest.fn(async (_options?: { throwOnError?: boolean }) => ({ data: freshRows }));
+    const upsertAsync = jest.fn(async (_payload: { datasetId: string; records: string }) => ({
+      insertedCount: 1,
+      updatedCount: 0,
+    }));
+    const invalidateAfterUpsert = jest.fn();
+
+    jest.mocked(useFetchTraces).mockReturnValue({
+      data: cachedRows,
+      isLoading: false,
+      refetch,
+    } as unknown as ReturnType<typeof useFetchTraces>);
+    jest.mocked(useUpsertDatasetRecordsMutation).mockReturnValue({
+      upsertDatasetRecordsMutationAsync: upsertAsync,
+      invalidateAfterUpsert,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUpsertDatasetRecordsMutation>);
+
+    renderWithDesignSystem(
+      <ExportTracesToDatasetModal
+        experimentId="exp-1"
+        visible
+        setVisible={() => {}}
+        selectedTraceInfos={[{ trace_id: 'tr-1', trace_location: {} } as any]}
+      />,
+    );
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalledWith({ throwOnError: true });
+      expect(upsertAsync).toHaveBeenCalledWith({
+        datasetId: 'ds-1',
+        records: JSON.stringify(freshRows),
+      });
+      expect(invalidateAfterUpsert).toHaveBeenCalledTimes(1);
+      expect(invalidateAfterUpsert).toHaveBeenCalledWith(['ds-1']);
+    });
+  });
+
+  test('does not upsert when refetch fails', async () => {
+    const user = userEvent.setup();
+    const errorSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
+    const setVisible = jest.fn();
+    const refetch = jest.fn(async (_options?: { throwOnError?: boolean }) => {
+      throw new Error('refetch failed');
+    });
+    const upsertAsync = jest.fn(async (_payload: { datasetId: string; records: string }) => ({
+      insertedCount: 1,
+      updatedCount: 0,
+    }));
+    const invalidateAfterUpsert = jest.fn();
+
+    jest.mocked(useFetchTraces).mockReturnValue({
+      data: [{ inputs: { q: 'stale' }, expectations: {} }],
+      isLoading: false,
+      refetch,
+    } as unknown as ReturnType<typeof useFetchTraces>);
+    jest.mocked(useUpsertDatasetRecordsMutation).mockReturnValue({
+      upsertDatasetRecordsMutationAsync: upsertAsync,
+      invalidateAfterUpsert,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUpsertDatasetRecordsMutation>);
+
+    renderWithDesignSystem(
+      <ExportTracesToDatasetModal
+        experimentId="exp-1"
+        visible
+        setVisible={setVisible}
+        selectedTraceInfos={[{ trace_id: 'tr-1', trace_location: {} } as any]}
+      />,
+    );
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalledWith({ throwOnError: true });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(upsertAsync).not.toHaveBeenCalled();
+    expect(invalidateAfterUpsert).not.toHaveBeenCalled();
+    expect(setVisible).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  test('waits for in-flight upserts before showing an error and re-enabling Export', async () => {
+    const user = userEvent.setup();
+    const errorSpy = jest.spyOn(Utils, 'displayGlobalErrorNotification').mockImplementation(() => {});
+    let resolveSlowUpsert: (value: { insertedCount: number; updatedCount: number }) => void = () => {};
+    const slowUpsert = new Promise<{ insertedCount: number; updatedCount: number }>((resolve) => {
+      resolveSlowUpsert = resolve;
+    });
+    const invalidateAfterUpsert = jest.fn();
+    const upsertAsync = jest.fn(async ({ datasetId }: { datasetId: string; records: string }) => {
+      if (datasetId === 'ds-1') {
+        throw new Error('first destination failed');
+      }
+      return slowUpsert;
+    });
+
+    jest.mocked(useSearchEvaluationDatasets).mockReturnValue({
+      data: [dataset, secondDataset],
+      isLoading: false,
+      isFetching: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    } as unknown as ReturnType<typeof useSearchEvaluationDatasets>);
+    jest.mocked(useFetchTraces).mockReturnValue({
+      data: [{ inputs: { q: 'fresh' }, expectations: {} }],
+      isLoading: false,
+      refetch: jest.fn(async () => ({ data: [{ inputs: { q: 'fresh' }, expectations: {} }] })),
+    } as unknown as ReturnType<typeof useFetchTraces>);
+    jest.mocked(useUpsertDatasetRecordsMutation).mockReturnValue({
+      upsertDatasetRecordsMutationAsync: upsertAsync,
+      invalidateAfterUpsert,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUpsertDatasetRecordsMutation>);
+
+    renderWithDesignSystem(
+      <ExportTracesToDatasetModal
+        experimentId="exp-1"
+        visible
+        setVisible={() => {}}
+        selectedTraceInfos={[{ trace_id: 'tr-1', trace_location: {} } as any]}
+      />,
+    );
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => {
+      expect(upsertAsync).toHaveBeenCalledTimes(2);
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(invalidateAfterUpsert).not.toHaveBeenCalled();
+    expect(
+      document.querySelector('[data-component-id="mlflow.export-traces-to-dataset-modal.footer.ok"]'),
+    ).toBeDisabled();
+
+    resolveSlowUpsert({ insertedCount: 1, updatedCount: 0 });
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(invalidateAfterUpsert).toHaveBeenCalledTimes(1);
+      expect(invalidateAfterUpsert).toHaveBeenCalledWith(['ds-2']);
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal.tsx
@@ -15,7 +15,7 @@ import {
 import type { ColumnDef } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel } from '@tanstack/react-table';
 import { useReactTable_unverifiedWithReact18 as useReactTable } from '@databricks/web-shared/react-table';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
 import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatasets';
 import type { EvaluationDataset } from '../types';
@@ -28,6 +28,7 @@ import { useUpsertDatasetRecordsMutation } from '../hooks/useUpsertDatasetRecord
 import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
 import { useFetchTraces } from '../hooks/useFetchTraces';
 import { useCheckMultiturnDatasets } from '../hooks/useCheckMultiturnDatasets';
+import Utils from '@mlflow/mlflow/src/common/utils/Utils';
 
 const columns: ColumnDef<EvaluationDataset, string>[] = [
   {
@@ -49,6 +50,7 @@ export const ExportTracesToDatasetModal = ({
   selectedTraceInfos: ModelTrace['info'][];
 }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const [searchFilter, setSearchFilter] = useState('');
   const [internalSearchFilter, setInternalSearchFilter] = useState(searchFilter);
 
@@ -57,8 +59,10 @@ export const ExportTracesToDatasetModal = ({
     // the full trace, which is not available in the trace table
     getModelTraceId({ info: traceInfo, data: { spans: [] } }),
   );
-  const { data: traces, isLoading: isLoadingTraces } = useFetchTraces({ traceIds });
-  const datasetRowsToExport = extractDatasetInfoFromTraces(compact(traces));
+  const { isLoading: isLoadingTraces, refetch: refetchTraces } = useFetchTraces({
+    traceIds,
+  });
+  const [isExporting, setIsExporting] = useState(false);
 
   const {
     data: datasets,
@@ -93,22 +97,47 @@ export const ExportTracesToDatasetModal = ({
     datasetIds: selectedDatasetIds,
   });
 
-  const { upsertDatasetRecordsMutation, isLoading: isUpsertingDatasetRecords } = useUpsertDatasetRecordsMutation({
-    onSuccess: () => {
-      setVisible(false);
-    },
-  });
+  const {
+    upsertDatasetRecordsMutationAsync,
+    invalidateAfterUpsert,
+    isLoading: isUpsertingDatasetRecords,
+  } = useUpsertDatasetRecordsMutation();
 
-  const handleExport = useCallback(() => {
-    Promise.all(
-      selectedDatasets.map((dataset) =>
-        upsertDatasetRecordsMutation({
-          datasetId: dataset.dataset_id,
-          records: JSON.stringify(datasetRowsToExport),
+  const handleExport = useCallback(async () => {
+    setIsExporting(true);
+    try {
+      // This modal stays mounted, so FETCH_TRACES can be from before the user
+      // added expectations. Refetch at export time so the dataset snapshot
+      // includes current assessments.
+      const { data: freshTraces } = await refetchTraces({ throwOnError: true });
+      const datasetRowsToExport = extractDatasetInfoFromTraces(compact(freshTraces));
+      const results = await Promise.allSettled(
+        selectedDatasets.map((dataset) =>
+          upsertDatasetRecordsMutationAsync({
+            datasetId: dataset.dataset_id,
+            records: JSON.stringify(datasetRowsToExport),
+          }),
+        ),
+      );
+      const succeededDatasetIds = selectedDatasets.flatMap((dataset, index) =>
+        results[index].status === 'fulfilled' ? [dataset.dataset_id] : [],
+      );
+      invalidateAfterUpsert(succeededDatasetIds);
+      if (results.some((result) => result.status === 'rejected')) {
+        throw new Error('Failed to export traces to datasets.');
+      }
+      setVisible(false);
+    } catch {
+      Utils.displayGlobalErrorNotification(
+        intl.formatMessage({
+          defaultMessage: 'Failed to export traces to datasets.',
+          description: 'Error toast when exporting traces to evaluation datasets fails',
         }),
-      ),
-    );
-  }, [selectedDatasets, upsertDatasetRecordsMutation, datasetRowsToExport]);
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  }, [selectedDatasets, upsertDatasetRecordsMutationAsync, invalidateAfterUpsert, refetchTraces, intl, setVisible]);
 
   return (
     <Modal
@@ -117,8 +146,9 @@ export const ExportTracesToDatasetModal = ({
       onCancel={() => setVisible(false)}
       okText={<FormattedMessage defaultMessage="Export" description="Export traces to dataset modal action button" />}
       okButtonProps={{
-        disabled: isLoadingTraces || selectedDatasets.length === 0 || hasMultiturnDataset || isCheckingMultiturn,
-        loading: isUpsertingDatasetRecords,
+        disabled:
+          isLoadingTraces || isExporting || selectedDatasets.length === 0 || hasMultiturnDataset || isCheckingMultiturn,
+        loading: isUpsertingDatasetRecords || isExporting,
       }}
       onOk={handleExport}
       title={

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
@@ -1,5 +1,7 @@
 import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
-import { useMutation } from '@databricks/web-shared/query-client';
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@databricks/web-shared/query-client';
+import { GET_DATASET_RECORDS_QUERY_KEY, SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
 
 type UpsertDatasetRecordsPayload = {
   datasetId: string;
@@ -12,14 +14,9 @@ type UpsertDatasetRecordsResponse = {
   updatedCount: number;
 };
 
-export const useUpsertDatasetRecordsMutation = ({
-  onSuccess,
-  onError,
-}: {
-  onSuccess?: () => void;
-  onError?: (error: any) => void;
-}) => {
-  const { mutate: upsertDatasetRecordsMutation, isLoading } = useMutation({
+export const useUpsertDatasetRecordsMutation = () => {
+  const queryClient = useQueryClient();
+  const { mutateAsync: upsertDatasetRecordsMutationAsync, isLoading } = useMutation({
     mutationFn: async ({ datasetId, records }: UpsertDatasetRecordsPayload) => {
       const requestBody = {
         dataset_id: datasetId,
@@ -33,16 +30,25 @@ export const useUpsertDatasetRecordsMutation = ({
 
       return response;
     },
-    onSuccess: () => {
-      onSuccess?.();
-    },
-    onError: (error) => {
-      onError?.(error);
-    },
   });
 
+  const invalidateAfterUpsert = useCallback(
+    (datasetIds: string[]) => {
+      if (datasetIds.length === 0) {
+        return;
+      }
+      // Search holds dataset.profile (record count); records is the open table.
+      queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });
+      for (const datasetId of datasetIds) {
+        queryClient.invalidateQueries({ queryKey: [GET_DATASET_RECORDS_QUERY_KEY, datasetId] });
+      }
+    },
+    [queryClient],
+  );
+
   return {
-    upsertDatasetRecordsMutation,
+    upsertDatasetRecordsMutationAsync,
+    invalidateAfterUpsert,
     isLoading,
   };
 };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1879,6 +1879,10 @@
     "defaultMessage": "Key name",
     "description": "API key name column header"
   },
+  "6Hpgz8": {
+    "defaultMessage": "Failed to export traces to datasets.",
+    "description": "Error toast when exporting traces to evaluation datasets fails"
+  },
   "6I8pKa": {
     "defaultMessage": "Auth Type:",
     "description": "Auth type label"


### PR DESCRIPTION
### Related Issues/PRs

Closes https://github.com/mlflow/mlflow/issues/25274

### What changes are proposed in this pull request?

The export modal stays mounted, so cached traces can miss expectations added after the first fetch. Refetch on Export so the snapshot is current. After upsert, invalidate the dataset search and records queries so the UI record count matches the table.

<img width="1627" height="837" alt="Screenshot From 2026-08-21 15-42-30" src="https://github.com/user-attachments/assets/496168d0-8f09-4f3a-bdc5-5766ca8a8b85" />

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
