### PR TITLE
Point `AGENT_BROWSER_SCREENSHOT_DIR` at the directory `embed-media` reads

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -214,10 +214,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
-          AGENT_BROWSER_SCREENSHOT_DIR: /tmp/review-shots
+          AGENT_BROWSER_SCREENSHOT_DIR: /tmp/review-media
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
-          mkdir -p /tmp/review-media
+          mkdir -p "$AGENT_BROWSER_SCREENSHOT_DIR"
 
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25144

### What changes are proposed in this pull request?

`review.yml` set `AGENT_BROWSER_SCREENSHOT_DIR=/tmp/review-shots`, a path nothing
reads: the `Upload review media` step uploads from `--dir /tmp/review-media`, and
the `pr-review` skill is told to capture to and cite `/tmp/review-media/`.

That directory was also never created, which is the trigger for a silent failure.
With a missing target directory, agent-browser saves to
`~/.agent-browser/tmp/screenshots/` and still reports success with exit code 0
(vercel-labs/agent-browser#1534). The reviewer records the capture as successful,
cites a path that never existed, and `embed-media` rewrites the dangling citation
to plain prose, so a finding loses its evidence with nothing in the job log to say
so.

Point the variable at `/tmp/review-media` and derive the `mkdir` from it so the
two cannot drift apart again.

Separately, this workflow never runs `agent-browser install`, so captures still
fail for an unrelated reason (vercel-labs/agent-browser#1711). Left for its own PR.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release