### PR TITLE
Allow minimum-version checks against unpublished workspace packages

### DIFF
--- a/libs/typescript/scripts/check-min-mlflow-deps.sh
+++ b/libs/typescript/scripts/check-min-mlflow-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Type-check each integration against the *lowest published version* of every
-# @mlflow/* workspace dependency its package.json allows.
+# Type-check each integration against the lowest version of every @mlflow/*
+# workspace dependency its package.json allows.
 #
 # Why this exists: in the workspace, node_modules/@mlflow/core is a symlink to
 # ../../core (always the latest source), so `tsc`, eslint, and jest all resolve
@@ -10,9 +10,13 @@
 # floor, where the symbol is missing, and crashes at runtime (see mlflow#24167).
 #
 # This gate reproduces the user's install: for each @mlflow/* dependency, it
-# resolves the lowest version the declared range allows, installs that published
-# version into the integration's own node_modules (shadowing the symlink), and
-# runs `tsc --noEmit`. A newer-than-floor symbol becomes a hard compile error.
+# resolves the lowest version the declared range allows and installs it into the
+# integration's own node_modules (shadowing the symlink). Published floors come
+# from npm. During a coordinated release, an unpublished floor may instead come
+# from a packed local workspace whose name and version match exactly. Running
+# `tsc --noEmit` against that package makes a newer-than-floor symbol a hard
+# compile error while still allowing core and its integrations to be bumped in
+# one PR.
 #
 # To stay immune to unrelated noise (a third-party module missing from a local
 # sandbox, a pre-existing type error), it type-checks TWICE -- once against
@@ -26,6 +30,8 @@ cd "$(dirname "$0")/.."
 ROOT="$PWD"
 TSC="$ROOT/node_modules/.bin/tsc"
 ALLOWLIST="$ROOT/scripts/known-floor-violations.txt"
+LOCAL_PACKAGE_CACHE="$(mktemp -d)"
+trap 'rm -rf "$LOCAL_PACKAGE_CACHE"' EXIT
 
 # Integrations grandfathered in: they violate the floor today (same class as
 # mlflow#24167) but must not fail the gate yet. New violations still fail.
@@ -39,6 +45,61 @@ is_allowlisted() {
 summary() {
   [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] && printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
   return 0
+}
+
+published_version_exists() {
+  local dep="$1"
+  local version="$2"
+  local versions
+
+  if ! versions="$(npm view "$dep" versions --json)"; then
+    echo "        ERROR: failed to query published versions for $dep" >&2
+    return 2
+  fi
+
+  node -e '
+    const fs = require("fs");
+    const value = JSON.parse(fs.readFileSync(0, "utf8"));
+    const versions = Array.isArray(value) ? value : [value];
+    process.exit(versions.includes(process.argv[1]) ? 0 : 1);
+  ' "$version" <<< "$versions"
+}
+
+workspace_package_path() {
+  node -e '
+    const lock = require("./package-lock.json");
+    const name = process.argv[1];
+    const match = Object.entries(lock.packages).find(
+      ([path, pkg]) => path && !path.startsWith("node_modules/") && pkg.name === name,
+    );
+    if (match) process.stdout.write(match[0]);
+  ' "$1"
+}
+
+pack_workspace_package() {
+  local dep="$1"
+  local version="$2"
+  local workspace_path="$3"
+  local cache_key="${dep//@/_}"
+  local pack_json
+  local packed_filename
+  local tarball
+
+  cache_key="${cache_key//\//_}"
+  tarball="$LOCAL_PACKAGE_CACHE/$cache_key-$version.tgz"
+  if [[ ! -f "$tarball" ]]; then
+    echo "        BUILD $dep@$version from workspace $workspace_path" >&2
+    npm run -C "$workspace_path" build >&2
+    pack_json="$(npm pack "./$workspace_path" --pack-destination "$LOCAL_PACKAGE_CACHE" --json)"
+    packed_filename="$(node -e '
+      const fs = require("fs");
+      const result = JSON.parse(fs.readFileSync(0, "utf8"));
+      process.stdout.write(result[0].filename);
+    ' <<< "$pack_json")"
+    mv "$LOCAL_PACKAGE_CACHE/$packed_filename" "$tarball"
+  fi
+
+  printf '%s' "$tarball"
 }
 
 new_failures=()      # not allowlisted -> fail the build
@@ -104,15 +165,49 @@ for pkg_json in integrations/*/package.json; do
       console.log(floors.sort(cmp)[0]);
     " "$range")"
     echo "        $dep  range='$range'  floor=$floor"
-    # Install the published floor into a temp prefix, then copy it into the
-    # integration's node_modules so Node/tsc resolution finds it before the
-    # hoisted workspace symlink.
+    # Prefer the published floor. For a coordinated release, fall back to a
+    # packed workspace only when npm does not contain the floor and the local
+    # package has the exact same name and version. This keeps ordinary feature
+    # PRs pinned to published artifacts while allowing release PRs to validate
+    # the package that will be published.
+    install_spec="$dep@$floor"
+    if published_version_exists "$dep" "$floor"; then
+      echo "        SOURCE npm ($install_spec)"
+    else
+      status=$?
+      if [[ $status -eq 2 ]]; then
+        rm -rf "$shadow"
+        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
+        exit 1
+      fi
+
+      workspace_path="$(workspace_package_path "$dep")"
+      if [[ -z "$workspace_path" ]]; then
+        echo "        ERROR: $dep@$floor is unpublished and has no local workspace" >&2
+        rm -rf "$shadow"
+        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
+        exit 1
+      fi
+      workspace_version="$(node -p "require('./$workspace_path/package.json').version")"
+      if [[ "$workspace_version" != "$floor" ]]; then
+        echo "        ERROR: $dep@$floor is unpublished and workspace version is $workspace_version" >&2
+        rm -rf "$shadow"
+        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
+        exit 1
+      fi
+
+      install_spec="$(pack_workspace_package "$dep" "$floor" "$workspace_path")"
+      echo "        SOURCE workspace package ($workspace_path)"
+    fi
+
+    # Install the floor into a temp prefix, then copy it into the integration's
+    # node_modules so Node/tsc resolution finds it before the hoisted symlink.
     tmp="$(mktemp -d)"
-    # Silence normal progress on stdout but keep stderr, so a failed install
-    # (unpublished version, network error) surfaces its reason in CI logs.
-    if ! npm install --prefix "$tmp" "$dep@$floor" \
+    # Silence normal progress on stdout but keep stderr so failures surface in
+    # CI logs.
+    if ! npm install --prefix "$tmp" "$install_spec" \
       --no-save --no-package-lock --no-audit --no-fund >/dev/null; then
-      echo "        ERROR: failed to install $dep@$floor (see npm output above)" >&2
+      echo "        ERROR: failed to install $install_spec (see npm output above)" >&2
       rm -rf "$tmp" "$shadow"
       [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
       exit 1

--- a/libs/typescript/scripts/check-min-mlflow-deps.sh
+++ b/libs/typescript/scripts/check-min-mlflow-deps.sh
@@ -89,14 +89,27 @@ pack_workspace_package() {
   tarball="$LOCAL_PACKAGE_CACHE/$cache_key-$version.tgz"
   if [[ ! -f "$tarball" ]]; then
     echo "        BUILD $dep@$version from workspace $workspace_path" >&2
-    npm run -C "$workspace_path" build >&2
-    pack_json="$(npm pack "./$workspace_path" --pack-destination "$LOCAL_PACKAGE_CACHE" --json)"
-    packed_filename="$(node -e '
+    if ! npm run -C "$workspace_path" build >&2; then
+      echo "        ERROR: failed to build workspace package $dep@$version" >&2
+      return 1
+    fi
+    if ! pack_json="$(npm pack "./$workspace_path" --pack-destination "$LOCAL_PACKAGE_CACHE" --json)"; then
+      echo "        ERROR: failed to pack workspace package $dep@$version" >&2
+      return 1
+    fi
+    if ! packed_filename="$(node -e '
       const fs = require("fs");
       const result = JSON.parse(fs.readFileSync(0, "utf8"));
+      if (typeof result[0]?.filename !== "string") process.exit(1);
       process.stdout.write(result[0].filename);
-    ' <<< "$pack_json")"
-    mv "$LOCAL_PACKAGE_CACHE/$packed_filename" "$tarball"
+    ' <<< "$pack_json")"; then
+      echo "        ERROR: failed to parse npm pack output for $dep@$version" >&2
+      return 1
+    fi
+    if ! mv "$LOCAL_PACKAGE_CACHE/$packed_filename" "$tarball"; then
+      echo "        ERROR: failed to cache packed workspace package $dep@$version" >&2
+      return 1
+    fi
   fi
 
   printf '%s' "$tarball"
@@ -196,7 +209,12 @@ for pkg_json in integrations/*/package.json; do
         exit 1
       fi
 
-      install_spec="$(pack_workspace_package "$dep" "$floor" "$workspace_path")"
+      if ! install_spec="$(pack_workspace_package "$dep" "$floor" "$workspace_path")"; then
+        echo "        ERROR: failed to prepare workspace package $dep@$floor" >&2
+        rm -rf "$shadow"
+        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
+        exit 1
+      fi
       echo "        SOURCE workspace package ($workspace_path)"
     fi
 

--- a/libs/typescript/scripts/check-min-mlflow-deps.sh
+++ b/libs/typescript/scripts/check-min-mlflow-deps.sh
@@ -13,10 +13,11 @@
 # resolves the lowest version the declared range allows and installs it into the
 # integration's own node_modules (shadowing the symlink). Published floors come
 # from npm. During a coordinated release, an unpublished floor may instead come
-# from a packed local workspace whose name and version match exactly. Running
-# `tsc --noEmit` against that package makes a newer-than-floor symbol a hard
-# compile error while still allowing core and its integrations to be bumped in
-# one PR.
+# from a packed local workspace whose name and version match exactly. Published
+# floors retain the compatibility comparison described below. For an unpublished
+# workspace floor, the baseline and package come from the same source, so the
+# check only verifies that the package builds, installs, and type-checks; it
+# cannot detect API-floor violations until that version is published.
 #
 # To stay immune to unrelated noise (a third-party module missing from a local
 # sandbox, a pre-existing type error), it type-checks TWICE -- once against
@@ -31,7 +32,39 @@ ROOT="$PWD"
 TSC="$ROOT/node_modules/.bin/tsc"
 ALLOWLIST="$ROOT/scripts/known-floor-violations.txt"
 LOCAL_PACKAGE_CACHE="$(mktemp -d)"
-trap 'rm -rf "$LOCAL_PACKAGE_CACHE"' EXIT
+shadow=""
+backup=""
+tmp=""
+shadow_active=false
+
+restore_shadow() {
+  local backup_dir
+
+  if [[ -n "$tmp" ]]; then
+    rm -rf "$tmp"
+    tmp=""
+  fi
+  if [[ "$shadow_active" != true ]]; then
+    return 0
+  fi
+
+  rm -rf "$shadow"
+  if [[ -n "$backup" && -e "$backup" ]]; then
+    backup_dir="$(dirname "$backup")"
+    mv "$backup" "$shadow"
+    rmdir "$backup_dir"
+  fi
+  shadow=""
+  backup=""
+  shadow_active=false
+}
+
+cleanup() {
+  restore_shadow
+  rm -rf "$LOCAL_PACKAGE_CACHE"
+}
+
+trap cleanup EXIT
 
 # Integrations grandfathered in: they violate the floor today (same class as
 # mlflow#24167) but must not fail the gate yet. New violations still fail.
@@ -100,8 +133,9 @@ pack_workspace_package() {
     if ! packed_filename="$(node -e '
       const fs = require("fs");
       const result = JSON.parse(fs.readFileSync(0, "utf8"));
-      if (typeof result[0]?.filename !== "string") process.exit(1);
-      process.stdout.write(result[0].filename);
+      const packed = Array.isArray(result) ? result : Object.values(result);
+      if (typeof packed[0]?.filename !== "string") process.exit(1);
+      process.stdout.write(packed[0].filename);
     ' <<< "$pack_json")"; then
       echo "        ERROR: failed to parse npm pack output for $dep@$version" >&2
       return 1
@@ -149,10 +183,17 @@ for pkg_json in integrations/*/package.json; do
   # so the check never leaves the working tree modified.
   shadow="$dir/node_modules"
   backup=""
+  tmp=""
+  shadow_active=false
   if [[ -e "$shadow" ]]; then
-    backup="$(mktemp -d)/node_modules"
-    mv "$shadow" "$backup"
+    backup_dir="$(mktemp -d)"
+    if ! mv "$shadow" "$backup_dir/node_modules"; then
+      rmdir "$backup_dir"
+      exit 1
+    fi
+    backup="$backup_dir/node_modules"
   fi
+  shadow_active=true
   mkdir -p "$shadow/@mlflow"
   while IFS= read -r dep; do
     [[ -z "$dep" ]] && continue
@@ -189,30 +230,22 @@ for pkg_json in integrations/*/package.json; do
     else
       status=$?
       if [[ $status -eq 2 ]]; then
-        rm -rf "$shadow"
-        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
         exit 1
       fi
 
       workspace_path="$(workspace_package_path "$dep")"
       if [[ -z "$workspace_path" ]]; then
         echo "        ERROR: $dep@$floor is unpublished and has no local workspace" >&2
-        rm -rf "$shadow"
-        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
         exit 1
       fi
       workspace_version="$(node -p "require('./$workspace_path/package.json').version")"
       if [[ "$workspace_version" != "$floor" ]]; then
         echo "        ERROR: $dep@$floor is unpublished and workspace version is $workspace_version" >&2
-        rm -rf "$shadow"
-        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
         exit 1
       fi
 
       if ! install_spec="$(pack_workspace_package "$dep" "$floor" "$workspace_path")"; then
         echo "        ERROR: failed to prepare workspace package $dep@$floor" >&2
-        rm -rf "$shadow"
-        [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
         exit 1
       fi
       echo "        SOURCE workspace package ($workspace_path)"
@@ -226,23 +259,18 @@ for pkg_json in integrations/*/package.json; do
     if ! npm install --prefix "$tmp" "$install_spec" \
       --no-save --no-package-lock --no-audit --no-fund >/dev/null; then
       echo "        ERROR: failed to install $install_spec (see npm output above)" >&2
-      rm -rf "$tmp" "$shadow"
-      [[ -n "$backup" ]] && mv "$backup" "$shadow" && rmdir "$(dirname "$backup")"
       exit 1
     fi
     rm -rf "$shadow/$dep"
     cp -R "$tmp/node_modules/$dep" "$shadow/$dep"
     rm -rf "$tmp"
+    tmp=""
   done <<< "$mlflow_deps"
 
   # At-floor errors minus baseline errors == breakage caused purely by the floor.
   floor_errors="$(errors_here || true)"
   violations="$(comm -13 <(printf '%s\n' "$baseline") <(printf '%s\n' "$floor_errors"))"
-  rm -rf "$shadow"
-  if [[ -n "$backup" ]]; then
-    mv "$backup" "$shadow"
-    rmdir "$(dirname "$backup")"
-  fi
+  restore_shadow
 
   if [[ -z "$violations" ]]; then
     if is_allowlisted "$slug"; then


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24268 and #25326

### What changes are proposed in this pull request?

Allow the TypeScript minimum-version gate to validate a coordinated release before the new `@mlflow/core` version exists on npm.

The gate still prefers published dependency floors. When a floor is not published, it now requires an exact name and version match with a local workspace, builds and packs that workspace, and type-checks the integration against the resulting tarball. An unpublished floor without an exact workspace match remains an error.

This preserves the original published-floor regression protection while allowing core and integrations to be bumped together in one release PR. Core can then be published first, followed by the integrations.

### How is this PR tested?

- [x] Manual tests

Validated these paths locally:

- Current published floors: the full check passes and reports `SOURCE npm`.
- Temporary matching bump (`@mlflow/core@0.4.0` with an integration requiring `^0.4.0`): the script builds and packs local core, reports `SOURCE workspace package`, and passes.
- Temporary mismatch (integration requires unpublished `^0.5.0` while local core is `0.4.0`): the script exits 1 and reports the version mismatch.
- `bash -n scripts/check-min-mlflow-deps.sh`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
