### PR TITLE
Add default metrics.path to Helm chart values

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -235,6 +235,7 @@ networkPolicy:
 # metrics at the specified HTTP path.
 metrics:
   enabled: false
+  path: /metrics
 
 # Prometheus ServiceMonitor for metrics scraping (requires the Prometheus
 # Operator CRD to be installed in the cluster).


### PR DESCRIPTION
## Why is this change needed?

The ServiceMonitor template references `.Values.metrics.path` directly (`charts/templates/servicemonitor.yaml:14`), but the chart values never defined the key. With `metrics.enabled=true` and `serviceMonitor.enabled=true`, the rendered ServiceMonitor contains:

```yaml
endpoints:
- port: http
  path: null
```

which the Prometheus Operator CRD schema rejects on apply:

```
ServiceMonitor.monitoring.coreos.com "mlflow" is invalid:
spec.endpoints[0].path: Invalid value: "null": spec.endpoints[0].path in body must be of type string: "null"
```

This makes the metrics feature unusable out of the box on chart v0.1.0 — every sync fails on the ServiceMonitor object.

Fixes #25269

## What is the new behavior?

`metrics.path` defaults to `/metrics` (where the prometheus exporter serves), so the ServiceMonitor applies cleanly. Explicit overrides still work.

## Implementation notes

One-line values addition — no template change needed.

## Testing checklist

- [x] `helm lint charts/` passes
- [x] `helm template` with `metrics.enabled=true,serviceMonitor.enabled=true` renders `endpoints[0].path: /metrics` (string)
- [x] `helm template` with `metrics.path=/custom` override renders the custom path
- [x] Default (`metrics.enabled=false`) renders no ServiceMonitor, unchanged
