### PR TITLE
Advise contributors to use GitHub-native stacked PRs

### DIFF
--- a/.github/workflows/advice.js
+++ b/.github/workflows/advice.js
@@ -2,6 +2,7 @@ const ACTIVITY_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_REPOS_TO_DISPLAY = 10;
 
 const UI_FILE = /^mlflow\/server\/js\/src\/.+\.(tsx|jsx|ts|js|css|scss|less)$/;
+const STACKED_PR_SECTION = /^(#{1,6}|>)\s.*\bStacked PRs?\b/m;
 const MEDIA =
   /!\[[^\]]*\]\([^)]+\)|<(img|video)\b|https:\/\/github\.com\/user-attachments\/|https?:\/\/\S+\.(png|jpe?g|gif|webp|mp4|mov|webm)\b/i;
 
@@ -187,6 +188,15 @@ ${activitySection}
       "#### &#x274C; Invalid PR template\n\n" +
         "The PR description is missing required sections. " +
         "Please use the [PR template](https://raw.githubusercontent.com/mlflow/mlflow/master/.github/pull_request_template.md)."
+    );
+  }
+
+  if (STACKED_PR_SECTION.test(body || "")) {
+    messages.push(
+      "#### &#x1F95E; Not a GitHub stack\n\n" +
+        "GitHub now supports " +
+        "[stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) " +
+        "natively. Please use those instead."
     );
   }
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`advice.js` now comments on stacks that aren't GitHub stacks. A stack section in the description is written by third-party stacking tools and never by native stacks, which GitHub renders itself, so its presence is the available signal that the stack is non-native. The section itself is fine to keep.

Detection matches the line that opens the section, either a heading (`## 🥞 Stacked PR`) or a blockquote (`> **Stacked PR (1 of 2)**`).

Non-native stacks degrade two existing checks:

- `pr-size.js` falls back to parsing compare links out of the body to compute the incremental diff.
- `protect.js` only honors the `unprotect` label on native stacks.

### How is this PR tested?

- [x] Manual tests

Checked against 40 PR bodies containing the phrase: 34 match, and the six misses are prose mentions (this PR's own body among them). The PR template does not match. Since `advice.yml` runs on `pull_request_target` and checks out the base branch, this PR does not exercise its own change.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

