### PR TITLE
Retry the `build-wheel` GitHub install step with a bounded timeout

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -160,7 +160,14 @@ jobs:
             URL="git+https://github.com/${REPO}.git@${REF}"
           fi
 
-          uv run --isolated --no-project --with $URL python -I -c 'import mlflow; print(mlflow.__version__)'
+          for attempt in 1 2 3; do
+            if timeout -k 10 240 uv run --isolated --no-project --with "$URL" python -I -c 'import mlflow; print(mlflow.__version__)'; then
+              exit 0
+            fi
+            echo "::warning::Installation attempt ${attempt} failed or timed out"
+            [ "$attempt" -lt 3 ] && sleep 10
+          done
+          exit 1
 
       - name: Test dev/install-skinny.sh
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25247

### What changes are proposed in this pull request?

`Test installation from GitHub` occasionally hangs until the job hits `timeout-minutes: 20`. The step fetches the full mlflow history (~1.4 GB, 190k objects, no depth or blob filter), and the transfer sometimes stalls with no output, since `UV_NO_PROGRESS=1` hides progress.

68 jobs across 59 runs have died this way since 2026-07-28 (~1.3% of build-wheel jobs), all stopping on the same line: `Updating https://github.com/mlflow/mlflow.git (<ref>)`. The three months of runs before that date contain no such timeouts.

Most recent occurrences:

| Started (UTC) | Job | Link |
| --- | --- | --- |
| 2026-08-25T13:19Z | `build (skinny)` | [97816928753](https://github.com/mlflow/mlflow/actions/runs/32852631744/job/97816928753) |
| 2026-08-25T13:15Z | `build (dev)` | [97815786679](https://github.com/mlflow/mlflow/actions/runs/32852284117/job/97815786679) |
| 2026-08-25T12:32Z | `build (skinny)` | [97802538188](https://github.com/mlflow/mlflow/actions/runs/32848140783/job/97802538188) |
| 2026-08-24T22:21Z | `build (skinny)` | [97612721313](https://github.com/mlflow/mlflow/actions/runs/32784252005/job/97612721313) |
| 2026-08-24T21:18Z | `build (tracing)` | [97595865842](https://github.com/mlflow/mlflow/actions/runs/32778774529/job/97595865842) |
| 2026-08-24T20:00Z | `build (skinny)` | [97572487598](https://github.com/mlflow/mlflow/actions/runs/32771311980/job/97572487598) |
| 2026-08-24T18:21Z | `build (dev)` | [97542517222](https://github.com/mlflow/mlflow/actions/runs/32761922473/job/97542517222) |
| 2026-08-24T14:15Z | `build (tracing)` | [97463914071](https://github.com/mlflow/mlflow/actions/runs/32593975908/job/97463914071) |
| 2026-08-24T14:15Z | `build (dev)` | [97463913979](https://github.com/mlflow/mlflow/actions/runs/32593975908/job/97463913979) |
| 2026-08-20T18:33Z | `build (dev)` | [96538085537](https://github.com/mlflow/mlflow/actions/runs/32403829122/job/96538085537) |

This bounds each attempt to 240s and retries up to 3 times, so a stalled fetch fails fast and gets a fresh connection instead of consuming the whole job budget. `-k 10` sends SIGKILL after SIGTERM because the observed hangs left `git-remote-https` alive until the runner reaped it.

240s sits inside the healthy tail rather than above it. Across 180 successful executions of this step:

| p50 | p90 | p95 | p99 | max |
| --- | --- | --- | --- | --- |
| 40s | 185s | 295s | 690s | 1077s |

So the bound preempts ~7% of attempts that would have succeeded. That is acceptable because the slowness is per-connection, not network-wide: in every slow sample the sibling matrix jobs in the same run finished in 34-56s (e.g. run 32788427044 recorded 41s, 40s, 1077s), so a preempted attempt retries into the fast regime at ~40s. A longer bound does not fit, since 3x300s exceeds the ~15.5 min the dev matrix has left after its ~4-minute UI build, whereas 3x240s plus backoff is 12m20s.

Pre-resolving the ref to a SHA was measured and does not help: branch ref, full SHA, and PR merge ref all produce an identical ~1.4 GB non-shallow fetch, because uv resolves the ref only after fetching. If stalls persist, the next option is avoiding the network fetch altogether.

The retries emit `::warning::` annotations so recurring stalls stay visible instead of being silently absorbed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified the retry loop's exit semantics under `bash -e -o pipefail` (first-try success, recovery on attempt 3, failure after 3 attempts) and that the workflow still passes `check-github-workflows`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


