### PR TITLE
Stop uploading media when the fault is not about the file

### DIFF
--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -265,12 +265,12 @@ def run(args: argparse.Namespace) -> None:
             try:
                 urls[str(path)] = upload_asset(path, args.repository_id, token)
             except UploadFailed as e:
-                # A rejected credential fails every remaining upload, so stop rather
-                # than retry. The step is continue-on-error, so without an annotation
-                # an expired token would silently stop attaching media on every
-                # future review.
-                if e.status == 401:
-                    print("::warning::the GitHub token was rejected (401); it may have expired")
+                # A fault that is not about this file fails every remaining upload, so
+                # stop rather than retry. The step is continue-on-error, so without an
+                # annotation this would silently stop attaching media on every future
+                # review.
+                if e.fatal:
+                    print(f"::warning::media upload stopped: {e}")
                     break
                 print(f"  failed {e}", file=sys.stderr)
             else:

--- a/.claude/skills/src/skills/commands/upload_media.py
+++ b/.claude/skills/src/skills/commands/upload_media.py
@@ -61,10 +61,11 @@ def run(args: argparse.Namespace) -> None:
             print(f"{path}\t{upload_asset(path, repository_id, token)}")
         except UploadFailed as e:
             failed = True
-            # A rejected credential fails every remaining upload, so stop asking, and
-            # name the credential this command actually resolved.
-            if e.status == 401:
-                print(f"failed {e}; check GH_TOKEN or run `gh auth login`", file=sys.stderr)
+            # A fault that is not about this file fails every remaining upload, so
+            # stop asking, and name the credential this command resolved.
+            if e.fatal:
+                hint = "; check GH_TOKEN or run `gh auth login`" if e.status == 401 else ""
+                print(f"failed {e}{hint}", file=sys.stderr)
                 break
             print(f"failed {e}", file=sys.stderr)
 

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -28,6 +28,10 @@ MIME_TYPES = {
 VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
 
 
+# Answered for a fault that is not about the file at hand, so every remaining upload in
+# the run would fail the same way.
+FATAL_STATUSES = frozenset({401, 403, 404})
+
 # The endpoint serves only OAuth tokens, classic PATs, and fine-grained PATs bound to the
 # target repository. Actions and App installation tokens are refused whatever their
 # permissions, and the refusal is a bare 404, so name the kind rather than leave the
@@ -59,6 +63,11 @@ class UploadFailed(Exception):
     def __init__(self, message: str, status: int | None = None) -> None:
         super().__init__(message)
         self.status = status
+
+    @property
+    def fatal(self) -> bool:
+        """Whether retrying the remaining files would fail identically."""
+        return self.status in FATAL_STATUSES
 
 
 MAX_IMAGE_BYTES = 10 * 1024 * 1024

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -56,8 +56,8 @@ def describe_token(token: str) -> str:
 class UploadFailed(Exception):
     """Raised when one asset does not reach the store; the message says why.
 
-    ``status`` carries the HTTP code when the endpoint answered, so a caller can tell
-    a dead credential (401) from a fault that only affects the file at hand.
+    ``status`` carries the HTTP code when the endpoint answered, and ``fatal`` says
+    whether the rest of the run can continue.
     """
 
     def __init__(self, message: str, status: int | None = None) -> None:

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -245,7 +245,7 @@ def test_cli_annotates_once_and_degrades_when_the_token_is_rejected(
 
     # One annotation for the run, and the loop stops rather than retrying a dead token.
     out = capsys.readouterr().out
-    assert out.count("::warning::the GitHub token was rejected (401)") == 1
+    assert out.count("::warning::media upload stopped: the credential was rejected (401)") == 1
     assert uploader.call_count == 1
     assert target.read_text() == "evidence: the bug and more"
 

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -87,12 +87,32 @@ def test_a_failed_file_does_not_stop_the_rest(
     assert capsys.readouterr().out == f"{shot}\t{URL}\n"
 
 
-def test_a_rejected_credential_stops_the_remaining_uploads(
-    tmp_path: Path, shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_a_credential_fault_stops_the_remaining_uploads(
+    tmp_path: Path, shot: Path, credentials: None, capsys: pytest.CaptureFixture[str], status: int
 ) -> None:
     second = tmp_path / "second.png"
     second.write_bytes(b"\x89PNG")
     args = build_args(str(shot), str(second))
+
+    with (
+        mock.patch.object(
+            upload_media,
+            "upload_asset",
+            side_effect=UploadFailed(f"shot.png: refused ({status})", status=status),
+        ) as uploader,
+        pytest.raises(SystemExit, match="^1$"),
+    ):
+        args.func(args)
+
+    uploader.assert_called_once_with(shot, REPO_ID, "t")
+    assert f"failed shot.png: refused ({status})" in capsys.readouterr().err
+
+
+def test_only_a_401_suggests_reauthenticating(
+    shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = build_args(str(shot))
 
     with (
         mock.patch.object(
@@ -105,8 +125,7 @@ def test_a_rejected_credential_stops_the_remaining_uploads(
         args.func(args)
 
     uploader.assert_called_once_with(shot, REPO_ID, "t")
-    err = capsys.readouterr().err
-    assert "check GH_TOKEN or run `gh auth login`" in err
+    assert "check GH_TOKEN or run `gh auth login`" in capsys.readouterr().err
 
 
 def test_a_missing_path_is_reported_without_uploading(

--- a/.claude/skills/tests/test_upload_media.py
+++ b/.claude/skills/tests/test_upload_media.py
@@ -106,26 +106,10 @@ def test_a_credential_fault_stops_the_remaining_uploads(
         args.func(args)
 
     uploader.assert_called_once_with(shot, REPO_ID, "t")
-    assert f"failed shot.png: refused ({status})" in capsys.readouterr().err
-
-
-def test_only_a_401_suggests_reauthenticating(
-    shot: Path, credentials: None, capsys: pytest.CaptureFixture[str]
-) -> None:
-    args = build_args(str(shot))
-
-    with (
-        mock.patch.object(
-            upload_media,
-            "upload_asset",
-            side_effect=UploadFailed("shot.png: the credential was rejected (401)", status=401),
-        ) as uploader,
-        pytest.raises(SystemExit, match="^1$"),
-    ):
-        args.func(args)
-
-    uploader.assert_called_once_with(shot, REPO_ID, "t")
-    assert "check GH_TOKEN or run `gh auth login`" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert f"failed shot.png: refused ({status})" in err
+    # Only a rejected credential is worth re-authenticating for; a 403 or a 404 is not.
+    assert ("check GH_TOKEN or run `gh auth login`" in err) == (status == 401)
 
 
 def test_a_missing_path_is_reported_without_uploading(

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -142,6 +142,7 @@ def test_upload_asset_explains_a_credential_failure(
 
     opener.assert_called_once()
     assert excinfo.value.status == code
+    assert excinfo.value.fatal
 
 
 def test_a_404_names_the_credential_kind_without_printing_it(tmp_path: Path) -> None:
@@ -179,9 +180,12 @@ def test_upload_asset_carries_the_status_of_other_http_errors(tmp_path: Path) ->
     path.write_bytes(b"\x89PNG")
 
     with (
-        mock.patch("urllib.request.urlopen", side_effect=http_error(500)),
+        mock.patch("urllib.request.urlopen", side_effect=http_error(500)) as opener,
         pytest.raises(uploads.UploadFailed, match="shot.png") as excinfo,
     ):
         uploads.upload_asset(path, "1", "t")
 
+    opener.assert_called_once()
     assert excinfo.value.status == 500
+    # A server fault is worth retrying with the next file; a credential fault is not.
+    assert not excinfo.value.fatal


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25342, the layer below in this stack.

### What changes are proposed in this pull request?

Only a 401 ended an upload run. A 403 or a 404 is equally about the credential
or the repository rather than the file at hand, so every remaining file was
uploaded only to be refused the same way.

Keys the decision off the status instead, via `UploadFailed.fatal`, and lets the
CI annotation carry whichever refusal stopped the run rather than naming an
expired token for every case.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
