### PR TITLE
Renew job leases while jobs run on the executor engine

### DIFF
--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -21,6 +21,7 @@ import random
 import signal
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Callable
 
@@ -50,6 +51,87 @@ _logger = logging.getLogger("mlflow.server.jobs._executor_runner")
 _POLL_INTERVAL = 1.0
 # On shutdown, how long to wait for each in-flight worker before stopping the executor.
 _SHUTDOWN_JOIN_TIMEOUT = 5.0
+
+# How many times a running job's lease is renewed per lease TTL: the renew interval is the TTL
+# divided by this, so the lease is refreshed well before it expires. The interval is floored so a
+# short TTL cannot drive a busy renew loop.
+_LEASE_RENEWALS_PER_TTL = 3.0
+_MIN_LEASE_RENEW_INTERVAL = 0.2
+# Smallest lease TTL the executor accepts: the TTL at which the floored interval still fits the
+# designed renewals-per-TTL (i.e. _MIN_LEASE_RENEW_INTERVAL * _LEASE_RENEWALS_PER_TTL, written as a
+# literal to avoid float rounding rejecting the exact boundary). The scheduler rejects a configured
+# TTL below this at startup, so the renew interval is always strictly below the TTL (the floor
+# never reaches it) — no near-zero busy loop and no renewal that first fires after the lease has
+# already expired.
+_MIN_LEASE_TTL = 0.6
+
+
+class _LeaseRenewer:
+    """Keeps a running job's lease alive until the job finishes.
+
+    ``claim_job`` sets an initial lease when it moves a job to RUNNING. A job that runs longer than
+    the lease TTL would otherwise look abandoned to stale-job recovery, so while the job runs this
+    renews the lease on a daemon thread and stops as soon as the job returns. Used as a context
+    manager wrapping both ``submit_job`` and ``wait_for_job``, so the renewal also covers any
+    long synchronous setup ``submit_job`` performs (e.g. installing the job's environment).
+    """
+
+    def __init__(
+        self,
+        job_store: AbstractJobStore,
+        job_id: str,
+        lease_duration: float,
+        workspace: str | None,
+    ) -> None:
+        self._job_store = job_store
+        self._job_id = job_id
+        self._lease_duration = lease_duration
+        # The renewer runs on its own thread, which does not inherit the worker's workspace
+        # ContextVar. Rebind it here so the workspace-aware store resolves the right tenant;
+        # without it renew_job_lease would raise "Active workspace is required" on every tick.
+        self._workspace = workspace
+        # Renew at TTL/N, floored so a short TTL cannot drive a busy loop. The scheduler validates
+        # the configured TTL is >= _MIN_LEASE_TTL at startup, so this interval is always strictly
+        # below the lease (the floor never reaches the TTL) and fires before it expires.
+        self._interval = max(lease_duration / _LEASE_RENEWALS_PER_TTL, _MIN_LEASE_RENEW_INTERVAL)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._renew_until_stopped,
+            name=f"mlflow-job-lease-renewer-{job_id}",
+            daemon=True,
+        )
+
+    def _renew_until_stopped(self) -> None:
+        # Event.wait returns True once stopped and False on each timeout; renew on timeout.
+        with ServerWorkspaceContext(self._workspace):
+            while not self._stop.wait(self._interval):
+                try:
+                    status = self._job_store.renew_job_lease(self._job_id, self._lease_duration)
+                except Exception:
+                    # A transient store error must not silently kill renewal: log and retry on the
+                    # next tick so the lease keeps being refreshed while the job runs.
+                    _logger.exception("Failed to renew lease for job %s; will retry", self._job_id)
+                    continue
+                if status != JobUpdateStatus.APPLIED:
+                    # The job row is no longer renewable (finalized or reset elsewhere); stop.
+                    return
+
+    def __enter__(self) -> "_LeaseRenewer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        # `_stop.set()` wakes the thread immediately even mid-interval, so it only needs time to
+        # finish an in-flight renew call — bound that by the fixed shutdown budget, not the
+        # (possibly large) renewal interval, so a big TTL can't stretch shutdown.
+        self._thread.join(timeout=_SHUTDOWN_JOIN_TIMEOUT)
+        if self._thread.is_alive():
+            # A renew call is wedged (e.g. a hung store); the daemon thread will not block process
+            # exit, but surface it rather than leaking silently.
+            _logger.warning(
+                "Lease renewer for job %s did not stop within the join budget", self._job_id
+            )
 
 
 def _select_executor() -> AbstractJobExecutor:
@@ -135,11 +217,16 @@ def _execute_claimed_job(
     executor: AbstractJobExecutor,
     job: Job,
     on_submitted: Callable[[], None] | None = None,
+    lease_duration: float | None = None,
+    workspace: str | None = None,
 ) -> None:
     """Execute a job that has already been claimed (moved to RUNNING) and record its result.
 
     ``on_submitted`` is invoked right after the job reaches the executor, so the scheduler can
     start forwarding cancellations only once there is a backend job to cancel.
+
+    While the job runs, its lease is renewed in the background (when ``lease_duration`` is set) so
+    a long-running job is not treated as abandoned by stale-job recovery.
     """
     from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
@@ -158,19 +245,31 @@ def _execute_claimed_job(
     backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
     _logger.info(f"Executor engine running job {job.job_id} ({job.job_name}) on backend {backend}")
 
-    # Contract: every submit_job pairs with exactly one wait_for_job.
-    executor.submit_job(
-        job_id=job.job_id,
-        job_name=job.job_name,
-        fn_fullname=fn_fullname,
-        params=params,
-        context=context,
-        python_env=python_env,
-        timeout=job.timeout,
+    # Renew the lease across both submission and the wait, starting BEFORE submission. submit_job
+    # can do long synchronous setup (e.g. installing a job's environment) that outlasts the lease
+    # TTL, which would let stale-job recovery reclaim healthy work; renewing from here covers it.
+    # Starting the renewer first also keeps the submit/wait contract intact: if the renewer thread
+    # fails to start, it fails before submission, so there is never a submit_job without a paired
+    # wait_for_job.
+    lease_renewer = (
+        _LeaseRenewer(job_store, job.job_id, lease_duration, workspace)
+        if lease_duration is not None
+        else nullcontext()
     )
-    if on_submitted is not None:
-        on_submitted()
-    result = executor.wait_for_job(job.job_id)
+    with lease_renewer:
+        # Contract: every submit_job pairs with exactly one wait_for_job.
+        executor.submit_job(
+            job_id=job.job_id,
+            job_name=job.job_name,
+            fn_fullname=fn_fullname,
+            params=params,
+            context=context,
+            python_env=python_env,
+            timeout=job.timeout,
+        )
+        if on_submitted is not None:
+            on_submitted()
+        result = executor.wait_for_job(job.job_id)
     _logger.info(f"Executor engine job {job.job_id} finished with status {result.status.value}")
     _record_result(job_store, job.job_id, job.job_name, result)
 
@@ -218,6 +317,12 @@ class _JobScheduler:
         executor: AbstractJobExecutor,
         lease_duration: float | None,
     ) -> None:
+        if lease_duration is not None and lease_duration < _MIN_LEASE_TTL:
+            raise MlflowException(
+                f"The job lease TTL must be at least {_MIN_LEASE_TTL} seconds so a running job's "
+                f"lease can be renewed before it expires, but got {lease_duration}. Set "
+                f"MLFLOW_SERVER_JOB_LEASE_TTL to a larger value."
+            )
         self._job_store = job_store
         self._executor = executor
         self._lease_duration = lease_duration
@@ -440,6 +545,8 @@ class _JobScheduler:
                     self._executor,
                     job,
                     on_submitted=lambda: self._mark_submitted(job.job_id),
+                    lease_duration=self._lease_duration,
+                    workspace=workspace,
                 )
         except Exception as exc:
             # A claimed job left RUNNING would be stuck; fail it so recovery is not needed.

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -22,6 +22,7 @@ from mlflow.server.jobs.utils import (
     _exec_job,
     _job_name_to_fn_fullname_map,
 )
+from mlflow.store.jobs.abstract_store import JobUpdateStatus
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
 from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
@@ -859,3 +860,173 @@ def test_launch_job_execution_runner_dispatch(monkeypatch, engine, expected):
     launchers.pop(expected).assert_called_once_with(env_map, 1234)
     for unused in launchers.values():
         unused.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Job-lease renewal
+# ---------------------------------------------------------------------------
+
+
+def test_lease_renewer_renews_while_running_then_stops():
+    store = mock.MagicMock()
+    calls = []
+    reached_two = threading.Event()
+
+    def _renew(job_id, lease_duration):
+        calls.append(job_id)
+        if len(calls) >= 2:
+            reached_two.set()
+        return JobUpdateStatus.APPLIED
+
+    store.renew_job_lease.side_effect = _renew
+    with runner._LeaseRenewer(store, "job-1", lease_duration=0.6, workspace=None):
+        # Wait for two renewals to fire, then exit; no wall-clock sleep drives the count.
+        assert reached_two.wait(timeout=5.0)
+    # __exit__ joins the renewer thread, so the count is final and no renewals fire after.
+    assert store.renew_job_lease.call_count >= 2
+    store.renew_job_lease.assert_called_with("job-1", 0.6)
+
+
+def test_lease_renewer_stops_when_lease_no_longer_renewable():
+    store = mock.MagicMock()
+    renewed = threading.Event()
+
+    def _renew(job_id, lease_duration):
+        renewed.set()
+        return JobUpdateStatus.WRONG_STATE
+
+    store.renew_job_lease.side_effect = _renew
+    with runner._LeaseRenewer(store, "job-1", lease_duration=0.6, workspace=None):
+        assert renewed.wait(timeout=5.0)
+    # A non-APPLIED status makes the renewer stop on its own after a single attempt.
+    assert store.renew_job_lease.call_count == 1
+
+
+def test_lease_renewer_survives_renew_error_and_keeps_renewing():
+    store = mock.MagicMock()
+    calls = []
+    reached_second = threading.Event()
+
+    def _renew(job_id, lease_duration):
+        calls.append(job_id)
+        if len(calls) == 1:
+            raise RuntimeError("transient store error")
+        reached_second.set()
+        return JobUpdateStatus.APPLIED
+
+    store.renew_job_lease.side_effect = _renew
+    with mock.patch.object(runner, "_logger") as mock_logger:
+        with runner._LeaseRenewer(store, "job-1", lease_duration=0.6, workspace=None):
+            # The first renewal raises; the renewer must log and keep going to a second.
+            assert reached_second.wait(timeout=5.0)
+    mock_logger.exception.assert_called()
+    assert store.renew_job_lease.call_count >= 2
+
+
+@pytest.mark.parametrize("lease_duration", [runner._MIN_LEASE_TTL, 60.0])
+def test_lease_renewer_interval_below_ttl_and_at_or_above_floor(lease_duration):
+    # For any accepted TTL (>= _MIN_LEASE_TTL) the renewal interval fires before the lease expires
+    # (strictly below the TTL) while never dropping below the busy-loop floor.
+    renewer = runner._LeaseRenewer(mock.MagicMock(), "job-1", lease_duration, workspace=None)
+    assert runner._MIN_LEASE_RENEW_INTERVAL <= renewer._interval < lease_duration
+
+
+def test_scheduler_rejects_lease_ttl_below_minimum():
+    # A configured TTL too small to renew before expiry is rejected at startup rather than left to
+    # busy-loop the store; the boundary value itself is accepted.
+    with pytest.raises(MlflowException, match="job lease TTL must be at least"):
+        runner._JobScheduler(mock.MagicMock(), mock.MagicMock(), lease_duration=0.1)
+    runner._JobScheduler(mock.MagicMock(), mock.MagicMock(), lease_duration=runner._MIN_LEASE_TTL)
+
+
+def test_lease_renewed_during_submit_job(registered_jobs, job_store, monkeypatch):
+    # Renewal must cover submit_job, not just wait_for_job: a submit_job that outlasts the lease
+    # (e.g. installing a job environment) must still see renewals. Prove it by blocking submit_job
+    # until a renewal has landed — which can only happen if the renewer started before submission.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, lease_duration=60.0)
+    job = job_store.get_job(created.job_id)
+
+    renewed = threading.Event()
+    real_renew = job_store.renew_job_lease
+
+    def _spy(job_id, lease_duration):
+        renewed.set()
+        return real_renew(job_id, lease_duration)
+
+    monkeypatch.setattr(job_store, "renew_job_lease", _spy)
+
+    executor = mock.MagicMock()
+    executor.submit_job.side_effect = lambda **kwargs: renewed.wait(timeout=5.0)
+    executor.wait_for_job.return_value = JobResult(status=JobStatus.SUCCEEDED, result="ok")
+
+    runner._execute_claimed_job(
+        job_store, executor, job, lease_duration=runner._MIN_LEASE_TTL, workspace=None
+    )
+
+    executor.submit_job.assert_called_once()
+    executor.wait_for_job.assert_called_once()
+    assert renewed.is_set()
+
+
+def test_long_running_job_lease_is_renewed(registered_jobs, job_store, executor, monkeypatch):
+    created = job_store.create_job("executor_engine_sleep", json.dumps({"sleep_secs": 1.0}))
+    renewed_ok = []
+    real_renew = job_store.renew_job_lease
+
+    def _spy(job_id, lease_duration):
+        # Record only successful renewals, so the assertion proves renewal actually landed rather
+        # than merely that it was attempted.
+        status = real_renew(job_id, lease_duration)
+        renewed_ok.append(job_id)
+        return status
+
+    monkeypatch.setattr(job_store, "renew_job_lease", _spy)
+    # Short lease so renewal (~lease/3) fires several times during the ~1s job.
+    _run_to_completion(job_store, executor, lease_duration=0.6)
+
+    assert created.job_id in renewed_ok
+    assert job_store.get_job(created.job_id).status == JobStatus.SUCCEEDED
+
+
+def test_long_running_job_lease_is_renewed_with_workspaces(registered_jobs, tmp_path, monkeypatch):
+    # The renewer runs on its own thread; with workspaces enabled it must rebind the workspace so
+    # renew_job_lease resolves the tenant instead of raising "Active workspace is required". Without
+    # the workspace threading this fails: no renewal lands and the job would still succeed, so the
+    # renewal assertion is what proves the cross-thread workspace fix.
+    from mlflow.entities import Workspace
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    store = WorkspaceAwareSqlAlchemyJobStore(f"sqlite:///{tmp_path / 'ws.db'}")
+    with WorkspaceContext("workspace-b"):
+        created = store.create_job("executor_engine_sleep", json.dumps({"sleep_secs": 1.0}))
+
+    renewed_ok = []
+    real_renew = store.renew_job_lease
+
+    def _spy(job_id, lease_duration):
+        # real_renew raises "Active workspace is required" if the renewer thread didn't rebind the
+        # workspace (the bug), so recording only after it returns makes this assertion prove the
+        # cross-thread workspace fix rather than just the attempt.
+        status = real_renew(job_id, lease_duration)
+        renewed_ok.append(job_id)
+        return status
+
+    monkeypatch.setattr(store, "renew_job_lease", _spy)
+
+    ex = LocalJobExecutor(JobExecutorConfig(default_timeout=60.0))
+    ex.start_executor()
+    mock_workspace_store = mock.MagicMock()
+    mock_workspace_store.list_workspaces.return_value = [Workspace(name="workspace-b")]
+    try:
+        with mock.patch(
+            "mlflow.server.workspace_helpers._get_workspace_store",
+            return_value=mock_workspace_store,
+        ):
+            _run_to_completion(store, ex, lease_duration=0.6)
+    finally:
+        ex.stop_executor()
+
+    assert created.job_id in renewed_ok
+    with WorkspaceContext("workspace-b"):
+        assert store.get_job(created.job_id).status == JobStatus.SUCCEEDED


### PR DESCRIPTION
### Related Issues/PRs

Relates to the executor-backed job-execution engine on this branch (the `AbstractJobExecutor` framework and its `local` runner).

### What changes are proposed in this pull request?

When the executor engine runs a job, its lease (set at `claim_job` time) is now renewed periodically while the job runs, so a job that runs longer than `MLFLOW_SERVER_JOB_LEASE_TTL` no longer loses its lease.

- A small `_LeaseRenewer` daemon-thread context manager wraps the blocking `executor.wait_for_job`, calling `store.renew_job_lease(...)` at roughly one-third of the lease TTL (floored) until the job finishes.
- It survives transient store errors: a failed renewal is logged and retried on the next tick rather than silently killing the renewer.
- It stops when the job reaches a terminal/reset state (renewal returns a non-`APPLIED` status) or when the context exits (join on the thread).
- Only runs on the executor engine (`MLFLOW_SERVER_JOB_EXECUTION_ENGINE=executor`); the default Huey path is untouched.

Out of scope (follow-ups): exclusive-job locking and multi-replica scheduler-lease coordination. No schema or migration changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests: the renewer renews while a job runs and stops after the context exits (event-driven, no wall-clock timing); it survives a renewal that raises and keeps renewing; a real ~1s job has its lease renewed. Plus a live dev-server run confirming a long job keeps its lease.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Internal to the opt-in executor job engine (off by default).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
