### PR TITLE
fix: align monitoring ranges to UTC day boundaries

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/timeRange.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/timeRange.ts
@@ -49,6 +49,13 @@ export interface StartEndTime {
  * `startTimeLabelToStartEndTime` (incl. the 5/15-minute cases).
  */
 export const getStartEndForLabel = (dateNow: Date, label: TracesV4TimeLabel): StartEndTime => {
+  const startOfUtcDay = (daysAgo: number): string => {
+    const startTime = new Date(dateNow);
+    startTime.setUTCHours(0, 0, 0, 0);
+    startTime.setUTCDate(startTime.getUTCDate() - daysAgo);
+    return startTime.toISOString();
+  };
+
   switch (label) {
     case 'LAST_5_MINUTES':
       return {
@@ -72,12 +79,12 @@ export const getStartEndForLabel = (dateNow: Date, label: TracesV4TimeLabel): St
       };
     case 'LAST_7_DAYS':
       return {
-        startTime: new Date(new Date(dateNow).setUTCDate(new Date().getUTCDate() - 7)).toISOString(),
+        startTime: startOfUtcDay(7),
         endTime: dateNow.toISOString(),
       };
     case 'LAST_30_DAYS':
       return {
-        startTime: new Date(new Date(dateNow).setUTCDate(new Date().getUTCDate() - 30)).toISOString(),
+        startTime: startOfUtcDay(30),
         endTime: dateNow.toISOString(),
       };
     case 'LAST_YEAR':

--- a/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.test.tsx
@@ -1,7 +1,11 @@
 import { jest, describe, beforeEach, it, expect } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 
-import { useMonitoringFilters, type MonitoringFilters } from './useMonitoringFilters';
+import {
+  startTimeLabelToStartEndTime,
+  useMonitoringFilters,
+  type MonitoringFilters,
+} from './useMonitoringFilters';
 import { useParams, useSearchParams } from '../../common/utils/RoutingUtils';
 
 jest.mock('../../common/utils/RoutingUtils', () => ({
@@ -82,6 +86,21 @@ describe('useMonitoringFilters - persistence', () => {
       renderHook(() => useMonitoringFilters({ loadPersistedValues: true }));
 
       expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('startTimeLabelToStartEndTime', () => {
+  it('anchors day-based ranges at midnight UTC', () => {
+    const dateNow = new Date('2025-01-15T18:30:00Z');
+
+    expect(startTimeLabelToStartEndTime(dateNow, 'LAST_7_DAYS')).toEqual({
+      startTime: '2025-01-08T00:00:00.000Z',
+      endTime: '2025-01-15T18:30:00.000Z',
+    });
+    expect(startTimeLabelToStartEndTime(dateNow, 'LAST_30_DAYS')).toEqual({
+      startTime: '2024-12-16T00:00:00.000Z',
+      endTime: '2025-01-15T18:30:00.000Z',
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/useMonitoringFilters.tsx
@@ -154,6 +154,13 @@ export function startTimeLabelToStartEndTime(
   startTime: string | undefined;
   endTime: string | undefined;
 } {
+  const startOfUtcDay = (daysAgo: number): string => {
+    const startTime = new Date(dateNow);
+    startTime.setUTCHours(0, 0, 0, 0);
+    startTime.setUTCDate(startTime.getUTCDate() - daysAgo);
+    return startTime.toISOString();
+  };
+
   switch (startTimeLabel) {
     case 'LAST_HOUR':
       return {
@@ -167,12 +174,12 @@ export function startTimeLabelToStartEndTime(
       };
     case 'LAST_7_DAYS':
       return {
-        startTime: new Date(new Date(dateNow).setUTCDate(new Date().getUTCDate() - 7)).toISOString(),
+        startTime: startOfUtcDay(7),
         endTime: dateNow.toISOString(),
       };
     case 'LAST_30_DAYS':
       return {
-        startTime: new Date(new Date(dateNow).setUTCDate(new Date().getUTCDate() - 30)).toISOString(),
+        startTime: startOfUtcDay(30),
         endTime: dateNow.toISOString(),
       };
     case 'LAST_YEAR':


### PR DESCRIPTION
### Related Issues/PRs

Closes #25170

### What changes are proposed in this pull request?

Day-based monitoring ranges now start at midnight UTC before subtracting the requested number of days. This prevents the oldest chart bucket from dropping data earlier on that day. The V4 time-range helper is kept consistent and regression coverage verifies both 7-day and 30-day ranges.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

The focused JavaScript unit tests were not run locally because the checkout has no installed frontend dependencies. `git diff --check` passed.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Monitoring charts no longer omit part of the oldest day bucket.
- [ ] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [x] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release