### PR TITLE
Reject an empty file before uploading it to `user-attachments`

### DIFF
--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -145,9 +145,12 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
 
     for name in sorted(cited):
         cite = str(by_name[name])
+        size = by_name[name].stat().st_size
         if Path(name).suffix.lower() not in MIME_TYPES:
             report.errors.append(f"{name}: unsupported extension, so the reference is dropped")
-        elif (size := by_name[name].stat().st_size) > (limit := max_bytes(name)):
+        elif size == 0:
+            report.errors.append(f"{name}: empty, so the reference is dropped")
+        elif size > (limit := max_bytes(name)):
             report.errors.append(
                 f"{name}: {size} bytes exceeds the {limit} byte cap, so the reference is dropped"
             )

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -144,8 +144,9 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
                 )
 
     for name in sorted(cited):
-        cite = str(by_name[name])
-        size = by_name[name].stat().st_size
+        path = by_name[name]
+        cite = str(path)
+        size = path.stat().st_size
         if Path(name).suffix.lower() not in MIME_TYPES:
             report.errors.append(f"{name}: unsupported extension, so the reference is dropped")
         elif size == 0:

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
 
-# The name's extension must agree with content_type or the endpoint returns 422.
+# The name's extension must agree with content_type or the endpoint returns 422. The
+# allowlist is narrower than the formats GitHub documents for attachments: svg and audio
+# are both refused, so extend this map only against a live 201.
 MIME_TYPES = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
@@ -56,6 +58,10 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str:
         raise UploadFailed(f"{path.name}: unsupported extension")
 
     size = path.stat().st_size
+    if size == 0:
+        # The endpoint refuses an empty file as 422 "Yowza that's a big file. Try again
+        # with a file size less than 10MB", which points at the opposite problem.
+        raise UploadFailed(f"{path.name}: the file is empty")
     if size > (limit := max_bytes(path.name)):
         raise UploadFailed(f"{path.name}: {size} bytes exceeds {limit}")
 

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -401,7 +401,8 @@ def test_check_rejects_a_cited_file_with_an_unsupported_extension(tmp_path: Path
 
 
 def test_check_rejects_a_cited_file_that_is_empty(tmp_path: Path) -> None:
-    media = make_media(tmp_path)
+    media = tmp_path / "media"
+    media.mkdir()
     (media / "shot.png").write_bytes(b"")
     report = embed_media.check_media(media, [f"![the bug]({media / 'shot.png'})"])
     assert report.errors == ["shot.png: empty, so the reference is dropped"]

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -400,6 +400,13 @@ def test_check_rejects_a_cited_file_with_an_unsupported_extension(tmp_path: Path
     assert report.errors == ["notes.txt: unsupported extension, so the reference is dropped"]
 
 
+def test_check_rejects_a_cited_file_that_is_empty(tmp_path: Path) -> None:
+    media = make_media(tmp_path)
+    (media / "shot.png").write_bytes(b"")
+    report = embed_media.check_media(media, [f"![the bug]({media / 'shot.png'})"])
+    assert report.errors == ["shot.png: empty, so the reference is dropped"]
+
+
 def test_check_rejects_a_cited_file_over_the_size_cap(tmp_path: Path) -> None:
     with mock.patch.object(uploads, "MAX_IMAGE_BYTES", 2):
         report = check(tmp_path, "![the bug]({p})")

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -72,6 +72,15 @@ def test_upload_asset_rejects_an_unsupported_extension(tmp_path: Path) -> None:
         uploads.upload_asset(path, "1", "t")
 
 
+def test_upload_asset_rejects_an_empty_file(tmp_path: Path) -> None:
+    # The endpoint blames the size cap for this, so catching it here is the only way the
+    # message points at the real problem.
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"")
+    with pytest.raises(uploads.UploadFailed, match="the file is empty"):
+        uploads.upload_asset(path, "1", "t")
+
+
 def test_upload_asset_rejects_a_file_over_the_size_cap(tmp_path: Path) -> None:
     path = tmp_path / "big.png"
     path.write_bytes(b"12345")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25342, the next layer in this stack.

### What changes are proposed in this pull request?

`upload-media` and `embed-media` happily send a zero-byte file to GitHub's
`user-attachments` endpoint, which refuses it with 422 `size Yowza that's a big
file. Try again with a file size less than 10MB`. That names the opposite
problem and sends anyone debugging it toward the size cap, so reject an empty
file locally instead, in the upload path and in `embed-media --check` alike.

Also records on `MIME_TYPES` that the endpoint's allowlist is narrower than the
formats GitHub documents for attachments: `image/svg+xml` is refused the same
way audio already is, so that map only grows against a live 201.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Both refusals were measured against `mlflow/mlflow` before the checks were
written: a 0-byte PNG and a 4-byte SVG each came back 422.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
