### PR TITLE
Add an opt-in executor-backed job-execution engine

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1537,13 +1537,14 @@ MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND = _EnvironmentVariable(
     "MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", str, None
 )
 
-#: Selects the engine that runs server-side jobs. ``"huey"`` (default) uses the
-#: built-in Huey consumers. ``"executor"`` routes job execution through the
-#: ``AbstractJobExecutor`` framework (``LocalJobExecutor`` by default). Periodic
-#: tasks always run on Huey regardless of this setting.
-#: (default: ``"huey"``)
+#: Opt-in switch for the executor job-execution engine. Leave unset to use the default engine
+#: (currently the built-in Huey consumers); set to ``"executor"`` to route job execution through
+#: the ``AbstractJobExecutor`` framework (``LocalJobExecutor`` by default). It is intentionally
+#: not settable to ``"huey"`` — unset it to use the default. Periodic tasks always run on Huey
+#: regardless of this setting.
+#: (default: unset, i.e. the default engine)
 MLFLOW_SERVER_JOB_EXECUTION_ENGINE = _EnvironmentVariable(
-    "MLFLOW_SERVER_JOB_EXECUTION_ENGINE", str, "huey"
+    "MLFLOW_SERVER_JOB_EXECUTION_ENGINE", str, None
 )
 
 #: Default timeout in seconds applied by the executor framework when a job

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1537,6 +1537,15 @@ MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND = _EnvironmentVariable(
     "MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", str, None
 )
 
+#: Selects the engine that runs server-side jobs. ``"huey"`` (default) uses the
+#: built-in Huey consumers. ``"executor"`` routes job execution through the
+#: ``AbstractJobExecutor`` framework (``LocalJobExecutor`` by default). Periodic
+#: tasks always run on Huey regardless of this setting.
+#: (default: ``"huey"``)
+MLFLOW_SERVER_JOB_EXECUTION_ENGINE = _EnvironmentVariable(
+    "MLFLOW_SERVER_JOB_EXECUTION_ENGINE", str, "huey"
+)
+
 #: Default timeout in seconds applied by the executor framework when a job
 #: submission does not specify one explicitly.
 #: (default: ``3600.0``)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -462,8 +462,12 @@ def _run_server(
 
         if job_execution_enabled:
             from mlflow.server.jobs.executor_registry import validate_executor_config
+            from mlflow.server.jobs.utils import get_job_execution_engine
 
             validate_executor_config()
+            # Validate the engine selection before the server is spawned below, so an
+            # invalid value fails fast instead of leaving an unmanaged server running.
+            get_job_execution_engine()
 
     if app_name == "basic-auth" and job_execution_enabled:
         # Generate the token here (before forking uvicorn workers) so that all
@@ -500,7 +504,7 @@ def _run_server(
 
     if job_execution_enabled:
         from mlflow.environment_variables import MLFLOW_GATEWAY_URI, MLFLOW_TRACKING_URI
-        from mlflow.server.jobs.utils import _launch_job_runner
+        from mlflow.server.jobs.utils import _launch_job_execution_runner
 
         server_uri = f"http://{host}:{port}"
         job_env = {
@@ -515,6 +519,6 @@ def _run_server(
         # gateway routing (e.g., judge LLM calls via /gateway/mlflow/v1/).
         if not MLFLOW_GATEWAY_URI.is_set():
             job_env[MLFLOW_GATEWAY_URI.name] = server_uri
-        _launch_job_runner(job_env, server_proc.pid)
+        _launch_job_execution_runner(job_env, server_proc.pid)
 
     server_proc.wait()

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -185,6 +185,7 @@ def submit_job(
         _check_requirements,
         _get_or_init_huey_instance,
         _validate_function_parameters,
+        get_job_execution_engine,
     )
 
     if not MLFLOW_SERVER_ENABLE_JOB_EXECUTION.get():
@@ -226,13 +227,33 @@ def submit_job(
     # Validate that required parameters are provided
     _validate_function_parameters(function, params)
 
+    # Resolve (and validate) the engine before persisting the job, so a rejected
+    # submission never leaves a runnable PENDING row behind.
+    engine = get_job_execution_engine()
+    if engine == "executor" and extra_envs:
+        # The AbstractJobExecutor.submit_job contract has no extra_envs parameter, so
+        # honoring them would silently drop caller-supplied environment (e.g.
+        # invoke_issue_detection_job passes credentials). Fail loudly instead.
+        # NOTE: full extra_envs support on the executor engine is a follow-up.
+        raise MlflowException(
+            "extra_envs is not yet supported on the executor job-execution engine; "
+            "use the huey engine (unset MLFLOW_SERVER_JOB_EXECUTION_ENGINE) instead."
+        )
+
     job_store = _get_job_store()
     serialized_params = json.dumps(params)
     job = job_store.create_job(fn_meta.name, serialized_params, timeout)
+
+    if engine == "executor":
+        # Executor engine: the job is persisted as PENDING and the executor runner loop
+        # (mlflow.server.jobs._executor_runner) claims and runs it. Nothing to enqueue here.
+        # NOTE: exclusive-job dedup and per-function max_workers/concurrency are not yet
+        # honored on this path (a follow-up). The default Huey path is unchanged.
+        return job
+
+    # Huey engine (default): enqueue to the per-job Huey execution pool.
     # Only propagate workspace to subprocess when workspaces are enabled
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
-
-    # enqueue job
     huey_instance = _get_or_init_huey_instance(fn_meta.name)
     huey_instance.submit_task(
         job.job_id,

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -249,8 +249,8 @@ def submit_job(
     if engine == "executor":
         # Executor engine: the job is persisted as PENDING and the executor runner loop
         # (mlflow.server.jobs._executor_runner) claims and runs it. Nothing to enqueue here.
-        # NOTE: exclusive-job dedup and per-function max_workers/concurrency are not yet
-        # honored on this path (a follow-up). The default Huey path is unchanged.
+        # NOTE: exclusive-job dedup is not yet honored on this path (a follow-up). The default
+        # Huey path is unchanged.
         return job
 
     # Huey engine (default): enqueue to the per-job Huey execution pool.

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -234,7 +234,9 @@ def submit_job(
         # The AbstractJobExecutor.submit_job contract has no extra_envs parameter, so
         # honoring them would silently drop caller-supplied environment (e.g.
         # invoke_issue_detection_job passes credentials). Fail loudly instead.
-        # NOTE: full extra_envs support on the executor engine is a follow-up.
+        # TODO (follow-up, before Huey stops being the default): migrate the only production
+        # caller that uses extra_envs (issue detection) — e.g. pass secret_id/provider in the
+        # job params and resolve them in the executor — so this path is not needed.
         raise MlflowException(
             "extra_envs is not yet supported on the executor job-execution engine; "
             "use the huey engine (unset MLFLOW_SERVER_JOB_EXECUTION_ENGINE) instead."

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -28,6 +28,7 @@ from mlflow.environment_variables import (
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
     MLFLOW_TRACKING_URI,
 )
+from mlflow.exceptions import MlflowException
 from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
 from mlflow.server.jobs.executor_registry import get_executor_registry
 from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
@@ -94,9 +95,15 @@ def _record_result(
     elif result.status == JobStatus.TIMEOUT:
         job_store.report_job_result(job_id, JobStatus.TIMEOUT, error_message=result.error_message)
     elif result.status == JobStatus.CANCELED:
-        # Defensive: cancellation moves the job to a terminal CANCELED state through
-        # cancel_job(), so there is nothing to record here.
-        return
+        # The executor reported the job as canceled while the store row is not CANCELED (a row
+        # canceled through the store is already handled by the early return above). Record the
+        # terminal CANCELED state so the claimed row is not left RUNNING forever. Tolerate a
+        # concurrent store cancel that finalized the row between the check above and here.
+        try:
+            job_store.report_job_result(job_id, JobStatus.CANCELED)
+        except MlflowException:
+            if job_store.get_job(job_id).status != JobStatus.CANCELED:
+                raise
     elif result.is_transient_error:
         # A transient error resets the job to PENDING (non-terminal) so a later poll can
         # re-claim it, so this cannot go through report_job_result.
@@ -181,6 +188,9 @@ class _JobScheduler:
         # called at most once per in-flight job (AbstractJobExecutor.cancel_job does not promise
         # idempotency for plugin backends). Guarded by _in_flight_lock.
         self._canceled_forwarded: set[str] = set()
+        # job_ids whose cancel forward has failed at least once, so the traceback is logged only
+        # once per job instead of on every retry. Guarded by _in_flight_lock.
+        self._cancel_forward_failed: set[str] = set()
         self._in_flight_lock = threading.Lock()
 
     def _slot_for(self, job_name: str) -> threading.Semaphore:
@@ -211,14 +221,30 @@ class _JobScheduler:
             with self._in_flight_lock:
                 if job_id in self._canceled_forwarded:
                     continue
-                self._canceled_forwarded.add(job_id)
             try:
                 # Stop the still-running job so it cannot keep performing side effects after the
                 # caller cancelled it. The worker's wait_for_job then returns and _record_result
                 # skips the already-CANCELED row.
                 self._executor.cancel_job(job_id)
             except Exception:
-                _logger.exception("Failed to forward cancellation to executor for %s", job_id)
+                # Leave it unmarked so the next tick retries the cancel rather than letting the
+                # canceled job run to normal completion. Log the traceback once; the per-tick
+                # retries then stay quiet.
+                with self._in_flight_lock:
+                    first_failure = job_id not in self._cancel_forward_failed
+                    self._cancel_forward_failed.add(job_id)
+                if first_failure:
+                    _logger.exception(
+                        "Failed to forward cancellation to executor for %s; retrying each tick",
+                        job_id,
+                    )
+                continue
+            with self._in_flight_lock:
+                # Only mark forwarded while the job is still in flight: cancel_job may already have
+                # unblocked the worker, whose finally pops _in_flight and discards these markers,
+                # and re-adding here would orphan the id in the set for the runner's lifetime.
+                if job_id in self._in_flight:
+                    self._canceled_forwarded.add(job_id)
 
     def _schedule_pending(self) -> int:
         from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
@@ -230,6 +256,14 @@ class _JobScheduler:
                 # exclusive per experiment) is not enforced here; it builds on the job-lock work
                 # in #25200 and lands once that is available.
                 for job in list(self._job_store.list_jobs(statuses=[JobStatus.PENDING])):
+                    with self._in_flight_lock:
+                        already_in_flight = job.job_id in self._in_flight
+                    if already_in_flight:
+                        # A prior worker for this job is still finishing (e.g. backing off before
+                        # it re-pends a transient failure). Skip it so the job stays unclaimable
+                        # until that worker releases it, otherwise a free slot would re-claim it
+                        # mid-backoff and bypass the retry delay.
+                        continue
                     try:
                         sem = self._slot_for(job.job_name)
                     except Exception as exc:
@@ -333,6 +367,7 @@ class _JobScheduler:
             with self._in_flight_lock:
                 self._in_flight.pop(job.job_id, None)
                 self._canceled_forwarded.discard(job.job_id)
+                self._cancel_forward_failed.discard(job.job_id)
 
     def join(self, timeout: float | None = None) -> None:
         """Best-effort wait for in-flight workers to finish.

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -41,7 +41,11 @@ _POLL_INTERVAL = 1.0
 def _select_executor() -> AbstractJobExecutor:
     """Resolve the executor backend named by ``MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND``.
 
-    For now this is always ``local`` (``LocalJobExecutor``).
+    Defaults to ``local`` (``LocalJobExecutor``); a configured plugin backend is honored too.
+
+    TODO (follow-up): select the backend per job at submit time via a job-executor router
+    (matching the job against the configured executor) rather than a single process-wide
+    backend, so different job types can target different executors.
     """
     backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
     return get_executor_registry().get(backend)
@@ -147,6 +151,11 @@ def _poll_and_execute_once(
     executed = 0
     for workspace_ctx in _workspace_contexts_for_recovery():
         with workspace_ctx:
+            # TODO (follow-up): this claims and runs PENDING jobs serially. Two things are not
+            # yet enforced here and land in follow-ups: (1) per-function ``max_workers`` and
+            # concurrent scheduling, so one job type cannot starve another; (2) exclusive job
+            # locking by key (e.g. keeping online scoring exclusive per experiment), which
+            # builds on the job-lock work in #25200.
             for job in list(job_store.list_jobs(statuses=[JobStatus.PENDING])):
                 if job_store.claim_job(job.job_id, lease_duration) != JobUpdateStatus.APPLIED:
                     # A concurrent worker claimed it first, or its status changed.
@@ -180,11 +189,14 @@ def run_executor_loop(
     job_store = _get_job_store()
     executor = _select_executor()
     lease_duration = executor.config.job_lease_ttl
-    executor.start_executor()
-    _logger.info(
-        f"Started executor-backed job runner (backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
-    )
+    # start_executor() runs inside the try so a failure during startup (e.g. a plugin backend
+    # that allocates resources and then raises) still triggers stop_executor() for cleanup.
     try:
+        executor.start_executor()
+        _logger.info(
+            "Started executor-backed job runner "
+            f"(backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
+        )
         while not stop_event.is_set():
             try:
                 executed = _poll_and_execute_once(job_store, executor, lease_duration)
@@ -194,6 +206,8 @@ def run_executor_loop(
                 # so log it and try again on the next poll.
                 _logger.exception("Executor job loop iteration failed; continuing.")
                 executed = 0
+            if executed:
+                _logger.debug("Executor engine processed %d job(s) this poll.", executed)
             if executed == 0:
                 stop_event.wait(poll_interval)
     finally:

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -1,0 +1,218 @@
+"""Executor-engine job runner.
+
+Launched in place of the Huey ``_job_runner`` when
+``MLFLOW_SERVER_JOB_EXECUTION_ENGINE=executor``. It runs a loop that claims
+PENDING jobs from the job store and executes them through the configured
+``AbstractJobExecutor`` backend (``LocalJobExecutor`` by default), then records
+the terminal state back to the store.
+
+Only job execution moves to the executor framework here. Periodic tasks (e.g. the
+online scoring scheduler) still run on Huey via ``_launch_periodic_tasks_consumer``.
+"""
+
+import json
+import logging
+import threading
+import time
+
+from mlflow.entities._job import Job
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import (
+    MLFLOW_ENABLE_WORKSPACES,
+    MLFLOW_GATEWAY_URI,
+    MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND,
+    MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
+    MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
+    MLFLOW_TRACKING_URI,
+)
+from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
+from mlflow.server.jobs.executor_registry import get_executor_registry
+from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
+
+# Use an explicit logger name rather than __name__: this module is launched as
+# ``python -m mlflow.server.jobs._executor_runner``, where __name__ is "__main__" and would
+# fall outside the "mlflow" logger hierarchy, so its logs would miss MLflow's log handler.
+_logger = logging.getLogger("mlflow.server.jobs._executor_runner")
+
+# How long the loop sleeps when it finds no PENDING jobs to run.
+_POLL_INTERVAL = 1.0
+
+
+def _select_executor() -> AbstractJobExecutor:
+    """Resolve the executor backend named by ``MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND``.
+
+    For now this is always ``local`` (``LocalJobExecutor``).
+    """
+    backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
+    return get_executor_registry().get(backend)
+
+
+def _build_execution_context(job: Job) -> JobExecutionContext:
+    workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
+    return JobExecutionContext(
+        job_id=job.job_id,
+        tracking_uri=MLFLOW_TRACKING_URI.get(),
+        gateway_uri=MLFLOW_GATEWAY_URI.get(),
+        workspace=workspace,
+    )
+
+
+def _backoff_after_transient_retry(retry_count: int) -> None:
+    # Mirror the Huey path's exponential backoff. The loop is serial for now, so
+    # this briefly blocks other jobs; non-blocking scheduling is a later refinement.
+    base_delay = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY.get()
+    max_delay = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY.get()
+    time.sleep(min(base_delay * (2 ** (retry_count - 1)), max_delay))
+
+
+def _record_result(
+    job_store: AbstractJobStore, job_id: str, job_name: str, result: JobResult
+) -> None:
+    """Map an executor ``JobResult`` onto the terminal job-store transition.
+
+    Mirrors the outcome handling in the Huey ``_exec_job`` path.
+    """
+    # If the job was canceled after it was claimed, it still ran to completion, but the
+    # cancel already finalized the row. Recording a terminal result now would raise an
+    # invalid-transition error and log a scary traceback for a normal user action, so skip it.
+    if job_store.get_job(job_id).status == JobStatus.CANCELED:
+        return
+
+    if result.status == JobStatus.SUCCEEDED:
+        job_store.report_job_result(job_id, JobStatus.SUCCEEDED, result=result.result)
+    elif result.status == JobStatus.TIMEOUT:
+        job_store.report_job_result(job_id, JobStatus.TIMEOUT, error_message=result.error_message)
+    elif result.status == JobStatus.CANCELED:
+        # Defensive: cancellation moves the job to a terminal CANCELED state through
+        # cancel_job(), so there is nothing to record here.
+        return
+    elif result.is_transient_error:
+        # A transient error resets the job to PENDING (non-terminal) so a later poll can
+        # re-claim it, so this cannot go through report_job_result.
+        retry_count = job_store.retry_or_fail_job(job_id, result.error_message or "")
+        if retry_count is not None:
+            _backoff_after_transient_retry(retry_count)
+    else:
+        _logger.error(f"Job {job_id} ({job_name}) failed with error: {result.error_message}")
+        job_store.report_job_result(
+            job_id, JobStatus.FAILED, error_message=result.error_message or ""
+        )
+
+
+def _execute_claimed_job(
+    job_store: AbstractJobStore, executor: AbstractJobExecutor, job: Job
+) -> None:
+    """Execute a job that has already been claimed (moved to RUNNING) and record its result."""
+    from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
+
+    fn_fullname = get_job_fn_fullname(job.job_name)
+    function = _load_function(fn_fullname)
+    python_env = function._job_fn_metadata.python_env
+    params = json.loads(job.params)
+    context = _build_execution_context(job)
+
+    backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
+    _logger.info(f"Executor engine running job {job.job_id} ({job.job_name}) on backend {backend}")
+
+    # Contract: every submit_job pairs with exactly one wait_for_job.
+    executor.submit_job(
+        job_id=job.job_id,
+        job_name=job.job_name,
+        fn_fullname=fn_fullname,
+        params=params,
+        context=context,
+        python_env=python_env,
+        timeout=job.timeout,
+    )
+    result = executor.wait_for_job(job.job_id)
+    _logger.info(f"Executor engine job {job.job_id} finished with status {result.status.value}")
+    _record_result(job_store, job.job_id, job.job_name, result)
+
+
+def _poll_and_execute_once(
+    job_store: AbstractJobStore, executor: AbstractJobExecutor, lease_duration: float | None
+) -> int:
+    """Claim and run every currently-PENDING job. Returns the number executed.
+
+    A single iteration of the loop; separated out so it can be driven directly in tests.
+
+    Workspace scoping mirrors the Huey ``_enqueue_unfinished_jobs`` path: on a
+    workspace-enabled deployment the store only returns jobs for the active workspace, so
+    the listing, claim, execution, and result-recording for each tenant all run inside that
+    tenant's ``WorkspaceContext``. When workspaces are disabled this is a single
+    ``nullcontext`` and behavior is unchanged.
+    """
+    from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
+
+    executed = 0
+    for workspace_ctx in _workspace_contexts_for_recovery():
+        with workspace_ctx:
+            for job in list(job_store.list_jobs(statuses=[JobStatus.PENDING])):
+                if job_store.claim_job(job.job_id, lease_duration) != JobUpdateStatus.APPLIED:
+                    # A concurrent worker claimed it first, or its status changed.
+                    continue
+                try:
+                    _execute_claimed_job(job_store, executor, job)
+                except Exception as exc:
+                    # A claimed job left RUNNING would be stuck; fail it so recovery is
+                    # not needed.
+                    _logger.error(
+                        f"Job {job.job_id} ({job.job_name}) raised in the executor loop: {exc!r}",
+                        exc_info=True,
+                    )
+                    try:
+                        job_store.fail_job(job.job_id, repr(exc))
+                    except Exception:
+                        _logger.exception(f"Failed to transition job {job.job_id} to FAILED")
+                executed += 1
+    return executed
+
+
+def run_executor_loop(
+    stop_event: threading.Event | None = None, poll_interval: float = _POLL_INTERVAL
+) -> None:
+    """Run the executor job-execution loop until ``stop_event`` is set."""
+    from mlflow.server.handlers import _get_job_store
+
+    # Only PENDING jobs are claimed here. Recovering orphaned RUNNING jobs on server
+    # restart is a follow-up; this loop does not handle it yet.
+    stop_event = stop_event or threading.Event()
+    job_store = _get_job_store()
+    executor = _select_executor()
+    lease_duration = executor.config.job_lease_ttl
+    executor.start_executor()
+    _logger.info(
+        f"Started executor-backed job runner (backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
+    )
+    try:
+        while not stop_event.is_set():
+            try:
+                executed = _poll_and_execute_once(job_store, executor, lease_duration)
+            except Exception:
+                # The loop-level store and workspace calls run outside the per-job handler.
+                # A transient error here must not kill the runner (nothing would restart it),
+                # so log it and try again on the next poll.
+                _logger.exception("Executor job loop iteration failed; continuing.")
+                executed = 0
+            if executed == 0:
+                stop_event.wait(poll_interval)
+    finally:
+        executor.stop_executor()
+
+
+def main() -> None:
+    from mlflow.server.jobs.logging_utils import configure_logging_for_jobs
+    from mlflow.server.jobs.utils import (
+        _launch_periodic_tasks_consumer,
+        _start_watcher_to_kill_job_runner_if_mlflow_server_dies,
+    )
+
+    configure_logging_for_jobs()
+    _start_watcher_to_kill_job_runner_if_mlflow_server_dies()
+    # Periodic tasks (e.g. the online scoring scheduler) still run on Huey.
+    _launch_periodic_tasks_consumer()
+    run_executor_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -36,7 +36,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE, ErrorCode
-from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR, MLFLOW_SERVER_UP_TIME
+from mlflow.server.constants import MLFLOW_SERVER_UP_TIME
 from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
 from mlflow.server.jobs.executor_registry import get_executor_registry
 from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
@@ -68,14 +68,13 @@ def _select_executor() -> AbstractJobExecutor:
 
 def _build_execution_context(job: Job) -> JobExecutionContext:
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
-    # The job subprocess talks to the tracking store through this URI. On the server
-    # MLFLOW_TRACKING_URI is usually unset (the server knows its store as the backend-store URI),
-    # so fall back to that; otherwise a job that touches the store from the subprocess would have
-    # no reachable tracking URI.
-    tracking_uri = MLFLOW_TRACKING_URI.get() or os.environ.get(BACKEND_STORE_URI_ENV_VAR)
+    # The runner is launched with MLFLOW_TRACKING_URI set to the server's HTTP URI (see the job
+    # env built in mlflow/server/__init__.py), so the job subprocess reaches the tracking store
+    # the same way the Huey path's subprocess does — through the server — rather than opening the
+    # backend store directly.
     return JobExecutionContext(
         job_id=job.job_id,
-        tracking_uri=tracking_uri,
+        tracking_uri=MLFLOW_TRACKING_URI.get(),
         gateway_uri=MLFLOW_GATEWAY_URI.get(),
         workspace=workspace,
     )
@@ -294,16 +293,16 @@ class _JobScheduler:
         # Randomize the per-workspace order so a fixed (e.g. alphabetical) order can't let the
         # earliest workspaces consistently claim the max_workers slots and starve the rest.
         #
-        # TODO (Phase C item C4, "pending-aware workspace scheduling"): with workspaces enabled,
-        # _workspace_contexts_for_recovery() returns every defined workspace, and the loop below
-        # runs one list_jobs(status=PENDING) query per workspace on every tick (~1s) even when
-        # most have nothing pending — cost scales with total workspaces, not active ones. To fix:
+        # TODO: with workspaces enabled, _workspace_contexts_for_recovery() returns every defined
+        # workspace, and the loop below runs one list_jobs(status=PENDING) query per workspace on
+        # every tick (~1s) even when most have nothing pending — cost scales with total workspaces,
+        # not active ones. To make it scale with active workspaces instead:
         #   1. add an AbstractJobStore method that returns, in a single cross-workspace query, the
         #      distinct workspaces that currently have PENDING jobs (the workspace-aware store
         #      filters by the active workspace today, so this query must not be workspace-scoped);
         #   2. have the scheduler iterate only those workspaces here instead of all of them;
         #   3. cover it with workspace-aware tests (see the jobs store's workspace test module).
-        # Deferred to Phase C because the per-tick cost only bites at multi-tenant scale.
+        # Left as a follow-up since the per-tick cost only becomes material at multi-tenant scale.
         workspace_contexts = list(_workspace_contexts_for_recovery())
         random.shuffle(workspace_contexts)
         scheduled = 0
@@ -328,7 +327,7 @@ class _JobScheduler:
                         # removed across an upgrade). Fail it, matching the old serial path, so it
                         # reaches a terminal state instead of staying PENDING and re-logging on
                         # every tick.
-                        self._fail_unschedulable_job(job, exc)
+                        self._fail_unschedulable_job(job, workspace, exc)
                         continue
                     if not sem.acquire(blocking=False):
                         # This job type is already at max_workers; leave it PENDING for a
@@ -387,8 +386,12 @@ class _JobScheduler:
                 _logger.exception("Unexpected error transitioning job %s to FAILED", job_id)
                 return
 
-    def _fail_unschedulable_job(self, job: Job, exc: Exception) -> None:
-        """Claim and fail a PENDING job whose function cannot be resolved."""
+    def _fail_unschedulable_job(self, job: Job, workspace: str | None, exc: Exception) -> None:
+        """Claim and fail a PENDING job whose function cannot be resolved.
+
+        ``workspace`` is the active workspace the claim runs under, so the fail targets the same
+        workspace scope as the claim.
+        """
         try:
             claimed = (
                 self._job_store.claim_job(job.job_id, self._lease_duration)
@@ -400,7 +403,7 @@ class _JobScheduler:
         if not claimed:
             return
         _logger.error("Job %s (%s) is not runnable: %r", job.job_id, job.job_name, exc)
-        self._fail_claimed_job(job.job_id, job.workspace, repr(exc))
+        self._fail_claimed_job(job.job_id, workspace, repr(exc))
 
     def _start_worker(self, job: Job, workspace: str | None, sem: threading.Semaphore) -> bool:
         """Start the worker thread for a claimed job. Returns whether it started.
@@ -549,9 +552,8 @@ def _recover_orphaned_executor_jobs(job_store: AbstractJobStore) -> None:
     claims PENDING jobs on its next tick.
 
     This is the single-instance crash/restart recovery. Reclaiming a job whose lease expires while
-    the runner is still live (a wedged worker, or another replica's jobs) is Phase C item C3 (live
-    stale-lease reclaim), which the lease primitive exists to enable once there is more than one
-    owner.
+    the runner is still live (a wedged worker, or another replica's jobs) is a follow-up that the
+    lease primitive exists to enable once there is more than one owner.
     """
     from mlflow.server.jobs.utils import _for_each_unfinished_job
 
@@ -597,11 +599,13 @@ def main() -> None:
 
     # Own the executor lifecycle here rather than inside the claim loop, so that when more than
     # one backend can be configured at a time (e.g. a custom-scorer backend alongside the default)
-    # main() can start and stop each configured executor independently. start_executor() runs
-    # inside the try so a failure during startup still triggers stop_executor() for cleanup.
-    executor = _select_executor()
+    # main() can start and stop each configured executor independently. Resolving and starting the
+    # executor both run inside the try so any failure there (the runner re-validates the backend
+    # registry independently of the parent) still triggers cleanup and the SIGTERM below.
+    executor: AbstractJobExecutor | None = None
     fatal_exit = False
     try:
+        executor = _select_executor()
         executor.start_executor()
         _logger.info(
             "Started executor-backed job runner "
@@ -617,10 +621,11 @@ def main() -> None:
         # Guard stop_executor so a failure here (e.g. a half-initialized backend when
         # start_executor raised) cannot skip the SIGTERM below — that signal is the only thing
         # that tears the process down, since the periodic-tasks consumer thread is non-daemon.
-        try:
-            executor.stop_executor()
-        except Exception:
-            _logger.exception("Failed to stop executor during shutdown.")
+        if executor is not None:
+            try:
+                executor.stop_executor()
+            except Exception:
+                _logger.exception("Failed to stop executor during shutdown.")
     if fatal_exit:
         # A non-daemon thread (the periodic-tasks consumer) keeps this process alive, so an
         # unhandled exit from the loop — e.g. a startup failure — would otherwise leave a live

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -7,7 +7,8 @@ backend (``LocalJobExecutor`` by default), then records the terminal state back 
 
 Concurrency is bounded per job function by a semaphore sized to that function's ``max_workers``,
 so one job type cannot starve another and the scheduler thread never blocks on a running job.
-Each tick also forwards store-side cancellations to the executor for in-flight jobs.
+Each tick also forwards store-side cancellations to the executor for in-flight jobs. On startup the
+runner recovers jobs left unfinished by a previous server generation.
 
 Only job execution moves to the executor framework here. Periodic tasks (e.g. the online scoring
 scheduler) still run on Huey via ``_launch_periodic_tasks_consumer``.
@@ -15,8 +16,13 @@ scheduler) still run on Huey via ``_launch_periodic_tasks_consumer``.
 
 import json
 import logging
+import os
+import random
+import signal
 import threading
 import time
+from dataclasses import dataclass
+from typing import Callable
 
 from mlflow.entities._job import Job
 from mlflow.entities._job_status import JobStatus
@@ -29,6 +35,8 @@ from mlflow.environment_variables import (
     MLFLOW_TRACKING_URI,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE, ErrorCode
+from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR, MLFLOW_SERVER_UP_TIME
 from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
 from mlflow.server.jobs.executor_registry import get_executor_registry
 from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
@@ -60,9 +68,14 @@ def _select_executor() -> AbstractJobExecutor:
 
 def _build_execution_context(job: Job) -> JobExecutionContext:
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
+    # The job subprocess talks to the tracking store through this URI. On the server
+    # MLFLOW_TRACKING_URI is usually unset (the server knows its store as the backend-store URI),
+    # so fall back to that; otherwise a job that touches the store from the subprocess would have
+    # no reachable tracking URI.
+    tracking_uri = MLFLOW_TRACKING_URI.get() or os.environ.get(BACKEND_STORE_URI_ENV_VAR)
     return JobExecutionContext(
         job_id=job.job_id,
-        tracking_uri=MLFLOW_TRACKING_URI.get(),
+        tracking_uri=tracking_uri,
         gateway_uri=MLFLOW_GATEWAY_URI.get(),
         workspace=workspace,
     )
@@ -118,9 +131,16 @@ def _record_result(
 
 
 def _execute_claimed_job(
-    job_store: AbstractJobStore, executor: AbstractJobExecutor, job: Job
+    job_store: AbstractJobStore,
+    executor: AbstractJobExecutor,
+    job: Job,
+    on_submitted: Callable[[], None] | None = None,
 ) -> None:
-    """Execute a job that has already been claimed (moved to RUNNING) and record its result."""
+    """Execute a job that has already been claimed (moved to RUNNING) and record its result.
+
+    ``on_submitted`` is invoked right after the job reaches the executor, so the scheduler can
+    start forwarding cancellations only once there is a backend job to cancel.
+    """
     from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
     fn_fullname = get_job_fn_fullname(job.job_name)
@@ -128,6 +148,12 @@ def _execute_claimed_job(
     python_env = function._job_fn_metadata.python_env
     params = json.loads(job.params)
     context = _build_execution_context(job)
+
+    # A cancellation that arrived after the claim but before submission can't be forwarded to the
+    # executor (there is no backend job yet). Check the store here so such a job is not started at
+    # all; the row is already terminal CANCELED, so there is nothing to record.
+    if job_store.get_job(job.job_id).status == JobStatus.CANCELED:
+        return
 
     backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
     _logger.info(f"Executor engine running job {job.job_id} ({job.job_name}) on backend {backend}")
@@ -142,6 +168,8 @@ def _execute_claimed_job(
         python_env=python_env,
         timeout=job.timeout,
     )
+    if on_submitted is not None:
+        on_submitted()
     result = executor.wait_for_job(job.job_id)
     _logger.info(f"Executor engine job {job.job_id} finished with status {result.status.value}")
     _record_result(job_store, job.job_id, job.job_name, result)
@@ -153,6 +181,20 @@ def _max_workers_for(job_name: str) -> int:
 
     max_workers = _load_function(get_job_fn_fullname(job_name))._job_fn_metadata.max_workers
     return max(1, max_workers or 1)
+
+
+@dataclass
+class _InFlightJob:
+    """Bookkeeping for a claimed job while its worker thread runs."""
+
+    workspace: str | None
+    thread: threading.Thread
+    # Set once the job has reached the executor. Cancellation is forwarded only after this, since
+    # there is no backend job to cancel before submission.
+    submitted: bool = False
+    # Set once a store-side cancellation has been successfully forwarded to the executor, so it is
+    # forwarded at most once (AbstractJobExecutor.cancel_job is not required to be idempotent).
+    cancel_forwarded: bool = False
 
 
 class _JobScheduler:
@@ -182,24 +224,28 @@ class _JobScheduler:
         # One semaphore per job_name (value = that function's max_workers).
         self._slots: dict[str, threading.Semaphore] = {}
         self._slots_lock = threading.Lock()
-        # job_id -> (workspace, worker thread), for the cancel sweep and shutdown join.
-        self._in_flight: dict[str, tuple[str | None, threading.Thread]] = {}
-        # job_ids whose cancellation was already forwarded to the executor, so cancel_job is
-        # called at most once per in-flight job (AbstractJobExecutor.cancel_job does not promise
-        # idempotency for plugin backends). Guarded by _in_flight_lock.
-        self._canceled_forwarded: set[str] = set()
-        # job_ids whose cancel forward has failed at least once, so the traceback is logged only
-        # once per job instead of on every retry. Guarded by _in_flight_lock.
-        self._cancel_forward_failed: set[str] = set()
+        # job_id -> _InFlightJob, for the cancel sweep and shutdown join. Guarded by
+        # _in_flight_lock.
+        self._in_flight: dict[str, _InFlightJob] = {}
         self._in_flight_lock = threading.Lock()
 
     def _slot_for(self, job_name: str) -> threading.Semaphore:
         with self._slots_lock:
             sem = self._slots.get(job_name)
-            if sem is None:
-                sem = threading.Semaphore(_max_workers_for(job_name))
-                self._slots[job_name] = sem
+        if sem is not None:
             return sem
+        # Resolve max_workers (which may import the job module) before taking the lock, so the
+        # import runs outside the lock's critical section. This is a no-op under the single
+        # scheduler thread today, but keeps the hold time minimal if the scheduler ever runs
+        # multi-threaded.
+        max_workers = _max_workers_for(job_name)
+        with self._slots_lock:
+            return self._slots.setdefault(job_name, threading.Semaphore(max_workers))
+
+    def _mark_submitted(self, job_id: str) -> None:
+        with self._in_flight_lock:
+            if (handle := self._in_flight.get(job_id)) is not None:
+                handle.submitted = True
 
     def tick(self) -> int:
         """Run one scheduler iteration. Returns the number of jobs newly scheduled."""
@@ -209,48 +255,59 @@ class _JobScheduler:
     def _forward_cancellations(self) -> None:
         with self._in_flight_lock:
             snapshot = list(self._in_flight.items())
-        for job_id, (workspace, _thread) in snapshot:
+        for job_id, handle in snapshot:
+            # Only forward once the job has reached the executor and not already forwarded. Before
+            # submission there is no backend job to cancel; the worker's own pre-submit check
+            # (see _execute_claimed_job) handles a cancel that arrives in that window.
+            if not handle.submitted or handle.cancel_forwarded:
+                continue
             try:
-                with ServerWorkspaceContext(workspace):
+                with ServerWorkspaceContext(handle.workspace):
                     canceled = self._job_store.get_job(job_id).status == JobStatus.CANCELED
             except Exception:
                 _logger.exception("Failed to check cancellation state for job %s", job_id)
                 continue
             if not canceled:
                 continue
-            with self._in_flight_lock:
-                if job_id in self._canceled_forwarded:
-                    continue
             try:
                 # Stop the still-running job so it cannot keep performing side effects after the
                 # caller cancelled it. The worker's wait_for_job then returns and _record_result
                 # skips the already-CANCELED row.
                 self._executor.cancel_job(job_id)
             except Exception:
-                # Leave it unmarked so the next tick retries the cancel rather than letting the
-                # canceled job run to normal completion. Log the traceback once; the per-tick
-                # retries then stay quiet.
-                with self._in_flight_lock:
-                    first_failure = job_id not in self._cancel_forward_failed
-                    self._cancel_forward_failed.add(job_id)
-                if first_failure:
-                    _logger.exception(
-                        "Failed to forward cancellation to executor for %s; retrying each tick",
-                        job_id,
-                    )
+                # Leave cancel_forwarded false so the next tick retries rather than letting the
+                # canceled job run to normal completion. Log every failure: a repeated failure may
+                # differ each time, so silencing later ones could hide something useful.
+                _logger.exception(
+                    "Failed to forward cancellation to executor for %s; retrying next tick", job_id
+                )
                 continue
             with self._in_flight_lock:
-                # Only mark forwarded while the job is still in flight: cancel_job may already have
-                # unblocked the worker, whose finally pops _in_flight and discards these markers,
-                # and re-adding here would orphan the id in the set for the runner's lifetime.
-                if job_id in self._in_flight:
-                    self._canceled_forwarded.add(job_id)
+                # cancel_job may already have unblocked the worker, whose finally pops _in_flight;
+                # only record on the live handle so a finished job's id is not left behind.
+                if (live := self._in_flight.get(job_id)) is not None:
+                    live.cancel_forwarded = True
 
     def _schedule_pending(self) -> int:
         from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
 
+        # Randomize the per-workspace order so a fixed (e.g. alphabetical) order can't let the
+        # earliest workspaces consistently claim the max_workers slots and starve the rest.
+        #
+        # TODO (Phase C item C4, "pending-aware workspace scheduling"): with workspaces enabled,
+        # _workspace_contexts_for_recovery() returns every defined workspace, and the loop below
+        # runs one list_jobs(status=PENDING) query per workspace on every tick (~1s) even when
+        # most have nothing pending — cost scales with total workspaces, not active ones. To fix:
+        #   1. add an AbstractJobStore method that returns, in a single cross-workspace query, the
+        #      distinct workspaces that currently have PENDING jobs (the workspace-aware store
+        #      filters by the active workspace today, so this query must not be workspace-scoped);
+        #   2. have the scheduler iterate only those workspaces here instead of all of them;
+        #   3. cover it with workspace-aware tests (see the jobs store's workspace test module).
+        # Deferred to Phase C because the per-tick cost only bites at multi-tenant scale.
+        workspace_contexts = list(_workspace_contexts_for_recovery())
+        random.shuffle(workspace_contexts)
         scheduled = 0
-        for workspace_ctx in _workspace_contexts_for_recovery():
+        for workspace_ctx in workspace_contexts:
             with workspace_ctx as workspace:
                 # TODO (follow-up): exclusive job-locking by key (e.g. keeping online scoring
                 # exclusive per experiment) is not enforced here; it builds on the job-lock work
@@ -290,9 +347,45 @@ class _JobScheduler:
                         # A concurrent worker claimed it first, or its status changed.
                         sem.release()
                         continue
-                    if self._start_worker(job, workspace, sem):
+                    try:
+                        started = self._start_worker(job, workspace, sem)
+                    except Exception:
+                        # _start_worker owns releasing the slot on the failure paths it handles;
+                        # this guards the unexpected case so the slot is not leaked if it raises.
+                        sem.release()
+                        _logger.exception("Failed to start worker for job %s", job.job_id)
+                        continue
+                    if started:
                         scheduled += 1
         return scheduled
+
+    def _fail_claimed_job(self, job_id: str, workspace: str | None, error: str) -> None:
+        """Transition a claimed (RUNNING) job to FAILED, retrying once on a transient store error.
+
+        A claimed job left RUNNING with no worker is only reclaimable by startup recovery, so a
+        transient store failure on the first attempt should not strand it there. The managed
+        session surfaces a transient DB error as ``MlflowException`` with
+        ``error_code == TEMPORARILY_UNAVAILABLE``; that is retried once. Anything else — an invalid
+        transition (the row is no longer RUNNING) or any other error — won't succeed on a retry, so
+        it is logged once and not retried.
+        """
+        temporarily_unavailable = ErrorCode.Name(TEMPORARILY_UNAVAILABLE)
+        for attempt in (1, 2):
+            try:
+                with ServerWorkspaceContext(workspace):
+                    self._job_store.fail_job(job_id, error)
+                return
+            except MlflowException as e:
+                if attempt == 1 and e.error_code == temporarily_unavailable:
+                    _logger.warning("Transient store error failing job %s; retrying once", job_id)
+                    continue
+                _logger.exception("Could not transition job %s to FAILED", job_id)
+                return
+            except Exception:
+                # The store wraps its errors as MlflowException; a bare exception here is
+                # unexpected and not something a retry would fix, so log once and stop.
+                _logger.exception("Unexpected error transitioning job %s to FAILED", job_id)
+                return
 
     def _fail_unschedulable_job(self, job: Job, exc: Exception) -> None:
         """Claim and fail a PENDING job whose function cannot be resolved."""
@@ -307,10 +400,7 @@ class _JobScheduler:
         if not claimed:
             return
         _logger.error("Job %s (%s) is not runnable: %r", job.job_id, job.job_name, exc)
-        try:
-            self._job_store.fail_job(job.job_id, repr(exc))
-        except Exception:
-            _logger.exception("Failed to transition unschedulable job %s to FAILED", job.job_id)
+        self._fail_claimed_job(job.job_id, job.workspace, repr(exc))
 
     def _start_worker(self, job: Job, workspace: str | None, sem: threading.Semaphore) -> bool:
         """Start the worker thread for a claimed job. Returns whether it started.
@@ -326,7 +416,7 @@ class _JobScheduler:
             daemon=True,
         )
         with self._in_flight_lock:
-            self._in_flight[job.job_id] = (workspace, thread)
+            self._in_flight[job.job_id] = _InFlightJob(workspace=workspace, thread=thread)
         try:
             thread.start()
         except Exception:
@@ -334,20 +424,19 @@ class _JobScheduler:
             with self._in_flight_lock:
                 self._in_flight.pop(job.job_id, None)
             sem.release()
-            try:
-                with ServerWorkspaceContext(workspace):
-                    self._job_store.fail_job(job.job_id, "Failed to start executor worker thread")
-            except Exception:
-                _logger.exception(
-                    "Failed to transition job %s to FAILED after worker start failure", job.job_id
-                )
+            self._fail_claimed_job(job.job_id, workspace, "Failed to start executor worker thread")
             return False
         return True
 
     def _run_worker(self, job: Job, workspace: str | None, sem: threading.Semaphore) -> None:
         try:
             with ServerWorkspaceContext(workspace):
-                _execute_claimed_job(self._job_store, self._executor, job)
+                _execute_claimed_job(
+                    self._job_store,
+                    self._executor,
+                    job,
+                    on_submitted=lambda: self._mark_submitted(job.job_id),
+                )
         except Exception as exc:
             # A claimed job left RUNNING would be stuck; fail it so recovery is not needed.
             _logger.error(
@@ -357,17 +446,11 @@ class _JobScheduler:
                 exc,
                 exc_info=True,
             )
-            try:
-                with ServerWorkspaceContext(workspace):
-                    self._job_store.fail_job(job.job_id, repr(exc))
-            except Exception:
-                _logger.exception("Failed to transition job %s to FAILED", job.job_id)
+            self._fail_claimed_job(job.job_id, workspace, repr(exc))
         finally:
             sem.release()
             with self._in_flight_lock:
                 self._in_flight.pop(job.job_id, None)
-                self._canceled_forwarded.discard(job.job_id)
-                self._cancel_forward_failed.discard(job.job_id)
 
     def join(self, timeout: float | None = None) -> None:
         """Best-effort wait for in-flight workers to finish.
@@ -375,7 +458,7 @@ class _JobScheduler:
         ``timeout`` is a total budget across all workers, not per worker, so shutdown is bounded.
         """
         with self._in_flight_lock:
-            threads = [thread for _workspace, thread in self._in_flight.values()]
+            threads = [handle.thread for handle in self._in_flight.values()]
         if timeout is None:
             for thread in threads:
                 thread.join()
@@ -387,29 +470,58 @@ class _JobScheduler:
                 break
             thread.join(remaining)
 
+    def mark_orphans_for_recovery(self) -> None:
+        """Flag any still-in-flight jobs as needing recovery on shutdown.
+
+        Workers are daemon threads: if any are still running when the process exits, their
+        ``finally`` blocks may not run, leaving the store row RUNNING with nothing executing it.
+        Marking those rows NEEDS_RECOVERY lets startup recovery re-queue them on the next launch.
+        """
+        with self._in_flight_lock:
+            orphans = [(job_id, handle.workspace) for job_id, handle in self._in_flight.items()]
+        if not orphans:
+            return
+        _logger.warning(
+            "Shutdown cut off %d still-running job(s) before completion; marking them for "
+            "recovery on the next launch: %s",
+            len(orphans),
+            ", ".join(job_id for job_id, _ in orphans),
+        )
+        for job_id, workspace in orphans:
+            try:
+                with ServerWorkspaceContext(workspace):
+                    self._job_store.mark_job_needs_recovery(job_id)
+            except Exception:
+                _logger.exception("Failed to mark orphaned job %s for recovery", job_id)
+
 
 def run_executor_loop(
-    stop_event: threading.Event | None = None, poll_interval: float = _POLL_INTERVAL
+    executor: AbstractJobExecutor,
+    stop_event: threading.Event | None = None,
+    poll_interval: float = _POLL_INTERVAL,
 ) -> None:
-    """Run the executor job-execution loop until ``stop_event`` is set."""
+    """Run the executor claim loop until ``stop_event`` is set.
+
+    ``executor`` must already be started; the caller (``main``) owns ``start_executor()`` /
+    ``stop_executor()``. Keeping lifecycle out of this loop lets the caller start and stop several
+    configured backends independently, once more than one backend can be configured at a time,
+    rather than tying it to this single-executor claim loop.
+    """
     from mlflow.server.handlers import _get_job_store
 
-    # Only PENDING jobs are claimed here. Recovering orphaned RUNNING jobs on server
-    # restart is a follow-up; this loop does not handle it yet.
     stop_event = stop_event or threading.Event()
     job_store = _get_job_store()
-    executor = _select_executor()
     lease_duration = executor.config.job_lease_ttl
-    scheduler: _JobScheduler | None = None
-    # start_executor() runs inside the try so a failure during startup (e.g. a plugin backend
-    # that allocates resources and then raises) still triggers stop_executor() for cleanup.
+    # Reclaim jobs left RUNNING/NEEDS_RECOVERY by a previous server generation (a crash, or a
+    # shutdown that killed daemon workers) so they are re-scheduled instead of stuck. A transient
+    # store error here must not crash the runner (same reasoning as the tick loop below): log it
+    # and proceed to claim PENDING jobs; the next launch's recovery retries the reset.
     try:
-        executor.start_executor()
-        _logger.info(
-            "Started executor-backed job runner "
-            f"(backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
-        )
-        scheduler = _JobScheduler(job_store, executor, lease_duration)
+        _recover_orphaned_executor_jobs(job_store)
+    except Exception:
+        _logger.exception("Executor job recovery failed at startup; continuing.")
+    scheduler = _JobScheduler(job_store, executor, lease_duration)
+    try:
         while not stop_event.is_set():
             try:
                 scheduled = scheduler.tick()
@@ -423,9 +535,52 @@ def run_executor_loop(
                 _logger.debug("Executor engine scheduled %d job(s) this tick.", scheduled)
             stop_event.wait(poll_interval)
     finally:
-        if scheduler is not None:
-            scheduler.join(timeout=_SHUTDOWN_JOIN_TIMEOUT)
-        executor.stop_executor()
+        scheduler.join(timeout=_SHUTDOWN_JOIN_TIMEOUT)
+        # Any worker still in flight after the join budget won't get to finalize its row on a
+        # daemon-thread exit; flag it so the next launch's recovery re-queues it.
+        scheduler.mark_orphans_for_recovery()
+
+
+def _recover_orphaned_executor_jobs(job_store: AbstractJobStore) -> None:
+    """Reset jobs left unfinished by a previous server generation back to PENDING.
+
+    Only jobs created before this server launch are touched, so it never races jobs submitted to
+    the running server. Unlike the Huey recovery path there is nothing to re-enqueue: the scheduler
+    claims PENDING jobs on its next tick.
+
+    This is the single-instance crash/restart recovery. Reclaiming a job whose lease expires while
+    the runner is still live (a wedged worker, or another replica's jobs) is Phase C item C3 (live
+    stale-lease reclaim), which the lease primitive exists to enable once there is more than one
+    owner.
+    """
+    from mlflow.server.jobs.utils import _for_each_unfinished_job
+
+    server_up_time = os.environ.get(MLFLOW_SERVER_UP_TIME)
+    if server_up_time is None:
+        # Set by the server that launches this runner; without it we cannot bound recovery to the
+        # previous generation, so skip rather than risk resetting freshly submitted jobs.
+        _logger.debug("%s is unset; skipping executor job recovery.", MLFLOW_SERVER_UP_TIME)
+        return
+    try:
+        launch_ts = int(server_up_time)
+    except ValueError:
+        _logger.warning(
+            "%s is not an integer (%r); skipping executor job recovery.",
+            MLFLOW_SERVER_UP_TIME,
+            server_up_time,
+        )
+        return
+
+    def _reset(job: Job, _workspace: str | None) -> None:
+        try:
+            job_store.reset_job(job.job_id)
+            _logger.info("Recovered orphaned job %s (%s) to PENDING", job.job_id, job.job_name)
+        except Exception:
+            _logger.exception("Failed to recover orphaned job %s", job.job_id)
+
+    _for_each_unfinished_job(
+        job_store, [JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY], launch_ts, _reset
+    )
 
 
 def main() -> None:
@@ -439,7 +594,39 @@ def main() -> None:
     _start_watcher_to_kill_job_runner_if_mlflow_server_dies()
     # Periodic tasks (e.g. the online scoring scheduler) still run on Huey.
     _launch_periodic_tasks_consumer()
-    run_executor_loop()
+
+    # Own the executor lifecycle here rather than inside the claim loop, so that when more than
+    # one backend can be configured at a time (e.g. a custom-scorer backend alongside the default)
+    # main() can start and stop each configured executor independently. start_executor() runs
+    # inside the try so a failure during startup still triggers stop_executor() for cleanup.
+    executor = _select_executor()
+    fatal_exit = False
+    try:
+        executor.start_executor()
+        _logger.info(
+            "Started executor-backed job runner "
+            f"(backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
+        )
+        run_executor_loop(executor)
+    except Exception:
+        # (KeyboardInterrupt/SystemExit are intentionally not caught: a clean shutdown signal
+        # should propagate normally rather than be reported as an unexpected exit.)
+        _logger.exception("Executor job runner exited unexpectedly; terminating process.")
+        fatal_exit = True
+    finally:
+        # Guard stop_executor so a failure here (e.g. a half-initialized backend when
+        # start_executor raised) cannot skip the SIGTERM below — that signal is the only thing
+        # that tears the process down, since the periodic-tasks consumer thread is non-daemon.
+        try:
+            executor.stop_executor()
+        except Exception:
+            _logger.exception("Failed to stop executor during shutdown.")
+    if fatal_exit:
+        # A non-daemon thread (the periodic-tasks consumer) keeps this process alive, so an
+        # unhandled exit from the loop — e.g. a startup failure — would otherwise leave a live
+        # process with no executor while jobs pile up PENDING. Terminate so the failure is visible.
+        # Sent after stop_executor() above so backend cleanup is not skipped by the signal.
+        os.kill(os.getpid(), signal.SIGTERM)
 
 
 if __name__ == "__main__":

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -1,13 +1,16 @@
 """Executor-engine job runner.
 
 Launched in place of the Huey ``_job_runner`` when
-``MLFLOW_SERVER_JOB_EXECUTION_ENGINE=executor``. It runs a loop that claims
-PENDING jobs from the job store and executes them through the configured
-``AbstractJobExecutor`` backend (``LocalJobExecutor`` by default), then records
-the terminal state back to the store.
+``MLFLOW_SERVER_JOB_EXECUTION_ENGINE=executor``. A scheduler loop claims PENDING jobs from the
+job store and runs each in its own worker thread through the configured ``AbstractJobExecutor``
+backend (``LocalJobExecutor`` by default), then records the terminal state back to the store.
 
-Only job execution moves to the executor framework here. Periodic tasks (e.g. the
-online scoring scheduler) still run on Huey via ``_launch_periodic_tasks_consumer``.
+Concurrency is bounded per job function by a semaphore sized to that function's ``max_workers``,
+so one job type cannot starve another and the scheduler thread never blocks on a running job.
+Each tick also forwards store-side cancellations to the executor for in-flight jobs.
+
+Only job execution moves to the executor framework here. Periodic tasks (e.g. the online scoring
+scheduler) still run on Huey via ``_launch_periodic_tasks_consumer``.
 """
 
 import json
@@ -28,14 +31,17 @@ from mlflow.environment_variables import (
 from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
 from mlflow.server.jobs.executor_registry import get_executor_registry
 from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
+from mlflow.utils.workspace_context import ServerWorkspaceContext
 
 # Use an explicit logger name rather than __name__: this module is launched as
 # ``python -m mlflow.server.jobs._executor_runner``, where __name__ is "__main__" and would
 # fall outside the "mlflow" logger hierarchy, so its logs would miss MLflow's log handler.
 _logger = logging.getLogger("mlflow.server.jobs._executor_runner")
 
-# How long the loop sleeps when it finds no PENDING jobs to run.
+# How long the scheduler sleeps between ticks (workers run in the background between ticks).
 _POLL_INTERVAL = 1.0
+# On shutdown, how long to wait for each in-flight worker before stopping the executor.
+_SHUTDOWN_JOIN_TIMEOUT = 5.0
 
 
 def _select_executor() -> AbstractJobExecutor:
@@ -62,8 +68,8 @@ def _build_execution_context(job: Job) -> JobExecutionContext:
 
 
 def _backoff_after_transient_retry(retry_count: int) -> None:
-    # Mirror the Huey path's exponential backoff. The loop is serial for now, so
-    # this briefly blocks other jobs; non-blocking scheduling is a later refinement.
+    # Mirror the Huey path's exponential backoff. This runs on the per-job worker thread, so it
+    # only delays that job's slot — it does not block the scheduler or other job types.
     base_delay = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY.get()
     max_delay = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY.get()
     time.sleep(min(base_delay * (2 ** (retry_count - 1)), max_delay))
@@ -76,9 +82,10 @@ def _record_result(
 
     Mirrors the outcome handling in the Huey ``_exec_job`` path.
     """
-    # If the job was canceled after it was claimed, it still ran to completion, but the
-    # cancel already finalized the row. Recording a terminal result now would raise an
-    # invalid-transition error and log a scary traceback for a normal user action, so skip it.
+    # If the job was canceled after it was claimed, it still ran to completion (or was killed by
+    # a forwarded cancel), but the cancel already finalized the row. Recording a terminal result
+    # now would raise an invalid-transition error and log a scary traceback for a normal user
+    # action, so skip it.
     if job_store.get_job(job_id).status == JobStatus.CANCELED:
         return
 
@@ -133,48 +140,217 @@ def _execute_claimed_job(
     _record_result(job_store, job.job_id, job.job_name, result)
 
 
-def _poll_and_execute_once(
-    job_store: AbstractJobStore, executor: AbstractJobExecutor, lease_duration: float | None
-) -> int:
-    """Claim and run every currently-PENDING job. Returns the number executed.
+def _max_workers_for(job_name: str) -> int:
+    """Concurrency limit for a job function, from its ``@job(max_workers=...)`` metadata."""
+    from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
-    A single iteration of the loop; separated out so it can be driven directly in tests.
+    max_workers = _load_function(get_job_fn_fullname(job_name))._job_fn_metadata.max_workers
+    return max(1, max_workers or 1)
 
-    Workspace scoping mirrors the Huey ``_enqueue_unfinished_jobs`` path: on a
-    workspace-enabled deployment the store only returns jobs for the active workspace, so
-    the listing, claim, execution, and result-recording for each tenant all run inside that
-    tenant's ``WorkspaceContext``. When workspaces are disabled this is a single
-    ``nullcontext`` and behavior is unchanged.
+
+class _JobScheduler:
+    """Non-blocking scheduler for the executor engine.
+
+    Each ``tick()`` (1) forwards store-side cancellations to the executor for in-flight jobs, then
+    (2) claims PENDING jobs it has capacity for and runs each in a worker thread. A per-``job_name``
+    semaphore sized to that function's ``max_workers`` bounds how many jobs of a given type run at
+    once (a process-wide budget per job type, matching the Huey engine's per-function pool), so the
+    scheduler thread never blocks on a running job.
+
+    Worker threads re-enter the job's workspace with ``ServerWorkspaceContext``, which binds only
+    the thread-local request ContextVar. ``WorkspaceContext`` must not be used here: it also mutates
+    the process-global ``MLFLOW_WORKSPACE`` env, which concurrent workers in different workspaces
+    would race on. The store resolves the ContextVar first (see ``get_request_workspace``).
     """
-    from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
 
-    executed = 0
-    for workspace_ctx in _workspace_contexts_for_recovery():
-        with workspace_ctx:
-            # TODO (follow-up): this claims and runs PENDING jobs serially. Two things are not
-            # yet enforced here and land in follow-ups: (1) per-function ``max_workers`` and
-            # concurrent scheduling, so one job type cannot starve another; (2) exclusive job
-            # locking by key (e.g. keeping online scoring exclusive per experiment), which
-            # builds on the job-lock work in #25200.
-            for job in list(job_store.list_jobs(statuses=[JobStatus.PENDING])):
-                if job_store.claim_job(job.job_id, lease_duration) != JobUpdateStatus.APPLIED:
-                    # A concurrent worker claimed it first, or its status changed.
+    def __init__(
+        self,
+        job_store: AbstractJobStore,
+        executor: AbstractJobExecutor,
+        lease_duration: float | None,
+    ) -> None:
+        self._job_store = job_store
+        self._executor = executor
+        self._lease_duration = lease_duration
+        # One semaphore per job_name (value = that function's max_workers).
+        self._slots: dict[str, threading.Semaphore] = {}
+        self._slots_lock = threading.Lock()
+        # job_id -> (workspace, worker thread), for the cancel sweep and shutdown join.
+        self._in_flight: dict[str, tuple[str | None, threading.Thread]] = {}
+        # job_ids whose cancellation was already forwarded to the executor, so cancel_job is
+        # called at most once per in-flight job (AbstractJobExecutor.cancel_job does not promise
+        # idempotency for plugin backends). Guarded by _in_flight_lock.
+        self._canceled_forwarded: set[str] = set()
+        self._in_flight_lock = threading.Lock()
+
+    def _slot_for(self, job_name: str) -> threading.Semaphore:
+        with self._slots_lock:
+            sem = self._slots.get(job_name)
+            if sem is None:
+                sem = threading.Semaphore(_max_workers_for(job_name))
+                self._slots[job_name] = sem
+            return sem
+
+    def tick(self) -> int:
+        """Run one scheduler iteration. Returns the number of jobs newly scheduled."""
+        self._forward_cancellations()
+        return self._schedule_pending()
+
+    def _forward_cancellations(self) -> None:
+        with self._in_flight_lock:
+            snapshot = list(self._in_flight.items())
+        for job_id, (workspace, _thread) in snapshot:
+            try:
+                with ServerWorkspaceContext(workspace):
+                    canceled = self._job_store.get_job(job_id).status == JobStatus.CANCELED
+            except Exception:
+                _logger.exception("Failed to check cancellation state for job %s", job_id)
+                continue
+            if not canceled:
+                continue
+            with self._in_flight_lock:
+                if job_id in self._canceled_forwarded:
                     continue
-                try:
-                    _execute_claimed_job(job_store, executor, job)
-                except Exception as exc:
-                    # A claimed job left RUNNING would be stuck; fail it so recovery is
-                    # not needed.
-                    _logger.error(
-                        f"Job {job.job_id} ({job.job_name}) raised in the executor loop: {exc!r}",
-                        exc_info=True,
-                    )
+                self._canceled_forwarded.add(job_id)
+            try:
+                # Stop the still-running job so it cannot keep performing side effects after the
+                # caller cancelled it. The worker's wait_for_job then returns and _record_result
+                # skips the already-CANCELED row.
+                self._executor.cancel_job(job_id)
+            except Exception:
+                _logger.exception("Failed to forward cancellation to executor for %s", job_id)
+
+    def _schedule_pending(self) -> int:
+        from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
+
+        scheduled = 0
+        for workspace_ctx in _workspace_contexts_for_recovery():
+            with workspace_ctx as workspace:
+                # TODO (follow-up): exclusive job-locking by key (e.g. keeping online scoring
+                # exclusive per experiment) is not enforced here; it builds on the job-lock work
+                # in #25200 and lands once that is available.
+                for job in list(self._job_store.list_jobs(statuses=[JobStatus.PENDING])):
                     try:
-                        job_store.fail_job(job.job_id, repr(exc))
+                        sem = self._slot_for(job.job_name)
+                    except Exception as exc:
+                        # The function backing this job cannot be resolved (e.g. it was renamed or
+                        # removed across an upgrade). Fail it, matching the old serial path, so it
+                        # reaches a terminal state instead of staying PENDING and re-logging on
+                        # every tick.
+                        self._fail_unschedulable_job(job, exc)
+                        continue
+                    if not sem.acquire(blocking=False):
+                        # This job type is already at max_workers; leave it PENDING for a
+                        # later tick, once a slot frees.
+                        continue
+                    try:
+                        claimed = (
+                            self._job_store.claim_job(job.job_id, self._lease_duration)
+                            == JobUpdateStatus.APPLIED
+                        )
                     except Exception:
-                        _logger.exception(f"Failed to transition job {job.job_id} to FAILED")
-                executed += 1
-    return executed
+                        sem.release()
+                        _logger.exception("Failed to claim job %s", job.job_id)
+                        continue
+                    if not claimed:
+                        # A concurrent worker claimed it first, or its status changed.
+                        sem.release()
+                        continue
+                    if self._start_worker(job, workspace, sem):
+                        scheduled += 1
+        return scheduled
+
+    def _fail_unschedulable_job(self, job: Job, exc: Exception) -> None:
+        """Claim and fail a PENDING job whose function cannot be resolved."""
+        try:
+            claimed = (
+                self._job_store.claim_job(job.job_id, self._lease_duration)
+                == JobUpdateStatus.APPLIED
+            )
+        except Exception:
+            _logger.exception("Failed to claim unschedulable job %s", job.job_id)
+            return
+        if not claimed:
+            return
+        _logger.error("Job %s (%s) is not runnable: %r", job.job_id, job.job_name, exc)
+        try:
+            self._job_store.fail_job(job.job_id, repr(exc))
+        except Exception:
+            _logger.exception("Failed to transition unschedulable job %s to FAILED", job.job_id)
+
+    def _start_worker(self, job: Job, workspace: str | None, sem: threading.Semaphore) -> bool:
+        """Start the worker thread for a claimed job. Returns whether it started.
+
+        If the thread cannot be started (e.g. the OS thread limit is hit), the claim's effects are
+        undone — the slot is released and the job is failed — so the slot is not leaked and the job
+        does not stay RUNNING with nothing running it.
+        """
+        thread = threading.Thread(
+            target=self._run_worker,
+            args=(job, workspace, sem),
+            name=f"mlflow-executor-job-{job.job_id}",
+            daemon=True,
+        )
+        with self._in_flight_lock:
+            self._in_flight[job.job_id] = (workspace, thread)
+        try:
+            thread.start()
+        except Exception:
+            _logger.exception("Failed to start worker thread for job %s", job.job_id)
+            with self._in_flight_lock:
+                self._in_flight.pop(job.job_id, None)
+            sem.release()
+            try:
+                with ServerWorkspaceContext(workspace):
+                    self._job_store.fail_job(job.job_id, "Failed to start executor worker thread")
+            except Exception:
+                _logger.exception(
+                    "Failed to transition job %s to FAILED after worker start failure", job.job_id
+                )
+            return False
+        return True
+
+    def _run_worker(self, job: Job, workspace: str | None, sem: threading.Semaphore) -> None:
+        try:
+            with ServerWorkspaceContext(workspace):
+                _execute_claimed_job(self._job_store, self._executor, job)
+        except Exception as exc:
+            # A claimed job left RUNNING would be stuck; fail it so recovery is not needed.
+            _logger.error(
+                "Job %s (%s) raised in the executor worker: %r",
+                job.job_id,
+                job.job_name,
+                exc,
+                exc_info=True,
+            )
+            try:
+                with ServerWorkspaceContext(workspace):
+                    self._job_store.fail_job(job.job_id, repr(exc))
+            except Exception:
+                _logger.exception("Failed to transition job %s to FAILED", job.job_id)
+        finally:
+            sem.release()
+            with self._in_flight_lock:
+                self._in_flight.pop(job.job_id, None)
+                self._canceled_forwarded.discard(job.job_id)
+
+    def join(self, timeout: float | None = None) -> None:
+        """Best-effort wait for in-flight workers to finish.
+
+        ``timeout`` is a total budget across all workers, not per worker, so shutdown is bounded.
+        """
+        with self._in_flight_lock:
+            threads = [thread for _workspace, thread in self._in_flight.values()]
+        if timeout is None:
+            for thread in threads:
+                thread.join()
+            return
+        deadline = time.monotonic() + timeout
+        for thread in threads:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            thread.join(remaining)
 
 
 def run_executor_loop(
@@ -189,6 +365,7 @@ def run_executor_loop(
     job_store = _get_job_store()
     executor = _select_executor()
     lease_duration = executor.config.job_lease_ttl
+    scheduler: _JobScheduler | None = None
     # start_executor() runs inside the try so a failure during startup (e.g. a plugin backend
     # that allocates resources and then raises) still triggers stop_executor() for cleanup.
     try:
@@ -197,20 +374,22 @@ def run_executor_loop(
             "Started executor-backed job runner "
             f"(backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
         )
+        scheduler = _JobScheduler(job_store, executor, lease_duration)
         while not stop_event.is_set():
             try:
-                executed = _poll_and_execute_once(job_store, executor, lease_duration)
+                scheduled = scheduler.tick()
             except Exception:
-                # The loop-level store and workspace calls run outside the per-job handler.
-                # A transient error here must not kill the runner (nothing would restart it),
+                # The tick's store and workspace calls run outside the per-job worker. A
+                # transient error here must not kill the scheduler (nothing would restart it),
                 # so log it and try again on the next poll.
-                _logger.exception("Executor job loop iteration failed; continuing.")
-                executed = 0
-            if executed:
-                _logger.debug("Executor engine processed %d job(s) this poll.", executed)
-            if executed == 0:
-                stop_event.wait(poll_interval)
+                _logger.exception("Executor job scheduler tick failed; continuing.")
+                scheduled = 0
+            if scheduled:
+                _logger.debug("Executor engine scheduled %d job(s) this tick.", scheduled)
+            stop_event.wait(poll_interval)
     finally:
+        if scheduler is not None:
+            scheduler.join(timeout=_SHUTDOWN_JOIN_TIMEOUT)
         executor.stop_executor()
 
 

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -32,11 +32,10 @@ from mlflow.environment_variables import (
     MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
-    MLFLOW_TRACKING_URI,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE, ErrorCode
-from mlflow.server.constants import MLFLOW_SERVER_UP_TIME
+from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR, MLFLOW_SERVER_UP_TIME
 from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
 from mlflow.server.jobs.executor_registry import get_executor_registry
 from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
@@ -68,13 +67,15 @@ def _select_executor() -> AbstractJobExecutor:
 
 def _build_execution_context(job: Job) -> JobExecutionContext:
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
-    # The runner is launched with MLFLOW_TRACKING_URI set to the server's HTTP URI (see the job
-    # env built in mlflow/server/__init__.py), so the job subprocess reaches the tracking store
-    # the same way the Huey path's subprocess does — through the server — rather than opening the
-    # backend store directly.
+    # Jobs get the backend store URI (the DB), not MLFLOW_TRACKING_URI. The runner is launched with
+    # MLFLOW_TRACKING_URI set to the server's own HTTP URI, but a job can't authenticate to the
+    # tracking API over HTTP (its only credential, the internal token, is gateway-only), and jobs
+    # do privileged work directly against the store anyway — scorer jobs already call
+    # _get_tracking_store(), which flips tracking to the DB. Gateway routing still needs the HTTP
+    # URI, so it travels separately as MLFLOW_GATEWAY_URI.
     return JobExecutionContext(
         job_id=job.job_id,
-        tracking_uri=MLFLOW_TRACKING_URI.get(),
+        tracking_uri=os.environ.get(BACKEND_STORE_URI_ENV_VAR),
         gateway_uri=MLFLOW_GATEWAY_URI.get(),
         workspace=workspace,
     )

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -744,21 +744,30 @@ def _launch_job_runner(env_map, server_proc_pid):
     )
 
 
-_VALID_JOB_EXECUTION_ENGINES = ("huey", "executor")
+# MLFLOW_SERVER_JOB_EXECUTION_ENGINE is an opt-in: unset -> the default engine (Huey today), or
+# "executor" to opt into the executor framework. "huey" is intentionally not settable by name
+# (see get_job_execution_engine), so nothing has to change when Huey is retired.
+_DEFAULT_JOB_EXECUTION_ENGINE = "huey"
+_EXECUTOR_JOB_EXECUTION_ENGINE = "executor"
 
 
 def get_job_execution_engine() -> str:
-    """Return the validated, case-normalized job execution engine.
+    """Return the job execution engine to use.
 
-    Raises ``MlflowException`` for any value other than ``"huey"`` or ``"executor"``
-    (after case-normalization), so an unrecognized value fails loudly instead of
-    silently falling back to Huey and disabling the feature.
+    ``MLFLOW_SERVER_JOB_EXECUTION_ENGINE`` is an opt-in switch: leave it unset to use the default
+    engine (currently Huey), or set it to ``"executor"`` to route job execution through the
+    ``AbstractJobExecutor`` framework. It is intentionally *not* settable to ``"huey"`` — pinning
+    the current default by name would silently break once Huey is retired — so any explicit value
+    other than ``"executor"`` is rejected rather than silently accepted.
     """
+    if not MLFLOW_SERVER_JOB_EXECUTION_ENGINE.is_set():
+        return _DEFAULT_JOB_EXECUTION_ENGINE
     engine = MLFLOW_SERVER_JOB_EXECUTION_ENGINE.get().strip().lower()
-    if engine not in _VALID_JOB_EXECUTION_ENGINES:
+    if engine != _EXECUTOR_JOB_EXECUTION_ENGINE:
         raise MlflowException.invalid_parameter_value(
-            f"Invalid value for {MLFLOW_SERVER_JOB_EXECUTION_ENGINE.name}: {engine!r}. "
-            f"Valid values are {_VALID_JOB_EXECUTION_ENGINES}."
+            f"{MLFLOW_SERVER_JOB_EXECUTION_ENGINE.name} may only be set to "
+            f"{_EXECUTOR_JOB_EXECUTION_ENGINE!r} to opt into the executor engine; unset it to use "
+            f"the default engine (got {engine!r})."
         )
     return engine
 

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -22,6 +22,7 @@ from mlflow.entities._job_status import JobStatus
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_LOGGING_LEVEL,
+    MLFLOW_SERVER_JOB_EXECUTION_ENGINE,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
     MLFLOW_WORKSPACE,
@@ -741,6 +742,49 @@ def _launch_job_runner(env_map, server_proc_pid):
             MLFLOW_SERVER_UP_TIME: server_up_time,
         },
     )
+
+
+_VALID_JOB_EXECUTION_ENGINES = ("huey", "executor")
+
+
+def get_job_execution_engine() -> str:
+    """Return the validated, case-normalized job execution engine.
+
+    Raises ``MlflowException`` for any value other than ``"huey"`` or ``"executor"``
+    (after case-normalization), so an unrecognized value fails loudly instead of
+    silently falling back to Huey and disabling the feature.
+    """
+    engine = MLFLOW_SERVER_JOB_EXECUTION_ENGINE.get().strip().lower()
+    if engine not in _VALID_JOB_EXECUTION_ENGINES:
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid value for {MLFLOW_SERVER_JOB_EXECUTION_ENGINE.name}: {engine!r}. "
+            f"Valid values are {_VALID_JOB_EXECUTION_ENGINES}."
+        )
+    return engine
+
+
+def _launch_executor_runner(env_map, server_proc_pid):
+    server_up_time = str(int(time.time() * 1000))
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow.server.jobs._executor_runner",
+        ],
+        env={
+            **os.environ,
+            **env_map,
+            "MLFLOW_SERVER_PID": str(server_proc_pid),
+            MLFLOW_SERVER_UP_TIME: server_up_time,
+        },
+    )
+
+
+def _launch_job_execution_runner(env_map, server_proc_pid):
+    """Launch the job runner for the configured execution engine."""
+    if get_job_execution_engine() == "executor":
+        return _launch_executor_runner(env_map, server_proc_pid)
+    return _launch_job_runner(env_map, server_proc_pid)
 
 
 def _start_watcher_to_kill_job_runner_if_mlflow_server_dies(check_interval: float = 1.0) -> None:

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -40,6 +40,7 @@ from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 if TYPE_CHECKING:
     import huey
 
+    from mlflow.entities._job import Job
     from mlflow.store.jobs.abstract_store import AbstractJobStore
 
 _logger = logging.getLogger(__name__)
@@ -850,42 +851,60 @@ def _workspace_contexts_for_recovery() -> list[ContextManager[str | None]]:
     return [WorkspaceContext(workspace.name) for workspace in store.list_workspaces()]
 
 
+def _for_each_unfinished_job(
+    job_store: "AbstractJobStore",
+    statuses: list[JobStatus],
+    end_timestamp: int,
+    handler: "Callable[[Job, str | None], None]",
+) -> None:
+    """Apply ``handler`` to each unfinished job created at/before ``end_timestamp``, per workspace.
+
+    Shared by both engines' startup recovery. It owns the per-workspace iteration and the
+    launch-time bound (so a job submitted to the freshly started server is never touched); the
+    status set and the per-job action stay with each caller, since the engines act differently
+    (Huey resets then re-enqueues; the executor only resets and lets the scheduler re-claim).
+    """
+    for workspace_ctx in _workspace_contexts_for_recovery():
+        with workspace_ctx as workspace:
+            for job in list(job_store.list_jobs(statuses=statuses, end_timestamp=end_timestamp)):
+                handler(job, workspace)
+
+
 def _enqueue_unfinished_jobs(server_launching_timestamp: int) -> None:
     from mlflow.server.handlers import _get_job_store
 
     job_store = _get_job_store()
 
-    for workspace_ctx in _workspace_contexts_for_recovery():
-        with workspace_ctx as workspace:
-            unfinished_jobs = job_store.list_jobs(
-                statuses=[JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY],
-                # filter out jobs created after the server is launched.
-                end_timestamp=server_launching_timestamp,
-            )
+    def _reset_and_enqueue(job: "Job", workspace: str | None) -> None:
+        if job.status in {JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY}:
+            job_store.reset_job(job.job_id)  # reset the job status to PENDING
 
-            for job in unfinished_jobs:
-                if job.status in {JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY}:
-                    job_store.reset_job(job.job_id)  # reset the job status to PENDING
+        params = json.loads(job.params)
+        timeout = job.timeout
+        # Only propagate workspace to subprocess when workspaces are enabled
+        if MLFLOW_ENABLE_WORKSPACES.get():
+            job_workspace = job.workspace or workspace or DEFAULT_WORKSPACE_NAME
+        else:
+            job_workspace = None
+        # Look up exclusive flag from function metadata
+        fn_fullname = get_job_fn_fullname(job.job_name)
+        fn_metadata = _load_function(fn_fullname)._job_fn_metadata
+        # enqueue job
+        _get_or_init_huey_instance(job.job_name).submit_task(
+            job.job_id,
+            job_workspace,
+            job.job_name,
+            params,
+            timeout,
+            fn_metadata.exclusive,
+        )
 
-                params = json.loads(job.params)
-                timeout = job.timeout
-                # Only propagate workspace to subprocess when workspaces are enabled
-                if MLFLOW_ENABLE_WORKSPACES.get():
-                    job_workspace = job.workspace or workspace or DEFAULT_WORKSPACE_NAME
-                else:
-                    job_workspace = None
-                # Look up exclusive flag from function metadata
-                fn_fullname = get_job_fn_fullname(job.job_name)
-                fn_metadata = _load_function(fn_fullname)._job_fn_metadata
-                # enqueue job
-                _get_or_init_huey_instance(job.job_name).submit_task(
-                    job.job_id,
-                    job_workspace,
-                    job.job_name,
-                    params,
-                    timeout,
-                    fn_metadata.exclusive,
-                )
+    _for_each_unfinished_job(
+        job_store,
+        [JobStatus.PENDING, JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY],
+        server_launching_timestamp,
+        _reset_and_enqueue,
+    )
 
 
 def _validate_function_parameters(function: Callable[..., Any], params: dict[str, Any]) -> None:

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from unittest import mock
@@ -22,7 +23,7 @@ from mlflow.server.jobs.utils import (
 )
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
-from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
 
 pytestmark = [
     pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
@@ -48,6 +49,11 @@ def executor_engine_sleep(sleep_secs):
     time.sleep(sleep_secs)
 
 
+@job(name="executor_engine_parallel", max_workers=2)
+def executor_engine_parallel(x):
+    return x
+
+
 @job(
     name="executor_engine_flaky",
     max_workers=1,
@@ -68,12 +74,14 @@ _JOB_FULLNAMES = [
     "tests.server.jobs.test_executor_engine.executor_engine_add",
     "tests.server.jobs.test_executor_engine.executor_engine_boom",
     "tests.server.jobs.test_executor_engine.executor_engine_sleep",
+    "tests.server.jobs.test_executor_engine.executor_engine_parallel",
     "tests.server.jobs.test_executor_engine.executor_engine_flaky",
 ]
 _JOB_NAMES = [
     "executor_engine_add",
     "executor_engine_boom",
     "executor_engine_sleep",
+    "executor_engine_parallel",
     "executor_engine_flaky",
 ]
 
@@ -118,6 +126,73 @@ def executor():
         ex.stop_executor()
 
 
+def _run_to_completion(job_store, executor, lease_duration=60.0):
+    """Schedule all currently-PENDING jobs and wait for their worker threads to finish.
+
+    The scheduler runs each claimed job in a worker thread, so tests join before asserting the
+    terminal state. Returns the number of jobs scheduled by the single tick.
+    """
+    scheduler = runner._JobScheduler(job_store, executor, lease_duration)
+    scheduled = scheduler.tick()
+    scheduler.join(timeout=60.0)
+    return scheduled
+
+
+class _BlockingExecutor:
+    """Executor stub whose ``wait_for_job`` blocks until released.
+
+    Holding a job in ``wait_for_job`` lets a test observe the scheduler's state while a job is
+    in flight (e.g. concurrency limits, cancellation forwarding), which a real executor that runs
+    to completion immediately would not allow.
+    """
+
+    def __init__(self):
+        self._release = threading.Event()
+        self._lock = threading.Lock()
+        self.submitted = []
+        self.canceled = []
+        # job_id -> workspace resolved on the worker thread at submit time. Records what
+        # get_request_workspace() returns inside each worker, to prove per-thread isolation.
+        self.observed_workspace = {}
+
+    def start_executor(self):
+        pass
+
+    def stop_executor(self):
+        pass
+
+    def submit_job(self, *, job_id, **kwargs):
+        with self._lock:
+            self.submitted.append(job_id)
+            self.observed_workspace[job_id] = get_request_workspace()
+
+    def wait_for_job(self, job_id):
+        self._release.wait(30.0)
+        return JobResult(status=JobStatus.SUCCEEDED, result="ok")
+
+    def cancel_job(self, job_id):
+        with self._lock:
+            self.canceled.append(job_id)
+        self._release.set()
+
+    def wait_until_submitted(self, count=1, timeout=10.0):
+        # Workers submit from their own threads, so tests wait for the jobs to actually reach the
+        # executor before inspecting or cancelling them, rather than racing the workers.
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._lock:
+                if len(self.submitted) >= count:
+                    return
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"only {len(self.submitted)} of {count} jobs submitted in time"
+                )
+            time.sleep(0.02)
+
+    def release(self):
+        self._release.set()
+
+
 def test_select_executor_defaults_to_local():
     assert isinstance(runner._select_executor(), LocalJobExecutor)
 
@@ -125,7 +200,7 @@ def test_select_executor_defaults_to_local():
 def test_loop_runs_pending_job_to_success(registered_jobs, job_store, executor):
     created = job_store.create_job("executor_engine_add", json.dumps({"x": 3, "y": 4}))
 
-    executed = runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    executed = _run_to_completion(job_store, executor, lease_duration=60.0)
 
     assert executed == 1
     updated = job_store.get_job(created.job_id)
@@ -137,14 +212,14 @@ def test_loop_runs_pending_job_to_success(registered_jobs, job_store, executor):
 def test_loop_records_failure(registered_jobs, job_store, executor):
     created = job_store.create_job("executor_engine_boom", "{}")
 
-    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    _run_to_completion(job_store, executor, lease_duration=60.0)
 
     updated = job_store.get_job(created.job_id)
     assert updated.status == JobStatus.FAILED
 
 
 def test_loop_no_pending_jobs_is_noop(registered_jobs, job_store, executor):
-    assert runner._poll_and_execute_once(job_store, executor, lease_duration=60.0) == 0
+    assert _run_to_completion(job_store, executor, lease_duration=60.0) == 0
 
 
 def test_loop_marks_timed_out_job(registered_jobs, job_store, executor):
@@ -152,7 +227,7 @@ def test_loop_marks_timed_out_job(registered_jobs, job_store, executor):
         "executor_engine_sleep", json.dumps({"sleep_secs": 30}), timeout=1.0
     )
 
-    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    _run_to_completion(job_store, executor, lease_duration=60.0)
 
     updated = job_store.get_job(created.job_id)
     assert updated.status == JobStatus.TIMEOUT
@@ -170,13 +245,13 @@ def test_loop_retries_transient_error_then_succeeds(
     monkeypatch.setattr(runner, "_backoff_after_transient_retry", lambda retry_count: None)
 
     # First poll: transient error -> retry_or_fail_job resets the job to PENDING.
-    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    _run_to_completion(job_store, executor, lease_duration=60.0)
     after_first = job_store.get_job(created.job_id)
     assert after_first.status == JobStatus.PENDING
     assert after_first.retry_count == 1
 
     # Second poll: the retried job is re-claimed and succeeds.
-    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    _run_to_completion(job_store, executor, lease_duration=60.0)
     after_second = job_store.get_job(created.job_id)
     assert after_second.status == JobStatus.SUCCEEDED
     assert after_second.result == "2"
@@ -199,13 +274,111 @@ def test_loop_runs_job_in_non_default_workspace(registered_jobs, tmp_path, execu
         "mlflow.server.workspace_helpers._get_workspace_store",
         return_value=mock_workspace_store,
     ):
-        executed = runner._poll_and_execute_once(store, executor, lease_duration=60.0)
+        executed = _run_to_completion(store, executor, lease_duration=60.0)
 
     assert executed == 1
     with WorkspaceContext("workspace-b"):
         updated = store.get_job(created.job_id)
     assert updated.status == JobStatus.SUCCEEDED
     assert updated.result == "11"
+
+
+def test_scheduler_limits_concurrency_to_max_workers(registered_jobs, job_store):
+    # executor_engine_add is declared with max_workers=1, so only one may run at a time; a second
+    # PENDING job of the same type must stay queued until the first frees its slot.
+    j1 = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    j2 = job_store.create_job("executor_engine_add", json.dumps({"x": 3, "y": 4}))
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+
+    # First tick fills the single slot with one job; the other cannot be claimed.
+    assert scheduler.tick() == 1
+    statuses = {job_store.get_job(j1.job_id).status, job_store.get_job(j2.job_id).status}
+    assert statuses == {JobStatus.RUNNING, JobStatus.PENDING}
+    # The slot is still held, so a further tick schedules nothing new.
+    assert scheduler.tick() == 0
+
+    # Let the in-flight job finish; its worker releases the slot.
+    ex.release()
+    scheduler.join(timeout=30.0)
+
+    # With the slot free, the queued job is now schedulable.
+    assert scheduler.tick() == 1
+    scheduler.join(timeout=30.0)
+    assert job_store.get_job(j1.job_id).status == JobStatus.SUCCEEDED
+    assert job_store.get_job(j2.job_id).status == JobStatus.SUCCEEDED
+
+
+def test_scheduler_forwards_cancellation_to_executor(registered_jobs, job_store):
+    # A job cancelled while running must be stopped in the executor, not just marked CANCELED in
+    # the store, so it cannot keep performing side effects after the caller cancelled it.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+
+    assert scheduler.tick() == 1  # claims the job and starts its (blocked) worker
+    ex.wait_until_submitted()
+    assert ex.submitted == [created.job_id]
+
+    # The caller cancels the running job; the store row transitions to CANCELED.
+    job_store.cancel_job(created.job_id)
+
+    # The next tick's cancel sweep forwards the cancellation to the executor.
+    scheduler.tick()
+    scheduler.join(timeout=30.0)
+
+    assert ex.canceled == [created.job_id]
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+
+def test_scheduler_isolates_concurrent_workspaces(registered_jobs, tmp_path, monkeypatch):
+    from mlflow.entities import Workspace
+
+    # Two jobs of a max_workers=2 type run concurrently, one per workspace. Each worker must
+    # resolve its own workspace via the thread-local ContextVar; if they instead shared the
+    # process-global env, the two in-flight workers would race and observe the wrong tenant.
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    store = WorkspaceAwareSqlAlchemyJobStore(f"sqlite:///{tmp_path / 'ws.db'}")
+    with WorkspaceContext("workspace-a"):
+        job_a = store.create_job("executor_engine_parallel", json.dumps({"x": 1}))
+    with WorkspaceContext("workspace-b"):
+        job_b = store.create_job("executor_engine_parallel", json.dumps({"x": 2}))
+
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(store, ex, lease_duration=60.0)
+    mock_workspace_store = mock.MagicMock()
+    mock_workspace_store.list_workspaces.return_value = [
+        Workspace(name="workspace-a"),
+        Workspace(name="workspace-b"),
+    ]
+    with mock.patch(
+        "mlflow.server.workspace_helpers._get_workspace_store",
+        return_value=mock_workspace_store,
+    ):
+        # Both jobs are scheduled in one tick (two slots) and their workers block in wait_for_job.
+        assert scheduler.tick() == 2
+        ex.wait_until_submitted(count=2)
+        ex.release()
+        scheduler.join(timeout=30.0)
+
+    # Each worker resolved its own workspace, not the other's.
+    assert ex.observed_workspace == {job_a.job_id: "workspace-a", job_b.job_id: "workspace-b"}
+    with WorkspaceContext("workspace-a"):
+        assert store.get_job(job_a.job_id).status == JobStatus.SUCCEEDED
+    with WorkspaceContext("workspace-b"):
+        assert store.get_job(job_b.job_id).status == JobStatus.SUCCEEDED
+
+
+def test_scheduler_fails_job_with_unresolvable_function(registered_jobs, job_store):
+    # A persisted job whose function can't be resolved (e.g. renamed or removed across an upgrade)
+    # must reach a terminal FAILED state, not stay PENDING and re-log on every tick.
+    created = job_store.create_job("executor_engine_unknown", "{}")
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+
+    assert scheduler.tick() == 0
+    assert ex.submitted == []
+    assert job_store.get_job(created.job_id).status == JobStatus.FAILED
 
 
 @pytest.mark.parametrize(
@@ -227,7 +400,7 @@ def test_engines_produce_equivalent_terminal_state(
     # Executor engine: drive the loop directly.
     exec_store = SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'exec.db'}")
     exec_job = exec_store.create_job(job_name, json.dumps(params))
-    runner._poll_and_execute_once(exec_store, executor, lease_duration=60.0)
+    _run_to_completion(exec_store, executor, lease_duration=60.0)
     exec_result = exec_store.get_job(exec_job.job_id)
 
     # Huey engine: drive _exec_job directly, pointing _get_job_store at the huey store.

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -371,7 +371,9 @@ def test_submit_job_executor_engine_rejects_extra_envs(monkeypatch, registered_j
     store.create_job.assert_not_called()
 
 
-@pytest.mark.parametrize("engine", ["spark", "kubernetes", ""])
+# "huey" is explicitly rejected: unset uses the default engine, and "executor" is the only
+# settable value, so pinning "huey" by name is not allowed (it would break once Huey is retired).
+@pytest.mark.parametrize("engine", ["spark", "kubernetes", "huey", ""])
 def test_submit_job_rejects_invalid_engine(monkeypatch, registered_jobs, engine):
     _submit_job_env(monkeypatch, engine=engine)
     store = mock.MagicMock()
@@ -379,9 +381,7 @@ def test_submit_job_rejects_invalid_engine(monkeypatch, registered_jobs, engine)
     with (
         mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
         mock.patch("mlflow.server.jobs.utils._check_requirements"),
-        pytest.raises(
-            MlflowException, match="Invalid value for MLFLOW_SERVER_JOB_EXECUTION_ENGINE"
-        ),
+        pytest.raises(MlflowException, match="may only be set to 'executor'"),
     ):
         submit_job(executor_engine_add, {"x": 1, "y": 2})
 
@@ -410,8 +410,7 @@ def test_record_result_skips_job_canceled_after_claim(registered_jobs, job_store
 @pytest.mark.parametrize(
     ("engine", "expected"),
     [
-        (None, "_launch_job_runner"),
-        ("huey", "_launch_job_runner"),
+        (None, "_launch_job_runner"),  # unset -> default engine (Huey)
         ("executor", "_launch_executor_runner"),
     ],
 )

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -329,6 +329,10 @@ def test_scheduler_forwards_cancellation_to_executor(registered_jobs, job_store)
 
     assert ex.canceled == [created.job_id]
     assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+    # The worker finished and cleaned up its bookkeeping, so nothing is orphaned in the
+    # cancel-tracking sets.
+    assert scheduler._canceled_forwarded == set()
+    assert scheduler._cancel_forward_failed == set()
 
 
 def test_scheduler_isolates_concurrent_workspaces(registered_jobs, tmp_path, monkeypatch):
@@ -379,6 +383,66 @@ def test_scheduler_fails_job_with_unresolvable_function(registered_jobs, job_sto
     assert scheduler.tick() == 0
     assert ex.submitted == []
     assert job_store.get_job(created.job_id).status == JobStatus.FAILED
+
+
+def test_scheduler_skips_pending_job_already_in_flight(registered_jobs, job_store):
+    # A job a prior worker re-pended (e.g. during a transient-retry backoff) is still in
+    # _in_flight. Even with a free slot (max_workers=2), the scheduler must not re-claim it, or
+    # the backoff would be bypassed by a concurrent re-run.
+    created = job_store.create_job("executor_engine_parallel", json.dumps({"x": 1}))
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+    with scheduler._in_flight_lock:
+        scheduler._in_flight[created.job_id] = (None, threading.current_thread())
+
+    assert scheduler._schedule_pending() == 0
+    assert ex.submitted == []
+    assert job_store.get_job(created.job_id).status == JobStatus.PENDING
+
+
+def test_scheduler_retries_cancel_forward_when_executor_raises(registered_jobs, job_store):
+    # If forwarding a cancellation to the executor raises, the job must not be marked as
+    # forwarded, so a later tick retries the cancel instead of letting the canceled job run on.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    ex = _BlockingExecutor()
+    cancel_calls = []
+    forward_ok = ex.cancel_job
+
+    def flaky_cancel(job_id):
+        cancel_calls.append(job_id)
+        if len(cancel_calls) == 1:
+            raise RuntimeError("backend blip")
+        forward_ok(job_id)
+
+    ex.cancel_job = flaky_cancel
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+
+    assert scheduler.tick() == 1
+    ex.wait_until_submitted()
+    job_store.cancel_job(created.job_id)
+
+    scheduler.tick()  # first forward attempt raises and is not marked forwarded
+    assert cancel_calls == [created.job_id]
+    scheduler.tick()  # retried on the next tick
+    scheduler.join(timeout=30.0)
+
+    # The forward was attempted again after the first failure (the retry is the point here; the
+    # row was already CANCELED by the cancel_job call above, so its status alone proves nothing).
+    assert cancel_calls == [created.job_id, created.job_id]
+
+
+def test_record_result_canceled_result_finalizes_running_row(registered_jobs, job_store):
+    # An executor that reports CANCELED while the store row is still RUNNING (e.g. a backend
+    # self-cancel) must finalize the row to CANCELED, not leave it stuck RUNNING.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, lease_duration=60.0)
+    assert job_store.get_job(created.job_id).status == JobStatus.RUNNING
+
+    runner._record_result(
+        job_store, created.job_id, "executor_engine_add", JobResult(status=JobStatus.CANCELED)
+    )
+
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
 
 
 @pytest.mark.parametrize(

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -1,0 +1,433 @@
+import json
+import os
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mlflow.entities._job import Job
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs import _ALLOWED_JOB_NAME_LIST, _SUPPORTED_JOB_FUNCTION_LIST, job, submit_job
+from mlflow.server.jobs import _executor_runner as runner
+from mlflow.server.jobs.executor import JobExecutorConfig, JobResult
+from mlflow.server.jobs.executor_registry import shutdown_executor_registry
+from mlflow.server.jobs.local_executor import LocalJobExecutor
+from mlflow.server.jobs.utils import (
+    _build_job_name_to_fn_fullname_map,
+    _exec_job,
+    _job_name_to_fn_fullname_map,
+)
+from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
+from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
+from mlflow.utils.workspace_context import WorkspaceContext
+
+pytestmark = [
+    pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
+]
+
+
+class _EngineTransientError(RuntimeError):
+    pass
+
+
+@job(name="executor_engine_add", max_workers=1)
+def executor_engine_add(x, y):
+    return x + y
+
+
+@job(name="executor_engine_boom", max_workers=1)
+def executor_engine_boom():
+    raise RuntimeError("boom")
+
+
+@job(name="executor_engine_sleep", max_workers=1)
+def executor_engine_sleep(sleep_secs):
+    time.sleep(sleep_secs)
+
+
+@job(
+    name="executor_engine_flaky",
+    max_workers=1,
+    transient_error_classes=[_EngineTransientError],
+)
+def executor_engine_flaky(marker_path):
+    # Fail transiently on the first attempt, then succeed. The attempt count is tracked in
+    # a file so it survives across the per-attempt subprocesses the executor spawns.
+    marker = Path(marker_path)
+    attempts = (int(marker.read_text()) if marker.exists() else 0) + 1
+    marker.write_text(str(attempts))
+    if attempts < 2:
+        raise _EngineTransientError("flaky")
+    return attempts
+
+
+_JOB_FULLNAMES = [
+    "tests.server.jobs.test_executor_engine.executor_engine_add",
+    "tests.server.jobs.test_executor_engine.executor_engine_boom",
+    "tests.server.jobs.test_executor_engine.executor_engine_sleep",
+    "tests.server.jobs.test_executor_engine.executor_engine_flaky",
+]
+_JOB_NAMES = [
+    "executor_engine_add",
+    "executor_engine_boom",
+    "executor_engine_sleep",
+    "executor_engine_flaky",
+]
+
+
+@pytest.fixture
+def registered_jobs():
+    _SUPPORTED_JOB_FUNCTION_LIST.extend(_JOB_FULLNAMES)
+    _ALLOWED_JOB_NAME_LIST.extend(_JOB_NAMES)
+    _build_job_name_to_fn_fullname_map()
+    try:
+        yield
+    finally:
+        for name in _JOB_NAMES:
+            _job_name_to_fn_fullname_map.pop(name, None)
+            if name in _ALLOWED_JOB_NAME_LIST:
+                _ALLOWED_JOB_NAME_LIST.remove(name)
+        for fullname in _JOB_FULLNAMES:
+            if fullname in _SUPPORTED_JOB_FUNCTION_LIST:
+                _SUPPORTED_JOB_FUNCTION_LIST.remove(fullname)
+
+
+@pytest.fixture
+def job_store(tmp_path):
+    return SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'jobs.db'}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor_registry():
+    # _select_executor() builds the process-global executor registry singleton; tear it
+    # down after each test so it does not leak into later tests.
+    yield
+    shutdown_executor_registry()
+
+
+@pytest.fixture
+def executor():
+    ex = LocalJobExecutor(JobExecutorConfig(default_timeout=60.0))
+    ex.start_executor()
+    try:
+        yield ex
+    finally:
+        ex.stop_executor()
+
+
+def test_select_executor_defaults_to_local():
+    assert isinstance(runner._select_executor(), LocalJobExecutor)
+
+
+def test_loop_runs_pending_job_to_success(registered_jobs, job_store, executor):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 3, "y": 4}))
+
+    executed = runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    assert executed == 1
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.SUCCEEDED
+    assert updated.result == "7"
+    assert updated.retry_count == 0
+
+
+def test_loop_records_failure(registered_jobs, job_store, executor):
+    created = job_store.create_job("executor_engine_boom", "{}")
+
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.FAILED
+
+
+def test_loop_no_pending_jobs_is_noop(registered_jobs, job_store, executor):
+    assert runner._poll_and_execute_once(job_store, executor, lease_duration=60.0) == 0
+
+
+def test_loop_marks_timed_out_job(registered_jobs, job_store, executor):
+    created = job_store.create_job(
+        "executor_engine_sleep", json.dumps({"sleep_secs": 30}), timeout=1.0
+    )
+
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.TIMEOUT
+
+
+def test_loop_retries_transient_error_then_succeeds(
+    registered_jobs, job_store, executor, tmp_path, monkeypatch
+):
+    marker = tmp_path / "attempts.txt"
+    created = job_store.create_job(
+        "executor_engine_flaky", json.dumps({"marker_path": str(marker)})
+    )
+
+    # Avoid the real exponential backoff sleep between retries.
+    monkeypatch.setattr(runner, "_backoff_after_transient_retry", lambda retry_count: None)
+
+    # First poll: transient error -> retry_or_fail_job resets the job to PENDING.
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    after_first = job_store.get_job(created.job_id)
+    assert after_first.status == JobStatus.PENDING
+    assert after_first.retry_count == 1
+
+    # Second poll: the retried job is re-claimed and succeeds.
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    after_second = job_store.get_job(created.job_id)
+    assert after_second.status == JobStatus.SUCCEEDED
+    assert after_second.result == "2"
+
+
+def test_loop_runs_job_in_non_default_workspace(registered_jobs, tmp_path, executor, monkeypatch):
+    from mlflow.entities import Workspace
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    store = WorkspaceAwareSqlAlchemyJobStore(f"sqlite:///{tmp_path / 'ws.db'}")
+
+    with WorkspaceContext("workspace-b"):
+        created = store.create_job("executor_engine_add", json.dumps({"x": 5, "y": 6}))
+
+    # The loop enumerates workspaces via _workspace_contexts_for_recovery(), which reads the
+    # workspace store. Without the per-workspace context the loop would not see this job.
+    mock_workspace_store = mock.MagicMock()
+    mock_workspace_store.list_workspaces.return_value = [Workspace(name="workspace-b")]
+    with mock.patch(
+        "mlflow.server.workspace_helpers._get_workspace_store",
+        return_value=mock_workspace_store,
+    ):
+        executed = runner._poll_and_execute_once(store, executor, lease_duration=60.0)
+
+    assert executed == 1
+    with WorkspaceContext("workspace-b"):
+        updated = store.get_job(created.job_id)
+    assert updated.status == JobStatus.SUCCEEDED
+    assert updated.result == "11"
+
+
+@pytest.mark.parametrize(
+    ("job_name", "params", "expected_status"),
+    [
+        ("executor_engine_add", {"x": 3, "y": 4}, JobStatus.SUCCEEDED),
+        ("executor_engine_boom", {}, JobStatus.FAILED),
+    ],
+)
+def test_engines_produce_equivalent_terminal_state(
+    registered_jobs,
+    tmp_path,
+    executor,
+    monkeypatch,
+    job_name,
+    params,
+    expected_status,
+):
+    # Executor engine: drive the loop directly.
+    exec_store = SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'exec.db'}")
+    exec_job = exec_store.create_job(job_name, json.dumps(params))
+    runner._poll_and_execute_once(exec_store, executor, lease_duration=60.0)
+    exec_result = exec_store.get_job(exec_job.job_id)
+
+    # Huey engine: drive _exec_job directly, pointing _get_job_store at the huey store.
+    huey_store = SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'huey.db'}")
+    monkeypatch.setattr("mlflow.server.handlers._get_job_store", lambda *args, **kwargs: huey_store)
+    huey_job = huey_store.create_job(job_name, json.dumps(params))
+    _exec_job(huey_job.job_id, None, job_name, params, None)
+    huey_result = huey_store.get_job(huey_job.job_id)
+
+    # Both engines must reach the same terminal state from the same input.
+    assert exec_result.status == huey_result.status == expected_status
+    assert exec_result.result == huey_result.result
+    assert exec_result.retry_count == huey_result.retry_count == 0
+    if expected_status == JobStatus.SUCCEEDED:
+        assert exec_result.result == "7"
+
+
+def _make_job(status=JobStatus.RUNNING, retry_count=0) -> Job:
+    return Job(
+        job_id="job-1",
+        creation_time=0,
+        job_name="executor_engine_add",
+        params="{}",
+        timeout=None,
+        status=status,
+        result=None,
+        retry_count=retry_count,
+        last_update_time=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_call"),
+    [
+        (
+            JobResult(status=JobStatus.SUCCEEDED, result="7"),
+            mock.call("job-1", JobStatus.SUCCEEDED, result="7"),
+        ),
+        (
+            JobResult(status=JobStatus.TIMEOUT),
+            mock.call("job-1", JobStatus.TIMEOUT, error_message=None),
+        ),
+        (
+            JobResult(status=JobStatus.FAILED, error_message="boom"),
+            mock.call("job-1", JobStatus.FAILED, error_message="boom"),
+        ),
+    ],
+)
+def test_record_result_terminal_mapping(result, expected_call):
+    store = mock.MagicMock()
+    store.get_job.return_value = _make_job(status=JobStatus.RUNNING)
+    runner._record_result(store, "job-1", "executor_engine_add", result)
+    assert store.report_job_result.call_args == expected_call
+
+
+def test_record_result_transient_error_retries():
+    store = mock.MagicMock(**{"retry_or_fail_job.return_value": 1})
+    store.get_job.return_value = _make_job(status=JobStatus.RUNNING)
+    with mock.patch.object(runner, "_backoff_after_transient_retry") as backoff:
+        runner._record_result(
+            store,
+            "job-1",
+            "executor_engine_add",
+            JobResult(status=JobStatus.FAILED, error_message="temp", is_transient_error=True),
+        )
+    store.retry_or_fail_job.assert_called_once_with("job-1", "temp")
+    store.fail_job.assert_not_called()
+    backoff.assert_called_once_with(1)
+
+
+def test_record_result_transient_error_exhausted_does_not_backoff():
+    store = mock.MagicMock(**{"retry_or_fail_job.return_value": None})
+    store.get_job.return_value = _make_job(status=JobStatus.RUNNING)
+    with mock.patch.object(runner, "_backoff_after_transient_retry") as backoff:
+        runner._record_result(
+            store,
+            "job-1",
+            "executor_engine_add",
+            JobResult(status=JobStatus.FAILED, error_message="temp", is_transient_error=True),
+        )
+    store.retry_or_fail_job.assert_called_once()
+    backoff.assert_not_called()
+
+
+def _submit_job_env(monkeypatch, engine=None):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+    if engine is not None:
+        monkeypatch.setenv("MLFLOW_SERVER_JOB_EXECUTION_ENGINE", engine)
+
+
+def test_submit_job_defaults_to_huey_enqueue(monkeypatch, registered_jobs):
+    _submit_job_env(monkeypatch)  # engine unset -> defaults to "huey"
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    huey_instance = mock.MagicMock()
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        mock.patch(
+            "mlflow.server.jobs.utils._get_or_init_huey_instance", return_value=huey_instance
+        ),
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2})
+
+    # workspaces disabled -> workspace arg is None; exclusive=False and extra_envs=None.
+    huey_instance.submit_task.assert_called_once_with(
+        "job-1", None, "executor_engine_add", {"x": 1, "y": 2}, None, False, None
+    )
+
+
+@pytest.mark.parametrize("engine", ["executor", "Executor", "EXECUTOR"])
+def test_submit_job_executor_engine_skips_huey(monkeypatch, registered_jobs, engine):
+    _submit_job_env(monkeypatch, engine=engine)  # value is case-normalized
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        mock.patch("mlflow.server.jobs.utils._get_or_init_huey_instance") as get_huey,
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2})
+
+    store.create_job.assert_called_once_with(
+        "executor_engine_add", json.dumps({"x": 1, "y": 2}), None
+    )
+    get_huey.assert_not_called()
+
+
+def test_submit_job_executor_engine_rejects_extra_envs(monkeypatch, registered_jobs):
+    _submit_job_env(monkeypatch, engine="executor")
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        pytest.raises(MlflowException, match="extra_envs is not yet supported"),
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2}, extra_envs={"TOKEN": "secret"})
+
+    # Rejected before persisting, so no runnable PENDING row is left behind.
+    store.create_job.assert_not_called()
+
+
+@pytest.mark.parametrize("engine", ["spark", "kubernetes", ""])
+def test_submit_job_rejects_invalid_engine(monkeypatch, registered_jobs, engine):
+    _submit_job_env(monkeypatch, engine=engine)
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        pytest.raises(
+            MlflowException, match="Invalid value for MLFLOW_SERVER_JOB_EXECUTION_ENGINE"
+        ),
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2})
+
+    # Invalid engine is rejected before persisting, so no PENDING row is left behind.
+    store.create_job.assert_not_called()
+
+
+def test_record_result_skips_job_canceled_after_claim(registered_jobs, job_store):
+    # A job canceled after it was claimed runs to completion; recording a terminal result
+    # then must not raise (the cancel already finalized the row) and must leave it CANCELED.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, lease_duration=60.0)
+    job_store.cancel_job(created.job_id)
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+    runner._record_result(
+        job_store,
+        created.job_id,
+        "executor_engine_add",
+        JobResult(status=JobStatus.SUCCEEDED, result="3"),
+    )
+
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected"),
+    [
+        (None, "_launch_job_runner"),
+        ("huey", "_launch_job_runner"),
+        ("executor", "_launch_executor_runner"),
+    ],
+)
+def test_launch_job_execution_runner_dispatch(monkeypatch, engine, expected):
+    from mlflow.server.jobs.utils import _launch_job_execution_runner
+
+    if engine is not None:
+        monkeypatch.setenv("MLFLOW_SERVER_JOB_EXECUTION_ENGINE", engine)
+    env_map = {"FOO": "bar"}
+    with (
+        mock.patch("mlflow.server.jobs.utils._launch_executor_runner") as launch_executor,
+        mock.patch("mlflow.server.jobs.utils._launch_job_runner") as launch_huey,
+    ):
+        _launch_job_execution_runner(env_map, 1234)
+
+    launchers = {"_launch_executor_runner": launch_executor, "_launch_job_runner": launch_huey}
+    launchers.pop(expected).assert_called_once_with(env_map, 1234)
+    for unused in launchers.values():
+        unused.assert_not_called()

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -110,6 +110,15 @@ def job_store(tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def _backend_store_uri(tmp_path, monkeypatch):
+    # _build_execution_context hands jobs the backend store URI, which the real server always sets.
+    # The test jobs don't touch the store from their subprocess, so any valid URI suffices here.
+    from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR
+
+    monkeypatch.setenv(BACKEND_STORE_URI_ENV_VAR, f"sqlite:///{tmp_path / 'backend.db'}")
+
+
+@pytest.fixture(autouse=True)
 def _reset_executor_registry():
     # _select_executor() builds the process-global executor registry singleton; tear it
     # down after each test so it does not leak into later tests.
@@ -481,16 +490,19 @@ def test_scheduler_skips_submission_for_job_canceled_before_submit(registered_jo
     assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
 
 
-def test_build_execution_context_uses_tracking_uri_env(monkeypatch, registered_jobs):
-    # The runner is launched with MLFLOW_TRACKING_URI set to the server's HTTP URI, and the job
-    # subprocess reaches the store through it (the same way the Huey path does), not the backend
-    # store directly.
+def test_build_execution_context_uses_backend_store_uri(monkeypatch, registered_jobs):
+    from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR
+
+    # The job runs privileged work against the store, so it gets the backend store URI directly
+    # rather than the server's HTTP tracking URI (which has no general auth story when protected).
+    # An HTTP MLFLOW_TRACKING_URI in the runner env must be ignored for the job's tracking URI.
+    monkeypatch.setenv(BACKEND_STORE_URI_ENV_VAR, "sqlite:///backend.db")
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000")
     job = _make_job(status=JobStatus.PENDING)
 
     context = runner._build_execution_context(job)
 
-    assert context.tracking_uri == "http://127.0.0.1:5000"
+    assert context.tracking_uri == "sqlite:///backend.db"
 
 
 @pytest.mark.parametrize("orphan_status", [JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY])

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -481,18 +481,16 @@ def test_scheduler_skips_submission_for_job_canceled_before_submit(registered_jo
     assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
 
 
-def test_build_execution_context_falls_back_to_backend_store_uri(monkeypatch, registered_jobs):
-    from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR
-
-    # On the server MLFLOW_TRACKING_URI is usually unset; the job subprocess must still get a
-    # reachable tracking URI, which comes from the backend-store URI.
-    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
-    monkeypatch.setenv(BACKEND_STORE_URI_ENV_VAR, "sqlite:///backend.db")
+def test_build_execution_context_uses_tracking_uri_env(monkeypatch, registered_jobs):
+    # The runner is launched with MLFLOW_TRACKING_URI set to the server's HTTP URI, and the job
+    # subprocess reaches the store through it (the same way the Huey path does), not the backend
+    # store directly.
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000")
     job = _make_job(status=JobStatus.PENDING)
 
     context = runner._build_execution_context(job)
 
-    assert context.tracking_uri == "sqlite:///backend.db"
+    assert context.tracking_uri == "http://127.0.0.1:5000"
 
 
 @pytest.mark.parametrize("orphan_status", [JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY])
@@ -551,6 +549,32 @@ def test_fail_claimed_job_retries_once_on_transient_store_error(registered_jobs)
 
     assert store.fail_job.call_count == 2
     store.fail_job.assert_called_with("job-1", "boom")
+
+
+def test_fail_claimed_job_logs_and_stops_on_unexpected_error(registered_jobs):
+    # A non-MlflowException from the store is unexpected and not retryable: log once and stop
+    # (don't retry, don't propagate out of the fail path).
+    store = mock.MagicMock()
+    store.fail_job.side_effect = RuntimeError("unexpected")
+    scheduler = runner._JobScheduler(store, _BlockingExecutor(), lease_duration=60.0)
+
+    scheduler._fail_claimed_job("job-1", None, "boom")
+
+    store.fail_job.assert_called_once_with("job-1", "boom")
+
+
+def test_schedule_pending_releases_slot_if_start_worker_raises(registered_jobs, job_store):
+    # If _start_worker raises unexpectedly after the slot is acquired and the job claimed, the
+    # scheduler must release the slot so the job type is not permanently at capacity.
+    job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+
+    with mock.patch.object(scheduler, "_start_worker", side_effect=RuntimeError("boom")):
+        assert scheduler._schedule_pending() == 0
+
+    # The slot (max_workers=1 for executor_engine_add) was released, so it can be acquired again.
+    assert scheduler._slot_for("executor_engine_add").acquire(blocking=False)
 
 
 def test_fail_claimed_job_does_not_retry_invalid_transition(registered_jobs):

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -11,6 +11,7 @@ from mlflow.entities._job import Job
 from mlflow.entities._job_status import JobStatus
 from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE
 from mlflow.server.jobs import _ALLOWED_JOB_NAME_LIST, _SUPPORTED_JOB_FUNCTION_LIST, job, submit_job
 from mlflow.server.jobs import _executor_runner as runner
 from mlflow.server.jobs.executor import JobExecutorConfig, JobResult
@@ -126,6 +127,24 @@ def executor():
         ex.stop_executor()
 
 
+def _wait_until(predicate, timeout=10.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("condition not met in time")
+
+
+def _wait_submitted(scheduler, job_id, timeout=10.0):
+    # The worker marks the job submitted just after the executor's submit_job returns, on its own
+    # thread. The scheduler forwards cancellation only after that, so tests wait for it here rather
+    # than racing the worker.
+    _wait_until(
+        lambda: (h := scheduler._in_flight.get(job_id)) is not None and h.submitted, timeout
+    )
+
+
 def _run_to_completion(job_store, executor, lease_duration=60.0):
     """Schedule all currently-PENDING jobs and wait for their worker threads to finish.
 
@@ -151,6 +170,8 @@ class _BlockingExecutor:
         self._lock = threading.Lock()
         self.submitted = []
         self.canceled = []
+        # run_executor_loop reads executor.config.job_lease_ttl.
+        self.config = JobExecutorConfig(default_timeout=60.0)
         # job_id -> workspace resolved on the worker thread at submit time. Records what
         # get_request_workspace() returns inside each worker, to prove per-thread isolation.
         self.observed_workspace = {}
@@ -317,7 +338,7 @@ def test_scheduler_forwards_cancellation_to_executor(registered_jobs, job_store)
     scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
 
     assert scheduler.tick() == 1  # claims the job and starts its (blocked) worker
-    ex.wait_until_submitted()
+    _wait_submitted(scheduler, created.job_id)
     assert ex.submitted == [created.job_id]
 
     # The caller cancels the running job; the store row transitions to CANCELED.
@@ -329,10 +350,8 @@ def test_scheduler_forwards_cancellation_to_executor(registered_jobs, job_store)
 
     assert ex.canceled == [created.job_id]
     assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
-    # The worker finished and cleaned up its bookkeeping, so nothing is orphaned in the
-    # cancel-tracking sets.
-    assert scheduler._canceled_forwarded == set()
-    assert scheduler._cancel_forward_failed == set()
+    # The worker finished and removed its bookkeeping, so nothing is left in flight.
+    assert scheduler._in_flight == {}
 
 
 def test_scheduler_isolates_concurrent_workspaces(registered_jobs, tmp_path, monkeypatch):
@@ -393,7 +412,9 @@ def test_scheduler_skips_pending_job_already_in_flight(registered_jobs, job_stor
     ex = _BlockingExecutor()
     scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
     with scheduler._in_flight_lock:
-        scheduler._in_flight[created.job_id] = (None, threading.current_thread())
+        scheduler._in_flight[created.job_id] = runner._InFlightJob(
+            workspace=None, thread=threading.current_thread()
+        )
 
     assert scheduler._schedule_pending() == 0
     assert ex.submitted == []
@@ -418,7 +439,7 @@ def test_scheduler_retries_cancel_forward_when_executor_raises(registered_jobs, 
     scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
 
     assert scheduler.tick() == 1
-    ex.wait_until_submitted()
+    _wait_submitted(scheduler, created.job_id)
     job_store.cancel_job(created.job_id)
 
     scheduler.tick()  # first forward attempt raises and is not marked forwarded
@@ -443,6 +464,141 @@ def test_record_result_canceled_result_finalizes_running_row(registered_jobs, jo
     )
 
     assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+
+def test_scheduler_skips_submission_for_job_canceled_before_submit(registered_jobs, job_store):
+    # A job cancelled after the claim but before the worker submits must not be submitted at all:
+    # there is no backend job to cancel yet, so submitting would run the already-canceled job.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, lease_duration=60.0)
+    job_store.cancel_job(created.job_id)
+    ex = _BlockingExecutor()
+
+    # _execute_claimed_job runs on the worker; drive it directly for the pre-submit check.
+    runner._execute_claimed_job(job_store, ex, created)
+
+    assert ex.submitted == []
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+
+def test_build_execution_context_falls_back_to_backend_store_uri(monkeypatch, registered_jobs):
+    from mlflow.server.constants import BACKEND_STORE_URI_ENV_VAR
+
+    # On the server MLFLOW_TRACKING_URI is usually unset; the job subprocess must still get a
+    # reachable tracking URI, which comes from the backend-store URI.
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    monkeypatch.setenv(BACKEND_STORE_URI_ENV_VAR, "sqlite:///backend.db")
+    job = _make_job(status=JobStatus.PENDING)
+
+    context = runner._build_execution_context(job)
+
+    assert context.tracking_uri == "sqlite:///backend.db"
+
+
+@pytest.mark.parametrize("orphan_status", [JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY])
+def test_recover_orphaned_executor_jobs_resets_to_pending(
+    registered_jobs, job_store, monkeypatch, orphan_status
+):
+    # A job left RUNNING or NEEDS_RECOVERY by a previous server generation (created at/before this
+    # launch) is reset to PENDING so the scheduler re-claims it, while a RUNNING job created after
+    # launch (i.e. on the live server) is left alone. NEEDS_RECOVERY is the state the shutdown
+    # handoff (mark_orphans_for_recovery) writes, so both must be recovered.
+    old = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(old.job_id, lease_duration=60.0)
+    if orphan_status == JobStatus.NEEDS_RECOVERY:
+        job_store.mark_job_needs_recovery(old.job_id)
+    assert job_store.get_job(old.job_id).status == orphan_status
+    launch_ts = job_store.get_job(old.job_id).creation_time
+    monkeypatch.setenv("_MLFLOW_SERVER_UP_TIME", str(launch_ts))
+
+    time.sleep(0.01)  # ensure the next job's creation_time is strictly after launch_ts
+    new = job_store.create_job("executor_engine_add", json.dumps({"x": 3, "y": 4}))
+    job_store.claim_job(new.job_id, lease_duration=60.0)
+    assert job_store.get_job(new.job_id).creation_time > launch_ts
+
+    runner._recover_orphaned_executor_jobs(job_store)
+
+    assert job_store.get_job(old.job_id).status == JobStatus.PENDING
+    assert job_store.get_job(new.job_id).status == JobStatus.RUNNING
+
+
+def test_recover_orphaned_executor_jobs_skips_without_launch_time(
+    registered_jobs, job_store, monkeypatch
+):
+    # Without a recorded launch time, recovery cannot bound itself to the previous generation, so
+    # it must skip rather than risk resetting freshly submitted jobs.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, lease_duration=60.0)
+    monkeypatch.delenv("_MLFLOW_SERVER_UP_TIME", raising=False)
+
+    runner._recover_orphaned_executor_jobs(job_store)
+
+    assert job_store.get_job(created.job_id).status == JobStatus.RUNNING
+
+
+def test_fail_claimed_job_retries_once_on_transient_store_error(registered_jobs):
+    # The managed session surfaces a transient DB error as MlflowException(TEMPORARILY_UNAVAILABLE)
+    # — the type the real store actually raises — and it must be retried so a RUNNING row is not
+    # stranded.
+    store = mock.MagicMock()
+    store.fail_job.side_effect = [
+        MlflowException("db unavailable", error_code=TEMPORARILY_UNAVAILABLE),
+        None,
+    ]
+    scheduler = runner._JobScheduler(store, _BlockingExecutor(), lease_duration=60.0)
+
+    scheduler._fail_claimed_job("job-1", None, "boom")
+
+    assert store.fail_job.call_count == 2
+    store.fail_job.assert_called_with("job-1", "boom")
+
+
+def test_fail_claimed_job_does_not_retry_invalid_transition(registered_jobs):
+    # An invalid transition (the row is no longer RUNNING) surfaces as an INVALID_PARAMETER_VALUE
+    # MlflowException; it can't succeed on retry, so it is logged once and not retried.
+    store = mock.MagicMock()
+    store.fail_job.side_effect = MlflowException.invalid_parameter_value("invalid transition")
+    scheduler = runner._JobScheduler(store, _BlockingExecutor(), lease_duration=60.0)
+
+    scheduler._fail_claimed_job("job-1", None, "boom")
+
+    store.fail_job.assert_called_once_with("job-1", "boom")
+
+
+def test_run_executor_loop_recovers_then_exits_on_stop(registered_jobs, job_store, monkeypatch):
+    # run_executor_loop assumes an already-started executor, recovers orphaned rows before the
+    # claim loop, and exits cleanly when stop_event is set. Pre-set the stop_event so the loop
+    # body does not run and the test stays deterministic.
+    orphan = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(orphan.job_id, lease_duration=60.0)
+    monkeypatch.setenv(
+        "_MLFLOW_SERVER_UP_TIME", str(job_store.get_job(orphan.job_id).creation_time)
+    )
+
+    ex = _BlockingExecutor()
+    stop = threading.Event()
+    stop.set()
+    with mock.patch("mlflow.server.handlers._get_job_store", return_value=job_store):
+        runner.run_executor_loop(ex, stop_event=stop, poll_interval=0.01)
+
+    # Recovery ran before the loop returned.
+    assert job_store.get_job(orphan.job_id).status == JobStatus.PENDING
+
+
+def test_scheduler_marks_in_flight_jobs_for_recovery_on_shutdown(registered_jobs, job_store):
+    # Workers are daemon threads; any still in flight at shutdown must be flagged so the next
+    # launch's recovery can re-queue them instead of leaving the row stuck RUNNING.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    ex = _BlockingExecutor()
+    scheduler = runner._JobScheduler(job_store, ex, lease_duration=60.0)
+    assert scheduler.tick() == 1
+    _wait_submitted(scheduler, created.job_id)
+
+    scheduler.mark_orphans_for_recovery()
+
+    assert job_store.get_job(created.job_id).status == JobStatus.NEEDS_RECOVERY
+    ex.release()
+    scheduler.join(timeout=30.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Relates to the server job-execution framework on this branch (the `AbstractJobExecutor` registry and the built-in `LocalJobExecutor`).

### What changes are proposed in this pull request?

Adds an opt-in job-execution engine that runs server jobs through the `AbstractJobExecutor` framework (the built-in `LocalJobExecutor`) instead of Huey, selected by a new environment variable `MLFLOW_SERVER_JOB_EXECUTION_ENGINE`. It defaults to `huey`, so existing behavior is unchanged unless an operator opts in.

When set to `executor`:
- A non-blocking scheduler (`_executor_runner`) claims PENDING jobs per workspace and runs each in its own worker thread — bounded per job function by its `max_workers` so one job type cannot starve another — then records the terminal state, mirroring the Huey path's retry and timeout handling. It forwards store-side cancellations to the executor for in-flight jobs, and on startup resets jobs left RUNNING/NEEDS_RECOVERY by a previous server generation back to PENDING so they are re-scheduled. `LocalJobExecutor` runs the job subprocess.
- `submit_job` routes to the executor engine only when the flag is set; the default Huey enqueue path is unchanged.
- `get_job_execution_engine()` validates and normalizes the flag value, so an invalid value fails loudly instead of silently falling back to Huey.
- `extra_envs` is rejected with a clear error on the executor engine for now, since the executor contract does not carry it yet.

Out of scope (follow-ups): reclaiming a job whose lease expires while the runner is still live (multi-owner stale-lease reclaim), exclusive-lock/lease wiring into the loop, and full `extra_envs` support. Periodic tasks continue to run on the existing path. No schema or migration changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New `tests/server/jobs/test_executor_engine.py` covers the loop (success, failure, timeout, transient-retry), the `JobResult`-to-store-state mapping, flag validation, `extra_envs` rejection, workspace scoping, and default-path equivalence with the Huey engine. Existing job, workspace, and registry tests pass unchanged.

Started a server and set the env variables to validate that a submitted job was handled by the executor and that a failed job still fails as expected.

Server logging (executor):
```
2026/08/24 03:14:01 INFO mlflow.server.jobs._executor_runner: Executor engine job 7b69b567-7a6e-48c1-ba57-5c0d2511c752 finished with status SUCCEEDED
2026/08/24 03:14:31 INFO mlflow.server.jobs._executor_runner: Executor engine running job bdee0746-ae6d-461f-9b89-979ac9813847 (pr1_boom) on backend local
2026/08/24 03:14:33 INFO mlflow.server.jobs._executor_runner: Executor engine job bdee0746-ae6d-461f-9b89-979ac9813847 finished with status FAILED
2026/08/24 03:14:33 ERROR mlflow.server.jobs._executor_runner: Job bdee0746-ae6d-461f-9b89-979ac9813847 (pr1_boom) failed with error: RuntimeError('boom from pr1 test job')
```

I also ran the job w/o the variables to ensure huey still runs the job.

Server logging (huey):
```
2026/08/24 03:26:22 INFO huey: mlflow.server.jobs.utils.online_scoring_scheduler: e8850c12-9f8c-41b8-a849-df0f8a143b81 executed in 0.056s
[2026-08-24 03:26:22,299] INFO:huey:Worker-4:mlflow.server.jobs.utils.online_scoring_scheduler: e8850c12-9f8c-41b8-a849-df0f8a143b81 executed in 0.056s
2026/08/24 03:26:46 INFO:     127.0.0.1:57679 - "GET /health HTTP/1.1" 200 OK
2026/08/24 03:27:12 INFO huey: Executing mlflow.server.jobs.utils._exec_job: 1f8cfa91-db65-4117-a0d5-3f8aae733c18
[2026-08-24 03:27:12,347] INFO:huey:Worker-1:Executing mlflow.server.jobs.utils._exec_job: 1f8cfa91-db65-4117-a0d5-3f8aae733c18
2026/08/24 03:27:15 INFO huey: mlflow.server.jobs.utils._exec_job: 1f8cfa91-db65-4117-a0d5-3f8aae733c18 executed in 3.050s
[2026-08-24 03:27:15,398] INFO:huey:Worker-1:mlflow.server.jobs.utils._exec_job: 1f8cfa91-db65-4117-a0d5-3f8aae733c18 executed in 3.050s
2026/08/24 03:27:22 INFO huey.consumer.Scheduler: Enqueueing periodic task mlflow.server.jobs.utils.online_scoring_scheduler: adeba8ce-fc6a-4c88-9953-b93cbcddb06e.
[2026-08-24 03:27:22,140] INFO:huey.consumer.Scheduler:Scheduler:Enqueueing periodic task mlflow.server.jobs.utils.online_scoring_scheduler: adeba8ce-fc6a-4c88-9953-b93cbcddb06e.
2026/08/24 03:27:22 INFO huey.consumer.Scheduler: Enqueueing periodic task mlflow.server.jobs.utils.trace_archival_scheduler: 5f7c92c9-cbfe-4bbd-9388-395c1197520a.
[2026-08-24 03:27:22,140] INFO:huey.consumer.Scheduler:Scheduler:Enqueueing periodic task mlflow.server.jobs.utils.trace_archival_scheduler: 5f7c92c9-cbfe-4bbd-9388-395c1197520a.
2026/08/24 03:27:28 INFO huey: Executing mlflow.server.jobs.utils.online_scoring_scheduler: adeba8ce-fc6a-4c88-9953-b93cbcddb06e
[2026-08-24 03:27:28,745] INFO:huey:Worker-1:Executing mlflow.server.jobs.utils.online_scoring_scheduler: adeba8ce-fc6a-4c88-9953-b93cbcddb06e
2026/08/24 03:27:28 INFO huey: Executing mlflow.server.jobs.utils.trace_archival_scheduler: 5f7c92c9-cbfe-4bbd-9388-395c1197520a
[2026-08-24 03:27:28,747] INFO:huey:Worker-5:Executing mlflow.server.jobs.utils.trace_archival_scheduler: 5f7c92c9-cbfe-4bbd-9388-395c1197520a
2026/08/24 03:27:28 DEBUG mlflow.genai.scorers.job: Online scoring scheduler found 0 active scorers
2026/08/24 03:27:28 DEBUG mlflow.genai.scorers.job: Grouped into 0 experiments, submitting jobs per experiment
2026/08/24 03:27:28 INFO huey: mlflow.server.jobs.utils.trace_archival_scheduler: 5f7c92c9-cbfe-4bbd-9388-395c1197520a executed in 0.001s
[2026-08-24 03:27:28,750] INFO:huey:Worker-5:mlflow.server.jobs.utils.trace_archival_scheduler: 5f7c92c9-cbfe-4bbd-9388-395c1197520a executed in 0.001s
2026/08/24 03:27:28 INFO huey: mlflow.server.jobs.utils.online_scoring_scheduler: adeba8ce-fc6a-4c88-9953-b93cbcddb06e executed in 0.005s
[2026-08-24 03:27:28,750] INFO:huey:Worker-1:mlflow.server.jobs.utils.online_scoring_scheduler: adeba8ce-fc6a-4c88-9953-b93cbcddb06e executed in 0.005s
2026/08/24 03:28:22 INFO huey.consumer.Scheduler: Enqueueing periodic task mlflow.server.jobs.utils.online_scoring_scheduler: 01750c53-e903-48fe-aab8-6fa8dcc1891b.
[2026-08-24 03:28:22,208] INFO:huey.consumer.Scheduler:Scheduler:Enqueueing periodic task mlflow.server.jobs.utils.online_scoring_scheduler: 01750c53-e903-48fe-aab8-6fa8dcc1891b.
2026/08/24 03:28:22 INFO huey.consumer.Scheduler: Enqueueing periodic task mlflow.server.jobs.utils.trace_archival_scheduler: 50b9a80d-1627-476f-8c94-4fec921e16fe.
[2026-08-24 03:28:22,210] INFO:huey.consumer.Scheduler:Scheduler:Enqueueing periodic task mlflow.server.jobs.utils.trace_archival_scheduler: 50b9a80d-1627-476f-8c94-4fec921e16fe.
2026/08/24 03:28:26 INFO huey: Executing mlflow.server.jobs.utils.online_scoring_scheduler: 01750c53-e903-48fe-aab8-6fa8dcc1891b
[2026-08-24 03:28:26,627] INFO:huey:Worker-1:Executing mlflow.server.jobs.utils.online_scoring_scheduler: 01750c53-e903-48fe-aab8-6fa8dcc1891b
2026/08/24 03:28:26 DEBUG mlflow.genai.scorers.job: Online scoring scheduler found 0 active scorers
2026/08/24 03:28:26 INFO huey: Executing mlflow.server.jobs.utils.trace_archival_scheduler: 50b9a80d-1627-476f-8c94-4fec921e16fe
[2026-08-24 03:28:26,630] INFO:huey:Worker-5:Executing mlflow.server.jobs.utils.trace_archival_scheduler: 50b9a80d-1627-476f-8c94-4fec921e16fe
2026/08/24 03:28:26 DEBUG mlflow.genai.scorers.job: Grouped into 0 experiments, submitting jobs per experiment
2026/08/24 03:28:26 INFO huey: mlflow.server.jobs.utils.online_scoring_scheduler: 01750c53-e903-48fe-aab8-6fa8dcc1891b executed in 0.003s
[2026-08-24 03:28:26,630] INFO:huey:Worker-1:mlflow.server.jobs.utils.online_scoring_scheduler: 01750c53-e903-48fe-aab8-6fa8dcc1891b executed in 0.003s
2026/08/24 03:28:26 INFO huey: mlflow.server.jobs.utils.trace_archival_scheduler: 50b9a80d-1627-476f-8c94-4fec921e16fe executed in 0.000s
[2026-08-24 03:28:26,630] INFO:huey:Worker-5:mlflow.server.jobs.utils.trace_archival_scheduler: 50b9a80d-1627-476f-8c94-4fec921e16fe executed in 0.000s
2026/08/24 03:28:28 INFO huey: Executing mlflow.server.jobs.utils._exec_job: 1b1fd738-6f8c-48d2-9589-92f4cb4b3e9c
[2026-08-24 03:28:28,841] INFO:huey:Worker-1:Executing mlflow.server.jobs.utils._exec_job: 1b1fd738-6f8c-48d2-9589-92f4cb4b3e9c
Job function pr1_jobs.boom failed with error:
Traceback (most recent call last):
  File "/Users/kris.concepcion/mlflow-2/.claude/worktrees/agent-ae4536c424a8f03c6/mlflow/server/jobs/_job_subproc_entry.py", line 76, in _main
    value = function(**params)
  File "/Users/kris.concepcion/databricks-scripts/delight/pr1_jobs.py", line 17, in boom
    raise RuntimeError("boom from pr1 test job")
RuntimeError: boom from pr1 test job

2026/08/24 03:28:30 ERROR mlflow.server.jobs.utils: Job ccb5c3a2-2305-4f5d-a99d-7ccf24156e19 (pr1_boom) failed with error: RuntimeError('boom from pr1 test job')
2026/08/24 03:28:30 INFO huey: mlflow.server.jobs.utils._exec_job: 1b1fd738-6f8c-48d2-9589-92f4cb4b3e9c executed in 2.041s
[2026-08-24 03:28:30,883] INFO:huey:Worker-1:mlflow.server.jobs.utils._exec_job: 1b1fd738-6f8c-48d2-9589-92f4cb4b3e9c executed in 2.041s
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Opt-in and off by default; not yet a documented feature.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
