### PR TITLE
Propagate eval_retry_context flags into the scorer thread pool

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import queue
 import threading
@@ -974,7 +975,17 @@ def _compute_eval_scores(
         max_workers=max_scorer_workers,
         thread_name_prefix="MlflowGenAIEvalScorer",
     ) as executor:
-        futures = {executor.submit(run_scorer, scorer): scorer for scorer in scorers}
+        # Scorers run in worker threads, which do not inherit the calling thread's
+        # contextvars. eval_retry_context() (entered by the caller in _run_score /
+        # the online scoring path) sets ContextVar flags that disable litellm and
+        # HTTP-layer 429 retries so rate-limit errors propagate to call_with_retry's
+        # AIMD logic. Copy the current context per submission so each worker runs
+        # under those flags. A fresh copy per submit is required: a single shared
+        # Context cannot be entered by more than one thread concurrently.
+        futures = {
+            executor.submit(contextvars.copy_context().run, run_scorer, scorer): scorer
+            for scorer in scorers
+        }
 
         try:
             results = []

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -975,13 +975,9 @@ def _compute_eval_scores(
         max_workers=max_scorer_workers,
         thread_name_prefix="MlflowGenAIEvalScorer",
     ) as executor:
-        # Scorers run in worker threads, which do not inherit the calling thread's
-        # contextvars. eval_retry_context() (entered by the caller in _run_score /
-        # the online scoring path) sets ContextVar flags that disable litellm and
-        # HTTP-layer 429 retries so rate-limit errors propagate to call_with_retry's
-        # AIMD logic. Copy the current context per submission so each worker runs
-        # under those flags. A fresh copy per submit is required: a single shared
-        # Context cannot be entered by more than one thread concurrently.
+        # Carry the caller's context (e.g. eval_retry_context() flags) into each
+        # worker; a fresh copy per submit is required since a Context can't be
+        # entered by two threads at once.
         futures = {
             executor.submit(contextvars.copy_context().run, run_scorer, scorer): scorer
             for scorer in scorers

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -478,8 +478,14 @@ def _run_scores_capturing_flags(num_scorers):
     scorer_objs = [make_probe(f"probe_{i}") for i in range(num_scorers)]
     item = EvalItem(request_id="r1", inputs={}, outputs="x", expectations={})
 
-    with eval_retry_context():
-        _compute_eval_scores(eval_item=item, scorers=scorer_objs, max_retries=0)
+    # Force both adapters active so the flags are set regardless of litellm being
+    # installed or the tracking URI, isolating the test to context propagation.
+    with patch(
+        "mlflow.genai.judges.adapters.rate_limit_retry_adapters._RETRY_ADAPTER_REGISTRY",
+        _BOTH_ADAPTERS_ACTIVE,
+    ):
+        with eval_retry_context():
+            _compute_eval_scores(eval_item=item, scorers=scorer_objs, max_retries=0)
     return captured
 
 

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -1,10 +1,15 @@
+import contextvars
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import patch
 
 import pytest
 
 import mlflow.genai.judges.adapters.rate_limit_retry_adapters  # noqa: F401
+from mlflow.genai.evaluation.entities import EvalItem
 from mlflow.genai.evaluation.harness import (
     AUTO_INITIAL_RPS,
+    _compute_eval_scores,
     _make_rate_limiter,
     _parse_rate_limit,
 )
@@ -21,6 +26,7 @@ from mlflow.genai.judges.adapters.litellm_adapter import (
     is_litellm_rate_limit_retries_disabled,
 )
 from mlflow.genai.judges.adapters.rate_limit_retry_adapters import RateLimitRetryAdapter
+from mlflow.genai.scorers.base import scorer
 from mlflow.utils.rest_utils import disable_429_retry, is_429_retry_disabled
 
 
@@ -434,3 +440,148 @@ def test_litellm_retry_policy_disables_rate_limit_retries_when_flag_set():
         policy = _get_litellm_retry_policy(3)
     assert policy.RateLimitErrorRetries == 0
     assert policy.TimeoutErrorRetries == 3
+
+
+# ── contextvar propagation into the scorer thread pool ──
+#
+# eval_retry_context() sets its retry-suppression flags via contextvars.ContextVar.
+# _compute_eval_scores runs each scorer in a worker thread. Worker threads do NOT
+# inherit the submitting thread's context, so the flags must be explicitly carried
+# across the pool boundary or they silently read their defaults inside the scorer —
+# defeating the whole "let 429s bubble up to the AIMD limiter" mechanism.
+
+
+def _flags_in_current_thread() -> tuple[str, bool, bool]:
+    return (
+        threading.current_thread().name,
+        is_litellm_rate_limit_retries_disabled(),
+        is_429_retry_disabled(),
+    )
+
+
+def _run_scores_capturing_flags(num_scorers):
+    """Run scorers through _compute_eval_scores inside eval_retry_context().
+
+    Returns the (thread_name, litellm_disabled, http_429_disabled) tuple each
+    scorer observed from inside its worker thread. A barrier forces every scorer
+    to run concurrently so the parallel path is genuinely exercised.
+    """
+    captured: list[tuple[str, bool, bool]] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(num_scorers)
+
+    def make_probe(name):
+        @scorer(name=name)
+        def probe(outputs):
+            barrier.wait()
+            observed = _flags_in_current_thread()
+            with lock:
+                captured.append(observed)
+            return 1.0
+
+        return probe
+
+    scorer_objs = [make_probe(f"probe_{i}") for i in range(num_scorers)]
+    item = EvalItem(request_id="r1", inputs={}, outputs="x", expectations={})
+
+    with eval_retry_context():
+        _compute_eval_scores(eval_item=item, scorers=scorer_objs, max_retries=0)
+    return captured
+
+
+def test_scorer_thread_sees_retry_flags_single():
+    captured = _run_scores_capturing_flags(num_scorers=1)
+
+    assert len(captured) == 1
+    thread_name, litellm_disabled, http_disabled = captured[0]
+    # The scorer runs in a worker thread, not the caller's thread.
+    assert thread_name != threading.current_thread().name
+    assert thread_name.startswith("MlflowGenAIEvalScorer")
+    # Both flags set by eval_retry_context() reached the worker thread.
+    assert litellm_disabled is True
+    assert http_disabled is True
+
+
+def test_scorer_threads_see_retry_flags_under_concurrency():
+    # The probe's barrier forces all five scorers to run at once, so multiple
+    # workers hold their (fresh) contexts simultaneously — a single shared copied
+    # Context would raise "already entered" here.
+    captured = _run_scores_capturing_flags(num_scorers=5)
+
+    assert len(captured) == 5
+    worker_threads = {name for name, _, _ in captured}
+    # Genuinely ran across multiple distinct worker threads.
+    assert len(worker_threads) > 1
+    assert all(name.startswith("MlflowGenAIEvalScorer") for name, _, _ in captured)
+    # Every worker observed both flags as disabled.
+    assert all(litellm and http for _, litellm, http in captured)
+
+
+def test_retry_flags_reset_in_caller_thread_after_scoring():
+    assert not _retry_flags_active()
+
+    _run_scores_capturing_flags(num_scorers=2)
+
+    # The caller's thread context is unchanged after the with-block exits.
+    assert not _retry_flags_active()
+
+
+# The following three tests pin the raw contextvars semantics the fix relies on,
+# independent of MLflow, so a future refactor that reintroduces the bug fails loudly
+# with an explanatory test name rather than a silent behavioral regression.
+
+_probe_cv: contextvars.ContextVar[str] = contextvars.ContextVar("_probe_cv", default="DEFAULT")
+
+
+def test_threadpool_does_not_inherit_context_by_default():
+    _probe_cv.set("SET")
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="cv-test") as ex:
+        observed = list(ex.map(lambda _: _probe_cv.get(), range(2)))
+    # This is the bug: plain submit loses the caller's contextvars.
+    assert observed == ["DEFAULT", "DEFAULT"]
+
+
+def test_single_shared_context_cannot_be_entered_concurrently():
+    _probe_cv.set("SET")
+    shared = contextvars.copy_context()
+    hold = threading.Event()
+
+    def work(_):
+        # Keep the first worker holding the context open long enough for the
+        # second submission to attempt entry and collide. We do NOT rendezvous
+        # here (a barrier would deadlock, since the colliding worker fails to
+        # enter and never runs work()).
+        hold.wait(timeout=2)
+        return _probe_cv.get()
+
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="cv-test") as ex:
+        futures = [ex.submit(shared.run, work, i) for i in range(2)]
+        errors = []
+        results = []
+        try:
+            for f in as_completed(futures):
+                try:
+                    results.append(f.result())
+                except RuntimeError as e:
+                    errors.append(str(e))
+                    hold.set()  # release the other worker so the pool can drain
+        finally:
+            hold.set()
+    # Reusing one Context across concurrent workers is illegal — this is why the
+    # fix copies the context per submission rather than once.
+    assert any("already entered" in e for e in errors)
+
+
+def test_fresh_context_copy_per_submit_propagates_value():
+    _probe_cv.set("SET")
+    started = threading.Barrier(3)
+
+    def work(_):
+        started.wait()
+        return _probe_cv.get()
+
+    with ThreadPoolExecutor(max_workers=3, thread_name_prefix="cv-test") as ex:
+        futures = [ex.submit(contextvars.copy_context().run, work, i) for i in range(3)]
+        observed = [f.result() for f in as_completed(futures)]
+    # A fresh copy per submit both carries the value and tolerates concurrency.
+    assert observed == ["SET", "SET", "SET"]

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -443,12 +443,6 @@ def test_litellm_retry_policy_disables_rate_limit_retries_when_flag_set():
 
 
 # ── contextvar propagation into the scorer thread pool ──
-#
-# eval_retry_context() sets its retry-suppression flags via contextvars.ContextVar.
-# _compute_eval_scores runs each scorer in a worker thread. Worker threads do NOT
-# inherit the submitting thread's context, so the flags must be explicitly carried
-# across the pool boundary or they silently read their defaults inside the scorer —
-# defeating the whole "let 429s bubble up to the AIMD limiter" mechanism.
 
 
 def _flags_in_current_thread() -> tuple[str, bool, bool]:
@@ -494,26 +488,19 @@ def test_scorer_thread_sees_retry_flags_single():
 
     assert len(captured) == 1
     thread_name, litellm_disabled, http_disabled = captured[0]
-    # The scorer runs in a worker thread, not the caller's thread.
     assert thread_name != threading.current_thread().name
     assert thread_name.startswith("MlflowGenAIEvalScorer")
-    # Both flags set by eval_retry_context() reached the worker thread.
     assert litellm_disabled is True
     assert http_disabled is True
 
 
 def test_scorer_threads_see_retry_flags_under_concurrency():
-    # The probe's barrier forces all five scorers to run at once, so multiple
-    # workers hold their (fresh) contexts simultaneously — a single shared copied
-    # Context would raise "already entered" here.
     captured = _run_scores_capturing_flags(num_scorers=5)
 
     assert len(captured) == 5
     worker_threads = {name for name, _, _ in captured}
-    # Genuinely ran across multiple distinct worker threads.
     assert len(worker_threads) > 1
     assert all(name.startswith("MlflowGenAIEvalScorer") for name, _, _ in captured)
-    # Every worker observed both flags as disabled.
     assert all(litellm and http for _, litellm, http in captured)
 
 
@@ -547,28 +534,24 @@ def test_single_shared_context_cannot_be_entered_concurrently():
     hold = threading.Event()
 
     def work(_):
-        # Keep the first worker holding the context open long enough for the
-        # second submission to attempt entry and collide. We do NOT rendezvous
-        # here (a barrier would deadlock, since the colliding worker fails to
-        # enter and never runs work()).
+        # Hold the context open so the other submission collides trying to enter
+        # it. No barrier: the colliding worker never runs work(), so a rendezvous
+        # would deadlock.
         hold.wait(timeout=2)
         return _probe_cv.get()
 
     with ThreadPoolExecutor(max_workers=2, thread_name_prefix="cv-test") as ex:
         futures = [ex.submit(shared.run, work, i) for i in range(2)]
         errors = []
-        results = []
         try:
             for f in as_completed(futures):
                 try:
-                    results.append(f.result())
+                    f.result()
                 except RuntimeError as e:
                     errors.append(str(e))
                     hold.set()  # release the other worker so the pool can drain
         finally:
             hold.set()
-    # Reusing one Context across concurrent workers is illegal — this is why the
-    # fix copies the context per submission rather than once.
     assert any("already entered" in e for e in errors)
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24702

### What changes are proposed in this pull request?

`_compute_eval_scores` runs each scorer in a `ThreadPoolExecutor` worker thread. `eval_retry_context()` sets `ContextVar` flags that disable litellm's and the HTTP layer's internal 429 retries, so rate-limit errors propagate up to `call_with_retry`'s AIMD logic (the adaptive rate limiter).

The problem: worker threads do **not** inherit the submitting thread's `contextvars`. So the flags set by `eval_retry_context()` in the caller thread read their defaults (`False`) inside the scorer worker. litellm/databricks keep retrying 429s internally, the errors never surface to `call_with_retry`, and the adaptive rate limiter never sees a throttle signal on the judge/scorer path. This affects both the offline evaluation path (`_run_score`) and the online/automatic scoring path, since both go through `_compute_eval_scores`.

The fix copies the active context per submission (`contextvars.copy_context().run`) so each worker runs under the flags. A **fresh copy per submit** is required — a single `Context` cannot be entered by more than one thread concurrently (raises `RuntimeError: cannot enter context: ... is already entered`).

```python
futures = {
    executor.submit(contextvars.copy_context().run, run_scorer, scorer): scorer
    for scorer in scorers
}
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/genai/evaluate/test_rate_limiter.py`:

- `test_scorer_thread_sees_retry_flags_single` / `..._under_concurrency` — assert both flags reach the scorer worker thread (the concurrent variant forces all scorers to run at once via a barrier, exercising the "fresh copy per submit" requirement). Both **fail without the fix**.
- `test_retry_flags_reset_in_caller_thread_after_scoring` — the caller thread's context is unchanged after scoring.
- Three tests pin the raw `contextvars` semantics the fix relies on so a future refactor that reintroduces the bug fails loudly: plain `submit` loses context; a single shared context errors under concurrency; a fresh per-submit copy propagates correctly.

Verified against `test_rate_limiter.py`, `test_trace_processor.py`, and `test_evaluation.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The adaptive evaluation rate limiter now actually receives 429/throttle signals from judge (scorer) LLM calls, so it can back off as designed instead of relying on the LLM client's internal retries.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release