### PR TITLE
Name what the `user-attachments` endpoint refused

### DIFF
--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -64,7 +64,7 @@ def run(args: argparse.Namespace) -> None:
             # A rejected credential fails every remaining upload, so stop asking, and
             # name the credential this command actually resolved.
             if e.status == 401:
-                print(f"failed {path}: {e}; check GH_TOKEN or run `gh auth login`", file=sys.stderr)
+                print(f"failed {e}; check GH_TOKEN or run `gh auth login`", file=sys.stderr)
                 break
             print(f"failed {e}", file=sys.stderr)
 

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -28,6 +28,26 @@ MIME_TYPES = {
 VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
 
 
+# The endpoint serves only OAuth tokens, classic PATs, and fine-grained PATs bound to the
+# target repository. App and Actions tokens are refused whatever their permissions, and the
+# refusal is a bare 404, so name the kind rather than leave the caller guessing.
+TOKEN_KINDS = {
+    "gho_": "an OAuth user token",
+    "ghp_": "a classic PAT",
+    "github_pat_": "a fine-grained PAT",
+    "ghu_": "a GitHub App user-to-server token",
+    "ghs_": "a GitHub App or Actions token",
+    "ghr_": "a refresh token",
+}
+
+
+def describe_token(token: str) -> str:
+    for prefix, kind in TOKEN_KINDS.items():
+        if token.startswith(prefix):
+            return kind
+    return "a credential of unrecognized kind"
+
+
 class UploadFailed(Exception):
     """Raised when one asset does not reach the store; the message says why.
 
@@ -81,9 +101,20 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str:
             body = json.load(resp)
     # Must precede OSError: HTTPError is a URLError, which is an OSError.
     except urllib.error.HTTPError as e:
+        # Callers resolve credentials differently, so name none of them here.
         if e.code == 401:
-            # Callers resolve credentials differently, so name none of them here.
-            raise UploadFailed("the credential was rejected (401)", status=401) from e
+            raise UploadFailed(f"{path.name}: the credential was rejected (401)", status=401) from e
+        if e.code == 403:
+            raise UploadFailed(
+                f"{path.name}: the credential is not scoped to this repository (403)",
+                status=403,
+            ) from e
+        if e.code == 404:
+            raise UploadFailed(
+                f"{path.name}: 404, so either repository_id={repository_id} does not resolve or "
+                f"the endpoint refuses this credential, which is {describe_token(token)}",
+                status=404,
+            ) from e
         raise UploadFailed(f"{path.name}: {e}", status=e.code) from e
     except (OSError, http.client.HTTPException, ValueError) as e:
         raise UploadFailed(f"{path.name}: {e}") from e

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -29,8 +29,9 @@ VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
 
 
 # The endpoint serves only OAuth tokens, classic PATs, and fine-grained PATs bound to the
-# target repository. App and Actions tokens are refused whatever their permissions, and the
-# refusal is a bare 404, so name the kind rather than leave the caller guessing.
+# target repository. Actions and App installation tokens are refused whatever their
+# permissions, and the refusal is a bare 404, so name the kind rather than leave the
+# caller guessing.
 TOKEN_KINDS = {
     "gho_": "an OAuth user token",
     "ghp_": "a classic PAT",
@@ -101,12 +102,12 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str:
             body = json.load(resp)
     # Must precede OSError: HTTPError is a URLError, which is an OSError.
     except urllib.error.HTTPError as e:
-        # Callers resolve credentials differently, so name none of them here.
         if e.code == 401:
+            # Callers resolve credentials differently, so name none of them here.
             raise UploadFailed(f"{path.name}: the credential was rejected (401)", status=401) from e
         if e.code == 403:
             raise UploadFailed(
-                f"{path.name}: the credential is not scoped to this repository (403)",
+                f"{path.name}: 403, most likely a credential that is not scoped to this repository",
                 status=403,
             ) from e
         if e.code == 404:

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -98,7 +98,7 @@ def test_a_rejected_credential_stops_the_remaining_uploads(
         mock.patch.object(
             upload_media,
             "upload_asset",
-            side_effect=UploadFailed("the credential was rejected (401)", status=401),
+            side_effect=UploadFailed("shot.png: the credential was rejected (401)", status=401),
         ) as uploader,
         pytest.raises(SystemExit, match="^1$"),
     ):

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -119,17 +119,57 @@ def http_error(code: int) -> urllib.error.HTTPError:
     return urllib.error.HTTPError(uploads.UPLOAD_URL, code, "nope", {}, None)  # type: ignore[arg-type]
 
 
-def test_upload_asset_flags_a_rejected_token_with_its_status(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        (401, r"the credential was rejected \(401\)"),
+        (403, r"not scoped to this repository \(403\)"),
+        # A 404 is ambiguous, so the message has to offer both readings.
+        (404, r"repository_id=1 does not resolve or the endpoint refuses this credential"),
+    ],
+)
+def test_upload_asset_explains_a_credential_failure(
+    tmp_path: Path, code: int, expected: str
+) -> None:
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
 
     with (
-        mock.patch("urllib.request.urlopen", side_effect=http_error(401)),
-        pytest.raises(uploads.UploadFailed, match="rejected \\(401\\)") as excinfo,
+        mock.patch("urllib.request.urlopen", side_effect=http_error(code)) as opener,
+        pytest.raises(uploads.UploadFailed, match=expected) as excinfo,
     ):
         uploads.upload_asset(path, "1", "t")
 
-    assert excinfo.value.status == 401
+    opener.assert_called_once()
+    assert excinfo.value.status == code
+
+
+def test_a_404_names_the_credential_kind_without_printing_it(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(404)) as opener,
+        pytest.raises(uploads.UploadFailed, match="a GitHub App or Actions token") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "ghs_secret")
+
+    opener.assert_called_once()
+    assert "ghs_secret" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("gho_x", "an OAuth user token"),
+        ("ghp_x", "a classic PAT"),
+        ("github_pat_x", "a fine-grained PAT"),
+        ("ghs_x", "a GitHub App or Actions token"),
+        ("x", "a credential of unrecognized kind"),
+    ],
+)
+def test_describe_token_names_the_kind(token: str, expected: str) -> None:
+    assert uploads.describe_token(token) == expected
 
 
 def test_upload_asset_carries_the_status_of_other_http_errors(tmp_path: Path) -> None:

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -123,7 +123,7 @@ def http_error(code: int) -> urllib.error.HTTPError:
     ("code", "expected"),
     [
         (401, r"the credential was rejected \(401\)"),
-        (403, r"not scoped to this repository \(403\)"),
+        (403, r"403, most likely a credential that is not scoped"),
         # A 404 is ambiguous, so the message has to offer both readings.
         (404, r"repository_id=1 does not resolve or the endpoint refuses this credential"),
     ],
@@ -164,7 +164,9 @@ def test_a_404_names_the_credential_kind_without_printing_it(tmp_path: Path) -> 
         ("gho_x", "an OAuth user token"),
         ("ghp_x", "a classic PAT"),
         ("github_pat_x", "a fine-grained PAT"),
+        ("ghu_x", "a GitHub App user-to-server token"),
         ("ghs_x", "a GitHub App or Actions token"),
+        ("ghr_x", "a refresh token"),
         ("x", "a credential of unrecognized kind"),
     ],
 )


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25341, the layer below in this stack.

### What changes are proposed in this pull request?

Every non-401 refusal from the `user-attachments` endpoint became
`shot.png: HTTP Error 404: Not Found`, which names no cause and is actively
misleading here. The endpoint answers 404 both for a `repository_id` it cannot
resolve and for a credential kind it refuses, and answers 403 when a
fine-grained PAT is not scoped to the repository.

Gives each its own message, spells out both readings of a 404, and names the
credential kind from its token prefix without ever printing the token.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Which credential kinds the endpoint serves was established earlier against
`mlflow/mlflow` (see #25141): OAuth tokens, classic PATs, and repo-scoped
fine-grained PATs upload, while Actions and App installation tokens get 404
whatever permissions they carry.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
