### PR TITLE
fix: Use Python 3.6 compatible type annotations in telemetry schemas (closes #5474)

### DIFF
--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -15,12 +15,14 @@ class Status(str, Enum):
 
 
 @dataclass
+from typing import Any, Dict, Optional
+
 class Record:
     event_name: str
     timestamp_ns: int
-    params: dict[str, Any] | None = None
+    params: Optional[Dict[str, Any]] = None
     status: Status = Status.UNKNOWN
-    duration_ms: int | None = None
+    duration_ms: Optional[int] = None
     # installation and session ID usually comes from the telemetry client,
     # but callers can override with these fields (e.g. in UI telemetry records)
     installation_id: str | None = None


### PR DESCRIPTION
## What
Using modern type annotations such as `dict[str, Any]` and `int | None` in `mlflow/telemetry/schemas.py` breaks Python 3.6 compatibility, which is required by the MLflow version and the issue's environment (Python 3.6.10). When the dataclass is defined, those annotations cause `TypeError: 'type' object is not subscriptable`.

## Fix
Replace PEP 585/604 syntax with `typing.Dict` and `typing.Optional` equivalents, which work on Python 3.6 and later.

Closes #5474