### PR TITLE
Carry the upload endpoint's own explanation for 422 and 429

### DIFF
--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -30,7 +31,7 @@ VIDEO_SUFFIXES = {".mp4", ".mov", ".webm"}
 
 # Answered for a fault that is not about the file at hand, so every remaining upload in
 # the run would fail the same way.
-FATAL_STATUSES = frozenset({401, 403, 404})
+FATAL_STATUSES = frozenset({401, 403, 404, 429})
 
 # The endpoint serves only OAuth tokens, classic PATs, and fine-grained PATs bound to the
 # target repository. Actions and App installation tokens are refused whatever their
@@ -72,6 +73,32 @@ class UploadFailed(Exception):
 
 MAX_IMAGE_BYTES = 10 * 1024 * 1024
 MAX_VIDEO_BYTES = 100 * 1024 * 1024
+
+
+def error_detail(e: urllib.error.HTTPError) -> str:
+    """Join what the endpoint said about the refusal.
+
+    The reason phrase names no cause; a 422 explains itself only in the body, and that
+    is the status that separates a bad content type from an oversized file.
+    """
+    try:
+        body = json.loads(e.read())
+    except (OSError, ValueError):
+        return ""
+
+    parts: list[str] = []
+    match body:
+        case {"message": str(message)}:
+            parts.append(message)
+    match body:
+        case {"errors": [*errors]}:
+            for error in errors:
+                match error:
+                    case {"message": str(message)}:
+                        # The size refusal embeds markup meant for the web uploader, and
+                        # dropping the tags leaves the whitespace that sat between them.
+                        parts.append(re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", message)).strip())
+    return "; ".join(dict.fromkeys(parts))
 
 
 def is_video(name: str) -> bool:
@@ -125,7 +152,17 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str:
                 f"the endpoint refuses this credential, which is {describe_token(token)}",
                 status=404,
             ) from e
-        raise UploadFailed(f"{path.name}: {e}", status=e.code) from e
+        if e.code == 429:
+            after = e.headers.get("Retry-After")
+            raise UploadFailed(
+                f"{path.name}: rate limited (429)" + (f"; retry after {after}s" if after else ""),
+                status=429,
+            ) from e
+        detail = error_detail(e)
+        raise UploadFailed(
+            f"{path.name}: {e.code} {e.reason}" + (f": {detail}" if detail else ""),
+            status=e.code,
+        ) from e
     except (OSError, http.client.HTTPException, ValueError) as e:
         raise UploadFailed(f"{path.name}: {e}") from e
 

--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -98,6 +98,12 @@ def error_detail(e: urllib.error.HTTPError) -> str:
                         # The size refusal embeds markup meant for the web uploader, and
                         # dropping the tags leaves the whitespace that sat between them.
                         parts.append(re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", message)).strip())
+                    # Only `code: custom` is documented to carry a message, so name the
+                    # field and code rather than collapse to a bare "Validation Failed".
+                    case {"code": str(code), "field": str(field)}:
+                        parts.append(f"{field}: {code}")
+                    case {"code": str(code)}:
+                        parts.append(code)
     return "; ".join(dict.fromkeys(parts))
 
 
@@ -153,9 +159,14 @@ def upload_asset(path: Path, repository_id: str, token: str) -> str:
                 status=404,
             ) from e
         if e.code == 429:
+            # Retry-After rides along only on a secondary limit; a primary one explains
+            # itself in the body, and the two need different waits.
             after = e.headers.get("Retry-After")
+            detail = error_detail(e)
             raise UploadFailed(
-                f"{path.name}: rate limited (429)" + (f"; retry after {after}s" if after else ""),
+                f"{path.name}: rate limited (429)"
+                + (f": {detail}" if detail else "")
+                + (f"; retry after {after}s" if after else ""),
                 status=429,
             ) from e
         detail = error_detail(e)

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -1,6 +1,7 @@
 import http.client
 import io
 import json
+import re
 import urllib.error
 from pathlib import Path
 from unittest import mock
@@ -272,3 +273,48 @@ def test_rate_limiting_stops_the_run_and_reports_the_wait(
     opener.assert_called_once()
     assert str(excinfo.value) == f"shot.png: {expected}"
     assert excinfo.value.fatal
+
+
+def test_a_429_carries_the_body_when_retry_after_is_absent(tmp_path: Path) -> None:
+    # Retry-After rides along only on a secondary limit, so a primary one would otherwise
+    # report nothing but the status.
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+    body = json.dumps({"message": "You have exceeded a secondary rate limit"}).encode()
+
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(429, body)) as opener,
+        pytest.raises(uploads.UploadFailed, match="secondary rate limit") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    opener.assert_called_once()
+    assert str(excinfo.value) == (
+        "shot.png: rate limited (429): You have exceeded a secondary rate limit"
+    )
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        ({"field": "content_type", "code": "invalid"}, "content_type: invalid"),
+        ({"code": "unprocessable"}, "unprocessable"),
+    ],
+)
+def test_a_per_field_error_without_a_message_still_names_the_cause(
+    tmp_path: Path, error: dict[str, str], expected: str
+) -> None:
+    # Only `code: custom` is documented to carry a message; without this the report
+    # collapses to a bare "Validation Failed".
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+    body = json.dumps({"message": "Validation Failed", "errors": [error]}).encode()
+
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(422, body)) as opener,
+        pytest.raises(uploads.UploadFailed, match=re.escape(expected)) as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    opener.assert_called_once()
+    assert str(excinfo.value) == f"shot.png: 422 nope: Validation Failed; {expected}"

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -247,15 +247,21 @@ def test_a_body_that_is_not_json_leaves_the_status_readable(tmp_path: Path) -> N
     assert str(excinfo.value) == "shot.png: 500 nope"
 
 
+RATE_LIMITED = json.dumps({"message": "You have exceeded a secondary rate limit"}).encode()
+SECONDARY = "You have exceeded a secondary rate limit"
+
+
 @pytest.mark.parametrize(
-    ("headers", "expected"),
+    ("body", "headers", "expected"),
     [
-        ({"Retry-After": "60"}, "rate limited (429); retry after 60s"),
-        ({}, "rate limited (429)"),
+        (b"", {"Retry-After": "60"}, "rate limited (429); retry after 60s"),
+        (b"", {}, "rate limited (429)"),
+        # Both halves at once, so the formatting between them is pinned.
+        (RATE_LIMITED, {"Retry-After": "60"}, f"rate limited (429): {SECONDARY}; retry after 60s"),
     ],
 )
 def test_rate_limiting_stops_the_run_and_reports_the_wait(
-    tmp_path: Path, headers: dict[str, str], expected: str
+    tmp_path: Path, body: bytes, headers: dict[str, str], expected: str
 ) -> None:
     # Every remaining file would be refused too, so the run has to stop rather than
     # spend the rest of the batch on it.
@@ -263,9 +269,7 @@ def test_rate_limiting_stops_the_run_and_reports_the_wait(
     path.write_bytes(b"\x89PNG")
 
     with (
-        mock.patch(
-            "urllib.request.urlopen", side_effect=http_error(429, headers=headers)
-        ) as opener,
+        mock.patch("urllib.request.urlopen", side_effect=http_error(429, body, headers)) as opener,
         pytest.raises(uploads.UploadFailed, match=r"rate limited \(429\)") as excinfo,
     ):
         uploads.upload_asset(path, "1", "t")
@@ -280,18 +284,15 @@ def test_a_429_carries_the_body_when_retry_after_is_absent(tmp_path: Path) -> No
     # report nothing but the status.
     path = tmp_path / "shot.png"
     path.write_bytes(b"\x89PNG")
-    body = json.dumps({"message": "You have exceeded a secondary rate limit"}).encode()
 
     with (
-        mock.patch("urllib.request.urlopen", side_effect=http_error(429, body)) as opener,
+        mock.patch("urllib.request.urlopen", side_effect=http_error(429, RATE_LIMITED)) as opener,
         pytest.raises(uploads.UploadFailed, match="secondary rate limit") as excinfo,
     ):
         uploads.upload_asset(path, "1", "t")
 
     opener.assert_called_once()
-    assert str(excinfo.value) == (
-        "shot.png: rate limited (429): You have exceeded a secondary rate limit"
-    )
+    assert str(excinfo.value) == f"shot.png: rate limited (429): {SECONDARY}"
 
 
 @pytest.mark.parametrize(

--- a/.claude/skills/tests/test_uploads.py
+++ b/.claude/skills/tests/test_uploads.py
@@ -115,8 +115,27 @@ def test_a_video_between_the_image_and_video_caps_is_not_skipped(tmp_path: Path)
         assert uploads.upload_asset(path, "1", "t") == URL
 
 
-def http_error(code: int) -> urllib.error.HTTPError:
-    return urllib.error.HTTPError(uploads.UPLOAD_URL, code, "nope", {}, None)  # type: ignore[arg-type]
+def http_error(
+    code: int, body: bytes = b"", headers: dict[str, str] | None = None
+) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        uploads.UPLOAD_URL,
+        code,
+        "nope",
+        headers or {},  # type: ignore[arg-type]
+        io.BytesIO(body),
+    )
+
+
+SIZE_REFUSAL = json.dumps({
+    "message": "Validation Failed",
+    "errors": [
+        {
+            "field": "size",
+            "message": "size Yowza that's a big file. <span class='x'> </span>Try again.",
+        }
+    ],
+}).encode()
 
 
 @pytest.mark.parametrize(
@@ -189,3 +208,67 @@ def test_upload_asset_carries_the_status_of_other_http_errors(tmp_path: Path) ->
     assert excinfo.value.status == 500
     # A server fault is worth retrying with the next file; a credential fault is not.
     assert not excinfo.value.fatal
+
+
+def test_a_422_carries_what_the_endpoint_objected_to(tmp_path: Path) -> None:
+    # The reason phrase is "Unprocessable Entity" whatever went wrong, so the body is
+    # the only thing that separates a bad content type from an oversized file.
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch("urllib.request.urlopen", side_effect=http_error(422, SIZE_REFUSAL)) as opener,
+        pytest.raises(uploads.UploadFailed, match="Validation Failed") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    opener.assert_called_once()
+    message = str(excinfo.value)
+    assert "Yowza that's a big file. Try again." in message
+    # The endpoint answers with markup meant for the web uploader.
+    assert "<span" not in message
+    assert not excinfo.value.fatal
+
+
+def test_a_body_that_is_not_json_leaves_the_status_readable(tmp_path: Path) -> None:
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch(
+            "urllib.request.urlopen", side_effect=http_error(500, b"<html>oops</html>")
+        ) as opener,
+        pytest.raises(uploads.UploadFailed, match="shot.png: 500 nope") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    opener.assert_called_once()
+    assert str(excinfo.value) == "shot.png: 500 nope"
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        ({"Retry-After": "60"}, "rate limited (429); retry after 60s"),
+        ({}, "rate limited (429)"),
+    ],
+)
+def test_rate_limiting_stops_the_run_and_reports_the_wait(
+    tmp_path: Path, headers: dict[str, str], expected: str
+) -> None:
+    # Every remaining file would be refused too, so the run has to stop rather than
+    # spend the rest of the batch on it.
+    path = tmp_path / "shot.png"
+    path.write_bytes(b"\x89PNG")
+
+    with (
+        mock.patch(
+            "urllib.request.urlopen", side_effect=http_error(429, headers=headers)
+        ) as opener,
+        pytest.raises(uploads.UploadFailed, match=r"rate limited \(429\)") as excinfo,
+    ):
+        uploads.upload_asset(path, "1", "t")
+
+    opener.assert_called_once()
+    assert str(excinfo.value) == f"shot.png: {expected}"
+    assert excinfo.value.fatal


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25343, the layer below in this stack.

### What changes are proposed in this pull request?

A 422 reason phrase is `Unprocessable Entity` whatever went wrong, and the
response body is the only thing separating a rejected content type from an
oversized file, yet it was being thrown away. Reads it and joins the top-level
message with the per-field ones, stripping the markup GitHub writes for the web
uploader.

A 429 had no handling at all, so it fell through as retryable and the rest of
the batch was spent getting rate limited too. Reports the wait from
`Retry-After` and stops the run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

The 422 shape under test is the real one: the size refusal genuinely arrives as
`Validation Failed` plus a per-field message carrying `<span>` markup meant for
the web uploader.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
