### PR TITLE
Normalize span links from OTLP endpoints in the trace explorer

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -43,6 +43,7 @@ import {
   getTotalTokens,
   getTraceCost,
   convertOtelAttributesToMap,
+  decodeLinkTraceId,
   isSessionLevelAssessment,
   createTraceV4SerializedLocation,
   parseTraceV4SerializedLocation,
@@ -1368,6 +1369,77 @@ describe('convertOtelAttributesToMap', () => {
       span_id: '1',
       events: [{ attributes: { converted: 'value' } }],
     });
+  });
+
+  it('should normalize OTLP-format links (base64 ids, key-value array attributes)', () => {
+    // shape returned by OTLP-based endpoints (V3 traces/get): base64-encoded
+    // ids and K/V-list attributes that the links UI expects as tr-<hex> + map
+    const modelTraceSpan = {
+      span_id: '1',
+      links: [
+        {
+          trace_id: 'r/bfSxmZcIKSljvv1ZuvFA==',
+          span_id: 'OMvyqZzI1C0=',
+          attributes: [
+            { key: 'relationship', value: { string_value: 'triggered_by' } },
+            { key: 'handoff', value: { string_value: 'research' } },
+          ],
+        },
+      ],
+    } as any;
+
+    const result = convertOtelAttributesToMap(modelTraceSpan);
+
+    expect(result).toEqual({
+      span_id: '1',
+      links: [
+        {
+          trace_id: 'tr-aff6df4b1999708292963befd59baf14',
+          span_id: '38cbf2a99cc8d42d',
+          attributes: {
+            relationship: 'triggered_by',
+            handoff: 'research',
+          },
+        },
+      ],
+    });
+  });
+
+  it('should leave already-normalized links (tr- id, map attributes) unchanged', () => {
+    // shape returned by the artifact route: already tr-<hex> + hex span id + map
+    const modelTraceSpan = {
+      span_id: '1',
+      links: [
+        {
+          trace_id: 'tr-aff6df4b1999708292963befd59baf14',
+          span_id: '38cbf2a99cc8d42d',
+          attributes: { relationship: 'triggered_by' },
+        },
+      ],
+    } as any;
+
+    const result = convertOtelAttributesToMap(modelTraceSpan);
+
+    expect(result).toEqual(modelTraceSpan);
+  });
+});
+
+describe('decodeLinkTraceId', () => {
+  it('should decode a base64-encoded trace id to tr-<hex>', () => {
+    expect(decodeLinkTraceId('r/bfSxmZcIKSljvv1ZuvFA==')).toBe('tr-aff6df4b1999708292963befd59baf14');
+  });
+
+  it('should leave a tr- prefixed id unchanged', () => {
+    expect(decodeLinkTraceId('tr-aff6df4b1999708292963befd59baf14')).toBe('tr-aff6df4b1999708292963befd59baf14');
+  });
+
+  it('should leave a V4 trace:/ id unchanged', () => {
+    expect(decodeLinkTraceId('trace:/catalog.schema/abc123')).toBe('trace:/catalog.schema/abc123');
+  });
+
+  it('should return an empty string for nullish input', () => {
+    expect(decodeLinkTraceId(undefined)).toBe('');
+    expect(decodeLinkTraceId(null)).toBe('');
   });
 });
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -40,6 +40,7 @@ import type {
   ModelTraceEvent,
   ModelTraceLocation,
   ModelTraceInputAudio,
+  ModelTraceSpanLink,
 } from './ModelTrace.types';
 import {
   ModelSpanType,
@@ -636,6 +637,27 @@ export const decodeSpanId = (spanId: string | null | undefined, isV3Span: boolea
 
   // new V2 span ids have the prefix stripped
   return spanId;
+};
+
+// Link trace ids arrive base64-encoded from OTLP endpoints (V3 traces/get,
+// V4 batchGet) but as `tr-<hex>` from the artifact route. Normalize to the
+// `tr-<hex>` form the links UI and batch trace-info lookup expect.
+export const decodeLinkTraceId = (traceId: string | null | undefined): string => {
+  if (!traceId) {
+    return '';
+  }
+
+  // Already in MLflow V3 (`tr-…`) or V4 (`trace:/…`) form.
+  if (traceId.startsWith('tr-') || traceId.startsWith('trace:/')) {
+    return traceId;
+  }
+
+  try {
+    return `tr-${base64ToHex(traceId)}`;
+  } catch (e) {
+    // if base64 decoding fails, just return the original traceId
+    return traceId;
+  }
 };
 
 export function isV3ModelTraceInfo(
@@ -1421,6 +1443,15 @@ export const convertOtelAttributesToMap = (modelTraceSpan: ModelTraceSpan): Mode
     );
   };
 
+  // Links from OTLP endpoints carry base64-encoded ids and K/V-list attributes,
+  // so normalize them the same way as span ids and attributes above.
+  const convertLink = (link: ModelTraceSpanLink): ModelTraceSpanLink => ({
+    ...link,
+    trace_id: decodeLinkTraceId(link.trace_id),
+    span_id: decodeSpanId(link.span_id, true),
+    ...(link.attributes && { attributes: convertAttributes(link.attributes) }),
+  });
+
   return {
     ...modelTraceSpan,
     ...(modelTraceSpan.attributes && { attributes: convertAttributes(modelTraceSpan.attributes) }),
@@ -1430,7 +1461,7 @@ export const convertOtelAttributesToMap = (modelTraceSpan: ModelTraceSpan): Mode
         attributes: convertAttributes(event.attributes),
       })),
     }),
-    ...(modelTraceSpan.links && { links: modelTraceSpan.links }),
+    ...(modelTraceSpan.links && { links: modelTraceSpan.links.map(convertLink) }),
   };
 };
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #25317

### What changes are proposed in this pull request?

The `traces/get` endpoint (used for tracking-store spans, the OSS default) returns spans in OTLP proto-JSON, where a span link's `trace_id`/`span_id` are base64-encoded and its `attributes` are key-value arrays. `convertOtelAttributesToMap` normalized a span's own ids and attributes but passed the `links` field through unchanged. As a result, the trace explorer's **Links** tab showed base64 trace ids with no clickable hyperlink and rendered link attributes as indexed objects instead of key/value rows.

This PR normalizes span links the same way as the rest of the span: link `trace_id` → `tr-<hex>`, `span_id` → hex, and attributes → map (via a new `decodeLinkTraceId` helper). Links from the artifact route (already in `tr-`/map form) are left unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests cover `convertOtelAttributesToMap` link normalization (OTLP → `tr-`/map, and already-normalized links left unchanged) and the `decodeLinkTraceId` helper. Manually verified in the trace explorer that an SDK-created span link now renders as a clickable `tr-` hyperlink with clean key/value attribute rows.

### Does this PR require documentation update?

- [x] No.

User-facing docs for span links are tracked separately in #24276.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed span links rendering with base64 trace ids and no clickable hyperlink in the trace explorer Links tab for traces whose spans are stored in the tracking store.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

<sub>Generated by Claude Code under the supervision of Khaled Sulayman</sub>