### PR TITLE
Add default metrics.path to Helm chart values

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -235,6 +235,7 @@ networkPolicy:
 # metrics at the specified HTTP path.
 metrics:
   enabled: false
+  path: /metrics
 
 # Prometheus ServiceMonitor for metrics scraping (requires the Prometheus
 # Operator CRD to be installed in the cluster).


### PR DESCRIPTION
### Related Issues/PRs

Fixes #25269. Supersedes #25270 (auto-closed: unsigned commit + missing PR template — resubmitted correctly here).

### What changes are proposed in this pull request?

Adds a default value for `metrics.path` (`/metrics`) in `charts/values.yaml`.

The ServiceMonitor template references `.Values.metrics.path` directly (`charts/templates/servicemonitor.yaml:14`), but the chart values never defined the key. With `metrics.enabled=true` and `serviceMonitor.enabled=true`, the rendered ServiceMonitor contains `endpoints[0].path: null`, which the Prometheus Operator CRD schema rejects on apply:

```
ServiceMonitor.monitoring.coreos.com "mlflow" is invalid:
spec.endpoints[0].path: Invalid value: "null": spec.endpoints[0].path in body must be of type string: "null"
```

This makes the metrics feature unusable out of the box — every sync of the chart fails on the ServiceMonitor object.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

`helm lint charts/` passes. `helm template` renders:

With defaults (`metrics.enabled=true, serviceMonitor.enabled=true`):
```yaml
endpoints:
- port: http
  path: /metrics
```

With an explicit override (`metrics.path=/custom`):
```yaml
endpoints:
- port: http
  path: /custom
```

With `metrics.enabled=false` (default): no ServiceMonitor rendered, unchanged.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Helm chart: fixed the ServiceMonitor failing to apply when metrics are enabled (`metrics.path` now defaults to `/metrics`; previously rendered as `null` and rejected by the Prometheus Operator CRD schema).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Frontend, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
