### PR TITLE
Add `build-docs` workflow for publishing release docs (#24857)

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,175 @@
+name: build-docs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - dev/build_docs.py
+      - .github/workflows/build-docs.yml
+      # `build_docs.py` mirrors the docs build steps, so re-verify it when they change
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to build from. Must contain dev/build_docs.py, i.e. be cut after it landed (e.g., branch-3.16). Cherry-pick it onto older release branches to publish their docs."
+        required: true
+      release_post:
+        description: "Create a release post on mlflow/mlflow-website"
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: "Skip push and PR creation"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.ref }}
+  # Cancel superseded PR runs, never a release build.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
+
+jobs:
+  # Both commands, end-to-end. `--dry-run` skips push and PR creation, so no token.
+  test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python
+      - name: Read release version
+        id: version
+        run: |
+          echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          repository: mlflow/mlflow-website
+          path: website
+      # Fetch only the ~3 of ~105 version directories a publish writes. Anything
+      # missing here is skip-worktree, and files written under it are silently
+      # dropped from the commit.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          repository: mlflow/mlflow-legacy-website
+          path: legacy-website
+          sparse-checkout: |
+            /docs/versions.json
+            /docs/latest/
+            /docs/${{ steps.version.outputs.value }}*/
+          sparse-checkout-cone-mode: false
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-node
+      - name: Configure committer
+        run: |
+          git config --global user.name 'mlflow-app[bot]'
+          git config --global user.email 'mlflow-app[bot]@users.noreply.github.com'
+      - name: Test release-post
+        run: |
+          uv run dev/build_docs.py --dry-run release-post --website-dir website
+      - name: Test build-docs
+        run: |
+          uv run dev/build_docs.py --dry-run build-docs --website-dir legacy-website
+      # The ~100 skip-worktree directories must never become staged deletions.
+      - name: Check the commit only touches this release
+        working-directory: legacy-website
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          git show --shortstat --format= HEAD
+          paths="$(git show --name-only --format= HEAD)"
+          # Here-strings, not pipes: `grep -q` exits on the first match, and the
+          # resulting EPIPE would fail the pipeline under `pipefail`.
+          unexpected="$(grep -vE "^docs/(versions\.json|latest/|${VERSION}[^/]*/)" <<< "$paths" || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Commit touches paths outside this release:"
+            echo "$unexpected"
+            exit 1
+          fi
+          if ! grep -q "^docs/${VERSION}/" <<< "$paths"; then
+            echo "::error::Commit is missing docs/${VERSION}/ - the sparse checkout excluded it"
+            exit 1
+          fi
+
+  run:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: mlflow-legacy-website,mlflow-website
+          owner: mlflow
+          permission-contents: write
+          permission-pull-requests: write
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/setup-python
+      - name: Read release version
+        id: version
+        run: |
+          echo "value=$(uv version --short)" >> "$GITHUB_OUTPUT"
+      # `true` is required for the script to push.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          repository: mlflow/mlflow-website
+          path: website
+      # See the `test` job for why the sparse set must cover every path written.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+          repository: mlflow/mlflow-legacy-website
+          path: legacy-website
+          sparse-checkout: |
+            /docs/versions.json
+            /docs/latest/
+            /docs/${{ steps.version.outputs.value }}*/
+          sparse-checkout-cone-mode: false
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-node
+      - name: Configure committer
+        run: |
+          git config --global user.name 'mlflow-app[bot]'
+          git config --global user.email 'mlflow-app[bot]@users.noreply.github.com'
+      # First because it's cheap, and shouldn't be lost to a docs build failure.
+      - name: Create release post
+        if: inputs.release_post
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          uv run dev/build_docs.py $DRY_RUN_FLAG release-post --website-dir website
+      - name: Build docs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          uv run dev/build_docs.py $DRY_RUN_FLAG build-docs \
+            --gtm-id GTM-N6WMTTJ \
+            --website-dir legacy-website

--- a/dev/build_docs.py
+++ b/dev/build_docs.py
@@ -1,0 +1,281 @@
+"""Build MLflow release documentation and publish to mlflow-legacy-website."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+# Local git operations finish in seconds, even staging a full docs build. Pushing
+# one is the outlier, since it uploads thousands of files.
+_GIT_TIMEOUT = 5 * 60
+_GIT_PUSH_TIMEOUT = 30 * 60
+
+
+class Repo:
+    """A website repository checkout that this script commits and pushes to.
+
+    The caller provides the checkout, its credentials and the committer identity;
+    `gh` picks up `$GH_TOKEN` from the environment.
+    """
+
+    def __init__(self, repo: str, root: Path, *, default_branch: str = "main"):
+        self.repo = repo
+        self.root = root
+        self.default_branch = default_branch
+
+    def git(self, *args: str, timeout: int = _GIT_TIMEOUT) -> None:
+        subprocess.check_call(["git", *args], cwd=self.root, timeout=timeout)
+
+    def has_changes(self) -> bool:
+        result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=self.root)
+        return result.returncode != 0
+
+    def create_pr(self, *, head: str, title: str, body: str) -> str:
+        output = subprocess.check_output(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                self.repo,
+                "--head",
+                head,
+                "--base",
+                self.default_branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            text=True,
+        )
+        return output.strip()
+
+
+def _read_version(repo_root: Path) -> str:
+    output = subprocess.check_output(["uv", "version", "--short"], cwd=repo_root, text=True)
+    return output.strip()
+
+
+def build_docs(args: argparse.Namespace) -> None:
+    mlflow_dir = Path(args.mlflow_dir).resolve()
+    release_version = _read_version(mlflow_dir)
+    print(f"Building docs for MLflow {release_version}")
+
+    subprocess.check_call(["uv", "sync", "--group", "docs", "--extra", "gateway"], cwd=mlflow_dir)
+    subprocess.check_call(["uv", "pip", "install", "-r", "requirements/torch.txt"], cwd=mlflow_dir)
+    docs_dir = mlflow_dir / "docs"
+    env = {**os.environ, "GTM_ID": args.gtm_id}
+    subprocess.check_call(["npm", "ci"], cwd=docs_dir, env=env)
+    subprocess.check_call(["npm", "run", "build-all", "--", "--use-npm"], cwd=docs_dir, env=env)
+
+    website_repo = Repo("mlflow/mlflow-legacy-website", Path(args.website_dir).resolve())
+    branch_name = f"docs-{release_version}-{uuid.uuid4().hex[:8]}"
+    website_repo.git("checkout", "-q", "-b", branch_name)
+
+    version = Version(release_version)
+
+    _remove_stale_prereleases(website_repo.root / "docs", version)
+
+    # Copy built docs. `build-all.py` produces a separate build per target
+    # (e.g. `build/3.11.1` and `build/latest`), each with its own baseUrl,
+    # so we must copy from the matching directory rather than reusing one source.
+    for dest_name in _version_targets(version, website_repo.root):
+        src = docs_dir / "build" / dest_name
+        dst = website_repo.root / "docs" / dest_name
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+    # Update versions.json
+    _update_versions_json(website_repo.root / "docs" / "versions.json", version)
+
+    website_repo.git("add", "-A")
+
+    if not website_repo.has_changes():
+        print("No changes to commit, skipping.")
+        return
+
+    # `-q`: a docs publish creates ~6k files, and git lists every one of them
+    website_repo.git("commit", "-q", "-m", "Add docs")
+
+    if args.dry_run:
+        return
+
+    website_repo.git("push", "origin", branch_name, timeout=_GIT_PUSH_TIMEOUT)
+    pr_url = website_repo.create_pr(
+        head=branch_name,
+        title=f"Add documentation for {release_version}",
+        body="",
+    )
+    print(f"Created {pr_url}")
+
+
+def _remove_stale_prereleases(docs_root: Path, version: Version) -> None:
+    """Drop release candidate docs for `version` once the final release is published."""
+    if version.is_prerelease:
+        return
+
+    for p in docs_root.iterdir():
+        if not p.is_dir():
+            continue
+        try:
+            v = Version(p.name)
+        except InvalidVersion:
+            continue
+        if v.is_prerelease and v.base_version == version.base_version:
+            shutil.rmtree(p)
+
+
+def _version_targets(version: Version, website_root: Path) -> list[str]:
+    json_path = website_root / "docs" / "versions.json"
+    versions_json = json.loads(json_path.read_text())
+    latest_version = max(map(Version, versions_json["versions"]))
+    targets = [str(version)]
+    if version >= latest_version:
+        targets.append("latest")
+    return targets
+
+
+def _update_versions_json(json_path: Path, release_version: Version) -> None:
+    data = json.loads(json_path.read_text())
+    versions = [Version(v) for v in data["versions"]]
+    if release_version not in versions:
+        versions.append(release_version)
+
+    # Keep only the highest version for each minor release
+    latest_by_minor: dict[tuple[int, int], Version] = {}
+    for v in versions:
+        key = (v.major, v.minor)
+        if key not in latest_by_minor or v > latest_by_minor[key]:
+            latest_by_minor[key] = v
+
+    data["versions"] = [str(v) for v in sorted(latest_by_minor.values(), reverse=True)]
+    json_path.write_text(json.dumps(data, indent=2))
+
+
+def release_post(args: argparse.Namespace) -> None:
+    mlflow_dir = Path(args.mlflow_dir).resolve()
+    release_version = _read_version(mlflow_dir)
+    print(f"Creating release post for MLflow {release_version}")
+
+    website_repo = Repo("mlflow/mlflow-website", Path(args.website_dir).resolve())
+    branch_name = f"release-post-{release_version}-{uuid.uuid4().hex[:8]}"
+    website_repo.git("checkout", "-q", "-b", branch_name)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    name = f"{today}-{release_version}-release.md"
+    post_path = website_repo.root / "website" / "releases" / name
+    post_path.write_text(_render_release_post(Version(release_version)))
+
+    website_repo.git("add", "-A")
+
+    if not website_repo.has_changes():
+        print("No changes to commit, skipping.")
+        return
+
+    website_repo.git("commit", "-q", "-m", "Add release post")
+
+    if args.dry_run:
+        return
+
+    website_repo.git("push", "origin", branch_name, timeout=_GIT_PUSH_TIMEOUT)
+    pr_url = website_repo.create_pr(
+        head=branch_name,
+        title=f"Add release post for {release_version}",
+        body="Be sure to fill in the contents",
+    )
+    print(f"Created {pr_url}")
+
+
+def _render_release_post(version: Version) -> str:
+    if version.is_prerelease:
+        return _RC_TEMPLATE.format(version=version, base_version=version.base_version)
+    return _RELEASE_TEMPLATE.format(version=version)
+
+
+_RELEASE_TEMPLATE = """\
+---
+title: MLflow {version}
+slug: {version}
+authors: [mlflow-maintainers]
+---
+
+<REPLACE_ME>
+
+For a comprehensive list of changes, see the
+[release change log](https://github.com/mlflow/mlflow/releases/tag/v{version}),
+and check out the latest documentation on [mlflow.org](http://mlflow.org/).
+"""
+
+_RC_TEMPLATE = """\
+---
+title: MLflow {version}
+slug: {version}
+authors: [mlflow-maintainers]
+---
+
+MLflow {version} is a release candidate for {base_version}. To install, run the following command:
+
+```sh
+pip install mlflow=={version}
+```
+
+<!-- Major changes that need to be highlighted in the release post go here -->
+<REPLACE_ME>
+
+Please try it out and report any issues on [the issue tracker](https://github.com/mlflow/mlflow/issues).
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="MLflow release documentation tools")
+    parser.add_argument(
+        "--mlflow-dir",
+        default=".",
+        help="Path to the local MLflow repository checkout",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip push and PR creation",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    docs_parser = subparsers.add_parser("build-docs", help="Build and publish MLflow documentation")
+    docs_parser.add_argument("--gtm-id", default="GTM-TEST", help="Google Tag Manager ID")
+    docs_parser.add_argument(
+        "--website-dir",
+        required=True,
+        help="Path to a mlflow/mlflow-legacy-website checkout to publish into",
+    )
+    post_parser = subparsers.add_parser("release-post", help="Create a release post")
+    post_parser.add_argument(
+        "--website-dir",
+        required=True,
+        help="Path to a mlflow/mlflow-website checkout to publish into",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    match args.command:
+        case "build-docs":
+            build_docs(args)
+        case "release-post":
+            release_post(args)
+        case _:
+            raise ValueError(f"Unexpected command: {args.command!r}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Related Issues/PRs

Backport of #24857 to `branch-3.15`.

### What changes are proposed in this pull request?

Cherry-pick of #24857 (`29ad469243dde0a3450c5410e60e05a32dcf4bff`) onto the 3.15 release branch. The cherry-pick applied cleanly.

This adds the `build-docs` workflow and `dev/build_docs.py` so release documentation for `branch-3.15` can be built and published through a workflow dispatch.

### How is this PR tested?

- [x] Manual tests

`uv run --frozen ruff check dev/build_docs.py` and `uv run --frozen python -m py_compile dev/build_docs.py` pass on this branch. The source PR also exercised both commands in dry-run mode in CI.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
