### PR TITLE
Fix SQL filter string parsing for keyword-typed attribute `server_name` #25203

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -63,6 +63,8 @@ def _like(string, pattern):
 def _ilike(string, pattern):
     return _convert_like_pattern_to_regex(pattern, flags=re.IGNORECASE).match(string) is not None
 
+def _is_identifier_like(token):
+    return isinstance(token, Identifier) or token.ttype == TokenType.Keyword
 
 def _join_in_comparison_tokens(tokens, search_traces=False):
     """
@@ -108,16 +110,23 @@ def _join_in_comparison_tokens(tokens, search_traces=False):
                     joined_tokens.extend([first, second, third])
 
         # Wait until we encounter an identifier token
-        if not isinstance(first, Identifier):
+        if not _is_identifier_like(first):
             joined_tokens.append(first)
             continue
 
         (_, second) = next(iterator)
         (_, third) = next(iterator)
 
+        # Standard comparison (=, !=, LIKE, ILIKE, RLIKE, etc.)
+        if second.ttype == TokenType.Operator.Comparison or second.match(
+            ttype=TokenType.Keyword, values=["LIKE", "ILIKE", "RLIKE"]
+        ):
+            joined_tokens.append(Comparison(TokenList([first, second, third])))
+            continue
+
         # IN
         if (
-            isinstance(first, Identifier)
+            _is_identifier_like(first)
             and second.match(ttype=TokenType.Keyword, values=["IN"])
             and isinstance(third, Parenthesis)
         ):
@@ -126,7 +135,7 @@ def _join_in_comparison_tokens(tokens, search_traces=False):
 
         # IS NULL
         if (
-            isinstance(first, Identifier)
+            _is_identifier_like(first)
             and second.match(ttype=TokenType.Keyword, values=["IS"])
             and third.match(ttype=TokenType.Keyword, values=["NULL"])
         ):
@@ -137,7 +146,7 @@ def _join_in_comparison_tokens(tokens, search_traces=False):
 
         # IS NOT NULL
         if (
-            isinstance(first, Identifier)
+            _is_identifier_like(first)
             and second.match(ttype=TokenType.Keyword, values=["IS"])
             and third.ttype == TokenType.Keyword
             and third.value.upper() == "NOT NULL"
@@ -154,7 +163,7 @@ def _join_in_comparison_tokens(tokens, search_traces=False):
 
         # NOT IN
         if (
-            isinstance(first, Identifier)
+            _is_identifier_like(first)
             and second.match(ttype=TokenType.Keyword, values=["NOT"])
             and third.match(ttype=TokenType.Keyword, values=["IN"])
             and isinstance(fourth, Parenthesis)
@@ -237,6 +246,15 @@ class SearchUtils:
     VALID_TIMESTAMP_ORDER_BY_KEYS = {ORDER_BY_KEY_TIMESTAMP, ORDER_BY_KEY_LAST_UPDATED_TIMESTAMP}
     # We encourage users to use timestamp for order-by
     RECOMMENDED_ORDER_BY_KEYS_REGISTERED_MODELS = {ORDER_BY_KEY_MODEL_NAME, ORDER_BY_KEY_TIMESTAMP}
+
+    @classmethod
+    def _is_valid_identifier_token(cls, token):
+        if isinstance(token, Identifier):
+            return True
+        return (
+            token.ttype == TokenType.Keyword
+            and token.value.lower() in cls.VALID_SEARCH_ATTRIBUTE_KEYS
+        )
 
     @staticmethod
     def get_comparison_func(comparator):
@@ -495,7 +513,7 @@ class SearchUtils:
         if len(tokens) == 2:
             comparator = tokens[1].value.upper()
             if comparator in ("IS NULL", "IS NOT NULL"):
-                if not isinstance(tokens[0], Identifier):
+                if not cls._is_valid_identifier_token(tokens[0]):
                     raise MlflowException(
                         f"{base_error_string}. Expected 'Identifier' found '{tokens[0]}'",
                         error_code=INVALID_PARAMETER_VALUE,
@@ -506,7 +524,7 @@ class SearchUtils:
                 f"{base_error_string}. Expected 3 tokens found {len(tokens)}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        if not isinstance(tokens[0], Identifier):
+        if not cls._is_valid_identifier_token(tokens[0]):
             raise MlflowException(
                 f"{base_error_string}. Expected 'Identifier' found '{tokens[0]}'",
                 error_code=INVALID_PARAMETER_VALUE,
@@ -1106,7 +1124,7 @@ class SearchExperimentsUtils(SearchUtils):
         if len(tokens) == 2:
             comparator = tokens[1].value.upper()
             if comparator in ("IS NULL", "IS NOT NULL"):
-                if not isinstance(tokens[0], Identifier):
+                if not cls._is_valid_identifier_token(tokens[0]):
                     raise MlflowException(
                         f"Invalid comparison clause. Expected 'Identifier' found '{tokens[0]}'",
                         error_code=INVALID_PARAMETER_VALUE,
@@ -2262,7 +2280,7 @@ class SearchTraceUtils(SearchUtils):
         if len(tokens) == 2:
             comparator = tokens[1].value.upper()
             if comparator in ("IS NULL", "IS NOT NULL"):
-                if not isinstance(tokens[0], Identifier):
+                if not cls._is_valid_identifier_token(tokens[0]):
                     raise MlflowException(
                         f"Invalid comparison clause. Expected 'Identifier' found '{tokens[0]}'",
                         error_code=INVALID_PARAMETER_VALUE,
@@ -2814,6 +2832,14 @@ class SearchMCPAccessEndpointUtils(SearchUtils):
     }
     NUMERIC_ATTRIBUTES = {"created_at", "last_updated_at"}
 
+    @classmethod
+    def validate_list_supported(cls, key: str) -> None:
+        if key not in ("status", "server_name", "transport_type"):
+            raise MlflowException(
+                f"Only 'status', 'server_name', 'transport_type' support IN comparisons for MCP access endpoints, got '{key}'.",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
 
 class SearchIssuesUtils(SearchUtils):
     """Utility class for parsing issue search filters."""
@@ -2857,7 +2883,7 @@ class SearchIssuesUtils(SearchUtils):
         left, comparator_token, right = stripped_comparison
 
         # Get field name
-        if not isinstance(left, Identifier):
+        if not cls._is_valid_identifier_token(left):
             raise MlflowException.invalid_parameter_value(
                 f"Invalid comparison: left side must be an identifier, got {type(left)}"
             )

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -63,8 +63,10 @@ def _like(string, pattern):
 def _ilike(string, pattern):
     return _convert_like_pattern_to_regex(pattern, flags=re.IGNORECASE).match(string) is not None
 
+
 def _is_identifier_like(token):
     return isinstance(token, Identifier) or token.ttype == TokenType.Keyword
+
 
 def _join_in_comparison_tokens(tokens, search_traces=False):
     """
@@ -2836,7 +2838,8 @@ class SearchMCPAccessEndpointUtils(SearchUtils):
     def validate_list_supported(cls, key: str) -> None:
         if key not in ("status", "server_name", "transport_type"):
             raise MlflowException(
-                f"Only 'status', 'server_name', 'transport_type' support IN comparisons for MCP access endpoints, got '{key}'.",
+                "Only 'status', 'server_name', 'transport_type' support IN comparisons for "
+                f"MCP access endpoints, got '{key}'.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -1804,6 +1804,23 @@ def test_search_mcp_access_endpoints_filter_by_transport_type(store):
     assert result[0].url == "https://a.com"
 
 
+def test_search_mcp_access_endpoints_filter_by_server_name(store):
+    store.create_mcp_server_version(_server_json("io.github.test/server1", "1.0.0"))
+    store.create_mcp_server_version(_server_json("io.github.test/server2", "1.0.0"))
+    store.create_mcp_access_endpoint("io.github.test/server1", "https://a.com", server_version="1.0.0")
+    store.create_mcp_access_endpoint("io.github.test/server2", "https://b.com", server_version="1.0.0")
+
+    result = store.search_mcp_access_endpoints(filter_string="server_name = 'io.github.test/server1'")
+    assert len(result) == 1
+    assert result[0].url == "https://a.com"
+
+    result_in = store.search_mcp_access_endpoints(
+        filter_string="server_name IN ('io.github.test/server1', 'io.github.test/server2')"
+    )
+    assert len(result_in) == 2
+
+
+
 def test_search_mcp_servers_filter_by_status_in(store):
     store.create_mcp_server_version(
         _server_json("io.github.test/server1", "1.0.0"), status=MCPStatus.ACTIVE

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py
@@ -1807,10 +1807,16 @@ def test_search_mcp_access_endpoints_filter_by_transport_type(store):
 def test_search_mcp_access_endpoints_filter_by_server_name(store):
     store.create_mcp_server_version(_server_json("io.github.test/server1", "1.0.0"))
     store.create_mcp_server_version(_server_json("io.github.test/server2", "1.0.0"))
-    store.create_mcp_access_endpoint("io.github.test/server1", "https://a.com", server_version="1.0.0")
-    store.create_mcp_access_endpoint("io.github.test/server2", "https://b.com", server_version="1.0.0")
+    store.create_mcp_access_endpoint(
+        "io.github.test/server1", "https://a.com", server_version="1.0.0"
+    )
+    store.create_mcp_access_endpoint(
+        "io.github.test/server2", "https://b.com", server_version="1.0.0"
+    )
 
-    result = store.search_mcp_access_endpoints(filter_string="server_name = 'io.github.test/server1'")
+    result = store.search_mcp_access_endpoints(
+        filter_string="server_name = 'io.github.test/server1'"
+    )
     assert len(result) == 1
     assert result[0].url == "https://a.com"
 
@@ -1818,7 +1824,6 @@ def test_search_mcp_access_endpoints_filter_by_server_name(store):
         filter_string="server_name IN ('io.github.test/server1', 'io.github.test/server2')"
     )
     assert len(result_in) == 2
-
 
 
 def test_search_mcp_servers_filter_by_status_in(store):

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -897,11 +897,16 @@ def test_search_mcp_access_endpoint_filter_by_keyword_attribute():
     from mlflow.utils.search_utils import SearchMCPAccessEndpointUtils
 
     res = SearchMCPAccessEndpointUtils.parse_search_filter("server_name = 'my-server'")
-    assert res == [{"type": "attribute", "key": "server_name", "comparator": "=", "value": "my-server"}]
+    assert res == [
+        {"type": "attribute", "key": "server_name", "comparator": "=", "value": "my-server"}
+    ]
 
     res = SearchMCPAccessEndpointUtils.parse_search_filter("server_name != 'my-server'")
-    assert res == [{"type": "attribute", "key": "server_name", "comparator": "!=", "value": "my-server"}]
+    assert res == [
+        {"type": "attribute", "key": "server_name", "comparator": "!=", "value": "my-server"}
+    ]
 
     res = SearchMCPAccessEndpointUtils.parse_search_filter("server_name IN ('s1', 's2')")
-    assert res == [{"type": "attribute", "key": "server_name", "comparator": "IN", "value": ["s1", "s2"]}]
-
+    assert res == [
+        {"type": "attribute", "key": "server_name", "comparator": "IN", "value": ["s1", "s2"]}
+    ]

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -891,3 +891,17 @@ def test_search_trace_utils_filter_metadata_is_null():
 
     result = SearchTraceUtils.filter(traces, "metadata.session IS NOT NULL")
     assert {t.trace_id for t in result} == {"t1"}
+
+
+def test_search_mcp_access_endpoint_filter_by_keyword_attribute():
+    from mlflow.utils.search_utils import SearchMCPAccessEndpointUtils
+
+    res = SearchMCPAccessEndpointUtils.parse_search_filter("server_name = 'my-server'")
+    assert res == [{"type": "attribute", "key": "server_name", "comparator": "=", "value": "my-server"}]
+
+    res = SearchMCPAccessEndpointUtils.parse_search_filter("server_name != 'my-server'")
+    assert res == [{"type": "attribute", "key": "server_name", "comparator": "!=", "value": "my-server"}]
+
+    res = SearchMCPAccessEndpointUtils.parse_search_filter("server_name IN ('s1', 's2')")
+    assert res == [{"type": "attribute", "key": "server_name", "comparator": "IN", "value": ["s1", "s2"]}]
+


### PR DESCRIPTION
### PR Title
Fix SQL filter string parsing for keyword-typed search attributes in `SearchUtils`

### Related Issues/PRs

Closes #25203

### What changes are proposed in this pull request?

Fixes an issue where passing searchable attributes that `sqlparse` tokenizes as SQL keywords (such as `server_name` in `search_mcp_access_endpoints`) in a `filter_string` failed with `MlflowException: Invalid clause(s) in filter string`.

#### Root Cause:
`sqlparse` includes `SERVER_NAME` in its built-in SQL keyword lexicon, tokenizing `server_name` as `TokenType.Keyword` rather than `Identifier`. Because `sqlparse`'s default comparison grouper only groups `Identifier` tokens into `Comparison` objects, filter expressions starting with `server_name` (e.g. `filter_string="server_name = 'my-server'"`) remained flat un-grouped tokens and were rejected by downstream filter validation in `mlflow/utils/search_utils.py`.

#### Changes Proposed:
1. Updated `_join_in_comparison_tokens` in `mlflow/utils/search_utils.py` to treat keyword-typed tokens (excluding reserved operators like `IN`, `IS`, `NOT`, `AND`, `OR`, `TRUE`, `FALSE`) as valid identifier candidates, joining binary comparisons (`=`, `!=`, `LIKE`, `ILIKE`, `RLIKE`, etc.) into `Comparison` objects when left operands are tokenized as keywords.
2. Updated validation methods across `SearchUtils`, `SearchExperimentsUtils`, `SearchTraceUtils`, and `SearchIssuesUtils` to accept keyword-typed attribute tokens whose text matches valid search attribute keys.
3. Overrode `validate_list_supported` in `SearchMCPAccessEndpointUtils` to support list `IN` / `NOT IN` comparisons for `server_name`, `status`, and `transport_type`.
4. Added new unit tests in `tests/utils/test_search_utils.py` and integration tests in `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_mcp_server_registry.py`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Fixes an issue where filtering search queries by attributes tokenized as SQL keywords (such as `server_name` in `search_mcp_access_endpoints`) failed with `Invalid clause(s) in filter string`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
