### PR TITLE
Drop the empty-`comments` bullet from the `pr-review` skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -142,7 +142,6 @@ Authoring rules not captured by the schema:
   suggestion block already shows.
 - Use suggestion blocks for simple fixes: fence with ` ```suggestion ` and preserve original
   indentation.
-- If you have no findings, emit an empty `comments` array.
 - To attach an image or video (a diagram, a chart, a captured repro), write the file into
   `/tmp/review-media/` and cite it by the absolute path you wrote it to:
   `![desc](/tmp/review-media/name.png)` to embed, or `[desc](/tmp/review-media/name.png)`


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24974

### What changes are proposed in this pull request?

`pr-review/SKILL.md` told the reviewer "If you have no findings, emit an empty
`comments` array." That was the only place in the skill naming a payload key, so
it read as a shortcut past the schema that step 4 tells the reviewer to read
first. Two consecutive Sonnet reviews took the shortcut: each wrote
`{"comments": []}` verbatim as its first payload, failed `validate-review` on the
missing `event` and `body`, then read the schema and rewrote.

- Smoke run: https://github.com/mlflow/mlflow/actions/runs/32756706621/job/97525854078
- `/review` run: https://github.com/mlflow/mlflow/actions/runs/32757088546/job/97527065030

Both show the same sequence:

```
Write: /tmp/review-payload.json  {"comments": []}
Bash:  skills validate-review /tmp/review-payload.json   -> exit 1
Read:  .claude/skills/pr-review/review-payload.schema.json
Write: /tmp/review-payload.json  {"event": "APPROVE", "body": ..., "comments": []}
```

Nothing is lost by deleting it. The schema already documents the case verbatim
(`Inline review comments. Empty array is allowed (e.g., clean APPROVE).`) and
lists `event`, `body`, and `comments` as required, so the bullet duplicated the
schema under a heading that says these are rules the schema does *not* capture.
Deleting it makes reading the schema the only route to the payload shape, which
is what step 4 asks for and what #24974 made authoritative.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

This PR touches `.claude/skills/pr-review/**`, which is in `review.yml`'s
`pull_request` paths filter, so its own smoke run reviews it under the edited
skill. That run is the test: it should now write a complete payload on the first
`Write` rather than looping through a failed validation.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release