### PR TITLE
Install review tools in parallel

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -135,21 +135,20 @@ jobs:
           # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
           # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
           fetch-depth: 2
-      - uses: ./.github/actions/setup-python
-        with:
-          pin-micro-version: false
-      - uses: ./.github/actions/setup-node
-      - name: Install Claude CLI
-        run: |
-          .claude/scripts/install-claude.sh
-      - name: Verify Claude CLI
+      - parallel:
+          - uses: ./.github/actions/setup-python
+            with:
+              pin-micro-version: false
+          - uses: ./.github/actions/setup-node
+          - name: Install Claude CLI
+            run: |
+              .claude/scripts/install-claude.sh
+          - name: Install agent-browser
+            run: |
+              .claude/scripts/install-agent-browser.sh
+      - name: Verify tools
         run: |
           claude --version
-      - name: Install agent-browser
-        run: |
-          .claude/scripts/install-agent-browser.sh
-      - name: Verify agent-browser
-        run: |
           agent-browser --version
 
       - name: Parse review arguments


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25335

### What changes are proposed in this pull request?

Group the review job's four install steps into a `parallel:` block, using the step-parallelism controls GitHub [shipped in June 2026](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/).

They ran sequentially for ~17s (setup-python 6s, setup-node 4s, Claude CLI 6s, agent-browser 1s) despite being independent: the setup actions write to the tool cache and PATH, while the scripts drop distinct binaries into `~/.local/bin`, which is already on PATH. Nothing in the group reads what another member writes, so the cost becomes the slowest member rather than the sum. The two per-tool verify steps collapse into one after the group, where it doubles as a check that PATH survived.

This also answers an open question: background steps are reportedly unsupported *within* composite actions, and both setups are composite. The smoke run shows that limitation is about authoring a composite action's own step list, not about calling one from a parallel block, since both ran concurrently without issue.

### How is this PR tested?

- [x] Manual tests

Filed from an upstream branch so the `pull_request` smoke run executes the modified workflow. It passed, and the step timestamps show all four starting together:

```
setup-python           13:43:04 -> 13:43:08   (4s)
setup-node             13:43:04 -> 13:43:10   (6s)
Install Claude CLI     13:43:04 -> 13:43:06   (2s)
Install agent-browser  13:43:04 -> 13:43:04   (0s)
Parallel group         13:43:04 -> 13:43:10   (6s)
Verify tools           13:43:10               success
```

6s for the group against ~17s sequentially in the prior run, and `Verify tools` confirms both binaries resolved on PATH afterward.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
