### PR TITLE
Add incremental mypy strict harness and type small mlflow.entities

### DIFF
--- a/mlflow/entities/_job_status.py
+++ b/mlflow/entities/_job_status.py
@@ -50,7 +50,7 @@ class JobStatus(str, Enum):
         }
         return mapping.get(self, ProtoJobStatus.JOB_STATUS_UNSPECIFIED)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
     @staticmethod

--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -1,10 +1,12 @@
 import pprint
 from abc import abstractmethod
+from collections.abc import Iterator
 from functools import cached_property
+from typing import Any
 
 
 class _MlflowObject:
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         # Iterate through list of properties and yield as key -> value
         for prop in self._properties():
             yield prop, self.__getattribute__(prop)
@@ -21,32 +23,32 @@ class _MlflowObject:
 
     @classmethod
     @abstractmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: Any) -> "_MlflowObject":
         pass
 
     @classmethod
-    def from_dictionary(cls, the_dict):
+    def from_dictionary(cls, the_dict: dict[str, Any]) -> "_MlflowObject":
         filtered_dict = {key: value for key, value in the_dict.items() if key in cls._properties()}
         return cls(**filtered_dict)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return to_string(self)
 
 
-def to_string(obj):
+def to_string(obj: Any) -> str:
     return _MlflowObjectPrinter().to_string(obj)
 
 
-def get_classname(obj):
+def get_classname(obj: Any) -> str:
     return type(obj).__name__
 
 
 class _MlflowObjectPrinter:
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.printer = pprint.PrettyPrinter()
 
-    def to_string(self, obj):
+    def to_string(self, obj: Any) -> str:
         if isinstance(obj, _MlflowObject):
             return f"<{get_classname(obj)}: {self._entity_to_string(obj)}>"
         return self.printer.pformat(obj)

--- a/mlflow/entities/assessment_error.py
+++ b/mlflow/entities/assessment_error.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.assessments_pb2 import AssessmentError as ProtoAssessmentError
@@ -44,7 +45,7 @@ class AssessmentError(_MlflowObject):
     error_message: str | None = None
     stack_trace: str | None = None
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoAssessmentError:
         error = ProtoAssessmentError()
         error.error_code = self.error_code
         if self.error_message:
@@ -58,14 +59,14 @@ class AssessmentError(_MlflowObject):
         return error
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoAssessmentError) -> "AssessmentError":
         return cls(
             error_code=proto.error_code,
             error_message=proto.error_message or None,
             stack_trace=proto.stack_trace or None,
         )
 
-    def to_dictionary(self):
+    def to_dictionary(self) -> dict[str, Any]:
         return {
             "error_code": self.error_code,
             "error_message": self.error_message,
@@ -73,5 +74,5 @@ class AssessmentError(_MlflowObject):
         }
 
     @classmethod
-    def from_dictionary(cls, error_dict):
+    def from_dictionary(cls, error_dict: dict[str, Any]) -> "AssessmentError":
         return cls(**error_dict)

--- a/mlflow/entities/dataset_input.py
+++ b/mlflow/entities/dataset_input.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.dataset import Dataset
 from mlflow.entities.input_tag import InputTag
@@ -9,9 +11,9 @@ class DatasetInput(_MlflowObject):
 
     def __init__(self, dataset: Dataset, tags: list[InputTag] | None = None) -> None:
         self._dataset = dataset
-        self._tags = tags or []
+        self._tags: list[InputTag] = tags or []
 
-    def __eq__(self, other: _MlflowObject) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
@@ -29,20 +31,20 @@ class DatasetInput(_MlflowObject):
         """Dataset."""
         return self._dataset
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoDatasetInput:
         dataset_input = ProtoDatasetInput()
         dataset_input.tags.extend([tag.to_proto() for tag in self.tags])
         dataset_input.dataset.MergeFrom(self.dataset.to_proto())
         return dataset_input
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoDatasetInput) -> "DatasetInput":
         dataset_input = cls(Dataset.from_proto(proto.dataset))
         for input_tag in proto.tags:
             dataset_input._add_tag(InputTag.from_proto(input_tag))
         return dataset_input
 
-    def to_dictionary(self):
+    def to_dictionary(self) -> dict[str, Any]:
         return {
             "dataset": self.dataset.to_dictionary(),
             "tags": {tag.key: tag.value for tag in self.tags},

--- a/mlflow/entities/dataset_summary.py
+++ b/mlflow/entities/dataset_summary.py
@@ -8,34 +8,34 @@ class _DatasetSummary:
     This is used to return a list of dataset summaries across one or more experiments in the UI.
     """
 
-    def __init__(self, experiment_id, name, digest, context):
+    def __init__(self, experiment_id: str, name: str, digest: str, context: str | None) -> None:
         self._experiment_id = experiment_id
         self._name = name
         self._digest = digest
         self._context = context
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
 
     @property
-    def experiment_id(self):
+    def experiment_id(self) -> str:
         return self._experiment_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def digest(self):
+    def digest(self) -> str:
         return self._digest
 
     @property
-    def context(self):
+    def context(self) -> str | None:
         return self._context
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, str | None]:
         return {
             "experiment_id": self.experiment_id,
             "name": self.name,
@@ -43,7 +43,7 @@ class _DatasetSummary:
             "context": self.context,
         }
 
-    def to_proto(self):
+    def to_proto(self) -> DatasetSummary:
         dataset_summary = DatasetSummary()
         dataset_summary.experiment_id = self.experiment_id
         dataset_summary.name = self.name
@@ -53,7 +53,7 @@ class _DatasetSummary:
         return dataset_summary
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: DatasetSummary) -> "_DatasetSummary":
         return cls(
             experiment_id=proto.experiment_id,
             name=proto.name,

--- a/mlflow/entities/document.py
+++ b/mlflow/entities/document.py
@@ -19,7 +19,7 @@ class Document:
     id: str | None = None
 
     @classmethod
-    def from_langchain_document(cls, document):
+    def from_langchain_document(cls, document: Any) -> "Document":
         # older versions of langchain do not have the id attribute
         id = getattr(document, "id", None)
 
@@ -30,7 +30,7 @@ class Document:
         )
 
     @classmethod
-    def from_llama_index_node_with_score(cls, node_with_score):
+    def from_llama_index_node_with_score(cls, node_with_score: Any) -> "Document":
         metadata = {
             "score": node_with_score.get_score(),
             # update after setting score so that it can be
@@ -44,5 +44,5 @@ class Document:
             id=node_with_score.node_id,
         )
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/mlflow/entities/experiment_tag.py
+++ b/mlflow/entities/experiment_tag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import ExperimentTag as ProtoExperimentTag
 
@@ -5,31 +7,31 @@ from mlflow.protos.service_pb2 import ExperimentTag as ProtoExperimentTag
 class ExperimentTag(_MlflowObject):
     """Tag object associated with an experiment."""
 
-    def __init__(self, key, value):
+    def __init__(self, key: str, value: str) -> None:
         self._key = key
         self._value = value
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
 
     @property
-    def key(self):
+    def key(self) -> str:
         """String name of the tag."""
         return self._key
 
     @property
-    def value(self):
+    def value(self) -> str:
         """String value of the tag."""
         return self._value
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoExperimentTag:
         param = ProtoExperimentTag()
         param.key = self.key
         param.value = self.value
         return param
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoExperimentTag) -> ExperimentTag:
         return cls(proto.key, proto.value)

--- a/mlflow/entities/file_info.py
+++ b/mlflow/entities/file_info.py
@@ -7,32 +7,32 @@ class FileInfo(_MlflowObject):
     Metadata about a file or directory.
     """
 
-    def __init__(self, path, is_dir, file_size):
+    def __init__(self, path: str, is_dir: bool, file_size: int | None) -> None:
         self._path = path
         self._is_dir = is_dir
         self._bytes = file_size
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
 
     @property
-    def path(self):
+    def path(self) -> str:
         """String path of the file or directory."""
         return self._path
 
     @property
-    def is_dir(self):
+    def is_dir(self) -> bool:
         """Whether the FileInfo corresponds to a directory."""
         return self._is_dir
 
     @property
-    def file_size(self):
+    def file_size(self) -> int | None:
         """Size of the file or directory. If the FileInfo is a directory, returns None."""
         return self._bytes
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoFileInfo:
         proto = ProtoFileInfo()
         proto.path = self.path
         proto.is_dir = self.is_dir
@@ -41,5 +41,5 @@ class FileInfo(_MlflowObject):
         return proto
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoFileInfo) -> "FileInfo":
         return cls(proto.path, proto.is_dir, proto.file_size)

--- a/mlflow/entities/input_tag.py
+++ b/mlflow/entities/input_tag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import InputTag as ProtoInputTag
 
@@ -9,7 +11,7 @@ class InputTag(_MlflowObject):
         self._key = key
         self._value = value
 
-    def __eq__(self, other: _MlflowObject) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
@@ -24,12 +26,12 @@ class InputTag(_MlflowObject):
         """String value of the input tag."""
         return self._value
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoInputTag:
         tag = ProtoInputTag()
         tag.key = self.key
         tag.value = self.value
         return tag
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoInputTag) -> InputTag:
         return cls(proto.key, proto.value)

--- a/mlflow/entities/lifecycle_stage.py
+++ b/mlflow/entities/lifecycle_stage.py
@@ -8,7 +8,7 @@ class LifecycleStage:
     _VALID_STAGES = {ACTIVE, DELETED}
 
     @classmethod
-    def view_type_to_stages(cls, view_type=ViewType.ALL):
+    def view_type_to_stages(cls, view_type: int = ViewType.ALL) -> list[str]:
         stages = []
         if view_type in (ViewType.ACTIVE_ONLY, ViewType.ALL):
             stages.append(cls.ACTIVE)
@@ -17,11 +17,11 @@ class LifecycleStage:
         return stages
 
     @classmethod
-    def is_valid(cls, lifecycle_stage):
+    def is_valid(cls, lifecycle_stage: str) -> bool:
         return lifecycle_stage in cls._VALID_STAGES
 
     @classmethod
-    def matches_view_type(cls, view_type, lifecycle_stage):
+    def matches_view_type(cls, view_type: int, lifecycle_stage: str) -> bool:
         if not cls.is_valid(lifecycle_stage):
             raise MlflowException(f"Invalid lifecycle stage '{lifecycle_stage}'")
 

--- a/mlflow/entities/link.py
+++ b/mlflow/entities/link.py
@@ -2,6 +2,8 @@ import base64
 from dataclasses import dataclass
 from typing import Any
 
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
+
 from mlflow.entities._mlflow_object import _MlflowObject
 
 
@@ -43,7 +45,7 @@ class Link(_MlflowObject):
         )
 
     @classmethod
-    def from_otel_proto(cls, proto_link) -> "Link":
+    def from_otel_proto(cls, proto_link: OTelProtoSpan.Link) -> "Link":
         from mlflow.tracing.utils import encode_span_id, generate_mlflow_trace_id_from_otel_trace_id
         from mlflow.tracing.utils.otlp import _decode_otel_proto_anyvalue, _otel_proto_bytes_to_id
 

--- a/mlflow/entities/logged_model_input.py
+++ b/mlflow/entities/logged_model_input.py
@@ -8,7 +8,7 @@ class LoggedModelInput(_MlflowObject):
     def __init__(self, model_id: str):
         self._model_id = model_id
 
-    def __eq__(self, other: _MlflowObject) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
@@ -18,9 +18,9 @@ class LoggedModelInput(_MlflowObject):
         """Model ID."""
         return self._model_id
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoModelInput:
         return ProtoModelInput(model_id=self._model_id)
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoModelInput) -> "LoggedModelInput":
         return cls(proto.model_id)

--- a/mlflow/entities/logged_model_output.py
+++ b/mlflow/entities/logged_model_output.py
@@ -1,5 +1,5 @@
 from mlflow.entities._mlflow_object import _MlflowObject
-from mlflow.protos.service_pb2 import ModelOutput
+from mlflow.protos.service_pb2 import ModelOutput as ProtoModelOutput
 
 
 class LoggedModelOutput(_MlflowObject):
@@ -9,7 +9,7 @@ class LoggedModelOutput(_MlflowObject):
         self._model_id = model_id
         self._step = step
 
-    def __eq__(self, other: _MlflowObject) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
@@ -20,16 +20,16 @@ class LoggedModelOutput(_MlflowObject):
         return self._model_id
 
     @property
-    def step(self) -> str:
+    def step(self) -> int:
         """Step at which the model was logged"""
         return self._step
 
-    def to_proto(self):
-        return ModelOutput(model_id=self.model_id, step=self.step)
+    def to_proto(self) -> ProtoModelOutput:
+        return ProtoModelOutput(model_id=self.model_id, step=self.step)
 
     def to_dictionary(self) -> dict[str, str | int]:
         return {"model_id": self.model_id, "step": self.step}
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoModelOutput) -> "LoggedModelOutput":
         return cls(proto.model_id, proto.step)

--- a/mlflow/entities/logged_model_parameter.py
+++ b/mlflow/entities/logged_model_parameter.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import sys
 
 from mlflow.entities._mlflow_object import _MlflowObject
-from mlflow.protos import service_pb2 as pb2
+from mlflow.protos.service_pb2 import LoggedModelParameter as ProtoLoggedModelParameter
 
 
 class LoggedModelParameter(_MlflowObject):
@@ -9,7 +11,7 @@ class LoggedModelParameter(_MlflowObject):
     MLflow entity representing a parameter of a Model.
     """
 
-    def __init__(self, key, value):
+    def __init__(self, key: str, value: str) -> None:
         if "pyspark.ml" in sys.modules:
             import pyspark.ml.param
 
@@ -20,27 +22,27 @@ class LoggedModelParameter(_MlflowObject):
         self._value = value
 
     @property
-    def key(self):
+    def key(self) -> str:
         """String key corresponding to the parameter name."""
         return self._key
 
     @property
-    def value(self):
+    def value(self) -> str:
         """String value of the parameter."""
         return self._value
 
-    def __eq__(self, __o):
+    def __eq__(self, __o: object) -> bool:
         if isinstance(__o, self.__class__):
             return self._key == __o._key
 
         return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._key)
 
-    def to_proto(self):
-        return pb2.LoggedModelParameter(key=self._key, value=self._value)
+    def to_proto(self) -> ProtoLoggedModelParameter:
+        return ProtoLoggedModelParameter(key=self._key, value=self._value)
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoLoggedModelParameter) -> LoggedModelParameter:
         return cls(key=proto.key, value=proto.value)

--- a/mlflow/entities/logged_model_tag.py
+++ b/mlflow/entities/logged_model_tag.py
@@ -1,33 +1,35 @@
+from __future__ import annotations
+
 from mlflow.entities._mlflow_object import _MlflowObject
-from mlflow.protos import service_pb2 as pb2
+from mlflow.protos.service_pb2 import LoggedModelTag as ProtoLoggedModelTag
 
 
 class LoggedModelTag(_MlflowObject):
     """Tag object associated with a Model."""
 
-    def __init__(self, key, value):
+    def __init__(self, key: str, value: str) -> None:
         self._key = key
         self._value = value
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             # TODO deep equality here?
             return self.__dict__ == other.__dict__
         return False
 
     @property
-    def key(self):
+    def key(self) -> str:
         """String name of the tag."""
         return self._key
 
     @property
-    def value(self):
+    def value(self) -> str:
         """String value of the tag."""
         return self._value
 
-    def to_proto(self):
-        return pb2.LoggedModelTag(key=self._key, value=self._value)
+    def to_proto(self) -> ProtoLoggedModelTag:
+        return ProtoLoggedModelTag(key=self._key, value=self._value)
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoLoggedModelTag) -> LoggedModelTag:
         return cls(key=proto.key, value=proto.value)

--- a/mlflow/entities/multipart_upload.py
+++ b/mlflow/entities/multipart_upload.py
@@ -7,23 +7,26 @@ from mlflow.protos.mlflow_artifacts_pb2 import (
 from mlflow.protos.mlflow_artifacts_pb2 import (
     MultipartUploadCredential as ProtoMultipartUploadCredential,
 )
+from mlflow.protos.mlflow_artifacts_pb2 import (
+    MultipartUploadPart as ProtoMultipartUploadPart,
+)
 
 
 @dataclass
 class MultipartUploadPart:
     part_number: int
-    etag: str
+    etag: str | None
     url: str | None = None
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoMultipartUploadPart) -> "MultipartUploadPart":
         return cls(
             proto.part_number,
             proto.etag or None,
             proto.url or None,
         )
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "part_number": self.part_number,
             "etag": self.etag,
@@ -37,7 +40,7 @@ class MultipartUploadCredential:
     part_number: int
     headers: dict[str, Any]
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoMultipartUploadCredential:
         credential = ProtoMultipartUploadCredential()
         credential.url = self.url
         credential.part_number = self.part_number
@@ -45,7 +48,7 @@ class MultipartUploadCredential:
         return credential
 
     @classmethod
-    def from_dict(cls, dict_):
+    def from_dict(cls, dict_: dict[str, Any]) -> "MultipartUploadCredential":
         return cls(
             url=dict_["url"],
             part_number=dict_["part_number"],
@@ -58,7 +61,7 @@ class CreateMultipartUploadResponse:
     upload_id: str | None
     credentials: list[MultipartUploadCredential]
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoCreateMultipartUpload.Response:
         response = ProtoCreateMultipartUpload.Response()
         if self.upload_id:
             response.upload_id = self.upload_id
@@ -66,7 +69,7 @@ class CreateMultipartUploadResponse:
         return response
 
     @classmethod
-    def from_dict(cls, dict_):
+    def from_dict(cls, dict_: dict[str, Any]) -> "CreateMultipartUploadResponse":
         credentials = [MultipartUploadCredential.from_dict(cred) for cred in dict_["credentials"]]
         return cls(
             upload_id=dict_.get("upload_id"),

--- a/mlflow/entities/param.py
+++ b/mlflow/entities/param.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from mlflow.entities._mlflow_object import _MlflowObject
@@ -9,7 +11,7 @@ class Param(_MlflowObject):
     Parameter object.
     """
 
-    def __init__(self, key, value):
+    def __init__(self, key: str, value: str) -> None:
         if "pyspark.ml" in sys.modules:
             import pyspark.ml.param
 
@@ -20,30 +22,30 @@ class Param(_MlflowObject):
         self._value = value
 
     @property
-    def key(self):
+    def key(self) -> str:
         """String key corresponding to the parameter name."""
         return self._key
 
     @property
-    def value(self):
+    def value(self) -> str:
         """String value of the parameter."""
         return self._value
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoParam:
         param = ProtoParam()
         param.key = self.key
         param.value = self.value
         return param
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoParam) -> Param:
         return cls(proto.key, proto.value)
 
-    def __eq__(self, __o):
+    def __eq__(self, __o: object) -> bool:
         if isinstance(__o, self.__class__):
             return self._key == __o._key
 
         return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._key)

--- a/mlflow/entities/presigned_download.py
+++ b/mlflow/entities/presigned_download.py
@@ -16,7 +16,7 @@ class PresignedDownloadUrlResponse:
     file_size: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        result = {
+        result: dict[str, Any] = {
             "url": self.url,
             "headers": self.headers,
         }

--- a/mlflow/entities/presigned_upload.py
+++ b/mlflow/entities/presigned_upload.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from mlflow.protos.service_pb2 import CreatePresignedUploadUrl as ProtoCreatePresignedUploadUrl
+
 
 @dataclass
 class CreatePresignedUploadResponse:
@@ -11,18 +13,16 @@ class CreatePresignedUploadResponse:
     presigned_url: str
     headers: dict[str, str] = field(default_factory=dict)
 
-    def to_proto(self):
-        from mlflow.protos.service_pb2 import (
-            CreatePresignedUploadUrl as ProtoCreatePresignedUploadUrl,
-        )
-
+    def to_proto(self) -> ProtoCreatePresignedUploadUrl.Response:
         response = ProtoCreatePresignedUploadUrl.Response()
         response.presigned_url = self.presigned_url
         response.headers.update(self.headers)
         return response
 
     @classmethod
-    def from_proto(cls, proto) -> CreatePresignedUploadResponse:
+    def from_proto(
+        cls, proto: ProtoCreatePresignedUploadUrl.Response
+    ) -> CreatePresignedUploadResponse:
         return cls(
             presigned_url=proto.presigned_url,
             headers=dict(proto.headers),

--- a/mlflow/entities/run_inputs.py
+++ b/mlflow/entities/run_inputs.py
@@ -15,9 +15,9 @@ class RunInputs(_MlflowObject):
         model_inputs: list[LoggedModelInput] | None = None,
     ) -> None:
         self._dataset_inputs = dataset_inputs
-        self._model_inputs = model_inputs or []
+        self._model_inputs: list[LoggedModelInput] = model_inputs or []
 
-    def __eq__(self, other: _MlflowObject) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
@@ -32,7 +32,7 @@ class RunInputs(_MlflowObject):
         """Array of model inputs."""
         return self._model_inputs
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoRunInputs:
         run_inputs = ProtoRunInputs()
         run_inputs.dataset_inputs.extend([
             dataset_input.to_proto() for dataset_input in self.dataset_inputs
@@ -49,7 +49,7 @@ class RunInputs(_MlflowObject):
         }
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoRunInputs) -> "RunInputs":
         dataset_inputs = [
             DatasetInput.from_proto(dataset_input) for dataset_input in proto.dataset_inputs
         ]

--- a/mlflow/entities/run_outputs.py
+++ b/mlflow/entities/run_outputs.py
@@ -11,7 +11,7 @@ class RunOutputs(_MlflowObject):
     def __init__(self, model_outputs: list[LoggedModelOutput]) -> None:
         self._model_outputs = model_outputs
 
-    def __eq__(self, other: _MlflowObject) -> bool:
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             return self.__dict__ == other.__dict__
         return False
@@ -21,7 +21,7 @@ class RunOutputs(_MlflowObject):
         """Array of model outputs."""
         return self._model_outputs
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoRunOutputs:
         run_outputs = ProtoRunOutputs()
         run_outputs.model_outputs.extend([
             model_output.to_proto() for model_output in self.model_outputs
@@ -35,7 +35,7 @@ class RunOutputs(_MlflowObject):
         }
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoRunOutputs) -> "RunOutputs":
         model_outputs = [
             LoggedModelOutput.from_proto(model_output) for model_output in proto.model_outputs
         ]

--- a/mlflow/entities/run_status.py
+++ b/mlflow/entities/run_status.py
@@ -4,18 +4,18 @@ from mlflow.protos.service_pb2 import RunStatus as ProtoRunStatus
 class RunStatus:
     """Enum for status of an :py:class:`mlflow.entities.Run`."""
 
-    RUNNING = ProtoRunStatus.Value("RUNNING")
-    SCHEDULED = ProtoRunStatus.Value("SCHEDULED")
-    FINISHED = ProtoRunStatus.Value("FINISHED")
-    FAILED = ProtoRunStatus.Value("FAILED")
-    KILLED = ProtoRunStatus.Value("KILLED")
+    RUNNING: int = ProtoRunStatus.Value("RUNNING")
+    SCHEDULED: int = ProtoRunStatus.Value("SCHEDULED")
+    FINISHED: int = ProtoRunStatus.Value("FINISHED")
+    FAILED: int = ProtoRunStatus.Value("FAILED")
+    KILLED: int = ProtoRunStatus.Value("KILLED")
 
-    _STRING_TO_STATUS = {k: ProtoRunStatus.Value(k) for k in ProtoRunStatus.keys()}
+    _STRING_TO_STATUS: dict[str, int] = {k: ProtoRunStatus.Value(k) for k in ProtoRunStatus.keys()}
     _STATUS_TO_STRING = {value: key for key, value in _STRING_TO_STATUS.items()}
     _TERMINATED_STATUSES = {FINISHED, FAILED, KILLED}
 
     @staticmethod
-    def from_string(status_str):
+    def from_string(status_str: str) -> int:
         if status_str not in RunStatus._STRING_TO_STATUS:
             raise Exception(
                 f"Could not get run status corresponding to string {status_str}. Valid run "
@@ -24,7 +24,7 @@ class RunStatus:
         return RunStatus._STRING_TO_STATUS[status_str]
 
     @staticmethod
-    def to_string(status):
+    def to_string(status: int) -> str:
         if status not in RunStatus._STATUS_TO_STRING:
             raise Exception(
                 f"Could not get string corresponding to run status {status}. Valid run "
@@ -33,9 +33,9 @@ class RunStatus:
         return RunStatus._STATUS_TO_STRING[status]
 
     @staticmethod
-    def is_terminated(status):
+    def is_terminated(status: int) -> bool:
         return status in RunStatus._TERMINATED_STATUSES
 
     @staticmethod
-    def all_status():
+    def all_status() -> list[int]:
         return list(RunStatus._STATUS_TO_STRING.keys())

--- a/mlflow/entities/run_tag.py
+++ b/mlflow/entities/run_tag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.service_pb2 import RunTag as ProtoRunTag
 
@@ -5,32 +7,32 @@ from mlflow.protos.service_pb2 import RunTag as ProtoRunTag
 class RunTag(_MlflowObject):
     """Tag object associated with a run."""
 
-    def __init__(self, key, value):
+    def __init__(self, key: str, value: str) -> None:
         self._key = key
         self._value = value
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if type(other) is type(self):
             # TODO deep equality here?
             return self.__dict__ == other.__dict__
         return False
 
     @property
-    def key(self):
+    def key(self) -> str:
         """String name of the tag."""
         return self._key
 
     @property
-    def value(self):
+    def value(self) -> str:
         """String value of the tag."""
         return self._value
 
-    def to_proto(self):
+    def to_proto(self) -> ProtoRunTag:
         param = ProtoRunTag()
         param.key = self.key
         param.value = self.value
         return param
 
     @classmethod
-    def from_proto(cls, proto):
+    def from_proto(cls, proto: ProtoRunTag) -> RunTag:
         return cls(proto.key, proto.value)

--- a/mlflow/entities/source_type.py
+++ b/mlflow/entities/source_type.py
@@ -13,7 +13,7 @@ class SourceType:
     SOURCETYPE_TO_STRING = {value: key for key, value in _STRING_TO_SOURCETYPE.items()}
 
     @staticmethod
-    def from_string(status_str):
+    def from_string(status_str: str) -> int:
         if status_str not in SourceType._STRING_TO_SOURCETYPE:
             raise Exception(
                 f"Could not get run status corresponding to string {status_str}. Valid run "
@@ -22,7 +22,7 @@ class SourceType:
         return SourceType._STRING_TO_SOURCETYPE[status_str]
 
     @staticmethod
-    def to_string(status):
+    def to_string(status: int) -> str:
         if status not in SourceType.SOURCETYPE_TO_STRING:
             raise Exception(
                 f"Could not get string corresponding to run status {status}. Valid run "

--- a/mlflow/entities/span_event.py
+++ b/mlflow/entities/span_event.py
@@ -3,7 +3,9 @@ import time
 import traceback
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any, cast
 
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as OTelProtoSpan
 from opentelemetry.util.types import AttributeValue
 
 from mlflow.entities._mlflow_object import _MlflowObject
@@ -33,7 +35,7 @@ class SpanEvent(_MlflowObject):
     attributes: dict[str, AttributeValue] = field(default_factory=dict)
 
     @classmethod
-    def from_exception(cls, exception: Exception):
+    def from_exception(cls, exception: Exception) -> "SpanEvent":
         "Create a span event from an exception."
 
         stack_trace = cls._get_stacktrace(exception)
@@ -56,7 +58,7 @@ class SpanEvent(_MlflowObject):
         except Exception:
             return msg
 
-    def json(self):
+    def json(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "timestamp": self.timestamp,
@@ -65,7 +67,7 @@ class SpanEvent(_MlflowObject):
             else None,
         }
 
-    def to_otel_proto(self):
+    def to_otel_proto(self) -> OTelProtoSpan.Event:
         """
         Convert to OpenTelemetry protobuf event format for OTLP export.
         This is an internal method used for logging spans via OTel protocol.
@@ -73,9 +75,7 @@ class SpanEvent(_MlflowObject):
         Returns:
             An OpenTelemetry protobuf Span.Event message.
         """
-        from opentelemetry.proto.trace.v1.trace_pb2 import Span
-
-        otel_event = Span.Event()
+        otel_event = OTelProtoSpan.Event()
         otel_event.name = self.name
         otel_event.time_unix_nano = self.timestamp
 
@@ -92,9 +92,11 @@ class CustomEncoder(json.JSONEncoder):
     Custom encoder to handle json serialization.
     """
 
-    def default(self, o):
+    def default(self, o: object) -> str:
         try:
-            return super().default(o)
+            # JSONEncoder.default always raises TypeError; cast to reflect the
+            # effective return type of this override.
+            return cast(str, super().default(o))
         except TypeError:
             # convert datetime to string format by default
             if isinstance(o, datetime):

--- a/mlflow/entities/trace_state.py
+++ b/mlflow/entities/trace_state.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import cast
 
 from opentelemetry import trace as trace_api
 
@@ -19,18 +20,19 @@ class TraceState(str, Enum):
     ERROR = "ERROR"
     IN_PROGRESS = "IN_PROGRESS"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
-    def to_proto(self):
-        return pb.TraceInfoV3.State.Value(self)
+    def to_proto(self) -> int:
+        # `EnumTypeWrapper.Value` is untyped upstream, hence the cast.
+        return cast(int, pb.TraceInfoV3.State.Value(self))
 
     @classmethod
     def from_proto(cls, proto: int) -> "TraceState":
         return TraceState(pb.TraceInfoV3.State.Name(proto))
 
     @staticmethod
-    def from_otel_status(otel_status: trace_api.Status):
+    def from_otel_status(otel_status: trace_api.Status) -> "TraceState":
         """Convert OpenTelemetry status code to MLflow TraceState."""
         return _OTEL_STATUS_CODE_TO_MLFLOW[otel_status.status_code]
 

--- a/mlflow/entities/trace_status.py
+++ b/mlflow/entities/trace_status.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import cast
 
 from opentelemetry import trace as trace_api
 
@@ -39,24 +40,25 @@ class TraceStatus(str, Enum):
             return cls.IN_PROGRESS
         raise ValueError(f"Unknown TraceState: {state}")
 
-    def to_proto(self):
-        return ProtoTraceStatus.Value(self)
+    def to_proto(self) -> int:
+        # `EnumTypeWrapper.Value` is untyped upstream, hence the cast.
+        return cast(int, ProtoTraceStatus.Value(self))
 
     @staticmethod
-    def from_proto(proto_status):
+    def from_proto(proto_status: int) -> "TraceStatus":
         return TraceStatus(ProtoTraceStatus.Name(proto_status))
 
     @staticmethod
-    def from_otel_status(otel_status: trace_api.Status):
+    def from_otel_status(otel_status: trace_api.Status) -> "TraceStatus":
         return _OTEL_STATUS_CODE_TO_MLFLOW[otel_status.status_code]
 
     @classmethod
-    def pending_statuses(cls):
+    def pending_statuses(cls) -> set["TraceStatus"]:
         """Traces in pending statuses can be updated to any statuses."""
         return {cls.IN_PROGRESS}
 
     @classmethod
-    def end_statuses(cls):
+    def end_statuses(cls) -> set["TraceStatus"]:
         """Traces in end statuses cannot be updated to any statuses."""
         return {cls.UNSPECIFIED, cls.OK, cls.ERROR}
 

--- a/mlflow/entities/view_type.py
+++ b/mlflow/entities/view_type.py
@@ -13,7 +13,7 @@ class ViewType:
     _STRING_TO_VIEW = {value: key for key, value in _VIEW_TO_STRING.items()}
 
     @classmethod
-    def from_string(cls, view_str):
+    def from_string(cls, view_str: str) -> int:
         if view_str not in cls._STRING_TO_VIEW:
             raise Exception(
                 f"Could not get valid view type corresponding to string {view_str}. "
@@ -22,7 +22,7 @@ class ViewType:
         return cls._STRING_TO_VIEW[view_str]
 
     @classmethod
-    def to_string(cls, view_type):
+    def to_string(cls, view_type: int) -> str:
         if view_type not in cls._VIEW_TO_STRING:
             raise Exception(
                 f"Could not get valid view type corresponding to string {view_type}. "
@@ -31,7 +31,7 @@ class ViewType:
         return cls._VIEW_TO_STRING[view_type]
 
     @classmethod
-    def to_proto(cls, view_type):
+    def to_proto(cls, view_type: int) -> service_pb2.ViewType:
         if view_type == cls.ACTIVE_ONLY:
             return service_pb2.ACTIVE_ONLY
         elif view_type == cls.DELETED_ONLY:
@@ -41,7 +41,7 @@ class ViewType:
         raise ValueError(f"Unexpected view_type: {view_type}")
 
     @classmethod
-    def from_proto(cls, proto_view_type):
+    def from_proto(cls, proto_view_type: service_pb2.ViewType) -> int:
         if proto_view_type == service_pb2.ACTIVE_ONLY:
             return cls.ACTIVE_ONLY
         elif proto_view_type == service_pb2.DELETED_ONLY:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -583,3 +583,22 @@ timeout = "1200"
 python_version = "3.10"
 strict = true
 exclude_gitignore = true
+
+[[tool.mypy.overrides]]
+# The `mlflow/**` package is adopted into strict typing incrementally: modules
+# passed explicitly to mypy are checked (with definition rules relaxed until
+# they are fully annotated), while anything merely imported from them is
+# analyzed silently - its annotations still inform checking, but its errors
+# don't surface. Fully-typed modules graduate into a follow-up override block
+# that restores full strictness for them.
+module = "mlflow.*"
+follow_imports = "silent"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+
+[[tool.mypy.overrides]]
+# Generated protobuf modules: never hand-checked (excluded from ruff/clint for
+# the same reason); suppress all diagnostics raised within them.
+module = "mlflow.protos.*"
+ignore_errors = true


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25292
### What changes are proposed in this pull request?

First slice of an incremental strict-typing adoption for the `mlflow` package, in two commits:

1. **Mypy harness** (`pyproject.toml` only, no runtime code): `mlflow.*` modules are checked
   under mypy `strict = true` when passed explicitly (`follow_imports = "silent"`, definition
   rules relaxed until a module is fully annotated); generated `mlflow.protos.*` are silenced.
2. **Small `mlflow.entities` modules**: public-API input/output annotations for the simple
   entity classes (status/source/lifecycle enums, tags/params/links, file info, dataset
   inputs, logged-model parts, multipart upload, `_MlflowObject` base, and similar) —
   behavior-preserving, signatures only.

This PR is deliberately small so the approach can be reviewed before typing more of the
package. **If reviewers prefer, I'm happy to fold more of the series into *this* PR** —
the complete work (stores, artifact repositories, `types/`, client facades, decorator
signatures, ~129 files total) is already done on the
[`feat/mypy-typing-harness`](https://github.com/IgorShishkin12/mlflow/tree/feat/mypy-typing-harness)
branch of my fork; say the word and I'll push additional slices here.

Remaining narrow suppressions carry one-line justifications where protobuf or dynamic
surfaces defeat inference.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Annotations only; existing suites pass unchanged (`tests/entities`, import smoke of
`mlflow.entities`, full-repo mypy over touched files reports zero issues).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release