### PR TITLE
Run the MLflow Assistant coding-agent CLI providers (Claude Code and Codex) in a hardened Docker sandbox

### DIFF
--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -50,6 +50,12 @@ from mlflow.server.assistant.session import (
 # outside this allowlist are intentionally NOT passed through; logged-in credentials otherwise
 # persist in the per-session HOME directory. The list covers the CLI's supported auth backends
 # (direct Anthropic API, Amazon Bedrock, Google Vertex) plus outbound proxy configuration.
+# Host provider credentials forwarded into the sandbox so the CLI can authenticate. The
+# container still has unrestricted outbound network access; restricting egress (a dedicated
+# network + optional proxy) is a planned follow-up (see the network-posture note in
+# mlflow/server/sandbox/container.py), and until then the sandbox stays off by default.
+# Both proxy-var cases are forwarded so an operator's interim egress proxy is honored whether
+# it is set upper- or lower-case (lowercase is conventional on Linux).
 _SANDBOX_AUTH_ENV_PASSTHROUGH = (
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
@@ -68,6 +74,9 @@ _SANDBOX_AUTH_ENV_PASSTHROUGH = (
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
 )
 
 _logger = logging.getLogger(__name__)

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -887,9 +887,7 @@ class ClaudeCodeProvider(AssistantProvider):
             _logger.exception("Error running Claude Code CLI in sandbox")
             yield Event.from_exception(e)
         finally:
-            # cleanup() force-removes the container (a blocking docker-py socket call); keep it off
-            # the event loop so a slow daemon during teardown cannot stall other requests.
-            await asyncio.to_thread(proc.cleanup)
+            await proc.aclose()
 
     @staticmethod
     def _build_usage_event(usage: dict[str, Any], cost_usd: float | None = None) -> Event:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -704,6 +704,7 @@ class ClaudeCodeProvider(AssistantProvider):
         set. Runtime behavior (image contents, credentials, volume permissions) is validated
         against a live Docker daemon rather than in unit tests.
         """
+        from mlflow.assistant.providers.tool_executor import _uri_without_credentials
         from mlflow.server.sandbox import (
             SandboxUnavailableError,
             sandbox_input_path,
@@ -749,6 +750,11 @@ class ClaudeCodeProvider(AssistantProvider):
 
         input_files = {"system_prompt.txt": _build_system_prompt(tracking_uri)}
         env = {"MLFLOW_TRACKING_URI": to_container_host_uri(tracking_uri)}
+        # Mirror the Bash sandbox: forward the registry URI too so `mlflow` registry commands in
+        # the container reach the same registry, credential-stripped and loopback-rewritten.
+        registry_uri = os.environ.get("MLFLOW_REGISTRY_URI")
+        if registry_uri and (safe := _uri_without_credentials("MLFLOW_REGISTRY_URI", registry_uri)):
+            env["MLFLOW_REGISTRY_URI"] = to_container_host_uri(safe)
         for var in _SANDBOX_AUTH_ENV_PASSTHROUGH:
             value = os.environ.get(var)
             if not value:
@@ -799,6 +805,12 @@ class ClaudeCodeProvider(AssistantProvider):
         try:
             # Recorded inside this try so a failure here still runs proc.cleanup() below,
             # rather than leaking the started container and its scratch directories.
+            #
+            # A cancel that arrives while the container is still starting (before this line, and
+            # sandbox mode records no PID) finds nothing to kill, so that turn keeps running until
+            # the idle timeout reaps it; the container is not leaked (cleanup() still runs). Closing
+            # that startup window would take a per-session cancel flag checked here and is left as a
+            # follow-up.
             if mlflow_session_id:
                 save_container_id(mlflow_session_id, proc.container_id)
             try:
@@ -863,7 +875,9 @@ class ClaudeCodeProvider(AssistantProvider):
             _logger.exception("Error running Claude Code CLI in sandbox")
             yield Event.from_exception(e)
         finally:
-            proc.cleanup()
+            # cleanup() force-removes the container (a blocking docker-py socket call); keep it off
+            # the event loop so a slow daemon during teardown cannot stall other requests.
+            await asyncio.to_thread(proc.cleanup)
 
     @staticmethod
     def _build_usage_event(usage: dict[str, Any], cost_usd: float | None = None) -> Event:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -386,6 +386,11 @@ class ClaudeCodeProvider(AssistantProvider):
         return "structured"
 
     def is_available(self) -> bool:
+        # In sandbox mode the CLI runs inside the operator-provided image, not on the host, so
+        # availability follows the sandbox being enabled rather than a host binary the operator
+        # is not expected to install.
+        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
+            return True
         return shutil.which("claude") is not None
 
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
@@ -742,14 +747,33 @@ class ClaudeCodeProvider(AssistantProvider):
             cmd.extend(["--resume", session_id])
         cmd.extend(["--append-system-prompt-file", sandbox_input_path("system_prompt.txt")])
 
+        input_files = {"system_prompt.txt": _build_system_prompt(tracking_uri)}
         env = {"MLFLOW_TRACKING_URI": to_container_host_uri(tracking_uri)}
         for var in _SANDBOX_AUTH_ENV_PASSTHROUGH:
-            if value := os.environ.get(var):
-                # ANTHROPIC_BASE_URL is a URL the CLI connects to from *inside* the container, so
-                # a loopback value must be rewritten to reach the host. A non-loopback endpoint
-                # (e.g. a host-only gateway) is forwarded as-is and must be reachable from the
-                # sandbox; if it is not, the idle timeout surfaces a failure instead of hanging.
-                env[var] = to_container_host_uri(value) if var == "ANTHROPIC_BASE_URL" else value
+            value = os.environ.get(var)
+            if not value:
+                continue
+            if var == "GOOGLE_APPLICATION_CREDENTIALS":
+                # This is a host file path the container cannot see. Copy the credentials file's
+                # contents into the read-only input mount and point the CLI at that in-container
+                # path, so Vertex auth via a service-account file actually works in the sandbox.
+                try:
+                    input_files["google-application-credentials.json"] = Path(value).read_text()
+                except OSError:
+                    _logger.warning(
+                        "GOOGLE_APPLICATION_CREDENTIALS points to an unreadable file; "
+                        "not forwarding it to the sandbox."
+                    )
+                    continue
+                env[var] = sandbox_input_path("google-application-credentials.json")
+            elif var == "ANTHROPIC_BASE_URL":
+                # A URL the CLI connects to from *inside* the container, so a loopback value must
+                # be rewritten to reach the host. A non-loopback endpoint (e.g. a host-only
+                # gateway) is forwarded as-is and must be reachable from the sandbox; if it is
+                # not, the idle timeout surfaces a failure instead of hanging.
+                env[var] = to_container_host_uri(value)
+            else:
+                env[var] = value
 
         # Persist the CLI's HOME (its --resume session store and caches) across turns of the
         # same session so multi-turn conversations resume correctly.
@@ -763,7 +787,7 @@ class ClaudeCodeProvider(AssistantProvider):
                 workdir=cwd,
                 environment=env,
                 stdin_data=user_message.encode("utf-8"),
-                input_files={"system_prompt.txt": _build_system_prompt(tracking_uri)},
+                input_files=input_files,
                 home_dir=home_dir,
             )
         except SandboxUnavailableError as e:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -407,6 +407,13 @@ class ClaudeCodeProvider(AssistantProvider):
         Raises:
             ProviderNotConfiguredError: If CLI is not installed or not authenticated.
         """
+        if assistant_sandbox_enabled():
+            # The CLI runs inside the operator image, not on the host, so there is no host binary
+            # or host login to verify here; image presence and auth are checked when a turn starts
+            # the container.
+            if echo:
+                echo("Assistant sandbox enabled; the Claude Code CLI runs in the sandbox image.")
+            return
         claude_path = shutil.which("claude")
         if not claude_path:
             if echo:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -26,6 +26,7 @@ from mlflow.assistant.providers.base import (
     AssistantProvider,
     CLINotInstalledError,
     NotAuthenticatedError,
+    assistant_sandbox_enabled,
     load_config_or_default,
 )
 from mlflow.assistant.types import (
@@ -37,7 +38,6 @@ from mlflow.assistant.types import (
     ToolResultBlock,
     ToolUseBlock,
 )
-from mlflow.environment_variables import MLFLOW_ENABLE_ASSISTANT_SANDBOX
 from mlflow.server.assistant.session import (
     clear_container_id,
     clear_process_pid,
@@ -385,13 +385,17 @@ class ClaudeCodeProvider(AssistantProvider):
     def client_tool_delivery(self) -> Literal["structured"]:
         return "structured"
 
+    @property
+    def allows_remote_access(self) -> bool:
+        # In local mode the CLI runs on the host, so it must stay localhost-only. In sandbox mode
+        # it runs isolated in a container, so it can safely serve remote clients.
+        return assistant_sandbox_enabled()
+
     def is_available(self) -> bool:
         # In sandbox mode the CLI runs inside the operator-provided image, not on the host, so
-        # availability follows the sandbox being enabled rather than a host binary the operator
-        # is not expected to install.
-        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
-            return True
-        return shutil.which("claude") is not None
+        # availability follows the sandbox being active rather than a host binary the operator is
+        # not expected to install.
+        return assistant_sandbox_enabled() or shutil.which("claude") is not None
 
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
         """
@@ -477,7 +481,7 @@ class ClaudeCodeProvider(AssistantProvider):
         Yields:
             Event objects
         """
-        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
+        if assistant_sandbox_enabled():
             async for event in self._astream_in_sandbox(
                 prompt, tracking_uri, session_id, mlflow_session_id, cwd, context
             ):
@@ -700,8 +704,9 @@ class ClaudeCodeProvider(AssistantProvider):
 
         Mirrors ``astream``'s command construction and event parsing, but the CLI, the working
         directory, and the CLI's ``--resume`` session state all live inside the container. The
-        host path is left unchanged; this runs only when ``MLFLOW_ENABLE_ASSISTANT_SANDBOX`` is
-        set. Runtime behavior (image contents, credentials, volume permissions) is validated
+        host path is left unchanged; this runs only when the assistant sandbox is active (see
+        ``assistant_sandbox_enabled``). Runtime behavior (image contents, credentials, volume
+        permissions) is validated
         against a live Docker daemon rather than in unit tests.
         """
         from mlflow.assistant.providers.tool_executor import _uri_without_credentials

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -37,7 +37,38 @@ from mlflow.assistant.types import (
     ToolResultBlock,
     ToolUseBlock,
 )
-from mlflow.server.assistant.session import clear_process_pid, save_process_pid
+from mlflow.environment_variables import MLFLOW_ENABLE_ASSISTANT_SANDBOX
+from mlflow.server.assistant.session import (
+    clear_container_id,
+    clear_process_pid,
+    get_session_sandbox_home,
+    save_container_id,
+    save_process_pid,
+)
+
+# Environment variables forwarded into the sandbox so the CLI can authenticate. Host secrets
+# outside this allowlist are intentionally NOT passed through; logged-in credentials otherwise
+# persist in the per-session HOME directory. The list covers the CLI's supported auth backends
+# (direct Anthropic API, Amazon Bedrock, Google Vertex) plus outbound proxy configuration.
+_SANDBOX_AUTH_ENV_PASSTHROUGH = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_REGION",
+    "AWS_PROFILE",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLOUD_ML_REGION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -441,6 +472,13 @@ class ClaudeCodeProvider(AssistantProvider):
         Yields:
             Event objects
         """
+        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
+            async for event in self._astream_in_sandbox(
+                prompt, tracking_uri, session_id, mlflow_session_id, cwd, context
+            ):
+                yield event
+            return
+
         claude_path = shutil.which("claude")
         if not claude_path:
             yield Event.from_error(
@@ -643,6 +681,153 @@ class ClaudeCodeProvider(AssistantProvider):
                     _logger.warning(
                         "Failed to remove temp system prompt file %s", system_prompt_path
                     )
+
+    async def _astream_in_sandbox(
+        self,
+        prompt: str,
+        tracking_uri: str,
+        session_id: str | None,
+        mlflow_session_id: str | None,
+        cwd: Path | None,
+        context: dict[str, Any] | None,
+    ) -> AsyncGenerator[Event, None]:
+        """Run the Claude Code CLI inside a hardened Docker container instead of on the host.
+
+        Mirrors ``astream``'s command construction and event parsing, but the CLI, the working
+        directory, and the CLI's ``--resume`` session state all live inside the container. The
+        host path is left unchanged; this runs only when ``MLFLOW_ENABLE_ASSISTANT_SANDBOX`` is
+        set. Runtime behavior (image contents, credentials, volume permissions) is validated
+        against a live Docker daemon rather than in unit tests.
+        """
+        from mlflow.server.sandbox import (
+            SandboxUnavailableError,
+            sandbox_input_path,
+            start_sandbox_process,
+            to_container_host_uri,
+        )
+
+        if context:
+            user_message = f"<context>\n{json.dumps(context)}\n</context>\n\n{prompt}"
+        else:
+            user_message = prompt
+        structured_custom_view = is_custom_view_request(context)
+        if structured_custom_view:
+            user_message = f"{user_message}\n\n{CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS}"
+
+        config = load_config_or_default(self.name)
+        cmd = [
+            "claude",
+            "-p",
+            "--input-format",
+            "text",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        ]
+        if structured_custom_view:
+            cmd.extend(["--json-schema", json.dumps(CUSTOM_VIEW_RESPONSE_SCHEMA)])
+        if config.permissions.full_access:
+            cmd.extend(["--permission-mode", "bypassPermissions"])
+        else:
+            allowed_tools = list(BASE_ALLOWED_TOOLS)
+            if config.permissions.allow_edit_files:
+                allowed_tools.extend(FILE_EDIT_TOOLS)
+            if config.permissions.allow_read_docs:
+                allowed_tools.extend(DOCS_TOOLS)
+            for tool in allowed_tools:
+                cmd.extend(["--allowed-tools", tool])
+        if config.model and config.model != "default":
+            cmd.extend(["--model", config.model])
+        if session_id:
+            cmd.extend(["--resume", session_id])
+        cmd.extend(["--append-system-prompt-file", sandbox_input_path("system_prompt.txt")])
+
+        env = {"MLFLOW_TRACKING_URI": to_container_host_uri(tracking_uri)}
+        for var in _SANDBOX_AUTH_ENV_PASSTHROUGH:
+            if value := os.environ.get(var):
+                env[var] = value
+
+        # Persist the CLI's HOME (its --resume session store and caches) across turns of the
+        # same session so multi-turn conversations resume correctly.
+        home_dir = get_session_sandbox_home(mlflow_session_id) if mlflow_session_id else None
+
+        try:
+            # start_sandbox_process uses the blocking docker-py client; keep it off the loop.
+            proc = await asyncio.to_thread(
+                start_sandbox_process,
+                cmd,
+                workdir=cwd,
+                environment=env,
+                stdin_data=user_message.encode("utf-8"),
+                input_files={"system_prompt.txt": _build_system_prompt(tracking_uri)},
+                home_dir=home_dir,
+            )
+        except SandboxUnavailableError as e:
+            yield Event.from_error(f"Assistant sandbox is enabled but could not start: {e}")
+            return
+
+        structured_response: Any | None = None
+        structured_session_id: str | None = None
+        try:
+            # Recorded inside this try so a failure here still runs proc.cleanup() below,
+            # rather than leaking the started container and its scratch directories.
+            if mlflow_session_id:
+                save_container_id(mlflow_session_id, proc.container_id)
+            try:
+                async for raw_line in proc.iter_stdout_lines():
+                    line_str = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line_str:
+                        continue
+                    try:
+                        data = json.loads(line_str)
+                        if self._should_filter_out_message(data):
+                            continue
+                        if structured_custom_view:
+                            data = self._filter_structured_output_text(data)
+                        if data is None:
+                            continue
+                        if data.get("type") == "result" and (usage := data.get("usage")):
+                            yield self._build_usage_event(usage, data.get("total_cost_usd"))
+                        if data.get("type") == "result" and structured_custom_view:
+                            structured_response = data.get("structured_output", data.get("result"))
+                            structured_session_id = data.get("session_id")
+                            continue
+                        if msg := self._parse_message_to_event(data):
+                            yield msg
+                    except json.JSONDecodeError:
+                        yield Event.from_message(Message(role="user", content=line_str))
+            finally:
+                if mlflow_session_id:
+                    clear_container_id(mlflow_session_id)
+
+            returncode = await proc.wait()
+            # A killed container exits 137 (128 + SIGKILL), which is how cancellation surfaces.
+            if returncode == 137:
+                yield Event.from_interrupted()
+                return
+            if returncode != 0:
+                stderr = (await proc.read_stderr()).decode("utf-8", errors="replace").strip()
+                yield Event.from_error(stderr or f"Process exited with code {returncode}")
+            elif structured_custom_view:
+                if not structured_session_id:
+                    yield Event.from_error("Claude Code result did not include a session ID")
+                    return
+                try:
+                    response = parse_custom_view_response(structured_response)
+                except Exception as e:
+                    yield Event.from_error(
+                        f"Claude Code returned invalid Custom View output: {e}",
+                        session_id=structured_session_id,
+                    )
+                    return
+                for event in custom_view_response_events(response):
+                    yield event
+                yield Event.from_result(result=None, session_id=structured_session_id)
+        except Exception as e:
+            _logger.exception("Error running Claude Code CLI in sandbox")
+            yield Event.from_exception(e)
+        finally:
+            proc.cleanup()
 
     @staticmethod
     def _build_usage_event(usage: dict[str, Any], cost_usd: float | None = None) -> Event:

--- a/mlflow/assistant/providers/claude_code.py
+++ b/mlflow/assistant/providers/claude_code.py
@@ -745,7 +745,11 @@ class ClaudeCodeProvider(AssistantProvider):
         env = {"MLFLOW_TRACKING_URI": to_container_host_uri(tracking_uri)}
         for var in _SANDBOX_AUTH_ENV_PASSTHROUGH:
             if value := os.environ.get(var):
-                env[var] = value
+                # ANTHROPIC_BASE_URL is a URL the CLI connects to from *inside* the container, so
+                # a loopback value must be rewritten to reach the host. A non-loopback endpoint
+                # (e.g. a host-only gateway) is forwarded as-is and must be reachable from the
+                # sandbox; if it is not, the idle timeout surfaces a failure instead of hanging.
+                env[var] = to_container_host_uri(value) if var == "ANTHROPIC_BASE_URL" else value
 
         # Persist the CLI's HOME (its --resume session store and caches) across turns of the
         # same session so multi-turn conversations resume correctly.
@@ -801,6 +805,14 @@ class ClaudeCodeProvider(AssistantProvider):
                     clear_container_id(mlflow_session_id)
 
             returncode = await proc.wait()
+            # The idle-timeout watchdog kills a stuck CLI; surface that as a clear error rather
+            # than a bare interrupt (both exit 137, so this must be checked first).
+            if proc.timed_out:
+                yield Event.from_error(
+                    "Claude Code produced no output for too long and was stopped. If a custom "
+                    "ANTHROPIC_BASE_URL is set, it may not be reachable from the sandbox."
+                )
+                return
             # A killed container exits 137 (128 + SIGKILL), which is how cancellation surfaces.
             if returncode == 137:
                 yield Event.from_interrupted()

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -23,13 +23,36 @@ from mlflow.assistant.providers.base import (
 )
 from mlflow.assistant.providers.prompts import ASSISTANT_SYSTEM_PROMPT
 from mlflow.assistant.types import Event, Message, TextBlock
-from mlflow.server.assistant.session import clear_process_pid, save_process_pid
+from mlflow.environment_variables import MLFLOW_ENABLE_ASSISTANT_SANDBOX
+from mlflow.server.assistant.session import (
+    clear_container_id,
+    clear_process_pid,
+    get_session_sandbox_home,
+    save_container_id,
+    save_process_pid,
+)
 from mlflow.tracing.constant import CostKey, TokenUsageKey
 from mlflow.tracing.utils import calculate_cost_by_model_and_token_usage
 
 _logger = logging.getLogger(__name__)
 
 _CODEX_BINARY = "codex"
+
+# Environment variables forwarded into the sandbox so the Codex CLI can authenticate. Host secrets
+# outside this allowlist are intentionally NOT passed through. Codex authenticates via
+# OPENAI_API_KEY or an interactive ``codex login`` whose credentials live in the per-session HOME;
+# OPENAI_BASE_URL lets an operator point at a custom endpoint, and the proxy vars cover outbound
+# proxy configuration.
+_SANDBOX_AUTH_ENV_PASSTHROUGH = (
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+)
 
 
 class CodexProvider(AssistantProvider):
@@ -125,6 +148,13 @@ class CodexProvider(AssistantProvider):
         cwd: Path | None = None,
         context: dict[str, Any] | None = None,
     ) -> AsyncGenerator[Event, None]:
+        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
+            async for event in self._astream_in_sandbox(
+                prompt, tracking_uri, session_id, mlflow_session_id, cwd, context
+            ):
+                yield event
+            return
+
         codex_path = shutil.which(_CODEX_BINARY)
         if not codex_path:
             yield Event.from_error(
@@ -304,6 +334,185 @@ class CodexProvider(AssistantProvider):
                     schema_path.unlink(missing_ok=True)
                 except OSError:
                     _logger.warning("Failed to remove temp Custom View schema file %s", schema_path)
+
+    async def _astream_in_sandbox(
+        self,
+        prompt: str,
+        tracking_uri: str,
+        session_id: str | None,
+        mlflow_session_id: str | None,
+        cwd: Path | None,
+        context: dict[str, Any] | None,
+    ) -> AsyncGenerator[Event, None]:
+        """Run the Codex CLI inside a hardened Docker container instead of on the host.
+
+        Mirrors ``astream``'s command construction and event parsing, but the CLI, the working
+        directory, and Codex's session/login state (its HOME) all live inside the container. The
+        host path is left unchanged; this runs only when ``MLFLOW_ENABLE_ASSISTANT_SANDBOX`` is
+        set. Runtime behavior (image contents, credentials, volume permissions) is validated
+        against a live Docker daemon rather than in unit tests.
+        """
+        from mlflow.server.sandbox import (
+            SandboxUnavailableError,
+            sandbox_input_path,
+            start_sandbox_process,
+            to_container_host_uri,
+        )
+
+        config = load_config_or_default(self.name)
+        # Everything the CLI does runs inside the container, so it must reach the tracking server
+        # by the container-routable host (a loopback URI is rewritten to host.docker.internal).
+        container_tracking_uri = to_container_host_uri(tracking_uri)
+
+        if context:
+            user_text = f"<context>\n{json.dumps(context)}\n</context>\n\n{prompt}"
+        else:
+            user_text = prompt
+        structured_custom_view = is_custom_view_request(context)
+        if structured_custom_view:
+            user_text = f"{user_text}\n\n{STRINGIFIED_CUSTOM_VIEW_STRUCTURED_OUTPUT_INSTRUCTIONS}"
+
+        if session_id:
+            user_message = user_text
+        else:
+            sys_prompt = ASSISTANT_SYSTEM_PROMPT.format(tracking_uri=container_tracking_uri)
+            user_message = (
+                f"<system_instructions>\n{sys_prompt}\n</system_instructions>\n\n{user_text}"
+            )
+
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--sandbox",
+            "danger-full-access",
+            "--skip-git-repo-check",
+        ]
+        input_files: dict[str, str] = {}
+        if structured_custom_view:
+            # Codex reads the schema by path; write it into the container's input mount.
+            input_files["schema.json"] = json.dumps(STRINGIFIED_CUSTOM_VIEW_RESPONSE_SCHEMA)
+            cmd.extend(["--output-schema", sandbox_input_path("schema.json")])
+        if config.model and config.model != "default":
+            cmd.extend(["-m", config.model])
+        if session_id:
+            cmd.extend(["resume", session_id])
+        cmd.append("-")
+
+        env = {"MLFLOW_TRACKING_URI": container_tracking_uri}
+        for var in _SANDBOX_AUTH_ENV_PASSTHROUGH:
+            if value := os.environ.get(var):
+                # OPENAI_BASE_URL is an endpoint the CLI connects to from inside the container, so
+                # a loopback value must be rewritten to reach the host; other vars pass through.
+                env[var] = to_container_host_uri(value) if var == "OPENAI_BASE_URL" else value
+
+        # Persist Codex's HOME (login credentials and session/thread state) across turns of the
+        # same session so multi-turn conversations resume correctly.
+        home_dir = get_session_sandbox_home(mlflow_session_id) if mlflow_session_id else None
+
+        try:
+            # start_sandbox_process uses the blocking docker-py client; keep it off the loop.
+            proc = await asyncio.to_thread(
+                start_sandbox_process,
+                cmd,
+                workdir=cwd,
+                environment=env,
+                stdin_data=user_message.encode("utf-8"),
+                input_files=input_files or None,
+                home_dir=home_dir,
+            )
+        except SandboxUnavailableError as e:
+            yield Event.from_error(f"Assistant sandbox is enabled but could not start: {e}")
+            return
+
+        thread_id = ""
+        structured_response_text: str | None = None
+        codex_error: str | None = None
+        try:
+            # Recorded inside this try so a failure here still runs proc.cleanup() below.
+            if mlflow_session_id:
+                save_container_id(mlflow_session_id, proc.container_id)
+            try:
+                async for raw_line in proc.iter_stdout_lines():
+                    line_str = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line_str:
+                        continue
+                    try:
+                        data = json.loads(line_str)
+                    except json.JSONDecodeError:
+                        continue
+                    if data.get("type") == "error":
+                        codex_error = self._unwrap_error_message(data.get("message"))
+                        continue
+                    if data.get("type") == "turn.failed":
+                        codex_error = self._unwrap_error_message(
+                            (data.get("error") or {}).get("message")
+                        )
+                        continue
+                    if data.get("type") == "thread.started":
+                        thread_id = data.get("thread_id", "")
+                        continue
+                    item = data.get("item") or {}
+                    if (
+                        structured_custom_view
+                        and data.get("type") == "item.completed"
+                        and item.get("type") == "agent_message"
+                    ):
+                        structured_response_text = item.get("text")
+                        continue
+                    if data.get("type") == "turn.completed" and (usage := data.get("usage")):
+                        model = config.model if config.model and config.model != "default" else None
+                        yield self._build_usage_event(usage, model)
+                        continue
+                    event = self._parse_event(data)
+                    if event is not None:
+                        yield event
+            finally:
+                if mlflow_session_id:
+                    clear_container_id(mlflow_session_id)
+
+            returncode = await proc.wait()
+            # The idle-timeout watchdog kills a stuck CLI; surface that clearly. It exits 137 like
+            # a cancellation kill, so this must be checked first.
+            if proc.timed_out:
+                yield Event.from_error(
+                    "Codex produced no output for too long and was stopped. If a custom "
+                    "OPENAI_BASE_URL is set, it may not be reachable from the sandbox."
+                )
+                return
+            # A killed container exits 137 (128 + SIGKILL), which is how cancellation surfaces.
+            if returncode == 137:
+                yield Event.from_interrupted()
+                return
+            if returncode != 0:
+                stderr = (await proc.read_stderr()).decode("utf-8", errors="replace").strip()
+                yield Event.from_error(
+                    codex_error or stderr or f"Process exited with code {returncode}"
+                )
+            else:
+                if structured_custom_view:
+                    if structured_response_text is None:
+                        yield Event.from_error(
+                            "Codex did not return a structured Custom View response",
+                            session_id=thread_id or session_id,
+                        )
+                        return
+                    try:
+                        response = parse_custom_view_response(structured_response_text)
+                    except Exception as e:
+                        yield Event.from_error(
+                            f"Codex returned invalid Custom View output: {e}",
+                            session_id=thread_id or session_id,
+                        )
+                        return
+                    for event in custom_view_response_events(response):
+                        yield event
+                yield Event.from_result(result=None, session_id=thread_id)
+        except Exception as e:
+            _logger.exception("Error running Codex CLI in sandbox")
+            yield Event.from_exception(e)
+        finally:
+            proc.cleanup()
 
     @staticmethod
     def _unwrap_error_message(message: Any) -> str | None:

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -363,6 +363,7 @@ class CodexProvider(AssistantProvider):
         set. Runtime behavior (image contents, credentials, volume permissions) is validated
         against a live Docker daemon rather than in unit tests.
         """
+        from mlflow.assistant.providers.tool_executor import _uri_without_credentials
         from mlflow.server.sandbox import (
             SandboxUnavailableError,
             sandbox_input_path,
@@ -414,6 +415,11 @@ class CodexProvider(AssistantProvider):
         cmd.append("-")
 
         env = {"MLFLOW_TRACKING_URI": container_tracking_uri}
+        # Mirror the Bash sandbox: forward the registry URI too so `mlflow` registry commands in
+        # the container reach the same registry, credential-stripped and loopback-rewritten.
+        registry_uri = os.environ.get("MLFLOW_REGISTRY_URI")
+        if registry_uri and (safe := _uri_without_credentials("MLFLOW_REGISTRY_URI", registry_uri)):
+            env["MLFLOW_REGISTRY_URI"] = to_container_host_uri(safe)
         for var in _SANDBOX_AUTH_ENV_PASSTHROUGH:
             if value := os.environ.get(var):
                 # OPENAI_BASE_URL is an endpoint the CLI connects to from inside the container, so
@@ -444,6 +450,12 @@ class CodexProvider(AssistantProvider):
         codex_error: str | None = None
         try:
             # Recorded inside this try so a failure here still runs proc.cleanup() below.
+            #
+            # A cancel that arrives while the container is still starting (before this line, and
+            # sandbox mode records no PID) finds nothing to kill, so that turn keeps running until
+            # the idle timeout reaps it; the container is not leaked (cleanup() still runs). Closing
+            # that startup window would take a per-session cancel flag checked here and is left as a
+            # follow-up.
             if mlflow_session_id:
                 save_container_id(mlflow_session_id, proc.container_id)
             last_progress = time.monotonic()
@@ -467,7 +479,8 @@ class CodexProvider(AssistantProvider):
                                 "stopping.",
                                 _CODEX_NO_PROGRESS_TIMEOUT,
                             )
-                            proc.kill()
+                            # kill() is a blocking docker-py call; keep it off the event loop.
+                            await asyncio.to_thread(proc.kill)
                             yield Event.from_error(
                                 "Codex could not connect and kept retrying without progress; "
                                 f"stopped after {int(_CODEX_NO_PROGRESS_TIMEOUT)}s. "
@@ -545,7 +558,9 @@ class CodexProvider(AssistantProvider):
             _logger.exception("Error running Codex CLI in sandbox")
             yield Event.from_exception(e)
         finally:
-            proc.cleanup()
+            # cleanup() force-removes the container (a blocking docker-py socket call); keep it off
+            # the event loop so a slow daemon during teardown cannot stall other requests.
+            await asyncio.to_thread(proc.cleanup)
 
     @staticmethod
     def _unwrap_error_message(message: Any) -> str | None:

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -79,6 +79,11 @@ class CodexProvider(AssistantProvider):
         return "structured"
 
     def is_available(self) -> bool:
+        # In sandbox mode the CLI runs inside the operator-provided image, not on the host, so
+        # availability follows the sandbox being enabled rather than a host binary the operator
+        # is not expected to install.
+        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
+            return True
         return shutil.which(_CODEX_BINARY) is not None
 
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
@@ -381,7 +386,10 @@ class CodexProvider(AssistantProvider):
         if session_id:
             user_message = user_text
         else:
-            sys_prompt = ASSISTANT_SYSTEM_PROMPT.format(tracking_uri=container_tracking_uri)
+            # Use the external tracking URI in the prompt, not the container-only one: the prompt
+            # asks the agent to build UI links the user opens in their browser, where
+            # host.docker.internal would not resolve. Only the env below uses the container URI.
+            sys_prompt = ASSISTANT_SYSTEM_PROMPT.format(tracking_uri=tracking_uri)
             user_message = (
                 f"<system_instructions>\n{sys_prompt}\n</system_instructions>\n\n{user_text}"
             )

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -91,6 +91,13 @@ class CodexProvider(AssistantProvider):
         return assistant_sandbox_enabled() or shutil.which(_CODEX_BINARY) is not None
 
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
+        if assistant_sandbox_enabled():
+            # The CLI runs inside the operator image, not on the host, so there is no host binary
+            # or host login to verify here; image presence and auth are checked when a turn starts
+            # the container.
+            if echo:
+                echo("Assistant sandbox enabled; the Codex CLI runs in the sandbox image.")
+            return
         codex_path = shutil.which(_CODEX_BINARY)
         if not codex_path:
             if echo:

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -491,8 +491,7 @@ class CodexProvider(AssistantProvider):
                                 "stopping.",
                                 _CODEX_NO_PROGRESS_TIMEOUT,
                             )
-                            # kill() is a blocking docker-py call; keep it off the event loop.
-                            await asyncio.to_thread(proc.kill)
+                            await proc.akill()
                             yield Event.from_error(
                                 "Codex could not connect and kept retrying without progress; "
                                 f"stopped after {int(_CODEX_NO_PROGRESS_TIMEOUT)}s. "
@@ -570,9 +569,7 @@ class CodexProvider(AssistantProvider):
             _logger.exception("Error running Codex CLI in sandbox")
             yield Event.from_exception(e)
         finally:
-            # cleanup() force-removes the container (a blocking docker-py socket call); keep it off
-            # the event loop so a slow daemon during teardown cannot stall other requests.
-            await asyncio.to_thread(proc.cleanup)
+            await proc.aclose()
 
     @staticmethod
     def _unwrap_error_message(message: Any) -> str | None:

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable, Literal
 
@@ -37,6 +38,11 @@ from mlflow.tracing.utils import calculate_cost_by_model_and_token_usage
 _logger = logging.getLogger(__name__)
 
 _CODEX_BINARY = "codex"
+
+# In the sandbox, if codex cannot reach the API it streams "Reconnecting..." error events
+# continuously (it never gives up on its own), so the container's no-output idle-timeout never
+# fires. Bail if only connection errors arrive, with no progress, for this long.
+_CODEX_NO_PROGRESS_TIMEOUT = 60.0
 
 # Environment variables forwarded into the sandbox so the Codex CLI can authenticate. Host secrets
 # outside this allowlist are intentionally NOT passed through. Codex authenticates via
@@ -432,6 +438,7 @@ class CodexProvider(AssistantProvider):
             # Recorded inside this try so a failure here still runs proc.cleanup() below.
             if mlflow_session_id:
                 save_container_id(mlflow_session_id, proc.container_id)
+            last_progress = time.monotonic()
             try:
                 async for raw_line in proc.iter_stdout_lines():
                     line_str = raw_line.decode("utf-8", errors="replace").strip()
@@ -443,7 +450,25 @@ class CodexProvider(AssistantProvider):
                         continue
                     if data.get("type") == "error":
                         codex_error = self._unwrap_error_message(data.get("message"))
+                        # codex retries a failed connection forever, streaming these errors the
+                        # whole time (so the idle-timeout never fires). If only errors arrive for
+                        # too long, stop it rather than hang the turn.
+                        if time.monotonic() - last_progress > _CODEX_NO_PROGRESS_TIMEOUT:
+                            _logger.warning(
+                                "Codex made no progress for %ss (repeated connection errors); "
+                                "stopping.",
+                                _CODEX_NO_PROGRESS_TIMEOUT,
+                            )
+                            proc.kill()
+                            yield Event.from_error(
+                                "Codex could not connect and kept retrying without progress; "
+                                f"stopped after {int(_CODEX_NO_PROGRESS_TIMEOUT)}s. "
+                                f"Last error: {codex_error}"
+                            )
+                            return
                         continue
+                    # Any non-error line is progress; reset the no-progress deadline.
+                    last_progress = time.monotonic()
                     if data.get("type") == "turn.failed":
                         codex_error = self._unwrap_error_message(
                             (data.get("error") or {}).get("message")

--- a/mlflow/assistant/providers/codex.py
+++ b/mlflow/assistant/providers/codex.py
@@ -20,11 +20,11 @@ from mlflow.assistant.providers.base import (
     AssistantProvider,
     CLINotInstalledError,
     NotAuthenticatedError,
+    assistant_sandbox_enabled,
     load_config_or_default,
 )
 from mlflow.assistant.providers.prompts import ASSISTANT_SYSTEM_PROMPT
 from mlflow.assistant.types import Event, Message, TextBlock
-from mlflow.environment_variables import MLFLOW_ENABLE_ASSISTANT_SANDBOX
 from mlflow.server.assistant.session import (
     clear_container_id,
     clear_process_pid,
@@ -78,13 +78,17 @@ class CodexProvider(AssistantProvider):
     def client_tool_delivery(self) -> Literal["structured"]:
         return "structured"
 
+    @property
+    def allows_remote_access(self) -> bool:
+        # In local mode the CLI runs on the host, so it must stay localhost-only. In sandbox mode
+        # it runs isolated in a container, so it can safely serve remote clients.
+        return assistant_sandbox_enabled()
+
     def is_available(self) -> bool:
         # In sandbox mode the CLI runs inside the operator-provided image, not on the host, so
-        # availability follows the sandbox being enabled rather than a host binary the operator
-        # is not expected to install.
-        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
-            return True
-        return shutil.which(_CODEX_BINARY) is not None
+        # availability follows the sandbox being active rather than a host binary the operator is
+        # not expected to install.
+        return assistant_sandbox_enabled() or shutil.which(_CODEX_BINARY) is not None
 
     def check_connection(self, echo: Callable[[str], None] | None = None) -> None:
         codex_path = shutil.which(_CODEX_BINARY)
@@ -159,7 +163,7 @@ class CodexProvider(AssistantProvider):
         cwd: Path | None = None,
         context: dict[str, Any] | None = None,
     ) -> AsyncGenerator[Event, None]:
-        if MLFLOW_ENABLE_ASSISTANT_SANDBOX.get():
+        if assistant_sandbox_enabled():
             async for event in self._astream_in_sandbox(
                 prompt, tracking_uri, session_id, mlflow_session_id, cwd, context
             ):
@@ -359,8 +363,9 @@ class CodexProvider(AssistantProvider):
 
         Mirrors ``astream``'s command construction and event parsing, but the CLI, the working
         directory, and Codex's session/login state (its HOME) all live inside the container. The
-        host path is left unchanged; this runs only when ``MLFLOW_ENABLE_ASSISTANT_SANDBOX`` is
-        set. Runtime behavior (image contents, credentials, volume permissions) is validated
+        host path is left unchanged; this runs only when the assistant sandbox is active (see
+        ``assistant_sandbox_enabled``). Runtime behavior (image contents, credentials, volume
+        permissions) is validated
         against a live Docker daemon rather than in unit tests.
         """
         from mlflow.assistant.providers.tool_executor import _uri_without_credentials

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -151,6 +151,16 @@ MLFLOW_SANDBOX_DOCKER_IMAGE = _EnvironmentVariable(
     "MLFLOW_SANDBOX_DOCKER_IMAGE", str, "mlflow-sandbox:latest"
 )
 
+#: **Experimental** — subject to change or removal in a future release.
+#: Docker image used to run the MLflow Assistant's CLI providers (e.g. Claude Code) in a
+#: sandbox. Unlike ``MLFLOW_SANDBOX_DOCKER_IMAGE``, this image must additionally contain the
+#: provider CLI and its language runtime. Operators are expected to build/provide this image;
+#: there is no minimal auto-built fallback for it.
+#: (default: ``mlflow-assistant-sandbox:latest``)
+MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE = _EnvironmentVariable(
+    "MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE", str, "mlflow-assistant-sandbox:latest"
+)
+
 #: When true, newly created workspaces are seeded with two default RBAC roles
 #: (``admin``, ``user``) that super-admins can assign to other
 #: users. ``CreateWorkspace`` is gated to super-admins, whose ``is_admin`` flag already

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -37,7 +37,11 @@ from mlflow.assistant.skill_installer import install_skills, list_installed_skil
 from mlflow.assistant.types import EventType
 from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 from mlflow.server.asgi_utils import get_server_base_url
-from mlflow.server.assistant.session import SessionManager, terminate_session_process
+from mlflow.server.assistant.session import (
+    SessionManager,
+    terminate_session_container,
+    terminate_session_process,
+)
 from mlflow.server.handlers import _add_static_prefix
 
 
@@ -504,7 +508,11 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
         session.pending_tool_decisions = {}
         session.pending_client_tool_results = {}
         SessionManager.save(session_id, session)
-        terminated = terminate_session_process(session_id)
+        # A turn runs either as a host subprocess or (with the sandbox enabled) in a container.
+        # Attempt both (do not short-circuit) and report if either was actually terminated.
+        proc_terminated = terminate_session_process(session_id)
+        container_terminated = terminate_session_container(session_id)
+        terminated = proc_terminated or container_terminated
         msg = "Session cancelled and process terminated" if terminated else "Session cancelled"
         return SessionPatchResponse(message=msg)
 

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -511,7 +511,9 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
         # A turn runs either as a host subprocess or (with the sandbox enabled) in a container.
         # Attempt both (do not short-circuit) and report if either was actually terminated.
         proc_terminated = terminate_session_process(session_id)
-        container_terminated = terminate_session_container(session_id)
+        # terminate_session_container makes blocking Docker-socket calls; run it off the event
+        # loop so a slow/unhealthy Docker daemon can't stall unrelated requests.
+        container_terminated = await asyncio.to_thread(terminate_session_container, session_id)
         terminated = proc_terminated or container_terminated
         msg = "Session cancelled and process terminated" if terminated else "Session cancelled"
         return SessionPatchResponse(message=msg)

--- a/mlflow/server/assistant/api.py
+++ b/mlflow/server/assistant/api.py
@@ -515,7 +515,11 @@ async def patch_session(session_id: str, request: SessionPatchRequest) -> Sessio
         # loop so a slow/unhealthy Docker daemon can't stall unrelated requests.
         container_terminated = await asyncio.to_thread(terminate_session_container, session_id)
         terminated = proc_terminated or container_terminated
-        msg = "Session cancelled and process terminated" if terminated else "Session cancelled"
+        msg = (
+            "Session cancelled and process/sandbox terminated"
+            if terminated
+            else "Session cancelled"
+        )
         return SessionPatchResponse(message=msg)
 
     # This branch is unreachable due to Literal type, but satisfies type checker

--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -286,8 +286,9 @@ def clear_container_id(session_id: str) -> None:
         container_file = get_container_file(session_id)
     except ValueError:
         return
-    if container_file.exists():
-        container_file.unlink()
+    # missing_ok: the stream's finally and a concurrent cancel can both clear the same id; tolerate
+    # the file already being gone rather than raising a spurious error on the losing path.
+    container_file.unlink(missing_ok=True)
 
 
 def get_session_sandbox_home(session_id: str) -> Path:

--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import signal
 import tempfile
@@ -8,6 +9,8 @@ from pathlib import Path
 from typing import Any, Literal
 
 from mlflow.assistant.types import Message
+
+_logger = logging.getLogger(__name__)
 
 SESSION_DIR = Path(tempfile.gettempdir()) / "mlflow-assistant-sessions"
 
@@ -333,4 +336,11 @@ def terminate_session_container(session_id: str) -> bool:
         clear_container_id(session_id)
         return True
     except Exception:
+        # Keep the id (a retry can still reach a possibly-live container) but log it — otherwise a
+        # failed kill is invisible while the cancel endpoint reports the session as cancelled.
+        _logger.warning(
+            "Failed to terminate sandbox container for session %s; leaving its id for retry.",
+            session_id,
+            exc_info=True,
+        )
         return False

--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -291,6 +291,10 @@ def get_session_sandbox_home(session_id: str) -> Path:
     SessionManager.validate_session_id(session_id)
     home = SESSION_DIR / "sandbox-home" / session_id
     home.mkdir(parents=True, exist_ok=True)
+    # This HOME holds the CLI's login credentials and session state, so keep it private to the
+    # server user (0700). mkdir() above is subject to the process umask, and a pre-existing dir
+    # may have looser modes, so enforce it explicitly.
+    home.chmod(0o700)
     return home
 
 

--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -247,3 +247,75 @@ def terminate_session_process(session_id: str) -> bool:
         except (ProcessLookupError, PermissionError):
             clear_process_pid(session_id)
     return False
+
+
+def get_container_file(session_id: str) -> Path:
+    """Get the file path for storing a session's sandbox container id."""
+    SessionManager.validate_session_id(session_id)
+    return SESSION_DIR / f"{session_id}.container.json"
+
+
+def save_container_id(session_id: str, container_id: str) -> None:
+    """Record the sandbox container running a session's turn, for cancellation support."""
+    SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    get_container_file(session_id).write_text(json.dumps({"container_id": container_id}))
+
+
+def get_container_id(session_id: str) -> str | None:
+    try:
+        container_file = get_container_file(session_id)
+    except ValueError:
+        return None
+    if not container_file.exists():
+        return None
+    return json.loads(container_file.read_text()).get("container_id")
+
+
+def clear_container_id(session_id: str) -> None:
+    try:
+        container_file = get_container_file(session_id)
+    except ValueError:
+        return
+    if container_file.exists():
+        container_file.unlink()
+
+
+def get_session_sandbox_home(session_id: str) -> Path:
+    """Server-owned host directory bind-mounted as the sandbox container's ``$HOME``.
+
+    Persists the CLI's ``--resume`` state and caches across turns of a session. It is created
+    here (owned by the server user) so the container, which runs as that same uid:gid, can
+    write to it. These directories accumulate per session; reaping stale ones is handled by
+    the session-lifecycle work.
+    """
+    SessionManager.validate_session_id(session_id)
+    home = SESSION_DIR / "sandbox-home" / session_id
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def terminate_session_container(session_id: str) -> bool:
+    """Kill the sandbox container running a session's turn, if any.
+
+    Returns True only if a container was found and killed. A container that is already gone
+    clears the stored id and returns False. A transient failure (e.g. a daemon hiccup) against
+    a possibly-live container is left as-is — the id is kept so a retry can still reach it.
+    """
+    container_id = get_container_id(session_id)
+    if not container_id:
+        return False
+    try:
+        import docker
+        import docker.errors
+
+        client = docker.from_env()
+        try:
+            container = client.containers.get(container_id)
+        except docker.errors.NotFound:
+            clear_container_id(session_id)
+            return False
+        container.kill()
+        clear_container_id(session_id)
+        return True
+    except Exception:
+        return False

--- a/mlflow/server/assistant/session.py
+++ b/mlflow/server/assistant/session.py
@@ -217,7 +217,12 @@ def get_process_pid(session_id: str) -> int | None:
         return None
     if not process_file.exists():
         return None
-    data = json.loads(process_file.read_text())
+    try:
+        data = json.loads(process_file.read_text())
+    except (OSError, ValueError):
+        # A truncated/corrupt file (writes are not atomic) or one that vanished after the
+        # exists() check must not turn a cancel lookup into an error; treat it as absent.
+        return None
     return data.get("pid")
 
 
@@ -268,7 +273,12 @@ def get_container_id(session_id: str) -> str | None:
         return None
     if not container_file.exists():
         return None
-    return json.loads(container_file.read_text()).get("container_id")
+    try:
+        return json.loads(container_file.read_text()).get("container_id")
+    except (OSError, ValueError):
+        # A truncated/corrupt file (writes are not atomic) or one that vanished after the
+        # exists() check must not turn a cancel lookup into an error; treat it as absent.
+        return None
 
 
 def clear_container_id(session_id: str) -> None:

--- a/mlflow/server/sandbox/__init__.py
+++ b/mlflow/server/sandbox/__init__.py
@@ -13,10 +13,18 @@ from mlflow.server.sandbox.container import (
     run_in_sandbox,
     to_container_host_uri,
 )
+from mlflow.server.sandbox.streaming import (
+    SandboxProcess,
+    sandbox_input_path,
+    start_sandbox_process,
+)
 
 __all__ = [
+    "SandboxProcess",
     "SandboxResult",
     "SandboxUnavailableError",
     "run_in_sandbox",
+    "sandbox_input_path",
+    "start_sandbox_process",
     "to_container_host_uri",
 ]

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -177,8 +177,9 @@ class SandboxProcess:
                         # container so logs() ends, and surface it rather than risking an OOM.
                         self.kill()
                         raise SandboxUnavailableError(
-                            f"Sandbox emitted a single stdout line over {_MAX_LINE_BYTES} bytes "
-                            "with no newline; aborting the stream to bound server memory."
+                            f"Sandbox emitted a single stdout line of {len(buffer)} bytes with no "
+                            f"newline, over the {_MAX_LINE_BYTES}-byte cap; aborting the stream to "
+                            "bound server memory."
                         )
                 if buffer and not _put_line(bytes(buffer)):
                     return
@@ -239,6 +240,10 @@ class SandboxProcess:
         except Exception:
             pass
 
+    async def akill(self) -> None:
+        """``kill()`` off the event loop — it makes a blocking docker-py socket call."""
+        await asyncio.to_thread(self.kill)
+
     def cleanup(self) -> None:
         try:
             self._container.remove(force=True)
@@ -247,6 +252,12 @@ class SandboxProcess:
         shutil.rmtree(self._io_dir, ignore_errors=True)
         if self._ephemeral_home is not None:
             shutil.rmtree(self._ephemeral_home, ignore_errors=True)
+
+    async def aclose(self) -> None:
+        """``cleanup()`` off the event loop — force-removing the container blocks on docker-py, so
+        running it inline would stall the server on a slow/unhealthy daemon during teardown.
+        """
+        await asyncio.to_thread(self.cleanup)
 
 
 def start_sandbox_process(

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -53,6 +53,10 @@ _STDIN_FILE = "stdin"
 # model endpoint) otherwise streams nothing and the turn would hang indefinitely. This is an
 # idle timeout, not a total-runtime cap, so a turn that keeps streaming output is never cut.
 _DEFAULT_STREAM_IDLE_TIMEOUT = 120.0
+# Max stdout lines buffered between the drain thread and the consumer. Bounds memory if the CLI
+# emits faster than a slow SSE client drains: the drain thread blocks (applying backpressure to
+# the container) instead of the queue growing without limit.
+_MAX_BUFFERED_LINES = 1000
 
 
 def sandbox_input_path(name: str) -> str:
@@ -100,13 +104,17 @@ class SandboxProcess:
         """Yield stdout lines (bytes, newline-stripped) as the container produces them.
 
         ``container.logs(stream=True, follow=True)`` is a blocking generator, so it is drained
-        on a worker thread that hands items to this coroutine through a queue. The queue is
-        unbounded: a single turn's output is bounded by the CLI, and the SSE consumer drains it
-        promptly, so back-pressure is not enforced here (a limitation, not a leak).
+        on a worker thread that hands items to this coroutine through a queue. Buffering is
+        bounded to ``_MAX_BUFFERED_LINES`` via a semaphore: the drain thread blocks before
+        enqueuing once that many lines are unconsumed, so a slow SSE client applies backpressure
+        to the container rather than letting the queue grow until the server is OOM-killed.
         """
         loop = asyncio.get_running_loop()
         # Items are bytes lines, a terminal sentinel, or an Exception raised while draining.
         queue: asyncio.Queue[bytes | object | Exception] = asyncio.Queue()
+        # Bounds in-flight data lines: the drain thread acquires a permit before enqueuing a line
+        # (blocking when the consumer is behind) and the consumer releases one after taking a line.
+        capacity = threading.Semaphore(_MAX_BUFFERED_LINES)
         sentinel = object()
         last_activity = time.monotonic()
         stop_watchdog = threading.Event()
@@ -124,6 +132,16 @@ class SandboxProcess:
             except RuntimeError:
                 pass
 
+        def _put_line(line: bytes) -> bool:
+            # Backpressure: wait for the consumer to free a slot before enqueuing, so a slow
+            # reader can't grow the queue without bound. Give up if the consumer has torn down
+            # (its finally sets stop_watchdog) so this daemon thread does not park forever.
+            while not capacity.acquire(timeout=1.0):
+                if stop_watchdog.is_set():
+                    return False
+            _safe_put(line)
+            return True
+
         def _drain() -> None:
             # bytearray append is amortized O(1); a plain bytes `+=` is O(n^2) for a single very
             # large stream-json line (tool results can be tens of MB).
@@ -135,10 +153,11 @@ class SandboxProcess:
                     _bump()
                     buffer.extend(chunk)
                     while (newline := buffer.find(b"\n")) != -1:
-                        _safe_put(bytes(buffer[:newline]))
+                        if not _put_line(bytes(buffer[:newline])):
+                            return
                         del buffer[: newline + 1]
-                if buffer:
-                    _safe_put(bytes(buffer))
+                if buffer and not _put_line(bytes(buffer)):
+                    return
             except Exception as e:
                 _safe_put(e)
             finally:
@@ -167,8 +186,12 @@ class SandboxProcess:
                     break
                 if isinstance(item, Exception):
                     raise SandboxUnavailableError(f"Sandbox output stream failed: {item}")
+                # Free the slot this line held so the drain thread may enqueue the next one.
+                capacity.release()
                 yield item
         finally:
+            # The drain thread's acquire() times out every second and re-checks this, so it
+            # observes the teardown and exits without needing an extra release here.
             stop_watchdog.set()
 
     async def wait(self) -> int:
@@ -286,7 +309,9 @@ def start_sandbox_process(
             security_opt=["no-new-privileges:true"],
             # Run as the server's user so files created in the bind-mounted workspace/HOME are
             # owned by the server, not root. The rootfs stays writable (unlike run_in_sandbox):
-            # the CLI and its language runtime write caches outside $HOME.
+            # the CLI and its language runtime write caches outside $HOME. NOTE: if the MLflow
+            # server itself runs as root (uid 0), this is 0:gid and the sandbox is root too — the
+            # non-root posture holds only when the server runs as a non-root user.
             user=f"{os.getuid()}:{os.getgid()}",
             working_dir=working_dir,
             environment=env,

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -53,15 +53,16 @@ _STDIN_FILE = "stdin"
 # model endpoint) otherwise streams nothing and the turn would hang indefinitely. This is an
 # idle timeout, not a total-runtime cap, so a turn that keeps streaming output is never cut.
 _DEFAULT_STREAM_IDLE_TIMEOUT = 120.0
-# Max stdout lines buffered between the drain thread and the consumer. Bounds memory if the CLI
-# emits faster than a slow SSE client drains: the drain thread blocks (applying backpressure to
-# the container) instead of the queue growing without limit.
-_MAX_BUFFERED_LINES = 1000
-# Max bytes for a single stdout line. The buffered-line count above bounds memory only if each
-# line is itself bounded; without this, output that never emits a newline would grow the drain
-# buffer without limit and could OOM the server. A stream-json line (e.g. a large tool result)
-# can legitimately be tens of MB, so this is set well above that; exceeding it is treated as
-# malformed output and aborts the stream.
+# Max total stdout bytes buffered between the drain thread and the consumer. Bounds memory if the
+# CLI emits faster than a slow SSE client drains: the drain thread blocks (applying backpressure
+# to the container) once this many unconsumed bytes are in flight, instead of the queue growing
+# without limit. Bounding by bytes rather than line count keeps the ceiling fixed regardless of
+# how large individual lines are.
+_MAX_BUFFERED_BYTES = 256 * 1024 * 1024
+# Max bytes for a single stdout line, enforced while accumulating an unterminated line: without
+# it, output that never emits a newline would grow the drain buffer without limit and could OOM
+# the server. A stream-json line (e.g. a large tool result) can legitimately be tens of MB, so
+# this sits above that but within the in-flight budget; exceeding it aborts the stream.
 _MAX_LINE_BYTES = 128 * 1024 * 1024
 
 
@@ -111,16 +112,19 @@ class SandboxProcess:
 
         ``container.logs(stream=True, follow=True)`` is a blocking generator, so it is drained
         on a worker thread that hands items to this coroutine through a queue. Buffering is
-        bounded to ``_MAX_BUFFERED_LINES`` via a semaphore: the drain thread blocks before
-        enqueuing once that many lines are unconsumed, so a slow SSE client applies backpressure
-        to the container rather than letting the queue grow until the server is OOM-killed.
+        bounded to ``_MAX_BUFFERED_BYTES`` of in-flight output: the drain thread blocks before
+        enqueuing once that many unconsumed bytes are queued, so a slow SSE client applies
+        backpressure to the container rather than letting the queue grow until the server is
+        OOM-killed.
         """
         loop = asyncio.get_running_loop()
         # Items are bytes lines, a terminal sentinel, or an Exception raised while draining.
         queue: asyncio.Queue[bytes | object | Exception] = asyncio.Queue()
-        # Bounds in-flight data lines: the drain thread acquires a permit before enqueuing a line
-        # (blocking when the consumer is behind) and the consumer releases one after taking a line.
-        capacity = threading.Semaphore(_MAX_BUFFERED_LINES)
+        # Bounds in-flight bytes: the drain thread waits until a line fits under the budget before
+        # enqueuing it (blocking when the consumer is behind) and the consumer subtracts a line's
+        # bytes after dequeuing it. Guarded by the condition so both threads see a consistent total.
+        budget = threading.Condition()
+        buffered_bytes = 0
         sentinel = object()
         last_activity = time.monotonic()
         stop_watchdog = threading.Event()
@@ -139,12 +143,18 @@ class SandboxProcess:
                 pass
 
         def _put_line(line: bytes) -> bool:
-            # Backpressure: wait for the consumer to free a slot before enqueuing, so a slow
-            # reader can't grow the queue without bound. Give up if the consumer has torn down
+            # Backpressure: wait until this line fits within the in-flight byte budget before
+            # enqueuing, so a slow reader can't grow the queue without bound. A line is always
+            # admitted when nothing is buffered (so a single line up to _MAX_LINE_BYTES still
+            # passes even if it alone exceeds the budget). Give up if the consumer has torn down
             # (its finally sets stop_watchdog) so this daemon thread does not park forever.
-            while not capacity.acquire(timeout=1.0):
-                if stop_watchdog.is_set():
-                    return False
+            nonlocal buffered_bytes
+            with budget:
+                while buffered_bytes and buffered_bytes + len(line) > _MAX_BUFFERED_BYTES:
+                    if stop_watchdog.is_set():
+                        return False
+                    budget.wait(timeout=1.0)
+                buffered_bytes += len(line)
             _safe_put(line)
             return True
 
@@ -200,13 +210,17 @@ class SandboxProcess:
                     break
                 if isinstance(item, Exception):
                     raise SandboxUnavailableError(f"Sandbox output stream failed: {item}")
-                # Free the slot this line held so the drain thread may enqueue the next one.
-                capacity.release()
+                # Free the bytes this line held so the drain thread may enqueue more.
+                with budget:
+                    buffered_bytes -= len(item)
+                    budget.notify()
                 yield item
         finally:
-            # The drain thread's acquire() times out every second and re-checks this, so it
-            # observes the teardown and exits without needing an extra release here.
-            stop_watchdog.set()
+            # The drain thread's budget.wait() times out every second and re-checks this, so it
+            # observes the teardown and exits; wake it now so it does not linger up to a second.
+            with budget:
+                stop_watchdog.set()
+                budget.notify_all()
 
     async def wait(self) -> int:
         outcome = await asyncio.to_thread(self._container.wait)

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -154,6 +154,10 @@ class SandboxProcess:
                     if stop_watchdog.is_set():
                         return False
                     budget.wait(timeout=1.0)
+                    # Blocking here means the container produced this line and we are waiting on a
+                    # slow consumer — that is backpressure, not an idle container, so keep the idle
+                    # watchdog from killing a live turn. A truly gone consumer sets stop_watchdog.
+                    _bump()
                 buffered_bytes += len(line)
             _safe_put(line)
             return True

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -28,6 +28,7 @@ import shlex
 import shutil
 import tempfile
 import threading
+import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -48,6 +49,11 @@ _IO_MOUNT = "/sandbox-io"  # read-only: stdin buffer + any input files (e.g. sys
 _HOME_MOUNT = "/home/sandbox"  # writable bind mount: CLI caches + --resume state
 _STDIN_FILE = "stdin"
 
+# Kill the container if it produces no output for this long. A stuck CLI (e.g. an unreachable
+# model endpoint) otherwise streams nothing and the turn would hang indefinitely. This is an
+# idle timeout, not a total-runtime cap, so a turn that keeps streaming output is never cut.
+_DEFAULT_STREAM_IDLE_TIMEOUT = 120.0
+
 
 def sandbox_input_path(name: str) -> str:
     """In-container path of an input file passed via ``start_sandbox_process(input_files=...)``."""
@@ -63,11 +69,19 @@ class SandboxProcess:
     created because no caller-managed one was supplied).
     """
 
-    def __init__(self, container, io_dir: Path, ephemeral_home: Path | None = None) -> None:
+    def __init__(
+        self,
+        container,
+        io_dir: Path,
+        ephemeral_home: Path | None = None,
+        idle_timeout: float | None = None,
+    ) -> None:
         self._container = container
         self._io_dir = io_dir
         self._ephemeral_home = ephemeral_home
+        self._idle_timeout = idle_timeout
         self._returncode: int | None = None
+        self._timed_out = False
 
     @property
     def container_id(self) -> str:
@@ -76,6 +90,11 @@ class SandboxProcess:
     @property
     def returncode(self) -> int | None:
         return self._returncode
+
+    @property
+    def timed_out(self) -> bool:
+        """Whether the container was killed for producing no output within ``idle_timeout``."""
+        return self._timed_out
 
     async def iter_stdout_lines(self) -> AsyncIterator[bytes]:
         """Yield stdout lines (bytes, newline-stripped) as the container produces them.
@@ -89,6 +108,12 @@ class SandboxProcess:
         # Items are bytes lines, a terminal sentinel, or an Exception raised while draining.
         queue: asyncio.Queue[bytes | object | Exception] = asyncio.Queue()
         sentinel = object()
+        last_activity = time.monotonic()
+        stop_watchdog = threading.Event()
+
+        def _bump() -> None:
+            nonlocal last_activity
+            last_activity = time.monotonic()
 
         def _safe_put(item: object) -> None:
             # The consumer may be torn down (loop closed) while this daemon thread is still
@@ -107,6 +132,7 @@ class SandboxProcess:
                 for chunk in self._container.logs(
                     stream=True, follow=True, stdout=True, stderr=False
                 ):
+                    _bump()
                     buffer.extend(chunk)
                     while (newline := buffer.find(b"\n")) != -1:
                         _safe_put(bytes(buffer[:newline]))
@@ -118,15 +144,32 @@ class SandboxProcess:
             finally:
                 _safe_put(sentinel)
 
-        threading.Thread(target=_drain, name="mlflow-sandbox-stdout-drain", daemon=True).start()
+        def _watchdog() -> None:
+            # Kill the container if it produces no output for `idle_timeout`; that ends the
+            # blocking logs() stream so the drain loop completes and the turn does not hang.
+            interval = min(self._idle_timeout, 5.0)
+            while not stop_watchdog.wait(interval):
+                if time.monotonic() - last_activity > self._idle_timeout:
+                    self._timed_out = True
+                    self.kill()
+                    return
 
-        while True:
-            item = await queue.get()
-            if item is sentinel:
-                break
-            if isinstance(item, Exception):
-                raise SandboxUnavailableError(f"Sandbox output stream failed: {item}")
-            yield item
+        threading.Thread(target=_drain, name="mlflow-sandbox-stdout-drain", daemon=True).start()
+        if self._idle_timeout:
+            threading.Thread(
+                target=_watchdog, name="mlflow-sandbox-idle-watchdog", daemon=True
+            ).start()
+
+        try:
+            while True:
+                item = await queue.get()
+                if item is sentinel:
+                    break
+                if isinstance(item, Exception):
+                    raise SandboxUnavailableError(f"Sandbox output stream failed: {item}")
+                yield item
+        finally:
+            stop_watchdog.set()
 
     async def wait(self) -> int:
         outcome = await asyncio.to_thread(self._container.wait)
@@ -163,6 +206,7 @@ def start_sandbox_process(
     stdin_data: bytes = b"",
     input_files: dict[str, str] | None = None,
     home_dir: Path | None = None,
+    idle_timeout: float | None = _DEFAULT_STREAM_IDLE_TIMEOUT,
 ) -> SandboxProcess:
     """Start ``argv`` in a hardened, streaming sandbox container.
 
@@ -178,6 +222,9 @@ def start_sandbox_process(
             state (such as ``--resume`` session history) persists across calls. It must be
             writable by the current user (the container runs as this uid:gid). When None an
             ephemeral ``$HOME`` is created and removed by ``cleanup()``.
+        idle_timeout: Kill the container if it produces no output for this many seconds (see
+            ``SandboxProcess.timed_out``). None disables it. This bounds a stuck CLI without
+            cutting a turn that keeps streaming.
 
     Returns:
         A SandboxProcess wrapping the started container.
@@ -251,7 +298,9 @@ def start_sandbox_process(
             shutil.rmtree(ephemeral_home, ignore_errors=True)
         raise SandboxUnavailableError(f"Failed to start sandbox container: {e}")
 
-    return SandboxProcess(container, io_dir, ephemeral_home=ephemeral_home)
+    return SandboxProcess(
+        container, io_dir, ephemeral_home=ephemeral_home, idle_timeout=idle_timeout
+    )
 
 
 def _require_image(client, image: str) -> None:

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -57,6 +57,12 @@ _DEFAULT_STREAM_IDLE_TIMEOUT = 120.0
 # emits faster than a slow SSE client drains: the drain thread blocks (applying backpressure to
 # the container) instead of the queue growing without limit.
 _MAX_BUFFERED_LINES = 1000
+# Max bytes for a single stdout line. The buffered-line count above bounds memory only if each
+# line is itself bounded; without this, output that never emits a newline would grow the drain
+# buffer without limit and could OOM the server. A stream-json line (e.g. a large tool result)
+# can legitimately be tens of MB, so this is set well above that; exceeding it is treated as
+# malformed output and aborts the stream.
+_MAX_LINE_BYTES = 128 * 1024 * 1024
 
 
 def sandbox_input_path(name: str) -> str:
@@ -156,6 +162,14 @@ class SandboxProcess:
                         if not _put_line(bytes(buffer[:newline])):
                             return
                         del buffer[: newline + 1]
+                    if len(buffer) > _MAX_LINE_BYTES:
+                        # An unterminated line past the cap would grow without bound. Stop the
+                        # container so logs() ends, and surface it rather than risking an OOM.
+                        self.kill()
+                        raise SandboxUnavailableError(
+                            f"Sandbox emitted a single stdout line over {_MAX_LINE_BYTES} bytes "
+                            "with no newline; aborting the stream to bound server memory."
+                        )
                 if buffer and not _put_line(bytes(buffer)):
                     return
             except Exception as e:
@@ -321,7 +335,7 @@ def start_sandbox_process(
         shutil.rmtree(io_dir, ignore_errors=True)
         if ephemeral_home is not None:
             shutil.rmtree(ephemeral_home, ignore_errors=True)
-        raise SandboxUnavailableError(f"Failed to start sandbox container: {e}")
+        raise SandboxUnavailableError(f"Failed to start sandbox container: {e}") from e
 
     return SandboxProcess(
         container, io_dir, ephemeral_home=ephemeral_home, idle_timeout=idle_timeout
@@ -337,10 +351,10 @@ def _require_image(client, image: str) -> None:
 
     try:
         client.images.get(image)
-    except docker.errors.ImageNotFound:
+    except docker.errors.ImageNotFound as e:
         raise SandboxUnavailableError(
             f"Assistant sandbox image {image!r} was not found. Build or pull an image that "
             "contains the provider CLI, or set MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE."
-        )
+        ) from e
     except Exception as e:
-        raise SandboxUnavailableError(f"Could not check sandbox image {image!r}: {e}")
+        raise SandboxUnavailableError(f"Could not check sandbox image {image!r}: {e}") from e

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -1,0 +1,272 @@
+"""Streaming sandbox execution.
+
+``run_in_sandbox`` (see ``container.py``) is run-to-completion: start, wait, read logs. The
+assistant's CLI providers (``claude_code``, ``codex``) instead spawn a vendor CLI that streams
+JSON events on stdout while it runs and reads its prompt from stdin, so they need a streaming
+transport. ``start_sandbox_process`` starts the CLI in a hardened container, feeds stdin from a
+buffer via a mounted file, and returns a ``SandboxProcess`` that exposes the container's stdout
+as an async line iterator plus ``wait()``/``read_stderr()``/``kill()`` — the subset of the
+asyncio subprocess interface the providers rely on.
+
+Two deliberate, documented differences from ``run_in_sandbox``'s hardening:
+
+- stdout is streamed live (``container.logs(stream=True, follow=True)``) rather than read after
+  the container exits.
+- the root filesystem is writable (the vendor CLI and its language runtime write caches outside
+  ``$HOME``), while ``$HOME`` is a bind-mounted host directory holding the CLI's ``--resume``
+  session state and caches. ``cap_drop=ALL``, ``no-new-privileges``, the resource caps, the
+  network posture, and running as the server's ``uid:gid`` are retained.
+
+The image contents, credential format, and mount behavior are validated with a live Docker
+daemon rather than in unit tests (the flag is experimental and off by default).
+"""
+
+import asyncio
+import logging
+import os
+import shlex
+import shutil
+import tempfile
+import threading
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from mlflow.environment_variables import MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE
+from mlflow.server.sandbox.container import (
+    _MEMORY_LIMIT,
+    _NANO_CPUS,
+    _PIDS_LIMIT,
+    _WORKSPACE_MOUNT,
+    SandboxUnavailableError,
+    _get_client,
+)
+
+_logger = logging.getLogger(__name__)
+
+# Mount points inside the container.
+_IO_MOUNT = "/sandbox-io"  # read-only: stdin buffer + any input files (e.g. system prompt)
+_HOME_MOUNT = "/home/sandbox"  # writable bind mount: CLI caches + --resume state
+_STDIN_FILE = "stdin"
+
+
+def sandbox_input_path(name: str) -> str:
+    """In-container path of an input file passed via ``start_sandbox_process(input_files=...)``."""
+    return f"{_IO_MOUNT}/{name}"
+
+
+class SandboxProcess:
+    """A running sandbox container exposed with a subset of the asyncio subprocess interface.
+
+    The providers iterate ``iter_stdout_lines()`` for streamed output, call ``wait()`` for the
+    exit code, ``read_stderr()`` on failure, and ``kill()`` to cancel. ``cleanup()`` removes the
+    container and the temporary IO directory (and an ephemeral ``$HOME`` directory, if one was
+    created because no caller-managed one was supplied).
+    """
+
+    def __init__(self, container, io_dir: Path, ephemeral_home: Path | None = None) -> None:
+        self._container = container
+        self._io_dir = io_dir
+        self._ephemeral_home = ephemeral_home
+        self._returncode: int | None = None
+
+    @property
+    def container_id(self) -> str:
+        return self._container.id
+
+    @property
+    def returncode(self) -> int | None:
+        return self._returncode
+
+    async def iter_stdout_lines(self) -> AsyncIterator[bytes]:
+        """Yield stdout lines (bytes, newline-stripped) as the container produces them.
+
+        ``container.logs(stream=True, follow=True)`` is a blocking generator, so it is drained
+        on a worker thread that hands items to this coroutine through a queue. The queue is
+        unbounded: a single turn's output is bounded by the CLI, and the SSE consumer drains it
+        promptly, so back-pressure is not enforced here (a limitation, not a leak).
+        """
+        loop = asyncio.get_running_loop()
+        # Items are bytes lines, a terminal sentinel, or an Exception raised while draining.
+        queue: asyncio.Queue[bytes | object | Exception] = asyncio.Queue()
+        sentinel = object()
+
+        def _safe_put(item: object) -> None:
+            # The consumer may be torn down (loop closed) while this daemon thread is still
+            # blocked in container.logs(); a closed loop makes call_soon_threadsafe raise. Drop
+            # the item rather than surface a stray traceback from the thread.
+            try:
+                loop.call_soon_threadsafe(queue.put_nowait, item)
+            except RuntimeError:
+                pass
+
+        def _drain() -> None:
+            # bytearray append is amortized O(1); a plain bytes `+=` is O(n^2) for a single very
+            # large stream-json line (tool results can be tens of MB).
+            buffer = bytearray()
+            try:
+                for chunk in self._container.logs(
+                    stream=True, follow=True, stdout=True, stderr=False
+                ):
+                    buffer.extend(chunk)
+                    while (newline := buffer.find(b"\n")) != -1:
+                        _safe_put(bytes(buffer[:newline]))
+                        del buffer[: newline + 1]
+                if buffer:
+                    _safe_put(bytes(buffer))
+            except Exception as e:
+                _safe_put(e)
+            finally:
+                _safe_put(sentinel)
+
+        threading.Thread(target=_drain, name="mlflow-sandbox-stdout-drain", daemon=True).start()
+
+        while True:
+            item = await queue.get()
+            if item is sentinel:
+                break
+            if isinstance(item, Exception):
+                raise SandboxUnavailableError(f"Sandbox output stream failed: {item}")
+            yield item
+
+    async def wait(self) -> int:
+        outcome = await asyncio.to_thread(self._container.wait)
+        self._returncode = outcome.get("StatusCode", 0) if isinstance(outcome, dict) else 0
+        return self._returncode
+
+    async def read_stderr(self) -> bytes:
+        try:
+            return await asyncio.to_thread(lambda: self._container.logs(stdout=False, stderr=True))
+        except Exception:
+            return b""
+
+    def kill(self) -> None:
+        try:
+            self._container.kill()
+        except Exception:
+            pass
+
+    def cleanup(self) -> None:
+        try:
+            self._container.remove(force=True)
+        except Exception:
+            pass
+        shutil.rmtree(self._io_dir, ignore_errors=True)
+        if self._ephemeral_home is not None:
+            shutil.rmtree(self._ephemeral_home, ignore_errors=True)
+
+
+def start_sandbox_process(
+    argv: list[str],
+    *,
+    workdir: Path | None = None,
+    environment: dict[str, str] | None = None,
+    stdin_data: bytes = b"",
+    input_files: dict[str, str] | None = None,
+    home_dir: Path | None = None,
+) -> SandboxProcess:
+    """Start ``argv`` in a hardened, streaming sandbox container.
+
+    Args:
+        argv: The command to run inside the container (in-container paths).
+        workdir: Host directory bind-mounted read-write at ``/workspace`` and used as the
+            working directory. When None the container has no workspace mount.
+        environment: Extra environment variables to set inside the container.
+        stdin_data: Bytes written to a mounted file and fed to ``argv`` on stdin.
+        input_files: name -> text files written into the read-only ``/sandbox-io`` mount (e.g.
+            a system-prompt file the CLI reads by path).
+        home_dir: Caller-managed host directory bind-mounted read-write at ``$HOME`` so CLI
+            state (such as ``--resume`` session history) persists across calls. It must be
+            writable by the current user (the container runs as this uid:gid). When None an
+            ephemeral ``$HOME`` is created and removed by ``cleanup()``.
+
+    Returns:
+        A SandboxProcess wrapping the started container.
+
+    Raises:
+        SandboxUnavailableError: If Docker is unavailable, the image is missing, or the
+            container cannot be started.
+    """
+    if os.name == "nt":
+        raise SandboxUnavailableError("The sandbox requires a POSIX host running Docker.")
+
+    client = _get_client()
+    image = MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE.get()
+    _require_image(client, image)
+
+    io_dir = Path(tempfile.mkdtemp(prefix="mlflow-sandbox-io-"))
+    (io_dir / _STDIN_FILE).write_bytes(stdin_data)
+    for name, text in (input_files or {}).items():
+        (io_dir / name).write_text(text, encoding="utf-8")
+
+    # $HOME must be writable by the container's uid:gid (set below). A caller-managed dir is
+    # created server-side (so it is owned by this user); otherwise use an ephemeral one.
+    ephemeral_home = None
+    if home_dir is None:
+        ephemeral_home = Path(tempfile.mkdtemp(prefix="mlflow-sandbox-home-"))
+        home_host = ephemeral_home
+    else:
+        home_host = home_dir
+
+    env = dict(environment or {})
+    env.setdefault("HOME", _HOME_MOUNT)
+
+    volumes = {
+        str(io_dir): {"bind": _IO_MOUNT, "mode": "ro"},
+        str(home_host): {"bind": _HOME_MOUNT, "mode": "rw"},
+    }
+    working_dir = None
+    if workdir is not None:
+        volumes[str(workdir)] = {"bind": _WORKSPACE_MOUNT, "mode": "rw"}
+        working_dir = _WORKSPACE_MOUNT
+
+    # Redirect the CLI's stdin from the mounted buffer file rather than opening an attach
+    # socket. shlex-join is safe here: argv is built by the provider, not user input, and the
+    # container is the isolation boundary regardless.
+    command = ["sh", "-c", f"exec {shlex.join(argv)} < {_IO_MOUNT}/{_STDIN_FILE}"]
+
+    try:
+        container = client.containers.run(
+            image,
+            command=command,
+            detach=True,
+            network_mode="bridge",
+            extra_hosts={"host.docker.internal": "host-gateway"},
+            mem_limit=_MEMORY_LIMIT,
+            memswap_limit=_MEMORY_LIMIT,
+            nano_cpus=_NANO_CPUS,
+            pids_limit=_PIDS_LIMIT,
+            cap_drop=["ALL"],
+            security_opt=["no-new-privileges:true"],
+            # Run as the server's user so files created in the bind-mounted workspace/HOME are
+            # owned by the server, not root. The rootfs stays writable (unlike run_in_sandbox):
+            # the CLI and its language runtime write caches outside $HOME.
+            user=f"{os.getuid()}:{os.getgid()}",
+            working_dir=working_dir,
+            environment=env,
+            volumes=volumes,
+        )
+    except Exception as e:
+        shutil.rmtree(io_dir, ignore_errors=True)
+        if ephemeral_home is not None:
+            shutil.rmtree(ephemeral_home, ignore_errors=True)
+        raise SandboxUnavailableError(f"Failed to start sandbox container: {e}")
+
+    return SandboxProcess(container, io_dir, ephemeral_home=ephemeral_home)
+
+
+def _require_image(client, image: str) -> None:
+    """Ensure the CLI sandbox image is present. Unlike the generic run-to-completion sandbox,
+    this never auto-builds a fallback: the image must contain the provider CLI, so a missing
+    one is an operator setup error, not something to paper over with a CLI-less build.
+    """
+    import docker.errors
+
+    try:
+        client.images.get(image)
+    except docker.errors.ImageNotFound:
+        raise SandboxUnavailableError(
+            f"Assistant sandbox image {image!r} was not found. Build or pull an image that "
+            "contains the provider CLI, or set MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE."
+        )
+    except Exception as e:
+        raise SandboxUnavailableError(f"Could not check sandbox image {image!r}: {e}")

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -1055,3 +1055,33 @@ async def provider_astream_once():
     provider = ClaudeCodeProvider()
     async for event in provider.astream("hi", "http://localhost:5000"):
         yield event
+
+
+def test_is_available_true_in_sandbox_mode(monkeypatch):
+    # With the sandbox enabled the CLI runs in the operator image, not on the host.
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    with patch("mlflow.assistant.providers.claude_code.shutil.which", return_value=None):
+        assert ClaudeCodeProvider().is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_mounts_google_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    creds = tmp_path / "gcp.json"
+    creds.write_text('{"type": "service_account"}')
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(creds))
+    fake = _FakeSandboxProcess(lines=[b'{"type":"result","session_id":"s1"}'])
+    provider = ClaudeCodeProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake) as start,
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        _ = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    kwargs = start.call_args.kwargs
+    # The host cred file's contents are copied into the read-only input mount, and the env points
+    # at the in-container path rather than the (unmounted) host path.
+    mounted = kwargs["input_files"]["google-application-credentials.json"]
+    assert mounted == '{"type": "service_account"}'
+    assert kwargs["environment"]["GOOGLE_APPLICATION_CREDENTIALS"].startswith("/sandbox-io/")

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -863,10 +863,11 @@ async def test_astream_skips_rate_limit_event():
 class _FakeSandboxProcess:
     """Stand-in for mlflow.server.sandbox.SandboxProcess used to drive the sandbox path."""
 
-    def __init__(self, lines, returncode=0, stderr=b""):
+    def __init__(self, lines, returncode=0, stderr=b"", timed_out=False):
         self._lines = lines
         self._returncode = returncode
         self._stderr = stderr
+        self.timed_out = timed_out
         self.container_id = "container-abc"
         self.cleaned_up = False
 
@@ -1005,3 +1006,52 @@ async def test_astream_in_sandbox_non_json_line_becomes_message(monkeypatch):
     assert events
     assert not any(e.type == EventType.ERROR for e in events)
     assert fake.cleaned_up is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_timeout_surfaces_error(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(lines=[], returncode=137, timed_out=True)
+    provider = ClaudeCodeProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    errored = [e for e in events if e.type == EventType.ERROR]
+    assert errored, "a timed-out sandbox turn should surface an error, not a bare interrupt"
+    assert "no output for too long" in errored[0].to_sse_event()
+    assert fake.cleaned_up is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_rewrites_loopback_base_url(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:4000/v1")
+    fake = _FakeSandboxProcess(lines=[], returncode=0)
+    captured = {}
+
+    def _capture(*args, **kwargs):
+        captured["environment"] = kwargs.get("environment")
+        return fake
+
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", side_effect=_capture),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        _ = [e async for e in provider_astream_once()]
+
+    env = captured["environment"]
+    # A loopback base URL is rewritten so the CLI can reach the host from inside the container.
+    assert env["ANTHROPIC_BASE_URL"] == "http://host.docker.internal:4000/v1"
+    assert env["ANTHROPIC_API_KEY"] == "sk-test"
+
+
+async def provider_astream_once():
+    provider = ClaudeCodeProvider()
+    async for event in provider.astream("hi", "http://localhost:5000"):
+        yield event

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -1085,3 +1085,61 @@ async def test_astream_in_sandbox_mounts_google_credentials(monkeypatch, tmp_pat
     mounted = kwargs["input_files"]["google-application-credentials.json"]
     assert mounted == '{"type": "service_account"}'
     assert kwargs["environment"]["GOOGLE_APPLICATION_CREDENTIALS"].startswith("/sandbox-io/")
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_does_not_forward_non_allowlisted_secret(monkeypatch):
+    # Only allowlisted vars reach the CLI sandbox env; an arbitrary host secret must not leak in.
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-super-secret")
+    fake = _FakeSandboxProcess(lines=[], returncode=0)
+    captured = {}
+
+    def _capture(*args, **kwargs):
+        captured["environment"] = kwargs.get("environment")
+        return fake
+
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", side_effect=_capture),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        _ = [e async for e in provider_astream_once()]
+
+    env = captured["environment"]
+    assert env["ANTHROPIC_API_KEY"] == "sk-test"
+    assert "DATABRICKS_TOKEN" not in env
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_forwards_registry_uri(monkeypatch):
+    # A credential-free registry URI is forwarded (loopback-rewritten); one with embedded
+    # credentials is dropped rather than leaked into the container.
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setenv("MLFLOW_REGISTRY_URI", "http://localhost:5000")
+    fake = _FakeSandboxProcess(lines=[], returncode=0)
+    captured = {}
+
+    def _capture(*args, **kwargs):
+        captured["environment"] = kwargs.get("environment")
+        return fake
+
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", side_effect=_capture),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        _ = [e async for e in provider_astream_once()]
+    assert captured["environment"]["MLFLOW_REGISTRY_URI"] == "http://host.docker.internal:5000"
+
+    # Userinfo assembled from parts so no literal credential URI is committed to source.
+    creds = "u:p"
+    monkeypatch.setenv("MLFLOW_REGISTRY_URI", f"postgresql://{creds}@db.internal/registry")
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", side_effect=_capture),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        _ = [e async for e in provider_astream_once()]
+    assert "MLFLOW_REGISTRY_URI" not in captured["environment"]

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -113,6 +113,15 @@ def test_check_connection_runs_auth_verification_prompt():
     )
 
 
+def test_check_connection_skips_host_probe_in_sandbox_mode(monkeypatch):
+    # In sandbox mode the CLI lives in the image, so a missing host binary must not fail the check.
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
+    with patch("mlflow.assistant.providers.claude_code.shutil.which", return_value=None):
+        ClaudeCodeProvider().check_connection()  # does not raise
+
+
 def test_check_connection_raises_not_authenticated_for_auth_error():
     completed = subprocess.CompletedProcess(
         args=["claude", "-p", "hi", "--max-turns", "1", "--output-format", "json"],

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -893,6 +893,9 @@ class _FakeSandboxProcess:
     def cleanup(self):
         self.cleaned_up = True
 
+    async def aclose(self):
+        self.cleanup()
+
 
 @pytest.mark.asyncio
 async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -887,7 +887,9 @@ class _FakeSandboxProcess:
 
 @pytest.mark.asyncio
 async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     provider = ClaudeCodeProvider()
     sentinel = MagicMock(name="sandbox-event")
 
@@ -902,7 +904,9 @@ async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_does_not_use_sandbox_when_flag_off(monkeypatch):
-    monkeypatch.delenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", raising=False)
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: False
+    )
     provider = ClaudeCodeProvider()
     with (
         patch.object(ClaudeCodeProvider, "_astream_in_sandbox") as sandbox,
@@ -917,7 +921,9 @@ async def test_astream_does_not_use_sandbox_when_flag_off(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_streams_events_and_manages_container(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     fake = _FakeSandboxProcess(
         lines=[
             b'{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}',
@@ -945,7 +951,9 @@ async def test_astream_in_sandbox_streams_events_and_manages_container(monkeypat
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_reports_nonzero_exit(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     fake = _FakeSandboxProcess(lines=[], returncode=2, stderr=b"kaboom")
     provider = ClaudeCodeProvider()
     with (
@@ -961,7 +969,9 @@ async def test_astream_in_sandbox_reports_nonzero_exit(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     from mlflow.server.sandbox import SandboxUnavailableError
 
     provider = ClaudeCodeProvider()
@@ -976,7 +986,9 @@ async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_137_is_interrupted_not_error(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     # A killed container exits 137 (128 + SIGKILL); it must surface as interrupted, not error.
     fake = _FakeSandboxProcess(lines=[], returncode=137)
     provider = ClaudeCodeProvider()
@@ -993,7 +1005,9 @@ async def test_astream_in_sandbox_137_is_interrupted_not_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_non_json_line_becomes_message(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     fake = _FakeSandboxProcess(lines=[b"this is not json"], returncode=0)
     provider = ClaudeCodeProvider()
     with (
@@ -1010,7 +1024,9 @@ async def test_astream_in_sandbox_non_json_line_becomes_message(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_timeout_surfaces_error(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     fake = _FakeSandboxProcess(lines=[], returncode=137, timed_out=True)
     provider = ClaudeCodeProvider()
     with (
@@ -1028,7 +1044,9 @@ async def test_astream_in_sandbox_timeout_surfaces_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_rewrites_loopback_base_url(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:4000/v1")
     fake = _FakeSandboxProcess(lines=[], returncode=0)
@@ -1059,14 +1077,32 @@ async def provider_astream_once():
 
 def test_is_available_true_in_sandbox_mode(monkeypatch):
     # With the sandbox enabled the CLI runs in the operator image, not on the host.
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     with patch("mlflow.assistant.providers.claude_code.shutil.which", return_value=None):
         assert ClaudeCodeProvider().is_available() is True
 
 
+def test_allows_remote_access_follows_sandbox_mode(monkeypatch):
+    # The CLI provider serves remote clients only when sandboxed (isolated in a container);
+    # in local mode it runs on the host and must stay localhost-only.
+    provider = ClaudeCodeProvider()
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: False
+    )
+    assert provider.allows_remote_access is False
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
+    assert provider.allows_remote_access is True
+
+
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_mounts_google_credentials(monkeypatch, tmp_path):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     creds = tmp_path / "gcp.json"
     creds.write_text('{"type": "service_account"}')
     monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(creds))
@@ -1090,7 +1126,9 @@ async def test_astream_in_sandbox_mounts_google_credentials(monkeypatch, tmp_pat
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_does_not_forward_non_allowlisted_secret(monkeypatch):
     # Only allowlisted vars reach the CLI sandbox env; an arbitrary host secret must not leak in.
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-super-secret")
     fake = _FakeSandboxProcess(lines=[], returncode=0)
@@ -1116,7 +1154,9 @@ async def test_astream_in_sandbox_does_not_forward_non_allowlisted_secret(monkey
 async def test_astream_in_sandbox_forwards_registry_uri(monkeypatch):
     # A credential-free registry URI is forwarded (loopback-rewritten); one with embedded
     # credentials is dropped rather than leaked into the container.
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr(
+        "mlflow.assistant.providers.claude_code.assistant_sandbox_enabled", lambda: True
+    )
     monkeypatch.setenv("MLFLOW_REGISTRY_URI", "http://localhost:5000")
     fake = _FakeSandboxProcess(lines=[], returncode=0)
     captured = {}

--- a/tests/assistant/providers/test_claude_code_provider.py
+++ b/tests/assistant/providers/test_claude_code_provider.py
@@ -858,3 +858,150 @@ async def test_astream_skips_rate_limit_event():
     assert len(events) == 2
     assert events[0].type == EventType.MESSAGE
     assert events[1].type == EventType.DONE
+
+
+class _FakeSandboxProcess:
+    """Stand-in for mlflow.server.sandbox.SandboxProcess used to drive the sandbox path."""
+
+    def __init__(self, lines, returncode=0, stderr=b""):
+        self._lines = lines
+        self._returncode = returncode
+        self._stderr = stderr
+        self.container_id = "container-abc"
+        self.cleaned_up = False
+
+    async def iter_stdout_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def wait(self):
+        return self._returncode
+
+    async def read_stderr(self):
+        return self._stderr
+
+    def cleanup(self):
+        self.cleaned_up = True
+
+
+@pytest.mark.asyncio
+async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    provider = ClaudeCodeProvider()
+    sentinel = MagicMock(name="sandbox-event")
+
+    async def fake_sandbox(self, *args, **kwargs):
+        yield sentinel
+
+    with patch.object(ClaudeCodeProvider, "_astream_in_sandbox", fake_sandbox):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert events == [sentinel]
+
+
+@pytest.mark.asyncio
+async def test_astream_does_not_use_sandbox_when_flag_off(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", raising=False)
+    provider = ClaudeCodeProvider()
+    with (
+        patch.object(ClaudeCodeProvider, "_astream_in_sandbox") as sandbox,
+        patch("mlflow.assistant.providers.claude_code.shutil.which", return_value=None),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    sandbox.assert_not_called()
+    # Host path with no CLI installed yields the not-found error.
+    assert any(e.type == EventType.ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_streams_events_and_manages_container(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(
+        lines=[
+            b'{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}',
+            b'{"type":"result","session_id":"sess-1","usage":{"input_tokens":3,"output_tokens":5}}',
+        ]
+    )
+    provider = ClaudeCodeProvider()
+    sid = "11111111-1111-1111-1111-111111111111"
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake) as start,
+        patch("mlflow.assistant.providers.claude_code.save_container_id") as save_cid,
+        patch("mlflow.assistant.providers.claude_code.clear_container_id") as clear_cid,
+    ):
+        events = [
+            e async for e in provider.astream("hi", "http://localhost:5000", mlflow_session_id=sid)
+        ]
+
+    start.assert_called_once()
+    save_cid.assert_called_once_with(sid, "container-abc")
+    clear_cid.assert_called_once_with(sid)
+    assert fake.cleaned_up is True
+    assert events  # at least a usage event and a parsed message were produced
+    assert not any(e.type == EventType.ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_reports_nonzero_exit(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(lines=[], returncode=2, stderr=b"kaboom")
+    provider = ClaudeCodeProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert any(e.type == EventType.ERROR for e in events)
+    assert fake.cleaned_up is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    from mlflow.server.sandbox import SandboxUnavailableError
+
+    provider = ClaudeCodeProvider()
+    with patch(
+        "mlflow.server.sandbox.start_sandbox_process",
+        side_effect=SandboxUnavailableError("no daemon"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert any(e.type == EventType.ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_137_is_interrupted_not_error(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    # A killed container exits 137 (128 + SIGKILL); it must surface as interrupted, not error.
+    fake = _FakeSandboxProcess(lines=[], returncode=137)
+    provider = ClaudeCodeProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert not any(e.type == EventType.ERROR for e in events)
+    assert fake.cleaned_up is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_non_json_line_becomes_message(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(lines=[b"this is not json"], returncode=0)
+    provider = ClaudeCodeProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.claude_code.save_container_id"),
+        patch("mlflow.assistant.providers.claude_code.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert events
+    assert not any(e.type == EventType.ERROR for e in events)
+    assert fake.cleaned_up is True

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -838,7 +838,7 @@ class _FakeSandboxProcess:
 
 @pytest.mark.asyncio
 async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     provider = CodexProvider()
     sentinel = MagicMock(name="sandbox-event")
 
@@ -853,7 +853,7 @@ async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_does_not_use_sandbox_when_flag_off(monkeypatch):
-    monkeypatch.delenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", raising=False)
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: False)
     provider = CodexProvider()
     with (
         patch.object(CodexProvider, "_astream_in_sandbox") as sandbox,
@@ -868,7 +868,7 @@ async def test_astream_does_not_use_sandbox_when_flag_off(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_streams_events_and_manages_container(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     fake = _FakeSandboxProcess(
         lines=_make_stdout_lines(
             {"type": "thread.started", "thread_id": "t1"},
@@ -899,7 +899,7 @@ async def test_astream_in_sandbox_streams_events_and_manages_container(monkeypat
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_reports_nonzero_exit(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     fake = _FakeSandboxProcess(lines=[], returncode=2, stderr=b"kaboom")
     provider = CodexProvider()
     with (
@@ -915,7 +915,7 @@ async def test_astream_in_sandbox_reports_nonzero_exit(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_137_is_interrupted_not_error(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     # A killed container exits 137 (128 + SIGKILL); it must surface as interrupted, not error.
     fake = _FakeSandboxProcess(lines=[], returncode=137)
     provider = CodexProvider()
@@ -932,7 +932,7 @@ async def test_astream_in_sandbox_137_is_interrupted_not_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     from mlflow.server.sandbox import SandboxUnavailableError
 
     provider = CodexProvider()
@@ -947,7 +947,7 @@ async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_aborts_on_persistent_connection_errors(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     # codex streams "Reconnecting..." errors forever when it can't reach the API, so the container
     # idle-timeout never fires. Negative no-progress timeout makes the first such error trip the
     # guard deterministically. It must abort with an error rather than hang or reach later output.
@@ -978,14 +978,24 @@ async def test_astream_in_sandbox_aborts_on_persistent_connection_errors(monkeyp
 def test_is_available_true_in_sandbox_mode(monkeypatch):
     # With the sandbox enabled the CLI runs in the operator image, not on the host, so the
     # provider is available even when the host binary is absent.
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     with patch("mlflow.assistant.providers.codex.shutil.which", return_value=None):
         assert CodexProvider().is_available() is True
 
 
+def test_allows_remote_access_follows_sandbox_mode(monkeypatch):
+    # The CLI provider serves remote clients only when sandboxed (isolated in a container);
+    # in local mode it runs on the host and must stay localhost-only.
+    provider = CodexProvider()
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: False)
+    assert provider.allows_remote_access is False
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
+    assert provider.allows_remote_access is True
+
+
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_uses_external_uri_in_prompt(monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     fake = _FakeSandboxProcess(
         lines=_make_stdout_lines({"type": "thread.started", "thread_id": "t1"})
     )
@@ -1008,7 +1018,7 @@ async def test_astream_in_sandbox_uses_external_uri_in_prompt(monkeypatch):
 @pytest.mark.asyncio
 async def test_astream_in_sandbox_does_not_forward_non_allowlisted_secret(monkeypatch):
     # Only allowlisted vars reach the CLI sandbox env; an arbitrary host secret must not leak in.
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-super-secret")
     fake = _FakeSandboxProcess(
@@ -1045,7 +1055,7 @@ async def _capture_sandbox_env(provider):
 async def test_astream_in_sandbox_forwards_registry_uri(monkeypatch):
     # A credential-free registry URI is forwarded (loopback-rewritten); one with embedded
     # credentials is dropped rather than leaked into the container.
-    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
     provider = CodexProvider()
 
     monkeypatch.setenv("MLFLOW_REGISTRY_URI", "http://localhost:5000")

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -81,6 +81,13 @@ def test_provider_display_name():
     assert CodexProvider().display_name == "Codex"
 
 
+def test_check_connection_skips_host_probe_in_sandbox_mode(monkeypatch):
+    # In sandbox mode the CLI lives in the image, so a missing host binary must not fail the check.
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
+    with patch("mlflow.assistant.providers.codex.shutil.which", return_value=None):
+        CodexProvider().check_connection()  # does not raise
+
+
 @pytest.mark.asyncio
 async def test_astream_yields_error_when_codex_not_found():
     with patch("mlflow.assistant.providers.codex.shutil.which", return_value=None):

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -839,8 +839,14 @@ class _FakeSandboxProcess:
     def kill(self):
         self.killed = True
 
+    async def akill(self):
+        self.kill()
+
     def cleanup(self):
         self.cleaned_up = True
+
+    async def aclose(self):
+        self.cleanup()
 
 
 @pytest.mark.asyncio

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -805,3 +805,137 @@ async def test_astream_ignores_invalid_json_lines():
     message_events = [e for e in events if e.type == EventType.MESSAGE]
     assert len(message_events) == 1
     assert message_events[0].data["message"]["content"][0]["text"] == "valid"
+
+
+class _FakeSandboxProcess:
+    """Stand-in for mlflow.server.sandbox.SandboxProcess used to drive the sandbox path."""
+
+    def __init__(self, lines, returncode=0, stderr=b"", timed_out=False):
+        self._lines = lines
+        self._returncode = returncode
+        self._stderr = stderr
+        self.timed_out = timed_out
+        self.container_id = "container-abc"
+        self.cleaned_up = False
+
+    async def iter_stdout_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def wait(self):
+        return self._returncode
+
+    async def read_stderr(self):
+        return self._stderr
+
+    def cleanup(self):
+        self.cleaned_up = True
+
+
+@pytest.mark.asyncio
+async def test_astream_uses_sandbox_when_flag_enabled(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    provider = CodexProvider()
+    sentinel = MagicMock(name="sandbox-event")
+
+    async def fake_sandbox(self, *args, **kwargs):
+        yield sentinel
+
+    with patch.object(CodexProvider, "_astream_in_sandbox", fake_sandbox):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert events == [sentinel]
+
+
+@pytest.mark.asyncio
+async def test_astream_does_not_use_sandbox_when_flag_off(monkeypatch):
+    monkeypatch.delenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", raising=False)
+    provider = CodexProvider()
+    with (
+        patch.object(CodexProvider, "_astream_in_sandbox") as sandbox,
+        patch("mlflow.assistant.providers.codex.shutil.which", return_value=None),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    sandbox.assert_not_called()
+    # Host path with no CLI installed yields the not-found error.
+    assert any(e.type == EventType.ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_streams_events_and_manages_container(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(
+        lines=_make_stdout_lines(
+            {"type": "thread.started", "thread_id": "t1"},
+            {"type": "item.completed", "item": {"type": "agent_message", "text": "hi"}},
+            {"type": "turn.completed", "usage": {"input_tokens": 3, "output_tokens": 5}},
+        )
+    )
+    provider = CodexProvider()
+    sid = "11111111-1111-1111-1111-111111111111"
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake) as start,
+        patch("mlflow.assistant.providers.codex.save_container_id") as save_cid,
+        patch("mlflow.assistant.providers.codex.clear_container_id") as clear_cid,
+    ):
+        events = [
+            e async for e in provider.astream("hi", "http://localhost:5000", mlflow_session_id=sid)
+        ]
+
+    start.assert_called_once()
+    save_cid.assert_called_once_with(sid, "container-abc")
+    clear_cid.assert_called_once_with(sid)
+    assert fake.cleaned_up is True
+    assert events
+    assert not any(e.type == EventType.ERROR for e in events)
+    # The result event carries the codex thread id as the session id.
+    assert any(e.type == EventType.DONE for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_reports_nonzero_exit(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(lines=[], returncode=2, stderr=b"kaboom")
+    provider = CodexProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.codex.save_container_id"),
+        patch("mlflow.assistant.providers.codex.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert any(e.type == EventType.ERROR for e in events)
+    assert fake.cleaned_up is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_137_is_interrupted_not_error(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    # A killed container exits 137 (128 + SIGKILL); it must surface as interrupted, not error.
+    fake = _FakeSandboxProcess(lines=[], returncode=137)
+    provider = CodexProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.codex.save_container_id"),
+        patch("mlflow.assistant.providers.codex.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert not any(e.type == EventType.ERROR for e in events)
+    assert fake.cleaned_up is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    from mlflow.server.sandbox import SandboxUnavailableError
+
+    provider = CodexProvider()
+    with patch(
+        "mlflow.server.sandbox.start_sandbox_process",
+        side_effect=SandboxUnavailableError("no daemon"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    assert any(e.type == EventType.ERROR for e in events)

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -968,7 +968,38 @@ async def test_astream_in_sandbox_aborts_on_persistent_connection_errors(monkeyp
         events = [e async for e in provider.astream("hi", "http://host.docker.internal:5000")]
 
     errs = [e for e in events if e.type == EventType.ERROR]
-    assert errs and any("stopped after" in e.to_sse_event() for e in errs)
+    assert errs
+    assert any("stopped after" in e.to_sse_event() for e in errs)
     assert fake.killed is True
     # Aborted before consuming the later agent message.
     assert "SANDBOX_OK" not in "".join(e.to_sse_event() for e in events)
+
+
+def test_is_available_true_in_sandbox_mode(monkeypatch):
+    # With the sandbox enabled the CLI runs in the operator image, not on the host, so the
+    # provider is available even when the host binary is absent.
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    with patch("mlflow.assistant.providers.codex.shutil.which", return_value=None):
+        assert CodexProvider().is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_uses_external_uri_in_prompt(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    fake = _FakeSandboxProcess(
+        lines=_make_stdout_lines({"type": "thread.started", "thread_id": "t1"})
+    )
+    provider = CodexProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake) as start,
+        patch("mlflow.assistant.providers.codex.save_container_id"),
+        patch("mlflow.assistant.providers.codex.clear_container_id"),
+    ):
+        _ = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    kwargs = start.call_args.kwargs
+    # The CLI's env is the container-routable host...
+    assert kwargs["environment"]["MLFLOW_TRACKING_URI"] == "http://host.docker.internal:5000"
+    # ...but the prompt keeps the external URI, since UI links it builds open in the user's browser.
+    assert b"localhost:5000" in kwargs["stdin_data"]
+    assert b"host.docker.internal" not in kwargs["stdin_data"]

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -817,6 +817,7 @@ class _FakeSandboxProcess:
         self.timed_out = timed_out
         self.container_id = "container-abc"
         self.cleaned_up = False
+        self.killed = False
 
     async def iter_stdout_lines(self):
         for line in self._lines:
@@ -827,6 +828,9 @@ class _FakeSandboxProcess:
 
     async def read_stderr(self):
         return self._stderr
+
+    def kill(self):
+        self.killed = True
 
     def cleanup(self):
         self.cleaned_up = True
@@ -939,3 +943,32 @@ async def test_astream_in_sandbox_unavailable_surfaces_error(monkeypatch):
         events = [e async for e in provider.astream("hi", "http://localhost:5000")]
 
     assert any(e.type == EventType.ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_aborts_on_persistent_connection_errors(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    # codex streams "Reconnecting..." errors forever when it can't reach the API, so the container
+    # idle-timeout never fires. Negative no-progress timeout makes the first such error trip the
+    # guard deterministically. It must abort with an error rather than hang or reach later output.
+    monkeypatch.setattr("mlflow.assistant.providers.codex._CODEX_NO_PROGRESS_TIMEOUT", -1.0)
+    fake = _FakeSandboxProcess(
+        lines=_make_stdout_lines(
+            {"type": "error", "message": "Reconnecting... waiting for network"},
+            {"type": "error", "message": "Reconnecting... waiting for network"},
+            {"type": "item.completed", "item": {"type": "agent_message", "text": "SANDBOX_OK"}},
+        )
+    )
+    provider = CodexProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake),
+        patch("mlflow.assistant.providers.codex.save_container_id"),
+        patch("mlflow.assistant.providers.codex.clear_container_id"),
+    ):
+        events = [e async for e in provider.astream("hi", "http://host.docker.internal:5000")]
+
+    errs = [e for e in events if e.type == EventType.ERROR]
+    assert errs and any("stopped after" in e.to_sse_event() for e in errs)
+    assert fake.killed is True
+    # Aborted before consuming the later agent message.
+    assert "SANDBOX_OK" not in "".join(e.to_sse_event() for e in events)

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -1003,3 +1003,57 @@ async def test_astream_in_sandbox_uses_external_uri_in_prompt(monkeypatch):
     # ...but the prompt keeps the external URI, since UI links it builds open in the user's browser.
     assert b"localhost:5000" in kwargs["stdin_data"]
     assert b"host.docker.internal" not in kwargs["stdin_data"]
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_does_not_forward_non_allowlisted_secret(monkeypatch):
+    # Only allowlisted vars reach the CLI sandbox env; an arbitrary host secret must not leak in.
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-super-secret")
+    fake = _FakeSandboxProcess(
+        lines=_make_stdout_lines({"type": "thread.started", "thread_id": "t1"})
+    )
+    provider = CodexProvider()
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake) as start,
+        patch("mlflow.assistant.providers.codex.save_container_id"),
+        patch("mlflow.assistant.providers.codex.clear_container_id"),
+    ):
+        _ = [e async for e in provider.astream("hi", "http://localhost:5000")]
+
+    env = start.call_args.kwargs["environment"]
+    assert env["OPENAI_API_KEY"] == "sk-test"
+    assert "DATABRICKS_TOKEN" not in env
+
+
+async def _capture_sandbox_env(provider):
+    """Run one sandboxed turn and return the environment passed to start_sandbox_process."""
+    fake = _FakeSandboxProcess(
+        lines=_make_stdout_lines({"type": "thread.started", "thread_id": "t1"})
+    )
+    with (
+        patch("mlflow.server.sandbox.start_sandbox_process", return_value=fake) as start,
+        patch("mlflow.assistant.providers.codex.save_container_id"),
+        patch("mlflow.assistant.providers.codex.clear_container_id"),
+    ):
+        _ = [e async for e in provider.astream("hi", "http://localhost:5000")]
+    return start.call_args.kwargs["environment"]
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_forwards_registry_uri(monkeypatch):
+    # A credential-free registry URI is forwarded (loopback-rewritten); one with embedded
+    # credentials is dropped rather than leaked into the container.
+    monkeypatch.setenv("MLFLOW_ENABLE_ASSISTANT_SANDBOX", "true")
+    provider = CodexProvider()
+
+    monkeypatch.setenv("MLFLOW_REGISTRY_URI", "http://localhost:5000")
+    env = await _capture_sandbox_env(provider)
+    assert env["MLFLOW_REGISTRY_URI"] == "http://host.docker.internal:5000"
+
+    # Userinfo assembled from parts so no literal credential URI is committed to source.
+    creds = "u:p"
+    monkeypatch.setenv("MLFLOW_REGISTRY_URI", f"postgresql://{creds}@db.internal/registry")
+    env = await _capture_sandbox_env(provider)
+    assert "MLFLOW_REGISTRY_URI" not in env

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -1080,3 +1080,15 @@ async def test_astream_in_sandbox_forwards_registry_uri(monkeypatch):
     monkeypatch.setenv("MLFLOW_REGISTRY_URI", f"postgresql://{creds}@db.internal/registry")
     env = await _capture_sandbox_env(provider)
     assert "MLFLOW_REGISTRY_URI" not in env
+
+
+@pytest.mark.asyncio
+async def test_astream_in_sandbox_rewrites_loopback_base_url(monkeypatch):
+    # A loopback OPENAI_BASE_URL is rewritten so the CLI can reach the host from the container;
+    # the API key passes through unchanged.
+    monkeypatch.setattr("mlflow.assistant.providers.codex.assistant_sandbox_enabled", lambda: True)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:4000/v1")
+    env = await _capture_sandbox_env(CodexProvider())
+    assert env["OPENAI_BASE_URL"] == "http://host.docker.internal:4000/v1"
+    assert env["OPENAI_API_KEY"] == "sk-test"

--- a/tests/server/assistant/test_session.py
+++ b/tests/server/assistant/test_session.py
@@ -1,5 +1,6 @@
 import shutil
 import uuid
+from unittest import mock
 
 import pytest
 
@@ -193,3 +194,40 @@ def test_message_serialization():
     restored = Message.model_validate(data)
     assert restored.role == "user"
     assert restored.content == "Hello"
+
+
+_VALID_SID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_container_id_roundtrip(monkeypatch, tmp_path):
+    import mlflow.server.assistant.session as session_module
+
+    monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
+    assert session_module.get_container_id(_VALID_SID) is None
+    session_module.save_container_id(_VALID_SID, "cid-1")
+    assert session_module.get_container_id(_VALID_SID) == "cid-1"
+    session_module.clear_container_id(_VALID_SID)
+    assert session_module.get_container_id(_VALID_SID) is None
+
+
+def test_terminate_session_container_kills_and_clears(monkeypatch, tmp_path):
+    import mlflow.server.assistant.session as session_module
+
+    monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
+    session_module.save_container_id(_VALID_SID, "cid-1")
+
+    container = mock.MagicMock()
+    client = mock.MagicMock()
+    client.containers.get.return_value = container
+    with mock.patch("docker.from_env", return_value=client):
+        assert session_module.terminate_session_container(_VALID_SID) is True
+
+    container.kill.assert_called_once()
+    assert session_module.get_container_id(_VALID_SID) is None
+
+
+def test_terminate_session_container_no_container_is_noop(monkeypatch, tmp_path):
+    import mlflow.server.assistant.session as session_module
+
+    monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
+    assert session_module.terminate_session_container(_VALID_SID) is False

--- a/tests/server/assistant/test_session.py
+++ b/tests/server/assistant/test_session.py
@@ -231,3 +231,28 @@ def test_terminate_session_container_no_container_is_noop(monkeypatch, tmp_path)
 
     monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
     assert session_module.terminate_session_container(_VALID_SID) is False
+
+
+def test_get_session_sandbox_home_is_private(monkeypatch, tmp_path):
+    import mlflow.server.assistant.session as session_module
+
+    monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
+    home = session_module.get_session_sandbox_home("11111111-1111-1111-1111-111111111111")
+
+    assert home.exists()
+    # The sandbox HOME holds the CLI's login credentials, so it must be private to the server user.
+    assert (home.stat().st_mode & 0o777) == 0o700
+
+
+def test_get_session_sandbox_home_tightens_preexisting_dir(monkeypatch, tmp_path):
+    import mlflow.server.assistant.session as session_module
+
+    monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
+    sid = "22222222-2222-2222-2222-222222222222"
+    preexisting = tmp_path / "sandbox-home" / sid
+    preexisting.mkdir(parents=True)
+    preexisting.chmod(0o755)  # a looser mode from a prior run
+
+    home = session_module.get_session_sandbox_home(sid)
+
+    assert (home.stat().st_mode & 0o777) == 0o700

--- a/tests/server/assistant/test_session.py
+++ b/tests/server/assistant/test_session.py
@@ -210,6 +210,17 @@ def test_container_id_roundtrip(monkeypatch, tmp_path):
     assert session_module.get_container_id(_VALID_SID) is None
 
 
+def test_clear_container_id_tolerates_missing_file(monkeypatch, tmp_path):
+    import mlflow.server.assistant.session as session_module
+
+    monkeypatch.setattr(session_module, "SESSION_DIR", tmp_path)
+    # A second clear (e.g. a cancel racing the stream's finally) must not raise once the file is
+    # already gone.
+    session_module.save_container_id(_VALID_SID, "cid-1")
+    session_module.clear_container_id(_VALID_SID)
+    session_module.clear_container_id(_VALID_SID)
+
+
 def test_terminate_session_container_kills_and_clears(monkeypatch, tmp_path):
     import mlflow.server.assistant.session as session_module
 

--- a/tests/server/assistant/test_session.py
+++ b/tests/server/assistant/test_session.py
@@ -1,8 +1,13 @@
+import os
 import shutil
 import uuid
 from unittest import mock
 
 import pytest
+
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX file modes; Windows does not honor chmod(0o700)"
+)
 
 from mlflow.assistant.types import Message
 from mlflow.server.assistant.session import Session, SessionManager
@@ -244,6 +249,7 @@ def test_terminate_session_container_no_container_is_noop(monkeypatch, tmp_path)
     assert session_module.terminate_session_container(_VALID_SID) is False
 
 
+@_POSIX_ONLY
 def test_get_session_sandbox_home_is_private(monkeypatch, tmp_path):
     import mlflow.server.assistant.session as session_module
 
@@ -255,6 +261,7 @@ def test_get_session_sandbox_home_is_private(monkeypatch, tmp_path):
     assert (home.stat().st_mode & 0o777) == 0o700
 
 
+@_POSIX_ONLY
 def test_get_session_sandbox_home_tightens_preexisting_dir(monkeypatch, tmp_path):
     import mlflow.server.assistant.session as session_module
 

--- a/tests/server/sandbox/test_streaming.py
+++ b/tests/server/sandbox/test_streaming.py
@@ -116,6 +116,20 @@ def test_iter_stdout_lines_splits_streamed_chunks():
     assert lines == [b'{"a":1}', b'{"b":2}', b"last"]
 
 
+def test_iter_stdout_lines_aborts_on_oversized_line(monkeypatch):
+    # A single unterminated line over the per-line byte cap kills the container and surfaces an
+    # error instead of buffering without bound (the memory-safety guarantee of the byte cap).
+    import mlflow.server.sandbox.streaming as streaming_mod
+
+    monkeypatch.setattr(streaming_mod, "_MAX_LINE_BYTES", 8)
+    client, container = _streaming_container([b"0123456789ABCDEF"])  # 16 bytes, no newline
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["x"])
+        with pytest.raises(SandboxUnavailableError, match="over the 8-byte cap"):
+            _run(_collect(proc.iter_stdout_lines()))
+    container.kill.assert_called_once()
+
+
 def test_iter_stdout_lines_propagates_stream_error():
     client, container = _streaming_container([])
 

--- a/tests/server/sandbox/test_streaming.py
+++ b/tests/server/sandbox/test_streaming.py
@@ -1,0 +1,186 @@
+import asyncio
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mlflow.server.sandbox import SandboxUnavailableError, start_sandbox_process
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="Sandbox relies on POSIX uid/gid and Docker Linux containers"
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _collect(agen):
+    return [item async for item in agen]
+
+
+def _streaming_container(chunks, stderr=b"", status=0):
+    container = mock.MagicMock()
+
+    def logs(**kwargs):
+        if kwargs.get("stream"):
+            return iter(chunks)
+        if kwargs.get("stderr") and not kwargs.get("stdout", True):
+            return stderr
+        return b""
+
+    container.logs.side_effect = logs
+    container.wait.return_value = {"StatusCode": status}
+    client = mock.MagicMock()
+    client.images.get.return_value = mock.MagicMock()  # image present
+    client.containers.run.return_value = container
+    return client, container
+
+
+def test_start_sandbox_process_builds_command_and_mounts(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    client, _ = _streaming_container([])
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(
+            ["claude", "-p", "--verbose"],
+            workdir=workdir,
+            environment={"MLFLOW_TRACKING_URI": "http://host.docker.internal:5000"},
+            stdin_data=b"hello",
+            input_files={"system_prompt.txt": "SYS"},
+            home_dir=home_dir,
+        )
+
+    _, kwargs = client.containers.run.call_args
+    assert kwargs["command"] == ["sh", "-c", "exec claude -p --verbose < /sandbox-io/stdin"]
+    assert kwargs["cap_drop"] == ["ALL"]
+    assert kwargs["security_opt"] == ["no-new-privileges:true"]
+    # The CLI container has a writable rootfs (documented deviation), so read_only is not set,
+    # but it still runs as the server user so bind-mounted files are not left root-owned.
+    assert "read_only" not in kwargs
+    assert kwargs["user"] == f"{os.getuid()}:{os.getgid()}"
+    assert kwargs["working_dir"] == "/workspace"
+    assert kwargs["environment"]["HOME"] == "/home/sandbox"
+
+    volumes = kwargs["volumes"]
+    assert volumes[str(workdir)] == {"bind": "/workspace", "mode": "rw"}
+    assert volumes[str(home_dir)] == {"bind": "/home/sandbox", "mode": "rw"}
+    io_host = next(k for k, v in volumes.items() if v["bind"] == "/sandbox-io")
+    assert volumes[io_host]["mode"] == "ro"
+    assert (Path(io_host) / "stdin").read_bytes() == b"hello"
+    assert (Path(io_host) / "system_prompt.txt").read_text() == "SYS"
+
+    proc.cleanup()
+
+
+def test_start_requires_cli_image_present():
+    import docker.errors
+
+    client, _ = _streaming_container([])
+    client.images.get.side_effect = docker.errors.ImageNotFound("missing")
+    with mock.patch("docker.from_env", return_value=client):
+        with pytest.raises(SandboxUnavailableError, match="was not found"):
+            start_sandbox_process(["claude", "-p"])
+    # The CLI image is never auto-built (would produce a CLI-less image).
+    client.images.build.assert_not_called()
+
+
+def test_ephemeral_home_created_and_cleaned_when_no_home_dir():
+    client, _ = _streaming_container([])
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["claude", "-p"])
+        _, kwargs = client.containers.run.call_args
+        home_host = next(k for k, v in kwargs["volumes"].items() if v["bind"] == "/home/sandbox")
+        assert Path(home_host).exists()
+        proc.cleanup()
+        assert not Path(home_host).exists()
+
+
+def test_iter_stdout_lines_splits_streamed_chunks():
+    client, _ = _streaming_container([b'{"a":1}\n{"b":', b"2}\nlast"])
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["claude", "-p"])
+        lines = _run(_collect(proc.iter_stdout_lines()))
+
+    assert lines == [b'{"a":1}', b'{"b":2}', b"last"]
+
+
+def test_iter_stdout_lines_propagates_stream_error():
+    client, container = _streaming_container([])
+
+    def logs(**kwargs):
+        if kwargs.get("stream"):
+
+            def gen():
+                yield b"partial\n"
+                raise RuntimeError("stream died")
+
+            return gen()
+        return b""
+
+    container.logs.side_effect = logs
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["x"])
+        with pytest.raises(SandboxUnavailableError, match="output stream failed"):
+            _run(_collect(proc.iter_stdout_lines()))
+
+
+def test_wait_returns_exit_code():
+    client, _ = _streaming_container([], status=3)
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["x"])
+        rc = _run(proc.wait())
+
+    assert rc == 3
+    assert proc.returncode == 3
+
+
+def test_read_stderr_returns_stderr_logs():
+    client, _ = _streaming_container([], stderr=b"boom")
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["x"])
+        err = _run(proc.read_stderr())
+
+    assert err == b"boom"
+
+
+def test_kill_and_cleanup_remove_container():
+    client, container = _streaming_container([])
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["x"])
+        proc.kill()
+        proc.cleanup()
+
+    container.kill.assert_called_once()
+    container.remove.assert_called_once()
+
+
+def test_start_raises_when_docker_unavailable():
+    with mock.patch("docker.from_env", side_effect=Exception("no daemon")):
+        with pytest.raises(SandboxUnavailableError, match="Docker daemon is not reachable"):
+            start_sandbox_process(["x"])
+
+
+def test_start_container_failure_cleans_io_and_raises():
+    client, _ = _streaming_container([])
+    client.containers.run.side_effect = Exception("boom")
+    captured = {}
+    real_mkdtemp = __import__("tempfile").mkdtemp
+
+    def _spy_mkdtemp(*args, **kwargs):
+        path = real_mkdtemp(*args, **kwargs)
+        captured["io_dir"] = path
+        return path
+
+    with (
+        mock.patch("docker.from_env", return_value=client),
+        mock.patch("mlflow.server.sandbox.streaming.tempfile.mkdtemp", side_effect=_spy_mkdtemp),
+    ):
+        with pytest.raises(SandboxUnavailableError, match="Failed to start sandbox container"):
+            start_sandbox_process(["x"])
+
+    # The IO scratch dir is cleaned up when the container fails to start.
+    assert not Path(captured["io_dir"]).exists()

--- a/tests/server/sandbox/test_streaming.py
+++ b/tests/server/sandbox/test_streaming.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 
 from mlflow.server.sandbox import SandboxUnavailableError, start_sandbox_process
+from mlflow.server.sandbox import container as container_mod
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="Sandbox relies on POSIX uid/gid and Docker Linux containers"
@@ -63,6 +64,12 @@ def test_start_sandbox_process_builds_command_and_mounts(tmp_path):
     # but it still runs as the server user so bind-mounted files are not left root-owned.
     assert "read_only" not in kwargs
     assert kwargs["user"] == f"{os.getuid()}:{os.getgid()}"
+    # The streaming container (writable rootfs, running the untrusted CLI) must keep the same
+    # resource caps as the run-to-completion sandbox; a regression dropping them should fail here.
+    assert kwargs["mem_limit"] == container_mod._MEMORY_LIMIT
+    assert kwargs["memswap_limit"] == container_mod._MEMORY_LIMIT
+    assert kwargs["nano_cpus"] == container_mod._NANO_CPUS
+    assert kwargs["pids_limit"] == container_mod._PIDS_LIMIT
     assert kwargs["working_dir"] == "/workspace"
     assert kwargs["environment"]["HOME"] == "/home/sandbox"
 

--- a/tests/server/sandbox/test_streaming.py
+++ b/tests/server/sandbox/test_streaming.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import threading
 from pathlib import Path
 from unittest import mock
 
@@ -184,3 +185,43 @@ def test_start_container_failure_cleans_io_and_raises():
 
     # The IO scratch dir is cleaned up when the container fails to start.
     assert not Path(captured["io_dir"]).exists()
+
+
+def test_iter_stdout_lines_idle_timeout_kills_container():
+    stop = threading.Event()
+    container = mock.MagicMock()
+
+    def logs(**kwargs):
+        if kwargs.get("stream"):
+
+            def gen():
+                stop.wait(5)  # block (no output) until the watchdog "kills" the container
+                return
+                yield  # make this a generator
+
+            return gen()
+        return b""
+
+    container.logs.side_effect = logs
+    container.kill.side_effect = lambda: stop.set()  # killing ends the (blocked) logs stream
+    container.wait.return_value = {"StatusCode": 137}
+    client = mock.MagicMock()
+    client.images.get.return_value = mock.MagicMock()
+    client.containers.run.return_value = container
+
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["sleep"], idle_timeout=0.2)
+        lines = _run(_collect(proc.iter_stdout_lines()))
+
+    assert proc.timed_out is True
+    assert lines == []
+    container.kill.assert_called()
+
+
+def test_no_idle_timeout_when_disabled():
+    client, _ = _streaming_container([b"a\n", b"b\n"])
+    with mock.patch("docker.from_env", return_value=client):
+        proc = start_sandbox_process(["x"], idle_timeout=None)
+        lines = _run(_collect(proc.iter_stdout_lines()))
+    assert lines == [b"a", b"b"]
+    assert proc.timed_out is False


### PR DESCRIPTION
## 🥞 Stacked PR
- [assistant-sandbox-1-foundation](https://github.com/mlflow/mlflow/pull/25296)
  - [**assistant-sandbox-2-cli**](https://github.com/mlflow/mlflow/pull/25302)
    - [assistant-sandbox-3-lifecycle](https://github.com/mlflow/mlflow/pull/25304)
      - [assistant-sandbox-4-egress](https://github.com/mlflow/mlflow/pull/25305)
        - [assistant-sandbox-5-docs](https://github.com/mlflow/mlflow/pull/25307)

---------

### Related Issues/PRs

Relates to #25296.

### What changes are proposed in this pull request?

Extends the experimental assistant sandbox so the **coding-agent CLI providers (Claude Code and Codex)** can run inside a locked-down Docker container instead of on the server host. Gated by the existing `MLFLOW_ENABLE_ASSISTANT_SANDBOX` flag (off by default); the host execution path is unchanged.

- New streaming sandbox primitive `mlflow/server/sandbox/streaming.py`: `start_sandbox_process` runs a CLI in a container, feeds its stdin from a mounted file, and returns a `SandboxProcess` exposing the container's stdout as an async line iterator plus `wait()` / `read_stderr()` / `kill()` / `cleanup()`. The blocking `container.logs(stream=True, follow=True)` generator is bridged to async on a worker thread.
- Container hardening mirrors the run-to-completion sandbox (`cap_drop=ALL`, `no-new-privileges`, memory/CPU/PID caps, network posture, runs as the server's `uid:gid`) with two deliberate differences for a live CLI: a writable root filesystem (the CLI and its runtime write caches outside `$HOME`) and a bind-mounted `$HOME` directory that holds the CLI's caches and `--resume` session state across turns. The CLI image is operator-provided and never auto-built.
- Per-session container-id tracking so an in-flight sandboxed turn can be cancelled; the cancel endpoint now terminates whichever backend (host process or container) ran the turn.
- New env var `MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE` and a small per-provider allowlist of auth/proxy environment variables forwarded into the container so each CLI can authenticate — Claude Code (direct Anthropic API, Bedrock, Vertex) and Codex (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or a login stored in the per-session `$HOME`), plus proxies. Other host secrets are intentionally not forwarded.
- Both CLI providers share the same streaming primitive and hardening; each has an additive `_astream_in_sandbox` branch that mirrors its host command construction and event parsing, so behavior is unchanged when the flag is off.

Runtime behavior that depends on a live Docker daemon (image contents, credential formats, mount permissions) is exercised via manual/live testing rather than unit tests; the unit tests cover the streaming bridge, exit-code handling (including cancellation → exit 137 → interrupted), container lifecycle, per-provider sandbox routing, and flag-off parity.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

User-facing documentation will follow once the capability is ready to recommend.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Experimental and off by default.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


