### PR TITLE
Pin `litellm!=1.97.0` to avoid broken pydantic `Message` model

### DIFF
--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -79,7 +79,9 @@ ag2<1
 # which causes auto-logging tests to fail.
 dspy!=2.6.9
 # Required by mlflow.litellm
-litellm
+# 1.97.0 ships a broken `Message` pydantic model (unresolved forward ref
+# `ChatCompletionReasoningSummaryTextBlock`), see BerriAI/litellm#36384
+litellm!=1.97.0
 # Required by mlflow.gemini
 google-genai
 # Required by mlflow.groq

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -49,7 +49,9 @@ gepa
 # required for testing docker compose
 testcontainers
 # required for testing cost tracking
-litellm
+# 1.97.0 ships a broken `Message` pydantic model (unresolved forward ref
+# `ChatCompletionReasoningSummaryTextBlock`), see BerriAI/litellm#36384
+litellm!=1.97.0
 # required for testing Redis budget tracker
 fakeredis[lua]
 # required for testing claude_code tracing


### PR DESCRIPTION
### Related Issues/PRs


### What changes are proposed in this pull request?

`litellm` is installed unpinned in `requirements/test-requirements.txt`, so CI pulls whatever is newest on PyPI at run time. `litellm==1.97.0` (published 2026-08-23) ships a broken `Message` pydantic model with an unresolved forward reference (`ChatCompletionReasoningSummaryTextBlock`). Any code path that instantiates `Message` now raises:

```
pydantic.errors.PydanticUserError: `Message` is not fully defined; you should
define `ChatCompletionReasoningSummaryTextBlock`, then call `Message.model_rebuild()`.
.venv/lib/python3.10/site-packages/litellm/types/utils.py:1290: PydanticUserError
```

This deterministically breaks the `genai` test job (`tests/genai/judges/adapters/test_litellm_adapter.py` and others). It is not tied to any MLflow change — the last green master run installed `litellm==1.96.2`; every run since litellm 1.97.0 dropped installs the broken build and fails. It is currently red on `master` and on every open PR that runs the genai job.

This pins `litellm!=1.97.0`, forcing CI back to the working 1.96.x line while still allowing a future fixed release (e.g. 1.97.1) to be picked up automatically. The pin can be removed once the upstream fix lands.

### How is this PR tested?

- [x] Existing unit/integration tests

The `genai` job that fails on the broken build exercises this dependency; it should return to green once `litellm!=1.97.0` resolves to a working release.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release