### PR TITLE
Let the `pr-review` skill escalate to expensive verification

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -83,14 +83,13 @@ errors, so don't trust them for pre-change history.
 
 Verify rather than infer. A `grep` through the installed package, a `uv run python -c '...'`, or a
 quick search and fetch of the upstream docs will settle most questions in seconds, and an unverified
-finding should be dropped rather than hedged.
+finding should be dropped rather than hedged. When the cheap checks don't settle it, escalate to the
+expensive ones: build the docs site, build and boot the UI, start the backend, run the affected
+tests.
 
-Node and `agent-browser` are on PATH for docs and UI changes. Render when it settles whether the
-change is correct, or when a capture shows a finding more plainly than prose can. Building the
-docs site or the UI is expensive; do it only when the finding justifies it. Capture to an
-absolute path named for what it shows:
-`agent-browser screenshot --full $media_dir/traces-table.png`, and cite that same path
-in a finding.
+Node and `agent-browser` are on PATH for docs and UI changes. Capture to an absolute path named for
+what it shows: `agent-browser screenshot --full $media_dir/traces-table.png`, and cite that same
+path in a finding.
 
 Evaluate the changed code across these dimensions:
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -88,7 +88,7 @@ expensive ones: build the docs site, build and boot the UI, start the backend, r
 tests.
 
 Node and `agent-browser` are on PATH for docs and UI changes. Capture to an absolute path named for
-what it shows: `agent-browser screenshot --full $media_dir/traces-table.png`, and cite that same
+what it shows: `agent-browser screenshot --full $media_dir/example.png`, and cite that same
 path in a finding.
 
 Evaluate the changed code across these dimensions:


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25325

### What changes are proposed in this pull request?

The `pr-review` skill told the reviewer that building the docs site or the UI is expensive and to do it only when the finding justifies it. That biased it toward filing findings it had only read rather than run.

- Extend the "verify rather than infer" paragraph so the reviewer escalates past cheap `grep`/one-liner checks to building the docs, building and booting the UI, starting the backend, and running the affected tests.
- Cut the `agent-browser` note down to capture mechanics. Its "render when it settles correctness" half is now covered by the escalation clause, and its "when a capture beats prose" half already appears in the payload-authoring rules in step 4.

### How is this PR tested?

- [x] Manual tests

Prose-only change to a skill prompt; verified by reading the rendered section.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release