### PR TITLE
Fix autoscale layout state in metric charts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.test.tsx
@@ -51,4 +51,24 @@ describe('RunsMetricsLinePlot', () => {
     expect(getLastRenderedPlotProps().data[0]).toEqual(expect.objectContaining({ y: [10, 20, 30] }));
     cleanup();
   });
+
+  test('it should clear zoom ranges after autoscale', () => {
+    const { rerender } = renderWithIntl(<RunsMetricsLinePlot {...defaultProps} xRange={[1, 2]} yRange={[10, 20]} />);
+
+    expect(getLastRenderedPlotProps().layout).toEqual(
+      expect.objectContaining({
+        xaxis: expect.objectContaining({ range: [1, 2], autorange: false }),
+        yaxis: expect.objectContaining({ range: [10, 20], autorange: false }),
+      }),
+    );
+
+    rerender(<RunsMetricsLinePlot {...defaultProps} />);
+
+    expect(getLastRenderedPlotProps().layout).toEqual(
+      expect.objectContaining({
+        xaxis: expect.objectContaining({ range: undefined, autorange: true }),
+        yaxis: expect.objectContaining({ range: undefined, autorange: true }),
+      }),
+    );
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsMetricsLinePlot.tsx
@@ -737,34 +737,31 @@ export const RunsMetricsLinePlot = React.memo(
 
     const themedPlotlyLayout = useMemo(() => createThemedPlotlyLayout(theme), [theme]);
 
-    // When switching axis title, Plotly.js mutates its layout object
-    // internally which leads to desync problems and automatic axis range
-    // ends up with an invalid value. In order to fix it, we are mutating
-    // axis object and injecting metric key as title in
-    // the render phase.
-    // It could be fixed by wrapping plotly.js directly instead of using
-    // react-plotly.js - but the effort does not correspond to the plan of
-    // moving away from plotly soon.
-    const immediateLayout = layout;
-    if (immediateLayout.xaxis) {
-      immediateLayout.xaxis.title = xAxisKeyLabel;
-      immediateLayout.xaxis.type = xAxisPlotlyType;
-      if (xRange) {
-        immediateLayout.xaxis.range = xRange;
-      }
-      immediateLayout.xaxis.automargin = true;
-      immediateLayout.xaxis.tickformat =
-        shouldEnableRelativeTimeDateAxis() && dynamicXAxisKey === RunsChartsLineChartXAxisType.TIME_RELATIVE
-          ? '%H:%M:%S'
-          : undefined;
-    }
-    immediateLayout.template = { layout: themedPlotlyLayout };
-
-    if (immediateLayout.yaxis && yRange) {
-      immediateLayout.yaxis.range = yRange;
-      immediateLayout.yaxis.automargin = true;
-      immediateLayout.yaxis.tickformat = 'f';
-    }
+    // Plotly mutates the layout object it receives. Derive a fresh layout for each render so
+    // a zoom range cleared by autoscale cannot remain on the next Plotly update.
+    const immediateLayout: Partial<Layout> = {
+      ...layout,
+      template: { layout: themedPlotlyLayout },
+      xaxis: layout.xaxis && {
+        ...layout.xaxis,
+        title: xAxisKeyLabel,
+        type: xAxisPlotlyType,
+        range: xRange,
+        autorange: xRange === undefined,
+        automargin: true,
+        tickformat:
+          shouldEnableRelativeTimeDateAxis() && dynamicXAxisKey === RunsChartsLineChartXAxisType.TIME_RELATIVE
+            ? '%H:%M:%S'
+            : undefined,
+      },
+      yaxis: layout.yaxis && {
+        ...layout.yaxis,
+        range: yRange,
+        autorange: yRange === undefined,
+        automargin: true,
+        tickformat: 'f',
+      },
+    };
 
     const legendLabelData = useMemo(
       () =>


### PR DESCRIPTION
### Related Issues/PRs

Closes #25248

### What changes are proposed in this pull request?

Prevent stale zoom ranges from being retained by the metric line-chart layout after an autoscale action.

The layout passed to Plotly is now derived freshly for each render and always reflects the current axis ranges and `autorange` state. This avoids a cleared range being carried into the next Plotly update.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a regression test for applying autoscale after a chart has zoom ranges.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the MLflow Skills repository?

- [x] No.
- [ ] Yes.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Prevents metric charts from retaining a stale zoom range when autoscale is used.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release