### PR TITLE
basic-auth: enable fail-closed authorization by default

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1180,8 +1180,9 @@ MLFLOW_SERVER_X_FRAME_OPTIONS = _EnvironmentVariable(
 )
 
 #: Deny (403) authenticated requests to routes with no authorization decision in the
-#: built-in basic-auth app (fail-closed). Off by default. (default: ``False``)
-MLFLOW_BASIC_AUTH_FAIL_CLOSED = _BooleanEnvironmentVariable("MLFLOW_BASIC_AUTH_FAIL_CLOSED", False)
+#: built-in basic-auth app (fail-closed). On by default; set to ``False`` to restore the
+#: previous fail-open behavior. (default: ``True``)
+MLFLOW_BASIC_AUTH_FAIL_CLOSED = _BooleanEnvironmentVariable("MLFLOW_BASIC_AUTH_FAIL_CLOSED", True)
 
 #: Specifies the max length (in chars) of an experiment's artifact location.
 #: The default is 2048.

--- a/tests/server/auth/test_fail_closed_flag.py
+++ b/tests/server/auth/test_fail_closed_flag.py
@@ -11,13 +11,16 @@ class _Req:
         self.method = method
 
 
-def test_flag_defaults_off():
-    assert MLFLOW_BASIC_AUTH_FAIL_CLOSED.get() is False
+def test_flag_defaults_on():
+    assert MLFLOW_BASIC_AUTH_FAIL_CLOSED.get() is True
 
 
 def test_flag_reads_env(monkeypatch):
     monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
     assert MLFLOW_BASIC_AUTH_FAIL_CLOSED.get() is True
+    # The opt-out direction matters now that the default is True.
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "false")
+    assert MLFLOW_BASIC_AUTH_FAIL_CLOSED.get() is False
 
 
 def test_debt_list_is_empty():


### PR DESCRIPTION
### Related Issues/PRs

Capstone of the basic-auth authorization-hardening series (#25065, #25066, #25067, #25069,
#25070, #25071, #25101, #25102). Those PRs added the fail-closed net + CI coverage guards,
gated every Flask and native-FastAPI route family, and emptied both ungated-route debt lists.
This PR flips the switch.

> 🗣️ **Seeking maintainer sign-off before merge.** This changes the default security posture
> of the built-in basic-auth app. Proposing it for **3.16.0** — please weigh in on the timing
> and the breaking-change call below.

### What changes are proposed in this pull request?

Flip `MLFLOW_BASIC_AUTH_FAIL_CLOSED` from default `False` to default **`True`**.

- **Before:** an authenticated request to a route with no authorization decision was allowed
  through (fail-open).
- **After:** it is denied with 403 (fail-closed). `MLFLOW_BASIC_AUTH_FAIL_CLOSED=false`
  restores the previous behavior.

Prerequisites (all merged) make this safe:
- Every Flask route family is gated; `_KNOWN_UNGATED_ROUTE_MARKERS` is empty.
- Native FastAPI routes are gated + fail-closed enforced (#25101); `_KNOWN_UNGATED_FASTAPI_ROUTE_MARKERS` is empty.
- CI guards (`test_no_new_ungated_routes`, `test_no_ungated_fastapi_native_routes`) keep it that way.

**⚠️ Breaking change.** All of MLflow's own routes are gated, so first-party flows are
unaffected — but a **custom/third-party route or auth plugin** that relied on the old
fail-open behavior would now return 403. The opt-out env var is the escape hatch. This is
the intended end state of the hardening work, hence proposing it for a minor release with
a clear release note rather than a patch.

### How is this PR tested?

- [x] Existing unit/integration tests

The full basic-auth integration suite (`tests/server/auth/test_auth.py`, 264 tests) passes
with the flipped default, confirming first-party flows are unaffected. `test_fail_closed_flag.py`
is updated (`test_flag_defaults_on`); the opt-out path (`...allows_ungated_route_when_flag_off`)
still covers `MLFLOW_BASIC_AUTH_FAIL_CLOSED=false`.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The built-in basic-auth app now fails closed by default: authenticated requests to
  routes with no authorization decision are denied (403). Set `MLFLOW_BASIC_AUTH_FAIL_CLOSED=false`
  to restore the previous fail-open behavior.

#### What component(s) does this PR affect?

- [x] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

#### How should the PR be classified in the release notes?

- [x] `rn/breaking-change` - A change that breaks the existing behavior

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
