### PR TITLE
Recover orphaned jobs on executor-engine startup

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1537,6 +1537,15 @@ MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND = _EnvironmentVariable(
     "MLFLOW_JOB_CUSTOM_SCORER_EXECUTOR_BACKEND", str, None
 )
 
+#: Selects the engine that runs server-side jobs. ``"huey"`` (default) uses the
+#: built-in Huey consumers. ``"executor"`` routes job execution through the
+#: ``AbstractJobExecutor`` framework (``LocalJobExecutor`` by default). Periodic
+#: tasks always run on Huey regardless of this setting.
+#: (default: ``"huey"``)
+MLFLOW_SERVER_JOB_EXECUTION_ENGINE = _EnvironmentVariable(
+    "MLFLOW_SERVER_JOB_EXECUTION_ENGINE", str, "huey"
+)
+
 #: Default timeout in seconds applied by the executor framework when a job
 #: submission does not specify one explicitly.
 #: (default: ``3600.0``)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -462,8 +462,12 @@ def _run_server(
 
         if job_execution_enabled:
             from mlflow.server.jobs.executor_registry import validate_executor_config
+            from mlflow.server.jobs.utils import get_job_execution_engine
 
             validate_executor_config()
+            # Validate the engine selection before the server is spawned below, so an
+            # invalid value fails fast instead of leaving an unmanaged server running.
+            get_job_execution_engine()
 
     if app_name == "basic-auth" and job_execution_enabled:
         # Generate the token here (before forking uvicorn workers) so that all
@@ -500,7 +504,7 @@ def _run_server(
 
     if job_execution_enabled:
         from mlflow.environment_variables import MLFLOW_GATEWAY_URI, MLFLOW_TRACKING_URI
-        from mlflow.server.jobs.utils import _launch_job_runner
+        from mlflow.server.jobs.utils import _launch_job_execution_runner
 
         server_uri = f"http://{host}:{port}"
         job_env = {
@@ -515,6 +519,6 @@ def _run_server(
         # gateway routing (e.g., judge LLM calls via /gateway/mlflow/v1/).
         if not MLFLOW_GATEWAY_URI.is_set():
             job_env[MLFLOW_GATEWAY_URI.name] = server_uri
-        _launch_job_runner(job_env, server_proc.pid)
+        _launch_job_execution_runner(job_env, server_proc.pid)
 
     server_proc.wait()

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -185,6 +185,7 @@ def submit_job(
         _check_requirements,
         _get_or_init_huey_instance,
         _validate_function_parameters,
+        get_job_execution_engine,
     )
 
     if not MLFLOW_SERVER_ENABLE_JOB_EXECUTION.get():
@@ -226,13 +227,33 @@ def submit_job(
     # Validate that required parameters are provided
     _validate_function_parameters(function, params)
 
+    # Resolve (and validate) the engine before persisting the job, so a rejected
+    # submission never leaves a runnable PENDING row behind.
+    engine = get_job_execution_engine()
+    if engine == "executor" and extra_envs:
+        # The AbstractJobExecutor.submit_job contract has no extra_envs parameter, so
+        # honoring them would silently drop caller-supplied environment (e.g.
+        # invoke_issue_detection_job passes credentials). Fail loudly instead.
+        # NOTE: full extra_envs support on the executor engine is a follow-up.
+        raise MlflowException(
+            "extra_envs is not yet supported on the executor job-execution engine; "
+            "use the huey engine (unset MLFLOW_SERVER_JOB_EXECUTION_ENGINE) instead."
+        )
+
     job_store = _get_job_store()
     serialized_params = json.dumps(params)
     job = job_store.create_job(fn_meta.name, serialized_params, timeout)
+
+    if engine == "executor":
+        # Executor engine: the job is persisted as PENDING and the executor runner loop
+        # (mlflow.server.jobs._executor_runner) claims and runs it. Nothing to enqueue here.
+        # NOTE: exclusive-job dedup and per-function max_workers/concurrency are not yet
+        # honored on this path (a follow-up). The default Huey path is unchanged.
+        return job
+
+    # Huey engine (default): enqueue to the per-job Huey execution pool.
     # Only propagate workspace to subprocess when workspaces are enabled
     workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
-
-    # enqueue job
     huey_instance = _get_or_init_huey_instance(fn_meta.name)
     huey_instance.submit_task(
         job.job_id,

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -1,0 +1,218 @@
+"""Executor-engine job runner.
+
+Launched in place of the Huey ``_job_runner`` when
+``MLFLOW_SERVER_JOB_EXECUTION_ENGINE=executor``. It runs a loop that claims
+PENDING jobs from the job store and executes them through the configured
+``AbstractJobExecutor`` backend (``LocalJobExecutor`` by default), then records
+the terminal state back to the store.
+
+Only job execution moves to the executor framework here. Periodic tasks (e.g. the
+online scoring scheduler) still run on Huey via ``_launch_periodic_tasks_consumer``.
+"""
+
+import json
+import logging
+import threading
+import time
+
+from mlflow.entities._job import Job
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import (
+    MLFLOW_ENABLE_WORKSPACES,
+    MLFLOW_GATEWAY_URI,
+    MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND,
+    MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
+    MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
+    MLFLOW_TRACKING_URI,
+)
+from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
+from mlflow.server.jobs.executor_registry import get_executor_registry
+from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
+
+# Use an explicit logger name rather than __name__: this module is launched as
+# ``python -m mlflow.server.jobs._executor_runner``, where __name__ is "__main__" and would
+# fall outside the "mlflow" logger hierarchy, so its logs would miss MLflow's log handler.
+_logger = logging.getLogger("mlflow.server.jobs._executor_runner")
+
+# How long the loop sleeps when it finds no PENDING jobs to run.
+_POLL_INTERVAL = 1.0
+
+
+def _select_executor() -> AbstractJobExecutor:
+    """Resolve the executor backend named by ``MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND``.
+
+    For now this is always ``local`` (``LocalJobExecutor``).
+    """
+    backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
+    return get_executor_registry().get(backend)
+
+
+def _build_execution_context(job: Job) -> JobExecutionContext:
+    workspace = job.workspace if MLFLOW_ENABLE_WORKSPACES.get() else None
+    return JobExecutionContext(
+        job_id=job.job_id,
+        tracking_uri=MLFLOW_TRACKING_URI.get(),
+        gateway_uri=MLFLOW_GATEWAY_URI.get(),
+        workspace=workspace,
+    )
+
+
+def _backoff_after_transient_retry(retry_count: int) -> None:
+    # Mirror the Huey path's exponential backoff. The loop is serial for now, so
+    # this briefly blocks other jobs; non-blocking scheduling is a later refinement.
+    base_delay = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY.get()
+    max_delay = MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY.get()
+    time.sleep(min(base_delay * (2 ** (retry_count - 1)), max_delay))
+
+
+def _record_result(
+    job_store: AbstractJobStore, job_id: str, job_name: str, result: JobResult
+) -> None:
+    """Map an executor ``JobResult`` onto the terminal job-store transition.
+
+    Mirrors the outcome handling in the Huey ``_exec_job`` path.
+    """
+    # If the job was canceled after it was claimed, it still ran to completion, but the
+    # cancel already finalized the row. Recording a terminal result now would raise an
+    # invalid-transition error and log a scary traceback for a normal user action, so skip it.
+    if job_store.get_job(job_id).status == JobStatus.CANCELED:
+        return
+
+    if result.status == JobStatus.SUCCEEDED:
+        job_store.report_job_result(job_id, JobStatus.SUCCEEDED, result=result.result)
+    elif result.status == JobStatus.TIMEOUT:
+        job_store.report_job_result(job_id, JobStatus.TIMEOUT, error_message=result.error_message)
+    elif result.status == JobStatus.CANCELED:
+        # Defensive: cancellation moves the job to a terminal CANCELED state through
+        # cancel_job(), so there is nothing to record here.
+        return
+    elif result.is_transient_error:
+        # A transient error resets the job to PENDING (non-terminal) so a later poll can
+        # re-claim it, so this cannot go through report_job_result.
+        retry_count = job_store.retry_or_fail_job(job_id, result.error_message or "")
+        if retry_count is not None:
+            _backoff_after_transient_retry(retry_count)
+    else:
+        _logger.error(f"Job {job_id} ({job_name}) failed with error: {result.error_message}")
+        job_store.report_job_result(
+            job_id, JobStatus.FAILED, error_message=result.error_message or ""
+        )
+
+
+def _execute_claimed_job(
+    job_store: AbstractJobStore, executor: AbstractJobExecutor, job: Job
+) -> None:
+    """Execute a job that has already been claimed (moved to RUNNING) and record its result."""
+    from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
+
+    fn_fullname = get_job_fn_fullname(job.job_name)
+    function = _load_function(fn_fullname)
+    python_env = function._job_fn_metadata.python_env
+    params = json.loads(job.params)
+    context = _build_execution_context(job)
+
+    backend = MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()
+    _logger.info(f"Executor engine running job {job.job_id} ({job.job_name}) on backend {backend}")
+
+    # Contract: every submit_job pairs with exactly one wait_for_job.
+    executor.submit_job(
+        job_id=job.job_id,
+        job_name=job.job_name,
+        fn_fullname=fn_fullname,
+        params=params,
+        context=context,
+        python_env=python_env,
+        timeout=job.timeout,
+    )
+    result = executor.wait_for_job(job.job_id)
+    _logger.info(f"Executor engine job {job.job_id} finished with status {result.status.value}")
+    _record_result(job_store, job.job_id, job.job_name, result)
+
+
+def _poll_and_execute_once(
+    job_store: AbstractJobStore, executor: AbstractJobExecutor, lease_duration: float | None
+) -> int:
+    """Claim and run every currently-PENDING job. Returns the number executed.
+
+    A single iteration of the loop; separated out so it can be driven directly in tests.
+
+    Workspace scoping mirrors the Huey ``_enqueue_unfinished_jobs`` path: on a
+    workspace-enabled deployment the store only returns jobs for the active workspace, so
+    the listing, claim, execution, and result-recording for each tenant all run inside that
+    tenant's ``WorkspaceContext``. When workspaces are disabled this is a single
+    ``nullcontext`` and behavior is unchanged.
+    """
+    from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
+
+    executed = 0
+    for workspace_ctx in _workspace_contexts_for_recovery():
+        with workspace_ctx:
+            for job in list(job_store.list_jobs(statuses=[JobStatus.PENDING])):
+                if job_store.claim_job(job.job_id, lease_duration) != JobUpdateStatus.APPLIED:
+                    # A concurrent worker claimed it first, or its status changed.
+                    continue
+                try:
+                    _execute_claimed_job(job_store, executor, job)
+                except Exception as exc:
+                    # A claimed job left RUNNING would be stuck; fail it so recovery is
+                    # not needed.
+                    _logger.error(
+                        f"Job {job.job_id} ({job.job_name}) raised in the executor loop: {exc!r}",
+                        exc_info=True,
+                    )
+                    try:
+                        job_store.fail_job(job.job_id, repr(exc))
+                    except Exception:
+                        _logger.exception(f"Failed to transition job {job.job_id} to FAILED")
+                executed += 1
+    return executed
+
+
+def run_executor_loop(
+    stop_event: threading.Event | None = None, poll_interval: float = _POLL_INTERVAL
+) -> None:
+    """Run the executor job-execution loop until ``stop_event`` is set."""
+    from mlflow.server.handlers import _get_job_store
+
+    # Only PENDING jobs are claimed here. Recovering orphaned RUNNING jobs on server
+    # restart is a follow-up; this loop does not handle it yet.
+    stop_event = stop_event or threading.Event()
+    job_store = _get_job_store()
+    executor = _select_executor()
+    lease_duration = executor.config.job_lease_ttl
+    executor.start_executor()
+    _logger.info(
+        f"Started executor-backed job runner (backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
+    )
+    try:
+        while not stop_event.is_set():
+            try:
+                executed = _poll_and_execute_once(job_store, executor, lease_duration)
+            except Exception:
+                # The loop-level store and workspace calls run outside the per-job handler.
+                # A transient error here must not kill the runner (nothing would restart it),
+                # so log it and try again on the next poll.
+                _logger.exception("Executor job loop iteration failed; continuing.")
+                executed = 0
+            if executed == 0:
+                stop_event.wait(poll_interval)
+    finally:
+        executor.stop_executor()
+
+
+def main() -> None:
+    from mlflow.server.jobs.logging_utils import configure_logging_for_jobs
+    from mlflow.server.jobs.utils import (
+        _launch_periodic_tasks_consumer,
+        _start_watcher_to_kill_job_runner_if_mlflow_server_dies,
+    )
+
+    configure_logging_for_jobs()
+    _start_watcher_to_kill_job_runner_if_mlflow_server_dies()
+    # Periodic tasks (e.g. the online scoring scheduler) still run on Huey.
+    _launch_periodic_tasks_consumer()
+    run_executor_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -29,6 +29,7 @@ from mlflow.environment_variables import (
 from mlflow.server.jobs.executor import AbstractJobExecutor, JobExecutionContext, JobResult
 from mlflow.server.jobs.executor_registry import get_executor_registry
 from mlflow.store.jobs.abstract_store import AbstractJobStore, JobUpdateStatus
+from mlflow.utils.time import get_current_time_millis
 
 # Use an explicit logger name rather than __name__: this module is launched as
 # ``python -m mlflow.server.jobs._executor_runner``, where __name__ is "__main__" and would
@@ -236,14 +237,58 @@ def _poll_and_execute_once(
     return executed
 
 
+def _recover_orphaned_jobs(job_store: AbstractJobStore) -> None:
+    """Requeue jobs a previous runner left mid-flight before the poll loop starts.
+
+    The loop only claims PENDING jobs, so a job that was RUNNING when the server stopped
+    abruptly would otherwise stay RUNNING forever. On startup, reset such jobs back to
+    PENDING so the loop re-claims them. A job whose lease is still valid is left alone: a
+    live worker (for example another replica) may still be running it.
+    """
+    from mlflow.server.jobs.utils import _workspace_contexts_for_recovery
+
+    now = get_current_time_millis()
+    for workspace_ctx in _workspace_contexts_for_recovery():
+        try:
+            with workspace_ctx:
+                unfinished = list(
+                    job_store.list_jobs(statuses=[JobStatus.RUNNING, JobStatus.NEEDS_RECOVERY])
+                )
+                for job in unfinished:
+                    # This assumes a single active runner: recovery runs once at startup,
+                    # before the poll loop, so no lease renewer is running at the same time and
+                    # resetting an expired-lease job is safe. With multiple runners active at
+                    # once, a live worker on another runner could renew this lease between the
+                    # list_jobs call above and the reset_job call below, and the reset would then
+                    # requeue a job that is still running. Fully closing that window needs a
+                    # store-side conditional reset (reset only if the stored lease is still
+                    # expired), which is left to the multi-runner coordination work.
+                    lease_expired = job.lease_expires_at is None or job.lease_expires_at <= now
+                    if job.status != JobStatus.NEEDS_RECOVERY and not lease_expired:
+                        # A live worker still holds this job's lease; leave it running.
+                        continue
+                    _logger.info(
+                        f"Recovering orphaned job {job.job_id} ({job.job_name}) in status "
+                        f"{job.status.value}; resetting to PENDING"
+                    )
+                    try:
+                        job_store.reset_job(job.job_id)
+                    except Exception:
+                        # The job may have left RUNNING/NEEDS_RECOVERY between listing and reset
+                        # (e.g. another worker finalized it), which makes reset_job raise. Skip
+                        # this job and keep recovering the rest.
+                        _logger.exception(f"Failed to reset orphaned job {job.job_id}; skipping")
+        except Exception:
+            # One workspace failing to list or recover must not abort recovery for the others.
+            _logger.exception("Stale-job recovery failed for a workspace; continuing.")
+
+
 def run_executor_loop(
     stop_event: threading.Event | None = None, poll_interval: float = _POLL_INTERVAL
 ) -> None:
     """Run the executor job-execution loop until ``stop_event`` is set."""
     from mlflow.server.handlers import _get_job_store
 
-    # Only PENDING jobs are claimed here. Recovering orphaned RUNNING jobs on server
-    # restart is a follow-up; this loop does not handle it yet.
     stop_event = stop_event or threading.Event()
     job_store = _get_job_store()
     executor = _select_executor()
@@ -253,6 +298,11 @@ def run_executor_loop(
         f"Started executor-backed job runner (backend={MLFLOW_JOB_DEFAULT_EXECUTOR_BACKEND.get()})"
     )
     try:
+        try:
+            _recover_orphaned_jobs(job_store)
+        except Exception:
+            # Recovery is best-effort; a failure here must not stop the runner from starting.
+            _logger.exception("Stale-job recovery failed at startup; continuing.")
         while not stop_event.is_set():
             try:
                 executed = _poll_and_execute_once(job_store, executor, lease_duration)

--- a/mlflow/server/jobs/_executor_runner.py
+++ b/mlflow/server/jobs/_executor_runner.py
@@ -14,6 +14,7 @@ import json
 import logging
 import threading
 import time
+from contextlib import nullcontext
 
 from mlflow.entities._job import Job
 from mlflow.entities._job_status import JobStatus
@@ -36,6 +37,56 @@ _logger = logging.getLogger("mlflow.server.jobs._executor_runner")
 
 # How long the loop sleeps when it finds no PENDING jobs to run.
 _POLL_INTERVAL = 1.0
+
+# How many times a running job's lease is renewed per lease TTL: the renew interval is the
+# TTL divided by this, so the lease is refreshed well before it expires. The interval is
+# floored so a very short TTL cannot cause a busy loop.
+_LEASE_RENEWALS_PER_TTL = 3.0
+_MIN_LEASE_RENEW_INTERVAL = 0.2
+
+
+class _LeaseRenewer:
+    """Keeps a running job's lease alive until the job finishes.
+
+    ``claim_job`` sets an initial lease when it moves a job to RUNNING. A job that runs
+    longer than the lease TTL would otherwise look abandoned to stale-job recovery, so while
+    the job runs this renews the lease in the background and stops as soon as the job returns.
+    Used as a context manager around the blocking ``wait_for_job`` call.
+    """
+
+    def __init__(self, job_store: AbstractJobStore, job_id: str, lease_duration: float) -> None:
+        self._job_store = job_store
+        self._job_id = job_id
+        self._lease_duration = lease_duration
+        self._interval = max(lease_duration / _LEASE_RENEWALS_PER_TTL, _MIN_LEASE_RENEW_INTERVAL)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._renew_until_stopped,
+            name=f"mlflow-job-lease-renewer-{job_id}",
+            daemon=True,
+        )
+
+    def _renew_until_stopped(self) -> None:
+        # ``Event.wait`` returns True once stopped and False on each timeout; renew on timeout.
+        while not self._stop.wait(self._interval):
+            try:
+                status = self._job_store.renew_job_lease(self._job_id, self._lease_duration)
+            except Exception:
+                # A transient store error should not silently kill renewal: log and retry on
+                # the next tick so the lease keeps being refreshed while the job runs.
+                _logger.exception(f"Failed to renew lease for job {self._job_id}; will retry")
+                continue
+            if status != JobUpdateStatus.APPLIED:
+                # The job row is no longer renewable (finalized or reset elsewhere); stop.
+                return
+
+    def __enter__(self) -> "_LeaseRenewer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=self._interval + 5.0)
 
 
 def _select_executor() -> AbstractJobExecutor:
@@ -100,9 +151,16 @@ def _record_result(
 
 
 def _execute_claimed_job(
-    job_store: AbstractJobStore, executor: AbstractJobExecutor, job: Job
+    job_store: AbstractJobStore,
+    executor: AbstractJobExecutor,
+    job: Job,
+    lease_duration: float | None,
 ) -> None:
-    """Execute a job that has already been claimed (moved to RUNNING) and record its result."""
+    """Execute a job that has already been claimed (moved to RUNNING) and record its result.
+
+    While the job runs, its lease is renewed in the background so a long-running job is not
+    treated as abandoned by stale-job recovery.
+    """
     from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
     fn_fullname = get_job_fn_fullname(job.job_name)
@@ -124,7 +182,17 @@ def _execute_claimed_job(
         python_env=python_env,
         timeout=job.timeout,
     )
-    result = executor.wait_for_job(job.job_id)
+    # The lease is set at claim time; the renewer only covers wait_for_job. If submit_job does
+    # long setup first (e.g. installing a job's environment), the lease can lapse before the
+    # first renewal, but that renewal self-heals it since it only applies while the job is still
+    # RUNNING. If that window ever matters, raise the initial lease TTL rather than move this.
+    lease_renewer = (
+        _LeaseRenewer(job_store, job.job_id, lease_duration)
+        if lease_duration is not None
+        else nullcontext()
+    )
+    with lease_renewer:
+        result = executor.wait_for_job(job.job_id)
     _logger.info(f"Executor engine job {job.job_id} finished with status {result.status.value}")
     _record_result(job_store, job.job_id, job.job_name, result)
 
@@ -152,7 +220,7 @@ def _poll_and_execute_once(
                     # A concurrent worker claimed it first, or its status changed.
                     continue
                 try:
-                    _execute_claimed_job(job_store, executor, job)
+                    _execute_claimed_job(job_store, executor, job, lease_duration)
                 except Exception as exc:
                     # A claimed job left RUNNING would be stuck; fail it so recovery is
                     # not needed.

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -22,6 +22,7 @@ from mlflow.entities._job_status import JobStatus
 from mlflow.environment_variables import (
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_LOGGING_LEVEL,
+    MLFLOW_SERVER_JOB_EXECUTION_ENGINE,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY,
     MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY,
     MLFLOW_WORKSPACE,
@@ -741,6 +742,49 @@ def _launch_job_runner(env_map, server_proc_pid):
             MLFLOW_SERVER_UP_TIME: server_up_time,
         },
     )
+
+
+_VALID_JOB_EXECUTION_ENGINES = ("huey", "executor")
+
+
+def get_job_execution_engine() -> str:
+    """Return the validated, case-normalized job execution engine.
+
+    Raises ``MlflowException`` for any value other than ``"huey"`` or ``"executor"``
+    (after case-normalization), so an unrecognized value fails loudly instead of
+    silently falling back to Huey and disabling the feature.
+    """
+    engine = MLFLOW_SERVER_JOB_EXECUTION_ENGINE.get().strip().lower()
+    if engine not in _VALID_JOB_EXECUTION_ENGINES:
+        raise MlflowException.invalid_parameter_value(
+            f"Invalid value for {MLFLOW_SERVER_JOB_EXECUTION_ENGINE.name}: {engine!r}. "
+            f"Valid values are {_VALID_JOB_EXECUTION_ENGINES}."
+        )
+    return engine
+
+
+def _launch_executor_runner(env_map, server_proc_pid):
+    server_up_time = str(int(time.time() * 1000))
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow.server.jobs._executor_runner",
+        ],
+        env={
+            **os.environ,
+            **env_map,
+            "MLFLOW_SERVER_PID": str(server_proc_pid),
+            MLFLOW_SERVER_UP_TIME: server_up_time,
+        },
+    )
+
+
+def _launch_job_execution_runner(env_map, server_proc_pid):
+    """Launch the job runner for the configured execution engine."""
+    if get_job_execution_engine() == "executor":
+        return _launch_executor_runner(env_map, server_proc_pid)
+    return _launch_job_runner(env_map, server_proc_pid)
 
 
 def _start_watcher_to_kill_job_runner_if_mlflow_server_dies(check_interval: float = 1.0) -> None:

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -1,0 +1,433 @@
+import json
+import os
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mlflow.entities._job import Job
+from mlflow.entities._job_status import JobStatus
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs import _ALLOWED_JOB_NAME_LIST, _SUPPORTED_JOB_FUNCTION_LIST, job, submit_job
+from mlflow.server.jobs import _executor_runner as runner
+from mlflow.server.jobs.executor import JobExecutorConfig, JobResult
+from mlflow.server.jobs.executor_registry import shutdown_executor_registry
+from mlflow.server.jobs.local_executor import LocalJobExecutor
+from mlflow.server.jobs.utils import (
+    _build_job_name_to_fn_fullname_map,
+    _exec_job,
+    _job_name_to_fn_fullname_map,
+)
+from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
+from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
+from mlflow.utils.workspace_context import WorkspaceContext
+
+pytestmark = [
+    pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
+]
+
+
+class _EngineTransientError(RuntimeError):
+    pass
+
+
+@job(name="executor_engine_add", max_workers=1)
+def executor_engine_add(x, y):
+    return x + y
+
+
+@job(name="executor_engine_boom", max_workers=1)
+def executor_engine_boom():
+    raise RuntimeError("boom")
+
+
+@job(name="executor_engine_sleep", max_workers=1)
+def executor_engine_sleep(sleep_secs):
+    time.sleep(sleep_secs)
+
+
+@job(
+    name="executor_engine_flaky",
+    max_workers=1,
+    transient_error_classes=[_EngineTransientError],
+)
+def executor_engine_flaky(marker_path):
+    # Fail transiently on the first attempt, then succeed. The attempt count is tracked in
+    # a file so it survives across the per-attempt subprocesses the executor spawns.
+    marker = Path(marker_path)
+    attempts = (int(marker.read_text()) if marker.exists() else 0) + 1
+    marker.write_text(str(attempts))
+    if attempts < 2:
+        raise _EngineTransientError("flaky")
+    return attempts
+
+
+_JOB_FULLNAMES = [
+    "tests.server.jobs.test_executor_engine.executor_engine_add",
+    "tests.server.jobs.test_executor_engine.executor_engine_boom",
+    "tests.server.jobs.test_executor_engine.executor_engine_sleep",
+    "tests.server.jobs.test_executor_engine.executor_engine_flaky",
+]
+_JOB_NAMES = [
+    "executor_engine_add",
+    "executor_engine_boom",
+    "executor_engine_sleep",
+    "executor_engine_flaky",
+]
+
+
+@pytest.fixture
+def registered_jobs():
+    _SUPPORTED_JOB_FUNCTION_LIST.extend(_JOB_FULLNAMES)
+    _ALLOWED_JOB_NAME_LIST.extend(_JOB_NAMES)
+    _build_job_name_to_fn_fullname_map()
+    try:
+        yield
+    finally:
+        for name in _JOB_NAMES:
+            _job_name_to_fn_fullname_map.pop(name, None)
+            if name in _ALLOWED_JOB_NAME_LIST:
+                _ALLOWED_JOB_NAME_LIST.remove(name)
+        for fullname in _JOB_FULLNAMES:
+            if fullname in _SUPPORTED_JOB_FUNCTION_LIST:
+                _SUPPORTED_JOB_FUNCTION_LIST.remove(fullname)
+
+
+@pytest.fixture
+def job_store(tmp_path):
+    return SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'jobs.db'}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_executor_registry():
+    # _select_executor() builds the process-global executor registry singleton; tear it
+    # down after each test so it does not leak into later tests.
+    yield
+    shutdown_executor_registry()
+
+
+@pytest.fixture
+def executor():
+    ex = LocalJobExecutor(JobExecutorConfig(default_timeout=60.0))
+    ex.start_executor()
+    try:
+        yield ex
+    finally:
+        ex.stop_executor()
+
+
+def test_select_executor_defaults_to_local():
+    assert isinstance(runner._select_executor(), LocalJobExecutor)
+
+
+def test_loop_runs_pending_job_to_success(registered_jobs, job_store, executor):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 3, "y": 4}))
+
+    executed = runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    assert executed == 1
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.SUCCEEDED
+    assert updated.result == "7"
+    assert updated.retry_count == 0
+
+
+def test_loop_records_failure(registered_jobs, job_store, executor):
+    created = job_store.create_job("executor_engine_boom", "{}")
+
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.FAILED
+
+
+def test_loop_no_pending_jobs_is_noop(registered_jobs, job_store, executor):
+    assert runner._poll_and_execute_once(job_store, executor, lease_duration=60.0) == 0
+
+
+def test_loop_marks_timed_out_job(registered_jobs, job_store, executor):
+    created = job_store.create_job(
+        "executor_engine_sleep", json.dumps({"sleep_secs": 30}), timeout=1.0
+    )
+
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.TIMEOUT
+
+
+def test_loop_retries_transient_error_then_succeeds(
+    registered_jobs, job_store, executor, tmp_path, monkeypatch
+):
+    marker = tmp_path / "attempts.txt"
+    created = job_store.create_job(
+        "executor_engine_flaky", json.dumps({"marker_path": str(marker)})
+    )
+
+    # Avoid the real exponential backoff sleep between retries.
+    monkeypatch.setattr(runner, "_backoff_after_transient_retry", lambda retry_count: None)
+
+    # First poll: transient error -> retry_or_fail_job resets the job to PENDING.
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    after_first = job_store.get_job(created.job_id)
+    assert after_first.status == JobStatus.PENDING
+    assert after_first.retry_count == 1
+
+    # Second poll: the retried job is re-claimed and succeeds.
+    runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+    after_second = job_store.get_job(created.job_id)
+    assert after_second.status == JobStatus.SUCCEEDED
+    assert after_second.result == "2"
+
+
+def test_loop_runs_job_in_non_default_workspace(registered_jobs, tmp_path, executor, monkeypatch):
+    from mlflow.entities import Workspace
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    store = WorkspaceAwareSqlAlchemyJobStore(f"sqlite:///{tmp_path / 'ws.db'}")
+
+    with WorkspaceContext("workspace-b"):
+        created = store.create_job("executor_engine_add", json.dumps({"x": 5, "y": 6}))
+
+    # The loop enumerates workspaces via _workspace_contexts_for_recovery(), which reads the
+    # workspace store. Without the per-workspace context the loop would not see this job.
+    mock_workspace_store = mock.MagicMock()
+    mock_workspace_store.list_workspaces.return_value = [Workspace(name="workspace-b")]
+    with mock.patch(
+        "mlflow.server.workspace_helpers._get_workspace_store",
+        return_value=mock_workspace_store,
+    ):
+        executed = runner._poll_and_execute_once(store, executor, lease_duration=60.0)
+
+    assert executed == 1
+    with WorkspaceContext("workspace-b"):
+        updated = store.get_job(created.job_id)
+    assert updated.status == JobStatus.SUCCEEDED
+    assert updated.result == "11"
+
+
+@pytest.mark.parametrize(
+    ("job_name", "params", "expected_status"),
+    [
+        ("executor_engine_add", {"x": 3, "y": 4}, JobStatus.SUCCEEDED),
+        ("executor_engine_boom", {}, JobStatus.FAILED),
+    ],
+)
+def test_engines_produce_equivalent_terminal_state(
+    registered_jobs,
+    tmp_path,
+    executor,
+    monkeypatch,
+    job_name,
+    params,
+    expected_status,
+):
+    # Executor engine: drive the loop directly.
+    exec_store = SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'exec.db'}")
+    exec_job = exec_store.create_job(job_name, json.dumps(params))
+    runner._poll_and_execute_once(exec_store, executor, lease_duration=60.0)
+    exec_result = exec_store.get_job(exec_job.job_id)
+
+    # Huey engine: drive _exec_job directly, pointing _get_job_store at the huey store.
+    huey_store = SqlAlchemyJobStore(f"sqlite:///{tmp_path / 'huey.db'}")
+    monkeypatch.setattr("mlflow.server.handlers._get_job_store", lambda *args, **kwargs: huey_store)
+    huey_job = huey_store.create_job(job_name, json.dumps(params))
+    _exec_job(huey_job.job_id, None, job_name, params, None)
+    huey_result = huey_store.get_job(huey_job.job_id)
+
+    # Both engines must reach the same terminal state from the same input.
+    assert exec_result.status == huey_result.status == expected_status
+    assert exec_result.result == huey_result.result
+    assert exec_result.retry_count == huey_result.retry_count == 0
+    if expected_status == JobStatus.SUCCEEDED:
+        assert exec_result.result == "7"
+
+
+def _make_job(status=JobStatus.RUNNING, retry_count=0) -> Job:
+    return Job(
+        job_id="job-1",
+        creation_time=0,
+        job_name="executor_engine_add",
+        params="{}",
+        timeout=None,
+        status=status,
+        result=None,
+        retry_count=retry_count,
+        last_update_time=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_call"),
+    [
+        (
+            JobResult(status=JobStatus.SUCCEEDED, result="7"),
+            mock.call("job-1", JobStatus.SUCCEEDED, result="7"),
+        ),
+        (
+            JobResult(status=JobStatus.TIMEOUT),
+            mock.call("job-1", JobStatus.TIMEOUT, error_message=None),
+        ),
+        (
+            JobResult(status=JobStatus.FAILED, error_message="boom"),
+            mock.call("job-1", JobStatus.FAILED, error_message="boom"),
+        ),
+    ],
+)
+def test_record_result_terminal_mapping(result, expected_call):
+    store = mock.MagicMock()
+    store.get_job.return_value = _make_job(status=JobStatus.RUNNING)
+    runner._record_result(store, "job-1", "executor_engine_add", result)
+    assert store.report_job_result.call_args == expected_call
+
+
+def test_record_result_transient_error_retries():
+    store = mock.MagicMock(**{"retry_or_fail_job.return_value": 1})
+    store.get_job.return_value = _make_job(status=JobStatus.RUNNING)
+    with mock.patch.object(runner, "_backoff_after_transient_retry") as backoff:
+        runner._record_result(
+            store,
+            "job-1",
+            "executor_engine_add",
+            JobResult(status=JobStatus.FAILED, error_message="temp", is_transient_error=True),
+        )
+    store.retry_or_fail_job.assert_called_once_with("job-1", "temp")
+    store.fail_job.assert_not_called()
+    backoff.assert_called_once_with(1)
+
+
+def test_record_result_transient_error_exhausted_does_not_backoff():
+    store = mock.MagicMock(**{"retry_or_fail_job.return_value": None})
+    store.get_job.return_value = _make_job(status=JobStatus.RUNNING)
+    with mock.patch.object(runner, "_backoff_after_transient_retry") as backoff:
+        runner._record_result(
+            store,
+            "job-1",
+            "executor_engine_add",
+            JobResult(status=JobStatus.FAILED, error_message="temp", is_transient_error=True),
+        )
+    store.retry_or_fail_job.assert_called_once()
+    backoff.assert_not_called()
+
+
+def _submit_job_env(monkeypatch, engine=None):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "true")
+    if engine is not None:
+        monkeypatch.setenv("MLFLOW_SERVER_JOB_EXECUTION_ENGINE", engine)
+
+
+def test_submit_job_defaults_to_huey_enqueue(monkeypatch, registered_jobs):
+    _submit_job_env(monkeypatch)  # engine unset -> defaults to "huey"
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    huey_instance = mock.MagicMock()
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        mock.patch(
+            "mlflow.server.jobs.utils._get_or_init_huey_instance", return_value=huey_instance
+        ),
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2})
+
+    # workspaces disabled -> workspace arg is None; exclusive=False and extra_envs=None.
+    huey_instance.submit_task.assert_called_once_with(
+        "job-1", None, "executor_engine_add", {"x": 1, "y": 2}, None, False, None
+    )
+
+
+@pytest.mark.parametrize("engine", ["executor", "Executor", "EXECUTOR"])
+def test_submit_job_executor_engine_skips_huey(monkeypatch, registered_jobs, engine):
+    _submit_job_env(monkeypatch, engine=engine)  # value is case-normalized
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        mock.patch("mlflow.server.jobs.utils._get_or_init_huey_instance") as get_huey,
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2})
+
+    store.create_job.assert_called_once_with(
+        "executor_engine_add", json.dumps({"x": 1, "y": 2}), None
+    )
+    get_huey.assert_not_called()
+
+
+def test_submit_job_executor_engine_rejects_extra_envs(monkeypatch, registered_jobs):
+    _submit_job_env(monkeypatch, engine="executor")
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        pytest.raises(MlflowException, match="extra_envs is not yet supported"),
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2}, extra_envs={"TOKEN": "secret"})
+
+    # Rejected before persisting, so no runnable PENDING row is left behind.
+    store.create_job.assert_not_called()
+
+
+@pytest.mark.parametrize("engine", ["spark", "kubernetes", ""])
+def test_submit_job_rejects_invalid_engine(monkeypatch, registered_jobs, engine):
+    _submit_job_env(monkeypatch, engine=engine)
+    store = mock.MagicMock()
+    store.create_job.return_value = _make_job(status=JobStatus.PENDING)
+    with (
+        mock.patch("mlflow.server.jobs._get_job_store", return_value=store),
+        mock.patch("mlflow.server.jobs.utils._check_requirements"),
+        pytest.raises(
+            MlflowException, match="Invalid value for MLFLOW_SERVER_JOB_EXECUTION_ENGINE"
+        ),
+    ):
+        submit_job(executor_engine_add, {"x": 1, "y": 2})
+
+    # Invalid engine is rejected before persisting, so no PENDING row is left behind.
+    store.create_job.assert_not_called()
+
+
+def test_record_result_skips_job_canceled_after_claim(registered_jobs, job_store):
+    # A job canceled after it was claimed runs to completion; recording a terminal result
+    # then must not raise (the cancel already finalized the row) and must leave it CANCELED.
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, lease_duration=60.0)
+    job_store.cancel_job(created.job_id)
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+    runner._record_result(
+        job_store,
+        created.job_id,
+        "executor_engine_add",
+        JobResult(status=JobStatus.SUCCEEDED, result="3"),
+    )
+
+    assert job_store.get_job(created.job_id).status == JobStatus.CANCELED
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected"),
+    [
+        (None, "_launch_job_runner"),
+        ("huey", "_launch_job_runner"),
+        ("executor", "_launch_executor_runner"),
+    ],
+)
+def test_launch_job_execution_runner_dispatch(monkeypatch, engine, expected):
+    from mlflow.server.jobs.utils import _launch_job_execution_runner
+
+    if engine is not None:
+        monkeypatch.setenv("MLFLOW_SERVER_JOB_EXECUTION_ENGINE", engine)
+    env_map = {"FOO": "bar"}
+    with (
+        mock.patch("mlflow.server.jobs.utils._launch_executor_runner") as launch_executor,
+        mock.patch("mlflow.server.jobs.utils._launch_job_runner") as launch_huey,
+    ):
+        _launch_job_execution_runner(env_map, 1234)
+
+    launchers = {"_launch_executor_runner": launch_executor, "_launch_job_runner": launch_huey}
+    launchers.pop(expected).assert_called_once_with(env_map, 1234)
+    for unused in launchers.values():
+        unused.assert_not_called()

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from unittest import mock
@@ -20,6 +21,7 @@ from mlflow.server.jobs.utils import (
     _exec_job,
     _job_name_to_fn_fullname_map,
 )
+from mlflow.store.jobs.abstract_store import JobUpdateStatus
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
 from mlflow.utils.workspace_context import WorkspaceContext
@@ -431,3 +433,81 @@ def test_launch_job_execution_runner_dispatch(monkeypatch, engine, expected):
     launchers.pop(expected).assert_called_once_with(env_map, 1234)
     for unused in launchers.values():
         unused.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Job-lease renewal
+# ---------------------------------------------------------------------------
+
+
+def test_lease_renewer_renews_while_running_then_stops():
+    store = mock.MagicMock()
+    calls = []
+    reached_two = threading.Event()
+
+    def _renew(job_id, lease_duration):
+        calls.append(job_id)
+        if len(calls) >= 2:
+            reached_two.set()
+        return JobUpdateStatus.APPLIED
+
+    store.renew_job_lease.side_effect = _renew
+    with runner._LeaseRenewer(store, "job-1", lease_duration=0.6):
+        # Wait for two renewals to fire, then exit; no wall-clock sleep drives the count.
+        assert reached_two.wait(timeout=5.0)
+    # __exit__ joins the renewer thread, so the count is final and no renewals fire after.
+    assert store.renew_job_lease.call_count >= 2
+    store.renew_job_lease.assert_called_with("job-1", 0.6)
+
+
+def test_lease_renewer_stops_when_lease_no_longer_renewable():
+    store = mock.MagicMock()
+    renewed = threading.Event()
+
+    def _renew(job_id, lease_duration):
+        renewed.set()
+        return JobUpdateStatus.WRONG_STATE
+
+    store.renew_job_lease.side_effect = _renew
+    with runner._LeaseRenewer(store, "job-1", lease_duration=0.6):
+        assert renewed.wait(timeout=5.0)
+    # A non-APPLIED status makes the renewer stop on its own after a single attempt.
+    assert store.renew_job_lease.call_count == 1
+
+
+def test_lease_renewer_survives_renew_error_and_keeps_renewing():
+    store = mock.MagicMock()
+    calls = []
+    reached_second = threading.Event()
+
+    def _renew(job_id, lease_duration):
+        calls.append(job_id)
+        if len(calls) == 1:
+            raise RuntimeError("transient store error")
+        reached_second.set()
+        return JobUpdateStatus.APPLIED
+
+    store.renew_job_lease.side_effect = _renew
+    with mock.patch.object(runner, "_logger") as mock_logger:
+        with runner._LeaseRenewer(store, "job-1", lease_duration=0.6):
+            # The first renewal raises; the renewer must log and keep going to a second.
+            assert reached_second.wait(timeout=5.0)
+    mock_logger.exception.assert_called()
+    assert store.renew_job_lease.call_count >= 2
+
+
+def test_long_running_job_lease_is_renewed(registered_jobs, job_store, executor, monkeypatch):
+    created = job_store.create_job("executor_engine_sleep", json.dumps({"sleep_secs": 1.0}))
+    renew_calls = []
+    real_renew = job_store.renew_job_lease
+
+    def _spy(job_id, lease_duration):
+        renew_calls.append(job_id)
+        return real_renew(job_id, lease_duration)
+
+    monkeypatch.setattr(job_store, "renew_job_lease", _spy)
+    # Short lease so renewal (~lease/3) fires several times during the ~1s job.
+    runner._poll_and_execute_once(job_store, executor, lease_duration=0.6)
+
+    assert created.job_id in renew_calls
+    assert job_store.get_job(created.job_id).status == JobStatus.SUCCEEDED

--- a/tests/server/jobs/test_executor_engine.py
+++ b/tests/server/jobs/test_executor_engine.py
@@ -24,7 +24,8 @@ from mlflow.server.jobs.utils import (
 from mlflow.store.jobs.abstract_store import JobUpdateStatus
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 from mlflow.store.jobs.sqlalchemy_workspace_store import WorkspaceAwareSqlAlchemyJobStore
-from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.time import get_current_time_millis
+from mlflow.utils.workspace_context import WorkspaceContext, get_request_workspace
 
 pytestmark = [
     pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
@@ -511,3 +512,167 @@ def test_long_running_job_lease_is_renewed(registered_jobs, job_store, executor,
 
     assert created.job_id in renew_calls
     assert job_store.get_job(created.job_id).status == JobStatus.SUCCEEDED
+
+
+# ---------------------------------------------------------------------------
+# Startup stale-job recovery
+# ---------------------------------------------------------------------------
+
+
+def _expired_now():
+    # A "now" far in the future so a normally-set lease looks expired.
+    return get_current_time_millis() + 10**9
+
+
+def test_recovery_resets_running_job_with_expired_lease(registered_jobs, job_store):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    assert job_store.claim_job(created.job_id, 60.0) == JobUpdateStatus.APPLIED
+
+    with mock.patch.object(runner, "get_current_time_millis", side_effect=_expired_now):
+        runner._recover_orphaned_jobs(job_store)
+
+    assert job_store.get_job(created.job_id).status == JobStatus.PENDING
+
+
+def test_recovery_leaves_running_job_with_valid_lease(registered_jobs, job_store):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    assert job_store.claim_job(created.job_id, 60.0) == JobUpdateStatus.APPLIED
+
+    runner._recover_orphaned_jobs(job_store)
+
+    # A live worker still holds a valid lease, so the job is left RUNNING.
+    assert job_store.get_job(created.job_id).status == JobStatus.RUNNING
+
+
+def test_recovery_resets_needs_recovery_job(registered_jobs, job_store):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, 60.0)
+    assert job_store.mark_job_needs_recovery(created.job_id) == JobUpdateStatus.APPLIED
+
+    runner._recover_orphaned_jobs(job_store)
+
+    assert job_store.get_job(created.job_id).status == JobStatus.PENDING
+
+
+def test_recovery_leaves_finalized_jobs_untouched(registered_jobs, job_store):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    job_store.claim_job(created.job_id, 60.0)
+    job_store.finish_job(created.job_id, "3")
+
+    runner._recover_orphaned_jobs(job_store)
+
+    assert job_store.get_job(created.job_id).status == JobStatus.SUCCEEDED
+
+
+def test_recovered_job_reruns_on_next_poll(registered_jobs, job_store, executor):
+    created = job_store.create_job("executor_engine_add", json.dumps({"x": 2, "y": 3}))
+    job_store.claim_job(created.job_id, 60.0)
+
+    with mock.patch.object(runner, "get_current_time_millis", side_effect=_expired_now):
+        runner._recover_orphaned_jobs(job_store)
+    assert job_store.get_job(created.job_id).status == JobStatus.PENDING
+
+    executed = runner._poll_and_execute_once(job_store, executor, lease_duration=60.0)
+
+    assert executed == 1
+    updated = job_store.get_job(created.job_id)
+    assert updated.status == JobStatus.SUCCEEDED
+    assert updated.result == "5"
+
+
+def test_recovery_is_scoped_per_workspace(registered_jobs, tmp_path, monkeypatch):
+    from mlflow.entities import Workspace
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    store = WorkspaceAwareSqlAlchemyJobStore(f"sqlite:///{tmp_path / 'ws.db'}")
+
+    created = {}
+    for ws in ("workspace-a", "workspace-b"):
+        with WorkspaceContext(ws):
+            j = store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+            assert store.claim_job(j.job_id, 60.0) == JobUpdateStatus.APPLIED
+            created[ws] = j.job_id
+
+    # Recovery enumerates workspaces via the workspace store; make both visible so each
+    # workspace's orphaned jobs are recovered in that workspace's context.
+    mock_workspace_store = mock.MagicMock()
+    mock_workspace_store.list_workspaces.return_value = [
+        Workspace(name="workspace-a"),
+        Workspace(name="workspace-b"),
+    ]
+    with (
+        mock.patch(
+            "mlflow.server.workspace_helpers._get_workspace_store",
+            return_value=mock_workspace_store,
+        ),
+        mock.patch.object(runner, "get_current_time_millis", side_effect=_expired_now),
+    ):
+        runner._recover_orphaned_jobs(store)
+
+    for ws, job_id in created.items():
+        with WorkspaceContext(ws):
+            assert store.get_job(job_id).status == JobStatus.PENDING
+
+
+def test_recovery_continues_after_reset_failure(registered_jobs, job_store):
+    first = job_store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+    second = job_store.create_job("executor_engine_add", json.dumps({"x": 3, "y": 4}))
+    assert job_store.claim_job(first.job_id, 60.0) == JobUpdateStatus.APPLIED
+    assert job_store.claim_job(second.job_id, 60.0) == JobUpdateStatus.APPLIED
+
+    real_reset = job_store.reset_job
+    attempted = []
+
+    def _reset(job_id):
+        attempted.append(job_id)
+        if job_id == first.job_id:
+            raise RuntimeError("reset failed")
+        return real_reset(job_id)
+
+    with (
+        mock.patch.object(job_store, "reset_job", side_effect=_reset),
+        mock.patch.object(runner, "get_current_time_millis", side_effect=_expired_now),
+    ):
+        runner._recover_orphaned_jobs(job_store)
+
+    # Both jobs were attempted; the first one failing did not abort recovery of the second.
+    assert set(attempted) == {first.job_id, second.job_id}
+    assert job_store.get_job(second.job_id).status == JobStatus.PENDING
+
+
+def test_recovery_continues_after_workspace_list_failure(registered_jobs, tmp_path, monkeypatch):
+    from mlflow.entities import Workspace
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    store = WorkspaceAwareSqlAlchemyJobStore(f"sqlite:///{tmp_path / 'ws.db'}")
+
+    with WorkspaceContext("workspace-b"):
+        j = store.create_job("executor_engine_add", json.dumps({"x": 1, "y": 2}))
+        assert store.claim_job(j.job_id, 60.0) == JobUpdateStatus.APPLIED
+
+    mock_workspace_store = mock.MagicMock()
+    mock_workspace_store.list_workspaces.return_value = [
+        Workspace(name="workspace-a"),
+        Workspace(name="workspace-b"),
+    ]
+
+    real_list_jobs = store.list_jobs
+
+    def _list_jobs(*args, **kwargs):
+        if get_request_workspace() == "workspace-a":
+            # Listing fails for the first workspace; recovery must continue to the next one.
+            raise RuntimeError("list_jobs failed")
+        return real_list_jobs(*args, **kwargs)
+
+    with (
+        mock.patch(
+            "mlflow.server.workspace_helpers._get_workspace_store",
+            return_value=mock_workspace_store,
+        ),
+        mock.patch.object(store, "list_jobs", side_effect=_list_jobs),
+        mock.patch.object(runner, "get_current_time_millis", side_effect=_expired_now),
+    ):
+        runner._recover_orphaned_jobs(store)
+
+    with WorkspaceContext("workspace-b"):
+        assert store.get_job(j.job_id).status == JobStatus.PENDING


### PR DESCRIPTION
### Related Issues/PRs

> **Stacked on #25293** — please review/merge #25293 (job-lease renewal) first. This branch is built on top of it, so the diff here shows two commits: the first is #25293, and the second (`Recover orphaned jobs on executor-engine startup`) is this PR's own change. Reviewing the second commit in isolation: `git show <this branch tip>`.

Relates to the executor-backed job-execution engine and its lease handling on this branch.

### What changes are proposed in this pull request?

On executor-engine startup, before the poll loop begins, orphaned jobs are recovered so they don't stay stuck. The loop only claims PENDING jobs, so a job that was RUNNING when the server stopped abruptly would otherwise remain RUNNING forever.

- `_recover_orphaned_jobs` lists `RUNNING`/`NEEDS_RECOVERY` jobs per workspace and resets to PENDING those that are `NEEDS_RECOVERY` or whose lease has expired, so the loop re-claims them. This mirrors the existing Huey startup recovery (`_enqueue_unfinished_jobs`).
- A job whose lease is still valid is left alone — a live worker (e.g. another replica) may still be running it.
- Recovery is best-effort and isolated: a failure listing one workspace, or resetting one job (which can raise if the job left `RUNNING`/`NEEDS_RECOVERY` between listing and reset), is logged and skipped without aborting recovery of the rest.
- Only runs on the executor engine; the default Huey path is untouched. No schema or migration changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests: an expired-lease RUNNING job is reset to PENDING and re-runs; a valid-lease RUNNING job is left alone; a `NEEDS_RECOVERY` job is reset; a finalized job is untouched; recovery is correctly scoped per workspace (workspaces-enabled).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Internal to the opt-in executor job engine (off by default).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release