### PR TITLE
Mask the proxy client key in `review.yml` logs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -200,6 +200,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
         run: |
           CLIENT_KEY=$(openssl rand -hex 32)
+          echo "::add-mask::$CLIENT_KEY"
           echo "client-key=$CLIENT_KEY" >> "$GITHUB_OUTPUT"
           printf '%s\n%s' "$ANTHROPIC_API_KEY" "$CLIENT_KEY" \
             | env -u ANTHROPIC_API_KEY node --disable-sigusr1 .claude/scripts/anthropic-proxy.mjs \


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25334

### What changes are proposed in this pull request?

Register the per-run Anthropic proxy client key with `::add-mask::` so the runner redacts it from the job log.

The key was being printed in plaintext: GitHub echoes a step's `env:` block inside the `##[group] Run` header, and the `Review` step takes `ANTHROPIC_API_KEY: ${{ steps.proxy.outputs.client-key }}`. Every review run therefore leaked it into a public log. Severity is low, since the key only authenticates to `127.0.0.1:8082` on an ephemeral runner that nothing external can reach, but a credential in a public log is worth closing.

The other credentials here were already covered: `create-github-app-token` calls `core.setSecret` on both app tokens, and `EXPERIMENTAL_ANTHROPIC_API_KEY` is masked as a repo secret. The client key was the only one without a mask, despite the transcript redaction step already treating it as one of the three secrets worth scrubbing. This does not replace that step, which scrubs the uploaded transcript the runner never sees.

### How is this PR tested?

- [x] Manual tests

Filed from an upstream branch so the `pull_request` smoke run executes the modified workflow. It passed, and the same log line differs across the two runs:

```
# before (run 32842858514, master's review.yml)
review  Review  ANTHROPIC_API_KEY: 8767316fde9cdb842264b4ff61cee351bf2efe8a4ac8c8214c2e7c909769e18a

# after (run 32843376654, this PR)
review  Review  ANTHROPIC_API_KEY: ***
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
