### PR TITLE
Drop `--frozen` from `uv run` invocations

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -262,7 +262,7 @@ jobs:
           GH_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
           REPO_ID: ${{ github.event.repository.id }}
         run: |
-          uv run --frozen --package skills skills embed-media \
+          uv run --package skills skills embed-media \
             --dir "$REVIEW_MEDIA" \
             --target "$REVIEW_PAYLOAD" \
             --repository-id "$REPO_ID"
@@ -273,7 +273,7 @@ jobs:
             echo "::error::Claude did not produce $REVIEW_PAYLOAD"
             exit 1
           fi
-          uv run --frozen --package skills skills validate-review "$REVIEW_PAYLOAD"
+          uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"
           jq . "$REVIEW_PAYLOAD"
           echo "::endgroup::"

--- a/.github/workflows/ui-review.yml
+++ b/.github/workflows/ui-review.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           mkdir -p /tmp/ui-review
           # Pre-populate the GenAI demo dataset (offline, no API key) so pages aren't empty.
-          uv run --frozen python -c "from mlflow.demo import generate_all_demos; generate_all_demos(refresh=True)"
+          uv run python -c "from mlflow.demo import generate_all_demos; generate_all_demos(refresh=True)"
           # Install a credential-free stub `claude` so the Assistant provider's auth
           # probe passes and its chat panel renders (the dev server has no
           # ANTHROPIC_API_KEY). Scoped to the dev server's own PATH; the real CLI in
@@ -205,7 +205,7 @@ jobs:
           # non-Assistant reviews and keeps the Assistant reviewable on any PR.
           # run_dev_server.py starts the backend + `yarn start` frontend (much faster than
           # a full `yarn build`) and honors MLFLOW_TRACKING_URI for the store.
-          uv run --frozen dev/run_dev_server.py --stub-providers claude > /tmp/dev-server.log 2>&1 &
+          uv run dev/run_dev_server.py --stub-providers claude > /tmp/dev-server.log 2>&1 &
           echo "DEV_PID=$!" >> "$GITHUB_ENV"
           APP_URL=""
           for _ in $(seq 1 120); do

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
       - id: normalize-chars
         name: normalize-chars
-        entry: uv run --frozen --only-group lint dev/normalize_chars.py
+        entry: uv run --only-group lint dev/normalize_chars.py
         language: system
         stages: [pre-commit]
         types: [text]
@@ -40,7 +40,7 @@ repos:
 
       - id: ruff
         name: ruff
-        entry: uv run --frozen --only-group lint dev/ruff.py
+        entry: uv run --only-group lint dev/ruff.py
         language: system
         files: '\.(py|ipynb)$'
         stages: [pre-commit]
@@ -48,7 +48,7 @@ repos:
 
       - id: format
         name: format
-        entry: uv run --frozen --only-group lint dev/format.py
+        entry: uv run --only-group lint dev/format.py
         language: system
         files: '\.(py|ipynb|md|mdx)$'
         stages: [pre-commit]
@@ -73,7 +73,7 @@ repos:
             dev/benchmarks/gateway/run\.py|
             dev/benchmarks/tracing/.*\.py
           )$
-        entry: uv run --frozen --only-group lint mypy
+        entry: uv run --only-group lint mypy
         require_serial: true
 
       - id: unresolved-import
@@ -82,7 +82,7 @@ repos:
         # unresolved imports (optional deps) are filtered out via grep.
         entry: |
           bash -c '
-            out=$(uv run --frozen --only-group lint ty check \
+            out=$(uv run --only-group lint ty check \
               --ignore all \
               --error unresolved-import \
               --output-format concise \
@@ -101,7 +101,7 @@ repos:
 
       - id: clint
         name: clint
-        entry: uv run --frozen --only-group lint clint
+        entry: uv run --only-group lint clint
         language: system
         files: '\.(py|ipynb|rst|mdx?)$'
         stages: [pre-commit]
@@ -109,7 +109,7 @@ repos:
 
       - id: check-github-workflows
         name: check-github-workflows
-        entry: uv run --frozen --only-group lint check-jsonschema --builtin-schema vendor.github-workflows
+        entry: uv run --only-group lint check-jsonschema --builtin-schema vendor.github-workflows
         language: system
         files: ^\.github/workflows/[^/]+\.ya?ml$
         stages: [pre-commit]
@@ -117,7 +117,7 @@ repos:
 
       - id: check-github-actions
         name: check-github-actions
-        entry: uv run --frozen --only-group lint check-jsonschema --builtin-schema vendor.github-actions
+        entry: uv run --only-group lint check-jsonschema --builtin-schema vendor.github-actions
         language: system
         files: ^\.github/actions/[^/]+/action\.ya?ml$
         stages: [pre-commit]
@@ -125,7 +125,7 @@ repos:
 
       - id: install-bin
         name: install-bin
-        entry: uv run --frozen --only-group lint bin/install.py
+        entry: uv run --only-group lint bin/install.py
         language: system
         stages: [pre-commit]
         require_serial: true
@@ -181,7 +181,7 @@ repos:
 
       - id: pyproject
         name: pyproject
-        entry: uv run --frozen --only-group lint dev/pyproject.py
+        entry: uv run --only-group lint dev/pyproject.py
         language: system
         stages: [pre-commit]
         require_serial: true
@@ -189,7 +189,7 @@ repos:
 
       - id: mlver
         name: ml-package-versions-consistency
-        entry: "uv run --frozen --only-group lint dev/update_ml_package_versions.py --skip-yml"
+        entry: "uv run --only-group lint dev/update_ml_package_versions.py --skip-yml"
         files: '^(mlflow/ml-package-versions\.yml|mlflow/ml_package_versions\.py)$'
         language: system
         stages: [pre-commit]
@@ -238,7 +238,7 @@ repos:
 
       - id: check-actions
         name: check-actions
-        entry: uv run --frozen --only-group lint dev/check_actions.py
+        entry: uv run --only-group lint dev/check_actions.py
         language: system
         files: '^\.github/(workflows|actions)/.*\.ya?ml$'
         pass_filenames: false
@@ -255,7 +255,7 @@ repos:
 
       - id: check-init-py
         name: check-init-py
-        entry: uv run --frozen --only-group lint dev/check_init_py.py
+        entry: uv run --only-group lint dev/check_init_py.py
         language: system
         files: '^(mlflow|tests)/.*\.py$'
         stages: [pre-commit]
@@ -309,7 +309,7 @@ repos:
 
       - id: skills
         name: skills
-        entry: uv run --frozen --only-group lint dev/check_skills.py
+        entry: uv run --only-group lint dev/check_skills.py
         language: system
         files: '(^|/)SKILL\.md$'
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         name: uv-lock
         entry: uv lock
         language: system
-        files: '^pyproject\.toml$'
+        files: '(^|/)pyproject\.toml$'
         stages: [pre-commit]
         require_serial: true
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,14 +85,6 @@ tail -f "$LOG"
 
 ## Development Commands
 
-### Offline / No-Network Usage
-
-If PyPI is unreachable, add `--frozen` to `uv run` commands that should use the existing `uv.lock` as-is without modifying the environment. This works when the required dependencies are already installed or available in the local cache:
-
-```bash
-uv run --frozen pytest tests/
-```
-
 ### Package Cooldown Period
 
 7-day cooldown on new package releases to guard against compromised or broken


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22505

### What changes are proposed in this pull request?

`--frozen` was added back when the dev environment needed to run against an
existing `uv.lock` without touching the network. That's no longer the case, so
drop it from the dev tooling:

- `.pre-commit-config.yaml`: 14 hook entries
- `.github/workflows/review.yml`, `.github/workflows/ui-review.yml`: 4 steps
- `CLAUDE.md`: removed the now-obsolete "Offline / No-Network Usage" section

`uv sync --frozen` in `mlflow/utils/uv_utils.py` is untouched: that's model
environment restoration, not dev tooling.

If you still need `--frozen` (e.g. working offline), mention it in your own
gitignored `CLAUDE.local.md`, not in the tracked `CLAUDE.md`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Pre-commit passed on this commit with the modified hook entries, and
`check-jsonschema` validates both workflows.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

