### PR TITLE
Add MiniMax M2.7 model metadata

### DIFF
--- a/mlflow/utils/model_catalog/minimax.json
+++ b/mlflow/utils/model_catalog/minimax.json
@@ -133,6 +133,27 @@
         "response_schema": false
       },
       "last_updated_at": "2026-06-22"
+    },
+    "MiniMax-M2.7": {
+      "mode": "chat",
+      "context_window": {
+        "max_input": 204800,
+        "max_output": 8192
+      },
+      "pricing": {
+        "input_per_million_tokens": 0.3,
+        "output_per_million_tokens": 1.2,
+        "cache_read_per_million_tokens": 0.06,
+        "cache_write_per_million_tokens": 0.375
+      },
+      "capabilities": {
+        "function_calling": true,
+        "vision": false,
+        "reasoning": true,
+        "prompt_caching": true,
+        "response_schema": false
+      },
+      "last_updated_at": "2026-08-22"
     }
   }
 }


### PR DESCRIPTION
Reason: Add the MiniMax M2.7 model to the catalog with current context and pricing metadata.

- Added MiniMax-M2.7 while preserving the existing MiniMax-M3 metadata.

- Included context, cache pricing, and capability flags from the current model parameters.
Checks:
- python3 -m json.tool mlflow/utils/model_catalog/minimax.json
- git diff --check
