### PR TITLE
Preserve chart section when switching chart type in `RunsChartsConfigureModal`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.test.tsx
@@ -1,7 +1,7 @@
 import { jest, describe, test, expect } from '@jest/globals';
 import { render, screen, waitFor } from '@testing-library/react';
 import { RunsChartsConfigureModal } from './RunsChartsConfigureModal';
-import type { RunsChartsLineCardConfig } from '../runs-charts.types';
+import type { RunsChartsCardConfig, RunsChartsLineCardConfig } from '../runs-charts.types';
 import { RunsChartType } from '../runs-charts.types';
 import { IntlProvider } from 'react-intl';
 import { MockedReduxStoreProvider } from '../../../../common/utils/TestUtils';
@@ -48,11 +48,11 @@ const sampleLineChartConfig: RunsChartsLineCardConfig = {
 };
 
 describe('RunsChartsConfigureModal', () => {
-  const renderTestComponent = (onSubmit?: () => void) => {
+  const renderTestComponent = (onSubmit?: () => void, config: RunsChartsCardConfig = sampleLineChartConfig) => {
     const queryClient = new QueryClient();
     render(
       <RunsChartsConfigureModal
-        config={sampleLineChartConfig}
+        config={config}
         chartRunData={sampleChartData}
         groupBy={null}
         metricKeyList={[]}
@@ -130,6 +130,35 @@ describe('RunsChartsConfigureModal', () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         displayPoints: true,
+      }),
+    );
+  });
+
+  test('it should preserve the metric section when switching chart type for a new chart', async () => {
+    const onSubmit = jest.fn();
+    const newChartConfig = {
+      type: RunsChartType.LINE,
+      deleted: false,
+      isGenerated: false,
+      metricSectionId: 'some-section-uuid',
+    } as RunsChartsCardConfig;
+
+    renderTestComponent(onSubmit, newChartConfig);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add new chart')).toBeInTheDocument();
+    });
+
+    // eslint-disable-next-line testing-library/no-node-access
+    await userEvent.click(document.getElementById('chart-type-select') as HTMLElement);
+    await userEvent.click(screen.getByText('Bar chart'));
+
+    await userEvent.click(screen.getByText('Add chart'));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: RunsChartType.BAR,
+        metricSectionId: 'some-section-uuid',
       }),
     );
   });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsConfigureModal.tsx
@@ -106,10 +106,15 @@ export const RunsChartsConfigureModal = ({
     if (!type) {
       return;
     }
-    const emptyChartCard = RunsChartsCardConfig.getEmptyChartCardByType(type, false);
-    if (emptyChartCard) {
-      setCurrentFormState(emptyChartCard);
-    }
+    setCurrentFormState((current) => {
+      const emptyChartCard = RunsChartsCardConfig.getEmptyChartCardByType(
+        type,
+        false,
+        current.uuid,
+        current.metricSectionId,
+      );
+      return emptyChartCard ?? current;
+    });
   }, []);
 
   const previewData = useMemo(() => chartRunData.filter(({ hidden }) => !hidden).reverse(), [chartRunData]);


### PR DESCRIPTION
### Related Issues/PRs

Closes #25267

### What changes are proposed in this pull request?

When adding a new chart from a run's Metrics tab (or the runs-compare page), switching the chart type dropdown inside the "Add chart" modal reset `metricSectionId` (and `uuid`) to their defaults in `updateChartType`. The chart was still saved into `compareRunCharts`, but `RunsChartsSectionAccordion` groups charts into panels by matching `metricSectionId` against a real section `uuid`. Since no section has an empty uuid, the newly added chart matched no section and silently failed to render anywhere, with no console error — matching the reported "click Add, nothing happens" behavior.

The fix preserves `uuid` and `metricSectionId` from the current form state when constructing the new empty chart config for the selected type, while still resetting all type-specific fields.

This only affects the "Add new chart" flow. The chart type selector is hidden while editing an existing chart (`isEditing` is `true` whenever `config.uuid` is set), so `updateChartType` is never invoked in the edit flow.

https://github.com/user-attachments/assets/c3691e9d-2af1-4570-a2ff-ec8368442434

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a regression test in `RunsChartsConfigureModal.test.tsx` that switches chart type on a new chart with a `metricSectionId` set and asserts the section id is preserved in the submitted config. Verified the test fails on the pre-fix code with `metricSectionId: undefined` and passes with the fix.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where switching the chart type in the "Add chart" modal (after already selecting a type) would cause the newly added chart to silently disappear instead of showing up in the metrics view.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release