### PR TITLE
basic-auth: redact gateway secrets-config passphrase signal from non-admins

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -4211,6 +4211,20 @@ def filter_list_gateway_secrets(resp: Response) -> None:
     resp.data = message_to_json(response_message)
 
 
+def redact_secrets_config_for_non_admins(resp: Response) -> None:
+    """Strip ``using_default_passphrase`` from the gateway secrets config for non-admins.
+
+    The endpoint is authenticated-open so the gateway UI can read ``secrets_available``, but
+    ``using_default_passphrase`` reveals whether gateway secrets use the default encryption
+    passphrase — a server security-posture signal that should stay admin-only.
+    """
+    if sender_is_admin():
+        return
+    body = resp.json
+    if isinstance(body, dict) and "using_default_passphrase" in body:
+        resp.data = json.dumps({k: v for k, v in body.items() if k != "using_default_passphrase"})
+
+
 AFTER_REQUEST_PATH_HANDLERS = {
     CreateExperiment: set_can_manage_experiment_permission,
     CreateRegisteredModel: set_can_manage_registered_model_permission,
@@ -4270,6 +4284,10 @@ WORKSPACE_PARAMETERIZED_AFTER_REQUEST_HANDLERS = {
     for (path, method), handler in AFTER_REQUEST_HANDLERS.items()
     if "<" in path and "/workspaces/" in path
 }
+
+# GATEWAY_SECRETS_CONFIG is excluded from the auto-built handlers above (it is an ajax gateway
+# path); register its non-admin redaction filter explicitly.
+AFTER_REQUEST_HANDLERS[(GATEWAY_SECRETS_CONFIG, "GET")] = redact_secrets_config_for_non_admins
 
 
 @catch_mlflow_exception

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -2511,13 +2511,26 @@ def test_gateway_secrets_permissions(client, monkeypatch):
         )
         response.raise_for_status()
 
+    # Non-admin reads the config (UI needs secrets_available) but the using_default_passphrase
+    # server-posture signal is redacted for them.
     with User(user1, password1, monkeypatch):
         response = requests.get(
             url=client.tracking_uri + "/ajax-api/3.0/mlflow/gateway/secrets/config",
             auth=(user1, password1),
         )
         response.raise_for_status()
-        assert "secrets_available" in response.json()
+        body = response.json()
+        assert "secrets_available" in body
+        assert "using_default_passphrase" not in body
+
+    # Admin sees the full config, including using_default_passphrase.
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        response = requests.get(
+            url=client.tracking_uri + "/ajax-api/3.0/mlflow/gateway/secrets/config",
+            auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+        )
+        response.raise_for_status()
+        assert "using_default_passphrase" in response.json()
 
     with User(user1, password1, monkeypatch):
         response = requests.delete(

--- a/tests/server/auth/test_authorization_coverage.py
+++ b/tests/server/auth/test_authorization_coverage.py
@@ -245,3 +245,31 @@ def test_filter_list_gateway_secrets_drops_unreadable(monkeypatch):
     a.filter_list_gateway_secrets(resp)
     ids = [s["secret_id"] for s in json.loads(resp.data)["secrets"]]
     assert ids == ["sec-allowed"]
+
+
+def test_secrets_config_redaction_registered():
+    # The redaction filter must be wired for the secrets/config GET so _after_request runs it
+    # (the path is otherwise excluded from the auto-built after-request handlers).
+    key = (a.GATEWAY_SECRETS_CONFIG, "GET")
+    assert a.AFTER_REQUEST_HANDLERS.get(key) is a.redact_secrets_config_for_non_admins
+
+
+def test_secrets_config_redacts_passphrase_for_non_admin(monkeypatch):
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+    resp = SimpleNamespace(
+        json={"secrets_available": True, "using_default_passphrase": True}, data=None
+    )
+    a.redact_secrets_config_for_non_admins(resp)
+    body = json.loads(resp.data)
+    assert body == {"secrets_available": True}
+    assert "using_default_passphrase" not in body
+
+
+def test_secrets_config_keeps_passphrase_for_admin(monkeypatch):
+    monkeypatch.setattr(a, "sender_is_admin", lambda: True)
+    resp = SimpleNamespace(
+        json={"secrets_available": True, "using_default_passphrase": True}, data=None
+    )
+    a.redact_secrets_config_for_non_admins(resp)
+    # Admin response is left untouched (data not rewritten).
+    assert resp.data is None


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #25070. In that PR, `GET /ajax-api/3.0/mlflow/gateway/secrets/config` was made
authenticated-open (from admin-only) so the gateway UI works for non-admins; a reviewer asked
that the sensitive `using_default_passphrase` field be locked down to admins as a follow-up.
This is that follow-up.

### What changes are proposed in this pull request?

`GET /ajax-api/3.0/mlflow/gateway/secrets/config` returns two fields:

- `secrets_available` — whether the gateway secrets feature is available (harmless; the UI
  reads it for any signed-in user).
- `using_default_passphrase` — whether gateway secrets are encrypted with the default (unset)
  KEK passphrase. This is a **server security-posture signal**: it tells a caller the secrets
  are protected by a known default key, useful reconnaissance for an attacker.

The endpoint needs to stay authenticated-open for the UI, so this redacts the sensitive
**field** rather than gating the whole route:

- Adds an after-request filter `redact_secrets_config_for_non_admins` that strips
  `using_default_passphrase` for non-admins while leaving `secrets_available`. Admins get the
  full response unchanged.
- The route is excluded from the auto-built `AFTER_REQUEST_HANDLERS` (it is an ajax gateway
  path), so the filter is registered explicitly for `(GATEWAY_SECRETS_CONFIG, "GET")`.

| Caller | `secrets_available` | `using_default_passphrase` |
|--------|---------------------|----------------------------|
| Admin | ✅ | ✅ |
| Non-admin | ✅ | redacted |
| Unauthenticated | 401 (unchanged) | — |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit tests

`test_secrets_config_redacts_passphrase_for_non_admin` / `_keeps_passphrase_for_admin` cover
the filter; `test_secrets_config_redaction_registered` asserts it is wired into
`AFTER_REQUEST_HANDLERS` so `_after_request` dispatches it; and `test_gateway_secrets_permissions`
is extended to assert end-to-end that a non-admin does not receive `using_default_passphrase`
while an admin does.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The gateway secrets-config endpoint no longer returns the `using_default_passphrase`
  field to non-admin users; admins are unaffected.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
