### PR TITLE
Route assistant sandbox egress through a dedicated network and optional proxy

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -167,6 +167,19 @@ MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE = _EnvironmentVariable(
 #: current generation just launched. Not intended to be set by users.
 _MLFLOW_SERVER_BOOT_ID = _EnvironmentVariable("_MLFLOW_SERVER_BOOT_ID", str, None)
 
+#: **Experimental** — subject to change or removal in a future release.
+#: URL of an outbound proxy for sandbox container egress (e.g. ``http://proxy.internal:3128``).
+#: When set, it is injected as ``HTTP_PROXY``/``HTTPS_PROXY`` into every sandbox container, with
+#: the MLflow tracking host excluded via ``NO_PROXY`` so it stays directly reachable. Point this
+#: at a proxy that allowlists only the destinations the sandbox needs (e.g. the model provider
+#: API) to steer egress through an operator-controlled chokepoint. Note this only shapes egress
+#: from *cooperative* HTTP clients that honor the proxy env; it is not a hard boundary, since the
+#: container still has network access and code that ignores the proxy env or opens raw sockets
+#: can reach other hosts. Pair it with host-level firewalling for a true egress boundary. When
+#: unset, sandbox containers have unrestricted egress.
+#: (default: ``None``)
+MLFLOW_SANDBOX_EGRESS_PROXY = _EnvironmentVariable("MLFLOW_SANDBOX_EGRESS_PROXY", str, None)
+
 #: When true, newly created workspaces are seeded with two default RBAC roles
 #: (``admin``, ``user``) that super-admins can assign to other
 #: users. ``CreateWorkspace`` is gated to super-admins, whose ``is_admin`` flag already

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -170,9 +170,11 @@ _MLFLOW_SERVER_BOOT_ID = _EnvironmentVariable("_MLFLOW_SERVER_BOOT_ID", str, Non
 #: **Experimental** — subject to change or removal in a future release.
 #: URL of an outbound proxy for sandbox container egress (e.g. ``http://proxy.internal:3128``).
 #: When set, it is injected as ``HTTP_PROXY``/``HTTPS_PROXY`` into every sandbox container, with
-#: the MLflow tracking host excluded via ``NO_PROXY`` so it stays directly reachable. Point this
-#: at a proxy that allowlists only the destinations the sandbox needs (e.g. the model provider
-#: API) to steer egress through an operator-controlled chokepoint. Note this only shapes egress
+#: only the fixed self-host bypass list (``host.docker.internal`` + loopback) excluded via
+#: ``NO_PROXY`` so a co-located tracking server stays reachable. A remote tracking host is NOT
+#: auto-exempted — it must be allowlisted in the proxy itself. Point this at a proxy that
+#: allowlists only the destinations the sandbox needs (e.g. the model provider API) to steer
+#: egress through an operator-controlled chokepoint. Note this only shapes egress
 #: from *cooperative* HTTP clients that honor the proxy env; it is not a hard boundary, since the
 #: container still has network access and code that ignores the proxy env or opens raw sockets
 #: can reach other hosts. Pair it with host-level firewalling for a true egress boundary. When

--- a/mlflow/server/sandbox/container.py
+++ b/mlflow/server/sandbox/container.py
@@ -8,24 +8,32 @@ privileges, read-only root filesystem, non-root user, memory / CPU / PID caps) a
 the container lifecycle (build image, run, wait with timeout, always clean up) live
 here so there is one place to audit and tighten the sandbox security posture.
 
-Network posture: the container runs on the default bridge with an added
-``host.docker.internal`` route so a command can reach an MLflow tracking server
-running on the host. Tightening egress to a strict allowlist (and blocking the
-link-local ``169.254.0.0/16`` range used by cloud metadata services) is a planned
-follow-up; until then a sandbox should not be granted host credentials it must not
-leak. The sandbox is off by default and gated behind an experimental flag.
+Network posture: sandbox containers run on a dedicated bridge network (isolating them from
+other containers on the host) with an added ``host.docker.internal`` route so a command can
+reach an MLflow tracking server on the host. An optional egress proxy
+(``MLFLOW_SANDBOX_EGRESS_PROXY``) steers HTTP(S) egress from cooperating clients through an
+operator-controlled chokepoint. Neither is a hard egress boundary: the container has network
+access, so code that opens raw sockets or ignores the proxy env (e.g. Node's fetch, which does
+not read ``HTTP_PROXY`` by default) can still reach other hosts, including the cloud metadata
+endpoint. A true egress boundary requires host-level firewalling. The sandbox is off by default
+and gated behind an experimental flag.
 """
 
 import logging
 import os
 import tempfile
 import urllib.parse
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
 import requests
 
-from mlflow.environment_variables import _MLFLOW_SERVER_BOOT_ID, MLFLOW_SANDBOX_DOCKER_IMAGE
+from mlflow.environment_variables import (
+    _MLFLOW_SERVER_BOOT_ID,
+    MLFLOW_SANDBOX_DOCKER_IMAGE,
+    MLFLOW_SANDBOX_EGRESS_PROXY,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -57,6 +65,80 @@ def sandbox_container_labels() -> dict[str, str]:
     if boot_id := _MLFLOW_SERVER_BOOT_ID.get():
         labels[SANDBOX_BOOT_LABEL] = boot_id
     return labels
+
+
+# Dedicated bridge network for sandbox containers, so they are isolated from other containers
+# on the host's default bridge (they can still reach the host via host.docker.internal).
+SANDBOX_NETWORK_NAME = "mlflow-sandbox"
+# Hosts a sandboxed command reaches directly instead of through the egress proxy: the MLflow
+# tracking host and loopback. The metadata endpoint is deliberately NOT here, so a
+# proxy-respecting client cannot reach it directly.
+_EGRESS_PROXY_BYPASS_HOSTS = ("host.docker.internal", "localhost", "127.0.0.1")
+
+
+def ensure_sandbox_network(client) -> str:
+    """Return the name of the dedicated sandbox bridge network, creating it if missing.
+
+    Handles the concurrent-first-launch race: a duplicate-create conflict is treated as the
+    network already existing rather than an error. Falls back to the default ``bridge`` network
+    (with a warning, since that reduces isolation) if the dedicated one truly cannot be used, so
+    a restricted Docker setup still runs the sandbox rather than failing outright.
+    """
+    import docker.errors
+
+    try:
+        try:
+            client.networks.get(SANDBOX_NETWORK_NAME)
+            return SANDBOX_NETWORK_NAME
+        except docker.errors.NotFound:
+            pass
+        try:
+            client.networks.create(SANDBOX_NETWORK_NAME, driver="bridge", check_duplicate=True)
+        except docker.errors.APIError:
+            # Lost a create race with a concurrent launch; the network exists now.
+            client.networks.get(SANDBOX_NETWORK_NAME)
+        return SANDBOX_NETWORK_NAME
+    except Exception as e:
+        _logger.warning(
+            "Falling back to the default bridge network for the sandbox; isolation from other "
+            "containers is reduced: %s",
+            e,
+        )
+        return "bridge"
+
+
+def sandbox_egress_env(no_proxy_hosts: Iterable[str] = ()) -> dict[str, str]:
+    """Environment that routes a sandbox container's HTTP(S) egress through the configured proxy.
+
+    Empty when no proxy is configured (the container then has unrestricted egress). This only
+    shapes egress for clients that honor the standard proxy env vars; it is not an enforcement
+    boundary — code that opens raw sockets, or a runtime that ignores the proxy env (e.g. Node's
+    fetch), can still reach any host. The tracking host and loopback bypass the proxy so they
+    stay reachable; ``no_proxy_hosts`` adds the caller's tracking host for the non-loopback case.
+    """
+    proxy = MLFLOW_SANDBOX_EGRESS_PROXY.get()
+    if not proxy:
+        return {}
+    hosts = [*_EGRESS_PROXY_BYPASS_HOSTS, *(h for h in no_proxy_hosts if h)]
+    no_proxy = ",".join(dict.fromkeys(hosts))  # de-dupe, preserve order
+    return {
+        "HTTP_PROXY": proxy,
+        "HTTPS_PROXY": proxy,
+        "http_proxy": proxy,
+        "https_proxy": proxy,
+        "NO_PROXY": no_proxy,
+        "no_proxy": no_proxy,
+    }
+
+
+def _uri_host(uri: str | None) -> str | None:
+    """Host component of a URI, or None if absent/unparseable (used to build NO_PROXY)."""
+    if not uri:
+        return None
+    try:
+        return urllib.parse.urlsplit(uri).hostname
+    except ValueError:
+        return None
 
 
 class SandboxUnavailableError(Exception):
@@ -198,6 +280,7 @@ def run_in_sandbox(
     # Read-only rootfs plus a writable /tmp: give the command a HOME it can write to
     # (the mlflow CLI and pip both write under HOME) without loosening the rootfs.
     env.setdefault("HOME", "/tmp")
+    env.update(sandbox_egress_env(no_proxy_hosts=[_uri_host(env.get("MLFLOW_TRACKING_URI"))]))
 
     container_command = command
     if use_shell:
@@ -217,7 +300,7 @@ def run_in_sandbox(
             command=container_command,
             detach=True,
             labels=sandbox_container_labels(),
-            network_mode="bridge",
+            network=ensure_sandbox_network(client),
             extra_hosts={"host.docker.internal": "host-gateway"},
             mem_limit=_MEMORY_LIMIT,
             memswap_limit=_MEMORY_LIMIT,

--- a/mlflow/server/sandbox/container.py
+++ b/mlflow/server/sandbox/container.py
@@ -23,7 +23,6 @@ import logging
 import os
 import tempfile
 import urllib.parse
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -107,20 +106,22 @@ def ensure_sandbox_network(client) -> str:
         return "bridge"
 
 
-def sandbox_egress_env(no_proxy_hosts: Iterable[str] = ()) -> dict[str, str]:
+def sandbox_egress_env() -> dict[str, str]:
     """Environment that routes a sandbox container's HTTP(S) egress through the configured proxy.
 
     Empty when no proxy is configured (the container then has unrestricted egress). This only
     shapes egress for clients that honor the standard proxy env vars; it is not an enforcement
     boundary — code that opens raw sockets, or a runtime that ignores the proxy env (e.g. Node's
-    fetch), can still reach any host. The tracking host and loopback bypass the proxy so they
-    stay reachable; ``no_proxy_hosts`` adds the caller's tracking host for the non-loopback case.
+    fetch), can still reach any host. Only the fixed self-host bypass list (``host.docker.internal``
+    + loopback) is exempted. The caller's tracking host is deliberately NOT auto-exempted: it is
+    request-derived (from ``request.base_url``), so a remote caller could set it to an internal
+    host to carve that destination out of the proxy. A local tracking server is reached via
+    ``host.docker.internal`` (already exempt); a remote one must be allowlisted in the proxy itself.
     """
     proxy = MLFLOW_SANDBOX_EGRESS_PROXY.get()
     if not proxy:
         return {}
-    hosts = [*_EGRESS_PROXY_BYPASS_HOSTS, *(h for h in no_proxy_hosts if h)]
-    no_proxy = ",".join(dict.fromkeys(hosts))  # de-dupe, preserve order
+    no_proxy = ",".join(_EGRESS_PROXY_BYPASS_HOSTS)
     return {
         "HTTP_PROXY": proxy,
         "HTTPS_PROXY": proxy,
@@ -129,16 +130,6 @@ def sandbox_egress_env(no_proxy_hosts: Iterable[str] = ()) -> dict[str, str]:
         "NO_PROXY": no_proxy,
         "no_proxy": no_proxy,
     }
-
-
-def _uri_host(uri: str | None) -> str | None:
-    """Host component of a URI, or None if absent/unparseable (used to build NO_PROXY)."""
-    if not uri:
-        return None
-    try:
-        return urllib.parse.urlsplit(uri).hostname
-    except ValueError:
-        return None
 
 
 class SandboxUnavailableError(Exception):
@@ -280,7 +271,7 @@ def run_in_sandbox(
     # Read-only rootfs plus a writable /tmp: give the command a HOME it can write to
     # (the mlflow CLI and pip both write under HOME) without loosening the rootfs.
     env.setdefault("HOME", "/tmp")
-    env.update(sandbox_egress_env(no_proxy_hosts=[_uri_host(env.get("MLFLOW_TRACKING_URI"))]))
+    env.update(sandbox_egress_env())
 
     container_command = command
     if use_shell:
@@ -350,12 +341,17 @@ def _is_read_timeout(exc: Exception) -> bool:
 
     docker-py maps the deadline being exceeded to a requests ``ReadTimeout``, or — on the Unix-
     socket transport — a ``ConnectionError`` wrapping urllib3's ``ReadTimeoutError``; both carry
-    "read timed out" in their message. This distinguishes those from genuine daemon errors
-    (e.g. connection refused) so a timeout is not misreported as a sandbox failure.
+    "read timed out" in their message. Match that specific signal, not a bare "timed out": a
+    ``ConnectTimeout`` (connection-establishment failure, also a ``ConnectionError``) says "timed
+    out" too, and that is a genuine daemon-unreachable error that must surface as a sandbox failure
+    rather than be misreported as the command timing out.
     """
     if isinstance(exc, requests.exceptions.ReadTimeout):
         return True
-    return isinstance(exc, requests.exceptions.ConnectionError) and "timed out" in str(exc).lower()
+    return (
+        isinstance(exc, requests.exceptions.ConnectionError)
+        and "read timed out" in str(exc).lower()
+    )
 
 
 def _logs(container) -> str:
@@ -408,11 +404,16 @@ def reap_orphaned_sandbox_containers() -> int:
         if (container.labels or {}).get(SANDBOX_BOOT_LABEL) == current_boot:
             continue  # belongs to this server generation; may be actively serving a turn
         # A different boot id alone does not prove the container is orphaned: two servers can share
-        # one Docker daemon, and a rolling restart overlaps generations. So never force-remove a
-        # *running* container (it may be a live turn owned by a concurrent server) — reap only ones
-        # that have already stopped. A truly orphaned container that is still running is left for a
-        # later startup to reap once it exits, rather than risk killing another server's live turn.
-        if getattr(container, "status", None) == "running":
+        # one Docker daemon, and a rolling restart overlaps generations. So reap only containers in
+        # a terminal state (exited/dead); leave any live or transitional state
+        # (running/created/restarting/paused/removing) alone, since force-removing one could kill a
+        # concurrent server's live or still-starting turn. An orphaned container is reaped on a
+        # later startup once it reaches a terminal state, which is the common case. One wedged in a
+        # non-terminal state (e.g. a `created` container left by a crash between create and start)
+        # is knowingly left rather than risk force-removing a concurrent server's still-starting
+        # container; reclaiming those safely needs ownership/lease metadata, which is future
+        # multi-replica work.
+        if getattr(container, "status", None) not in ("exited", "dead"):
             continue
         if _remove_quietly(container):
             removed += 1

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -40,7 +40,6 @@ from mlflow.server.sandbox.container import (
     _WORKSPACE_MOUNT,
     SandboxUnavailableError,
     _get_client,
-    _uri_host,
     ensure_sandbox_network,
     sandbox_container_labels,
     sandbox_egress_env,
@@ -326,7 +325,7 @@ def start_sandbox_process(
 
     env = dict(environment or {})
     env.setdefault("HOME", _HOME_MOUNT)
-    env.update(sandbox_egress_env(no_proxy_hosts=[_uri_host(env.get("MLFLOW_TRACKING_URI"))]))
+    env.update(sandbox_egress_env())
 
     volumes = {
         str(io_dir): {"bind": _IO_MOUNT, "mode": "ro"},

--- a/mlflow/server/sandbox/streaming.py
+++ b/mlflow/server/sandbox/streaming.py
@@ -40,7 +40,10 @@ from mlflow.server.sandbox.container import (
     _WORKSPACE_MOUNT,
     SandboxUnavailableError,
     _get_client,
+    _uri_host,
+    ensure_sandbox_network,
     sandbox_container_labels,
+    sandbox_egress_env,
 )
 
 _logger = logging.getLogger(__name__)
@@ -323,6 +326,7 @@ def start_sandbox_process(
 
     env = dict(environment or {})
     env.setdefault("HOME", _HOME_MOUNT)
+    env.update(sandbox_egress_env(no_proxy_hosts=[_uri_host(env.get("MLFLOW_TRACKING_URI"))]))
 
     volumes = {
         str(io_dir): {"bind": _IO_MOUNT, "mode": "ro"},
@@ -344,7 +348,7 @@ def start_sandbox_process(
             command=command,
             detach=True,
             labels=sandbox_container_labels(),
-            network_mode="bridge",
+            network=ensure_sandbox_network(client),
             extra_hosts={"host.docker.internal": "host-gateway"},
             mem_limit=_MEMORY_LIMIT,
             memswap_limit=_MEMORY_LIMIT,

--- a/tests/server/sandbox/test_container.py
+++ b/tests/server/sandbox/test_container.py
@@ -170,6 +170,23 @@ def test_run_in_sandbox_non_timeout_wait_error_raises_unavailable():
     container.remove.assert_called_once()
 
 
+def test_run_in_sandbox_connect_timeout_is_not_a_read_timeout():
+    # A connection-establishment timeout (daemon unreachable) is a ConnectionError whose message
+    # says "timed out" but NOT "read timed out". It must surface as a sandbox failure rather than
+    # be misreported as the command timing out, so the operator sees the daemon is down.
+    client, container = _mock_client()
+    container.wait.side_effect = requests.exceptions.ConnectionError(
+        "HTTPConnectionPool(host='localhost', port=2375): Max retries exceeded "
+        "(Caused by ConnectTimeoutError(...): Connection to localhost timed out.)"
+    )
+    with mock.patch("docker.from_env", return_value=client):
+        with pytest.raises(SandboxUnavailableError, match="failed while waiting"):
+            run_in_sandbox(["mlflow", "--version"])
+
+    container.kill.assert_called_once()
+    container.remove.assert_called_once()
+
+
 def test_run_in_sandbox_raises_when_docker_unavailable():
     with mock.patch("docker.from_env", side_effect=Exception("no daemon")):
         with pytest.raises(SandboxUnavailableError, match="Docker daemon is not reachable"):
@@ -258,20 +275,40 @@ def test_reap_removes_previous_generation_only(monkeypatch):
     assert kwargs["filters"] == {"label": container_mod.SANDBOX_CONTAINER_LABEL}
 
 
-def test_reap_skips_running_container_from_other_generation(monkeypatch):
+@pytest.mark.parametrize("status", ["running", "created", "restarting", "paused", "removing"])
+def test_reap_skips_non_terminal_container_from_other_generation(monkeypatch, status):
     from mlflow.server.sandbox import reap_orphaned_sandbox_containers
 
-    # A different boot id does not prove a container is orphaned (a concurrent server sharing the
-    # daemon), so a still-running one is left alone rather than force-killed mid-turn.
+    # Only terminal-state (exited/dead) containers are reaped. A container in any live or
+    # transitional state — running, or still starting up (created/restarting) — may belong to a
+    # concurrent server sharing the daemon, so a different boot id does not prove it is orphaned
+    # and force-removing it could kill another server's turn. It is left for a later startup to
+    # reap once it reaches a terminal state.
     monkeypatch.setenv("_MLFLOW_SERVER_BOOT_ID", "current-boot")
-    other_running = mock.MagicMock()
-    other_running.labels = {container_mod.SANDBOX_BOOT_LABEL: "other-boot"}
-    other_running.status = "running"
+    other = mock.MagicMock()
+    other.labels = {container_mod.SANDBOX_BOOT_LABEL: "other-boot"}
+    other.status = status
     client = mock.MagicMock()
-    client.containers.list.return_value = [other_running]
+    client.containers.list.return_value = [other]
     with mock.patch("docker.from_env", return_value=client):
         assert reap_orphaned_sandbox_containers() == 0
-    other_running.remove.assert_not_called()
+    other.remove.assert_not_called()
+
+
+def test_reap_removes_dead_container_from_other_generation(monkeypatch):
+    from mlflow.server.sandbox import reap_orphaned_sandbox_containers
+
+    # "dead" is a terminal state (a container that could not be fully removed), so it is reaped
+    # alongside "exited".
+    monkeypatch.setenv("_MLFLOW_SERVER_BOOT_ID", "current-boot")
+    dead = mock.MagicMock()
+    dead.labels = {container_mod.SANDBOX_BOOT_LABEL: "old-boot"}
+    dead.status = "dead"
+    client = mock.MagicMock()
+    client.containers.list.return_value = [dead]
+    with mock.patch("docker.from_env", return_value=client):
+        assert reap_orphaned_sandbox_containers() == 1
+    dead.remove.assert_called_once_with(force=True)
 
 
 def test_reap_skips_when_no_boot_id(monkeypatch):
@@ -291,8 +328,10 @@ def test_reap_counts_only_successful_removes(monkeypatch):
     monkeypatch.setenv("_MLFLOW_SERVER_BOOT_ID", "current-boot")
     ok = mock.MagicMock()
     ok.labels = {container_mod.SANDBOX_BOOT_LABEL: "old-boot"}
+    ok.status = "exited"
     fails = mock.MagicMock()
     fails.labels = {container_mod.SANDBOX_BOOT_LABEL: "old-boot"}
+    fails.status = "exited"
     fails.remove.side_effect = Exception("cannot remove")
     client = mock.MagicMock()
     client.containers.list.return_value = [ok, fails]
@@ -329,27 +368,29 @@ def test_sandbox_egress_env_injects_proxy_and_bypass(monkeypatch):
     from mlflow.server.sandbox.container import sandbox_egress_env
 
     monkeypatch.setenv("MLFLOW_SANDBOX_EGRESS_PROXY", "http://proxy.internal:3128")
-    env = sandbox_egress_env(no_proxy_hosts=["tracking.example.com"])
+    env = sandbox_egress_env()
     assert env["HTTP_PROXY"] == "http://proxy.internal:3128"
     assert env["HTTPS_PROXY"] == "http://proxy.internal:3128"
     # Lowercase variants for clients that only read them.
     assert env["no_proxy"] == env["NO_PROXY"]
     assert env["https_proxy"] == "http://proxy.internal:3128"
-    # The tracking host bypasses the proxy so it stays reachable...
+    # The self-host bypass entries let the container reach a local tracking server...
     assert "host.docker.internal" in env["NO_PROXY"]
-    assert "tracking.example.com" in env["NO_PROXY"]
+    assert "localhost" in env["NO_PROXY"]
+    assert "127.0.0.1" in env["NO_PROXY"]
     # ...but the cloud metadata endpoint must NOT bypass the proxy.
     assert "169.254.169.254" not in env["NO_PROXY"]
 
 
-def test_sandbox_egress_env_dedupes_no_proxy(monkeypatch):
-    from mlflow.server.sandbox.container import sandbox_egress_env
+def test_sandbox_egress_env_bypass_list_is_fixed_and_not_caller_controlled(monkeypatch):
+    from mlflow.server.sandbox.container import _EGRESS_PROXY_BYPASS_HOSTS, sandbox_egress_env
 
     monkeypatch.setenv("MLFLOW_SANDBOX_EGRESS_PROXY", "http://proxy.internal:3128")
-    # A loopback tracking host is already rewritten to host.docker.internal, so it must not be
-    # duplicated in NO_PROXY.
-    env = sandbox_egress_env(no_proxy_hosts=["host.docker.internal", None])
-    assert env["NO_PROXY"].split(",").count("host.docker.internal") == 1
+    # NO_PROXY is exactly the fixed self-host bypass list. It is not derived from any request or
+    # caller-supplied value, so a remote caller cannot name an internal host (e.g. its own
+    # request-derived tracking URI) to carve that destination out of the proxy.
+    env = sandbox_egress_env()
+    assert env["NO_PROXY"].split(",") == list(_EGRESS_PROXY_BYPASS_HOSTS)
 
 
 def test_run_in_sandbox_injects_egress_proxy(monkeypatch):

--- a/tests/server/sandbox/test_container.py
+++ b/tests/server/sandbox/test_container.py
@@ -92,7 +92,7 @@ def test_run_in_sandbox_applies_hardening_flags():
     assert kwargs["cap_drop"] == ["ALL"]
     assert kwargs["security_opt"] == ["no-new-privileges:true"]
     assert kwargs["read_only"] is True
-    assert kwargs["network_mode"] == "bridge"
+    assert kwargs["network"] == container_mod.SANDBOX_NETWORK_NAME
     assert kwargs["pids_limit"] == container_mod._PIDS_LIMIT
     assert kwargs["mem_limit"] == container_mod._MEMORY_LIMIT
     assert kwargs["user"] == f"{os.getuid()}:{os.getgid()}"
@@ -316,3 +316,79 @@ def test_reap_list_error_returns_zero(monkeypatch):
     client.containers.list.side_effect = Exception("api error")
     with mock.patch("docker.from_env", return_value=client):
         assert reap_orphaned_sandbox_containers() == 0
+
+
+def test_sandbox_egress_env_empty_when_unset(monkeypatch):
+    from mlflow.server.sandbox.container import sandbox_egress_env
+
+    monkeypatch.delenv("MLFLOW_SANDBOX_EGRESS_PROXY", raising=False)
+    assert sandbox_egress_env() == {}
+
+
+def test_sandbox_egress_env_injects_proxy_and_bypass(monkeypatch):
+    from mlflow.server.sandbox.container import sandbox_egress_env
+
+    monkeypatch.setenv("MLFLOW_SANDBOX_EGRESS_PROXY", "http://proxy.internal:3128")
+    env = sandbox_egress_env(no_proxy_hosts=["tracking.example.com"])
+    assert env["HTTP_PROXY"] == "http://proxy.internal:3128"
+    assert env["HTTPS_PROXY"] == "http://proxy.internal:3128"
+    # Lowercase variants for clients that only read them.
+    assert env["no_proxy"] == env["NO_PROXY"]
+    assert env["https_proxy"] == "http://proxy.internal:3128"
+    # The tracking host bypasses the proxy so it stays reachable...
+    assert "host.docker.internal" in env["NO_PROXY"]
+    assert "tracking.example.com" in env["NO_PROXY"]
+    # ...but the cloud metadata endpoint must NOT bypass the proxy.
+    assert "169.254.169.254" not in env["NO_PROXY"]
+
+
+def test_sandbox_egress_env_dedupes_no_proxy(monkeypatch):
+    from mlflow.server.sandbox.container import sandbox_egress_env
+
+    monkeypatch.setenv("MLFLOW_SANDBOX_EGRESS_PROXY", "http://proxy.internal:3128")
+    # A loopback tracking host is already rewritten to host.docker.internal, so it must not be
+    # duplicated in NO_PROXY.
+    env = sandbox_egress_env(no_proxy_hosts=["host.docker.internal", None])
+    assert env["NO_PROXY"].split(",").count("host.docker.internal") == 1
+
+
+def test_run_in_sandbox_injects_egress_proxy(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SANDBOX_EGRESS_PROXY", "http://proxy.internal:3128")
+    client, _ = _mock_client()
+    with mock.patch("docker.from_env", return_value=client):
+        run_in_sandbox(["echo", "hi"])
+    _, kwargs = client.containers.run.call_args
+    assert kwargs["environment"]["HTTPS_PROXY"] == "http://proxy.internal:3128"
+
+
+def test_ensure_sandbox_network_creates_when_missing():
+    import docker.errors
+
+    from mlflow.server.sandbox.container import SANDBOX_NETWORK_NAME, ensure_sandbox_network
+
+    client = mock.MagicMock()
+    client.networks.get.side_effect = docker.errors.NotFound("nope")
+    assert ensure_sandbox_network(client) == SANDBOX_NETWORK_NAME
+    client.networks.create.assert_called_once_with(
+        SANDBOX_NETWORK_NAME, driver="bridge", check_duplicate=True
+    )
+
+
+def test_ensure_sandbox_network_handles_create_race():
+    import docker.errors
+
+    from mlflow.server.sandbox.container import SANDBOX_NETWORK_NAME, ensure_sandbox_network
+
+    client = mock.MagicMock()
+    # First get: not found; create loses the race (409 duplicate); re-get: found.
+    client.networks.get.side_effect = [docker.errors.NotFound("no"), mock.MagicMock()]
+    client.networks.create.side_effect = docker.errors.APIError("network already exists")
+    assert ensure_sandbox_network(client) == SANDBOX_NETWORK_NAME
+
+
+def test_ensure_sandbox_network_falls_back_to_bridge_on_error():
+    from mlflow.server.sandbox.container import ensure_sandbox_network
+
+    client = mock.MagicMock()
+    client.networks.get.side_effect = Exception("permission denied")
+    assert ensure_sandbox_network(client) == "bridge"

--- a/tests/server/sandbox/test_streaming.py
+++ b/tests/server/sandbox/test_streaming.py
@@ -256,3 +256,15 @@ def test_start_sandbox_process_labels_container():
         start_sandbox_process(["claude", "-p"])
     _, kwargs = client.containers.run.call_args
     assert kwargs["labels"] == {SANDBOX_CONTAINER_LABEL: "1"}
+
+
+def test_start_sandbox_process_uses_dedicated_network_and_egress(monkeypatch):
+    from mlflow.server.sandbox.container import SANDBOX_NETWORK_NAME
+
+    monkeypatch.setenv("MLFLOW_SANDBOX_EGRESS_PROXY", "http://proxy.internal:3128")
+    client, _ = _streaming_container([])
+    with mock.patch("docker.from_env", return_value=client):
+        start_sandbox_process(["claude", "-p"])
+    _, kwargs = client.containers.run.call_args
+    assert kwargs["network"] == SANDBOX_NETWORK_NAME
+    assert kwargs["environment"]["HTTPS_PROXY"] == "http://proxy.internal:3128"


### PR DESCRIPTION
## 🥞 Stacked PR
- [assistant-sandbox-1-foundation](https://github.com/mlflow/mlflow/pull/25296)
  - [assistant-sandbox-2-cli](https://github.com/mlflow/mlflow/pull/25302)
    - [assistant-sandbox-3-lifecycle](https://github.com/mlflow/mlflow/pull/25304)
      - [**assistant-sandbox-4-egress**](https://github.com/mlflow/mlflow/pull/25305)
        - [assistant-sandbox-5-docs](https://github.com/mlflow/mlflow/pull/25307)

---------

### Related Issues/PRs

Relates to #25304.

### What changes are proposed in this pull request?

Adds egress controls for the experimental assistant Docker sandbox, gated by the existing `MLFLOW_ENABLE_ASSISTANT_SANDBOX` flag.

- **Dedicated network.** Sandbox containers now attach to a dedicated bridge network (`mlflow-sandbox`, created on demand) instead of the shared default bridge, isolating them from other containers on the host. The get-or-create handles the concurrent-launch race (a duplicate-create conflict is treated as success) and logs a warning — rather than silently downgrading isolation — if it must fall back to the default bridge.
- **Optional egress proxy.** New `MLFLOW_SANDBOX_EGRESS_PROXY`: when set, `HTTP(S)_PROXY` is injected into sandbox containers with only a fixed self-host bypass (`host.docker.internal`, `localhost`, `127.0.0.1`) excluded via `NO_PROXY`, so a co-located tracking server stays reachable while an operator steers the rest of egress through an allowlisting proxy. The request-derived tracking host is deliberately not auto-exempted (a remote caller could otherwise carve an internal destination out of the proxy); a remote tracking server must be allowlisted in the proxy itself.

**On what this does and does not enforce (important):** the proxy env and dedicated bridge *shape* egress for clients that honor the standard proxy env vars; they are **not** a hard boundary. The container has network access, so code that opens raw sockets — or a runtime that ignores the proxy env (e.g. Node's `fetch`, the runtime behind the Claude Code CLI) — can still reach other hosts, including the cloud metadata endpoint. A true egress boundary requires host-level firewalling. The docstrings state this explicitly so an operator does not mistake it for a hard control.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Unit tests cover the dedicated-network selection, the create-race recovery and the warning fallback, proxy-env injection (including the lowercase variants), the fixed self-host `NO_PROXY` bypass — asserting it is not caller-controlled — and the security-critical negatives: that the metadata endpoint is **not** in `NO_PROXY`, and that a request-derived tracking host cannot be exempted. The sandbox mechanics were also validated against a live Docker daemon. Enforcement behind a real allowlisting proxy is validated separately with an operator proxy.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

User-facing documentation will follow once the capability is ready to recommend.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Experimental and off by default.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


