### PR TITLE
Add System/Light/Dark theme preference with live OS following

### DIFF
--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -2000,7 +2000,7 @@ module.exports = {
   "mlflow.settings.general.preferences-card": "",
   "mlflow.settings.telemetry.documentation-link": "",
   "mlflow.settings.telemetry.toggle-switch": "",
-  "mlflow.settings.theme.toggle-switch": "",
+  "mlflow.settings.theme.selector": "",
   "mlflow.settings.webhooks.create-button": "",
   "mlflow.settings.webhooks.delete-button": "",
   "mlflow.settings.webhooks.delete-modal": "",

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -33,7 +33,7 @@ export function MLFlowRoot() {
   const queryClient = useMemo(() => new QueryClient(), []);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [isDarkTheme, setIsDarkTheme, MlflowThemeGlobalStyles] = useMLflowDarkTheme();
+  const [isDarkTheme, themePreference, setThemePreference, MlflowThemeGlobalStyles] = useMLflowDarkTheme();
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const logObservabilityEvent = useCallback((event: any) => {
@@ -56,7 +56,7 @@ export function MLFlowRoot() {
             <DesignSystemContainer isDarkTheme={isDarkTheme}>
               <ApplyGlobalStyles />
               <MlflowThemeGlobalStyles />
-              <DarkThemeProvider setIsDarkTheme={setIsDarkTheme}>
+              <DarkThemeProvider themePreference={themePreference} setThemePreference={setThemePreference}>
                 <QueryClientProvider client={queryClient}>
                   <ServerInfoProvider>
                     <MlflowRouter />

--- a/mlflow/server/js/src/common/contexts/DarkThemeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/DarkThemeContext.tsx
@@ -1,21 +1,28 @@
 import React, { createContext, useContext } from 'react';
+import type { MLflowThemePreference } from '../hooks/useMLflowDarkTheme';
 
 interface DarkThemeContextType {
-  setIsDarkTheme: (isDarkTheme: boolean) => void;
+  themePreference: MLflowThemePreference;
+  setThemePreference: (themePreference: MLflowThemePreference) => void;
 }
 
 const DarkThemeContext = createContext<DarkThemeContextType>({
-  setIsDarkTheme: () => {},
+  themePreference: 'system',
+  setThemePreference: () => {},
 });
 
 export const DarkThemeProvider = ({
   children,
-  setIsDarkTheme,
+  themePreference,
+  setThemePreference,
 }: {
   children: React.ReactNode;
-  setIsDarkTheme: (isDarkTheme: boolean) => void;
+  themePreference: MLflowThemePreference;
+  setThemePreference: (themePreference: MLflowThemePreference) => void;
 }) => {
-  return <DarkThemeContext.Provider value={{ setIsDarkTheme }}>{children}</DarkThemeContext.Provider>;
+  return (
+    <DarkThemeContext.Provider value={{ themePreference, setThemePreference }}>{children}</DarkThemeContext.Provider>
+  );
 };
 
 export const useDarkThemeContext = () => useContext(DarkThemeContext);

--- a/mlflow/server/js/src/common/hooks/useMLflowDarkTheme.tsx
+++ b/mlflow/server/js/src/common/hooks/useMLflowDarkTheme.tsx
@@ -1,10 +1,26 @@
 import { Global } from '@emotion/react';
 import { useEffect, useState } from 'react';
+import { useMediaQuery } from '@databricks/web-shared/hooks';
+
+export type MLflowThemePreference = 'system' | 'light' | 'dark';
 
 // bundled JS needs to read this key in order to enable dark mode
 const databricksDarkModePrefLocalStorageKey = 'databricks-dark-mode-pref';
-const darkModePrefLocalStorageKey = '_mlflow_dark_mode_toggle_enabled';
+const themePrefLocalStorageKey = '_mlflow_dark_mode_toggle_enabled';
 const darkModeBodyClassName = 'dark-mode';
+
+const parseThemePreference = (value: string | null): MLflowThemePreference => {
+  // Only honor explicit light/dark choices. Older builds persisted a boolean
+  // here on every page load, even without a manual toggle, so legacy values
+  // fall back to "system" rather than being treated as a deliberate choice.
+  if (value === 'dark') {
+    return 'dark';
+  }
+  if (value === 'light') {
+    return 'light';
+  }
+  return 'system';
+};
 
 // CSS attributes to be applied when dark mode is enabled. Affects inputs and other form elements.
 const darkModeCSSStyles = { body: { [`&.${darkModeBodyClassName}`]: { colorScheme: 'dark' } } };
@@ -12,35 +28,38 @@ const darkModeCSSStyles = { body: { [`&.${darkModeBodyClassName}`]: { colorSchem
 const DarkModeStylesComponent = () => <Global styles={darkModeCSSStyles} />;
 
 /**
- * This hook is used to toggle the dark mode for the entire app.
+ * This hook manages the color mode for the entire app.
+ * Supports three preferences: "system" (default) follows the OS color scheme and
+ * updates live when it changes, while "light" and "dark" override it explicitly.
  * Used in open source MLflow.
- * Returns a boolean value with the current state, setter function, and a component to be rendered in the root of the app.
+ * Returns a boolean value with the effective state, the preference value with its setter,
+ * and a component to be rendered in the root of the app.
  */
 export const useMLflowDarkTheme = (): [
   boolean,
-  React.Dispatch<React.SetStateAction<boolean>>,
+  MLflowThemePreference,
+  (themePreference: MLflowThemePreference) => void,
   React.ComponentType<React.PropsWithChildren<unknown>>,
 ] => {
-  const [isDarkTheme, setIsDarkTheme] = useState(() => {
-    // If the user has explicitly set a preference, use that.
+  const [themePreference, setThemePreference] = useState<MLflowThemePreference>(() => {
     // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-    const darkModePref = localStorage.getItem(darkModePrefLocalStorageKey);
-    if (darkModePref !== null) {
-      return darkModePref === 'true';
-    }
-    // Otherwise, use the system preference as a default.
-    return window.matchMedia('(prefers-color-scheme: dark)').matches || false;
+    return parseThemePreference(localStorage.getItem(themePrefLocalStorageKey));
   });
 
+  // Re-renders whenever the OS color-scheme preference changes, making
+  // "system" mode follow it live.
+  const systemPrefersDark = useMediaQuery('(prefers-color-scheme: dark)');
+  const isDarkTheme = themePreference === 'system' ? systemPrefersDark : themePreference === 'dark';
+
   useEffect(() => {
-    // Update the theme when the user changes their system preference.
+    // Update the theme when the preference or the system scheme changes.
     document.body.classList.toggle(darkModeBodyClassName, isDarkTheme);
     // Persist the user's preference in local storage.
     // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
-    localStorage.setItem(darkModePrefLocalStorageKey, isDarkTheme ? 'true' : 'false');
+    localStorage.setItem(themePrefLocalStorageKey, themePreference);
     // eslint-disable-next-line @databricks/no-direct-storage -- go/no-direct-storage
     localStorage.setItem(databricksDarkModePrefLocalStorageKey, isDarkTheme ? 'dark' : 'light');
-  }, [isDarkTheme]);
+  }, [isDarkTheme, themePreference]);
 
-  return [isDarkTheme, setIsDarkTheme, DarkModeStylesComponent];
+  return [isDarkTheme, themePreference, setThemePreference, DarkModeStylesComponent];
 };

--- a/mlflow/server/js/src/lang/de-DE.json
+++ b/mlflow/server/js/src/lang/de-DE.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "Klicken Sie auf eine einzelne Ausführung, um alle damit verbundenen Modelle anzuzeigen",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "Wählen Sie Ihr bevorzugtes Design: hell oder dunkel.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "Evaluierungsdatensatz erstellen",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "Trainingsdauer",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "Dunkel",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "Spannen",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "Keine Parameter verfügbar.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "Hell",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "Die Training-Notebooks kodierten Features auf Grundlage kategorischer Transformationen.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "Entfernen",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "System",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "Hell",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "Dunkel",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "Dem Farbschema des Systems folgen oder Hell bzw. Dunkel wählen.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -6963,6 +6963,10 @@
     "defaultMessage": "Name must start and end with a letter or digit, be less than 63 characters long, and contain only letters, digits, dots (.), underscores (_), and hyphens (-).",
     "description": "Webhook name validation error"
   },
+  "RwEpXi": {
+    "defaultMessage": "Light",
+    "description": "Light theme preference label"
+  },
   "Rwi+VC": {
     "defaultMessage": "avg score",
     "description": "Subtitle for average assessment score"
@@ -8579,6 +8583,10 @@
     "defaultMessage": "Start:",
     "description": "Label for the start time of a span"
   },
+  "YW+c+F": {
+    "defaultMessage": "Dark",
+    "description": "Dark theme preference label"
+  },
   "YXS+Tk": {
     "defaultMessage": "You're viewing a shared view. Your changes won't be saved unless you override your own view.",
     "description": "Traces page > shared view banner explaining that changes are not persisted while previewing"
@@ -8970,6 +8978,10 @@
   "aB6xFd": {
     "defaultMessage": "Outputs",
     "description": "Table subtitle for schema outputs in the model comparison page"
+  },
+  "aBuJid": {
+    "defaultMessage": "System",
+    "description": "Follow system color scheme theme preference label"
   },
   "aCzpU3": {
     "defaultMessage": "Off",
@@ -9411,10 +9423,6 @@
     "defaultMessage": "Delete dataset",
     "description": "Overflow-menu item to delete the current V2 evaluation dataset from its detail page"
   },
-  "c1it6D": {
-    "defaultMessage": "Select your theme preference between light and dark.",
-    "description": "Description for the theme setting in the settings page"
-  },
   "c1jD8u": {
     "defaultMessage": "Create an evaluation dataset",
     "description": "Evaluation datasets empty state title"
@@ -9722,6 +9730,10 @@
   "dA7hRP": {
     "defaultMessage": "Could not save. Try again.",
     "description": "Inline error shown when logging thumbs feedback fails in a custom trace view"
+  },
+  "dBPk0s": {
+    "defaultMessage": "Follow your system color scheme, or choose light or dark.",
+    "description": "Description for the theme setting in the settings page"
   },
   "dDbfnY": {
     "defaultMessage": "{count} {count, plural, one {hour} other {hours}}",
@@ -11247,10 +11259,6 @@
     "defaultMessage": "ID",
     "description": "Label for the ID section"
   },
-  "ioD6Ho": {
-    "defaultMessage": "Dark",
-    "description": "Dark theme label"
-  },
   "iq1aqV": {
     "defaultMessage": "Create dataset",
     "description": "Button label that opens the create-dataset modal on the v2 datasets list"
@@ -11870,10 +11878,6 @@
   "lNO3kK": {
     "defaultMessage": "No parameters to display.",
     "description": "Text shown when there are no parameters to display"
-  },
-  "lNv2QR": {
-    "defaultMessage": "Light",
-    "description": "Light theme label"
   },
   "lPNTq7": {
     "defaultMessage": "Metrics ({length})",

--- a/mlflow/server/js/src/lang/es-ES.json
+++ b/mlflow/server/js/src/lang/es-ES.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "Haga clic en una ejecución individual para ver todos los modelos asociados a ella",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "Seleccione su preferencia de tema entre claro y oscuro.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "Crear un conjunto de datos de evaluación",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "Duración del entrenamiento",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "Oscuro",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "Intervalos",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "No hay parámetros que mostrar.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "Claro",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "El cuaderno de entrenamiento codificó las características en función de transformaciones categóricas.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "Eliminar",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "Sistema",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "Claro",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "Oscuro",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "Seguir el esquema de color del sistema o elegir claro u oscuro.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/fr-FR.json
+++ b/mlflow/server/js/src/lang/fr-FR.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "Cliquez sur une exécution individuelle pour afficher tous les modèles qui lui sont associés",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "Choisissez votre thème préféré, à savoir clair ou foncé.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "Créer un jeu de données d'évaluation",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "Durée d'entraînement",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "Sombre",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "Portées",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "Aucun paramètre à afficher.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "Clair",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "Les notebooks d'entraînement ont encodé les features en fonction des transformations catégorielles.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "Supprimer",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "Système",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "Clair",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "Sombre",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "Suivre le jeu de couleurs du système ou choisir clair ou sombre.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/it-IT.json
+++ b/mlflow/server/js/src/lang/it-IT.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "Fai clic su una singola esecuzione per vedere tutti i modelli ad essa associati",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "Seleziona il tuo tema preferito tra chiaro e scuro.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "Crea un set di dati di valutazione",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "Durata dell'addestramento",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "Scuro",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "Estensioni",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "Nessun parametro da visualizzare.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "Chiaro",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "I notebook di addestramento hanno fatto l'encoding di features in base alle trasformazioni categoriche.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "Rimuovi",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "Sistema",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "Chiaro",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "Scuro",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "Segui la combinazione di colori del sistema oppure scegli chiaro o scuro.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/ja-JP.json
+++ b/mlflow/server/js/src/lang/ja-JP.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "個々の実行をクリックすると、それに関連付けられているすべてのモデルが表示されます。",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "テーマ設定をライトかダークで選択します。",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "評価データセットを作成",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "トレーニング期間",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "ダーク",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "スパン",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "表示するパラメータがありません。",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "ライト",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "学習用ノートブックはカテゴリに応じた変換に基づき特徴量を符号化しました。",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "削除",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "システム",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "ライト",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "ダーク",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "システムの配色に従うか、ライトかダークを選択します。",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/ko-KR.json
+++ b/mlflow/server/js/src/lang/ko-KR.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "개별 실행을 클릭하면 관련된 모든 모델을 볼 수 있습니다",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "테마 기본 설정을 밝은 테마와 어두운 테마 중에서 선택하세요.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "평가 데이터 집합 만들기",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "트레이닝 기간",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "다크",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "기간",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "표시할 매개 변수가 없습니다.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "라이트",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "학습 노트북이 범주형 변환을 기반으로 기능을 인코딩했습니다.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "제거",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "시스템",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "라이트",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "다크",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "시스템 색 구성표를 따르거나 밝은 테마 또는 어두운 테마를 선택하세요.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/pt-BR.json
+++ b/mlflow/server/js/src/lang/pt-BR.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "Clique em uma execução individual para ver todos os modelos associados a ela",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "Selecione sua preferência de tema entre claro e escuro.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "Criar um conjunto de dados de avaliação",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "Duração do treinamento",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "Escuro",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "Intervalos",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "Sem parâmetros para apresentar.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "Claro",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "Ao treinar os notebooks, o AutoML codificou caraterísticas com base em transformações categóricas.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "Remover",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "Sistema",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "Claro",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "Escuro",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "Seguir o esquema de cores do sistema ou escolher claro ou escuro.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/pt-PT.json
+++ b/mlflow/server/js/src/lang/pt-PT.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "Clique numa execução individual para ver todos os modelos associados à mesma",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "Selecione a sua preferência de tema entre claro e escuro.",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "Criar um conjunto de dados de avaliação",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "Duração da preparação",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "Escuro",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "Abrangências",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "Sem parameters para apresentar.",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "Claro",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "Ao treinar os notebooks, o AutoML codificou caraterísticas com base em transformações categóricas.",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "Remover",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "Sistema",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "Claro",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "Escuro",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "Seguir o esquema de cores do sistema ou escolher claro ou escuro.",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/zh-CN.json
+++ b/mlflow/server/js/src/lang/zh-CN.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "单击进入单个运行以查看与其关联的所有模型",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "在浅色和深色之间选择您喜欢的主题。",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "创建评估数据集",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "训练时间",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "深色",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "范围",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "没有可显示的参数。",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "浅色",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "训练笔记本根据分类转换对功能进行了编码。",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "移除",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "系统",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "浅色",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "深色",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "跟随系统配色，或选择浅色或深色。",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/zh-HK.json
+++ b/mlflow/server/js/src/lang/zh-HK.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "點繫進行單個執行，以查看所有與之關聯的模型",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "在淺色和深色之間選擇您的主題偏好。",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "建立評估資料集",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "訓練持續時間",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "深色",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "跨度",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "沒有可顯示的參數。",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "淺色",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "根據分類轉換的訓練筆記本編碼功能。",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "移除",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "系統",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "淺色",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "深色",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "跟隨系統配色，或選擇淺色或深色。",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/lang/zh-TW.json
+++ b/mlflow/server/js/src/lang/zh-TW.json
@@ -9563,10 +9563,6 @@
     "defaultMessage" : "點擊進入單一運行查看與其關聯的所有模型",
     "description" : "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
   },
-  "c1it6D" : {
-    "defaultMessage" : "請選擇您喜歡的主題顏色（淺色或深色）。",
-    "description" : "Description for the theme setting in the settings page"
-  },
   "c1jD8u" : {
     "defaultMessage" : "建立評估資料集",
     "description" : "Evaluation datasets empty state title"
@@ -11239,10 +11235,6 @@
     "defaultMessage" : "訓練持續時間",
     "description" : "Run Page > FinetuneParamsTable > Training Duration"
   },
-  "ioD6Ho" : {
-    "defaultMessage" : "深色",
-    "description" : "Dark theme label"
-  },
   "ipMyYm" : {
     "defaultMessage" : "跨距",
     "description" : "Label for the spans telemetry table"
@@ -11934,10 +11926,6 @@
   "lNO3kK" : {
     "defaultMessage" : "無可顯示的參數。",
     "description" : "Text shown when there are no parameters to display"
-  },
-  "lNv2QR" : {
-    "defaultMessage" : "淺色",
-    "description" : "Light theme label"
   },
   "lOfzvM" : {
     "defaultMessage" : "根據分類轉換的訓練筆記本編碼功能。",
@@ -15582,5 +15570,21 @@
   "zzrjqF" : {
     "defaultMessage" : "移除",
     "description" : "Tooltip text for removing a selected item"
+  },
+  "aBuJid" : {
+    "defaultMessage" : "系統",
+    "description" : "Follow system color scheme theme preference label"
+  },
+  "RwEpXi" : {
+    "defaultMessage" : "淺色",
+    "description" : "Light theme preference label"
+  },
+  "YW+c+F" : {
+    "defaultMessage" : "深色",
+    "description" : "Dark theme preference label"
+  },
+  "dBPk0s" : {
+    "defaultMessage" : "跟隨系統配色，或選擇淺色或深色。",
+    "description" : "Description for the theme setting in the settings page"
   }
 }

--- a/mlflow/server/js/src/settings/SettingsPage.test.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.test.tsx
@@ -40,7 +40,7 @@ describe('SettingsPage', () => {
             path="/settings/:section"
             element={
               <DesignSystemProvider>
-                <DarkThemeProvider setIsDarkTheme={() => {}}>
+                <DarkThemeProvider themePreference="system" setThemePreference={() => {}}>
                   <SettingsPage />
                 </DarkThemeProvider>
               </DesignSystemProvider>

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -1,6 +1,17 @@
-import { Button, Card, Modal, Spinner, Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  Button,
+  Card,
+  Modal,
+  SegmentedControlButton,
+  SegmentedControlGroup,
+  Spinner,
+  Switch,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useLocalStorage } from '@databricks/web-shared/hooks';
+import type { MLflowThemePreference } from '../common/hooks/useMLflowDarkTheme';
 import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from '../telemetry/utils';
 import { telemetryClient } from '../telemetry';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
@@ -79,8 +90,7 @@ const SettingsPage = () => {
   const { section: sectionParam } = useParams();
   const [isCleaningDemo, setIsCleaningDemo] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
-  const { setIsDarkTheme } = useDarkThemeContext();
-  const isDarkTheme = theme.isDarkMode;
+  const { themePreference, setThemePreference } = useDarkThemeContext();
 
   const activeSection: SettingsPathSegment = useMemo(() => {
     if (sectionParam && isSettingsPathSegment(sectionParam)) {
@@ -118,11 +128,11 @@ const SettingsPage = () => {
     [setIsTelemetryEnabled],
   );
 
-  const handleThemeToggle = useCallback(
-    (checked: boolean) => {
-      setIsDarkTheme(checked);
+  const handleThemePreferenceChange = useCallback(
+    (e) => {
+      setThemePreference(e.target.value as MLflowThemePreference);
     },
-    [setIsDarkTheme],
+    [setThemePreference],
   );
 
   const handleClearAllDemoData = useCallback(async () => {
@@ -176,18 +186,25 @@ const SettingsPage = () => {
               <SettingsRow
                 isFirst
                 trailing={
-                  <Switch
-                    componentId="mlflow.settings.theme.toggle-switch"
-                    checked={isDarkTheme}
-                    onChange={handleThemeToggle}
-                    label={
-                      isDarkTheme
-                        ? intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })
-                        : intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })
-                    }
-                    activeLabel={intl.formatMessage({ defaultMessage: 'Dark', description: 'Dark theme label' })}
-                    inactiveLabel={intl.formatMessage({ defaultMessage: 'Light', description: 'Light theme label' })}
-                  />
+                  <SegmentedControlGroup
+                    componentId="mlflow.settings.theme.selector"
+                    name="theme-preference"
+                    value={themePreference}
+                    onChange={handleThemePreferenceChange}
+                  >
+                    <SegmentedControlButton value="system">
+                      <FormattedMessage
+                        defaultMessage="System"
+                        description="Follow system color scheme theme preference label"
+                      />
+                    </SegmentedControlButton>
+                    <SegmentedControlButton value="light">
+                      <FormattedMessage defaultMessage="Light" description="Light theme preference label" />
+                    </SegmentedControlButton>
+                    <SegmentedControlButton value="dark">
+                      <FormattedMessage defaultMessage="Dark" description="Dark theme preference label" />
+                    </SegmentedControlButton>
+                  </SegmentedControlGroup>
                 }
               >
                 <Typography.Title level={4} withoutMargins>
@@ -195,7 +212,7 @@ const SettingsPage = () => {
                 </Typography.Title>
                 <Typography.Text>
                   <FormattedMessage
-                    defaultMessage="Select your theme preference between light and dark."
+                    defaultMessage="Follow your system color scheme, or choose light or dark."
                     description="Description for the theme setting in the settings page"
                   />
                 </Typography.Text>


### PR DESCRIPTION
### Related Issues/PRs

Closes #25286

### What changes are proposed in this pull request?

The MLflow UI previously offered a boolean dark-mode toggle. Once used, the choice was persisted and the operating system's color-scheme preference was never consulted again; the initial system default could not be restored from the UI.

This PR replaces it with a three-way preference on Settings > General:

- **System** (default) — follows `prefers-color-scheme` and switches live when the OS theme changes, via a `useMediaQuery` subscription
- **Light** / **Dark** — pin the mode explicitly, as before

Implementation notes:

- [`useMLflowDarkTheme.tsx`](mlflow/server/js/src/common/hooks/useMLflowDarkTheme.tsx) now stores `'system' | 'light' | 'dark'` in the existing `_mlflow_dark_mode_toggle_enabled` localStorage key and derives the effective mode from the preference plus the live media query. Legacy `'true'`/`'false'` values fall back to `'system'`.
- The existing shared hook `useMediaQuery` from `@databricks/web-shared/hooks` is reused; no new matchMedia plumbing or dependencies are added.
- Existing side effects are unchanged: body `dark-mode` class toggling and both localStorage keys (`_mlflow_dark_mode_toggle_enabled`, `databricks-dark-mode-pref`) keep their previous roles.
- The Switch is replaced by a `SegmentedControlGroup`/`SegmentedControlButton`, matching existing usage elsewhere in the app.
- New/changed UI strings are translated for all 11 locales that currently translate the theme setting (`en` + `de-DE`, `es-ES`, `fr-FR`, `it-IT`, `ja-JP`, `ko-KR`, `pt-BR`, `pt-PT`, `zh-CN`, `zh-HK`, `zh-TW`).

Backwards compatibility: users with an existing stored preference keep an equivalent behavior after migration mapping; no REST API or public Python API surface changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Existing `SettingsPage.test.tsx` passes with the updated provider props. Manually verified against the production build: System selected by default (including for browsers carrying legacy stored values), live flip when the OS theme changes without reload, Light/Dark pinning, and return-to-system resuming live following.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow UI theme setting now offers System / Light / Dark options. The new default, System, automatically follows the operating system's light/dark preference and updates live when it changes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
