### PR TITLE
Pass review payload and media paths to `pr-review` as arguments

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,14 +2,14 @@
 name: pr-review
 description: Review a pull request and emit a validated review payload.
 disable-model-invocation: true
-argument-hint: "<pr_url>"
-arguments: [pr_url]
+argument-hint: "<pr_url> <payload_path> <media_dir>"
+arguments: [pr_url, payload_path, media_dir]
 ---
 
 # Review Pull Request
 
-Review $pr_url and write a JSON review payload to `/tmp/review-payload.json`. Do not post anything:
-writing that payload is the whole job.
+Review $pr_url and write a JSON review payload to $payload_path. Do not post anything: writing
+that payload is the whole job.
 
 ## Instructions
 
@@ -89,7 +89,7 @@ Node and `agent-browser` are on PATH for docs and UI changes. Render when it set
 change is correct, or when a capture shows a finding more plainly than prose can. Building the
 docs site or the UI is expensive; do it only when the finding justifies it. Capture to an
 absolute path named for what it shows:
-`agent-browser screenshot --full /tmp/review-media/traces-table.png`, and cite that same path
+`agent-browser screenshot --full $media_dir/traces-table.png`, and cite that same path
 in a finding.
 
 Evaluate the changed code across these dimensions:
@@ -127,7 +127,7 @@ Classify each finding that survives those exclusions:
 ### 4. Write and validate the review payload
 
 Read [`review-payload.schema.json`](./review-payload.schema.json), then write
-`/tmp/review-payload.json` matching it. It defines the severity prefix each comment body carries
+`$payload_path` matching it. It defines the severity prefix each comment body carries
 and derives `event` from those prefixes.
 
 Authoring rules not captured by the schema:
@@ -143,8 +143,8 @@ Authoring rules not captured by the schema:
 - Use suggestion blocks for simple fixes: fence with ` ```suggestion ` and preserve original
   indentation.
 - To attach an image or video (a diagram, a chart, a captured repro), write the file into
-  `/tmp/review-media/` and cite it by the absolute path you wrote it to:
-  `![desc](/tmp/review-media/name.png)` to embed, or `[desc](/tmp/review-media/name.png)`
+  `$media_dir` and cite it by the absolute path you wrote it to:
+  `![desc]($media_dir/name.png)` to embed, or `[desc]($media_dir/name.png)`
   to link. A later workflow step uploads it and rewrites the reference to a URL. Do not
   upload anything yourself. Skip this unless a visual genuinely beats prose; most reviews
   need none.
@@ -155,11 +155,10 @@ Authoring rules not captured by the schema:
 Validate before finishing, then fix any errors and re-emit until both of these pass:
 
 ```bash
-uv run --package skills skills validate-review /tmp/review-payload.json
-# only when you wrote a file into /tmp/review-media/
-uv run --package skills skills embed-media --check \
-  --dir /tmp/review-media --target /tmp/review-payload.json
+uv run --package skills skills validate-review $payload_path
+# only when you wrote a file into $media_dir
+uv run --package skills skills embed-media --check --dir $media_dir --target $payload_path
 ```
 
 Do not post the review: no `gh pr review`, no review/comment APIs, no other skills. Stop
-after writing and validating `/tmp/review-payload.json`.
+after writing and validating `$payload_path`.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -90,6 +90,9 @@ jobs:
     # fails closed.
     permissions: {}
     timeout-minutes: 45
+    env:
+      REVIEW_PAYLOAD: /tmp/review-payload.json
+      REVIEW_MEDIA: /tmp/review-media
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -214,7 +217,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
-          AGENT_BROWSER_SCREENSHOT_DIR: /tmp/review-media
+          AGENT_BROWSER_SCREENSHOT_DIR: ${{ env.REVIEW_MEDIA }}
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
           mkdir -p "$AGENT_BROWSER_SCREENSHOT_DIR"
@@ -231,7 +234,7 @@ jobs:
             --print \
             --verbose \
             --output-format stream-json \
-            "/pr-review $PR_URL" \
+            "/pr-review $PR_URL $REVIEW_PAYLOAD $REVIEW_MEDIA" \
             | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 30 minutes"
@@ -260,19 +263,19 @@ jobs:
           REPO_ID: ${{ github.event.repository.id }}
         run: |
           uv run --frozen --package skills skills embed-media \
-            --dir /tmp/review-media \
-            --target /tmp/review-payload.json \
+            --dir "$REVIEW_MEDIA" \
+            --target "$REVIEW_PAYLOAD" \
             --repository-id "$REPO_ID"
 
       - name: Validate review payload
         run: |
-          if [ ! -f /tmp/review-payload.json ]; then
-            echo "::error::Claude did not produce /tmp/review-payload.json"
+          if [ ! -f "$REVIEW_PAYLOAD" ]; then
+            echo "::error::Claude did not produce $REVIEW_PAYLOAD"
             exit 1
           fi
-          uv run --frozen --package skills skills validate-review /tmp/review-payload.json
+          uv run --frozen --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"
-          jq . /tmp/review-payload.json
+          jq . "$REVIEW_PAYLOAD"
           echo "::endgroup::"
 
       - name: Post review
@@ -282,7 +285,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input /tmp/review-payload.json
+          gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input "$REVIEW_PAYLOAD"
 
       - name: Redact secrets from transcript
         if: always()


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

`/tmp/review-payload.json` and `/tmp/review-media` were hardcoded in seven places across `review.yml` and `pr-review/SKILL.md`, so changing either path meant editing both files and keeping them in sync by hand.

`review.yml` now defines both once as job-level env vars and passes them to the skill as positional arguments, matching how `ui-review.yml` already invokes `/ui-review`. The skill takes `<pr_url> <payload_path> <media_dir>` and carries no paths of its own.

### How is this PR tested?

- [x] Manual tests

Filed from a branch on `mlflow/mlflow` so the `pull_request` smoke path in `review.yml` runs `/pr-review` end-to-end (with Post gated off), exercising the new argument passing.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)