### PR TITLE
Fix test pollution: reset dynamic token config provider global in test

### DIFF
--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -420,6 +420,7 @@ def test_dynamic_token_config_provider_get_config_when_logger_unavailable(
             is_client_image=False, major=15, minor=0, is_gpu_image=False
         ),
     )
+    monkeypatch.setattr(databricks_utils, "_dynamic_token_config_provider", None)
     entry_point = _make_dynamic_token_entry_point(get_logger_raises)
     databricks_utils._init_databricks_dynamic_token_config_provider(entry_point)
     config = databricks_utils._dynamic_token_config_provider.get_config()


### PR DESCRIPTION
### Related Issues/PRs

Closes #25266

### What changes are proposed in this pull request?

`test_dynamic_token_config_provider_get_config_when_logger_unavailable` (added in #25207) calls `databricks_utils._init_databricks_dynamic_token_config_provider(entry_point)` directly, which sets the module-level global `_dynamic_token_config_provider` and never restores it.

This leaks a fake valid config into later tests running in the same process — e.g. `test_databricks_params_throws_errors`, which expects `get_databricks_host_creds()` to raise when no real credentials are configured. When the two tests run in the same pytest worker (guaranteed with `-p no:xdist`, and possible under `xdist` depending on scheduling), the leaked global causes `test_databricks_params_throws_errors` to fail with `DID NOT RAISE Exception`.

This PR resets the global with `monkeypatch.setattr(databricks_utils, "_dynamic_token_config_provider", None)` before calling `_init_databricks_dynamic_token_config_provider`, mirroring the existing pattern already used in `test_prioritize_env_var_config_provider`, so pytest restores the global automatically at teardown.

### How is this PR tested?

- [x] Existing unit/integration tests

`uv run pytest tests/utils/test_databricks_utils.py -p no:xdist -q` — 122 passed. `test_databricks_params_throws_errors`, which previously failed with `DID NOT RAISE Exception` when run after the polluting test, now passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release