### PR TITLE
Give each tool its own emoji in `stream.sh`

### DIFF
--- a/.claude/scripts/stream.sh
+++ b/.claude/scripts/stream.sh
@@ -3,12 +3,18 @@
 
 tee "${1:-/dev/null}" \
   | jq --unbuffered -r '
-    if .type == "assistant" then
+    {
+      Bash: "💻", Read: "📖", Write: "📝", Edit: "✏️",
+      NotebookEdit: "✏️", Glob: "📁", Grep: "🔬",
+      WebSearch: "🔍", WebFetch: "🌐", Task: "🤝",
+      Agent: "🤝", Skill: "🎓", TodoWrite: "☑️"
+    } as $tools
+    | if .type == "assistant" then
       .message.content[] |
       if .type == "text" then
         "🤖 \(.text)"
       elif .type == "tool_use" then
-        "🔧 \(.name)\(if .input then ": \(.input | tostring | .[0:200])" else "" end)"
+        "\($tools[.name] // "🔧") \(.name)\(if .input then ": \(.input | tostring | .[0:200])" else "" end)"
       elif .type == "thinking" and (.thinking | length) > 0 then
         "🧠 thinking (\(.thinking | length) chars)"
       else


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Every tool call in the streamed output rendered as `🔧`, so a run's shape was only legible by reading the tool names. The icon is now keyed off the tool name, falling back to `🔧` for anything unmapped.

```
💻 Bash    📖 Read    📝 Write    ✏️ Edit    🔍 WebSearch
📁 Glob    🔎 Grep    🌐 WebFetch    🤝 Task/Agent    🎓 Skill    ☑️ TodoWrite
```

### How is this PR tested?

- [x] Manual tests

Replayed the stream from a real `/review` run (`32598291192`) through the script: `Bash`, `Read`, `Write`, `Edit`, and `WebSearch` all render distinctly. `Grep` and `Task` were checked separately, along with an unmapped name falling back to `🔧`. This PR touches `.claude/scripts/**`, so the smoke run exercises the script end to end.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
