### PR TITLE
Fix scorer experiment_id VARCHAR binds on PostgreSQL + psycopg v3

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2807,7 +2807,13 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session
                 .query(SqlScorer)
                 .filter(
-                    SqlScorer.experiment_id == experiment_id,
+                    # ``Experiment.experiment_id`` (the entity field) is a
+                    # string while the column is INTEGER; psycopg v3 binds
+                    # strings as typed VARCHAR, which PostgreSQL rejects
+                    # ("operator does not exist: integer = character
+                    # varying"), so compare through int(). Safe: the id of a
+                    # validated experiment is always a stringified integer.
+                    SqlScorer.experiment_id == int(experiment.experiment_id),
                     SqlScorer.scorer_name == name,
                 )
                 .first()
@@ -2817,7 +2823,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 # Create the scorer record with a new UUID
                 scorer_id = str(uuid.uuid4())
                 scorer = SqlScorer(
-                    experiment_id=experiment_id,
+                    experiment_id=int(experiment.experiment_id),
                     scorer_name=name,
                     scorer_id=scorer_id,
                 )
@@ -2911,6 +2917,19 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         """
         if not experiment_ids:
             return []
+        # ``experiment_id`` is an INTEGER column but REST callers pass string
+        # IDs. psycopg2 sent them as untyped literals PostgreSQL would
+        # coerce; psycopg v3 binds them as typed VARCHAR and PostgreSQL
+        # rejects the comparison ("operator does not exist:
+        # integer = character varying"). Coerce with the same error contract
+        # as ``_get_experiment``.
+        try:
+            experiment_ids = [int(experiment_id) for experiment_id in experiment_ids]
+        except (ValueError, TypeError):
+            raise MlflowException(
+                "Invalid experiment IDs: experiment IDs must be valid integers.",
+                INVALID_PARAMETER_VALUE,
+            )
         with self.ManagedSessionMaker() as session:
             scorer_ids: list[str] = []
             for chunk_start in range(0, len(experiment_ids), self._LIST_SCORERS_CHUNK_SIZE):
@@ -2997,7 +3016,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session
                 .query(SqlScorer)
                 .filter(
-                    SqlScorer.experiment_id == experiment.experiment_id,
+                    # int(): see register_scorer — psycopg v3 VARCHAR binds
+                    # don't compare against the INTEGER column.
+                    SqlScorer.experiment_id == int(experiment.experiment_id),
                     SqlScorer.scorer_name == name,
                 )
                 .first()
@@ -3087,7 +3108,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session
                 .query(SqlScorer)
                 .filter(
-                    SqlScorer.experiment_id == experiment.experiment_id,
+                    # int(): see register_scorer — psycopg v3 VARCHAR binds
+                    # don't compare against the INTEGER column.
+                    SqlScorer.experiment_id == int(experiment.experiment_id),
                     SqlScorer.scorer_name == name,
                 )
                 .first()
@@ -3163,7 +3186,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session
                 .query(SqlScorer)
                 .filter(
-                    SqlScorer.experiment_id == experiment.experiment_id,
+                    # int(): see register_scorer — psycopg v3 VARCHAR binds
+                    # don't compare against the INTEGER column.
+                    SqlScorer.experiment_id == int(experiment.experiment_id),
                     SqlScorer.scorer_name == name,
                 )
                 .first()
@@ -3282,7 +3307,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 session
                 .query(SqlScorer)
                 .filter(
-                    SqlScorer.experiment_id == experiment.experiment_id,
+                    # int(): see register_scorer — psycopg v3 VARCHAR binds
+                    # don't compare against the INTEGER column.
+                    SqlScorer.experiment_id == int(experiment.experiment_id),
                     SqlScorer.scorer_name == scorer_name,
                 )
                 .first()

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_scorers.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_scorers.py
@@ -548,6 +548,39 @@ def test_list_scorers_across_experiments(store: SqlAlchemyStore, monkeypatch):
     assert [(s.experiment_id, s.scorer_name, s.scorer_version) for s in chunked] == expected
 
 
+def test_scorer_experiment_ids_are_coerced_to_int(store: SqlAlchemyStore):
+    """String experiment IDs must be bound as INTEGER, not VARCHAR.
+
+    ``experiments.experiment_id`` is an INTEGER column while the REST layer
+    hands IDs over as strings. SQLite (and psycopg2's untyped literals)
+    coerce silently, which is how the mismatch survived CI; psycopg v3 binds
+    typed VARCHAR parameters and PostgreSQL rejects the comparison with
+    ``operator does not exist: integer = character varying``. See
+    https://github.com/mlflow/mlflow/issues/25282 — this test pins the
+    coercion contract that keeps the PostgreSQL + psycopg v3 backend working.
+    """
+    exp_id = store.create_experiment("coercion_exp")
+    assert isinstance(exp_id, str)
+
+    registered = store.register_scorer(exp_id, "coerced", '{"v": 1}')
+    assert registered.experiment_id == exp_id
+    store.register_scorer(exp_id, "coerced", '{"v": 2}')
+
+    listed = store.list_scorers_across_experiments([exp_id])
+    assert [s.scorer_name for s in listed] == ["coerced"]
+    assert [s.scorer_name for s in store.list_scorers(exp_id)] == ["coerced"]
+
+    fetched = store.get_scorer(exp_id, "coerced")
+    assert fetched.scorer_version == 2
+    assert [v.scorer_version for v in store.list_scorer_versions(exp_id, "coerced")] == [1, 2]
+
+    store.delete_scorer(exp_id, "coerced", version=1)
+    assert [v.scorer_version for v in store.list_scorer_versions(exp_id, "coerced")] == [2]
+
+    with pytest.raises(MlflowException, match="must be valid integers"):
+        store.list_scorers_across_experiments(["not-a-number"])
+
+
 @pytest.mark.parametrize(
     ("name", "error_match"),
     [


### PR DESCRIPTION
### Related Issues/PRs

Closes #25282

### What changes are proposed in this pull request?

Coerce `experiment_id` to `int` at every `SqlScorer` comparison/insert site in the scorer store methods, and validate ids in `list_scorers_across_experiments` (raising `INVALID_PARAMETER_VALUE` for non-numeric ids, matching the store's convention elsewhere).

Two distinct sources of string binds are fixed:

1. `Experiment.experiment_id` (the entity field) is a `str` even after a validated `self.get_experiment(...)` lookup, so filters like `SqlScorer.experiment_id == experiment.experiment_id` bind VARCHAR against the INTEGER column in `register_scorer`, `get_scorer`, `delete_scorer`, `list_scorer_versions`, and `upsert_online_scoring_config`.
2. `list_scorers_across_experiments` bound the raw REST-layer string ids directly.

SQLite and psycopg2 coerce these silently, which is how the mismatch survived CI; psycopg v3 binds typed VARCHAR parameters and PostgreSQL rejects the comparison with `operator does not exist: integer = character varying`, breaking the entire scorer surface on a PostgreSQL + psycopg v3 backend.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

`tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_scorers.py::test_scorer_experiment_ids_are_coerced_to_int` pins the coercion contract across the full surface (register x2 versions, list, list-across, get, list_versions, delete, plus the invalid-id error). The full scorer test file passes (110 tests). Additionally verified against a real PostgreSQL 17 + psycopg v3 backend: all seven scorer operations succeed with string experiment ids.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the scorer registry (`register_scorer`, `list_scorers`, `get_scorer`, `delete_scorer`, and related APIs) failing with `operator does not exist: integer = character varying` on PostgreSQL tracking backends using psycopg v3.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components:
- [x] `area/scoring`: MLflow Scorers for agent and GenAI evaluation
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
