### PR TITLE
Set a global jest `testTimeout` to stabilize heavy JS test suites

### DIFF
--- a/mlflow/server/js/craco.config.js
+++ b/mlflow/server/js/craco.config.js
@@ -311,6 +311,10 @@ module.exports = function () {
         };
 
         jestConfig.resetMocks = false; // ML-20462 Restore resetMocks
+        // Full-page render suites (userEvent + MSW under jsdom) intermittently exceed jest's 5s
+        // default under parallel CI load. Raise the default so heavy-but-finite tests don't flake;
+        // genuinely-hung tests still fail. Per-test `}, N)` overrides remain authoritative.
+        jestConfig.testTimeout = 20000;
         jestConfig.collectCoverageFrom = ['src/**/*.{js,jsx}', '!**/*.test.{js,jsx}', '!**/__tests__/*.{js,jsx}'];
         jestConfig.coverageReporters = ['lcov'];
         jestConfig.setupFiles = ['jest-canvas-mock'];


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25028 and #25191 (per-test timeout stabilizations of individual `TracesV4PageContent` tests). Supersedes #25191 — this fixes the whole class at the config level. Surfaced as flaky CI on unrelated PRs (e.g. #25143, and the `MCPServerDetailPage` timeout on #25191's own CI).

### What changes are proposed in this pull request?

The jest config set no `testTimeout`, so every JS test ran against jest's 5000ms default. The newly-ported OSS page suites — `mcp-registry/*` and `experiment-tracking/.../traces-v4/*` — do heavy full-page renders (`userEvent` + MSW under jsdom) that intermittently exceed 5s under parallel CI load and flake with `Exceeded timeout of 5000 ms for a test`. Recent examples: `MCPServerDetailPage` › "opens edit display name modal from overflow menu", and the two `TracesV4PageContent` search tests.

This raises the default to `20000ms` via `jestConfig.testTimeout` in `craco.config.js`. Notes:

- This is the jest **config** option, distinct from the in-file `jest.setTimeout()` call the codebase deliberately avoids. It fixes the entire class at once (current and future suites) without sprinkling per-test bumps across 100+ tests.
- Genuinely-hung tests still fail (just after 20s instead of 5s).
- Existing per-test `}, N)` overrides remain authoritative — no behavior change for tests that already set their own timeout.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Verified the config override is active with a throwaway test that sleeps 6s with no per-test timeout: it passes only because the config default is now above 5s (it would fail under the old 5000ms default). `prettier --check` is clean on `craco.config.js`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release