### PR TITLE
Fix  streaming passthrough skipping fallback

### DIFF
--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -828,12 +828,45 @@ class FallbackProvider(BaseProvider):
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
         return await self._execute_with_fallback("embeddings", payload)
 
+    async def _passthrough_stream_with_fallback(
+        self,
+        action: PassthroughAction,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> AsyncIterable[Any]:
+        from fastapi import HTTPException
+
+        last_error = None
+
+        for attempt, provider in enumerate(self._providers[: self._max_attempts], 1):
+            try:
+                result = await provider.passthrough(action, payload, headers)
+                async for chunk in result:
+                    yield chunk
+                return
+            except Exception as e:
+                last_error = e
+                if attempt < self._max_attempts:
+                    continue
+                break
+
+        status_code = 500
+        if isinstance(last_error, (AIGatewayException, HTTPException)):
+            status_code = last_error.status_code
+
+        raise AIGatewayException(
+            status_code=status_code,
+            detail=f"All {self._max_attempts} fallback attempts failed. Last error: {last_error!s}",
+        )
+
     async def passthrough(
         self,
         action: PassthroughAction,
         payload: dict[str, Any],
         headers: dict[str, str] | None = None,
     ) -> dict[str, Any] | AsyncIterable[Any]:
+        if payload.get("stream"):
+            return self._passthrough_stream_with_fallback(action, payload, headers)
         return await self._execute_with_fallback("passthrough", action, payload, headers)
 
     async def proxy(

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -763,13 +763,18 @@ class FallbackProvider(BaseProvider):
             detail=f"All {self._max_attempts} fallback attempts failed. Last error: {last_error!s}",
         )
 
-    async def _execute_stream_with_fallback(self, method_name: str, *args, **kwargs):
+    async def _execute_stream_with_fallback(
+        self, method_name: str, *args, await_result: bool = False, **kwargs
+    ):
         """
         Execute a streaming method on providers with fallback logic.
 
         Args:
             method_name: Name of the streaming method to call on each provider
             *args: Positional arguments to pass to the method
+            await_result: When True, the method is a regular async function returning
+                an AsyncIterable rather than an async generator; the result is awaited
+                first and then iterated.
             **kwargs: Keyword arguments to pass to the method
 
         Yields:
@@ -779,19 +784,29 @@ class FallbackProvider(BaseProvider):
             AIGatewayException: If all fallback attempts fail, with status code
                 propagated from the last exception if it was an AIGatewayException
                 or HTTPException
+
+        Note:
+            Fallback is only attempted when an error occurs before any chunk has been
+            yielded. If an error surfaces mid-stream (after chunks have already been
+            sent to the caller), it is re-raised immediately because the caller has
+            already received partial data and a retry would produce a corrupt stream.
         """
         from fastapi import HTTPException
 
         last_error = None
 
         for attempt, provider in enumerate(self._providers[: self._max_attempts], 1):
+            yielded = False
             try:
                 method = getattr(provider, method_name)
-                async for chunk in method(*args, **kwargs):
+                stream = await method(*args, **kwargs) if await_result else method(*args, **kwargs)
+                async for chunk in stream:
+                    yielded = True
                     yield chunk
-                # Stream completed successfully
                 return
             except Exception as e:
+                if yielded:
+                    raise
                 last_error = e
                 if attempt < self._max_attempts:
                     continue
@@ -828,37 +843,6 @@ class FallbackProvider(BaseProvider):
     async def embeddings(self, payload: embeddings.RequestPayload) -> embeddings.ResponsePayload:
         return await self._execute_with_fallback("embeddings", payload)
 
-    async def _passthrough_stream_with_fallback(
-        self,
-        action: PassthroughAction,
-        payload: dict[str, Any],
-        headers: dict[str, str] | None = None,
-    ) -> AsyncIterable[Any]:
-        from fastapi import HTTPException
-
-        last_error = None
-
-        for attempt, provider in enumerate(self._providers[: self._max_attempts], 1):
-            try:
-                result = await provider.passthrough(action, payload, headers)
-                async for chunk in result:
-                    yield chunk
-                return
-            except Exception as e:
-                last_error = e
-                if attempt < self._max_attempts:
-                    continue
-                break
-
-        status_code = 500
-        if isinstance(last_error, (AIGatewayException, HTTPException)):
-            status_code = last_error.status_code
-
-        raise AIGatewayException(
-            status_code=status_code,
-            detail=f"All {self._max_attempts} fallback attempts failed. Last error: {last_error!s}",
-        )
-
     async def passthrough(
         self,
         action: PassthroughAction,
@@ -866,7 +850,9 @@ class FallbackProvider(BaseProvider):
         headers: dict[str, str] | None = None,
     ) -> dict[str, Any] | AsyncIterable[Any]:
         if payload.get("stream"):
-            return self._passthrough_stream_with_fallback(action, payload, headers)
+            return self._execute_stream_with_fallback(
+                "passthrough", action, payload, headers, await_result=True
+            )
         return await self._execute_with_fallback("passthrough", action, payload, headers)
 
     async def proxy(

--- a/tests/gateway/providers/test_fallback.py
+++ b/tests/gateway/providers/test_fallback.py
@@ -280,6 +280,83 @@ async def test_fallback_provider_passthrough():
         assert response["result"] == "success"
 
 
+@pytest.mark.asyncio
+async def test_fallback_passthrough_stream_first_provider_succeeds():
+    config = chat_config()
+    provider = _get_fallback_provider([config])
+
+    resp = chat_stream_response()
+    mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        from mlflow.gateway.providers.base import PassthroughAction
+
+        action = PassthroughAction.OPENAI_CHAT
+        payload = {"messages": [{"role": "user", "content": "Hello"}], "stream": True}
+
+        result = await provider.passthrough(action, payload)
+        chunks = [chunk async for chunk in result]
+        assert len(chunks) > 0
+        assert mock_client.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_passthrough_stream_second_provider_succeeds():
+    config1 = chat_config()
+    config2 = chat_config()
+    config2["name"] = "chat-fallback"
+
+    provider = _get_fallback_provider([config1, config2])
+
+    resp = chat_stream_response()
+
+    with mock.patch("aiohttp.ClientSession") as mock_session:
+        mock_client = mock_http_client(MockAsyncStreamingResponse(resp))
+        mock_session.return_value = mock_client
+        mock_client.post.side_effect = [
+            Exception("First provider failed"),
+            MockAsyncStreamingResponse(resp),
+        ]
+
+        from mlflow.gateway.providers.base import PassthroughAction
+
+        action = PassthroughAction.OPENAI_CHAT
+        payload = {"messages": [{"role": "user", "content": "Hello"}], "stream": True}
+
+        result = await provider.passthrough(action, payload)
+        chunks = [chunk async for chunk in result]
+        assert len(chunks) > 0
+        assert mock_client.post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fallback_passthrough_stream_all_providers_fail():
+    config1 = chat_config()
+    config2 = chat_config()
+    config2["name"] = "chat-fallback"
+
+    provider = _get_fallback_provider([config1, config2])
+
+    with mock.patch("aiohttp.ClientSession") as mock_session:
+        mock_client = mock_http_client(MockAsyncResponse({}))
+        mock_session.return_value = mock_client
+        mock_client.post.side_effect = [
+            Exception("First provider failed"),
+            Exception("Second provider failed"),
+        ]
+
+        from mlflow.gateway.providers.base import PassthroughAction
+
+        action = PassthroughAction.OPENAI_CHAT
+        payload = {"messages": [{"role": "user", "content": "Hello"}], "stream": True}
+
+        result = await provider.passthrough(action, payload)
+        with pytest.raises(Exception, match="All 2 fallback attempts failed"):
+            [chunk async for chunk in result]
+
+        assert mock_client.post.call_count == 2
+
+
 @pytest.mark.parametrize(
     ("exception", "expected_status"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Closes #25262

### What changes are proposed in this pull request?

`FallbackProvider.passthrough()` was routing all passthrough requests through `_execute_with_fallback`, which awaits the provider's `passthrough()` method and returns on the first non-raising call. For streaming requests, the underlying provider's `passthrough()` returns a lazy async generator immediately (no I/O yet), so `_execute_with_fallback` sees a "successful" return value and never tries the next fallback provider. The actual HTTP error only surfaces when the generator is consumed in `safe_stream()`, by which point response headers are already sent and the fallback loop is long gone.

The fix:
- Add `_passthrough_stream_with_fallback` async generator to `FallbackProvider` that awaits each provider's `passthrough()` and iterates the resulting generator inside a `try/except`, allowing fallback if an error is raised before or during streaming.
- Update `FallbackProvider.passthrough()` to route requests with `payload["stream"]` through this new method, mirroring the existing pattern used by `chat_stream` and `completions_stream`.

### How is this PR tested?

- [x] New unit/integration tests

Three new tests in `tests/gateway/providers/test_fallback.py`:
- `test_fallback_passthrough_stream_first_provider_succeeds` — basic happy path
- `test_fallback_passthrough_stream_second_provider_succeeds` — first provider fails, second succeeds
- `test_fallback_passthrough_stream_all_providers_fail` — all providers fail, correct exception raised

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Streaming passthrough requests to AI Gateway endpoints with fallback configuration now correctly retry the next fallback model when the primary model fails, instead of silently returning an SSE error chunk to the client.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release