### PR TITLE
Correct the svg claim in the upload allowlist comment

### DIFF
--- a/.claude/skills/src/skills/github/uploads.py
+++ b/.claude/skills/src/skills/github/uploads.py
@@ -13,8 +13,9 @@ from pathlib import Path
 UPLOAD_URL = "https://uploads.github.com/user-attachments/assets"
 
 # The name's extension must agree with content_type or the endpoint returns 422. The
-# allowlist is narrower than the formats GitHub documents for attachments: svg and audio
-# are both refused, so extend this map only against a live 201.
+# allowlist is narrower than the formats GitHub documents for attachments: audio is
+# refused, so extend this map only against a live 201. svg does upload, but is left out
+# until something confirms GitHub renders an svg attachment in markdown.
 MIME_TYPES = {
     ".png": "image/png",
     ".jpg": "image/jpeg",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25341, which introduced the incorrect comment.

### What changes are proposed in this pull request?

The `MIME_TYPES` comment claims svg and audio are both refused by the
`user-attachments` endpoint. Audio is. svg is not.

The probe behind that claim used bare `curl` with `content_type=image/svg+xml`
in the query string, where an unencoded `+` arrives as a space. The endpoint saw
`image/svg xml` and answered 422 for both the content type and a name that no
longer matched it, which read as "svg is unsupported".

`upload_asset` was never affected: it builds its query with
`urllib.parse.urlencode`, which escapes the mime correctly. Only the comment is
wrong, and it currently tells future maintainers not to add a format that works.

svg still stays out of the map, for a different reason now stated in the comment:
nothing has confirmed GitHub renders an svg attachment in markdown, and adding it
would let `embed-media --check` pass a citation that ships broken.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Re-measured against `mlflow/mlflow`: svg sent as `%2B` returns 201, sent with a
raw `+` returns 422; `.mp3` and `.wav` return 422 with correct encoding. A 422
naming both `content_type` and a name mismatch turns out to be the signature of
this mistake, since an unsupported type whose extension matches reports only the
`content_type` error.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
