### PR TITLE
feat: maintain SQL trace analytics daily rollups

### DIFF
--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -137,7 +137,7 @@ Enabling this variable does not populate the rollup tables by itself; a separate
 :::note[Backend-specific behavior]
 
 - **Percentiles** (p50/p90/p99) are served from rollups for trace metrics such as latency and token usage, and only on PostgreSQL. On other backends, and for assessment percentiles, percentile aggregations fall back to the raw path.
-- **Grouping** is limited to whole-experiment daily aggregates. Requests that group by a dimension, such as a per-status breakdown, use the raw path.
+- **Grouping** supports whole-experiment daily aggregates and trace-count breakdowns by trace status. Other dimension groupings use the raw path.
 - **Span cost** metrics are intentionally excluded from rollups and always use the raw path, because their day bucketing cannot be made row-identical to the raw query. All other ungrouped trace-metric and assessment aggregations are eligible.
 
 :::

--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -113,7 +113,7 @@ Trace analytics queries (used by the traces dashboards) aggregate metrics such a
 
 Rollups are an **opt-in read acceleration**. They never change query results: any day that is not yet rolled up, and any partial day at the edges of a requested range, is served from the raw path, so enabling rollups only changes query speed. This feature requires a database backend (it is not available for the file store).
 
-To let the query planner serve eligible whole days from the rollup tables, set the following environment variable on the tracking server:
+Configure rollup reads and maintenance with the following environment variables on the tracking server:
 
 <Table>
   <thead>
@@ -126,13 +126,31 @@ To let the query planner serve eligible whole days from the rollup tables, set t
   <tbody>
     <tr>
       <td>`MLFLOW_SQL_TRACE_ROLLUPS_ENABLED`</td>
-      <td>When `true`, trace analytics queries serve eligible whole days from precomputed rollup tables and fall back to the raw path for any day that is not covered. When `false`, all queries use the raw path.</td>
+      <td>When `true`, the server maintains daily rollups and trace analytics queries serve eligible whole days from them. When `false`, maintenance is a no-op and all queries use the raw path.</td>
       <td>`false`</td>
+    </tr>
+    <tr>
+      <td>`MLFLOW_TRACE_ROLLUPS_SCHEDULE`</td>
+      <td>Five-field UTC cron expression for the server-owned maintenance task.</td>
+      <td>`0 2 * * *`</td>
+    </tr>
+    <tr>
+      <td>`MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN`</td>
+      <td>Optional maximum number of daily partitions built or rebuilt by one maintenance run.</td>
+      <td>Unset (no limit)</td>
     </tr>
   </tbody>
 </Table>
 
-Enabling this variable does not populate the rollup tables by itself; a separate maintenance job builds and refreshes them. Until a day has been rolled up, queries for that day transparently use the raw path, so the feature is safe to turn on before any rollups exist.
+When job execution is available, MLflow registers the scheduled maintenance task automatically. The task builds only complete UTC-day partitions whose contributing traces have been complete or inactive for at least 24 hours. Writes that can make an existing partition stale add it to a durable rebuild queue; the next maintenance run atomically replaces that partition and removes its queue entry.
+
+Deployments that use an external scheduler, such as a Kubernetes `CronJob`, can invoke the same maintenance path without starting the MLflow scheduler:
+
+```bash
+mlflow db build-trace-rollups "$MLFLOW_TRACKING_URI"
+```
+
+The command and the server-owned task both no-op when `MLFLOW_SQL_TRACE_ROLLUPS_ENABLED` is `false`. Until a day has valid rollup coverage, queries for that day transparently use the raw path.
 
 :::note[Backend-specific behavior]
 

--- a/docs/docs/self-hosting/architecture/backend-store.mdx
+++ b/docs/docs/self-hosting/architecture/backend-store.mdx
@@ -107,6 +107,41 @@ You can inject some [SQLAlchemy connection pooling options](https://docs.sqlalch
   </tbody>
 </Table>
 
+## Trace Analytics Daily Rollups
+
+Trace analytics queries (used by the traces dashboards) aggregate metrics such as trace counts, latency, token usage, and assessment values over a time range. On large trace tables these queries scan a lot of rows. MLflow can serve the whole-day portions of such queries from precomputed daily rollup tables, which is much faster than scanning raw traces and spans.
+
+Rollups are an **opt-in read acceleration**. They never change query results: any day that is not yet rolled up, and any partial day at the edges of a requested range, is served from the raw path, so enabling rollups only changes query speed. This feature requires a database backend (it is not available for the file store).
+
+To let the query planner serve eligible whole days from the rollup tables, set the following environment variable on the tracking server:
+
+<Table>
+  <thead>
+    <tr>
+      <th>MLflow Environment Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`MLFLOW_SQL_TRACE_ROLLUPS_ENABLED`</td>
+      <td>When `true`, trace analytics queries serve eligible whole days from precomputed rollup tables and fall back to the raw path for any day that is not covered. When `false`, all queries use the raw path.</td>
+      <td>`false`</td>
+    </tr>
+  </tbody>
+</Table>
+
+Enabling this variable does not populate the rollup tables by itself; a separate maintenance job builds and refreshes them. Until a day has been rolled up, queries for that day transparently use the raw path, so the feature is safe to turn on before any rollups exist.
+
+:::note[Backend-specific behavior]
+
+- **Percentiles** (p50/p90/p99) are served from rollups for trace metrics such as latency and token usage, and only on PostgreSQL. On other backends, and for assessment percentiles, percentile aggregations fall back to the raw path.
+- **Grouping** is limited to whole-experiment daily aggregates. Requests that group by a dimension, such as a per-status breakdown, use the raw path.
+- **Span cost** metrics are intentionally excluded from rollups and always use the raw path, because their day bucketing cannot be made row-identical to the raw query. All other ungrouped trace-metric and assessment aggregations are eligible.
+
+:::
+
 ## MySQL SSL Options
 
 When connecting to a MySQL database that requires SSL certificates, you can set the following environment variables:

--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -103,6 +103,79 @@ def prepopulate_trace_analytics(url, batch_size):
             engine.dispose()
 
 
+@commands.command("build-trace-rollups")
+@click.argument("url", envvar="MLFLOW_TRACKING_URI")
+@click.option(
+    "--max-partitions",
+    type=click.IntRange(min=1),
+    default=None,
+    help=(
+        "Maximum number of daily partitions to rebuild in this run. Deferred partitions do not "
+        "count against this cap. Defaults to MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN, or "
+        "unlimited when unset."
+    ),
+)
+def build_trace_rollups(url, max_partitions):
+    """Build SQL daily trace analytics rollups and drain the rebuild queue.
+
+    URL may instead be supplied through MLFLOW_TRACKING_URI. This entrypoint is safe for external
+    schedulers such as a Kubernetes CronJob and delegates to the same maintenance function as the
+    server-owned scheduler.
+    """
+    import sqlalchemy.exc
+
+    import mlflow.store.db.utils
+    from mlflow.environment_variables import (
+        MLFLOW_SQL_TRACE_ROLLUPS_ENABLED,
+        MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN,
+    )
+    from mlflow.store.db.trace_rollups import run_sql_trace_rollups
+
+    if not MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.get():
+        click.echo("SQL trace rollups are disabled; no maintenance performed.")
+        return
+
+    max_partitions_per_run = (
+        max_partitions
+        if max_partitions is not None
+        else MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN.get()
+    )
+
+    engine = None
+    try:
+        engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
+        click.echo("Building SQL daily trace analytics rollups...")
+
+        def report_progress(family, family_stats):
+            click.echo(
+                f"{family} progress: built={family_stats.built}, "
+                f"emptied={family_stats.emptied}, deferred={family_stats.deferred}"
+            )
+
+        stats = run_sql_trace_rollups(
+            engine,
+            max_partitions_per_run=max_partitions_per_run,
+            progress_callback=report_progress,
+        )
+        for family, family_stats in (
+            ("trace_metric", stats.trace_metric),
+            ("assessment", stats.assessment),
+        ):
+            click.echo(
+                f"{family}: built={family_stats.built}, emptied={family_stats.emptied}, "
+                f"deferred={family_stats.deferred}, skipped_cap={family_stats.skipped_cap}"
+            )
+        click.echo("Rollup build completed.")
+    except (RuntimeError, ValueError) as e:
+        raise click.ClickException(str(e)) from e
+    except sqlalchemy.exc.SQLAlchemyError as e:
+        # Driver messages can contain the supplied DSN, including credentials.
+        raise click.ClickException(f"Database operation failed ({type(e).__name__}).") from e
+    finally:
+        if engine is not None:
+            engine.dispose()
+
+
 @commands.command("migrate-to-default-workspace")
 @click.argument("url")
 @click.option(

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1549,6 +1549,15 @@ MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY = _EnvironmentVariable(
 #: (default: ``None``)
 MLFLOW_TRACE_ARCHIVAL_CONFIG = _EnvironmentVariable("MLFLOW_TRACE_ARCHIVAL_CONFIG", str, None)
 
+#: Enables opt-in SQL daily rollups for trace analytics. When ``true``, the query planner serves
+#: eligible daily aggregate requests from precomputed rollup tables, falling back to the raw path
+#: for any day that is not covered. When ``false`` (the default), all trace analytics queries use
+#: the raw path.
+#: (default: ``False``)
+MLFLOW_SQL_TRACE_ROLLUPS_ENABLED = _BooleanEnvironmentVariable(
+    "MLFLOW_SQL_TRACE_ROLLUPS_ENABLED", False
+)
+
 #: Specifies the maximum number of workers for async judge invocation jobs.
 #: (default: ``10``)
 MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS = _EnvironmentVariable(

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1558,6 +1558,19 @@ MLFLOW_SQL_TRACE_ROLLUPS_ENABLED = _BooleanEnvironmentVariable(
     "MLFLOW_SQL_TRACE_ROLLUPS_ENABLED", False
 )
 
+#: Five-field UTC cron expression for the server-owned SQL trace rollup scheduler.
+#: (default: ``"0 2 * * *"``)
+MLFLOW_TRACE_ROLLUPS_SCHEDULE = _EnvironmentVariable(
+    "MLFLOW_TRACE_ROLLUPS_SCHEDULE", str, "0 2 * * *"
+)
+
+#: Caps the number of ``(experiment_id, rollup_day)`` partitions rebuilt in one maintenance pass.
+#: Unset (``None``) means no cap.
+#: (default: ``None``)
+MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN = _EnvironmentVariable(
+    "MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN", int, None
+)
+
 #: Specifies the maximum number of workers for async judge invocation jobs.
 #: (default: ``10``)
 MLFLOW_SERVER_JUDGE_INVOKE_MAX_WORKERS = _EnvironmentVariable(

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -809,3 +809,43 @@ def register_periodic_tasks(huey_instance) -> None:
         "Registered trace_archival_scheduler periodic task (polls every 1 minute and "
         "no-ops when trace archival is disabled or unconfigured)"
     )
+
+    from mlflow.tracing.trace_rollup_service import (
+        get_sql_trace_rollup_schedule,
+        run_sql_trace_rollup_scheduler,
+    )
+
+    try:
+        rollup_schedule = get_sql_trace_rollup_schedule()
+        rollup_crontab = crontab(
+            minute=rollup_schedule.minute,
+            hour=rollup_schedule.hour,
+            day=rollup_schedule.day,
+            month=rollup_schedule.month,
+            day_of_week=rollup_schedule.day_of_week,
+        )
+    except (MlflowException, ValueError):
+        _logger.warning(
+            "SQL trace rollup scheduler was not registered because "
+            "MLFLOW_TRACE_ROLLUPS_SCHEDULE is invalid.",
+            exc_info=True,
+        )
+        return
+
+    @huey_instance.periodic_task(rollup_crontab)
+    @huey_instance.lock_task("sql-trace-rollup-scheduler-lock")
+    def sql_trace_rollup_scheduler():
+        """Run SQL trace rollup maintenance on the configured UTC cron schedule."""
+        try:
+            run_sql_trace_rollup_scheduler()
+        except Exception as e:
+            _logger.exception(f"SQL trace rollup scheduler failed: {e!r}")
+
+    _logger.info(
+        "Registered sql_trace_rollup_scheduler periodic task (UTC cron: %s %s %s %s %s)",
+        rollup_schedule.minute,
+        rollup_schedule.hour,
+        rollup_schedule.day,
+        rollup_schedule.month,
+        rollup_schedule.day_of_week,
+    )

--- a/mlflow/store/db/trace_rollups.py
+++ b/mlflow/store/db/trace_rollups.py
@@ -206,7 +206,15 @@ def _assessment_days_with_data(session: Session) -> set[tuple[int, int]]:
     rows = (
         session
         .query(SqlAssessments.experiment_id, day_bucket.label("day_bucket"))
-        .filter(SqlAssessments.valid == true())
+        .filter(
+            SqlAssessments.valid == true(),
+            # The denormalized columns are nullable (online prepopulation adds them before
+            # backfill, and orphaned assessments never get backfilled). Such rows are excluded from
+            # every other assessment path (aggregate + has_rows filter on experiment_id/range), so
+            # skip them here too rather than let ``int(None)`` abort the whole run.
+            SqlAssessments.experiment_id.isnot(None),
+            SqlAssessments.trace_timestamp_ms.isnot(None),
+        )
         .group_by(SqlAssessments.experiment_id, day_bucket)
     )
     return {(int(exp), int(bucket)) for exp, bucket in rows}

--- a/mlflow/store/db/trace_rollups.py
+++ b/mlflow/store/db/trace_rollups.py
@@ -1,0 +1,587 @@
+"""Build job for opt-in SQL daily trace analytics rollups.
+
+This module populates the daily rollup tables from raw trace and assessment rows. It runs on a
+fully migrated database (the rollup tables already exist) and is meant to be invoked from a single
+worker on a schedule; application replicas never call it, they only read rollups and enqueue rebuild
+entries. See :mod:`mlflow.store.tracking.utils.sql_trace_rollups` for the read-side planning layer
+and the reasons span-cost rollups are neither built nor served yet.
+
+Each partition ``(experiment_id, rollup_day, family)`` is rebuilt in its own transaction that first
+takes a ``SELECT FOR UPDATE`` lock on the partition's rebuild-queue entry, then atomically replaces
+the rollup rows and deletes the entry. A writer that races with a rebuild locks the same entry in
+the transaction that changes the source rows, so it either waits and re-enqueues after publication
+or blocks the rebuild until it commits; a stale rollup is never left marked valid.
+"""
+
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Callable, Literal
+
+import sqlalchemy as sa
+from sqlalchemy import case, func, true
+from sqlalchemy.orm import Session, sessionmaker
+
+from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
+    SqlAssessments,
+    SqlSpan,
+    SqlTraceInfo,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
+)
+from mlflow.store.tracking.utils.sql_trace_rollups import (
+    FAMILY_MODEL,
+    MS_PER_DAY,
+    PERCENTILE_BACKENDS,
+    GroupingSet,
+    RollupFamily,
+    ensure_locked_rebuild_entry,
+)
+from mlflow.tracing.constant import AssessmentMetricKey, TraceMetricKey
+
+# A trace is eligible for rollup only once it has been inactive for this long; see the 24-hour rule
+# in RFC 0006. The rule controls eligibility, not correctness: late writes re-enqueue a rebuild and
+# readers fall back to raw for any queued or unbuilt day.
+ROLLUP_ELIGIBILITY_LAG_MS = 24 * 60 * 60 * 1000
+
+# Larger than any real settle time (epoch ms), used to force a trace with an open span to exceed the
+# inactivity cutoff so its day is never considered eligible while a span is still running.
+_ACTIVE_SENTINEL_MS = 1 << 62
+
+# Exact daily percentiles materialized for trace metrics on supported backends.
+_PERCENTILES: tuple[int, int, int] = (50, 90, 99)
+_PERCENTILE_COLUMNS = {50: "p50_value", 90: "p90_value", 99: "p99_value"}
+
+_BUILT_FAMILIES: tuple[RollupFamily, RollupFamily] = (
+    RollupFamily.TRACE_METRIC,
+    RollupFamily.ASSESSMENT,
+)
+
+DEFAULT_PROGRESS_EVERY_PARTITIONS = 100
+
+
+@dataclass(frozen=True)
+class _MetricSpec:
+    """One rollup metric and how to aggregate it.
+
+    Args:
+        metric_name: The metric name stored in ``metric_name`` and read back by the reader.
+        column: The source column. For ``count_only`` metrics it is the (non-null) column counted
+            into ``sample_count``; otherwise it is the value column summed and reduced.
+        count_only: ``True`` for pure count metrics (``trace_count``, ``assessment_count``) that
+            store only ``sample_count``.
+        percentile: ``True`` when the metric materializes daily percentiles (trace metrics only, and
+            only on backends in :data:`PERCENTILE_BACKENDS`).
+    """
+
+    metric_name: str
+    column: sa.Column
+    count_only: bool
+    percentile: bool
+
+
+_TRACE_METRIC_SPECS: tuple[_MetricSpec, ...] = (
+    _MetricSpec(
+        TraceMetricKey.TRACE_COUNT, SqlTraceInfo.request_id, count_only=True, percentile=False
+    ),
+    _MetricSpec(
+        TraceMetricKey.LATENCY, SqlTraceInfo.execution_time_ms, count_only=False, percentile=True
+    ),
+    _MetricSpec(
+        TraceMetricKey.INPUT_TOKENS, SqlTraceInfo.input_tokens, count_only=False, percentile=True
+    ),
+    _MetricSpec(
+        TraceMetricKey.OUTPUT_TOKENS, SqlTraceInfo.output_tokens, count_only=False, percentile=True
+    ),
+    _MetricSpec(
+        TraceMetricKey.TOTAL_TOKENS, SqlTraceInfo.total_tokens, count_only=False, percentile=True
+    ),
+    _MetricSpec(
+        TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        SqlTraceInfo.cache_read_input_tokens,
+        count_only=False,
+        percentile=True,
+    ),
+    _MetricSpec(
+        TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+        SqlTraceInfo.cache_creation_input_tokens,
+        count_only=False,
+        percentile=True,
+    ),
+)
+
+_ASSESSMENT_METRIC_SPECS: tuple[_MetricSpec, ...] = (
+    _MetricSpec(
+        AssessmentMetricKey.ASSESSMENT_COUNT,
+        SqlAssessments.assessment_id,
+        count_only=True,
+        percentile=False,
+    ),
+    _MetricSpec(
+        AssessmentMetricKey.ASSESSMENT_VALUE,
+        SqlAssessments.aggregate_value,
+        count_only=False,
+        percentile=False,
+    ),
+)
+
+_PartitionOutcome = Literal["built", "emptied", "deferred"]
+
+
+@dataclass
+class RollupFamilyBuildStats:
+    built: int = 0
+    emptied: int = 0
+    deferred: int = 0
+    skipped_cap: int = 0
+
+
+@dataclass(frozen=True)
+class RollupBuildStats:
+    trace_metric: RollupFamilyBuildStats
+    assessment: RollupFamilyBuildStats
+
+
+ProgressCallback = Callable[[str, RollupFamilyBuildStats], None]
+
+
+def _bucket_to_date(day_bucket: int) -> date:
+    return datetime.fromtimestamp(day_bucket * MS_PER_DAY / 1000, tz=timezone.utc).date()
+
+
+def _date_to_bucket(rollup_day: date) -> int:
+    dt = datetime(rollup_day.year, rollup_day.month, rollup_day.day, tzinfo=timezone.utc)
+    return int(dt.timestamp()) // (MS_PER_DAY // 1000)
+
+
+def _day_bucket_expr(timestamp_column: sa.Column):
+    return func.floor(timestamp_column / MS_PER_DAY)
+
+
+def _span_settle_subquery(session: Session):
+    """Per-trace span settle state: latest span end (ms) and whether any span is still open."""
+    return (
+        session
+        .query(
+            SqlSpan.trace_id.label("trace_id"),
+            func.max(SqlSpan.end_time_unix_nano).label("max_end_nano"),
+            func.max(case((SqlSpan.end_time_unix_nano.is_(None), 1), else_=0)).label("has_open"),
+        )
+        .group_by(SqlSpan.trace_id)
+        .subquery()
+    )
+
+
+def _trace_settle_expr(span_stat) -> sa.ColumnElement:
+    # A trace settles at its latest span end; a trace without spans settles at its own timestamp; a
+    # trace with any open span is treated as active (sentinel) so its day cannot become eligible.
+    return case(
+        (span_stat.c.trace_id.is_(None), SqlTraceInfo.timestamp_ms),
+        (span_stat.c.has_open == 1, _ACTIVE_SENTINEL_MS),
+        else_=span_stat.c.max_end_nano / 1_000_000.0,
+    )
+
+
+def _eligible_trace_days(
+    session: Session, cutoff_ms: int, current_day_bucket: int
+) -> set[tuple[int, int]]:
+    """Return ``(experiment_id, day_bucket)`` trace partitions whose every trace is inactive."""
+    span_stat = _span_settle_subquery(session)
+    settle = _trace_settle_expr(span_stat)
+    day_bucket = _day_bucket_expr(SqlTraceInfo.timestamp_ms)
+    rows = (
+        session
+        .query(SqlTraceInfo.experiment_id, day_bucket.label("day_bucket"))
+        .outerjoin(span_stat, span_stat.c.trace_id == SqlTraceInfo.request_id)
+        .filter(day_bucket < current_day_bucket)
+        .group_by(SqlTraceInfo.experiment_id, day_bucket)
+        .having(func.max(settle) <= cutoff_ms)
+    )
+    return {(int(exp), int(bucket)) for exp, bucket in rows}
+
+
+def _assessment_days_with_data(session: Session) -> set[tuple[int, int]]:
+    day_bucket = _day_bucket_expr(SqlAssessments.trace_timestamp_ms)
+    rows = (
+        session
+        .query(SqlAssessments.experiment_id, day_bucket.label("day_bucket"))
+        .filter(SqlAssessments.valid == true())
+        .group_by(SqlAssessments.experiment_id, day_bucket)
+    )
+    return {(int(exp), int(bucket)) for exp, bucket in rows}
+
+
+def _built_partitions(session: Session, family: RollupFamily) -> set[tuple[int, int]]:
+    model = FAMILY_MODEL[family]
+    rows = session.query(model.experiment_id, model.rollup_day).distinct()
+    return {(int(exp), _date_to_bucket(rollup_day)) for exp, rollup_day in rows}
+
+
+def _queued_partitions(session: Session, family: RollupFamily) -> list[tuple[int, int]]:
+    rows = (
+        session
+        .query(SqlTraceRollupRebuild.experiment_id, SqlTraceRollupRebuild.rollup_day)
+        .filter(SqlTraceRollupRebuild.rollup_family == family.value)
+        .order_by(SqlTraceRollupRebuild.experiment_id, SqlTraceRollupRebuild.rollup_day)
+    )
+    return [(int(exp), _date_to_bucket(rollup_day)) for exp, rollup_day in rows]
+
+
+def _trace_partition_state(
+    session: Session, experiment_id: int, day_bucket: int, cutoff_ms: int
+) -> tuple[bool, bool]:
+    """Return ``(eligible, has_rows)`` for a trace partition's contributing traces."""
+    lo = day_bucket * MS_PER_DAY
+    hi = lo + MS_PER_DAY
+    span_stat = _span_settle_subquery(session)
+    settle = _trace_settle_expr(span_stat)
+    count_value, max_settle = (
+        session
+        .query(func.count(SqlTraceInfo.request_id), func.max(settle))
+        .outerjoin(span_stat, span_stat.c.trace_id == SqlTraceInfo.request_id)
+        .filter(
+            SqlTraceInfo.experiment_id == experiment_id,
+            SqlTraceInfo.timestamp_ms >= lo,
+            SqlTraceInfo.timestamp_ms < hi,
+        )
+        .one()
+    )
+    has_rows = bool(count_value)
+    eligible = not has_rows or (max_settle is not None and max_settle <= cutoff_ms)
+    return eligible, has_rows
+
+
+def _assessment_has_rows(session: Session, experiment_id: int, day_bucket: int) -> bool:
+    lo = day_bucket * MS_PER_DAY
+    hi = lo + MS_PER_DAY
+    return (
+        session
+        .query(sa.literal(1))
+        .filter(
+            SqlAssessments.experiment_id == experiment_id,
+            SqlAssessments.valid == true(),
+            SqlAssessments.trace_timestamp_ms >= lo,
+            SqlAssessments.trace_timestamp_ms < hi,
+        )
+        .first()
+        is not None
+    )
+
+
+def _partition_state(
+    session: Session,
+    family: RollupFamily,
+    experiment_id: int,
+    day_bucket: int,
+    cutoff_ms: int,
+    current_day_bucket: int,
+) -> tuple[bool, bool]:
+    # A rollup is valid only for a complete UTC day. Keep current/future partitions queued so
+    # readers continue to use raw rows until a later maintenance run can publish them safely.
+    if day_bucket >= current_day_bucket:
+        return False, False
+    if family == RollupFamily.TRACE_METRIC:
+        return _trace_partition_state(session, experiment_id, day_bucket, cutoff_ms)
+    # Assessments inherit their trace's timestamp, so contributing traces are those of the same day.
+    trace_eligible, trace_has_rows = _trace_partition_state(
+        session, experiment_id, day_bucket, cutoff_ms
+    )
+    has_rows = _assessment_has_rows(session, experiment_id, day_bucket)
+    eligible = trace_eligible if trace_has_rows else True
+    return eligible, has_rows
+
+
+def _trace_percentiles(
+    session: Session,
+    base_filters: list[sa.ColumnElement],
+    group_column: sa.Column | None,
+) -> dict[str | None, dict[tuple[str, int], float | None]]:
+    columns = [
+        func
+        .percentile_cont(percentile / 100.0)
+        .within_group(spec.column)
+        .label(f"{spec.metric_name}__p{percentile}")
+        for spec in _TRACE_METRIC_SPECS
+        if spec.percentile
+        for percentile in _PERCENTILES
+    ]
+    select_columns = ([group_column.label("grp")] if group_column is not None else []) + columns
+    query = session.query(*select_columns).filter(*base_filters)
+    if group_column is not None:
+        query = query.group_by(group_column)
+
+    result: dict[str | None, dict[tuple[str, int], float | None]] = {}
+    for row in query:
+        key = row.grp if group_column is not None else None
+        result[key] = {
+            (spec.metric_name, percentile): getattr(row, f"{spec.metric_name}__p{percentile}")
+            for spec in _TRACE_METRIC_SPECS
+            if spec.percentile
+            for percentile in _PERCENTILES
+        }
+    return result
+
+
+def _aggregate_columns(specs: tuple[_MetricSpec, ...]) -> list[sa.ColumnElement]:
+    columns = []
+    for spec in specs:
+        columns.append(func.count(spec.column).label(f"{spec.metric_name}__n"))
+        if not spec.count_only:
+            columns.append(func.sum(spec.column).label(f"{spec.metric_name}__s"))
+            columns.append(func.min(spec.column).label(f"{spec.metric_name}__mn"))
+            columns.append(func.max(spec.column).label(f"{spec.metric_name}__mx"))
+    return columns
+
+
+def _aggregate_trace(
+    session: Session, experiment_id: int, day_bucket: int, db_type: str
+) -> list[SqlTraceMetricDailyRollup]:
+    lo = day_bucket * MS_PER_DAY
+    hi = lo + MS_PER_DAY
+    day = _bucket_to_date(day_bucket)
+    base_filters = [
+        SqlTraceInfo.experiment_id == experiment_id,
+        SqlTraceInfo.timestamp_ms >= lo,
+        SqlTraceInfo.timestamp_ms < hi,
+    ]
+    rows: list[SqlTraceMetricDailyRollup] = []
+    groupings = ((GroupingSet.GLOBAL, None), (GroupingSet.STATUS, SqlTraceInfo.status))
+    for grouping_set, group_column in groupings:
+        select_columns = (
+            [group_column.label("grp")] if group_column is not None else []
+        ) + _aggregate_columns(_TRACE_METRIC_SPECS)
+        query = session.query(*select_columns).filter(*base_filters)
+        if group_column is not None:
+            query = query.group_by(group_column)
+
+        percentiles = (
+            _trace_percentiles(session, base_filters, group_column)
+            if db_type in PERCENTILE_BACKENDS
+            else {}
+        )
+        for row in query:
+            status_value = row.grp if group_column is not None else None
+            # Raw grouped queries drop rows whose grouping dimension is null; mirror that here.
+            if group_column is not None and status_value is None:
+                continue
+            group_percentiles = percentiles.get(
+                status_value if group_column is not None else None, {}
+            )
+            for spec in _TRACE_METRIC_SPECS:
+                rollup = SqlTraceMetricDailyRollup(
+                    experiment_id=experiment_id,
+                    rollup_day=day,
+                    metric_name=spec.metric_name,
+                    grouping_set=grouping_set.value,
+                    trace_status=status_value,
+                    sample_count=getattr(row, f"{spec.metric_name}__n") or 0,
+                    sum_value=None if spec.count_only else getattr(row, f"{spec.metric_name}__s"),
+                    min_value=None if spec.count_only else getattr(row, f"{spec.metric_name}__mn"),
+                    max_value=None if spec.count_only else getattr(row, f"{spec.metric_name}__mx"),
+                )
+                if spec.percentile:
+                    for percentile in _PERCENTILES:
+                        setattr(
+                            rollup,
+                            _PERCENTILE_COLUMNS[percentile],
+                            group_percentiles.get((spec.metric_name, percentile)),
+                        )
+                rows.append(rollup)
+    return rows
+
+
+def _aggregate_assessment(
+    session: Session, experiment_id: int, day_bucket: int, db_type: str
+) -> list[SqlAssessmentDailyRollup]:
+    lo = day_bucket * MS_PER_DAY
+    hi = lo + MS_PER_DAY
+    day = _bucket_to_date(day_bucket)
+    row = (
+        session
+        .query(*_aggregate_columns(_ASSESSMENT_METRIC_SPECS))
+        .filter(
+            SqlAssessments.experiment_id == experiment_id,
+            SqlAssessments.valid == true(),
+            SqlAssessments.trace_timestamp_ms >= lo,
+            SqlAssessments.trace_timestamp_ms < hi,
+        )
+        .one()
+    )
+    return [
+        SqlAssessmentDailyRollup(
+            experiment_id=experiment_id,
+            rollup_day=day,
+            metric_name=spec.metric_name,
+            grouping_set=GroupingSet.GLOBAL.value,
+            sample_count=getattr(row, f"{spec.metric_name}__n") or 0,
+            sum_value=None if spec.count_only else getattr(row, f"{spec.metric_name}__s"),
+            min_value=None if spec.count_only else getattr(row, f"{spec.metric_name}__mn"),
+            max_value=None if spec.count_only else getattr(row, f"{spec.metric_name}__mx"),
+        )
+        for spec in _ASSESSMENT_METRIC_SPECS
+    ]
+
+
+def _aggregate(
+    session: Session, family: RollupFamily, experiment_id: int, day_bucket: int, db_type: str
+):
+    if family == RollupFamily.TRACE_METRIC:
+        return _aggregate_trace(session, experiment_id, day_bucket, db_type)
+    return _aggregate_assessment(session, experiment_id, day_bucket, db_type)
+
+
+def _rebuild_partition(
+    session_factory,
+    family: RollupFamily,
+    partition: tuple[int, int],
+    cutoff_ms: int,
+    current_day_bucket: int,
+) -> _PartitionOutcome:
+    experiment_id, day_bucket = partition
+    day = _bucket_to_date(day_bucket)
+    model = FAMILY_MODEL[family]
+    with session_factory() as session, session.begin():
+        db_type = session.get_bind().dialect.name
+        entry = ensure_locked_rebuild_entry(session, family, experiment_id, day)
+        eligible, has_rows = _partition_state(
+            session,
+            family,
+            experiment_id,
+            day_bucket,
+            cutoff_ms,
+            current_day_bucket,
+        )
+        if not eligible:
+            # The day is incomplete or contributing traces are still active. Leave it queued and
+            # keep serving raw rows.
+            return "deferred"
+        session.query(model).filter(
+            model.experiment_id == experiment_id, model.rollup_day == day
+        ).delete(synchronize_session=False)
+        if has_rows:
+            session.add_all(_aggregate(session, family, experiment_id, day_bucket, db_type))
+        session.delete(entry)
+        return "emptied" if not has_rows else "built"
+
+
+def _family_candidates(
+    session_factory,
+    family: RollupFamily,
+    eligible: set[tuple[int, int]],
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]]]:
+    with session_factory() as session:
+        queued = _queued_partitions(session, family)
+        built = _built_partitions(session, family)
+    queued_set = set(queued)
+    new = sorted(partition for partition in eligible if partition not in built | queued_set)
+    return queued, new
+
+
+def _process_candidates(
+    session_factory,
+    family: RollupFamily,
+    candidates: list[tuple[int, int]],
+    cutoff_ms: int,
+    current_day_bucket: int,
+    remaining_cap: int | None,
+    stats: RollupFamilyBuildStats,
+    progress_callback: ProgressCallback | None,
+    progress_every: int,
+) -> int | None:
+    processed = 0
+    for partition in candidates:
+        if remaining_cap is not None and remaining_cap <= 0:
+            stats.skipped_cap += 1
+            continue
+        outcome = _rebuild_partition(
+            session_factory, family, partition, cutoff_ms, current_day_bucket
+        )
+        match outcome:
+            case "built":
+                stats.built += 1
+            case "emptied":
+                stats.emptied += 1
+            case "deferred":
+                stats.deferred += 1
+        if outcome != "deferred" and remaining_cap is not None:
+            remaining_cap -= 1
+        processed += 1
+        if progress_callback is not None and processed % progress_every == 0:
+            progress_callback(family.value, stats)
+    if progress_callback is not None:
+        progress_callback(family.value, stats)
+    return remaining_cap
+
+
+def run_sql_trace_rollups(
+    engine: sa.Engine,
+    *,
+    now_ms: int | None = None,
+    max_partitions_per_run: int | None = None,
+    progress_callback: ProgressCallback | None = None,
+    progress_every: int = DEFAULT_PROGRESS_EVERY_PARTITIONS,
+) -> RollupBuildStats:
+    """Build eligible daily rollups and drain the rebuild queue.
+
+    Rebuilds each eligible or queued ``(experiment_id, rollup_day)`` partition for the trace-metric
+    and assessment families in its own locked transaction. Span-cost rollups are intentionally not
+    built; see :data:`mlflow.store.tracking.utils.sql_trace_rollups.SERVABLE_FAMILIES`.
+
+    Args:
+        engine: A SQLAlchemy engine bound to a fully migrated tracking database.
+        now_ms: Job start time in epoch milliseconds; defaults to the current time. Injectable so
+            eligibility (the 24-hour inactivity rule) is deterministic in tests.
+        max_partitions_per_run: Optional cap on the number of partitions actually rebuilt across all
+            families in one run. Deferred partitions do not count against the cap.
+        progress_callback: Optional callback invoked with ``(family, stats)`` during the run.
+        progress_every: Invoke ``progress_callback`` every this many processed partitions.
+
+    Returns:
+        Per-family build statistics.
+    """
+    if progress_every < 1:
+        raise ValueError("progress_every must be positive")
+    if max_partitions_per_run is not None and max_partitions_per_run < 1:
+        raise ValueError("max_partitions_per_run must be positive")
+
+    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    cutoff_ms = now_ms - ROLLUP_ELIGIBILITY_LAG_MS
+    current_day_bucket = now_ms // MS_PER_DAY
+    session_factory = sessionmaker(bind=engine)
+
+    with session_factory() as session:
+        eligible_trace_days = _eligible_trace_days(session, cutoff_ms, current_day_bucket)
+        assessment_data_days = _assessment_days_with_data(session)
+
+    eligible_by_family = {
+        RollupFamily.TRACE_METRIC: eligible_trace_days,
+        RollupFamily.ASSESSMENT: eligible_trace_days & assessment_data_days,
+    }
+
+    candidates_by_family = {
+        family: _family_candidates(session_factory, family, eligible_by_family[family])
+        for family in _BUILT_FAMILIES
+    }
+    family_stats = {family: RollupFamilyBuildStats() for family in _BUILT_FAMILIES}
+    remaining_cap = max_partitions_per_run
+    # RFC 0006 requires queued rebuilds to take priority globally. Drain both families' queues
+    # before using any remaining capacity for newly eligible, previously unbuilt partitions.
+    for candidate_index in (0, 1):
+        for family in _BUILT_FAMILIES:
+            remaining_cap = _process_candidates(
+                session_factory,
+                family,
+                candidates_by_family[family][candidate_index],
+                cutoff_ms,
+                current_day_bucket,
+                remaining_cap,
+                family_stats[family],
+                progress_callback,
+                progress_every,
+            )
+
+    return RollupBuildStats(
+        trace_metric=family_stats[RollupFamily.TRACE_METRIC],
+        assessment=family_stats[RollupFamily.ASSESSMENT],
+    )

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -175,6 +175,8 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     validate_query_trace_metrics_params,
 )
 from mlflow.store.tracking.utils.sql_trace_rollups import (
+    RollupFamily,
+    enqueue_rollup_rebuilds,
     order_and_limit_data_points,
     resolve_rollup_read,
     serve_rollup_read,
@@ -3724,6 +3726,7 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 sql_assessments.append(sql_assessment)
             sql_trace_info.assessments = sql_assessments
 
+            previous_partition: tuple[int, int] | None = None
             try:
                 # Happy path: attach metadata via cascade for a single flush.
                 # Emit rows in sorted key order so concurrent writers acquire the
@@ -3780,6 +3783,10 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         f"Cannot update traces that are no longer DB-backed: '{trace_id}'.",
                         error_code=INVALID_STATE,
                     )
+                previous_partition = (
+                    int(db_sql_trace_info.experiment_id),
+                    db_sql_trace_info.timestamp_ms,
+                )
                 # Advance the payload generation before staging ORM writes so a concurrent archival
                 # finalization cannot be hidden by autoflush re-publishing TRACKING_STORE.
                 self._advance_db_payload_generations_for_db_span_writes(session, [trace_id])
@@ -3825,6 +3832,19 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     session,
                     trace_id,
                     workspace=trace_write_workspace,
+                )
+
+            affected_partitions = [(int(trace_info.experiment_id), trace_info.request_time)]
+            if previous_partition is not None:
+                affected_partitions.append(previous_partition)
+            for experiment_id, timestamp_ms in set(affected_partitions):
+                enqueue_rollup_rebuilds(
+                    session, RollupFamily.TRACE_METRIC, experiment_id, [timestamp_ms]
+                )
+                # start_trace can attach assessments or move existing assessments to a different
+                # experiment/day, so both the old and new assessment partitions are invalidated.
+                enqueue_rollup_rebuilds(
+                    session, RollupFamily.ASSESSMENT, experiment_id, [timestamp_ms]
                 )
 
             return sql_trace_info.to_mlflow_entity()
@@ -4531,6 +4551,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 trace_id for trace_id in selected_trace_ids if trace_id not in archived_trace_ids
             ]
             if db_backed_trace_ids:
+                self._enqueue_rollup_rebuilds_for_trace_delete(
+                    session, int(experiment_id), db_backed_trace_ids
+                )
                 deleted_db_backed_count = (
                     session
                     .query(SqlTraceInfo)
@@ -4550,6 +4573,9 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             return deleted_db_backed_count
 
         with self.ManagedSessionMaker(read_only=False) as session:
+            self._enqueue_rollup_rebuilds_for_trace_delete(
+                session, int(experiment_id), deleted_archived_trace_ids
+            )
             deleted_archived_count = (
                 session
                 .query(SqlTraceInfo)
@@ -4583,6 +4609,19 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             )
             .delete(synchronize_session=False)
         )
+
+    def _enqueue_rollup_rebuilds_for_trace_delete(
+        self, session: Session, experiment_id: int, trace_ids: list[str]
+    ) -> None:
+        """Invalidate trace and assessment partitions before deleting their source rows."""
+        timestamps = [
+            timestamp_ms
+            for (timestamp_ms,) in session.query(SqlTraceInfo.timestamp_ms).filter(
+                SqlTraceInfo.request_id.in_(trace_ids)
+            )
+        ]
+        enqueue_rollup_rebuilds(session, RollupFamily.TRACE_METRIC, experiment_id, timestamps)
+        enqueue_rollup_rebuilds(session, RollupFamily.ASSESSMENT, experiment_id, timestamps)
 
     def _select_trace_ids_for_delete(
         self,
@@ -4754,6 +4793,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     "due to a constraint violation.",
                     INTERNAL_ERROR,
                 ) from e
+            enqueue_rollup_rebuilds(
+                session,
+                RollupFamily.ASSESSMENT,
+                sql_trace_info.experiment_id,
+                [sql_trace_info.timestamp_ms],
+            )
             return sql_assessment.to_mlflow_entity()
 
     def get_assessment(self, trace_id: str, assessment_id: str) -> Assessment:
@@ -4901,6 +4946,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 "is_numeric_value": is_numeric_value,
             })
 
+            enqueue_rollup_rebuilds(
+                session,
+                RollupFamily.ASSESSMENT,
+                existing_sql.experiment_id,
+                [existing_sql.trace_timestamp_ms],
+            )
             return updated_assessment
 
     def delete_assessment(self, trace_id: str, assessment_id: str) -> None:
@@ -4934,6 +4985,12 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     assessment_id=assessment_to_delete.overrides
                 ).update({"valid": True})
 
+            enqueue_rollup_rebuilds(
+                session,
+                RollupFamily.ASSESSMENT,
+                assessment_to_delete.experiment_id,
+                [assessment_to_delete.trace_timestamp_ms],
+            )
             session.delete(assessment_to_delete)
             session.commit()
 
@@ -5788,6 +5845,33 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         session.merge(
                             SqlTraceTag(request_id=trace_id, key=tag_key, value=tag_value)
                         )
+
+            # Any span batch can change trace status, latency, token aggregates, or the trace day.
+            # Queue invalidation in this transaction, preserving both the old and new day when an
+            # inferred trace timestamp moves earlier. Assessments inherit the trace timestamp.
+            trace_days_by_experiment: defaultdict[int, set[int]] = defaultdict(set)
+            assessment_days_by_experiment: defaultdict[int, set[int]] = defaultdict(set)
+            for trace_id in all_trace_ids:
+                sql_trace_info = existing_traces[trace_id]
+                agg = trace_aggregates[trace_id]
+                experiment_id = int(sql_trace_info.experiment_id)
+                trace_days_by_experiment[experiment_id].add(sql_trace_info.timestamp_ms)
+                if (
+                    trace_id not in finalized_trace_ids
+                    and sql_trace_info.timestamp_ms > agg.min_start_ms
+                ):
+                    trace_days_by_experiment[experiment_id].add(agg.min_start_ms)
+                    assessment_days_by_experiment[experiment_id].update((
+                        sql_trace_info.timestamp_ms,
+                        agg.min_start_ms,
+                    ))
+
+            for experiment_id, timestamps in trace_days_by_experiment.items():
+                enqueue_rollup_rebuilds(
+                    session, RollupFamily.TRACE_METRIC, experiment_id, timestamps
+                )
+            for experiment_id, timestamps in assessment_days_by_experiment.items():
+                enqueue_rollup_rebuilds(session, RollupFamily.ASSESSMENT, experiment_id, timestamps)
 
         return spans
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -923,13 +923,34 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         # in the assessment_metadata JSON field under the reserved
         # "mlflow.assessment.sourceRunId" key, not in the run_id column.
         source_run_id_pattern = f'"{AssessmentMetadataKey.SOURCE_RUN_ID}": "{run.run_uuid}"'
-        session.query(SqlAssessments).filter(
-            SqlAssessments.assessment_metadata.contains(source_run_id_pattern)
-        ).delete(synchronize_session=False)
+        assessment_filter = SqlAssessments.assessment_metadata.contains(source_run_id_pattern)
+        # Invalidate assessment rollups for every experiment/day these rows fall in
+        # before deleting them, so the maintenance engine rebuilds the affected
+        # partitions and stale aggregates are never served (mirrors delete_assessment
+        # and _enqueue_rollup_rebuilds_for_trace_delete).
+        self._enqueue_assessment_rebuilds_for_filter(session, assessment_filter)
+        session.query(SqlAssessments).filter(assessment_filter).delete(synchronize_session=False)
 
         run.lifecycle_stage = LifecycleStage.DELETED
         run.deleted_time = get_current_time_millis()
         session.add(run)
+
+    def _enqueue_assessment_rebuilds_for_filter(self, session, assessment_filter) -> None:
+        """Invalidate assessment partitions before bulk-deleting the matching rows.
+
+        The rows can span multiple experiments and days, so group the denormalized
+        ``experiment_id``/``trace_timestamp_ms`` by experiment and enqueue one
+        ASSESSMENT rebuild batch per experiment while the source rows still exist.
+        """
+        timestamps_by_experiment: dict[int, list[int]] = defaultdict(list)
+        for experiment_id, trace_timestamp_ms in session.query(
+            SqlAssessments.experiment_id, SqlAssessments.trace_timestamp_ms
+        ).filter(assessment_filter):
+            if experiment_id is None:
+                continue
+            timestamps_by_experiment[experiment_id].append(trace_timestamp_ms)
+        for experiment_id, timestamps in timestamps_by_experiment.items():
+            enqueue_rollup_rebuilds(session, RollupFamily.ASSESSMENT, experiment_id, timestamps)
 
     def _mark_run_active(self, session, run):
         run.lifecycle_stage = LifecycleStage.ACTIVE

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -174,6 +174,11 @@ from mlflow.store.tracking.utils.sql_trace_metrics_utils import (
     query_metrics,
     validate_query_trace_metrics_params,
 )
+from mlflow.store.tracking.utils.sql_trace_rollups import (
+    order_and_limit_data_points,
+    resolve_rollup_read,
+    serve_rollup_read,
+)
 from mlflow.store.tracking.utils.trace_analytics import (
     COST_COLUMN_BY_KEY,
     PROMOTED_TRACE_METADATA_KEYS,
@@ -4352,33 +4357,65 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
             experiment_ids_int = self._filter_experiment_ids(
                 session, [int(exp_id) for exp_id in experiment_ids]
             )
-            if view_type == MetricViewType.ASSESSMENTS:
-                query = session.query(SqlAssessments).filter(
-                    SqlAssessments.experiment_id.in_(experiment_ids_int)
-                )
-                timestamp_column = SqlAssessments.trace_timestamp_ms
-            else:
-                query = self._trace_query(session).filter(
-                    SqlTraceInfo.experiment_id.in_(experiment_ids_int)
-                )
-                timestamp_column = SqlTraceInfo.timestamp_ms
 
-            if start_time_ms is not None:
-                query = query.filter(timestamp_column >= start_time_ms)
-            if end_time_ms is not None:
-                query = query.filter(timestamp_column <= end_time_ms)
+            def raw_range_query(range_start_ms: int | None, range_end_ms: int | None):
+                if view_type == MetricViewType.ASSESSMENTS:
+                    query = session.query(SqlAssessments).filter(
+                        SqlAssessments.experiment_id.in_(experiment_ids_int)
+                    )
+                    timestamp_column = SqlAssessments.trace_timestamp_ms
+                else:
+                    query = self._trace_query(session).filter(
+                        SqlTraceInfo.experiment_id.in_(experiment_ids_int)
+                    )
+                    timestamp_column = SqlTraceInfo.timestamp_ms
+                if range_start_ms is not None:
+                    query = query.filter(timestamp_column >= range_start_ms)
+                if range_end_ms is not None:
+                    query = query.filter(timestamp_column <= range_end_ms)
+                return query
 
-            data_points = query_metrics(
+            def raw_range_points(range_start_ms: int | None, range_end_ms: int | None):
+                return query_metrics(
+                    view_type=view_type,
+                    db_type=self.db_type,
+                    query=raw_range_query(range_start_ms, range_end_ms),
+                    metric_name=metric_name,
+                    aggregations=aggregations,
+                    dimensions=dimensions,
+                    filters=filters,
+                    time_interval_seconds=time_interval_seconds,
+                    max_results=max_results,
+                )
+
+            # Opt-in fast path: serve whole covered UTC days from precomputed rollups and query only
+            # the partial-day edges (and any not-yet-built days) raw. resolve_rollup_read returns
+            # None whenever rollups are disabled or the request is not exactly rollup-servable, so
+            # the raw path below stays authoritative and results match the rollups-disabled case.
+            plan = resolve_rollup_read(
                 view_type=view_type,
-                db_type=self.db_type,
-                query=query,
                 metric_name=metric_name,
                 aggregations=aggregations,
                 dimensions=dimensions,
                 filters=filters,
                 time_interval_seconds=time_interval_seconds,
-                max_results=max_results,
+                start_time_ms=start_time_ms,
+                end_time_ms=end_time_ms,
+                experiment_ids=experiment_ids_int,
+                db_type=self.db_type,
             )
+            served = serve_rollup_read(session, plan) if plan is not None else None
+
+            if served is not None:
+                rollup_points, raw_ranges = served
+                data_points = list(rollup_points)
+                for range_start_ms, range_end_ms in raw_ranges:
+                    data_points.extend(raw_range_points(range_start_ms, range_end_ms))
+                # Match the single-query raw path: order by time bucket (then grouping dimensions)
+                # and apply the global max_results after merging rollup and raw sub-range results.
+                data_points = order_and_limit_data_points(data_points, max_results)
+            else:
+                data_points = raw_range_points(start_time_ms, end_time_ms)
 
             # TODO: Implement pagination with page_token
             return PagedList(data_points, None)

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -26,10 +26,12 @@ routing experiment ids the requester may access.
 """
 
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from enum import Enum
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from mlflow.entities.trace_metrics import (
@@ -593,3 +595,51 @@ def order_and_limit_data_points(
     rollups-disabled response.
     """
     return sorted(data_points, key=_data_point_ordering)[:max_results]
+
+
+def ensure_locked_rebuild_entry(
+    session: Session, family: RollupFamily, experiment_id: int, rollup_day: date
+) -> SqlTraceRollupRebuild:
+    """Insert (if absent) and lock a partition rebuild entry in the current transaction."""
+    query = session.query(SqlTraceRollupRebuild).filter(
+        SqlTraceRollupRebuild.experiment_id == experiment_id,
+        SqlTraceRollupRebuild.rollup_day == rollup_day,
+        SqlTraceRollupRebuild.rollup_family == family.value,
+    )
+    if entry := query.with_for_update().one_or_none():
+        return entry
+
+    savepoint = session.begin_nested()
+    try:
+        entry = SqlTraceRollupRebuild(
+            experiment_id=experiment_id,
+            rollup_day=rollup_day,
+            rollup_family=family.value,
+        )
+        session.add(entry)
+        session.flush()
+    except IntegrityError:
+        savepoint.rollback()
+        return query.with_for_update().one()
+    else:
+        savepoint.commit()
+        return entry
+
+
+def enqueue_rollup_rebuilds(
+    session: Session,
+    family: RollupFamily,
+    experiment_id: int | None,
+    timestamp_ms_values: Iterable[int | None],
+) -> None:
+    """Invalidate rollup partitions affected by a source mutation.
+
+    Invalidation is deliberately independent of the read feature gate. If rollups are disabled
+    after rows have been built, writes must continue marking those rows stale so they cannot be
+    served after the feature is enabled again.
+    """
+    if experiment_id is None or family not in SERVABLE_FAMILIES:
+        return
+    days = {_day_start_ms_to_date(ts) for ts in timestamp_ms_values if ts is not None}
+    for rollup_day in sorted(days):
+        ensure_locked_rebuild_entry(session, family, int(experiment_id), rollup_day)

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -1,0 +1,555 @@
+"""Opt-in SQL daily rollup planning for trace analytics.
+
+Daily rollups precompute per-day aggregates (``sample_count``, ``sum``, ``min``, ``max``, and, for
+trace metrics on PostgreSQL, daily ``p50``/``p90``/``p99``) keyed by
+``(experiment_id, rollup_day, metric_name, grouping_set, <dimension columns>)``. Eligible dashboard
+queries then read a handful of daily summary rows instead of scanning millions of raw rows. Rollups
+are opt-in via :data:`MLFLOW_SQL_TRACE_ROLLUPS_ENABLED` and always fall back to the raw query path,
+so an absent, stale, or partially built rollup can never change a query result, only its speed.
+
+This module holds the backend-agnostic planning layer plus the read-serving helpers: the
+family/grouping/metric taxonomy, the runtime-config gate, the read-eligibility decision, the
+UTC-midnight range split, and reading rollup rows to assemble a response. Populating the rollup
+tables lives in the separate rollup maintenance job.
+
+The reader trusts a full UTC day only when a matching rollup row exists for the metric and grouping
+set and no rebuild is queued for that day and family; it also demotes a covered day back to the raw
+path when the row is missing a column the request needs (a null aggregate value). Whole-day
+completeness of a grouping set is a maintenance-job guarantee, so the reader serves only the
+single-row ``global`` grouping set, whose one row per experiment-day is self-verifying. Multi-row
+grouping sets (for example per-status breakdowns) are served once the maintenance job that writes
+and invalidates them can guarantee that every group's row for a day is present before the day is
+treated as built.
+
+The rollup tables carry no ``workspace`` column (the shipped analytics schema scopes purely on
+``experiment_id``, which is globally unique), so workspace isolation is preserved by the caller only
+routing experiment ids the requester may access.
+"""
+
+import math
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+
+from sqlalchemy.orm import Session
+
+from mlflow.entities.trace_metrics import (
+    AggregationType,
+    MetricAggregation,
+    MetricDataPoint,
+    MetricViewType,
+)
+from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
+from mlflow.store.db import db_types
+from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
+    SqlSpanCostDailyRollup,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
+)
+from mlflow.store.tracking.utils.sql_trace_metrics_utils import TIME_BUCKET_LABEL
+from mlflow.tracing.constant import (
+    AssessmentMetricKey,
+    SpanMetricDimensionKey,
+    SpanMetricKey,
+    TraceMetricDimensionKey,
+    TraceMetricKey,
+)
+
+MS_PER_DAY = 86_400_000
+DAILY_INTERVAL_SECONDS = 86_400
+
+# Daily percentiles are not composable into coarser buckets, so rollups only serve these three exact
+# daily percentile values, and only for single-experiment complete-UTC-day requests.
+SUPPORTED_PERCENTILE_VALUES = frozenset({50.0, 90.0, 99.0})
+
+
+class RollupFamily(str, Enum):
+    """Rollup table family, persisted in ``sql_trace_rollup_rebuild_queue.rollup_family``."""
+
+    TRACE_METRIC = "trace_metric"
+    SPAN_COST = "span_cost"
+    ASSESSMENT = "assessment"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class GroupingSet(str, Enum):
+    """Dimension set a rollup row aggregates. Persisted in ``grouping_set`` columns.
+
+    ``global`` aggregates across all rows for the experiment and day without an optional dimension;
+    global rows are identified by this value, not by null dimension columns.
+    """
+
+    GLOBAL = "global"
+    STATUS = "status"
+    MODEL = "model"
+    PROVIDER = "provider"
+    MODEL_PROVIDER = "model_provider"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+VIEW_TYPE_TO_FAMILY: dict[MetricViewType, RollupFamily] = {
+    MetricViewType.TRACES: RollupFamily.TRACE_METRIC,
+    MetricViewType.SPANS: RollupFamily.SPAN_COST,
+    MetricViewType.ASSESSMENTS: RollupFamily.ASSESSMENT,
+}
+
+# Metrics each family materializes into rollups. Metrics outside these sets always use the raw path:
+# session counts (not composable across days/experiments), span counts and span latency (the span
+# rollup table is cost-only), and any assessment metric grouped by name or value.
+ROLLUP_METRICS: dict[RollupFamily, frozenset[str]] = {
+    RollupFamily.TRACE_METRIC: frozenset({
+        TraceMetricKey.TRACE_COUNT,
+        TraceMetricKey.LATENCY,
+        TraceMetricKey.INPUT_TOKENS,
+        TraceMetricKey.OUTPUT_TOKENS,
+        TraceMetricKey.TOTAL_TOKENS,
+        TraceMetricKey.CACHE_READ_INPUT_TOKENS,
+        TraceMetricKey.CACHE_CREATION_INPUT_TOKENS,
+    }),
+    RollupFamily.SPAN_COST: frozenset({
+        SpanMetricKey.INPUT_COST,
+        SpanMetricKey.OUTPUT_COST,
+        SpanMetricKey.TOTAL_COST,
+    }),
+    RollupFamily.ASSESSMENT: frozenset({
+        AssessmentMetricKey.ASSESSMENT_COUNT,
+        AssessmentMetricKey.ASSESSMENT_VALUE,
+    }),
+}
+
+# Only trace-metric rollups store daily percentile columns, and only PostgreSQL computes them.
+PERCENTILE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC})
+PERCENTILE_BACKENDS = frozenset({db_types.POSTGRES})
+
+# Families the reader may serve from rollups. Span cost is intentionally excluded: the raw span
+# query filters by the parent trace's timestamp (``trace_info.timestamp_ms``) but buckets by span
+# start time (``spans.start_time_unix_nano``), so a span-day rollup cannot be guaranteed row-for-row
+# identical to raw when a span and its trace fall on different UTC days (e.g. delayed or
+# long-running OTLP spans). Serving it would violate the invariant that rollups never change
+# results, only speed.
+# Span-cost rollups are therefore neither built nor read until the span read path filters by span
+# time; trace-metric and assessment queries filter and bucket on the same timestamp, so they are
+# always exactly reproducible from daily rollups.
+SERVABLE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC, RollupFamily.ASSESSMENT})
+
+# Grouping sets the reader may serve. Restricted to ``global`` because that grouping set has exactly
+# one row per experiment-day, so "a row exists and is not queued" already proves the day complete.
+# Multi-row grouping sets (status, model, provider) need the maintenance job to guarantee that every
+# group's row for a day is written before the day is treated as built; until that job lands, serving
+# them could under-report a day whose sibling rows are missing, so they stay on the raw path.
+SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL})
+
+
+def rollups_enabled() -> bool:
+    """Whether opt-in SQL trace rollups are enabled for this deployment."""
+    return MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.get()
+
+
+@dataclass
+class UtcDaySplit:
+    """Result of splitting an inclusive ``[start, end]`` ms range at UTC-midnight boundaries.
+
+    Args:
+        covered_day_starts_ms: Epoch-ms UTC-midnight starts of full days entirely inside the range.
+            These are candidates that a reader may serve from rollups if matching rows exist and no
+            rebuild is queued; any that are not covered fall back to their own raw day range.
+        raw_ranges: Inclusive ``(start_ms, end_ms)`` sub-ranges for the partial first/last days that
+            can never be served by whole-day rollups.
+    """
+
+    covered_day_starts_ms: list[int]
+    raw_ranges: list[tuple[int, int]]
+
+
+def split_range_into_utc_days(start_time_ms: int | None, end_time_ms: int | None) -> UtcDaySplit:
+    """Split an inclusive ``[start_time_ms, end_time_ms]`` range into full UTC days and raw edges.
+
+    A full UTC day ``[D, D + MS_PER_DAY)`` is a covered candidate only when the request range fully
+    contains it, i.e. ``start_time_ms <= D`` and ``end_time_ms >= D + MS_PER_DAY - 1``. This matches
+    the raw query filter (``timestamp >= start AND timestamp <= end``) so a rollup-served day is
+    exactly equivalent to the raw aggregate for that day. Partial first/last days become raw ranges.
+    """
+    if start_time_ms is None or end_time_ms is None or start_time_ms > end_time_ms:
+        has_range = start_time_ms is not None and end_time_ms is not None
+        raw = [(start_time_ms, end_time_ms)] if has_range else []
+        return UtcDaySplit(covered_day_starts_ms=[], raw_ranges=raw)
+
+    first_full_day_start = math.ceil(start_time_ms / MS_PER_DAY) * MS_PER_DAY
+    # Greatest UTC midnight D such that the whole day [D, D + MS_PER_DAY) fits inside the range,
+    # i.e. D + MS_PER_DAY - 1 <= end_time_ms.
+    last_full_day_start = ((end_time_ms + 1) // MS_PER_DAY) * MS_PER_DAY - MS_PER_DAY
+
+    covered = list(range(first_full_day_start, last_full_day_start + MS_PER_DAY, MS_PER_DAY))
+
+    raw_ranges: list[tuple[int, int]] = []
+    if not covered:
+        raw_ranges.append((start_time_ms, end_time_ms))
+    else:
+        if start_time_ms < first_full_day_start:
+            raw_ranges.append((start_time_ms, first_full_day_start - 1))
+        covered_end_exclusive = last_full_day_start + MS_PER_DAY
+        if covered_end_exclusive <= end_time_ms:
+            raw_ranges.append((covered_end_exclusive, end_time_ms))
+
+    return UtcDaySplit(covered_day_starts_ms=covered, raw_ranges=raw_ranges)
+
+
+def resolve_grouping_set(
+    view_type: MetricViewType, dimensions: list[str] | None
+) -> GroupingSet | None:
+    """Map requested grouping dimensions to a materialized grouping set, or ``None`` if unsupported.
+
+    User-controlled high-cardinality dimensions (trace name, assessment name/value, span name/type/
+    status) have no rollup grouping set and always return ``None`` so the request stays raw.
+    """
+    dims = set(dimensions or [])
+    match view_type:
+        case MetricViewType.TRACES:
+            if not dims:
+                return GroupingSet.GLOBAL
+            if dims == {TraceMetricDimensionKey.TRACE_STATUS}:
+                return GroupingSet.STATUS
+        case MetricViewType.SPANS:
+            if not dims:
+                return GroupingSet.GLOBAL
+            if dims == {SpanMetricDimensionKey.SPAN_MODEL_NAME}:
+                return GroupingSet.MODEL
+            if dims == {SpanMetricDimensionKey.SPAN_MODEL_PROVIDER}:
+                return GroupingSet.PROVIDER
+            if dims == {
+                SpanMetricDimensionKey.SPAN_MODEL_NAME,
+                SpanMetricDimensionKey.SPAN_MODEL_PROVIDER,
+            }:
+                return GroupingSet.MODEL_PROVIDER
+        case MetricViewType.ASSESSMENTS:
+            if not dims:
+                return GroupingSet.GLOBAL
+    return None
+
+
+@dataclass
+class RollupReadPlan:
+    """A validated plan describing how to serve a query from rollups.
+
+    Args:
+        family: The rollup table family to read.
+        metric_name: The metric whose rollup rows to read (matches the request metric name).
+        grouping_set: The materialized grouping set to read.
+        aggregations: The requested aggregations, all confirmed rollup-servable.
+        bucketed: ``True`` for one data point per UTC day (daily interval); ``False`` for a single
+            aggregate over the whole range.
+        experiment_id: The single experiment id to read (rollup serving is single-experiment only).
+        covered_day_starts_ms: Candidate full UTC days that may be served from rollups.
+        raw_ranges: Inclusive ``(start_ms, end_ms)`` partial-day ranges that must be served raw.
+        uses_percentiles: Whether any requested aggregation is a percentile.
+    """
+
+    family: RollupFamily
+    metric_name: str
+    grouping_set: GroupingSet
+    aggregations: list[MetricAggregation]
+    bucketed: bool
+    experiment_id: int
+    covered_day_starts_ms: list[int]
+    raw_ranges: list[tuple[int, int]]
+    uses_percentiles: bool
+
+
+def _aggregation_servable(
+    aggregation: MetricAggregation, family: RollupFamily, db_type: str, bucketed: bool
+) -> bool:
+    if aggregation.aggregation_type != AggregationType.PERCENTILE:
+        # COUNT/SUM/AVG/MIN/MAX derive from sample_count/sum_value/min_value/max_value in every
+        # family.
+        return True
+    # Percentiles are only materialized for trace metrics on supported backends, only for the three
+    # exact daily percentile values, and only when bucketed by day (a daily percentile is not
+    # composable across days into a single range aggregate).
+    return (
+        bucketed
+        and family in PERCENTILE_FAMILIES
+        and db_type in PERCENTILE_BACKENDS
+        and aggregation.percentile_value in SUPPORTED_PERCENTILE_VALUES
+    )
+
+
+def resolve_rollup_read(
+    view_type: MetricViewType,
+    metric_name: str,
+    aggregations: list[MetricAggregation],
+    dimensions: list[str] | None,
+    filters: list[str] | None,
+    time_interval_seconds: int | None,
+    start_time_ms: int | None,
+    end_time_ms: int | None,
+    experiment_ids: list[int],
+    db_type: str,
+) -> RollupReadPlan | None:
+    """Decide whether a trace metrics query can be served from rollups.
+
+    Returns a :class:`RollupReadPlan` when at least one full UTC day of the request is rollup
+    eligible, or ``None`` to signal the caller to use the raw path. Returning ``None`` is always a
+    safe, correct choice; this function never changes results, only whether rollups are consulted.
+
+    Requests fall back to raw for any of: rollups disabled, an unsupported view/metric/dimension/
+    aggregation, a grouping set not yet servable from rollups, any filter (rollups are unfiltered
+    aggregates), a non-daily bucket width, a missing time range, more than one experiment, or a
+    range containing no full UTC day.
+    """
+    if not rollups_enabled():
+        return None
+
+    family = VIEW_TYPE_TO_FAMILY.get(view_type)
+    if family is None or family not in SERVABLE_FAMILIES:
+        return None
+    if metric_name not in ROLLUP_METRICS[family]:
+        return None
+
+    # Rollups are unfiltered daily aggregates; any request-level filter must use the raw path.
+    if filters:
+        return None
+
+    grouping_set = resolve_grouping_set(view_type, dimensions)
+    if grouping_set is None or grouping_set not in SERVABLE_GROUPING_SETS:
+        return None
+
+    # Rollups are UTC-day aligned: serve only single-day buckets or a single whole-range aggregate.
+    if time_interval_seconds is not None and time_interval_seconds != DAILY_INTERVAL_SECONDS:
+        return None
+    bucketed = time_interval_seconds == DAILY_INTERVAL_SECONDS
+
+    if start_time_ms is None or end_time_ms is None:
+        return None
+
+    # Rollup serving is single-experiment: multi-experiment coverage cannot distinguish "no data
+    # that day" from "not built yet", and daily percentiles are single-experiment by definition.
+    if len(experiment_ids) != 1:
+        return None
+
+    if not all(_aggregation_servable(agg, family, db_type, bucketed) for agg in aggregations):
+        return None
+
+    split = split_range_into_utc_days(start_time_ms, end_time_ms)
+    if not split.covered_day_starts_ms:
+        return None
+
+    return RollupReadPlan(
+        family=family,
+        metric_name=metric_name,
+        grouping_set=grouping_set,
+        aggregations=aggregations,
+        bucketed=bucketed,
+        experiment_id=experiment_ids[0],
+        covered_day_starts_ms=split.covered_day_starts_ms,
+        raw_ranges=split.raw_ranges,
+        uses_percentiles=any(
+            agg.aggregation_type == AggregationType.PERCENTILE for agg in aggregations
+        ),
+    )
+
+
+FAMILY_MODEL = {
+    RollupFamily.TRACE_METRIC: SqlTraceMetricDailyRollup,
+    RollupFamily.SPAN_COST: SqlSpanCostDailyRollup,
+    RollupFamily.ASSESSMENT: SqlAssessmentDailyRollup,
+}
+
+
+def _day_start_ms_to_date(day_start_ms: int) -> date:
+    return datetime.fromtimestamp(day_start_ms / 1000, tz=timezone.utc).date()
+
+
+def _day_start_ms_to_iso(day_start_ms: int) -> str:
+    # Matches the raw path's time_bucket rendering in convert_results_to_metric_data_points.
+    return datetime.fromtimestamp(day_start_ms / 1000, tz=timezone.utc).isoformat()
+
+
+def _rollup_row_dimensions(plan: RollupReadPlan, row) -> dict[str, str]:
+    match plan.grouping_set:
+        case GroupingSet.STATUS:
+            return {TraceMetricDimensionKey.TRACE_STATUS: row.trace_status}
+        case GroupingSet.MODEL:
+            return {SpanMetricDimensionKey.SPAN_MODEL_NAME: row.model_name}
+        case GroupingSet.PROVIDER:
+            return {SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: row.model_provider}
+        case GroupingSet.MODEL_PROVIDER:
+            return {
+                SpanMetricDimensionKey.SPAN_MODEL_NAME: row.model_name,
+                SpanMetricDimensionKey.SPAN_MODEL_PROVIDER: row.model_provider,
+            }
+        case _:
+            return {}
+
+
+def _rollup_row_value(aggregation: MetricAggregation, row) -> float | None:
+    match aggregation.aggregation_type:
+        case AggregationType.COUNT:
+            return row.sample_count
+        case AggregationType.SUM:
+            return row.sum_value
+        case AggregationType.AVG:
+            if row.sample_count and row.sum_value is not None:
+                return row.sum_value / row.sample_count
+            return None
+        case AggregationType.MIN:
+            return row.min_value
+        case AggregationType.MAX:
+            return row.max_value
+        case AggregationType.PERCENTILE:
+            match aggregation.percentile_value:
+                case 50.0:
+                    return row.p50_value
+                case 90.0:
+                    return row.p90_value
+                case 99.0:
+                    return row.p99_value
+    return None
+
+
+def compute_covered_day_starts(session: Session, plan: RollupReadPlan) -> list[int]:
+    """Return the candidate days actually servable from rollups.
+
+    A day is covered when a matching rollup row exists for the metric and grouping set and no
+    rebuild entry is queued for the family and day. Missing or queued days fall back to the raw
+    path.
+    """
+    date_to_ms = {_day_start_ms_to_date(ms): ms for ms in plan.covered_day_starts_ms}
+    candidate_dates = list(date_to_ms.keys())
+    model = FAMILY_MODEL[plan.family]
+
+    built = {
+        row_day
+        for (row_day,) in session
+        .query(model.rollup_day)
+        .filter(
+            model.experiment_id == plan.experiment_id,
+            model.metric_name == plan.metric_name,
+            model.grouping_set == plan.grouping_set.value,
+            model.rollup_day.in_(candidate_dates),
+        )
+        .distinct()
+    }
+    queued = {
+        row_day
+        for (row_day,) in session.query(SqlTraceRollupRebuild.rollup_day).filter(
+            SqlTraceRollupRebuild.experiment_id == plan.experiment_id,
+            SqlTraceRollupRebuild.rollup_family == plan.family.value,
+            SqlTraceRollupRebuild.rollup_day.in_(candidate_dates),
+        )
+    }
+    covered = [ms for d, ms in date_to_ms.items() if d in built and d not in queued]
+    return sorted(covered)
+
+
+def read_rollup_data_points(
+    session: Session, plan: RollupReadPlan, covered_day_starts: list[int]
+) -> tuple[list[MetricDataPoint], list[int]]:
+    """Assemble daily data points from rollup rows, with the day starts actually served.
+
+    A covered day is served only when its rollup row yields a non-null value for every requested
+    aggregation. A day whose row is missing a needed column (a null aggregate) is left out of the
+    served set so the caller re-queries it raw rather than returning a crashing or short response,
+    keeping a served result identical to the rollups-disabled result.
+    """
+    date_to_ms = {_day_start_ms_to_date(ms): ms for ms in covered_day_starts}
+    model = FAMILY_MODEL[plan.family]
+    rows = session.query(model).filter(
+        model.experiment_id == plan.experiment_id,
+        model.metric_name == plan.metric_name,
+        model.grouping_set == plan.grouping_set.value,
+        model.rollup_day.in_(list(date_to_ms.keys())),
+    )
+
+    data_points = []
+    served_day_starts: set[int] = set()
+    for row in rows:
+        group_dims = _rollup_row_dimensions(plan, row)
+        # Mirror the raw path, which drops rows whose grouping dimension is null.
+        if any(v is None for v in group_dims.values()):
+            continue
+
+        values = {}
+        for agg in plan.aggregations:
+            value = _rollup_row_value(agg, row)
+            if value is None:
+                # A requested aggregation has no value for this day; demote the day to raw.
+                break
+            values[str(agg)] = value
+        else:
+            day_start_ms = date_to_ms[row.rollup_day]
+            served_day_starts.add(day_start_ms)
+            dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
+            dimensions.update(group_dims)
+            data_points.append(
+                MetricDataPoint(metric_name=plan.metric_name, dimensions=dimensions, values=values)
+            )
+    return data_points, sorted(served_day_starts)
+
+
+def _coalesce_day_starts_to_ranges(day_starts: list[int]) -> list[tuple[int, int]]:
+    """Merge consecutive UTC-day starts into inclusive ``(start_ms, end_ms)`` ranges."""
+    ranges: list[tuple[int, int]] = []
+    for day_start in sorted(day_starts):
+        day_end = day_start + MS_PER_DAY - 1
+        if ranges and day_start == ranges[-1][1] + 1:
+            ranges[-1] = (ranges[-1][0], day_end)
+        else:
+            ranges.append((day_start, day_end))
+    return ranges
+
+
+def remaining_raw_ranges(
+    plan: RollupReadPlan, covered_day_starts: list[int]
+) -> list[tuple[int, int]]:
+    """Inclusive ms ranges still requiring the raw path: partial edges plus uncovered full days."""
+    covered = set(covered_day_starts)
+    uncovered_days = [ms for ms in plan.covered_day_starts_ms if ms not in covered]
+    return plan.raw_ranges + _coalesce_day_starts_to_ranges(uncovered_days)
+
+
+def serve_rollup_read(
+    session: Session, plan: RollupReadPlan
+) -> tuple[list[MetricDataPoint], list[tuple[int, int]]] | None:
+    """Serve the rollup-eligible portion of a query.
+
+    Returns ``(rollup_data_points, raw_ranges)`` where ``raw_ranges`` are the inclusive ms ranges
+    the caller must still query raw and concatenate, or ``None`` to signal a full raw fallback
+    (nothing is servable from rollups). Non-bucketed single-range aggregates currently fall back to
+    raw; only daily time-series buckets are accelerated.
+
+    Days whose rollup row is missing a requested aggregation are demoted back into ``raw_ranges``,
+    so a served response always matches the raw one.
+    """
+    if not plan.bucketed:
+        return None
+    covered = compute_covered_day_starts(session, plan)
+    if not covered:
+        return None
+    data_points, served_day_starts = read_rollup_data_points(session, plan, covered)
+    if not served_day_starts:
+        return None
+    return data_points, remaining_raw_ranges(plan, served_day_starts)
+
+
+def _data_point_ordering(point: MetricDataPoint) -> tuple[str, tuple[str, ...]]:
+    dims = point.dimensions
+    time_bucket = dims.get(TIME_BUCKET_LABEL) or ""
+    grouping = tuple(v or "" for k, v in dims.items() if k != TIME_BUCKET_LABEL)
+    return (time_bucket, grouping)
+
+
+def order_and_limit_data_points(
+    data_points: list[MetricDataPoint], max_results: int
+) -> list[MetricDataPoint]:
+    """Order merged rollup and raw data points, then cap to ``max_results``.
+
+    Reproduces the single-query raw path's ``ORDER BY <time_bucket>, <dimensions>`` then
+    ``LIMIT max_results`` so a rollup-served response is row-for-row identical to the
+    rollups-disabled response.
+    """
+    return sorted(data_points, key=_data_point_ordering)[:max_results]

--- a/mlflow/store/tracking/utils/sql_trace_rollups.py
+++ b/mlflow/store/tracking/utils/sql_trace_rollups.py
@@ -14,12 +14,11 @@ tables lives in the separate rollup maintenance job.
 
 The reader trusts a full UTC day only when a matching rollup row exists for the metric and grouping
 set and no rebuild is queued for that day and family; it also demotes a covered day back to the raw
-path when the row is missing a column the request needs (a null aggregate value). Whole-day
-completeness of a grouping set is a maintenance-job guarantee, so the reader serves only the
-single-row ``global`` grouping set, whose one row per experiment-day is self-verifying. Multi-row
-grouping sets (for example per-status breakdowns) are served once the maintenance job that writes
-and invalidates them can guarantee that every group's row for a day is present before the day is
-treated as built.
+path when the row is missing a column the request needs (a null aggregate value). The single-row
+``global`` grouping set is self-verifying. Trace-status rows are served only when their distinct
+status counts add up to the corresponding global count, which proves the materialized breakdown is
+complete. Other multi-row grouping sets remain raw-only until they have an equivalent completeness
+proof.
 
 The rollup tables carry no ``workspace`` column (the shipped analytics schema scopes purely on
 ``experiment_id``, which is globally unique), so workspace isolation is preserved by the caller only
@@ -137,12 +136,10 @@ PERCENTILE_BACKENDS = frozenset({db_types.POSTGRES})
 # always exactly reproducible from daily rollups.
 SERVABLE_FAMILIES = frozenset({RollupFamily.TRACE_METRIC, RollupFamily.ASSESSMENT})
 
-# Grouping sets the reader may serve. Restricted to ``global`` because that grouping set has exactly
-# one row per experiment-day, so "a row exists and is not queued" already proves the day complete.
-# Multi-row grouping sets (status, model, provider) need the maintenance job to guarantee that every
-# group's row for a day is written before the day is treated as built; until that job lands, serving
-# them could under-report a day whose sibling rows are missing, so they stay on the raw path.
-SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL})
+# Trace-status rollups can be verified against their companion global count row: a day is served
+# only when the status rows' sample counts add up to that global count. Other multi-row grouping
+# sets have no equivalent completeness proof in the read schema and remain raw-only.
+SERVABLE_GROUPING_SETS = frozenset({GroupingSet.GLOBAL, GroupingSet.STATUS})
 
 
 def rollups_enabled() -> bool:
@@ -465,29 +462,72 @@ def read_rollup_data_points(
         model.rollup_day.in_(list(date_to_ms.keys())),
     )
 
+    rows_by_day: dict[date, list] = {}
+    for row in rows:
+        rows_by_day.setdefault(row.rollup_day, []).append(row)
+
+    global_rows_by_day: dict[date, list] = {}
+    if plan.grouping_set == GroupingSet.STATUS:
+        global_rows = session.query(model).filter(
+            model.experiment_id == plan.experiment_id,
+            model.metric_name == plan.metric_name,
+            model.grouping_set == GroupingSet.GLOBAL.value,
+            model.rollup_day.in_(list(date_to_ms.keys())),
+        )
+        for row in global_rows:
+            global_rows_by_day.setdefault(row.rollup_day, []).append(row)
+
     data_points = []
     served_day_starts: set[int] = set()
-    for row in rows:
-        group_dims = _rollup_row_dimensions(plan, row)
-        # Mirror the raw path, which drops rows whose grouping dimension is null.
-        if any(v is None for v in group_dims.values()):
+    for rollup_day, day_rows in rows_by_day.items():
+        # A global aggregate has exactly one row. Duplicate rows can occur while an external
+        # publisher is replacing a day's rollup, so treat them as incomplete rather than risking
+        # a duplicate data point.
+        if plan.grouping_set == GroupingSet.GLOBAL and len(day_rows) != 1:
             continue
 
-        values = {}
-        for agg in plan.aggregations:
-            value = _rollup_row_value(agg, row)
-            if value is None:
-                # A requested aggregation has no value for this day; demote the day to raw.
+        if plan.grouping_set == GroupingSet.STATUS:
+            global_rows = global_rows_by_day.get(rollup_day, [])
+            statuses = [row.trace_status for row in day_rows]
+            # The global row is the publication/completeness marker for a materialized status
+            # breakdown. It must be unique and equal to the sum of the distinct status rows.
+            if (
+                len(global_rows) != 1
+                or any(status is None for status in statuses)
+                or len(set(statuses)) != len(statuses)
+                or sum(row.sample_count for row in day_rows) != global_rows[0].sample_count
+            ):
+                continue
+
+        day_points = []
+        for row in day_rows:
+            group_dims = _rollup_row_dimensions(plan, row)
+            # Mirror the raw path, which drops rows whose grouping dimension is null.
+            if any(v is None for v in group_dims.values()):
                 break
-            values[str(agg)] = value
+
+            values = {}
+            for agg in plan.aggregations:
+                value = _rollup_row_value(agg, row)
+                if value is None:
+                    # A requested aggregation has no value for this day; demote the whole day to
+                    # raw so a grouped result cannot be only partially served.
+                    break
+                values[str(agg)] = value
+            else:
+                day_start_ms = date_to_ms[rollup_day]
+                dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
+                dimensions.update(group_dims)
+                day_points.append(
+                    MetricDataPoint(
+                        metric_name=plan.metric_name, dimensions=dimensions, values=values
+                    )
+                )
+                continue
+            break
         else:
-            day_start_ms = date_to_ms[row.rollup_day]
-            served_day_starts.add(day_start_ms)
-            dimensions = {TIME_BUCKET_LABEL: _day_start_ms_to_iso(day_start_ms)}
-            dimensions.update(group_dims)
-            data_points.append(
-                MetricDataPoint(metric_name=plan.metric_name, dimensions=dimensions, values=values)
-            )
+            served_day_starts.add(date_to_ms[rollup_day])
+            data_points.extend(day_points)
     return data_points, sorted(served_day_starts)
 
 

--- a/mlflow/tracing/trace_rollup_service.py
+++ b/mlflow/tracing/trace_rollup_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from mlflow.environment_variables import (
+    MLFLOW_SERVER_ENABLE_JOB_EXECUTION,
+    MLFLOW_SQL_TRACE_ROLLUPS_ENABLED,
+    MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN,
+    MLFLOW_TRACE_ROLLUPS_SCHEDULE,
+)
+from mlflow.exceptions import MlflowException
+from mlflow.store.db.trace_rollups import RollupBuildStats, run_sql_trace_rollups
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SqlTraceRollupSchedule:
+    minute: str
+    hour: str
+    day: str
+    month: str
+    day_of_week: str
+
+
+def get_sql_trace_rollup_schedule() -> SqlTraceRollupSchedule:
+    """Resolve the configured five-field UTC cron expression."""
+    schedule = MLFLOW_TRACE_ROLLUPS_SCHEDULE.get().strip()
+    fields = schedule.split()
+    if len(fields) != 5:
+        raise MlflowException.invalid_parameter_value(
+            f"{MLFLOW_TRACE_ROLLUPS_SCHEDULE.name} must be a five-field UTC cron expression, "
+            f"got {schedule!r}."
+        )
+    return SqlTraceRollupSchedule(*fields)
+
+
+def run_sql_trace_rollup_scheduler() -> RollupBuildStats | None:
+    """Run one server-owned rollup maintenance pass when scheduler prerequisites are enabled."""
+    if not MLFLOW_SERVER_ENABLE_JOB_EXECUTION.get() or not MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.get():
+        return None
+
+    from mlflow.server.handlers import _get_tracking_store
+
+    tracking_store = _get_tracking_store()
+    engine = getattr(tracking_store, "engine", None)
+    if engine is None:
+        _logger.info("SQL trace rollup scheduler skipped because the tracking store is not SQL.")
+        return None
+
+    stats = run_sql_trace_rollups(
+        engine,
+        max_partitions_per_run=MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN.get(),
+    )
+    _logger.info(
+        "SQL trace rollup maintenance completed: trace_metric=%s, assessment=%s",
+        stats.trace_metric,
+        stats.assessment,
+    )
+    return stats

--- a/tests/server/jobs/test_trace_rollup_jobs.py
+++ b/tests/server/jobs/test_trace_rollup_jobs.py
@@ -1,0 +1,142 @@
+from unittest.mock import Mock
+
+import pytest
+
+from mlflow.environment_variables import (
+    MLFLOW_SERVER_ENABLE_JOB_EXECUTION,
+    MLFLOW_SQL_TRACE_ROLLUPS_ENABLED,
+    MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN,
+    MLFLOW_TRACE_ROLLUPS_SCHEDULE,
+)
+from mlflow.exceptions import MlflowException
+from mlflow.server.jobs.utils import register_periodic_tasks
+from mlflow.store.db.trace_rollups import RollupBuildStats, RollupFamilyBuildStats
+from mlflow.tracing import trace_rollup_service
+from mlflow.tracing.trace_rollup_service import (
+    get_sql_trace_rollup_schedule,
+    run_sql_trace_rollup_scheduler,
+)
+
+
+class _RecordingHuey:
+    def __init__(self):
+        self.tasks = {}
+        self.locks = {}
+
+    def periodic_task(self, validation):
+        def decorator(fn):
+            self.tasks[fn.__name__] = (validation, fn)
+            return fn
+
+        return decorator
+
+    def lock_task(self, lock_name):
+        def decorator(fn):
+            self.locks[fn.__name__] = lock_name
+            return fn
+
+        return decorator
+
+
+def _stats():
+    return RollupBuildStats(
+        trace_metric=RollupFamilyBuildStats(built=1),
+        assessment=RollupFamilyBuildStats(emptied=1),
+    )
+
+
+def test_rollup_schedule_defaults_to_daily_0200_utc(monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACE_ROLLUPS_SCHEDULE.name, raising=False)
+
+    schedule = get_sql_trace_rollup_schedule()
+
+    assert (schedule.minute, schedule.hour, schedule.day, schedule.month, schedule.day_of_week) == (
+        "0",
+        "2",
+        "*",
+        "*",
+        "*",
+    )
+
+
+def test_rollup_schedule_accepts_five_field_cron(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACE_ROLLUPS_SCHEDULE.name, "15 */6 * * 1-5")
+
+    schedule = get_sql_trace_rollup_schedule()
+
+    assert schedule.minute == "15"
+    assert schedule.hour == "*/6"
+    assert schedule.day_of_week == "1-5"
+
+
+def test_rollup_schedule_rejects_wrong_field_count(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACE_ROLLUPS_SCHEDULE.name, "0 2 * *")
+
+    with pytest.raises(MlflowException, match="five-field UTC cron expression"):
+        get_sql_trace_rollup_schedule()
+
+
+def test_register_periodic_tasks_includes_locked_rollup_scheduler(monkeypatch):
+    monkeypatch.delenv(MLFLOW_TRACE_ROLLUPS_SCHEDULE.name, raising=False)
+    huey = _RecordingHuey()
+
+    register_periodic_tasks(huey)
+
+    assert "sql_trace_rollup_scheduler" in huey.tasks
+    assert huey.locks["sql_trace_rollup_scheduler"] == "sql-trace-rollup-scheduler-lock"
+
+
+def test_invalid_schedule_skips_only_rollup_registration(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACE_ROLLUPS_SCHEDULE.name, "invalid")
+    huey = _RecordingHuey()
+
+    register_periodic_tasks(huey)
+
+    assert "online_scoring_scheduler" in huey.tasks
+    assert "trace_archival_scheduler" in huey.tasks
+    assert "sql_trace_rollup_scheduler" not in huey.tasks
+
+
+@pytest.mark.parametrize(
+    ("job_execution", "rollups_enabled"),
+    [(False, False), (False, True), (True, False)],
+)
+def test_scheduler_noops_when_prerequisites_disabled(
+    monkeypatch, job_execution: bool, rollups_enabled: bool
+):
+    monkeypatch.setenv(
+        MLFLOW_SERVER_ENABLE_JOB_EXECUTION.name, "true" if job_execution else "false"
+    )
+    monkeypatch.setenv(
+        MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "true" if rollups_enabled else "false"
+    )
+    maintenance = Mock()
+    monkeypatch.setattr(trace_rollup_service, "run_sql_trace_rollups", maintenance)
+
+    assert run_sql_trace_rollup_scheduler() is None
+    maintenance.assert_not_called()
+
+
+def test_scheduler_noops_for_non_sql_tracking_store(monkeypatch):
+    monkeypatch.setenv(MLFLOW_SERVER_ENABLE_JOB_EXECUTION.name, "true")
+    monkeypatch.setenv(MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "true")
+    monkeypatch.setattr("mlflow.server.handlers._get_tracking_store", lambda: object())
+    maintenance = Mock()
+    monkeypatch.setattr(trace_rollup_service, "run_sql_trace_rollups", maintenance)
+
+    assert run_sql_trace_rollup_scheduler() is None
+    maintenance.assert_not_called()
+
+
+def test_scheduler_delegates_to_shared_maintenance_path(monkeypatch):
+    monkeypatch.setenv(MLFLOW_SERVER_ENABLE_JOB_EXECUTION.name, "true")
+    monkeypatch.setenv(MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "true")
+    monkeypatch.setenv(MLFLOW_TRACE_ROLLUPS_MAX_PARTITIONS_PER_RUN.name, "7")
+    engine = object()
+    monkeypatch.setattr("mlflow.server.handlers._get_tracking_store", lambda: Mock(engine=engine))
+    expected = _stats()
+    maintenance = Mock(return_value=expected)
+    monkeypatch.setattr(trace_rollup_service, "run_sql_trace_rollups", maintenance)
+
+    assert run_sql_trace_rollup_scheduler() == expected
+    maintenance.assert_called_once_with(engine, max_partitions_per_run=7)

--- a/tests/store/db/test_trace_rollups.py
+++ b/tests/store/db/test_trace_rollups.py
@@ -22,6 +22,7 @@ from mlflow.store.db.trace_rollups import (
 )
 from mlflow.store.tracking.dbmodels.models import (
     SqlAssessmentDailyRollup,
+    SqlAssessments,
     SqlSpan,
     SqlSpanCostDailyRollup,
     SqlTraceInfo,
@@ -30,7 +31,12 @@ from mlflow.store.tracking.dbmodels.models import (
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.tracking.utils.sql_trace_rollups import RollupFamily, enqueue_rollup_rebuilds
-from mlflow.tracing.constant import AssessmentMetricKey, TraceMetricKey, TraceTagKey
+from mlflow.tracing.constant import (
+    AssessmentMetadataKey,
+    AssessmentMetricKey,
+    TraceMetricKey,
+    TraceTagKey,
+)
 
 from tests.store.tracking.sqlalchemy_store.conftest import create_test_span
 
@@ -357,6 +363,65 @@ def test_assessment_mutations_enqueue_rebuild(store: SqlAlchemyStore, mutation: 
         store.delete_assessment(trace_id, assessment.assessment_id)
 
     assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.ASSESSMENT.value) == 1
+
+
+def test_run_deletion_enqueues_assessment_rebuild(store: SqlAlchemyStore):
+    # Deleting a run hard-deletes its source-run assessments via _mark_run_deleted, which must
+    # invalidate the assessment partitions those rows fell in so their rollups are rebuilt.
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    run = store.create_run(
+        experiment_id=exp_id,
+        user_id="tester",
+        start_time=DAY_A_MS,
+        tags=[],
+        run_name="eval-run",
+    )
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    store.create_assessment(
+        Feedback(
+            trace_id=trace_id,
+            name="quality",
+            value=0.3,
+            source=SOURCE,
+            metadata={AssessmentMetadataKey.SOURCE_RUN_ID: run.info.run_id},
+        )
+    )
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    assert _count(store, SqlTraceRollupRebuild) == 0
+
+    store.delete_run(run.info.run_id)
+
+    # Only the assessment family is invalidated: run deletion does not remove the trace rows.
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 0
+    with store.ManagedSessionMaker() as session:
+        queued = {
+            (row.experiment_id, row.rollup_day, row.rollup_family)
+            for row in session.query(SqlTraceRollupRebuild)
+        }
+    assert queued == {(int(exp_id), _day_of(DAY_A_MS), RollupFamily.ASSESSMENT.value)}
+
+
+def test_null_denormalized_assessment_does_not_abort_run(store: SqlAlchemyStore):
+    # The denormalized assessment columns are nullable (online prepopulation adds them before
+    # backfill; orphaned assessments never get backfilled). A valid row with NULL columns must be
+    # skipped by the day scan, not raise int(None) and abort maintenance for every experiment.
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    assessment = _add_feedback(store, trace_id, value=0.5)
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.query(SqlAssessments).filter(
+            SqlAssessments.assessment_id == assessment.assessment_id
+        ).update(
+            {"experiment_id": None, "trace_timestamp_ms": None},
+            synchronize_session=False,
+        )
+
+    stats = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    # The trace-metric partition still builds; the NULL assessment contributes to no rollup.
+    assert stats.trace_metric.built == 1
+    assert stats.assessment.built == 0
+    assert _count(store, SqlAssessmentDailyRollup) == 0
 
 
 def test_max_partitions_cap_limits_builds_across_runs(store: SqlAlchemyStore):

--- a/tests/store/db/test_trace_rollups.py
+++ b/tests/store/db/test_trace_rollups.py
@@ -1,0 +1,552 @@
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import sqlalchemy as sa
+from click.testing import CliRunner
+
+import mlflow.db
+import mlflow.store.db.utils
+from mlflow.entities import AssessmentSource, AssessmentSourceType, Feedback, trace_location
+from mlflow.entities.assessment import FeedbackValue
+from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_status import TraceStatus
+from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
+from mlflow.store.db import trace_rollups
+from mlflow.store.db.trace_rollups import (
+    ROLLUP_ELIGIBILITY_LAG_MS,
+    RollupBuildStats,
+    run_sql_trace_rollups,
+)
+from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
+    SqlSpan,
+    SqlSpanCostDailyRollup,
+    SqlTraceInfo,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
+)
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.store.tracking.utils.sql_trace_rollups import RollupFamily, enqueue_rollup_rebuilds
+from mlflow.tracing.constant import AssessmentMetricKey, TraceMetricKey, TraceTagKey
+
+from tests.store.tracking.sqlalchemy_store.conftest import create_test_span
+
+pytestmark = pytest.mark.notrackingurimock
+
+MS_PER_DAY = 86_400_000
+# A fixed instant on an arbitrary past UTC day, safely more than 24 hours before FUTURE_NOW_MS.
+DAY_A_MS = 20_000 * MS_PER_DAY + 5_000
+DAY_B_MS = DAY_A_MS + MS_PER_DAY
+# Far enough in the future that every seeded day clears the 24-hour inactivity lag.
+FUTURE_NOW_MS = 30_000 * MS_PER_DAY
+
+SOURCE = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="tester")
+
+
+@pytest.fixture
+def store(tmp_path: Path, db_uri: str) -> SqlAlchemyStore:
+    artifact_uri = tmp_path / "artifacts"
+    artifact_uri.mkdir()
+    return SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+
+
+def _day_of(timestamp_ms: int):
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).date()
+
+
+def _new_trace(store, exp_id, timestamp_ms, duration_ms=100, state=TraceStatus.OK):
+    trace_id = f"tr-{uuid.uuid4()}"
+    store.start_trace(
+        TraceInfo(
+            trace_id=trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=duration_ms,
+            state=state,
+            tags={TraceTagKey.TRACE_NAME: "rollup-test"},
+        )
+    )
+    return trace_id
+
+
+def _add_feedback(store, trace_id, value=0.5, name="quality"):
+    return store.create_assessment(
+        Feedback(trace_id=trace_id, name=name, value=value, source=SOURCE)
+    )
+
+
+def _count(store, model, **filters):
+    with store.ManagedSessionMaker() as session:
+        query = session.query(model)
+        if filters:
+            query = query.filter_by(**filters)
+        return query.count()
+
+
+def _enqueue_entry(store, family, experiment_id, timestamp_ms):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        enqueue_rollup_rebuilds(session, family, int(experiment_id), [timestamp_ms])
+
+
+def test_build_populates_trace_metric_and_assessment_rollups(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS, duration_ms=100)
+    _new_trace(store, exp_id, DAY_A_MS + 1000, duration_ms=300, state=TraceStatus.ERROR)
+    _add_feedback(store, trace_id, value=0.8)
+
+    stats = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    assert isinstance(stats, RollupBuildStats)
+    assert stats.trace_metric.built == 1
+    assert stats.assessment.built == 1
+    assert stats.trace_metric.deferred == 0
+    assert _count(store, SqlTraceMetricDailyRollup) > 0
+    assert _count(store, SqlAssessmentDailyRollup) > 0
+
+    with store.ManagedSessionMaker() as session:
+        # trace_count global sample_count equals the number of traces that day.
+        trace_count = (
+            session
+            .query(SqlTraceMetricDailyRollup)
+            .filter_by(
+                experiment_id=int(exp_id),
+                metric_name=TraceMetricKey.TRACE_COUNT,
+                grouping_set="global",
+            )
+            .one()
+        )
+        assert trace_count.sample_count == 2
+        # assessment_count global sample_count equals the number of assessments that day.
+        assessment_count = (
+            session
+            .query(SqlAssessmentDailyRollup)
+            .filter_by(
+                experiment_id=int(exp_id),
+                metric_name=AssessmentMetricKey.ASSESSMENT_COUNT,
+                grouping_set="global",
+            )
+            .one()
+        )
+        assert assessment_count.sample_count == 1
+
+
+def test_build_is_idempotent(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    first = _count(store, SqlTraceMetricDailyRollup)
+
+    second_stats = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    # Nothing new is eligible and the queue is empty, so the rerun is a no-op.
+    assert second_stats.trace_metric.built == 0
+    assert second_stats.assessment.built == 0
+    assert _count(store, SqlTraceMetricDailyRollup) == first
+
+
+def test_span_cost_rollups_are_never_built(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    assert _count(store, SqlSpanCostDailyRollup) == 0
+
+
+def test_recent_day_is_not_eligible(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+
+    # now is only 1 second after the trace, well inside the 24-hour inactivity lag.
+    stats = run_sql_trace_rollups(store.engine, now_ms=DAY_A_MS + 1000)
+
+    assert stats.trace_metric.built == 0
+    assert stats.assessment.built == 0
+    assert _count(store, SqlTraceMetricDailyRollup) == 0
+
+
+def test_empty_current_day_remains_queued(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    current_day_ms = FUTURE_NOW_MS
+    _enqueue_entry(store, RollupFamily.TRACE_METRIC, exp_id, current_day_ms)
+
+    stats = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS + 1000)
+
+    assert stats.trace_metric.deferred == 1
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 1
+
+
+def test_day_becomes_eligible_exactly_after_lag(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+
+    # One millisecond before the lag elapses: still ineligible.
+    before = run_sql_trace_rollups(store.engine, now_ms=DAY_A_MS + ROLLUP_ELIGIBILITY_LAG_MS - 1)
+    assert before.trace_metric.built == 0
+
+    # Exactly at the lag boundary: eligible.
+    at = run_sql_trace_rollups(store.engine, now_ms=DAY_A_MS + ROLLUP_ELIGIBILITY_LAG_MS)
+    assert at.trace_metric.built == 1
+
+
+def test_open_span_defers_queued_partition(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    # An unfinished span (no end time) keeps the trace active, so its day must never be built.
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlSpan(
+                trace_id=trace_id,
+                experiment_id=int(exp_id),
+                span_id="span-open",
+                status="UNSET",
+                start_time_unix_nano=DAY_A_MS * 1_000_000,
+                end_time_unix_nano=None,
+                content="{}",
+            )
+        )
+        session.commit()
+    _enqueue_entry(store, RollupFamily.TRACE_METRIC, exp_id, DAY_A_MS)
+
+    stats = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    assert stats.trace_metric.deferred == 1
+    assert stats.trace_metric.built == 0
+    # The queue entry survives so a later run retries once the span closes.
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 1
+    assert _count(store, SqlTraceMetricDailyRollup) == 0
+
+
+def test_emptied_partition_removes_rollups_and_queue_entry(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    assert _count(store, SqlTraceMetricDailyRollup) > 0
+
+    # Delete the source rows out from under the rollups, then enqueue the day.
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.query(SqlTraceInfo).filter_by(request_id=trace_id).delete()
+        session.commit()
+    _enqueue_entry(store, RollupFamily.TRACE_METRIC, exp_id, DAY_A_MS)
+
+    stats = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    assert stats.trace_metric.emptied == 1
+    assert _count(store, SqlTraceMetricDailyRollup) == 0
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 0
+
+
+def test_queue_entry_is_drained_on_rebuild(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+    _enqueue_entry(store, RollupFamily.TRACE_METRIC, exp_id, DAY_A_MS)
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 1
+
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    assert _count(store, SqlTraceRollupRebuild) == 0
+    assert _count(store, SqlTraceMetricDailyRollup) > 0
+
+
+def test_failed_rebuild_keeps_previous_rollup_and_queue_entry(
+    store: SqlAlchemyStore, monkeypatch: pytest.MonkeyPatch
+):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    previous_rollup_count = _count(store, SqlTraceMetricDailyRollup)
+
+    _new_trace(store, exp_id, DAY_A_MS + 1000)
+    monkeypatch.setattr(
+        trace_rollups,
+        "_aggregate",
+        Mock(side_effect=RuntimeError("aggregation failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="aggregation failed"):
+        run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    assert _count(store, SqlTraceMetricDailyRollup) == previous_rollup_count
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 1
+
+
+def test_source_writes_enqueue_while_reads_are_disabled(
+    store: SqlAlchemyStore, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "false")
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+
+    _new_trace(store, exp_id, DAY_A_MS)
+
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 1
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.ASSESSMENT.value) == 1
+
+
+def test_late_span_write_enqueues_trace_partition(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    assert _count(store, SqlTraceRollupRebuild) == 0
+
+    store.log_spans(
+        exp_id,
+        [
+            create_test_span(
+                trace_id=trace_id,
+                start_ns=DAY_A_MS * 1_000_000,
+                end_ns=(DAY_A_MS + 50) * 1_000_000,
+            )
+        ],
+    )
+
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.TRACE_METRIC.value) == 1
+
+
+def test_trace_move_enqueues_old_and_new_partitions(store: SqlAlchemyStore):
+    old_exp_id = store.create_experiment(f"old-{uuid.uuid4()}")
+    new_exp_id = store.create_experiment(f"new-{uuid.uuid4()}")
+    trace_id = _new_trace(store, old_exp_id, DAY_A_MS)
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    assert _count(store, SqlTraceRollupRebuild) == 0
+
+    store.start_trace(
+        TraceInfo(
+            trace_id=trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(new_exp_id),
+            request_time=DAY_B_MS,
+            execution_duration=250,
+            state=TraceStatus.OK,
+            tags={TraceTagKey.TRACE_NAME: "moved-trace"},
+        )
+    )
+
+    with store.ManagedSessionMaker() as session:
+        queued = {
+            (row.experiment_id, row.rollup_day, row.rollup_family)
+            for row in session.query(SqlTraceRollupRebuild)
+        }
+    assert queued == {
+        (int(old_exp_id), _day_of(DAY_A_MS), RollupFamily.TRACE_METRIC.value),
+        (int(old_exp_id), _day_of(DAY_A_MS), RollupFamily.ASSESSMENT.value),
+        (int(new_exp_id), _day_of(DAY_B_MS), RollupFamily.TRACE_METRIC.value),
+        (int(new_exp_id), _day_of(DAY_B_MS), RollupFamily.ASSESSMENT.value),
+    }
+
+
+@pytest.mark.parametrize("mutation", ["create", "update", "delete"])
+def test_assessment_mutations_enqueue_rebuild(store: SqlAlchemyStore, mutation: str):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    assessment = _add_feedback(store, trace_id, value=0.2)
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+    assert _count(store, SqlTraceRollupRebuild) == 0
+
+    if mutation == "create":
+        _add_feedback(store, trace_id, value=0.8, name="late")
+    elif mutation == "update":
+        store.update_assessment(
+            trace_id=trace_id,
+            assessment_id=assessment.assessment_id,
+            feedback=FeedbackValue(value=0.8),
+        )
+    else:
+        store.delete_assessment(trace_id, assessment.assessment_id)
+
+    assert _count(store, SqlTraceRollupRebuild, rollup_family=RollupFamily.ASSESSMENT.value) == 1
+
+
+def test_max_partitions_cap_limits_builds_across_runs(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+    _new_trace(store, exp_id, DAY_B_MS)
+
+    first = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS, max_partitions_per_run=1)
+    assert first.trace_metric.built == 1
+    assert first.trace_metric.skipped_cap >= 1
+
+    second = run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS, max_partitions_per_run=1)
+    assert second.trace_metric.built == 1
+
+    with store.ManagedSessionMaker() as session:
+        built_days = (
+            session
+            .query(SqlTraceMetricDailyRollup.rollup_day)
+            .filter_by(metric_name=TraceMetricKey.TRACE_COUNT, grouping_set="global")
+            .distinct()
+            .count()
+        )
+    assert built_days == 2
+
+
+def test_queued_rebuild_precedes_new_partition_across_families(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_id = _new_trace(store, exp_id, DAY_A_MS)
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    # This creates a queued assessment rebuild for day A.
+    _add_feedback(store, trace_id, value=0.7)
+    # Simulate raw data that predates queue invalidation support: day B is eligible but unbuilt and
+    # has no queue entry.
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlTraceInfo(
+                request_id=f"tr-{uuid.uuid4()}",
+                experiment_id=int(exp_id),
+                timestamp_ms=DAY_B_MS,
+                execution_time_ms=100,
+                status=TraceStatus.OK.value,
+            )
+        )
+
+    stats = run_sql_trace_rollups(
+        store.engine,
+        now_ms=FUTURE_NOW_MS,
+        max_partitions_per_run=1,
+    )
+
+    assert stats.assessment.built == 1
+    assert stats.trace_metric.built == 0
+    with store.ManagedSessionMaker() as session:
+        assert (
+            session
+            .query(SqlTraceMetricDailyRollup)
+            .filter_by(experiment_id=int(exp_id), rollup_day=_day_of(DAY_B_MS))
+            .count()
+            == 0
+        )
+
+
+def test_percentile_columns_are_null_on_sqlite(store: SqlAlchemyStore):
+    # Percentiles are Postgres-only (PERCENTILE_BACKENDS); on sqlite they must stay null.
+    if store.engine.dialect.name != "sqlite":
+        pytest.skip("sqlite-specific assertion")
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS, duration_ms=250)
+
+    run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS)
+
+    with store.ManagedSessionMaker() as session:
+        latency = (
+            session
+            .query(SqlTraceMetricDailyRollup)
+            .filter_by(metric_name=TraceMetricKey.LATENCY, grouping_set="global")
+            .one()
+        )
+        percentiles = (latency.p50_value, latency.p90_value, latency.p99_value)
+    assert percentiles == (None, None, None)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"progress_every": 0}, "progress_every must be positive"),
+        ({"max_partitions_per_run": 0}, "max_partitions_per_run must be positive"),
+    ],
+)
+def test_run_sql_trace_rollups_validates_arguments(
+    store: SqlAlchemyStore, kwargs: dict[str, int], message: str
+):
+    with pytest.raises(ValueError, match=message):
+        run_sql_trace_rollups(store.engine, now_ms=FUTURE_NOW_MS, **kwargs)
+
+
+def test_build_trace_rollups_cli(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _new_trace(store, exp_id, DAY_A_MS)
+    _add_feedback(store, _new_trace(store, exp_id, DAY_A_MS + 1000), value=0.9)
+
+    result = CliRunner().invoke(
+        mlflow.db.commands,
+        ["build-trace-rollups"],
+        env={
+            "MLFLOW_TRACKING_URI": store.engine.url.render_as_string(hide_password=False),
+            "MLFLOW_SQL_TRACE_ROLLUPS_ENABLED": "true",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Building SQL daily trace analytics rollups..." in result.output
+    assert "trace_metric: built=" in result.output
+    assert "assessment: built=" in result.output
+    assert "Rollup build completed." in result.output
+
+
+def test_build_trace_rollups_cli_noops_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    create_engine = Mock()
+    monkeypatch.setattr(mlflow.store.db.utils, "create_sqlalchemy_engine_with_retry", create_engine)
+
+    result = CliRunner().invoke(
+        mlflow.db.commands,
+        ["build-trace-rollups", "sqlite:///unused.db"],
+        env={"MLFLOW_SQL_TRACE_ROLLUPS_ENABLED": "false"},
+    )
+
+    assert result.exit_code == 0
+    assert "SQL trace rollups are disabled; no maintenance performed." in result.output
+    create_engine.assert_not_called()
+
+
+def test_build_trace_rollups_cli_reports_errors_and_disposes_engine(monkeypatch):
+    engine = Mock()
+    monkeypatch.setattr(
+        mlflow.store.db.utils,
+        "create_sqlalchemy_engine_with_retry",
+        lambda _: engine,
+    )
+    monkeypatch.setattr(
+        trace_rollups,
+        "run_sql_trace_rollups",
+        Mock(side_effect=RuntimeError("rollup build failed")),
+    )
+
+    result = CliRunner().invoke(
+        mlflow.db.commands,
+        ["build-trace-rollups", "sqlite:///unused.db"],
+        env={"MLFLOW_SQL_TRACE_ROLLUPS_ENABLED": "true"},
+    )
+
+    assert result.exit_code == 1
+    assert "Error: rollup build failed" in result.output
+    engine.dispose.assert_called_once_with()
+
+
+def test_build_trace_rollups_cli_does_not_expose_database_credentials(monkeypatch):
+    database_url = "postgresql://trace_user:super-secret@database.example/mlflow"
+    monkeypatch.setattr(
+        mlflow.store.db.utils,
+        "create_sqlalchemy_engine_with_retry",
+        Mock(
+            side_effect=sa.exc.OperationalError(
+                f"connect to {database_url}",
+                {},
+                RuntimeError(database_url),
+            )
+        ),
+    )
+
+    result = CliRunner().invoke(
+        mlflow.db.commands,
+        ["build-trace-rollups"],
+        env={
+            "MLFLOW_TRACKING_URI": database_url,
+            "MLFLOW_SQL_TRACE_ROLLUPS_ENABLED": "true",
+        },
+    )
+
+    assert result.exit_code == 1
+    assert "Database operation failed (OperationalError)" in result.output
+    assert "super-secret" not in result.output
+
+
+@pytest.mark.parametrize("max_partitions", ["0", "-1"])
+def test_build_trace_rollups_cli_rejects_nonpositive_max_partitions(max_partitions: str):
+    result = CliRunner().invoke(
+        mlflow.db.commands,
+        ["build-trace-rollups", "sqlite:///unused.db", "--max-partitions", max_partitions],
+    )
+    assert result.exit_code == 2
+    assert "Invalid value for '--max-partitions'" in result.output

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -232,11 +232,9 @@ def test_covered_bucketed_day_is_served_from_rollup(store: SqlAlchemyStore, monk
     assert served == [(raw[0][0], (("COUNT", float(SENTINEL_COUNT)),))]
 
 
-def test_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+def test_incomplete_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
     exp_id = _seed(store)
-    # Per-status breakdowns are not served from rollups yet: whole-day completeness of a multi-row
-    # grouping set is a maintenance-job guarantee, so a status request stays on the raw path and the
-    # seeded sentinel rows are ignored.
+    # A status breakdown without its global publication row is incomplete and must stay raw.
     for status in ("OK", "ERROR"):
         _insert_trace_metric_rollup(
             store,
@@ -255,6 +253,60 @@ def test_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
         TraceMetricKey.TRACE_COUNT,
         _COUNT,
         [TraceMetricDimensionKey.TRACE_STATUS],
+    )
+
+
+def test_complete_status_grouping_is_served_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT * 2,
+    )
+    for status in ("OK", "ERROR"):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.STATUS.value,
+            sample_count=SENTINEL_COUNT,
+            trace_status=status,
+        )
+
+    _set_enabled(monkeypatch, True)
+    served = _query(
+        store,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        [TraceMetricDimensionKey.TRACE_STATUS],
+    )
+
+    counts_by_status = {
+        dict(dimensions)[TraceMetricDimensionKey.TRACE_STATUS]: dict(values)["COUNT"]
+        for dimensions, values in served
+    }
+    assert counts_by_status == {"OK": float(SENTINEL_COUNT), "ERROR": float(SENTINEL_COUNT)}
+
+
+def test_duplicate_global_rollup_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    for _ in range(2):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.GLOBAL.value,
+            sample_count=SENTINEL_COUNT,
+        )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
     )
 
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -1,0 +1,616 @@
+# Read-path routing tests for opt-in SQL daily trace analytics rollups.
+#
+# Rollup rows are seeded directly through the ORM (the rollup build job lives elsewhere), so these
+# tests cover only what the query planner owns: routing an eligible request to the rollup tables and
+# falling back to the raw path for every ineligible case. Seeding by hand also lets a test store a
+# deliberately wrong ("sentinel") value: a query that falls back returns the raw result and ignores
+# the sentinel, while a served query returns the sentinel, pinning down exactly when rollups are
+# consulted.
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from mlflow.entities import AssessmentSource, AssessmentSourceType, Feedback, trace_location
+from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_metrics import AggregationType, MetricAggregation, MetricViewType
+from mlflow.entities.trace_state import TraceState
+from mlflow.environment_variables import MLFLOW_SQL_TRACE_ROLLUPS_ENABLED
+from mlflow.store.tracking.dbmodels.models import (
+    SqlAssessmentDailyRollup,
+    SqlTraceMetricDailyRollup,
+    SqlTraceRollupRebuild,
+)
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.store.tracking.utils.sql_trace_rollups import (
+    DAILY_INTERVAL_SECONDS,
+    GroupingSet,
+    RollupFamily,
+)
+from mlflow.tracing.constant import (
+    AssessmentMetricKey,
+    TraceMetricDimensionKey,
+    TraceMetricKey,
+    TraceTagKey,
+)
+
+pytestmark = pytest.mark.notrackingurimock
+
+MS_PER_DAY = 86_400_000
+# Two full UTC days, aligned to midnight so a whole-day request is exactly rollup-servable.
+DAY_A_START = 20_000 * MS_PER_DAY
+DAY_B_START = DAY_A_START + MS_PER_DAY
+DAY_A_RANGE = (DAY_A_START, DAY_A_START + MS_PER_DAY - 1)
+
+# A value no raw aggregate in these tests can produce, so it reveals whether a rollup was consulted.
+SENTINEL_COUNT = 987_654
+
+SOURCE = AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="tester")
+
+_COUNT = [MetricAggregation(aggregation_type=AggregationType.COUNT)]
+_AVG = [MetricAggregation(aggregation_type=AggregationType.AVG)]
+_P50 = [MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=50)]
+
+
+def _day_of(timestamp_ms: int):
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).date()
+
+
+def _new_trace(store, exp_id, timestamp_ms, duration_ms=100, state=TraceState.OK):
+    trace_id = f"tr-{uuid.uuid4()}"
+    store.start_trace(
+        TraceInfo(
+            trace_id=trace_id,
+            trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+            request_time=timestamp_ms,
+            execution_duration=duration_ms,
+            state=state,
+            tags={TraceTagKey.TRACE_NAME: "rollup-test"},
+        )
+    )
+    return trace_id
+
+
+def _add_feedback(store, trace_id, value=0.5, name="quality"):
+    return store.create_assessment(
+        Feedback(trace_id=trace_id, name=name, value=value, source=SOURCE)
+    )
+
+
+def _seed(store) -> str:
+    """Two OK/ERROR traces on day A, plus one trace and feedback on day B, in a new experiment."""
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    t1 = _new_trace(store, exp_id, DAY_A_START + 5_000, duration_ms=100, state=TraceState.OK)
+    _new_trace(store, exp_id, DAY_A_START + 6_000, duration_ms=300, state=TraceState.ERROR)
+    t3 = _new_trace(store, exp_id, DAY_B_START + 7_000, duration_ms=500, state=TraceState.OK)
+    _add_feedback(store, t1, value=0.4)
+    _add_feedback(store, t3, value=0.9)
+    return exp_id
+
+
+def _set_enabled(monkeypatch, enabled: bool):
+    monkeypatch.setenv(MLFLOW_SQL_TRACE_ROLLUPS_ENABLED.name, "true" if enabled else "false")
+
+
+def _insert_trace_metric_rollup(
+    store,
+    exp_id,
+    day_start_ms,
+    metric_name,
+    grouping_set,
+    *,
+    sample_count,
+    sum_value=None,
+    trace_status=None,
+    p50_value=None,
+):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlTraceMetricDailyRollup(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                metric_name=metric_name,
+                grouping_set=grouping_set,
+                trace_status=trace_status,
+                sample_count=sample_count,
+                sum_value=sum_value,
+                p50_value=p50_value,
+            )
+        )
+        session.commit()
+
+
+def _insert_assessment_rollup(
+    store, exp_id, day_start_ms, metric_name, grouping_set, *, sample_count, sum_value=None
+):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlAssessmentDailyRollup(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                metric_name=metric_name,
+                grouping_set=grouping_set,
+                sample_count=sample_count,
+                sum_value=sum_value,
+            )
+        )
+        session.commit()
+
+
+def _invalidate_day(store, family, exp_id, day_start_ms):
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.add(
+            SqlTraceRollupRebuild(
+                experiment_id=int(exp_id),
+                rollup_day=_day_of(day_start_ms),
+                rollup_family=family.value,
+            )
+        )
+        session.commit()
+
+
+def _normalize(points):
+    return sorted(
+        (
+            tuple(sorted((p.dimensions or {}).items())),
+            tuple(sorted((k, round(float(v), 6)) for k, v in p.values.items())),
+        )
+        for p in points
+    )
+
+
+def _query(
+    store,
+    exp_id,
+    view,
+    metric,
+    aggs,
+    dims,
+    *,
+    start=DAY_A_RANGE[0],
+    end=DAY_A_RANGE[1],
+    time_interval=DAILY_INTERVAL_SECONDS,
+    filters=None,
+    experiment_ids=None,
+):
+    return _normalize(
+        store.query_trace_metrics(
+            experiment_ids=experiment_ids or [exp_id],
+            view_type=view,
+            metric_name=metric,
+            aggregations=aggs,
+            dimensions=dims,
+            filters=filters,
+            time_interval_seconds=time_interval,
+            start_time_ms=start,
+            end_time_ms=end,
+        )
+    )
+
+
+def _raw_day_points(store, exp_id, view, metric, dims, day_start_ms):
+    """Raw single-day aggregate (no bucketing) used to seed correct rollup sample counts."""
+    return store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=view,
+        metric_name=metric,
+        aggregations=_COUNT,
+        dimensions=dims,
+        start_time_ms=day_start_ms,
+        end_time_ms=day_start_ms + MS_PER_DAY - 1,
+    )
+
+
+def _assert_enabled_equals_raw(
+    store, monkeypatch, exp_id, view, metric, aggs, dims, **query_kwargs
+):
+    _set_enabled(monkeypatch, False)
+    raw = _query(store, exp_id, view, metric, aggs, dims, **query_kwargs)
+    _set_enabled(monkeypatch, True)
+    fast = _query(store, exp_id, view, metric, aggs, dims, **query_kwargs)
+    assert raw == fast
+
+
+def test_covered_bucketed_day_is_served_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _set_enabled(monkeypatch, False)
+    raw = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None)
+    _set_enabled(monkeypatch, True)
+    served = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None)
+
+    # Same day bucket as raw, but the count comes from the rollup row rather than the raw scan.
+    assert [dims for dims, _ in served] == [dims for dims, _ in raw]
+    assert served == [(raw[0][0], (("COUNT", float(SENTINEL_COUNT)),))]
+
+
+def test_status_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # Per-status breakdowns are not served from rollups yet: whole-day completeness of a multi-row
+    # grouping set is a maintenance-job guarantee, so a status request stays on the raw path and the
+    # seeded sentinel rows are ignored.
+    for status in ("OK", "ERROR"):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.STATUS.value,
+            sample_count=SENTINEL_COUNT,
+            trace_status=status,
+        )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        [TraceMetricDimensionKey.TRACE_STATUS],
+    )
+
+
+def test_latency_avg_is_computed_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        sum_value=1000.0,
+    )
+    _set_enabled(monkeypatch, True)
+    served = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _AVG, None)
+
+    # AVG is derived from the stored sum and sample count: 1000 / 4.
+    assert served == [(served[0][0], (("AVG", 250.0),))]
+
+
+def test_assessment_value_avg_is_computed_from_rollup(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_assessment_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        AssessmentMetricKey.ASSESSMENT_VALUE,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        sum_value=2.0,
+    )
+    _set_enabled(monkeypatch, True)
+    served = _query(
+        store, exp_id, MetricViewType.ASSESSMENTS, AssessmentMetricKey.ASSESSMENT_VALUE, _AVG, None
+    )
+
+    # AVG is derived from the stored sum and sample count: 2.0 / 4.
+    assert served == [(served[0][0], (("AVG", 0.5),))]
+
+
+def test_latency_avg_falls_back_when_rollup_sum_is_null(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # A covered day whose AVG backing column is null must demote to the raw path, not divide by the
+    # sample count and raise.
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        sum_value=None,
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _AVG, None
+    )
+
+
+@pytest.mark.parametrize(
+    ("view", "metric"),
+    [
+        (MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT),
+        (MetricViewType.ASSESSMENTS, AssessmentMetricKey.ASSESSMENT_COUNT),
+    ],
+    ids=["trace_count global", "assessment_count global"],
+)
+def test_enabled_matches_raw_for_correct_count_rollups(
+    store: SqlAlchemyStore, monkeypatch, view, metric
+):
+    exp_id = _seed(store)
+    for day_start in (DAY_A_START, DAY_B_START):
+        for point in _raw_day_points(store, exp_id, view, metric, None, day_start):
+            sample_count = int(point.values["COUNT"])
+            if view == MetricViewType.ASSESSMENTS:
+                _insert_assessment_rollup(
+                    store,
+                    exp_id,
+                    day_start,
+                    metric,
+                    GroupingSet.GLOBAL.value,
+                    sample_count=sample_count,
+                )
+            else:
+                _insert_trace_metric_rollup(
+                    store,
+                    exp_id,
+                    day_start,
+                    metric,
+                    GroupingSet.GLOBAL.value,
+                    sample_count=sample_count,
+                )
+
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        view,
+        metric,
+        _COUNT,
+        None,
+        start=DAY_A_START,
+        end=DAY_B_START + MS_PER_DAY - 1,
+    )
+
+
+def test_partial_edges_query_raw_around_covered_day(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    # Whole day A is covered; day B is only partially in range, so its edge stays on the raw path.
+    end = DAY_B_START + 10_000
+    _set_enabled(monkeypatch, False)
+    raw = _query(
+        store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None, end=end
+    )
+    _set_enabled(monkeypatch, True)
+    merged = _query(
+        store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None, end=end
+    )
+
+    raw_by_bucket = {dims: dict(vals)["COUNT"] for dims, vals in raw}
+    merged_by_bucket = {dims: dict(vals)["COUNT"] for dims, vals in merged}
+    assert set(merged_by_bucket) == set(raw_by_bucket)
+    day_a_bucket = min(raw_by_bucket)
+    day_b_bucket = max(raw_by_bucket)
+    assert merged_by_bucket[day_a_bucket] == float(SENTINEL_COUNT)
+    assert merged_by_bucket[day_b_bucket] == raw_by_bucket[day_b_bucket]
+
+
+def test_merged_result_matches_raw_with_correct_rollup_values(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # Seed day A's real count, then request a range covering day A fully and only part of day B so a
+    # rollup-served day and a raw edge must merge into a result identical to the raw path.
+    for point in _raw_day_points(
+        store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, None, DAY_A_START
+    ):
+        _insert_trace_metric_rollup(
+            store,
+            exp_id,
+            DAY_A_START,
+            TraceMetricKey.TRACE_COUNT,
+            GroupingSet.GLOBAL.value,
+            sample_count=int(point.values["COUNT"]),
+        )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        end=DAY_B_START + 10_000,
+    )
+
+
+def test_disabled_ignores_rollups(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _set_enabled(monkeypatch, False)
+    result = _query(store, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None)
+
+    assert dict(result[0][1])["COUNT"] == 2.0
+
+
+def test_invalidated_day_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _invalidate_day(store, RollupFamily.TRACE_METRIC, exp_id, DAY_A_START)
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
+    )
+
+
+def test_uncovered_day_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    # A rollup exists for day B, but the request targets day A, which has none.
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_B_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
+    )
+
+
+def test_partial_day_only_range_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    # A range that never spans a full UTC day cannot use whole-day rollups.
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        start=DAY_A_START + 100,
+        end=DAY_A_START + MS_PER_DAY - 200,
+    )
+
+
+def test_non_daily_interval_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        time_interval=3_600,
+    )
+
+
+def test_filtered_request_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        filters=["trace.status = 'OK'"],
+    )
+
+
+def test_high_cardinality_grouping_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    # trace_name is not a materialized grouping set, so the request stays raw.
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        [TraceMetricDimensionKey.TRACE_NAME],
+    )
+
+
+def test_multi_experiment_request_falls_back_to_raw(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    other_exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store,
+        monkeypatch,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        experiment_ids=[exp_id, other_exp_id],
+    )
+
+
+def test_rollup_for_other_experiment_is_ignored(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    other_exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    # Rollup rows are keyed by experiment id, so another experiment's row must never satisfy this
+    # experiment's request. This is what keeps rollups workspace-isolated: the caller only ever
+    # routes accessible experiment ids into the planner.
+    _insert_trace_metric_rollup(
+        store,
+        other_exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=SENTINEL_COUNT,
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.TRACE_COUNT, _COUNT, None
+    )
+
+
+def test_percentiles_fall_back_to_raw_off_postgres(store: SqlAlchemyStore, monkeypatch):
+    if store.engine.dialect.name == "postgresql":
+        pytest.skip("percentiles are served from rollups on postgres")
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.LATENCY,
+        GroupingSet.GLOBAL.value,
+        sample_count=4,
+        p50_value=float(SENTINEL_COUNT),
+    )
+    _assert_enabled_equals_raw(
+        store, monkeypatch, exp_id, MetricViewType.TRACES, TraceMetricKey.LATENCY, _P50, None
+    )

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -86,6 +86,10 @@ def _seed(store) -> str:
     t3 = _new_trace(store, exp_id, DAY_B_START + 7_000, duration_ms=500, state=TraceState.OK)
     _add_feedback(store, t1, value=0.4)
     _add_feedback(store, t3, value=0.9)
+    # These read-routing tests seed rollup rows directly. Maintenance-owned invalidations created
+    # by the source writes are cleared so each test can explicitly control coverage and queue state.
+    with store.ManagedSessionMaker(read_only=False) as session:
+        session.query(SqlTraceRollupRebuild).delete()
     return exp_id
 
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_workspace_store.py
@@ -184,6 +184,30 @@ def test_trace_rollup_models_are_workspace_scoped(workspace_tracking_store, mode
                 assert [row.experiment_id for row in rows] == [experiment_ids[workspace]]
 
 
+def test_trace_rollup_invalidation_is_workspace_scoped(workspace_tracking_store):
+    experiment_ids = {}
+    for workspace in ("team-rollup-a", "team-rollup-b"):
+        with WorkspaceContext(workspace):
+            experiment_id = workspace_tracking_store.create_experiment(f"{workspace}-experiment")
+            experiment_ids[workspace] = int(experiment_id)
+            _create_trace(
+                workspace_tracking_store,
+                f"trace-{workspace}",
+                experiment_id,
+                request_time=1_700_000_000_000,
+            )
+
+    for workspace in ("team-rollup-a", "team-rollup-b"):
+        with WorkspaceContext(workspace):
+            with workspace_tracking_store.ManagedSessionMaker() as session:
+                entries = workspace_tracking_store._get_query(session, SqlTraceRollupRebuild).all()
+                assert {entry.experiment_id for entry in entries} == {experiment_ids[workspace]}
+                assert {entry.rollup_family for entry in entries} == {
+                    "trace_metric",
+                    "assessment",
+                }
+
+
 def test_experiments_are_workspace_scoped(workspace_tracking_store):
     with WorkspaceContext("team-a"):
         exp_a_id = workspace_tracking_store.create_experiment("exp-in-a")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25239

### What changes are proposed in this pull request?

This PR implements the MLflow-owned SQL trace rollup maintenance and scheduler service from RFC 0006:

- register a locked periodic rollup task using `MLFLOW_TRACE_ROLLUPS_SCHEDULE`
- no-op when job execution is unavailable, rollups are disabled, or the tracking store is not SQL-backed
- add one shared maintenance path used by the server scheduler and `mlflow db build-trace-rollups`
- select complete, inactive UTC-day partitions and prioritize queued rebuilds before new coverage
- atomically build, replace, or empty trace-metric and assessment rollup partitions
- enqueue durable rebuild invalidations for trace, span, assessment, trace-move/delete, and run-sourced assessment deletion paths
- preserve raw fallback during disabled periods, late writes, deferred builds, and failed rebuilds
- document scheduler, eligibility, work-cap, and external-entrypoint configuration

This is a draft stacked on #25239. It currently targets `rfc-0006`, so GitHub will show the two Ticket 1 commits until #25239 merges. After that merge, this branch will be rebased onto the updated base so the diff contains only maintenance/scheduler work.

The separate RHOAI operator work that creates a Kubernetes `CronJob` is out of scope. This PR provides the MLflow-side entrypoint that such a `CronJob` can invoke without depending on MLflow's jobs backend.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Test results:

- `tests/store/db/test_trace_rollups.py`: 29 passed
- Ticket 1 rollup read-routing suite: 42 passed
- scheduler, existing trace-archival, and workspace regression suites: 25 passed
- affected run/experiment deletion regressions: 9 passed
- broader affected trace/assessment SQL-store selection: 217 passed, 2 skipped
- Ruff lint and format checks passed
- `git diff --check` passed

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

The backend-store documentation now describes the feature gate, UTC schedule, optional per-run partition cap, eligibility behavior, and the shared external-scheduler entrypoint.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow can now schedule and maintain opt-in SQL trace analytics daily rollups, with safe raw-query fallback while partitions are missing, stale, active, or being rebuilt.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

