### PR TITLE
Preserve managed dataset identity for `ConversationSimulator` evaluations

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -317,6 +317,7 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
     # Handle ConversationSimulator: prepare for simulation, but run it inside the run context
     # so that traces are logged to the correct run.
     simulator = None
+    simulator_source_dataset = None
     sim_predict_fn = None
     precomputed_digest = None
     precomputed_dataset_name = None
@@ -331,6 +332,7 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
         # produce the same digest regardless of LLM non-determinism in generated conversations.
         precomputed_digest = data._compute_test_case_digest()
         precomputed_dataset_name = data._get_dataset_name()
+        simulator_source_dataset = data._source_dataset
 
         # Wrap async predict_fn for synchronous execution during simulation
         sim_predict_fn = predict_fn
@@ -402,7 +404,11 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
             )
             os.environ[MLFLOW_GENAI_EVAL_MAX_WORKERS.name] = os.environ["RAG_EVAL_MAX_WORKERS"]
 
-        if isinstance(data, (EvaluationDataset, EntityEvaluationDataset)):
+        if simulator_source_dataset is not None:
+            # Keep the generated traces as evaluation rows while logging the managed dataset
+            # that supplied the simulator's test cases as the run input.
+            mlflow_dataset = simulator_source_dataset
+        elif isinstance(data, (EvaluationDataset, EntityEvaluationDataset)):
             mlflow_dataset = data
             df = data.to_df()
         else:

--- a/mlflow/genai/simulators/simulator.py
+++ b/mlflow/genai/simulators/simulator.py
@@ -488,9 +488,6 @@ class ConversationSimulator:
                 f"user_agent_class must be a subclass of BaseSimulatedUserAgent, "
                 f"got {user_agent_class.__name__}"
             )
-        # Store original dataset reference if test_cases is an EvaluationDataset, so we can
-        # preserve the dataset name when creating the evaluation dataset.
-        self._source_dataset = test_cases if isinstance(test_cases, EvaluationDataset) else None
         self.test_cases = test_cases
         self.max_turns = max_turns
         self.user_model = user_model or get_default_simulation_model()
@@ -499,8 +496,10 @@ class ConversationSimulator:
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name == "test_cases":
+            source_dataset = value if isinstance(value, EvaluationDataset) else None
             value = self._normalize_test_cases(value)
             self._validate_test_cases(value)
+            super().__setattr__("_source_dataset", source_dataset)
         super().__setattr__(name, value)
 
     def _normalize_test_cases(

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,3 +1,4 @@
+import json
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -1642,10 +1643,54 @@ def test_evaluate_with_simulator_creates_single_run(tmp_path):
         "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
         return_value='{"rationale": "Goal achieved!", "result": "yes"}',
     ):
-        mlflow.genai.evaluate(data=simulator, predict_fn=mock_predict_fn, scorers=[])
+        result = mlflow.genai.evaluate(data=simulator, predict_fn=mock_predict_fn, scorers=[])
 
     runs = mlflow.search_runs()
     assert len(runs) == 1
+
+    run = mlflow.get_run(result.run_id)
+    assert len(run.inputs.dataset_inputs) == 1
+    dataset_input = run.inputs.dataset_inputs[0].dataset
+    assert dataset_input.name == "conversational_dataset"
+    assert dataset_input.source_type == "code"
+
+
+def test_evaluate_with_simulator_preserves_managed_dataset_identity(tmp_path):
+    mlflow.set_tracking_uri(f"sqlite:///{tmp_path}/mlflow.db")
+    experiment = mlflow.set_experiment("test-experiment")
+    dataset = create_dataset(
+        name="conversation-test-cases",
+        experiment_id=experiment.experiment_id,
+    )
+    dataset.merge_records([{"inputs": {"goal": "get help"}}])
+
+    simulator = ConversationSimulator(
+        test_cases=dataset,
+        max_turns=2,
+        user_agent_class=MockUserAgent,
+    )
+
+    def mock_predict_fn(input: list[dict[str, Any]], **kwargs):
+        return {"content": "Response"}
+
+    with mock.patch(
+        "mlflow.genai.simulators.simulator.invoke_model_without_tracing",
+        return_value='{"rationale": "Goal achieved!", "result": "yes"}',
+    ):
+        result = mlflow.genai.evaluate(
+            data=simulator,
+            predict_fn=mock_predict_fn,
+            scorers=[has_trace],
+        )
+
+    run = mlflow.get_run(result.run_id)
+    assert result.metrics["has_trace/mean"] == 1.0
+    assert len(run.inputs.dataset_inputs) == 1
+    dataset_input = run.inputs.dataset_inputs[0].dataset
+    assert dataset_input.name == dataset.name
+    assert dataset_input.digest == dataset.digest
+    assert dataset_input.source_type == "mlflow_evaluation_dataset"
+    assert json.loads(dataset_input.source)["dataset_id"] == dataset.dataset_id
 
 
 def test_evaluate_with_simulator_within_parent_run(tmp_path):

--- a/tests/genai/simulators/test_simulator.py
+++ b/tests/genai/simulators/test_simulator.py
@@ -459,6 +459,39 @@ def test_reassignment_with_dataframe(simple_test_case):
     assert simulator.test_cases == [{"goal": "Goal from DataFrame", "persona": "Analyst"}]
 
 
+def test_reassignment_from_evaluation_dataset_to_list_clears_source_dataset():
+    dataset = create_mock_evaluation_dataset([{"goal": "Original goal"}])
+    simulator = ConversationSimulator(test_cases=dataset, max_turns=2)
+
+    simulator.test_cases = [{"goal": "New goal"}]
+
+    assert simulator._source_dataset is None
+    assert simulator._get_dataset_name() == "conversational_dataset"
+
+
+def test_reassignment_from_list_to_evaluation_dataset_sets_source_dataset(simple_test_case):
+    simulator = ConversationSimulator(test_cases=[simple_test_case], max_turns=2)
+    dataset = create_mock_evaluation_dataset([{"goal": "Managed goal"}])
+    dataset.name = "managed-dataset"
+
+    simulator.test_cases = dataset
+
+    assert simulator._source_dataset is dataset
+    assert simulator._get_dataset_name() == "managed-dataset"
+
+
+def test_invalid_reassignment_preserves_source_dataset():
+    dataset = create_mock_evaluation_dataset([{"goal": "Original goal"}])
+    simulator = ConversationSimulator(test_cases=dataset, max_turns=2)
+    original_test_cases = simulator.test_cases
+
+    with pytest.raises(ValueError, match="test_cases cannot be empty"):
+        simulator.test_cases = []
+
+    assert simulator._source_dataset is dataset
+    assert simulator.test_cases == original_test_cases
+
+
 @pytest.mark.parametrize(
     ("invalid_test_cases", "expected_error"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Closes #25016

### What changes are proposed in this pull request?

When `ConversationSimulator` receives an existing managed `EvaluationDataset`, keep that dataset as the evaluation run input instead of replacing its provenance with an anonymous pandas dataset. This preserves the original dataset name, digest, source type, and dataset ID so the existing evaluation-dataset UI link can navigate to the correct Dataset Details page.

The simulated traces remain the rows consumed by the evaluation harness and scorers. List and DataFrame test cases keep the existing anonymous `conversational_dataset` behavior.

This also keeps the simulator's source-dataset reference synchronized when `test_cases` is reassigned, preventing stale or missing provenance after switching between managed and anonymous inputs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Tests cover managed dataset identity, anonymous list behavior, scoring of generated traces, and managed/list reassignment invariants.

```text
uv run --frozen pytest -q tests/genai/evaluate/test_evaluation.py tests/genai/simulators/test_simulator.py
156 passed, 35 skipped

uv run --frozen pre-commit run --files mlflow/genai/evaluation/base.py mlflow/genai/simulators/simulator.py tests/genai/evaluate/test_evaluation.py tests/genai/simulators/test_simulator.py
All applicable hooks passed
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Evaluation runs created from a `ConversationSimulator` backed by a managed `EvaluationDataset` now retain the original dataset identity and link to the correct Dataset Details page.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release