### PR TITLE
fix: Use full Base.metadata for table creation during DB init (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    Base.metadata.create_all(engine)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, `mlflow db upgrade` fails with an error like `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This occurs because `_initialize_tables()` uses `InitialBase.metadata` which only contains tables defined in `initial_models.py`. Tables added in newer versions (e.g., `secrets`) are not included in `InitialBase`, so they are not created before Alembic migrations run. The migration then attempts to create them again, causing a conflict.

## Fix
Change `_initialize_tables()` to use `Base.metadata` (the full MLflow ORM model set) instead of `InitialBase.metadata`. `create_all()` is idempotent (checks for existing tables), so this safely creates all current tables, including the new `secrets` table, before Alembic migrations run. This prevents the migration from trying to create tables that already exist. The `InitialBase` import is no longer needed and is removed.

Closes #19943