### PR TITLE
Cherry-picks for v3.15.2

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1023,6 +1023,7 @@ mlflow.genai.labeling.labeling.ReviewApp
 mlflow.genai.list_scorers
 mlflow.genai.load_prompt
 mlflow.genai.make_judge
+mlflow.genai.make_scorer_ensemble
 mlflow.genai.optimize.BasePromptOptimizer
 mlflow.genai.optimize.BasePromptOptimizer.optimize
 mlflow.genai.optimize.GepaPromptOptimizer
@@ -1151,6 +1152,8 @@ mlflow.genai.scorers.ToolCallEfficiency.get_input_fields
 mlflow.genai.scorers.ToolCallEfficiency.model_post_init
 mlflow.genai.scorers.UserFrustration
 mlflow.genai.scorers.UserFrustration.model_post_init
+mlflow.genai.scorers.agg_all
+mlflow.genai.scorers.agg_any
 mlflow.genai.scorers.base.Scorer
 mlflow.genai.scorers.base.ScorerSamplingConfig
 mlflow.genai.scorers.builtin_scorers.Completeness
@@ -1286,6 +1289,11 @@ mlflow.genai.scorers.guardrails.ToxicLanguage
 mlflow.genai.scorers.guardrails.ToxicLanguage.model_post_init
 mlflow.genai.scorers.guardrails.get_scorer
 mlflow.genai.scorers.list_scorers
+mlflow.genai.scorers.majority_vote
+mlflow.genai.scorers.make_scorer_ensemble
+mlflow.genai.scorers.maximum
+mlflow.genai.scorers.mean
+mlflow.genai.scorers.minimum
 mlflow.genai.scorers.phoenix.Hallucination
 mlflow.genai.scorers.phoenix.Hallucination.model_post_init
 mlflow.genai.scorers.phoenix.QA

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -883,6 +883,7 @@ mlflow.gemini.autolog
 mlflow.genai.Agent
 mlflow.genai.ConversationSimulator
 mlflow.genai.ConversationSimulator.simulate
+mlflow.genai.EvaluationDatasetVersion
 mlflow.genai.LabelingSession
 mlflow.genai.LabelingSession.add_dataset
 mlflow.genai.LabelingSession.add_traces
@@ -920,6 +921,7 @@ mlflow.genai.datasets.EvaluationDataset.delete_records
 mlflow.genai.datasets.EvaluationDataset.from_dict
 mlflow.genai.datasets.EvaluationDataset.from_proto
 mlflow.genai.datasets.EvaluationDataset.has_records
+mlflow.genai.datasets.EvaluationDataset.list_versions
 mlflow.genai.datasets.EvaluationDataset.merge_records
 mlflow.genai.datasets.EvaluationDataset.set_profile
 mlflow.genai.datasets.EvaluationDataset.to_df
@@ -930,6 +932,7 @@ mlflow.genai.datasets.add_dataset_to_experiments
 mlflow.genai.datasets.create_dataset
 mlflow.genai.datasets.delete_dataset
 mlflow.genai.datasets.delete_dataset_tag
+mlflow.genai.datasets.entities.EvaluationDatasetVersion
 mlflow.genai.datasets.evaluation_dataset.EvaluationDataset
 mlflow.genai.datasets.get_dataset
 mlflow.genai.datasets.remove_dataset_from_experiments

--- a/docs/api_reference/source/python_api/mlflow.genai.rst
+++ b/docs/api_reference/source/python_api/mlflow.genai.rst
@@ -46,6 +46,7 @@ mlflow.genai
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: EvaluationDatasetVersion
 
 .. automodule:: mlflow.genai.label_schemas
     :members:

--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -55,6 +55,7 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         profile: str | None = None,
         created_by: str | None = None,
         last_updated_by: str | None = None,
+        version: dict[str, Any] | int | None = None,
     ):
         """Initialize the EvaluationDataset."""
         self.dataset_id = dataset_id
@@ -65,6 +66,7 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
         self._profile = profile
         self.created_by = created_by
         self.last_updated_by = last_updated_by
+        self.version = version
         self._experiment_ids = None
         self._records = None
 
@@ -589,6 +591,8 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             "last_updated_by": self.last_updated_by,
             "experiment_ids": self.experiment_ids,
         })
+        if self.version is not None:
+            result["version"] = self.version
 
         result["records"] = [record.to_dict() for record in self.records]
 
@@ -619,6 +623,7 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             profile=data.get("profile"),
             created_by=data.get("created_by"),
             last_updated_by=data.get("last_updated_by"),
+            version=data.get("version"),
         )
         if "experiment_ids" in data:
             dataset._experiment_ids = data["experiment_ids"]

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1493,6 +1493,15 @@ _MLFLOW_TELEMETRY_SESSION_ID = _EnvironmentVariable("_MLFLOW_TELEMETRY_SESSION_I
 #: (default: ``False``)
 _MLFLOW_TELEMETRY_LOGGING = _BooleanEnvironmentVariable("_MLFLOW_TELEMETRY_LOGGING", False)
 
+
+#: Internal flag to import the Databricks SDK at ``import mlflow`` time inside Databricks, so
+#: the telemetry consumer thread never performs a first-time import of it. Set to ``false`` to
+#: opt out. Must be set before ``import mlflow`` to take effect.
+#: (default: ``True``)
+_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK = _BooleanEnvironmentVariable(
+    "_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK", True
+)
+
 #: Internal environment variable to indicate which SGI is being used,
 #: e.g. "uvicorn" or "gunicorn".
 #: This should never be set by users or explicitly.

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -5,6 +5,7 @@ from mlflow.genai import (
 )
 from mlflow.genai.agent_tester import test_agent
 from mlflow.genai.datasets import (
+    EvaluationDatasetVersion,
     create_dataset,
     delete_dataset,
     delete_dataset_tag,
@@ -93,6 +94,7 @@ __all__ = [
     "judges",
     "make_judge",
     "scorers",
+    "EvaluationDatasetVersion",
     "create_dataset",
     "delete_dataset",
     "delete_dataset_tag",

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -69,7 +69,14 @@ from mlflow.genai.prompts import (
 from mlflow.genai.scheduled_scorers import (
     ScorerScheduleConfig,
 )
-from mlflow.genai.scorers import Scorer, delete_scorer, get_scorer, list_scorers, scorer
+from mlflow.genai.scorers import (
+    Scorer,
+    delete_scorer,
+    get_scorer,
+    list_scorers,
+    make_scorer_ensemble,
+    scorer,
+)
 from mlflow.genai.simulators import ConversationSimulator
 
 __all__ = [
@@ -79,6 +86,7 @@ __all__ = [
     "to_predict_fn",
     "Scorer",
     "scorer",
+    "make_scorer_ensemble",
     "get_scorer",
     "list_scorers",
     "delete_scorer",

--- a/mlflow/genai/datasets/__init__.py
+++ b/mlflow/genai/datasets/__init__.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from mlflow.entities.evaluation_dataset import EvaluationDataset as EntityEvaluationDataset
 from mlflow.exceptions import MlflowException
+from mlflow.genai.datasets.entities import EvaluationDatasetVersion
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.store.tracking import SEARCH_EVALUATION_DATASETS_MAX_RESULTS
@@ -158,6 +159,14 @@ def _get_dataset_by_name(name: str) -> EntityEvaluationDataset:
                 "Use 'dataset_id' for unambiguous retrieval.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+
+
+def _resolve_dataset_version_arg(
+    version: int | EvaluationDatasetVersion | None,
+) -> int | None:
+    if isinstance(version, EvaluationDatasetVersion):
+        return version.version
+    return version
 
 
 @deprecated_parameter("uc_table_name", "name")
@@ -317,6 +326,7 @@ def delete_dataset(
 def get_dataset(
     name: str | None = None,
     dataset_id: str | None = None,
+    version: int | EvaluationDatasetVersion | None = None,
 ) -> "EvaluationDataset":
     """
     Get the dataset with the given name or ID.
@@ -325,6 +335,9 @@ def get_dataset(
         name: The name of the dataset. In Databricks, this is the UC table name.
             In non-Databricks environments, this will search for a dataset with the given name.
         dataset_id: The ID of the dataset (non-Databricks only).
+        version: The immutable Databricks dataset version to retrieve. This can be an integer
+            or an ``EvaluationDatasetVersion`` returned by ``dataset.list_versions()``. This
+            parameter is not supported in non-Databricks environments.
 
     Returns:
         An EvaluationDataset object representing the retrieved dataset.
@@ -367,14 +380,19 @@ def get_dataset(
 
     if is_databricks_uri(get_tracking_uri()):
         _validate_databricks_params(name, dataset_id)
+        resolved_version = _resolve_dataset_version_arg(version)
         try:
             from databricks.agents.datasets import get_dataset as db_get
 
             with _databricks_profile_env():
+                if version is not None:
+                    return EvaluationDataset(db_get(name, version=resolved_version))
                 return EvaluationDataset(db_get(name))
         except ImportError as e:
             raise ImportError(_ERROR_MSG) from e
     else:
+        if version is not None:
+            raise NotImplementedError("`version` is only supported for Databricks datasets.")
         _validate_non_databricks_get_params(name, dataset_id)
 
         if name is not None:
@@ -767,6 +785,7 @@ def remove_dataset_from_experiments(
 
 __all__ = [
     "EvaluationDataset",
+    "EvaluationDatasetVersion",
     "add_dataset_to_experiments",
     "create_dataset",
     "delete_dataset",

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -10,14 +10,21 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
     This source is used for datasets managed by the Databricks agents SDK.
     """
 
-    def __init__(self, table_name: str, dataset_id: str):
+    def __init__(
+        self,
+        table_name: str,
+        dataset_id: str,
+        version: int | None = None,
+    ):
         """
         Args:
             table_name: The three-level UC table name of the dataset
             dataset_id: The unique identifier of the dataset
+            version: The resolved dataset Delta version, if known
         """
         self._table_name = table_name
         self._dataset_id = dataset_id
+        self._version = version
 
     @property
     def table_name(self) -> str:
@@ -28,6 +35,11 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
     def dataset_id(self) -> str:
         """The unique identifier of the dataset."""
         return self._dataset_id
+
+    @property
+    def version(self) -> int | None:
+        """The resolved dataset Delta version."""
+        return self._version
 
     @staticmethod
     def _get_source_type() -> str:
@@ -64,17 +76,24 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
         """
         Returns a dictionary representation of the source.
         """
-        return {
+        result = {
             "table_name": self._table_name,
             "dataset_id": self._dataset_id,
         }
+        if self._version is not None:
+            result["version"] = self._version
+        return result
 
     @classmethod
     def from_dict(cls, source_dict: dict[str, Any]) -> "DatabricksEvaluationDatasetSource":
         """
         Creates an instance from a dictionary representation.
         """
-        return cls(table_name=source_dict["table_name"], dataset_id=source_dict["dataset_id"])
+        return cls(
+            table_name=source_dict["table_name"],
+            dataset_id=source_dict["dataset_id"],
+            version=source_dict.get("version"),
+        )
 
 
 class DatabricksUCTableDatasetSource(DatabricksEvaluationDatasetSource):

--- a/mlflow/genai/datasets/entities.py
+++ b/mlflow/genai/datasets/entities.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+
+def _format_datetime_for_repr(value: datetime) -> str:
+    formatted = value.isoformat(sep=" ", timespec="seconds")
+    if value.utcoffset() == timedelta(0):
+        return formatted.removesuffix("+00:00") + " UTC"
+    return formatted
+
+
+@dataclass(frozen=True)
+class EvaluationDatasetVersion:
+    version: int
+    created_at: datetime | None = None
+    created_by: str | None = None
+    operation: str | None = None
+
+    def __repr__(self) -> str:
+        created_at = (
+            repr(_format_datetime_for_repr(self.created_at))
+            if self.created_at is not None
+            else None
+        )
+        return (
+            f"{type(self).__name__}("
+            f"version={self.version!r}, "
+            f"created_at={created_at}, "
+            f"created_by={self.created_by!r}, "
+            f"operation={self.operation!r}"
+            ")"
+        )

--- a/mlflow/genai/datasets/evaluation_dataset.py
+++ b/mlflow/genai/datasets/evaluation_dataset.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from mlflow.data import Dataset
@@ -8,10 +9,49 @@ from mlflow.entities.evaluation_dataset import (
 from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
     DatabricksEvaluationDatasetSource,
 )
+from mlflow.genai.datasets.entities import EvaluationDatasetVersion
 
 if TYPE_CHECKING:
     import pandas as pd
     import pyspark.sql
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _to_evaluation_dataset_version(value: Any) -> EvaluationDatasetVersion | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, EvaluationDatasetVersion):
+        return value
+
+    if isinstance(value, dict):
+        raw_version = value.get("version")
+        created_at = value.get("created_at") or value.get("create_time")
+        created_by = value.get("created_by")
+        operation = value.get("operation")
+    else:
+        raw_version = getattr(value, "version", value)
+        created_at = getattr(value, "created_at", None) or getattr(value, "create_time", None)
+        created_by = getattr(value, "created_by", None)
+        operation = getattr(value, "operation", None)
+    if raw_version in (None, ""):
+        return None
+
+    return EvaluationDatasetVersion(
+        version=int(raw_version),
+        created_at=_parse_datetime(created_at),
+        created_by=created_by,
+        operation=operation,
+    )
 
 
 class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
@@ -101,11 +141,28 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
         return self._databricks_dataset.dataset_id if self._databricks_dataset else None
 
     @property
+    def version(self) -> int | None:
+        """The resolved dataset version number.
+
+        Returns the version number only. Use :meth:`list_versions` to retrieve full
+        version metadata (``created_at``, ``created_by``, ``operation``).
+        """
+        dataset = (
+            self._mlflow_dataset if self._mlflow_dataset is not None else self._databricks_dataset
+        )
+        resolved = _to_evaluation_dataset_version(getattr(dataset, "version", None))
+        return resolved.version if resolved else None
+
+    @property
     def source(self):
         """Source information for the dataset."""
         if self._mlflow_dataset:
             return self._mlflow_dataset.source
-        return DatabricksEvaluationDatasetSource(table_name=self.name, dataset_id=self.dataset_id)
+        return DatabricksEvaluationDatasetSource(
+            table_name=self.name,
+            dataset_id=self.dataset_id,
+            version=self.version,
+        )
 
     @property
     def source_type(self) -> str | None:
@@ -189,6 +246,23 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
 
         with _databricks_profile_env():
             self._databricks_dataset.delete_records(record_ids)
+
+    def list_versions(self) -> list[EvaluationDatasetVersion]:
+        """List immutable versions for this dataset."""
+        if self._mlflow_dataset:
+            raise NotImplementedError(
+                "Dataset versions are only supported for Databricks datasets."
+            )
+
+        from mlflow.genai.datasets import _databricks_profile_env
+
+        with _databricks_profile_env():
+            versions = self._databricks_dataset.list_versions()
+        return [
+            version
+            for version in (_to_evaluation_dataset_version(version) for version in versions)
+            if version is not None
+        ]
 
     def to_df(self) -> "pd.DataFrame":
         """Convert the dataset to a pandas DataFrame."""

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -20,6 +20,7 @@ from mlflow.genai.evaluation.utils import (
     _get_eval_data_size_and_fields,
 )
 from mlflow.genai.scorers import Scorer
+from mlflow.genai.scorers.base import flatten_scorers
 from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 from mlflow.genai.simulators import ConversationSimulator
@@ -370,7 +371,9 @@ def _run_harness(data, scorers, predict_fn, model_id) -> tuple["EvaluationResult
 
         df = _convert_to_eval_set(data)
 
-        builtin_scorers = [scorer for scorer in scorers if isinstance(scorer, BuiltInScorer)]
+        builtin_scorers = [
+            scorer for scorer in flatten_scorers(scorers) if isinstance(scorer, BuiltInScorer)
+        ]
         valid_data_for_builtin_scorers(df, builtin_scorers, predict_fn)
 
         sample_input = df.iloc[0][InputDatasetColumn.INPUTS]

--- a/mlflow/genai/judges/optimizers/memalign/optimizer.py
+++ b/mlflow/genai/judges/optimizers/memalign/optimizer.py
@@ -5,21 +5,22 @@ from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 import mlflow
-from mlflow.entities.assessment import Assessment, AssessmentSource, Feedback
-from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.entities.assessment import Assessment
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.base import AlignmentOptimizer, Judge, JudgeField
 from mlflow.genai.judges.optimizers.dspy_utils import (
     _check_dspy_installed,
     _get_api_base_key,
-    construct_dspy_lm,
     create_dspy_signature,
     trace_to_dspy_example,
 )
+from mlflow.genai.judges.optimizers.memalign.prompts import (
+    EXAMPLES_SECTION_HEADER,
+    GUIDELINES_SECTION_HEADER,
+)
 from mlflow.genai.judges.optimizers.memalign.utils import (
     Guideline,
-    create_extended_signature,
     distill_guidelines,
     get_default_embedding_model,
     get_query_field,
@@ -203,16 +204,13 @@ class MemoryAugmentedJudge(Judge):
             self._base_signature = None
             self._embedder = None
             self._retriever = None
-            self._predict_module = None
             self._episodic_memory: list["dspy.Example"] = []
             self._semantic_memory: list[Guideline] = []
         else:
             self._initialize_dspy_components(base_judge)
 
     def _initialize_dspy_components(self, base_judge: Judge | None = None) -> None:
-        """Initialize heavyweight DSPy components (embedder, predict module, memory index)."""
-        import dspy
-
+        """Initialize heavyweight DSPy components (embedder, memory index)."""
         effective_base_judge = base_judge or self._base_judge
 
         self._base_signature = create_dspy_signature(effective_base_judge)
@@ -233,10 +231,6 @@ class MemoryAugmentedJudge(Judge):
         else:
             self._episodic_memory: list["dspy.Example"] = []
             self._semantic_memory: list[Guideline] = []
-
-        extended_signature = create_extended_signature(self._base_signature)
-        self._predict_module = dspy.Predict(extended_signature)
-        self._predict_module.set_lm(construct_dspy_lm(effective_base_judge.model))
 
     def __call__(
         self,
@@ -270,31 +264,62 @@ class MemoryAugmentedJudge(Judge):
         relevant_examples = [example for example, _ in retrieved_results]
         retrieved_trace_ids = [trace_id for _, trace_id in retrieved_results]
 
-        import dspy
-        from dspy.adapters.json_adapter import JSONAdapter
-
-        with dspy.context(adapter=JSONAdapter()):
-            prediction = self._predict_module(
-                guidelines=guidelines,
-                example_judgements=relevant_examples,
-                inputs=inputs,
-                outputs=outputs,
-                expectations=expectations,
-                trace=value_to_embedding_text(trace) if trace is not None else None,
-            )
-
-        return Feedback(
-            name=self._base_judge.name,
-            source=AssessmentSource(
-                source_type=AssessmentSourceType.LLM_JUDGE,
-                source_id=self._base_judge.model,
-            ),
-            value=prediction.result,
-            rationale=prediction.rationale,
-            metadata={"retrieved_example_trace_ids": retrieved_trace_ids}
-            if retrieved_trace_ids
-            else {},
+        # Score through a per-call copy of the base judge: this preserves its invocation flow
+        # (agentic tool-calling for {{ trace }} judges) while keeping the retrieved examples,
+        # which differ per call, off the judge shared by concurrently scored rows. The copy is
+        # shallow because only _instructions is reassigned; nested state is never mutated.
+        scoring_judge = self._base_judge.model_copy()
+        scoring_judge._instructions = self._build_augmented_instructions(
+            guidelines, relevant_examples
         )
+
+        prediction = scoring_judge(
+            inputs=inputs,
+            outputs=outputs,
+            expectations=expectations,
+            trace=trace,
+        )
+
+        # Reset metadata["guideline"], which the UI renders as a short per-assertion label, to
+        # the base criterion so retrieved examples aren't persisted onto every assessment.
+        metadata = {**(prediction.metadata or {})}
+        if "guideline" in metadata:
+            metadata["guideline"] = self._base_judge.instructions
+        if retrieved_trace_ids:
+            metadata["retrieved_example_trace_ids"] = retrieved_trace_ids
+        prediction.metadata = metadata
+
+        return prediction
+
+    def _build_augmented_instructions(
+        self,
+        guidelines: list[str],
+        examples: list["dspy.Example"],
+    ) -> str:
+        """Build instructions augmented with MemAlign guidelines and retrieved examples.
+
+        Section order (examples, then guidelines) and header wording match the DSPy
+        signature this replaced, whose fields were prepended in that order.
+        """
+        parts = [self._base_judge.instructions]
+
+        if examples:
+            parts.append(f"\n\nExample Judgements ({len(examples)}):")
+            parts.append(EXAMPLES_SECTION_HEADER)
+            for i, example in enumerate(examples, 1):
+                example_dict = {
+                    k: v for k, v in example.items() if not k.startswith("dspy_") and k != "trace"
+                }
+                if hasattr(example, "trace") and example.trace is not None:
+                    example_dict["trace"] = value_to_embedding_text(example.trace)
+                parts.append(f"  Example {i}: {example_dict}")
+
+        if guidelines:
+            parts.append(f"\n\nDistilled Guidelines ({len(guidelines)}):")
+            parts.append(GUIDELINES_SECTION_HEADER)
+            parts.extend(f"  - {guideline}" for guideline in guidelines)
+
+        return "\n".join(parts)
 
     @property
     def name(self) -> str:
@@ -378,9 +403,9 @@ class MemoryAugmentedJudge(Judge):
         Override base _create_copy for Scorer.register().
 
         The base implementation uses model_copy(deep=True), which fails because
-        DSPy objects (_embedder, _retriever, _predict_module) contain thread locks
-        that can't be pickled. We create a new instance with _defer_init=True and
-        store trace IDs for lazy reconstruction.
+        DSPy objects (_embedder, _retriever) contain thread locks that can't be
+        pickled. We create a new instance with _defer_init=True and store trace
+        IDs for lazy reconstruction.
         """
         judge_copy = MemoryAugmentedJudge(
             base_judge=self._base_judge,
@@ -422,7 +447,7 @@ class MemoryAugmentedJudge(Judge):
 
         This method is called on first use (e.g., __call__) when the judge was created
         with _defer_init=True. It:
-        1. Creates DSPy components (embedder, predict module)
+        1. Creates the embedder
         2. Fetches traces by ID and reconstructs episodic memory
         3. Builds the episodic memory search index
 
@@ -431,15 +456,9 @@ class MemoryAugmentedJudge(Judge):
         if self._embedder is not None:
             return
 
-        import dspy
-
         self._base_signature = create_dspy_signature(self._base_judge)
 
         self._embedder = _build_embedder(self._embedding_model, self._embedding_dim)
-
-        extended_signature = create_extended_signature(self._base_signature)
-        self._predict_module = dspy.Predict(extended_signature)
-        self._predict_module.set_lm(construct_dspy_lm(self._base_judge.model))
 
         self._episodic_memory = self._reconstruct_episodic_memory()
 
@@ -482,6 +501,11 @@ class MemoryAugmentedJudge(Judge):
                 # aligned_judge_v2 now only retains feedback from
                 # `set(all_traces) - set(bad_traces)`
         """
+        # A judge loaded from the registry holds only trace IDs until its episodic memory is
+        # reconstructed. Without this, the check below would find nothing to remove and
+        # silently return an unchanged judge that still contains the retracted feedback.
+        self._lazy_init()
+
         trace_ids_to_remove = {trace.info.trace_id for trace in traces}
 
         if not any(

--- a/mlflow/genai/judges/optimizers/memalign/prompts.py
+++ b/mlflow/genai/judges/optimizers/memalign/prompts.py
@@ -50,28 +50,19 @@ above guideline is distilled from
 }
 """
 
+# Headers for the guidelines / retrieved-examples sections appended to a judge's
+# instructions at scoring time. The wording is carried over verbatim from the DSPy
+# InputField descriptions these replaced, so the aligned judge sees the same framing.
+GUIDELINES_SECTION_HEADER = (
+    "General guidelines you should always consider when evaluating an input. "
+    "IMPORTANT: Your output fields should NEVER directly refer to the presence "
+    "of these guidelines. Instead, weave the learned lessons into your reasoning."
+)
 
-def create_guidelines_field():
-    import dspy
-
-    return dspy.InputField(
-        desc=(
-            "General guidelines you should always consider when evaluating an input. "
-            "IMPORTANT: Your output fields should NEVER directly refer to the presence "
-            "of these guidelines. Instead, weave the learned lessons into your reasoning."
-        )
-    )
-
-
-def create_examples_field():
-    import dspy
-
-    return dspy.InputField(
-        desc=(
-            "Some example judgements (certain input fields might be omitted for "
-            "brevity). When evaluating the new input, try to align your judgements "
-            "with these examples. IMPORTANT: Your output fields should NEVER directly "
-            "refer to the presence of these examples. Instead, weave the learned "
-            "lessons into your reasoning."
-        )
-    )
+EXAMPLES_SECTION_HEADER = (
+    "Some example judgements (certain input fields might be omitted for "
+    "brevity). When evaluating the new input, try to align your judgements "
+    "with these examples. IMPORTANT: Your output fields should NEVER directly "
+    "refer to the presence of these examples. Instead, weave the learned "
+    "lessons into your reasoning."
+)

--- a/mlflow/genai/judges/optimizers/memalign/utils.py
+++ b/mlflow/genai/judges/optimizers/memalign/utils.py
@@ -23,8 +23,6 @@ from mlflow.genai.judges.optimizers.dspy_utils import (
 )
 from mlflow.genai.judges.optimizers.memalign.prompts import (
     DISTILLATION_PROMPT_TEMPLATE,
-    create_examples_field,
-    create_guidelines_field,
 )
 from mlflow.genai.utils.trace_utils import (
     extract_request_from_trace,
@@ -575,16 +573,3 @@ def retrieve_relevant_examples(
         )
         for i in indices
     ]
-
-
-def create_extended_signature(base_signature: "dspy.Signature") -> "dspy.Signature":
-    """Create extended DSPy signature with guidelines and example judgements fields.
-
-    Args:
-        base_signature: Base DSPy signature to extend
-
-    Returns:
-        Extended signature with guidelines and example_judgements fields prepended
-    """
-    extended_sig = base_signature.prepend("guidelines", create_guidelines_field())
-    return extended_sig.prepend("example_judgements", create_examples_field())

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
-from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, scorer
+from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, make_scorer_ensemble, scorer
+from mlflow.genai.scorers.ensemble import agg_all, agg_any, majority_vote, maximum, mean, minimum
 from mlflow.genai.scorers.registry import delete_scorer, get_scorer, list_scorers
 
 # Metadata keys for scorer feedback
@@ -137,7 +138,14 @@ __all__ = [
     "UserFrustration",
     "Scorer",
     "scorer",
+    "make_scorer_ensemble",
     "ScorerSamplingConfig",
+    "agg_all",
+    "agg_any",
+    "majority_vote",
+    "maximum",
+    "mean",
+    "minimum",
     "get_all_scorers",
     "get_scorer",
     "list_scorers",

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -15,6 +15,13 @@ from mlflow.entities import Assessment, Feedback
 from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.ensemble import (
+    BOOL_ENSEMBLES,
+    BUILTIN_ENSEMBLES,
+    NUMERIC_ENSEMBLES,
+    is_bool_feedback_type,
+    is_numeric_feedback_type,
+)
 from mlflow.genai.scorers.scorer_utils import (
     DECORATOR_SCORER_REGISTRATION_NOT_SUPPORTED_ERROR,
     THIRD_PARTY_SCORER_ALLOWED_MODULES,
@@ -52,6 +59,7 @@ class ScorerKind(Enum):
     GUIDELINES = "guidelines"
     THIRD_PARTY = "third_party"
     MEMORY_AUGMENTED = "memory_augmented"
+    ENSEMBLE = "ensemble"
 
 
 _ALLOWED_SCORERS_FOR_REGISTRATION = [
@@ -61,6 +69,7 @@ _ALLOWED_SCORERS_FOR_REGISTRATION = [
     ScorerKind.GUIDELINES,
     ScorerKind.MEMORY_AUGMENTED,
     ScorerKind.THIRD_PARTY,
+    ScorerKind.ENSEMBLE,
 ]
 
 
@@ -85,6 +94,62 @@ class ScorerSamplingConfig:
 
 
 AggregationFunc = Callable[[list[float]], float]  # List of per-row value -> aggregated value
+
+
+def _extract_scorer_value(result: Any) -> Any:
+    """Reduce a sub-scorer's return to a single aggregatable value.
+
+    Failures and empty assessments (``None`` or an error ``Feedback``) become ``None``
+    so the ensemble function decides how to treat them.
+    """
+    if result is None:
+        return None
+    if isinstance(result, Feedback):
+        return None if result.error is not None else result.value
+    if isinstance(result, list):
+        raise MlflowException.invalid_parameter_value(
+            "make_scorer_ensemble does not support sub-scorers that return a list of Feedback "
+            "objects."
+        )
+    return result
+
+
+def flatten_scorers(scorers: list[Any]) -> list[Any]:
+    """Expand ensemble scorers into their sub-scorers, recursively.
+
+    Callers that classify scorers by type -- required-column pre-validation, usage
+    telemetry -- must see through an ensemble to the scorers that actually run, otherwise
+    an ensemble wrapping built-in judges is treated as an opaque custom scorer and its
+    sub-scorers' input requirements go unchecked.
+    """
+    flattened = []
+    for scorer in scorers:
+        if getattr(scorer, "kind", None) == ScorerKind.ENSEMBLE:
+            flattened.extend(flatten_scorers(scorer._scorers))
+        else:
+            flattened.append(scorer)
+    return flattened
+
+
+def _is_feedbacks_mode(ensemble_fn: Callable[..., Any]) -> bool:
+    """Whether ``ensemble_fn`` opts into receiving full ``Feedback`` objects.
+
+    The aggregate input is passed positionally, so only the name of the first accepted
+    parameter selects the mode -- a ``feedbacks`` keyword elsewhere in the signature (e.g.
+    ``fn(values, feedbacks=None)``) must not flip it. Callables with no introspectable
+    signature (C builtins like ``max``) default to values-mode rather than raising.
+    """
+    try:
+        params = inspect.signature(ensemble_fn).parameters
+    except (ValueError, TypeError):
+        return False
+    positional = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.VAR_POSITIONAL,
+    )
+    first = next((p for p in params.values() if p.kind in positional), None)
+    return first is not None and first.name == "feedbacks"
 
 
 @dataclass
@@ -122,6 +187,10 @@ class SerializedScorer:
     #   {"module": ..., "class": ..., "metric_name": ..., "model": ..., "kwargs": {...}}
     third_party_scorer_data: dict[str, Any] | None = None
 
+    # Ensemble scorer fields (for make_scorer_ensemble()). Shape:
+    #   {"ensemble_fn": <builtin name>, "scorers": [<serialized sub-scorer dict>, ...]}
+    ensemble_scorer_data: dict[str, Any] | None = None
+
     def __post_init__(self):
         """Validate that exactly one type of scorer fields is present."""
         has_builtin_fields = self.builtin_scorer_class is not None
@@ -129,6 +198,7 @@ class SerializedScorer:
         has_instructions_fields = self.instructions_judge_pydantic_data is not None
         has_memory_augmented_fields = self.memory_augmented_judge_data is not None
         has_third_party_fields = self.third_party_scorer_data is not None
+        has_ensemble_fields = self.ensemble_scorer_data is not None
 
         # Count how many field types are present
         field_count = sum([
@@ -137,6 +207,7 @@ class SerializedScorer:
             has_instructions_fields,
             has_memory_augmented_fields,
             has_third_party_fields,
+            has_ensemble_fields,
         ])
 
         if field_count == 0:
@@ -145,7 +216,8 @@ class SerializedScorer:
                 "(builtin_scorer_class), decorator scorer fields (call_source), "
                 "instructions judge fields (instructions_judge_pydantic_data), "
                 "memory augmented judge fields (memory_augmented_judge_data), "
-                "or third-party scorer fields (third_party_scorer_data) present"
+                "third-party scorer fields (third_party_scorer_data), "
+                "or ensemble scorer fields (ensemble_scorer_data) present"
             )
 
         if field_count > 1:
@@ -526,6 +598,24 @@ class Scorer(BaseModel):
                 scorer_instance.aggregations = serialized.aggregations
             object.__setattr__(scorer_instance, "_cached_dump", asdict(serialized))
             return scorer_instance
+
+        # Handle ensemble scorers
+        elif serialized.ensemble_scorer_data is not None:
+            data = serialized.ensemble_scorer_data
+            fn_name = data.get("ensemble_fn")
+            if fn_name not in BUILTIN_ENSEMBLES:
+                raise MlflowException.invalid_parameter_value(
+                    f"Ensemble scorer '{serialized.name}': unknown ensemble function "
+                    f"'{fn_name}'. Available: {sorted(BUILTIN_ENSEMBLES)}."
+                )
+            sub_scorers = [cls.model_validate(d) for d in data.get("scorers", [])]
+            return make_scorer_ensemble(
+                name=serialized.name,
+                scorers=sub_scorers,
+                ensemble_fn=fn_name,
+                description=serialized.description,
+                aggregations=serialized.aggregations,
+            )
 
         # Invalid serialized data
         else:
@@ -1089,6 +1179,17 @@ class Scorer(BaseModel):
                 copy.description = self.description
             if self.aggregations is not None:
                 copy.aggregations = self.aggregations
+        elif self.kind == ScorerKind.ENSEMBLE:
+            # Copy each sub-scorer through its own _create_copy so kind-specific handling
+            # still applies; a deepcopy of `_scorers` would recurse infinitely on a
+            # third-party sub-scorer holding an `instructor`-wrapped client.
+            copy = make_scorer_ensemble(
+                name=self.name,
+                scorers=[s._create_copy() for s in self._scorers],
+                ensemble_fn=self._ensemble_fn_name or self._ensemble_fn,
+                description=self.description,
+                aggregations=self.aggregations,
+            )
         else:
             copy = self.model_copy(deep=True)
         # Duplicate the cached dump so modifications to the copy don't affect the original
@@ -1106,6 +1207,13 @@ class Scorer(BaseModel):
                     f"Got {self.kind}."
                 )
             raise MlflowException.invalid_parameter_value(error_message)
+
+        # An ensemble is only registerable if every sub-scorer is registerable too (e.g. an
+        # ensemble containing a decorator sub-scorer on a non-Databricks URI is rejected with
+        # the same rule the sub-scorer would raise on its own).
+        if self.kind == ScorerKind.ENSEMBLE:
+            for sub_scorer in self._scorers:
+                sub_scorer._check_can_be_registered(error_message)
 
         # NB: Custom (@scorer) scorers use exec() during deserialization, which poses a code
         # execution risk. Only allow registration when using Databricks tracking URI.
@@ -1395,3 +1503,225 @@ def scorer(
         description=description,
         aggregations=aggregations,
     )
+
+
+class EnsembleScorer(Scorer):
+    _SUB_FEEDBACKS_METADATA_KEY: ClassVar[str] = "mlflow.ensemble.sub_feedbacks"
+
+    _scorers: list[Scorer] = PrivateAttr(default_factory=list)
+    _ensemble_fn: Callable[..., Any] = PrivateAttr()
+    _ensemble_fn_name: str | None = PrivateAttr(default=None)
+    _is_session_level: bool = PrivateAttr(default=False)
+
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        if self._ensemble_fn_name is None:
+            raise MlflowException.invalid_parameter_value(
+                "This ensemble scorer uses a custom ensemble function and cannot be "
+                "serialized or registered. Pass one of the built-in ensemble functions "
+                f"({sorted(BUILTIN_ENSEMBLES)}) to make it serializable."
+            )
+        serialized = SerializedScorer(
+            name=self.name,
+            description=self.description,
+            aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
+            mlflow_version=mlflow.__version__,
+            serialization_version=_SERIALIZATION_VERSION,
+            ensemble_scorer_data={
+                "ensemble_fn": self._ensemble_fn_name,
+                "scorers": [s.model_dump() for s in self._scorers],
+            },
+        )
+        return asdict(serialized)
+
+    def _run_sub_scorer(self, sub_scorer: "Scorer", kwargs: dict[str, Any]) -> Any:
+        # Isolate sub-scorer failures: a raised exception becomes an error Feedback so one
+        # bad scorer doesn't abort the whole ensemble. Built-in ensemble fns still treat the
+        # resulting None as fatal; custom fns can tolerate it. (Sub-scorers run sequentially;
+        # parallel execution is future work.)
+        try:
+            return sub_scorer.run(**kwargs)
+        except Exception as e:
+            return Feedback(name=sub_scorer.name, error=e)
+
+    def _describe_failed_sub_scorers(self, sub_feedbacks: list[Feedback]) -> str:
+        # Built-in ensemble fns reject a missing value, and their generic "returned no value"
+        # message loses the underlying cause. Name the sub-scorers that failed and quote their
+        # errors so the aggregate failure stays actionable.
+        failures = [
+            f"'{fb.name}': {fb.error.error_message or fb.error.error_code}"
+            for fb in sub_feedbacks
+            if fb.error is not None
+        ]
+        return "; ".join(failures)
+
+    def _normalize_to_feedbacks(self, results: list[Any], values: list[Any]) -> list[Feedback]:
+        # feedbacks-mode ensemble fns and the sub-feedbacks metadata both need a real
+        # Feedback per sub-scorer; bare-value returns are wrapped and named after the scorer.
+        # Scorer.run() already renamed a default-named Feedback to the sub-scorer's name, so a
+        # returned Feedback needs no rename here.
+        return [
+            result if isinstance(result, Feedback) else Feedback(name=sub_scorer.name, value=value)
+            for sub_scorer, result, value in zip(self._scorers, results, values)
+        ]
+
+    def _build_sub_feedbacks_metadata(self, sub_feedbacks: list[Any]) -> dict[str, str]:
+        # Preserve each sub-scorer's full Feedback (value, rationale, source, error) on the
+        # aggregate so the ensemble result stays fully explainable — including which judge/human/
+        # code produced each sub-result. metadata is dict[str, str], so the list of Feedback
+        # dicts is JSON-encoded under a single key.
+        entries = [fb.to_dictionary() for fb in sub_feedbacks]
+        return {self._SUB_FEEDBACKS_METADATA_KEY: json.dumps(entries)}
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.ENSEMBLE
+
+    @property
+    def is_session_level_scorer(self) -> bool:
+        return self._is_session_level
+
+    def __call__(
+        self,
+        *,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+        trace: Trace | None = None,
+        session: list[Trace] | None = None,
+    ) -> Feedback:
+        if self._is_session_level:
+            kwargs = {"session": session, "expectations": expectations}
+        else:
+            kwargs = {
+                "inputs": inputs,
+                "outputs": outputs,
+                "expectations": expectations,
+                "trace": trace,
+            }
+
+        results = [self._run_sub_scorer(s, kwargs) for s in self._scorers]
+        values = [_extract_scorer_value(r) for r in results]
+
+        feedbacks_mode = _is_feedbacks_mode(self._ensemble_fn)
+        sub_feedbacks = self._normalize_to_feedbacks(results, values)
+        sub_metadata = self._build_sub_feedbacks_metadata(sub_feedbacks)
+
+        if not feedbacks_mode:
+            for sub_scorer, value in zip(self._scorers, values):
+                if value is not None and not isinstance(value, (bool, int, float, str)):
+                    raise MlflowException.invalid_parameter_value(
+                        f"make_scorer_ensemble only supports sub-scorers returning bool, "
+                        f"numeric, or categorical (str) values. Sub-scorer "
+                        f"'{sub_scorer.name}' returned {type(value).__name__}."
+                    )
+
+        agg_input = sub_feedbacks if feedbacks_mode else values
+        try:
+            result = self._ensemble_fn(agg_input)
+        except Exception as e:
+            # Attach the sub-scorer provenance to the failure so a crashed sub-scorer is
+            # debuggable: without this, a built-in fn's generic "returned no value" error
+            # hides both which sub-scorer failed and why.
+            failures = self._describe_failed_sub_scorers(sub_feedbacks)
+            suffix = f" Failed sub-scorers -- {failures}." if failures else ""
+            raise MlflowException.invalid_parameter_value(
+                f"Ensemble scorer '{self.name}' failed to aggregate its sub-scorer "
+                f"results: {e}{suffix}"
+            ) from e
+
+        if isinstance(result, Feedback):
+            if result.name == DEFAULT_FEEDBACK_NAME:
+                result.name = self.name
+            # Merge, letting the ensemble_fn's own metadata win on key collisions.
+            result.metadata = {**sub_metadata, **(result.metadata or {})}
+            return result
+        return Feedback(name=self.name, value=result, metadata=sub_metadata)
+
+
+@experimental(version="3.15.0")
+def make_scorer_ensemble(
+    *,
+    name: str,
+    scorers: list[Scorer],
+    ensemble_fn: str | Callable[..., Any],
+    description: str | None = None,
+    aggregations: list[_AggregationType] | None = None,
+) -> EnsembleScorer:
+    """
+    Create a scorer that runs several sub-scorers and aggregates their results.
+
+    Args:
+        name: Name of the ensemble scorer (and of the emitted Feedback).
+        scorers: Sub-scorers to run. Must be homogeneous in level — all session-level
+            or all single-turn. Each must return a bool, numeric, or categorical
+            (str) value.
+        ensemble_fn: A callable ``(values) -> value|Feedback``, or a callable
+            ``(feedbacks) -> value|Feedback`` to receive full Feedback objects, or the
+            string name of a built-in (one of ``mlflow.genai.scorers.ensemble``). The
+            callable may return a primitive (wrapped into a Feedback named after the
+            ensemble scorer) or a ``Feedback`` directly (passed through, with its name
+            defaulted to the ensemble scorer's name when unset).
+        description: Optional description.
+        aggregations: A list of aggregation functions to apply to the scorer's output
+            across rows. Each entry is either a string
+            (``"min"``, ``"max"``, ``"mean"``, ``"median"``, ``"variance"``, ``"p90"``)
+            or a callable ``(list[values]) -> float``. Defaults to ``"mean"``.
+    """
+    if not scorers:
+        raise MlflowException.invalid_parameter_value(
+            "make_scorer_ensemble requires at least one sub-scorer."
+        )
+
+    levels = {s.is_session_level_scorer for s in scorers}
+    if len(levels) > 1:
+        raise MlflowException.invalid_parameter_value(
+            "All sub-scorers passed to make_scorer_ensemble must be the same level: "
+            "either all session-level or all single-turn."
+        )
+    is_session_level = levels.pop()
+
+    if isinstance(ensemble_fn, str):
+        if ensemble_fn not in BUILTIN_ENSEMBLES:
+            raise MlflowException.invalid_parameter_value(
+                f"'{ensemble_fn}' is not a built-in ensemble function. "
+                f"Available: {sorted(BUILTIN_ENSEMBLES)}."
+            )
+        fn_name = ensemble_fn
+        fn = BUILTIN_ENSEMBLES[ensemble_fn]
+    else:
+        fn = ensemble_fn
+        # Record the built-in name when a built-in callable is passed directly, so the
+        # scorer stays serializable.
+        fn_name = next((n for n, f in BUILTIN_ENSEMBLES.items() if f is fn), None)
+
+    # Up-front validation: numeric built-ins reject sub-scorers that DECLARE a
+    # non-numeric feedback_value_type (e.g. a Literal["yes","no"] judge), giving a clear
+    # error before any evaluation runs. Only judges/builtin scorers declare this; decorator
+    # scorers omit it and are validated at call time by the runtime value-check.
+    if fn_name in NUMERIC_ENSEMBLES:
+        for s in scorers:
+            declared = getattr(s, "feedback_value_type", None)
+            if declared is not None and not is_numeric_feedback_type(declared):
+                raise MlflowException.invalid_parameter_value(
+                    f"Ensemble function '{fn_name}' requires numeric sub-scorer values, "
+                    f"but sub-scorer '{s.name}' declares a non-numeric feedback_value_type "
+                    f"({declared!r}). Use majority_vote for categorical scorers."
+                )
+    elif fn_name in BOOL_ENSEMBLES:
+        for s in scorers:
+            declared = getattr(s, "feedback_value_type", None)
+            if declared is not None and not is_bool_feedback_type(declared):
+                raise MlflowException.invalid_parameter_value(
+                    f"Ensemble function '{fn_name}' requires sub-scorer values with a "
+                    f"yes/no reading, but sub-scorer '{s.name}' declares a "
+                    f"feedback_value_type of {declared!r}. Use majority_vote for other "
+                    f"categorical scorers."
+                )
+
+    agg = EnsembleScorer(name=name, description=description, aggregations=aggregations)
+    object.__setattr__(agg, "_scorers", list(scorers))
+    object.__setattr__(agg, "_ensemble_fn", fn)
+    object.__setattr__(agg, "_ensemble_fn_name", fn_name)
+    object.__setattr__(agg, "_is_session_level", is_session_level)
+    return agg

--- a/mlflow/genai/scorers/ensemble.py
+++ b/mlflow/genai/scorers/ensemble.py
@@ -1,0 +1,167 @@
+"""Built-in ensemble functions for ``make_scorer_ensemble``.
+
+Each function receives the list of per-sub-scorer values and returns a single
+``Feedback``. The parameter is named ``values`` on purpose: ``make_scorer_ensemble``
+introspects the parameter name to decide whether to pass raw values or full
+``Feedback`` objects (a parameter named ``feedbacks`` opts into the latter).
+"""
+
+from collections import Counter
+from statistics import mean as _statistics_mean
+from typing import Any, Callable, Literal, get_args, get_origin
+
+from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
+
+NUMERIC_ENSEMBLES: set[str] = {"mean", "minimum", "maximum"}
+BOOL_ENSEMBLES: set[str] = {"agg_all", "agg_any"}
+
+
+def _coerce_to_bool(value: Any) -> bool | None:
+    """Map a sub-scorer value onto a bool, or ``None`` when it has no boolean reading.
+
+    Built-in judges return ``Literal["yes", "no"]`` rather than a bool, so the boolean
+    reducers accept the same affirmative/negative vocabulary the judges normalize to
+    (``CategoricalRating`` is a ``StrEnum``, so it compares equal to its string value).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _AFFIRMATIVE_VALUES:
+            return True
+        if normalized in _NEGATIVE_VALUES:
+            return False
+    return None
+
+
+def _require_numeric(values: list[Any]) -> None:
+    # Numeric built-ins (mean/minimum/maximum) reject categorical/string values with a
+    # clear error rather than letting statistics/min/max raise an opaque TypeError.
+    for v in values:
+        # bool is an int subclass and is acceptable as a numeric 0/1.
+        if not isinstance(v, (bool, int, float)):
+            raise MlflowException.invalid_parameter_value(
+                f"This ensemble function requires numeric sub-scorer values, but got a value of "
+                f"type {type(v).__name__}. Use majority_vote for categorical values."
+            )
+
+
+def _as_bools(values: list[Any]) -> list[bool]:
+    # agg_all/agg_any are boolean reducers, so never fall back to Python truthiness: a bare
+    # `all(["no", "no"])` is True because non-empty strings are truthy. Coerce each value to
+    # an explicit bool and reject anything with no boolean reading.
+    bools = []
+    for value in values:
+        coerced = _coerce_to_bool(value)
+        if coerced is None:
+            raise MlflowException.invalid_parameter_value(
+                f"This ensemble function requires boolean sub-scorer values, but got "
+                f"{value!r} (type {type(value).__name__}), which has no yes/no reading. "
+                f"Use majority_vote for other categorical values."
+            )
+        bools.append(coerced)
+    return bools
+
+
+def is_bool_feedback_type(feedback_value_type) -> bool:
+    """Whether a declared ``feedback_value_type`` denotes a boolean value.
+
+    Used to validate sub-scorers up front against boolean built-ins (agg_all/agg_any). A
+    ``Literal[...]`` qualifies when every member has a boolean reading, which includes the
+    ``Literal["yes", "no"]`` that built-in judges declare. Unknown/unannotated types return
+    False (caller treats them as non-bool).
+    """
+    if feedback_value_type is bool:
+        return True
+    if get_origin(feedback_value_type) is Literal:
+        return all(_coerce_to_bool(arg) is not None for arg in get_args(feedback_value_type))
+    return False
+
+
+def is_numeric_feedback_type(feedback_value_type) -> bool:
+    """Whether a declared ``feedback_value_type`` denotes a numeric value.
+
+    Used to validate sub-scorers up front against numeric built-ins. A ``Literal[...]`` is
+    numeric only when every member is an int/float. ``bool`` counts as numeric (0/1).
+    Unknown/unannotated types return False (caller treats them as categorical).
+    """
+    if feedback_value_type in (bool, int, float):
+        return True
+    if get_origin(feedback_value_type) is Literal:
+        return all(isinstance(arg, (bool, int, float)) for arg in get_args(feedback_value_type))
+    return False
+
+
+def _require_complete(values: list[Any]) -> None:
+    # Built-ins treat any failed/empty sub-scorer (surfaced as None) as fatal so a
+    # partial ensemble never silently produces a misleading aggregate.
+    if not values:
+        raise MlflowException.invalid_parameter_value(
+            "Aggregation failed: no sub-scorer values were provided."
+        )
+    if any(v is None for v in values):
+        raise MlflowException.invalid_parameter_value(
+            "Aggregation failed: at least one sub-scorer returned no value (it errored "
+            "or produced an empty assessment). Built-in aggregation functions require "
+            "every sub-scorer to return a value."
+        )
+
+
+def majority_vote(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    counts = Counter(values)
+    top = max(counts.values())
+    # Deterministic tie-break: lexicographic order of the string form of each tied value.
+    # This is intended for categorical/bool values. For numerics the string ordering is NOT
+    # numeric ordering (e.g. str(10) < str(9), and False sorts before True), so majority_vote
+    # is not appropriate for continuous numerics -- use mean/minimum/maximum for those.
+    winner = min((v for v, c in counts.items() if c == top), key=lambda v: str(v))
+    return Feedback(
+        value=winner,
+        rationale=f"Majority vote over {len(values)} scorers: {dict(counts)}",
+    )
+
+
+def mean(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    _require_numeric(values)
+    result = _statistics_mean(values)
+    return Feedback(value=result, rationale=f"Mean over {len(values)} scorers = {result}")
+
+
+def minimum(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    _require_numeric(values)
+    result = min(values)
+    return Feedback(value=result, rationale=f"Minimum over {len(values)} scorers = {result}")
+
+
+def maximum(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    _require_numeric(values)
+    result = max(values)
+    return Feedback(value=result, rationale=f"Maximum over {len(values)} scorers = {result}")
+
+
+def agg_all(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    result = all(_as_bools(values))
+    return Feedback(value=result, rationale=f"all() over {len(values)} scorers = {result}")
+
+
+def agg_any(values: list[Any]) -> Feedback:
+    _require_complete(values)
+    result = any(_as_bools(values))
+    return Feedback(value=result, rationale=f"any() over {len(values)} scorers = {result}")
+
+
+BUILTIN_ENSEMBLES: dict[str, Callable[[list[Any]], Feedback]] = {
+    "majority_vote": majority_vote,
+    "mean": mean,
+    "minimum": minimum,
+    "maximum": maximum,
+    "agg_all": agg_all,
+    "agg_any": agg_any,
+}

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -1013,6 +1013,7 @@ class DatabricksTracingRestStore(RestStore):
                 profile=None,
                 created_by=dataset_dict.get("created_by"),
                 last_updated_by=dataset_dict.get("last_updated_by"),
+                version=dataset_dict.get("version"),
             )
             datasets.append(dataset)
 

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -306,7 +306,9 @@ class SqlRun(Base):
 
     __table_args__ = (
         CheckConstraint(source_type.in_(SourceTypes), name="source_type"),
-        CheckConstraint(status.in_(RunStatusTypes), name="status"),
+        # Historical migrations generate this SQLite CHECK constraint without a stable name.
+        # Keep ORM metadata aligned with that schema so Alembic autogenerate sees no drift.
+        CheckConstraint(status.in_(RunStatusTypes)),
         CheckConstraint(
             lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
             name="runs_lifecycle_stage",

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -1,4 +1,6 @@
 import atexit
+import importlib
+import os
 import random
 import sys
 import threading
@@ -13,7 +15,12 @@ from typing import Any, Callable, Literal
 
 import requests
 
-from mlflow.environment_variables import _MLFLOW_TELEMETRY_SESSION_ID, MLFLOW_WORKSPACE
+from mlflow.environment_variables import (
+    _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK,
+    _MLFLOW_TELEMETRY_SESSION_ID,
+    MLFLOW_ENABLE_DB_SDK,
+    MLFLOW_WORKSPACE,
+)
 from mlflow.telemetry.constant import (
     BATCH_SIZE,
     BATCH_TIME_INTERVAL_SECONDS,
@@ -37,6 +44,17 @@ from mlflow.utils.logging_utils import should_suppress_logs_in_thread, suppress_
 from mlflow.utils.rest_utils import http_request
 
 _DATABRICKS_SCHEMES = ("databricks", "databricks-uc", "uc")
+
+# `_forward_to_databricks` resolves credentials, which first-time imports these on the
+# consumer thread. That re-enters the post-import-hook finders on `sys.meta_path`, which
+# hold a hook-registry lock while a user thread mid-import holds CPython's import locks,
+# in the opposite order. Importing here leaves the consumer with `sys.modules` lookups.
+_DATABRICKS_SDK_WARM_UP_MODULES = ("databricks.sdk",)
+
+# `databricks.sdk` does not import this; only `runtime_native_auth` does, and only under
+# Databricks Runtime. Elsewhere it starts a Databricks Connect session and resolves
+# credentials at module scope, so it stays gated on `DATABRICKS_RUNTIME_VERSION`.
+_DATABRICKS_RUNTIME_WARM_UP_MODULES = ("databricks.sdk.runtime",)
 
 
 # Cache per tracking URI; 16 is more than enough for any realistic number of
@@ -505,6 +523,35 @@ _MLFLOW_TELEMETRY_CLIENT = None
 _client_lock = threading.Lock()
 
 
+def _warm_up_databricks_sdk() -> None:
+    """
+    Load the Databricks SDK on the importing thread, so the telemetry consumer never
+    performs a first-time import of it.
+
+    `_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK=false` opts out, since this moves the SDK
+    import into every `import mlflow` inside Databricks.
+    """
+    if (
+        not _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.get()
+        or not _IS_IN_DATABRICKS
+        or _IS_MLFLOW_DEV_VERSION
+        or not MLFLOW_ENABLE_DB_SDK.get()
+    ):
+        return
+
+    modules = _DATABRICKS_SDK_WARM_UP_MODULES
+    # Mirrors the guard in `runtime_native_auth`: without this env var it never reaches its
+    # deferred `databricks.sdk.runtime` import, so there is nothing to warm.
+    if "DATABRICKS_RUNTIME_VERSION" in os.environ:
+        modules += _DATABRICKS_RUNTIME_WARM_UP_MODULES
+
+    for module in modules:
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            _log_error(f"Failed to pre-import {module} for telemetry: {e}")
+
+
 def set_telemetry_client():
     if is_telemetry_disabled():
         # set to None again so this function can be used to
@@ -512,6 +559,9 @@ def set_telemetry_client():
         _set_telemetry_client(None)
     else:
         try:
+            # Must happen before any consumer thread can exist, so the consumer never drives
+            # a first-time `databricks.sdk` import through the import hook finders.
+            _warm_up_databricks_sdk()
             _set_telemetry_client(TelemetryClient())
         except Exception as e:
             _log_error(f"Failed to set telemetry client: {e}")

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -71,13 +71,18 @@ sentence-transformers
 # Required by mlflow.anthropic
 anthropic
 # Required by mlflow.ag2
-ag2
+# TODO: Consider migrating to ag2 1.x, which renames the `autogen` module to `ag2` and drops
+# `runtime_logging`, and remove this pin.
+ag2<1
 # Required by mlflow.dspy
 # In dspy 2.6.9, `dspy.__name__` is not 'dspy', but 'dspy.__metadata__',
 # which causes auto-logging tests to fail.
 dspy!=2.6.9
 # Required by mlflow.litellm
-litellm
+# TODO: litellm>=1.97 references `ChatCompletionReasoningSummaryTextBlock`, which is not present
+# in the latest `openai` release available under the dependency cooldown, breaking
+# `litellm.Message.model_rebuild()`. Remove this pin once a compatible `openai` is available.
+litellm<1.97
 # Required by mlflow.gemini
 google-genai
 # Required by mlflow.groq

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -45,7 +45,10 @@ gepa
 # required for testing docker compose
 testcontainers
 # required for testing cost tracking
-litellm
+# TODO: litellm>=1.97 references `ChatCompletionReasoningSummaryTextBlock`, which is not present
+# in the latest `openai` release available under the dependency cooldown, breaking
+# `litellm.Message.model_rebuild()`. Remove this pin once a compatible `openai` is available.
+litellm<1.97
 # required for testing Redis budget tracker
 fakeredis[lua]
 # required for testing claude_code tracing

--- a/tests/entities/test_evaluation_dataset.py
+++ b/tests/entities/test_evaluation_dataset.py
@@ -160,6 +160,7 @@ def test_evaluation_dataset_to_from_dict():
         last_update_time=987654321,
         created_by="user1",
         last_updated_by="user2",
+        version={"version": 7, "created_by": "user1"},
     )
     dataset.experiment_ids = ["exp1", "exp2"]
 
@@ -184,6 +185,7 @@ def test_evaluation_dataset_to_from_dict():
     assert data["last_update_time"] == 987654321
     assert data["created_by"] == "user1"
     assert data["last_updated_by"] == "user2"
+    assert data["version"] == {"version": 7, "created_by": "user1"}
     assert data["experiment_ids"] == ["exp1", "exp2"]
     assert len(data["records"]) == 1
     assert data["records"][0]["inputs"]["question"] == "What is MLflow?"
@@ -199,6 +201,7 @@ def test_evaluation_dataset_to_from_dict():
     assert dataset2.last_update_time == dataset.last_update_time
     assert dataset2.created_by == dataset.created_by
     assert dataset2.last_updated_by == dataset.last_updated_by
+    assert dataset2.version == dataset.version
     assert dataset2._experiment_ids == ["exp1", "exp2"]
     assert dataset2.experiment_ids == ["exp1", "exp2"]
     assert len(dataset2._records) == 1

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -45,11 +45,39 @@ def test_databricks_evaluation_dataset_source_to_json():
     assert parsed == {"table_name": "catalog.schema.table", "dataset_id": "12345"}
 
 
+def test_databricks_evaluation_dataset_source_to_json_with_version():
+    source = DatabricksEvaluationDatasetSource(
+        table_name="catalog.schema.table",
+        dataset_id="12345",
+        version=7,
+    )
+
+    assert json.loads(source.to_json()) == {
+        "table_name": "catalog.schema.table",
+        "dataset_id": "12345",
+        "version": 7,
+    }
+
+
 def test_databricks_evaluation_dataset_source_from_json():
     json_str = json.dumps({"table_name": "catalog.schema.table", "dataset_id": "12345"})
     source = DatabricksEvaluationDatasetSource.from_json(json_str)
     assert source.table_name == "catalog.schema.table"
     assert source.dataset_id == "12345"
+
+
+def test_databricks_evaluation_dataset_source_from_json_with_version():
+    source = DatabricksEvaluationDatasetSource.from_json(
+        json.dumps({
+            "table_name": "catalog.schema.table",
+            "dataset_id": "12345",
+            "version": 7,
+        })
+    )
+
+    assert source.table_name == "catalog.schema.table"
+    assert source.dataset_id == "12345"
+    assert source.version == 7
 
 
 def test_databricks_evaluation_dataset_source_load_not_implemented():

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
@@ -16,6 +18,7 @@ from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
     DatabricksEvaluationDatasetSource,
     DatabricksUCTableDatasetSource,
 )
+from mlflow.genai.datasets.entities import EvaluationDatasetVersion
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 
 
@@ -41,6 +44,7 @@ def create_mock_managed_dataset(source_value: Any) -> Mock:
     mock_dataset.created_by = "test-user"
     mock_dataset.last_update_time = "2024-01-02T00:00:00"
     mock_dataset.last_updated_by = "test-user-2"
+    mock_dataset.version = None
 
     # Mock methods
     mock_dataset.to_df.return_value = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
@@ -156,6 +160,21 @@ def test_evaluation_dataset_to_mlflow_entity_with_existing_source():
     assert entity.profile == "test-profile"
 
 
+def test_evaluation_dataset_to_mlflow_entity_preserves_version():
+    source = DatabricksEvaluationDatasetSource(
+        table_name="catalog.schema.table",
+        dataset_id="test-dataset-id",
+        version=7,
+    )
+    dataset = create_dataset_with_source(source)
+    dataset._databricks_dataset.version = {"version": 7}
+
+    assert dataset.version == 7
+
+    entity = dataset._to_mlflow_entity()
+    assert json.loads(entity.source)["version"] == 7
+
+
 def test_evaluation_dataset_set_profile(mock_managed_dataset):
     dataset = EvaluationDataset(mock_managed_dataset)
 
@@ -179,6 +198,46 @@ def test_evaluation_dataset_delete_records(mock_managed_dataset):
     record_ids = ["record-1", "record-2"]
     dataset.delete_records(record_ids)
     mock_managed_dataset.delete_records.assert_called_once_with(record_ids)
+
+
+def test_evaluation_dataset_list_versions(mock_managed_dataset):
+    mock_managed_dataset.list_versions.return_value = [
+        SimpleNamespace(version=1),
+        SimpleNamespace(
+            version=2,
+            create_time="2026-07-08T22:37:21Z",
+            created_by="user@example.com",
+            operation="WRITE",
+        ),
+    ]
+
+    dataset = EvaluationDataset(mock_managed_dataset)
+    versions = dataset.list_versions()
+
+    assert versions == [
+        EvaluationDatasetVersion(version=1),
+        EvaluationDatasetVersion(
+            version=2,
+            created_at=datetime(2026, 7, 8, 22, 37, 21, tzinfo=timezone.utc),
+            created_by="user@example.com",
+            operation="WRITE",
+        ),
+    ]
+    mock_managed_dataset.list_versions.assert_called_once_with()
+
+
+def test_evaluation_dataset_version_repr_formats_created_at():
+    version = EvaluationDatasetVersion(
+        version=4,
+        created_at=datetime(2026, 7, 8, 22, 37, 21, tzinfo=timezone.utc),
+        created_by="user@example.com",
+        operation="OPTIMIZE",
+    )
+
+    assert repr(version) == (
+        "EvaluationDatasetVersion(version=4, created_at='2026-07-08 22:37:21 UTC', "
+        "created_by='user@example.com', operation='OPTIMIZE')"
+    )
 
 
 def test_evaluation_dataset_digest_computation(mock_managed_dataset):

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import warnings
+from types import SimpleNamespace
 from unittest import mock
 
 import pandas as pd
@@ -17,6 +18,7 @@ from mlflow.entities.evaluation_dataset import (
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import (
     EvaluationDataset,
+    EvaluationDatasetVersion,
     create_dataset,
     delete_dataset,
     delete_dataset_tag,
@@ -446,6 +448,33 @@ def test_search_datasets_databricks(mock_databricks_environment, mock_client):
     assert call_kwargs.get("order_by") is None
 
 
+def test_search_datasets_databricks_preserves_version(mock_databricks_environment, mock_client):
+    mock_client.search_datasets.return_value = PagedList(
+        [
+            EntityEvaluationDataset(
+                dataset_id="id1",
+                name="catalog.schema.dataset1",
+                digest="digest1",
+                created_time=123456789,
+                last_update_time=123456789,
+                version={"version": 7},
+            )
+        ],
+        None,
+    )
+
+    result = search_datasets(experiment_ids=["exp1"])
+
+    assert result[0].version == 7
+
+
+def test_get_dataset_version_non_databricks_unsupported(monkeypatch):
+    monkeypatch.setattr("mlflow.genai.datasets.is_databricks_uri", lambda _: False)
+
+    with pytest.raises(NotImplementedError, match="only supported for Databricks datasets"):
+        get_dataset(name="dataset", version=1)
+
+
 def test_databricks_import_error():
     with (
         mock.patch("mlflow.genai.datasets.is_databricks_uri", return_value=True),
@@ -605,6 +634,40 @@ def test_databricks_dataset_merge_records_uses_profile(monkeypatch):
     dataset.to_df()
     assert profile_during_to_df == "myprofile"
     assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
+
+
+def test_get_dataset_by_version_uses_versioning_sdk(monkeypatch):
+    calls = []
+
+    class MockAgentsDataset:
+        def list_versions(self):
+            return []
+
+    def db_get_dataset(name, version=None):
+        calls.append((name, version))
+        dataset = MockAgentsDataset()
+        dataset.name = name
+        dataset.dataset_id = name
+        dataset.digest = "digest"
+        dataset.version = version
+        return dataset
+
+    monkeypatch.setitem(
+        sys.modules,
+        "databricks.agents.datasets",
+        SimpleNamespace(Dataset=MockAgentsDataset, get_dataset=db_get_dataset),
+    )
+    monkeypatch.setattr("mlflow.genai.datasets.get_tracking_uri", lambda: "databricks")
+
+    assert get_dataset(name="catalog.schema.table", version=2).version == 2
+    assert (
+        get_dataset(
+            name="catalog.schema.table",
+            version=EvaluationDatasetVersion(version=3),
+        ).version
+        == 3
+    )
+    assert calls == [("catalog.schema.table", 2), ("catalog.schema.table", 3)]
 
 
 def test_create_dataset_with_user_tag(experiments):

--- a/tests/genai/judges/optimizers/memalign/test_optimizer.py
+++ b/tests/genai/judges/optimizers/memalign/test_optimizer.py
@@ -1,4 +1,6 @@
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +12,7 @@ from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges import make_judge
+from mlflow.genai.judges.instructions_judge import InstructionsJudge
 from mlflow.genai.judges.optimizers import MemAlignOptimizer
 from mlflow.genai.judges.optimizers.memalign.optimizer import (
     _DATABRICKS_EMBEDDING_BATCH_SIZE,
@@ -17,7 +20,13 @@ from mlflow.genai.judges.optimizers.memalign.optimizer import (
     MemoryAugmentedJudge,
     _build_embedder,
 )
+from mlflow.genai.judges.optimizers.memalign.prompts import (
+    EXAMPLES_SECTION_HEADER,
+    GUIDELINES_SECTION_HEADER,
+)
+from mlflow.genai.scorers import get_scorer
 from mlflow.genai.scorers.base import Scorer, ScorerKind, SerializedScorer
+from mlflow.tracking.fluent import _get_experiment_id
 
 _HUMAN_SOURCE = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="user1")
 
@@ -258,13 +267,23 @@ def test_judge_call_retrieves_relevant_examples(sample_judge, sample_traces):
         optimizer = MemAlignOptimizer()
         aligned_judge = optimizer.align(sample_judge, sample_traces[:3])
 
-        # Mock the predict module to return a result
-        mock_prediction = MagicMock()
-        mock_prediction.result = "yes"
-        mock_prediction.rationale = "Test rationale"
-        aligned_judge._predict_module = MagicMock(return_value=mock_prediction)
+        mock_feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id=sample_judge.model,
+            ),
+            value="yes",
+            rationale="Test rationale",
+        )
+        # Patch on the class: __call__ scores through a per-call copy of the scoring
+        # judge, so an instance-level mock would not be the object that gets invoked.
+        with patch.object(
+            InstructionsJudge, "__call__", return_value=mock_feedback
+        ) as mock_scoring_call:
+            assessment = aligned_judge(inputs="test input", outputs="test output")
 
-        assessment = aligned_judge(inputs="test input", outputs="test output")
+        mock_scoring_call.assert_called_once()
         mocks["search"].assert_called_once()
         assert "retrieved_example_trace_ids" in assessment.metadata
         # Should return trace IDs, not indices
@@ -478,7 +497,6 @@ def test_memory_augmented_judge_from_serialized(sample_judge, sample_traces):
         # Verify deferred components are None
         assert restored._base_signature is None
         assert restored._retriever is None
-        assert restored._predict_module is None
 
 
 def test_scorer_model_validate_routes_to_memory_augmented_judge(sample_judge, sample_traces):
@@ -549,27 +567,39 @@ def test_memory_augmented_judge_lazy_init_triggered_on_call(sample_judge, sample
 
         # Mock mlflow.get_trace and predict module for the call
         trace_map = {t.info.trace_id: t for t in sample_traces[:2]}
+
+        mock_feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id=sample_judge.model,
+            ),
+            value="yes",
+            rationale="Test",
+        )
+
         with (
             patch(
                 "mlflow.genai.judges.optimizers.memalign.optimizer.mlflow.get_trace",
                 side_effect=lambda tid, **kwargs: trace_map.get(tid),
             ) as mock_get_trace,
             patch("dspy.Embedder") as mock_embedder_class,
-            patch("dspy.Predict") as mock_predict_class,
             patch("dspy.retrievers.Embeddings"),
         ):
             mock_embedder_class.return_value = MagicMock()
-            mock_prediction = MagicMock()
-            mock_prediction.result = "yes"
-            mock_prediction.rationale = "Test"
-            mock_predict_instance = MagicMock(return_value=mock_prediction)
-            mock_predict_class.return_value = mock_predict_instance
 
-            restored(inputs="test", outputs="test")
-
-            # Verify initialization happened
+            # Trigger lazy init, then mock the scoring judge before call completes
+            restored._lazy_init()
             assert restored._embedder is not None
             assert mock_get_trace.call_count == 2
+
+            # Patch on the class: __call__ copies the base judge per call, so an
+            # instance-level mock would not be the object that gets invoked.
+            with patch.object(
+                InstructionsJudge, "__call__", return_value=mock_feedback
+            ) as mock_scoring_call:
+                restored(inputs="test", outputs="test")
+                mock_scoring_call.assert_called_once()
 
 
 def test_memory_augmented_judge_lazy_init_logs_warning_for_missing_traces(
@@ -591,24 +621,32 @@ def test_memory_augmented_judge_lazy_init_logs_warning_for_missing_traces(
                 return first_trace
             return None
 
+        mock_feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id=sample_judge.model,
+            ),
+            value="yes",
+            rationale="Test",
+        )
+
         with (
             patch(
                 "mlflow.genai.judges.optimizers.memalign.optimizer.mlflow.get_trace",
                 side_effect=mock_get_trace_fn,
             ),
             patch("dspy.Embedder"),
-            patch("dspy.Predict") as mock_predict_class,
             patch("dspy.retrievers.Embeddings"),
             patch("mlflow.genai.judges.optimizers.memalign.optimizer._logger") as mock_logger,
+            patch.object(
+                InstructionsJudge, "__call__", return_value=mock_feedback
+            ) as mock_scoring_call,
         ):
-            mock_prediction = MagicMock()
-            mock_prediction.result = "yes"
-            mock_prediction.rationale = "Test"
-            mock_predict_instance = MagicMock(return_value=mock_prediction)
-            mock_predict_class.return_value = mock_predict_instance
-
+            restored._lazy_init()
             restored(inputs="test", outputs="test")
 
+            mock_scoring_call.assert_called_once()
             mock_logger.warning.assert_called_once()
             warning_msg = mock_logger.warning.call_args[0][0]
             assert "Could not find 2 traces" in warning_msg
@@ -630,28 +668,36 @@ def test_memory_augmented_judge_create_copy_preserves_trace_ids(sample_judge, sa
         assert set(judge_copy._episodic_trace_ids) == set(aligned_judge._episodic_trace_ids)
 
 
-def test_judge_call_uses_json_adapter(sample_judge, sample_traces):
-    with mock_apis(guidelines=[]) as mocks:
+def test_judge_call_delegates_to_base_judge_copy(sample_judge, sample_traces):
+    with mock_apis(guidelines=["Be concise"]) as mocks:
         mocks["search"].return_value = MagicMock(indices=[0])
 
         optimizer = MemAlignOptimizer()
         aligned_judge = optimizer.align(sample_judge, sample_traces[:1])
 
-        mock_prediction = MagicMock()
-        mock_prediction.result = "yes"
-        mock_prediction.rationale = "Test rationale"
-        aligned_judge._predict_module = MagicMock(return_value=mock_prediction)
+        mock_feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id=sample_judge.model,
+            ),
+            value="yes",
+            rationale="Test rationale",
+        )
+        invoked_instructions = []
 
-        with patch("dspy.context") as mock_context:
-            mock_context.return_value.__enter__ = MagicMock()
-            mock_context.return_value.__exit__ = MagicMock(return_value=False)
+        def capture(self, **kwargs):
+            invoked_instructions.append(self._instructions)
+            return mock_feedback
+
+        with patch.object(InstructionsJudge, "__call__", capture):
             aligned_judge(inputs="test input", outputs="test output")
 
-            mock_context.assert_called_once()
-            adapter_arg = mock_context.call_args.kwargs["adapter"]
-            from dspy.adapters.json_adapter import JSONAdapter
-
-            assert isinstance(adapter_arg, JSONAdapter)
+        # The judge that was invoked carries instructions augmented with the guidelines.
+        assert len(invoked_instructions) == 1
+        assert "Be concise" in invoked_instructions[0]
+        # The shared base judge is left untouched, so context cannot bleed across calls.
+        assert "Be concise" not in aligned_judge._base_judge._instructions
 
 
 def test_memory_augmented_judge_extracts_inputs_outputs_from_trace(sample_judge, sample_traces):
@@ -661,19 +707,356 @@ def test_memory_augmented_judge_extracts_inputs_outputs_from_trace(sample_judge,
         optimizer = MemAlignOptimizer()
         aligned_judge = optimizer.align(sample_judge, sample_traces[:1])
 
-        mock_prediction = MagicMock()
-        mock_prediction.result = "yes"
-        mock_prediction.rationale = "Test rationale"
-        aligned_judge._predict_module = MagicMock(return_value=mock_prediction)
-
+        mock_feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id=sample_judge.model,
+            ),
+            value="yes",
+            rationale="Test rationale",
+        )
         # Call with only trace - inputs/outputs should be extracted from trace
         test_trace = sample_traces[0]
-        aligned_judge(trace=test_trace)
+        with patch.object(
+            InstructionsJudge, "__call__", return_value=mock_feedback
+        ) as mock_scoring_call:
+            aligned_judge(trace=test_trace)
 
-        # Verify predict_module was called with extracted inputs/outputs
-        call_kwargs = aligned_judge._predict_module.call_args.kwargs
+        # Verify scoring judge was called with extracted inputs/outputs and the trace
+        call_kwargs = mock_scoring_call.call_args.kwargs
         assert call_kwargs["inputs"] == {"inputs": "input_0"}
         assert call_kwargs["outputs"] == {"outputs": "output_0"}
+        assert call_kwargs["trace"] is test_trace
+
+
+# =============================================================================
+# Trace-based (agentic) scoring preservation tests
+#
+# An aligned judge must keep the base judge's invocation mode. For a
+# {{ trace }} judge that means the Trace object still reaches
+# invoke_judge_model() so the judge tools can inspect child spans; the old
+# implementation flattened the trace to root-span text and scored through
+# dspy.Predict, so anything below the root span was invisible at scoring time.
+# =============================================================================
+
+
+@pytest.fixture
+def trace_judge():
+    return make_judge(
+        name="test_judge",
+        instructions="Evaluate whether {{ trace }} used the calculator tool correctly",
+        model="openai:/gpt-4",
+    )
+
+
+def _start_trace_with_tool_span(root_name: str, tool_output: str) -> str:
+    with mlflow.start_span(name=root_name) as root:
+        root.set_inputs({"question": "what is 2+2?"})
+        with mlflow.start_span(name="calculator", span_type="TOOL") as tool:
+            tool.set_inputs({"expression": "2+2"})
+            tool.set_outputs({"result": tool_output})
+        root.set_outputs({"answer": "the answer is 4"})
+    return mlflow.get_last_active_trace_id()
+
+
+@pytest.fixture
+def tool_traces():
+    traces = []
+    for i in range(2):
+        trace_id = _start_trace_with_tool_span(f"agent_{i}", tool_output="4")
+        _log_human_feedback(trace_id, value="yes", rationale=f"Tool used correctly {i}")
+        traces.append(mlflow.get_trace(trace_id))
+    return traces
+
+
+def test_aligned_trace_judge_passes_trace_to_invoke_judge_model(trace_judge, tool_traces):
+    # The Trace object itself must reach invoke_judge_model so that the judge tools can
+    # read child spans. The pre-fix implementation scored via dspy.Predict and passed only
+    # value_to_embedding_text(trace) (root request/response), so trace=None reached the
+    # model layer and child TOOL spans were unreachable.
+    with mock_apis(guidelines=["Check the tool result"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(trace_judge, tool_traces)
+
+        target_trace = tool_traces[0]
+        feedback = Feedback(
+            name=trace_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=trace_judge.model
+            ),
+            value="yes",
+            rationale="Tool call verified",
+        )
+        with patch(
+            "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+            return_value=feedback,
+        ) as mock_invoke:
+            aligned_judge(trace=target_trace)
+
+        mock_invoke.assert_called_once()
+        assert mock_invoke.call_args.kwargs["trace"] is target_trace
+
+
+def test_aligned_trace_judge_keeps_agentic_system_prompt(trace_judge, tool_traces):
+    # Trace-based judges get the agentic system prompt that instructs the model to inspect
+    # the trace via tools. Delegating to a copy of the base judge preserves it; scoring
+    # through dspy.Predict did not produce this prompt at all.
+    with mock_apis(guidelines=["Check the tool result"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(trace_judge, tool_traces)
+
+        feedback = Feedback(
+            name=trace_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=trace_judge.model
+            ),
+            value="yes",
+            rationale="Tool call verified",
+        )
+        with patch(
+            "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+            return_value=feedback,
+        ) as mock_invoke:
+            aligned_judge(trace=tool_traces[0])
+
+        system_message = mock_invoke.call_args.kwargs["prompt"][0].content
+        assert "To read the actual trace, you will need to use the" in system_message
+        # Memory context rides along in the same system prompt.
+        assert "Check the tool result" in system_message
+        assert "Example Judgements" in system_message
+
+
+def test_aligned_judge_preserves_feedback_value_type(sample_traces):
+    # A non-str feedback_value_type is enforced by the base judge's response_format. The
+    # pre-fix path built its own DSPy signature, so the aligned judge could not be relied
+    # on to honor the base judge's declared output type.
+    bool_judge = make_judge(
+        name="test_judge",
+        instructions="Is {{ outputs }} a correct answer to {{ inputs }}?",
+        model="openai:/gpt-4",
+        feedback_value_type=bool,
+    )
+
+    with mock_apis(guidelines=[]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[])
+
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(bool_judge, sample_traces[:1])
+
+        feedback = Feedback(
+            name=bool_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=bool_judge.model
+            ),
+            value=True,
+            rationale="Correct",
+        )
+        with patch(
+            "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+            return_value=feedback,
+        ) as mock_invoke:
+            result = aligned_judge(inputs="test input", outputs="test output")
+
+        response_format = mock_invoke.call_args.kwargs["response_format"]
+        assert response_format.model_fields["result"].annotation is bool
+        assert result.value is True
+
+
+def test_aligned_judge_does_not_mutate_base_judge_instructions(sample_judge, sample_traces):
+    with mock_apis(guidelines=["Be concise"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(sample_judge, sample_traces[:1])
+
+        original_instructions = sample_judge.instructions
+
+        feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=sample_judge.model
+            ),
+            value="yes",
+            rationale="Test",
+        )
+        with patch(
+            "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+            return_value=feedback,
+        ) as mock_invoke:
+            aligned_judge(inputs="test input", outputs="test output")
+
+        mock_invoke.assert_called_once()
+        assert sample_judge.instructions == original_instructions
+
+
+def test_incremental_alignment_scores_through_unwrapped_base_judge(sample_judge, sample_traces):
+    # Re-aligning passes the previous MemoryAugmentedJudge in as base_judge. The judge
+    # scored through must be the unwrapped InstructionsJudge, not that wrapper: delegating
+    # to the wrapper would score through its stale inner memory and drop the per-call
+    # instructions the outer judge applies.
+    with mock_apis(guidelines=["Guideline A"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+
+        optimizer = MemAlignOptimizer()
+        judge_v2 = optimizer.align(sample_judge, sample_traces[:2])
+        judge_v3 = optimizer.align(judge_v2, sample_traces[2:4])
+
+        assert isinstance(judge_v3._base_judge, InstructionsJudge)
+        assert not isinstance(judge_v3._base_judge, MemoryAugmentedJudge)
+
+        # The re-aligned judge scores with its combined memory, applied once.
+        invoked_instructions = []
+        feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=sample_judge.model
+            ),
+            value="yes",
+            rationale="Test",
+        )
+
+        def capture(self, **kwargs):
+            invoked_instructions.append(self._instructions)
+            return feedback
+
+        with patch.object(InstructionsJudge, "__call__", capture):
+            judge_v3(inputs="test input", outputs="test output")
+
+        assert len(invoked_instructions) == 1
+        assert "Guideline A" in invoked_instructions[0]
+        assert "Example Judgements" in invoked_instructions[0]
+
+
+def test_augmented_instructions_preserve_dspy_section_headers(sample_judge, sample_traces):
+    # The section headers are carried over verbatim from the DSPy InputField descriptions
+    # that used to carry this framing, and examples precede guidelines as they did in the
+    # prepended signature. Pinned so the prompt the judge sees does not drift silently.
+    with mock_apis(guidelines=["Be concise"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(sample_judge, sample_traces[:1])
+
+        instructions = aligned_judge._build_augmented_instructions(
+            ["Be concise"], aligned_judge._episodic_memory[:1]
+        )
+
+        assert GUIDELINES_SECTION_HEADER in instructions
+        assert EXAMPLES_SECTION_HEADER in instructions
+        assert instructions.startswith(sample_judge.instructions)
+        # Examples precede guidelines, matching the order the DSPy fields were prepended in.
+        assert instructions.index("Example Judgements (1):") < instructions.index(
+            "Distilled Guidelines (1):"
+        )
+
+
+def test_aligned_judge_reports_base_criterion_in_guideline_metadata(sample_judge, sample_traces):
+    # InstructionsJudge stamps metadata["guideline"] with the instructions it ran on, and the
+    # UI renders that as a short per-assertion label (TestCaseDetail.tsx, rendererFunctions.tsx).
+    # It must stay the base criterion: the augmented text embeds retrieved examples, i.e. other
+    # traces' inputs/outputs, which would then be persisted onto every assessment.
+    with mock_apis(guidelines=["Be concise"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(sample_judge, sample_traces[:2])
+
+        feedback = Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=sample_judge.model
+            ),
+            value="yes",
+            rationale="Test",
+        )
+        with patch(
+            "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+            return_value=feedback,
+        ) as mock_invoke:
+            result = aligned_judge(inputs="test input", outputs="test output")
+
+        # The augmented context still reaches the model.
+        assert "Be concise" in mock_invoke.call_args.kwargs["prompt"][0].content
+
+        guideline_metadata = result.metadata["guideline"]
+        assert guideline_metadata == sample_judge.instructions
+        assert "Example Judgements" not in guideline_metadata
+        assert "input_0" not in guideline_metadata
+        # Retrieval metadata is still attached alongside.
+        assert result.metadata["retrieved_example_trace_ids"] == [sample_traces[0].info.trace_id]
+
+
+def test_concurrent_calls_do_not_leak_retrieved_examples_across_rows(sample_judge, sample_traces):
+    # The eval harness scores rows on a thread pool sharing one scorer instance
+    # (mlflow/genai/evaluation/harness.py:422-454), so two rows can be inside __call__ at
+    # once. Each row's prompt must carry only the examples retrieved for that row.
+    #
+    # The barrier sits at the start of _build_system_message, i.e. after both threads have
+    # published their per-call instructions but before either reads them back — the exact
+    # interleaving that a shared mutable _instructions attribute cannot survive.
+    with mock_apis(guidelines=[]) as mocks:
+        optimizer = MemAlignOptimizer()
+        aligned_judge = optimizer.align(sample_judge, sample_traces[:3])
+        assert mocks["embedder"] is not None
+
+    # Row 0 retrieves episodic example 0 ("input_0"); row 1 retrieves example 1 ("input_1").
+    index_by_row = {"row-0": [0], "row-1": [1]}
+    expected_example_text = {"row-0": "input_0", "row-1": "input_1"}
+    other_example_text = {"row-0": "input_1", "row-1": "input_0"}
+
+    barrier = threading.Barrier(2)
+    prompts: dict[str, str] = {}
+    prompts_lock = threading.Lock()
+
+    def retriever_side_effect(query, **kwargs):
+        row = "row-0" if "row-0" in str(query) else "row-1"
+        return MagicMock(indices=index_by_row[row])
+
+    original_build_system_message = InstructionsJudge._build_system_message
+
+    def barriered_build_system_message(self, is_trace_based):
+        barrier.wait(timeout=10)
+        return original_build_system_message(self, is_trace_based)
+
+    def invoke_side_effect(**kwargs):
+        user_message = kwargs["prompt"][1].content
+        row = "row-0" if "row-0" in user_message else "row-1"
+        with prompts_lock:
+            prompts[row] = kwargs["prompt"][0].content
+        return Feedback(
+            name=sample_judge.name,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id=sample_judge.model
+            ),
+            value="yes",
+            rationale="Test",
+        )
+
+    aligned_judge._retriever = MagicMock(side_effect=retriever_side_effect)
+
+    with (
+        patch(
+            "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+            side_effect=invoke_side_effect,
+        ),
+        patch.object(InstructionsJudge, "_build_system_message", barriered_build_system_message),
+        ThreadPoolExecutor(max_workers=2, thread_name_prefix="MemAlignRaceTest") as pool,
+    ):
+        futures = [
+            pool.submit(aligned_judge, inputs=row, outputs="out") for row in ("row-0", "row-1")
+        ]
+        for future in futures:
+            future.result(timeout=30)
+
+    assert set(prompts) == {"row-0", "row-1"}
+    for row, system_message in prompts.items():
+        assert expected_example_text[row] in system_message
+        assert other_example_text[row] not in system_message
 
 
 @pytest.mark.parametrize(
@@ -927,6 +1310,115 @@ def test_realign_after_unalign_roundtrip(sample_judge, sample_traces):
 
         assert set(judge_v3._episodic_trace_ids) == v1_trace_ids
         assert len(judge_v3._episodic_memory) == v1_episodic_count
+
+
+# =============================================================================
+# End-to-end lifecycle tests
+#
+# These drive the sequences a user actually performs and score at the end. The
+# older round-trip tests stop at state assertions, which no longer implies the
+# judge scores correctly now that scoring runs through a per-call copy of the
+# base judge.
+# =============================================================================
+
+
+def _mock_scoring_call(judge_name: str, model: str, value="yes"):
+    """Patch InstructionsJudge.__call__ and capture the instructions it ran on."""
+    feedback = Feedback(
+        name=judge_name,
+        source=AssessmentSource(source_type=AssessmentSourceType.LLM_JUDGE, source_id=model),
+        value=value,
+        rationale="Test rationale",
+    )
+    captured: list[str] = []
+
+    def capture(self, **kwargs):
+        captured.append(self._instructions)
+        return feedback
+
+    return patch.object(InstructionsJudge, "__call__", capture), captured
+
+
+def test_unalign_then_realign_then_score(sample_judge, sample_traces):
+    with mock_apis(guidelines=["Guideline A"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+        optimizer = MemAlignOptimizer()
+
+        judge_v1 = optimizer.align(sample_judge, sample_traces[:3])
+        unaligned = judge_v1.unalign(traces=sample_traces[:3])
+        assert unaligned._episodic_memory == []
+
+        judge_v3 = optimizer.align(unaligned, sample_traces[:3])
+        assert len(judge_v3._episodic_memory) == 3
+
+        patcher, captured = _mock_scoring_call(sample_judge.name, sample_judge.model)
+        with patcher:
+            result = judge_v3(inputs="test input", outputs="test output")
+
+        # Memory rebuilt by the re-align reaches the prompt, and scoring still works.
+        assert len(captured) == 1
+        assert "Guideline A" in captured[0]
+        assert "Example Judgements" in captured[0]
+        assert result.value == "yes"
+
+
+def test_register_then_load_then_score(sample_judge, sample_traces):
+    with mock_apis(guidelines=["Guideline A"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+        optimizer = MemAlignOptimizer()
+        aligned = optimizer.align(sample_judge, sample_traces[:3])
+
+        aligned.register()
+        loaded = get_scorer(name=sample_judge.name, experiment_id=_get_experiment_id())
+        assert isinstance(loaded, MemoryAugmentedJudge)
+        # Episodic memory is reconstructed lazily from the persisted trace IDs.
+        assert loaded._embedder is None
+        assert len(loaded._episodic_trace_ids) == 3
+
+        patcher, captured = _mock_scoring_call(sample_judge.name, sample_judge.model)
+        with patcher:
+            result = loaded(inputs="test input", outputs="test output")
+
+        # Semantic memory survived the round trip and episodic memory was rebuilt from
+        # the persisted trace IDs, so both reach the prompt the loaded judge scores with.
+        assert len(captured) == 1
+        assert "Guideline A" in captured[0]
+        assert "Example Judgements" in captured[0]
+        assert result.value == "yes"
+        assert result.metadata["retrieved_example_trace_ids"] == [sample_traces[0].info.trace_id]
+
+
+def test_register_then_load_then_unalign_then_score(sample_judge, sample_traces):
+    # unalign() must reconstruct episodic memory before filtering. A freshly loaded judge
+    # holds only trace IDs, so reading _episodic_memory directly would find nothing to
+    # remove and silently hand back an unchanged judge.
+    with mock_apis(guidelines=["Guideline A"]) as mocks:
+        mocks["search"].return_value = MagicMock(indices=[0])
+        optimizer = MemAlignOptimizer()
+        aligned = optimizer.align(sample_judge, sample_traces[:3])
+
+        aligned.register()
+        loaded = get_scorer(name=sample_judge.name, experiment_id=_get_experiment_id())
+        assert loaded._episodic_memory == []
+
+        updated = loaded.unalign(traces=[sample_traces[0]])
+
+        assert updated is not loaded
+        assert set(updated._episodic_trace_ids) == {
+            sample_traces[1].info.trace_id,
+            sample_traces[2].info.trace_id,
+        }
+        assert len(updated._episodic_memory) == 2
+        assert all(
+            ex._trace_id != sample_traces[0].info.trace_id for ex in updated._episodic_memory
+        )
+
+        patcher, captured = _mock_scoring_call(sample_judge.name, sample_judge.model)
+        with patcher:
+            result = updated(inputs="test input", outputs="test output")
+
+        assert len(captured) == 1
+        assert result.value == "yes"
 
 
 def test_align_dedupes_traces_within_a_single_call(sample_judge, sample_traces):

--- a/tests/genai/scorers/test_scorer_ensemble.py
+++ b/tests/genai/scorers/test_scorer_ensemble.py
@@ -1,0 +1,746 @@
+import json
+from typing import Literal
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import mlflow.genai
+import mlflow.genai.scorers as _public_scorers
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges import make_judge
+from mlflow.genai.judges.utils import CategoricalRating
+from mlflow.genai.scorers import scorer
+from mlflow.genai.scorers.base import (
+    EnsembleScorer,
+    Scorer,
+    ScorerKind,
+    _extract_scorer_value,
+    flatten_scorers,
+    make_scorer_ensemble,
+)
+from mlflow.genai.scorers.builtin_scorers import Correctness, Safety
+from mlflow.genai.scorers.ensemble import (
+    BUILTIN_ENSEMBLES,
+    agg_all,
+    agg_any,
+    is_bool_feedback_type,
+    is_numeric_feedback_type,
+    majority_vote,
+    maximum,
+    mean,
+    minimum,
+)
+
+# ---------------------------------------------------------------------------
+# Built-in ensemble function unit tests
+# ---------------------------------------------------------------------------
+
+_ALL_BUILTINS = [majority_vote, mean, minimum, maximum, agg_all, agg_any]
+_NUMERIC_BUILTINS = [mean, minimum, maximum]
+
+
+@pytest.mark.parametrize(
+    ("fn", "values", "expected"),
+    [
+        # majority_vote
+        pytest.param(majority_vote, [True, True, False], True, id="majority_vote-basic"),
+        pytest.param(majority_vote, [True, False], False, id="majority_vote-tie_false_wins"),
+        pytest.param(majority_vote, ["b", "a"], "a", id="majority_vote-categorical_tie"),
+        pytest.param(majority_vote, ["x", "x", "y"], "x", id="majority_vote-categorical_majority"),
+        pytest.param(majority_vote, [True], True, id="majority_vote-single"),
+        pytest.param(majority_vote, ["only"], "only", id="majority_vote-single_categorical"),
+        # mean
+        pytest.param(mean, [1.0, 2.0, 3.0], 2.0, id="mean-basic"),
+        pytest.param(mean, [2], 2, id="mean-single"),
+        pytest.param(mean, [True, False], 0.5, id="mean-bools"),
+        pytest.param(mean, [-1.0, 1.0], 0.0, id="mean-zero"),
+        # minimum
+        pytest.param(minimum, [3, 1, 2], 1, id="minimum-basic"),
+        pytest.param(minimum, [5], 5, id="minimum-single"),
+        pytest.param(minimum, [True, False], False, id="minimum-bools"),
+        # maximum
+        pytest.param(maximum, [3, 1, 2], 3, id="maximum-basic"),
+        pytest.param(maximum, [5], 5, id="maximum-single"),
+        pytest.param(maximum, [True, False], True, id="maximum-bools"),
+        # agg_all
+        pytest.param(agg_all, [True, True], True, id="agg_all-all_true"),
+        pytest.param(agg_all, [True, False], False, id="agg_all-mixed"),
+        pytest.param(agg_all, [True], True, id="agg_all-single"),
+        # agg_any
+        pytest.param(agg_any, [False, False], False, id="agg_any-all_false"),
+        pytest.param(agg_any, [False, True], True, id="agg_any-mixed"),
+        pytest.param(agg_any, [False], False, id="agg_any-single"),
+    ],
+)
+def test_builtin_happy_path(fn, values, expected):
+    result = fn(values)
+    assert isinstance(result, Feedback)
+    if isinstance(expected, bool):
+        assert result.value is expected
+    else:
+        assert result.value == expected
+
+
+@pytest.mark.parametrize("fn", _ALL_BUILTINS)
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param([True, None], id="with_none"),
+        pytest.param([None], id="all_none"),
+    ],
+)
+def test_builtins_raise_on_none_entry(fn, values):
+    with pytest.raises(MlflowException, match="failed"):
+        fn(values)
+
+
+@pytest.mark.parametrize("fn", _ALL_BUILTINS)
+def test_builtins_raise_on_empty_input(fn):
+    with pytest.raises(MlflowException, match="failed"):
+        fn([])
+
+
+@pytest.mark.parametrize("fn", _NUMERIC_BUILTINS)
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(["a", "b"], id="all_strings"),
+        pytest.param([1.0, "b"], id="mixed"),
+    ],
+)
+def test_numeric_builtins_reject_non_numeric(fn, values):
+    with pytest.raises(MlflowException, match="numeric"):
+        fn(values)
+
+
+@pytest.mark.parametrize("fn", [agg_all, agg_any])
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(["maybe", "no"], id="unmappable_string"),
+        pytest.param([1, 2], id="ints_not_bool"),
+        pytest.param([True, 1], id="mixed_bool_int"),
+    ],
+)
+def test_bool_builtins_reject_values_without_yes_no_reading(fn, values):
+    with pytest.raises(MlflowException, match="yes/no reading"):
+        fn(values)
+
+
+@pytest.mark.parametrize(
+    ("fn", "values", "expected"),
+    [
+        # Built-in judges return Literal["yes","no"], not bools. Truthiness would make every
+        # non-empty string True, so "no" must read as False.
+        pytest.param(agg_all, ["yes", "no"], False, id="agg_all-yes_no"),
+        pytest.param(agg_all, ["yes", "yes"], True, id="agg_all-all_yes"),
+        pytest.param(agg_any, ["no", "no"], False, id="agg_any-all_no"),
+        pytest.param(agg_any, ["no", "yes"], True, id="agg_any-one_yes"),
+        pytest.param(agg_all, [CategoricalRating.YES, "yes"], True, id="agg_all-rating_enum"),
+        pytest.param(agg_all, ["YES", " yes "], True, id="agg_all-case_and_space"),
+        pytest.param(agg_all, ["pass", True], True, id="agg_all-affirmative-synonym"),
+    ],
+)
+def test_bool_builtins_coerce_categorical_yes_no(fn, values, expected):
+    result = fn(values)
+    assert result.value is expected
+
+
+def test_builtin_registry_maps_names():
+    assert BUILTIN_ENSEMBLES["majority_vote"] is majority_vote
+    assert BUILTIN_ENSEMBLES["mean"] is mean
+    assert set(BUILTIN_ENSEMBLES) == {
+        "majority_vote",
+        "mean",
+        "minimum",
+        "maximum",
+        "agg_all",
+        "agg_any",
+    }
+
+
+# ---------------------------------------------------------------------------
+# ScorerKind and _extract_scorer_value unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_scorer_kind_has_ensemble():
+    assert ScorerKind.ENSEMBLE.value == "ensemble"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(Feedback(value=0.5), 0.5, id="feedback_value"),
+        pytest.param(True, True, id="bool_primitive"),
+        pytest.param(3, 3, id="int_primitive"),
+        pytest.param(None, None, id="none_input"),
+        pytest.param(Feedback(error=ValueError("boom")), None, id="error_feedback"),
+    ],
+)
+def test_extract_scorer_value(value, expected):
+    result = _extract_scorer_value(value)
+    if isinstance(expected, bool):
+        assert result is expected
+    else:
+        assert result == expected
+
+
+def test_extract_value_rejects_feedback_list():
+    with pytest.raises(MlflowException, match="list"):
+        _extract_scorer_value([Feedback(value=1), Feedback(value=2)])
+
+
+# ---------------------------------------------------------------------------
+# Module-level scorer fixtures used across integration tests
+# ---------------------------------------------------------------------------
+
+
+@scorer
+def _always_true(outputs) -> bool:
+    return True
+
+
+@scorer
+def _always_false(outputs) -> bool:
+    return False
+
+
+@scorer
+def _num_len(outputs) -> int:
+    return len(outputs)
+
+
+# ---------------------------------------------------------------------------
+# EnsembleScorer integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_ensemble_majority_vote_end_to_end():
+    agg = make_scorer_ensemble(
+        name="vote",
+        scorers=[_always_true, _always_true, _always_false],
+        ensemble_fn="majority_vote",
+    )
+    fb = agg(outputs="hello")
+    assert fb.value is True
+    assert fb.name == "vote"
+
+
+def test_ensemble_dispatches_mixed_signatures():
+    # _always_true takes outputs; _num_len takes outputs too; use maximum over ints/bools.
+    agg = make_scorer_ensemble(name="max_agg", scorers=[_num_len], ensemble_fn="maximum")
+    assert agg(outputs="abcd").value == 4
+
+
+def test_ensemble_fn_c_builtin_no_signature():
+    # C builtins like max expose no introspectable signature; the dispatch must not raise and
+    # should default to values-mode (max over the extracted values).
+    agg = make_scorer_ensemble(name="b", scorers=[_num_len, _num_len], ensemble_fn=max)
+    assert agg(outputs="abcd").value == 4
+
+
+def test_ensemble_resilient_to_sub_scorer_failure():
+    @scorer
+    def _boom(outputs) -> bool:
+        raise ValueError("kaboom")
+
+    def tolerant(feedbacks):
+        # One sub-scorer crashed; a feedbacks-mode fn can still produce a result.
+        return True
+
+    agg = make_scorer_ensemble(name="e", scorers=[_always_true, _boom], ensemble_fn=tolerant)
+    fb = agg(outputs="x")
+    assert fb.value is True
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    crashed = next(e for e in sub if e["assessment_name"] == "_boom")
+    assert crashed["feedback"]["error"]["error_code"] == "ValueError"
+
+
+def test_builtin_ensemble_failure_names_the_crashed_sub_scorer():
+    @scorer
+    def _boom(outputs) -> bool:
+        raise ValueError("kaboom")
+
+    # Built-in fns treat a missing sub-scorer value as fatal. The raised error must still
+    # identify which sub-scorer failed and why, rather than only "returned no value".
+    agg = make_scorer_ensemble(name="e", scorers=[_always_true, _boom], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="_boom.*kaboom"):
+        agg(outputs="x")
+
+
+@pytest.mark.parametrize(
+    ("ensemble_fn", "expects_feedbacks"),
+    [
+        pytest.param(lambda values: values, False, id="values"),
+        pytest.param(lambda feedbacks: feedbacks, True, id="feedbacks"),
+        # The aggregate input is passed positionally, so a `feedbacks` keyword that is not
+        # the first parameter must not flip the mode.
+        pytest.param(lambda values, feedbacks=None: values, False, id="feedbacks-not-first"),
+        pytest.param(lambda feedbacks, values=None: feedbacks, True, id="feedbacks-first"),
+    ],
+)
+def test_dispatch_mode_follows_first_positional_parameter(ensemble_fn, expects_feedbacks):
+    agg = make_scorer_ensemble(name="d", scorers=[_num_len], ensemble_fn=ensemble_fn)
+    received = agg(outputs="abcd").value
+    assert isinstance(received[0], Feedback) is expects_feedbacks
+
+
+def test_ensemble_create_copy_recurses_into_sub_scorers():
+    # Sub-scorers must be copied through their own _create_copy rather than deep-copied
+    # wholesale: a deepcopy recurses infinitely on a third-party sub-scorer that holds an
+    # `instructor`-wrapped client.
+    sub = Safety()
+    agg = make_scorer_ensemble(name="c", scorers=[sub], ensemble_fn="majority_vote")
+    copy = agg._create_copy()
+    assert isinstance(copy, EnsembleScorer)
+    assert copy.name == "c"
+    assert copy._ensemble_fn_name == "majority_vote"
+    assert isinstance(copy._scorers[0], Safety)
+    assert copy._scorers[0] is not sub
+
+
+def test_ensemble_custom_callable_on_values():
+    def spread(values):
+        return max(values) - min(values)
+
+    agg = make_scorer_ensemble(name="spread", scorers=[_num_len, _num_len], ensemble_fn=spread)
+    fb = agg(outputs="abc")
+    assert fb.value == 0  # both return 3
+    assert fb.name == "spread"
+
+
+def test_ensemble_feedbacks_mode():
+    def count_feedbacks(feedbacks):
+        return len(feedbacks)
+
+    agg = make_scorer_ensemble(
+        name="count", scorers=[_always_true, _always_false], ensemble_fn=count_feedbacks
+    )
+    assert agg(outputs="x").value == 2
+
+
+def test_ensemble_rejects_unsupported_value_type():
+    # A sub-scorer whose Feedback carries a non-str/numeric value (dict) is rejected in
+    # values-mode. The value is wrapped in a Feedback so it survives Scorer.run() validation
+    # and reaches the ensemble's own value-type guard.
+    @scorer
+    def _returns_dict(outputs) -> Feedback:
+        return Feedback(value={"key": "val"})
+
+    agg = make_scorer_ensemble(name="bad", scorers=[_returns_dict], ensemble_fn="majority_vote")
+    with pytest.raises(MlflowException, match="_returns_dict"):
+        agg(outputs="x")
+
+
+def test_ensemble_rejects_empty_scorers():
+    with pytest.raises(MlflowException, match="at least one"):
+        make_scorer_ensemble(name="e", scorers=[], ensemble_fn="mean")
+
+
+def test_ensemble_rejects_unknown_builtin_name():
+    with pytest.raises(MlflowException, match="not a built-in"):
+        make_scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="bogus")
+
+
+def test_ensemble_session_level_derivation_and_mixing():
+    @scorer
+    def _sess(session) -> bool:
+        return len(session) > 0
+
+    session_agg = make_scorer_ensemble(name="s", scorers=[_sess], ensemble_fn="agg_all")
+    assert session_agg.is_session_level_scorer is True
+
+    single_agg = make_scorer_ensemble(name="t", scorers=[_always_true], ensemble_fn="agg_all")
+    assert single_agg.is_session_level_scorer is False
+
+    with pytest.raises(MlflowException, match="same level"):
+        make_scorer_ensemble(name="m", scorers=[_sess, _always_true], ensemble_fn="agg_all")
+
+
+def test_ensemble_records_builtin_name_for_callable():
+    agg = make_scorer_ensemble(name="v", scorers=[_always_true], ensemble_fn=majority_vote)
+    assert agg._ensemble_fn_name == "majority_vote"
+
+
+def test_ensemble_custom_callable_has_no_builtin_name():
+    agg = make_scorer_ensemble(
+        name="c", scorers=[_always_true], ensemble_fn=lambda values: max(values)
+    )
+    assert agg._ensemble_fn_name is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization tests
+# ---------------------------------------------------------------------------
+# Round-trip tests use Safety() (a builtin scorer) as the sub-scorer because decorator-backed
+# sub-scorers require a Databricks tracking URI to reconstruct (_reconstruct_decorator_scorer
+# raises outside Databricks). Safety serializes/reconstructs locally without any network call.
+
+
+def test_ensemble_serialization_produces_ensemble_scorer_data():
+    """model_dump() on an ensemble scorer must produce ensemble_scorer_data, not trip the
+    SerializedScorer mutual-exclusion validator.
+    """
+    # Safety declares Literal["yes","no"]; use majority_vote (categorical-friendly).
+    agg = make_scorer_ensemble(
+        name="agg_safety",
+        scorers=[Safety()],
+        ensemble_fn="majority_vote",
+    )
+    dumped = agg.model_dump()
+    assert "ensemble_scorer_data" in dumped
+    assert dumped["ensemble_scorer_data"]["ensemble_fn"] == "majority_vote"
+    assert len(dumped["ensemble_scorer_data"]["scorers"]) == 1
+
+
+def test_ensemble_serialization_round_trip():
+    """Full dump → validate round-trip using a builtin sub-scorer (Safety) to avoid the
+    OSS decorator-reconstruction block.
+    """
+    # Safety declares Literal["yes","no"]; use majority_vote (categorical-friendly).
+    agg = make_scorer_ensemble(
+        name="agg_safety",
+        scorers=[Safety()],
+        ensemble_fn="majority_vote",
+    )
+    dumped = agg.model_dump()
+    assert dumped["ensemble_scorer_data"]["ensemble_fn"] == "majority_vote"
+    assert len(dumped["ensemble_scorer_data"]["scorers"]) == 1
+
+    restored = Scorer.model_validate(dumped)
+    assert restored.name == "agg_safety"
+    assert restored.kind.value == "ensemble"
+    assert restored._ensemble_fn_name == "majority_vote"
+    assert len(restored._scorers) == 1
+    assert isinstance(restored._scorers[0], Safety)
+
+
+def test_ensemble_serialization_preserves_aggregations():
+    agg = make_scorer_ensemble(
+        name="agg_safety",
+        scorers=[Safety()],
+        ensemble_fn="majority_vote",
+        aggregations=["min", "max"],
+    )
+    dumped = agg.model_dump()
+    assert dumped["aggregations"] == ["min", "max"]
+    restored = Scorer.model_validate(dumped)
+    assert restored.aggregations == ["min", "max"]
+
+
+def test_ensemble_custom_callable_not_serializable():
+    agg = make_scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: sum(values))
+    with pytest.raises(MlflowException, match="custom ensemble function"):
+        agg.model_dump()
+
+
+def test_public_exports():
+    assert mlflow.genai.make_scorer_ensemble is make_scorer_ensemble
+    for name, fn in [
+        ("majority_vote", majority_vote),
+        ("mean", mean),
+        ("minimum", minimum),
+        ("maximum", maximum),
+        ("agg_all", agg_all),
+        ("agg_any", agg_any),
+        ("make_scorer_ensemble", make_scorer_ensemble),
+    ]:
+        assert getattr(_public_scorers, name) is fn
+
+
+def test_ensemble_check_can_be_registered_passes_for_builtin_sub_scorers():
+    # An ensemble of builtin sub-scorers is registerable: _check_can_be_registered must not raise.
+    agg = make_scorer_ensemble(name="ok", scorers=[Safety()], ensemble_fn="majority_vote")
+    agg._check_can_be_registered()
+
+
+def test_ensemble_check_can_be_registered_rejects_decorator_sub_scorer_non_databricks():
+    # A decorator sub-scorer is only registerable under a Databricks tracking URI. The ensemble
+    # must be rejected with the same rule (recursion into sub-scorers), not silently allowed.
+    agg = make_scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="Custom scorer registration"):
+        agg._check_can_be_registered()
+
+
+def test_ensemble_in_evaluate(is_in_databricks):
+    data = pd.DataFrame({
+        "inputs": [{"q": "a"}, {"q": "b"}],
+        "outputs": ["yes", "no"],
+    })
+    agg = make_scorer_ensemble(
+        name="ensemble",
+        scorers=[_always_true, _always_false],
+        ensemble_fn="agg_any",
+    )
+    result = mlflow.genai.evaluate(data=data, scorers=[agg])
+    # agg_any is order-independent, so the ensemble feedback is logged for every row
+    assert "ensemble/mean" in result.metrics
+
+
+@pytest.mark.parametrize(
+    ("scorers", "expected_names"),
+    [
+        pytest.param([_always_true], ["_always_true"], id="plain"),
+        pytest.param(
+            [make_scorer_ensemble(name="e", scorers=[_always_true], ensemble_fn="agg_all")],
+            ["_always_true"],
+            id="ensemble",
+        ),
+        pytest.param(
+            [
+                make_scorer_ensemble(
+                    name="outer",
+                    scorers=[
+                        make_scorer_ensemble(
+                            name="inner", scorers=[_always_true], ensemble_fn="agg_all"
+                        ),
+                        _always_false,
+                    ],
+                    ensemble_fn="agg_all",
+                )
+            ],
+            ["_always_true", "_always_false"],
+            id="nested-ensemble",
+        ),
+    ],
+)
+def test_flatten_scorers_expands_ensembles(scorers, expected_names):
+    assert [s.name for s in flatten_scorers(scorers)] == expected_names
+
+
+def test_ensemble_sub_scorer_missing_columns_is_reported_upfront(is_in_databricks):
+    # Correctness requires `expectations`, which this dataset lacks. The warning must fire
+    # for a sub-scorer wrapped in an ensemble, not just a top-level built-in scorer.
+    data = pd.DataFrame({"inputs": [{"q": "a"}], "outputs": ["a"]})
+    agg = make_scorer_ensemble(
+        name="ensemble", scorers=[Correctness()], ensemble_fn="majority_vote"
+    )
+    with mock.patch("mlflow.genai.evaluation.base.valid_data_for_builtin_scorers") as mock_valid:
+        try:
+            mlflow.genai.evaluate(data=data, scorers=[agg])
+        except Exception:
+            pass
+    mock_valid.assert_called_once()
+    passed_scorers = mock_valid.call_args[0][1]
+    assert [type(s).__name__ for s in passed_scorers] == ["Correctness"]
+
+
+# ---------------------------------------------------------------------------
+# Categorical / Literal values and feedback_value_type validation
+# ---------------------------------------------------------------------------
+
+
+@scorer
+def _label(outputs) -> str:
+    return outputs
+
+
+def test_ensemble_majority_vote_categorical():
+    # majority_vote now handles categorical string values.
+    agg = make_scorer_ensemble(
+        name="cat", scorers=[_label, _label, _label], ensemble_fn="majority_vote"
+    )
+    assert agg(outputs="yes").value == "yes"
+
+
+def test_mean_rejects_categorical_values():
+    # mean must raise for string values at call time, not silently crash in statistics.mean.
+    agg = make_scorer_ensemble(name="m", scorers=[_label], ensemble_fn="mean")
+    with pytest.raises(MlflowException, match="numeric"):
+        agg(outputs="0.5")
+
+
+def test_feedbacks_mode_allows_non_numeric():
+    # feedbacks-mode bypasses the value-type check entirely; feedbacks contains Feedback objects.
+    def first_value(feedbacks):
+        return feedbacks[0].value
+
+    agg = make_scorer_ensemble(name="f", scorers=[_label], ensemble_fn=first_value)
+    assert agg(outputs="hello").value == "hello"
+
+
+def test_ensemble_feedbacks_mode_receives_feedback_objects():
+    captured = {}
+
+    def inspect_fn(feedbacks):
+        captured["types"] = [type(f).__name__ for f in feedbacks]
+        captured["names"] = [f.name for f in feedbacks]
+        return feedbacks[0].value
+
+    # _num_len returns a bare int; must be wrapped into a Feedback in feedbacks-mode.
+    agg = make_scorer_ensemble(name="fb", scorers=[_num_len], ensemble_fn=inspect_fn)
+    fb = agg(outputs="abcd")
+    assert captured["types"] == ["Feedback"]
+    assert captured["names"] == ["_num_len"]
+    assert fb.value == 4
+
+
+def test_numeric_builtin_rejects_literal_judge_upfront():
+    # Safety declares feedback_value_type == Literal["yes","no"]; mean must reject it early.
+    with pytest.raises(MlflowException, match="numeric"):
+        make_scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="mean")
+
+
+def test_majority_vote_accepts_literal_judge():
+    # majority_vote is categorical-friendly; Safety() constructs fine.
+    agg = make_scorer_ensemble(name="ok", scorers=[Safety()], ensemble_fn="majority_vote")
+    assert agg.name == "ok"
+
+
+@pytest.mark.parametrize(
+    ("feedback_type", "expected"),
+    [
+        pytest.param(float, True, id="float"),
+        pytest.param(int, True, id="int"),
+        pytest.param(bool, True, id="bool"),
+        pytest.param(Literal[1, 2, 3], True, id="literal_numeric"),
+        pytest.param(Literal["yes", "no"], False, id="literal_str"),
+        pytest.param(str, False, id="str"),
+        pytest.param(None, False, id="none"),
+    ],
+)
+def test_is_numeric_feedback_type(feedback_type, expected):
+    assert is_numeric_feedback_type(feedback_type) is expected
+
+
+@pytest.mark.parametrize(
+    ("feedback_type", "expected"),
+    [
+        pytest.param(bool, True, id="bool"),
+        pytest.param(Literal[True, False], True, id="literal_bool"),
+        pytest.param(int, False, id="int"),
+        pytest.param(float, False, id="float"),
+        pytest.param(Literal[1, 2, 3], False, id="literal_numeric"),
+        # Built-in judges declare Literal["yes","no"], which has a yes/no reading and so
+        # is usable with the boolean reducers.
+        pytest.param(Literal["yes", "no"], True, id="literal_yes_no"),
+        pytest.param(Literal["pass", "fail"], True, id="literal_pass_fail"),
+        pytest.param(Literal["great", "terrible"], False, id="literal_unmappable_str"),
+        pytest.param(str, False, id="str"),
+        pytest.param(None, False, id="none"),
+    ],
+)
+def test_is_bool_feedback_type(feedback_type, expected):
+    assert is_bool_feedback_type(feedback_type) is expected
+
+
+def test_bool_builtin_accepts_literal_yes_no_judge():
+    # "all judges must pass" over built-in judges is the primary agg_all use case. Safety
+    # declares Literal["yes","no"], which has a yes/no reading, so it must not be rejected.
+    agg = make_scorer_ensemble(name="x", scorers=[Safety()], ensemble_fn="agg_all")
+    assert agg.name == "x"
+
+
+def test_bool_builtin_rejects_non_boolean_literal_judge_upfront():
+    judge = make_judge(
+        name="grade",
+        instructions="Grade {{ outputs }}.",
+        model="openai:/gpt-4",
+        feedback_value_type=Literal["great", "terrible"],
+    )
+    with pytest.raises(MlflowException, match="yes/no reading"):
+        make_scorer_ensemble(name="x", scorers=[judge], ensemble_fn="agg_all")
+
+
+def test_agg_all_coerces_yes_no_at_call_time():
+    # A decorator scorer declares no feedback_value_type, so the up-front check is skipped.
+    # "yes" must still read as True rather than relying on string truthiness.
+    agg = make_scorer_ensemble(name="a", scorers=[_label], ensemble_fn="agg_all")
+    assert agg(outputs="yes").value is True
+    assert agg(outputs="no").value is False
+
+
+def test_agg_all_at_call_time_rejects_values_without_yes_no_reading():
+    agg = make_scorer_ensemble(name="a", scorers=[_label], ensemble_fn="agg_all")
+    with pytest.raises(MlflowException, match="yes/no reading"):
+        agg(outputs="maybe")
+
+
+# ---------------------------------------------------------------------------
+# Sub-scorer provenance in ensemble Feedback.metadata
+# ---------------------------------------------------------------------------
+
+
+def test_ensemble_preserves_sub_feedbacks_in_metadata():
+    @scorer
+    def _yes(outputs) -> Feedback:
+        return Feedback(value=True, rationale="looks safe")
+
+    @scorer
+    def _no(outputs) -> Feedback:
+        return Feedback(value=False, rationale="found an issue")
+
+    agg = make_scorer_ensemble(name="e", scorers=[_yes, _no], ensemble_fn="majority_vote")
+    fb = agg(outputs="x")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert len(sub) == 2
+    assert {e["assessment_name"] for e in sub} == {"_yes", "_no"}
+    assert {e["rationale"] for e in sub} == {"looks safe", "found an issue"}
+    # values live under the nested "feedback" key
+    assert {e["feedback"]["value"] for e in sub} == {True, False}
+
+
+def test_ensemble_metadata_captures_sub_feedback_source():
+    @scorer
+    def _judge(outputs) -> Feedback:
+        return Feedback(
+            value=True,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE, source_id="gpt-4o-mini"
+            ),
+        )
+
+    agg = make_scorer_ensemble(name="e", scorers=[_judge], ensemble_fn="agg_all")
+    fb = agg(outputs="x")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert sub[0]["source"]["source_type"] == "LLM_JUDGE"
+    assert sub[0]["source"]["source_id"] == "gpt-4o-mini"
+
+
+def test_ensemble_metadata_normalizes_bare_value():
+    agg = make_scorer_ensemble(name="c", scorers=[_num_len], ensemble_fn=lambda values: max(values))
+    fb = agg(outputs="abcd")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert sub[0]["assessment_name"] == "_num_len"
+    assert sub[0]["feedback"]["value"] == 4
+    assert sub[0]["source"]["source_type"] == "CODE"
+
+
+def test_ensemble_fn_metadata_wins_on_collision():
+    key = EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY
+
+    def fn_with_meta(feedbacks):
+        return Feedback(value=True, metadata={key: "override"})
+
+    agg = make_scorer_ensemble(name="m", scorers=[_always_true], ensemble_fn=fn_with_meta)
+    fb = agg(outputs="x")
+    # The ensemble_fn's own metadata wins on key collision.
+    assert fb.metadata[key] == "override"
+
+
+def test_ensemble_metadata_is_string_valued():
+    agg = make_scorer_ensemble(name="s", scorers=[_always_true], ensemble_fn="agg_all")
+    fb = agg(outputs="x")
+    for v in fb.metadata.values():
+        assert isinstance(v, str)
+
+
+def test_ensemble_metadata_captures_error_feedback():
+    @scorer
+    def _errs(outputs) -> Feedback:
+        return Feedback(error=ValueError("boom"))
+
+    def tolerant(feedbacks):
+        return True
+
+    agg = make_scorer_ensemble(name="e", scorers=[_errs], ensemble_fn=tolerant)
+    fb = agg(outputs="x")
+    sub = json.loads(fb.metadata[EnsembleScorer._SUB_FEEDBACKS_METADATA_KEY])
+    assert sub[0]["assessment_name"] == "_errs"
+    # to_dictionary() puts error info under the nested "feedback.error" key
+    assert sub[0]["feedback"]["error"]["error_code"] == "ValueError"
+    assert sub[0]["feedback"]["error"]["error_message"] == "boom"

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2657,7 +2657,10 @@ def test_lock_model_requirements_pip_requirements(monkeypatch: pytest.MonkeyPatc
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "httpx==" in contents
+    # `openai` migrated its HTTP client from `httpx` (1.x) to `httpx2` (2.x, a
+    # separate distribution), so an unpinned `openai` locks one or the other
+    # depending on the resolved version. Assert the family is locked either way.
+    assert "httpx==" in contents or "httpx2==" in contents
 
 
 def test_lock_model_requirements_extra_pip_requirements(
@@ -2675,7 +2678,7 @@ def test_lock_model_requirements_extra_pip_requirements(
     assert "# Locked requirements" in contents
     assert "mlflow==" in contents
     assert "openai==" in contents
-    assert "httpx==" in contents
+    assert "httpx==" in contents or "httpx2==" in contents
 
 
 def test_lock_model_requirements_constraints(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -449,6 +449,7 @@ def test_serving_artifacts_allows_pre_scoped_roots(workspace_tracking_store, mon
 
 def test_serving_artifacts_honors_workspace_override(workspace_tracking_store, monkeypatch):
     monkeypatch.setenv("_MLFLOW_SERVER_SERVE_ARTIFACTS", "true")
+    monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)
     workspace_tracking_store.artifact_root_uri = "mlflow-artifacts:/artifacts"
 
     class OverrideProvider:
@@ -472,6 +473,7 @@ def test_serving_artifacts_honors_workspace_override(workspace_tracking_store, m
 
 def test_create_experiment_requires_effective_artifact_root(workspace_tracking_store, monkeypatch):
     monkeypatch.delenv("_MLFLOW_SERVER_SERVE_ARTIFACTS", raising=False)
+    monkeypatch.delenv(MLFLOW_TRACE_ARCHIVAL_CONFIG.name, raising=False)
     workspace_tracking_store.artifact_root_uri = None
 
     class EmptyProvider:

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -1829,6 +1829,12 @@ def test_search_datasets_basic():
                 "source": '{"table_name":"main.default.test"}',
                 "source_type": "databricks-uc-table",
                 "last_sync_time": "1970-01-01T00:00:00Z",
+                "version": {
+                    "version": 7,
+                    "create_time": "2025-11-28T20:30:53.195Z",
+                    "created_by": "user@example.com",
+                    "operation": "WRITE",
+                },
             }
         ],
         "next_page_token": None,
@@ -1861,6 +1867,7 @@ def test_search_datasets_basic():
         assert result[0].digest == "abc123"
         assert result[0].created_by == "user@example.com"
         assert result[0].last_updated_by == "user@example.com"
+        assert result[0].version["version"] == 7
         assert result.token is None
 
 

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -8,8 +8,14 @@ from unittest import mock
 import pytest
 
 import mlflow
-from mlflow.environment_variables import _MLFLOW_TELEMETRY_SESSION_ID
+from mlflow.environment_variables import (
+    _MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK,
+    _MLFLOW_TELEMETRY_SESSION_ID,
+    MLFLOW_ENABLE_DB_SDK,
+)
 from mlflow.telemetry.client import (
+    _DATABRICKS_RUNTIME_WARM_UP_MODULES,
+    _DATABRICKS_SDK_WARM_UP_MODULES,
     BATCH_SIZE,
     BATCH_TIME_INTERVAL_SECONDS,
     MAX_QUEUE_SIZE,
@@ -18,7 +24,9 @@ from mlflow.telemetry.client import (
     UNRECOVERABLE_ERRORS,
     TelemetryClient,
     _is_localhost_uri,
+    _warm_up_databricks_sdk,
     get_telemetry_client,
+    set_telemetry_client,
 )
 from mlflow.telemetry.events import CreateLoggedModelEvent, CreateRunEvent
 from mlflow.telemetry.schemas import Record, SourceSDK, Status
@@ -1127,6 +1135,140 @@ def test_forward_to_databricks_retries_on_retryable_error(error_code):
             client._forward_to_databricks([record])
 
         assert mock_http.call_count == 3
+
+
+def test_set_telemetry_client_warms_databricks_sdk_before_creating_client():
+    """
+    The warm-up must land before a client exists, since the client is what later spawns the
+    consumer threads that would otherwise drive a first-time `databricks.sdk` import.
+    """
+    calls = []
+
+    def _make_client():
+        calls.append("TelemetryClient")
+        return mock.MagicMock(info={"session_id": "test_session_id"})
+
+    with (
+        mock.patch(
+            "mlflow.telemetry.client._warm_up_databricks_sdk",
+            side_effect=lambda: calls.append("warm_up"),
+        ),
+        mock.patch("mlflow.telemetry.client.TelemetryClient", side_effect=_make_client),
+    ):
+        set_telemetry_client()
+
+    assert calls == ["warm_up", "TelemetryClient"]
+
+
+@pytest.fixture
+def in_databricks_runtime(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.0")
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
+    ):
+        yield
+
+
+def test_databricks_sdk_not_warmed_up_when_flag_disabled(in_databricks_runtime, monkeypatch):
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "false")
+
+    with mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import:
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_warmed_up_by_default(monkeypatch):
+    monkeypatch.delenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, raising=False)
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.0")
+
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    assert [c.args[0] for c in mock_import.call_args_list] == [
+        *_DATABRICKS_SDK_WARM_UP_MODULES,
+        *_DATABRICKS_RUNTIME_WARM_UP_MODULES,
+    ]
+
+
+def test_databricks_sdk_warmed_up_in_databricks_runtime(in_databricks_runtime):
+    with mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import:
+        _warm_up_databricks_sdk()
+
+    assert [c.args[0] for c in mock_import.call_args_list] == [
+        *_DATABRICKS_SDK_WARM_UP_MODULES,
+        *_DATABRICKS_RUNTIME_WARM_UP_MODULES,
+    ]
+
+
+def test_databricks_sdk_runtime_not_warmed_up_without_runtime_version(monkeypatch):
+    """
+    In Databricks environments that are not DBR (e.g. model serving), `runtime_native_auth`
+    bails before its deferred import, and `databricks.sdk.runtime` would instead fall into
+    an OSS branch that starts a Databricks Connect session and resolves credentials.
+    """
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "true")
+
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    imported = [c.args[0] for c in mock_import.call_args_list]
+    assert imported == list(_DATABRICKS_SDK_WARM_UP_MODULES)
+    assert "databricks.sdk.runtime" not in imported
+
+
+def test_databricks_sdk_not_warmed_up_outside_databricks(monkeypatch):
+    monkeypatch.setenv(_MLFLOW_TELEMETRY_PRE_WARM_DATABRICKS_SDK.name, "true")
+
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", False),
+        mock.patch("mlflow.telemetry.client._IS_IN_DATABRICKS", False),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_not_warmed_up_when_db_sdk_disabled(in_databricks_runtime, monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_DB_SDK.name, "false")
+
+    with mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import:
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_not_warmed_up_for_dev_versions(in_databricks_runtime):
+    with (
+        mock.patch("mlflow.telemetry.client._IS_MLFLOW_DEV_VERSION", True),
+        mock.patch("mlflow.telemetry.client.importlib.import_module") as mock_import,
+    ):
+        _warm_up_databricks_sdk()
+
+    mock_import.assert_not_called()
+
+
+def test_databricks_sdk_warm_up_continues_past_import_errors(in_databricks_runtime):
+    with mock.patch(
+        "mlflow.telemetry.client.importlib.import_module",
+        side_effect=ImportError("no databricks-sdk installed"),
+    ) as mock_import:
+        _warm_up_databricks_sdk()
+
+    assert mock_import.call_count == len(_DATABRICKS_SDK_WARM_UP_MODULES) + len(
+        _DATABRICKS_RUNTIME_WARM_UP_MODULES
+    )
 
 
 @pytest.mark.no_mock_requests_get


### PR DESCRIPTION
Cherry-picks for the **v3.15.2** patch release onto `branch-3.15`.

## Commits

- #24749 — Add `scorer_ensemble` primitive for combining scorer results
- #24841 — Pre-import `databricks.sdk` in Databricks to avoid telemetry deadlock
- #24845 — [GenAI] Support immutable evaluation dataset versions
- #24883 — Preserve base judge invocation flow in MemAlign aligned judges

## Notes

The batch originally listed 5 commits; #24799 (Harden version parsing) was **skipped** because it is already present on `branch-3.15` (backported as #24813). The remaining 4 cherry-picked cleanly.

This pull request and its description were written by Isaac.