### PR TITLE
Refresh the Traces V4 table: row density, header, and navigation

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4DateSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4DateSelector.tsx
@@ -9,7 +9,6 @@ import {
   DialogComboboxOptionList,
   DialogComboboxOptionListSelectItem,
   RangePicker,
-  RefreshIcon,
   SyncIcon,
   Tooltip,
   Typography,
@@ -197,6 +196,7 @@ export const TracesV4RefreshButton = React.memo(function TracesV4RefreshButton({
           right edge rather than leaving a gap. */}
       <Typography.Text
         color="secondary"
+        size="sm"
         css={{
           display: 'inline-flex',
           alignItems: 'center',
@@ -208,10 +208,10 @@ export const TracesV4RefreshButton = React.memo(function TracesV4RefreshButton({
         }}
       >
         {isFetching ? (
-          <SyncIcon spin />
+          <SyncIcon spin css={{ fontSize: theme.typography.fontSizeSm }} />
         ) : (
           <>
-            <RefreshIcon />
+            <SyncIcon css={{ fontSize: theme.typography.fontSizeSm }} />
             <ToolbarCollapsibleLabel>
               <FormattedRelativeTime
                 value={(monitoringConfig.lastRefreshTime - Date.now()) / 1000}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4DisplayButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4DisplayButton.tsx
@@ -82,10 +82,15 @@ export const TracesV4DisplayButton = ({
           defaultMessage: 'Compact',
           description: 'Traces table row-height option: compact (dense) rows',
         })
-      : intl.formatMessage({
-          defaultMessage: 'Standard',
-          description: 'Traces table row-height option: standard (default) rows',
-        });
+      : density === 'standard'
+        ? intl.formatMessage({
+            defaultMessage: 'Standard',
+            description: 'Traces table row-height option: taller rows with two-line text previews',
+          })
+        : intl.formatMessage({
+            defaultMessage: 'Tall',
+            description: 'Traces table row-height option: tall rows with longer text previews',
+          });
 
   return (
     // Non-modal so the open menu doesn't aria-hide / scroll-lock the table behind it — the grid stays
@@ -94,7 +99,7 @@ export const TracesV4DisplayButton = ({
       <DropdownMenu.Trigger asChild>
         <Button
           componentId={`${COMPONENT_ID}.trigger`}
-          icon={<SlidersIcon />}
+          icon={<SlidersIcon css={{ color: theme.colors.textSecondary }} />}
           endIcon={<ChevronDownIcon />}
           // Names the button when its label collapses to icon-only.
           aria-label={intl.formatMessage({
@@ -275,11 +280,18 @@ export const TracesV4DisplayButton = ({
                   description="Traces table row-height option: compact (dense) rows"
                 />
               </DropdownMenu.RadioItem>
-              <DropdownMenu.RadioItem value="default">
+              <DropdownMenu.RadioItem value="standard">
                 <DropdownMenu.ItemIndicator />
                 <FormattedMessage
                   defaultMessage="Standard"
-                  description="Traces table row-height option: standard (default) rows"
+                  description="Traces table row-height option: taller rows with two-line text previews"
+                />
+              </DropdownMenu.RadioItem>
+              <DropdownMenu.RadioItem value="tall">
+                <DropdownMenu.ItemIndicator />
+                <FormattedMessage
+                  defaultMessage="Tall"
+                  description="Traces table row-height option: tall rows with longer text previews"
                 />
               </DropdownMenu.RadioItem>
             </DropdownMenu.RadioGroup>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
@@ -490,26 +490,24 @@ describe('TracesV4PageContent (interactions)', () => {
   });
 
   describe('Display popover: row height', () => {
-    // Compact rows keep the DS Table at its default typography size and apply compact padding in the
-    // traces table itself. Standard and Tall therefore both keep the DS row padding variable at the
-    // default value; their row height differs by minHeight and preview line clamp.
+    // Standard and Tall keep the same row padding; their row height differs by the density minHeight
+    // floor and preview line clamp.
     const STANDARD_ROW_PADDING = '6px';
     const STANDARD_ROW_MIN_HEIGHT = '48px';
     const TALL_ROW_MIN_HEIGHT = '128px';
     const firstTraceRow = () => screen.getByRole('row', { name: /Open trace tr-000 — input/ });
 
-    test('defaults to Standard when the stored preference uses the previous version', async () => {
+    test('defaults to Compact when the stored preference uses the previous version', async () => {
       const user = userEvent.setup();
       const densityKey = `${TRACE_DENSITY_STORAGE_KEY_PREFIX}.${EXPERIMENT_ID}`;
-      // A stale (previous-version) entry is ignored, so density falls back to the OSS default of
-      // Standard — unlike the managed app, which defaults to Compact.
+      // A stale (previous-version) entry is ignored, so density falls back to the Compact default.
       setLocalStorageItem(densityKey, DENSITY_STORAGE_VERSION - 1, true, 'tall');
 
       renderPage();
       await findTraceRow('tr-000');
 
       await openDisplaySubmenu(user, /^Row height/);
-      expect(await screen.findByRole('menuitemradio', { name: 'Standard', checked: true })).toBeInTheDocument();
+      expect(await screen.findByRole('menuitemradio', { name: 'Compact', checked: true })).toBeInTheDocument();
     });
 
     test('switching to Standard makes the table use standard-height rows with a larger minimum height', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
@@ -490,43 +490,77 @@ describe('TracesV4PageContent (interactions)', () => {
   });
 
   describe('Display popover: row height', () => {
-    // The DS Table sets a per-row `--table-row-vertical-padding` from its `size`: a data row is 6px at
-    // the default (Standard) size and theme.spacing.xs (4px) at the compact (small) size.
+    // Compact rows keep the DS Table at its default typography size and apply compact padding in the
+    // traces table itself. Standard and Tall therefore both keep the DS row padding variable at the
+    // default value; their row height differs by minHeight and preview line clamp.
     const STANDARD_ROW_PADDING = '6px';
-    const COMPACT_ROW_PADDING = '4px';
+    const STANDARD_ROW_MIN_HEIGHT = '48px';
+    const TALL_ROW_MIN_HEIGHT = '128px';
     const firstTraceRow = () => screen.getByRole('row', { name: /Open trace tr-000 — input/ });
 
-    test('defaults to Standard when the stored Compact preference uses the previous version', async () => {
+    test('defaults to Standard when the stored preference uses the previous version', async () => {
+      const user = userEvent.setup();
       const densityKey = `${TRACE_DENSITY_STORAGE_KEY_PREFIX}.${EXPERIMENT_ID}`;
-      setLocalStorageItem(densityKey, DENSITY_STORAGE_VERSION - 1, true, 'small');
+      // A stale (previous-version) entry is ignored, so density falls back to the OSS default of
+      // Standard — unlike the managed app, which defaults to Compact.
+      setLocalStorageItem(densityKey, DENSITY_STORAGE_VERSION - 1, true, 'tall');
 
       renderPage();
       await findTraceRow('tr-000');
-      expect(firstTraceRow()).toHaveStyle({ '--table-row-vertical-padding': STANDARD_ROW_PADDING });
+
+      await openDisplaySubmenu(user, /^Row height/);
+      expect(await screen.findByRole('menuitemradio', { name: 'Standard', checked: true })).toBeInTheDocument();
     });
 
-    test('switching to Compact makes the table use compact-height rows', async () => {
+    test('switching to Standard makes the table use standard-height rows with a larger minimum height', async () => {
       const user = userEvent.setup();
       renderPage();
       await findTraceRow('tr-000');
 
       await openDisplaySubmenu(user, /^Row height/);
-      await selectSubmenuItem('menuitemradio', 'Compact');
+      await selectSubmenuItem('menuitemradio', 'Standard');
 
-      expect(firstTraceRow()).toHaveStyle({ '--table-row-vertical-padding': COMPACT_ROW_PADDING });
-    }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
+      await waitFor(() =>
+        expect(firstTraceRow()).toHaveStyle({
+          '--table-row-vertical-padding': STANDARD_ROW_PADDING,
+          minHeight: STANDARD_ROW_MIN_HEIGHT,
+        }),
+      );
+    });
 
-    test('applies a Compact row height persisted from a prior session', async () => {
+    test('switching to Tall keeps standard table padding and uses a taller row height', async () => {
       const user = userEvent.setup();
+      renderPage();
+      await findTraceRow('tr-000');
+
+      await openDisplaySubmenu(user, /^Row height/);
+      await selectSubmenuItem('menuitemradio', 'Tall');
+
+      await waitFor(() =>
+        expect(firstTraceRow()).toHaveStyle({
+          '--table-row-vertical-padding': STANDARD_ROW_PADDING,
+          minHeight: TALL_ROW_MIN_HEIGHT,
+        }),
+      );
+    });
+
+    test('applies a Tall row height persisted from a prior session', async () => {
+      const user = userEvent.setup();
+      // A density chosen in a prior session (Tall) is read back on the next mount via
+      // the same scoped/versioned key the hook writes — the table uses standard rows and the Row height
+      // submenu shows Tall as the checked option.
       const densityKey = `${TRACE_DENSITY_STORAGE_KEY_PREFIX}.${EXPERIMENT_ID}`;
-      setLocalStorageItem(densityKey, DENSITY_STORAGE_VERSION, true, 'small');
+      setLocalStorageItem(densityKey, DENSITY_STORAGE_VERSION, true, 'tall');
 
       renderPage();
       await findTraceRow('tr-000');
-      expect(firstTraceRow()).toHaveStyle({ '--table-row-vertical-padding': COMPACT_ROW_PADDING });
+      expect(firstTraceRow()).toHaveStyle({
+        '--table-row-vertical-padding': STANDARD_ROW_PADDING,
+        minHeight: TALL_ROW_MIN_HEIGHT,
+      });
 
       await openDisplaySubmenu(user, /^Row height/);
-      expect(await screen.findByRole('menuitemradio', { name: 'Compact', checked: true })).toBeInTheDocument();
-    }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
+      expect(await screen.findByRole('menuitemradio', { name: 'Tall', checked: true })).toBeInTheDocument();
+    });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.test.tsx
@@ -336,6 +336,18 @@ describe('TracesV4PageContent', () => {
       expect(link).toHaveAttribute('href', expect.stringContaining('traceId=trace%3A%2Fcat.sch%2Ftr-000'));
     });
 
+    test('the trace link preserves the current URL params (filters survive opening a trace)', async () => {
+      // Land on the page with an existing filter param already on the URL; opening a trace should
+      // add `traceId` without dropping it, so a filtered view (or a Cmd/Ctrl+click into a new tab)
+      // reopens with the same filters rather than resetting to a bare Traces route.
+      const filterParam = new URLSearchParams({ filter: "trace.status = 'OK'" }).toString();
+      renderPage({ initialUrl: `${URL}?${filterParam}` });
+      const link = await findTraceRow('tr-000');
+      const href = link.getAttribute('href') ?? '';
+      expect(href).toContain('traceId=trace%3A%2Fcat.sch%2Ftr-000');
+      expect(href).toContain(filterParam);
+    });
+
     test('clicking a UC-backed row opens the drawer with a V4 long identifier (not a bare hex id)', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
       renderPage();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -49,6 +49,12 @@ interface TracesV4PageContentProps {
   experimentId: string;
 }
 
+const PREVIEW_LINE_CLAMP_BY_DENSITY = {
+  small: 1,
+  standard: 2,
+  tall: 6,
+} as const;
+
 // Narrows a column id to a standard `TraceColumnId` (assessment columns are namespaced separately).
 const isStandardColumnId = (id: string): id is TraceColumnId => (TRACE_COLUMN_IDS as readonly string[]).includes(id);
 
@@ -355,7 +361,8 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             sort={url.sort}
             dir={url.dir}
             onSort={url.setSort}
-            size={density}
+            size={density === 'small' ? 'small' : 'default'}
+            previewLineClamp={PREVIEW_LINE_CLAMP_BY_DENSITY[density]}
             getTraceHref={getTraceHref}
             getSessionHref={getSessionHref}
             onSessionSelected={handleSessionSelected}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -27,7 +27,7 @@ import { useDeleteTracesMutation } from '@mlflow/mlflow/src/experiment-tracking/
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
 import { AssistantAwareActionBar } from '@mlflow/mlflow/src/common/components/AssistantAwareActionBar';
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
-import { useNavigate, useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { useNavigate, useSearchParams, useLocation } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import { shouldEnableIssueDetection } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 import { SELECTED_TRACE_ID_QUERY_PARAM } from '@mlflow/mlflow/src/experiment-tracking/constants';
 // Reuse the generic (branding-free) "/" hotkey hook from datasets-v2.
@@ -62,6 +62,7 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const navigate = useNavigate();
+  const { pathname, search, hash } = useLocation();
   const { notify, notificationContainer } = useTracesV4Notifications();
   const searchInputRef = useRef<InputRef>(null);
   useSlashFocusSearch(searchInputRef);
@@ -167,12 +168,16 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
   );
   const closeDrawer = useCallback(() => url.setTraceId(undefined), [url]);
 
+  // Open a trace by adding `traceId` to the *current* location rather than resetting to a bare Traces
+  // route, so active filters/sort in the URL survive an open (and a Cmd/Ctrl+click into a new tab).
   const getTraceHref = useCallback<TraceHrefGetter>(
     (trace) => {
       const traceId = doesTraceSupportV4API(trace) ? createTraceV4LongIdentifier(trace) : trace.trace_id;
-      return `${Routes.getExperimentPageTracesTabRoute(experimentId)}?traceId=${encodeURIComponent(traceId)}`;
+      const searchParams = new URLSearchParams(search);
+      searchParams.set('traceId', traceId);
+      return `${pathname}?${searchParams.toString()}${hash}`;
     },
-    [experimentId],
+    [pathname, search, hash],
   );
 
   // The session cell's only product coupling: build the single-chat-session route (matching v1),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -361,7 +361,6 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             sort={url.sort}
             dir={url.dir}
             onSort={url.setSort}
-            size={density === 'small' ? 'small' : 'default'}
             previewLineClamp={PREVIEW_LINE_CLAMP_BY_DENSITY[density]}
             getTraceHref={getTraceHref}
             getSessionHref={getSessionHref}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4Toolbar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4Toolbar.tsx
@@ -241,10 +241,12 @@ export const useTracesV4ToolbarSlots = ({
           />
         )}
         <div css={{ flex: 1 }} />
-        <TracesV4RefreshButton isFetching={isRefreshing} />
-        {shouldEnableIssueDetection() && onDetectIssues && (
-          <DetectIssuesButton componentId="mlflow.traces-v4.detect-issues-button" onClick={onDetectIssues} />
-        )}
+        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <TracesV4RefreshButton isFetching={isRefreshing} />
+          {shouldEnableIssueDetection() && onDetectIssues && (
+            <DetectIssuesButton componentId="mlflow.traces-v4.detect-issues-button" onClick={onDetectIssues} />
+          )}
+        </div>
       </>
     ),
   };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4ColumnSizing.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4ColumnSizing.ts
@@ -2,12 +2,12 @@ import { useTraceColumnSizing, type TraceColumnSizing } from '@databricks/web-sh
 import { TRACE_COLUMN_SIZES_STORAGE_KEY_PREFIX } from '../utils/constants';
 
 // Bump when the column set or sizing scheme changes so stale pixel widths reset.
-// v2 → narrower State / Session / Duration defaults.
-export const COLUMN_SIZES_STORAGE_VERSION = 2;
+// v3 → narrower Trace ID / Session defaults.
+export const COLUMN_SIZES_STORAGE_VERSION = 3;
 
 /**
  * MLflow adapter over the shared `useTraceColumnSizing`: keeps the MLflow storage-key prefix (scoped
- * per experiment) and the v2 schema version. The uncontrolled-sizing settle-persist behavior lives
+ * per experiment) and the v3 schema version. The uncontrolled-sizing settle-persist behavior lives
  * in the shared hook.
  */
 export const useTracesV4ColumnSizing = (experimentId: string): TraceColumnSizing =>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Density.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Density.ts
@@ -3,17 +3,17 @@ import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { TRACE_DENSITY_STORAGE_KEY_PREFIX } from '../utils/constants';
 
 // Bump when the density options or default change so stale entries reset.
-export const DENSITY_STORAGE_VERSION = 2;
+export const DENSITY_STORAGE_VERSION = 4;
 
 /**
- * Row-height density for the V4 traces table. Maps to the DS `Table` `size` prop: `'default'` is the
- * standard row height, `'small'` is compact. The mock offers a third "Tall" option, but the DS Table
- * supports only these two sizes today, so density is a two-way choice.
+ * Row-height density for the V4 traces table. The design-system table supplies the compact and
+ * standard padding; Standard also allows input and output previews to use a readable second line.
+ * Tall keeps standard table padding and allows longer input/output previews.
  */
-export type TracesV4Density = 'default' | 'small';
+export type TracesV4Density = 'small' | 'standard' | 'tall';
 
-/** Standard rows by default for consistency with other MLflow tables. */
-const DEFAULT_DENSITY: TracesV4Density = 'default';
+/** Compact rows by default — the trace table is dense and most users scan many rows at once. OSS intentionally defaults to Standard (not Compact like the managed app). */
+const DEFAULT_DENSITY: TracesV4Density = 'standard';
 
 export interface TracesV4DensityControl {
   density: TracesV4Density;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Density.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Density.ts
@@ -3,7 +3,7 @@ import { useLocalStorage } from '@databricks/web-shared/hooks';
 import { TRACE_DENSITY_STORAGE_KEY_PREFIX } from '../utils/constants';
 
 // Bump when the density options or default change so stale entries reset.
-export const DENSITY_STORAGE_VERSION = 4;
+export const DENSITY_STORAGE_VERSION = 3;
 
 /**
  * Row-height density for the V4 traces table. The design-system table supplies the compact and
@@ -12,8 +12,8 @@ export const DENSITY_STORAGE_VERSION = 4;
  */
 export type TracesV4Density = 'small' | 'standard' | 'tall';
 
-/** Compact rows by default — the trace table is dense and most users scan many rows at once. OSS intentionally defaults to Standard (not Compact like the managed app). */
-const DEFAULT_DENSITY: TracesV4Density = 'standard';
+/** Compact rows by default — the trace table is dense and most users scan many rows at once. */
+const DEFAULT_DENSITY: TracesV4Density = 'small';
 
 export interface TracesV4DensityControl {
   density: TracesV4Density;

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2775,6 +2775,10 @@
     "defaultMessage": "Version status",
     "description": "Aria label for MCP server version status selector"
   },
+  "9RoNrt": {
+    "defaultMessage": "Standard",
+    "description": "Traces table row-height option: taller rows with two-line text previews"
+  },
   "9Sxo9h": {
     "defaultMessage": "Max length",
     "description": "Text max length input"
@@ -9127,6 +9131,10 @@
     "defaultMessage": "Column options",
     "description": "Accessible label for the per-column options menu button in the traces table header"
   },
+  "ZIR7dS": {
+    "defaultMessage": "Tall",
+    "description": "Traces table row-height option: tall rows with longer text previews"
+  },
   "ZJK1e+": {
     "defaultMessage": "The Sessions view has moved to the Traces tab.",
     "description": "Explanation that the Sessions view has moved to the Traces tab"
@@ -15378,10 +15386,6 @@
   "y2rjoF": {
     "defaultMessage": "No trace data recorded",
     "description": "Empty state in the v2 dataset record side-panel trace modal when the trace has no spans"
-  },
-  "y4BFou": {
-    "defaultMessage": "Standard",
-    "description": "Traces table row-height option: standard (default) rows"
   },
   "y4I2zP": {
     "defaultMessage": "Select all traces on this page",

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
@@ -36,6 +36,10 @@ import { formatTraceDuration } from './formatTraceDuration';
 // possible — an in-file const (resolved to a literal) is how these cells share a namespace.
 const COMPONENT_ID = 'web-shared.traces-table';
 const CELL_OVERLAY_MAX_WIDTH = 300;
+// Input/output previews carry long request/response bodies, so they get a wider hover overlay than
+// the short-text cells (id / name): a wider box means fewer wrapped lines, so the preview stops
+// running off the bottom of the tooltip.
+const CELL_PREVIEW_MAX_WIDTH = 560;
 // DuBois icons are 16px by default and look oversized beside the small cell text. Size them via
 // `fontSize` (their SVG is 1em, so this scales the glyph and its line-box together — width/height
 // alone shrinks the glyph but leaves a 16px box, dropping it below the text).
@@ -54,6 +58,16 @@ const truncateCss: CSSObject = {
   maxWidth: '100%',
   verticalAlign: 'middle',
 };
+
+const getMultilineTruncateCss = (lineClamp: number): CSSObject => ({
+  display: '-webkit-box',
+  whiteSpace: 'normal',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: lineClamp,
+  maxWidth: '100%',
+  overflow: 'hidden',
+  overflowWrap: 'anywhere',
+});
 
 const ACTIVATOR_BASE_CSS: CSSObject = {
   display: 'inline-block',
@@ -297,22 +311,28 @@ const TracePreviewCell = ({
   accessibleLabel,
   componentId,
   to,
+  previewLineClamp,
+  textColor = 'primary',
 }: {
   value: string;
   onActivate: () => void;
   accessibleLabel: string;
   componentId: string;
   to?: To;
+  previewLineClamp: number;
+  textColor?: 'primary' | 'secondary';
 }) => {
   const { theme } = useDesignSystemTheme();
   if (!value) {
     return <EmptyValue />;
   }
+  const multilinePreviewStyle: React.CSSProperties | undefined =
+    previewLineClamp > 1 ? { WebkitLineClamp: previewLineClamp, whiteSpace: 'normal' } : undefined;
   return (
     <Tooltip
       componentId={`${componentId}-tooltip`}
       content={<WrappedTooltipText>{value}</WrappedTooltipText>}
-      maxWidth={CELL_OVERLAY_MAX_WIDTH}
+      maxWidth={CELL_PREVIEW_MAX_WIDTH}
     >
       <TraceActivator
         to={to}
@@ -322,15 +342,27 @@ const TracePreviewCell = ({
         css={{ display: 'block', width: '100%' }}
       >
         {/* Plain text color, not link-blue: the whole row is the click target, so the preview reads as
-          content rather than a link. */}
-        <span css={[truncateCss, { color: theme.colors.textPrimary }]}>{value}</span>
+          content rather than a link (still keyboard/right-click navigable via the underlying anchor). */}
+        <span
+          style={multilinePreviewStyle}
+          css={[
+            previewLineClamp > 1 ? getMultilineTruncateCss(previewLineClamp) : truncateCss,
+            { color: textColor === 'secondary' ? theme.colors.textSecondary : theme.colors.textPrimary },
+          ]}
+        >
+          {value}
+        </span>
       </TraceActivator>
     </Tooltip>
   );
 };
 
-export const TraceInputCell: React.MemoExoticComponent<(props: TraceCellProps) => JSX.Element> = memo(
-  function TraceInputCell({ trace, onSelect, accessibleLabel, to }: TraceCellProps) {
+interface TracePreviewCellProps extends TraceCellProps {
+  previewLineClamp: number;
+}
+
+export const TraceInputCell: React.MemoExoticComponent<(props: TracePreviewCellProps) => JSX.Element> = memo(
+  function TraceInputCell({ trace, onSelect, accessibleLabel, to, previewLineClamp }: TracePreviewCellProps) {
     return (
       <TracePreviewCell
         value={getTraceInfoInputs(trace)}
@@ -338,13 +370,15 @@ export const TraceInputCell: React.MemoExoticComponent<(props: TraceCellProps) =
         accessibleLabel={accessibleLabel}
         componentId={`${COMPONENT_ID}.cell.input`}
         to={to}
+        previewLineClamp={previewLineClamp}
+        textColor="secondary"
       />
     );
   },
 );
 
-export const TraceOutputCell: React.MemoExoticComponent<(props: TraceCellProps) => JSX.Element> = memo(
-  function TraceOutputCell({ trace, onSelect, accessibleLabel, to }: TraceCellProps) {
+export const TraceOutputCell: React.MemoExoticComponent<(props: TracePreviewCellProps) => JSX.Element> = memo(
+  function TraceOutputCell({ trace, onSelect, accessibleLabel, to, previewLineClamp }: TracePreviewCellProps) {
     return (
       <TracePreviewCell
         value={getTraceInfoOutputs(trace)}
@@ -352,6 +386,7 @@ export const TraceOutputCell: React.MemoExoticComponent<(props: TraceCellProps) 
         accessibleLabel={accessibleLabel}
         componentId={`${COMPONENT_ID}.cell.output`}
         to={to}
+        previewLineClamp={previewLineClamp}
       />
     );
   },

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceColumnHeader.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceColumnHeader.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from './test-utils/renderWithProviders';
 const renderHeader = (over: Partial<React.ComponentProps<typeof TraceColumnHeader>> = {}) =>
   renderWithProviders(
     <TraceColumnHeader
+      columnId="input"
       label="Input"
       labelText="Input"
       sortable={false}

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceColumnHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceColumnHeader.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowUpIcon,
   Button,
   CheckIcon,
   ChevronDownIcon,
@@ -6,6 +7,7 @@ import {
   SortAscendingIcon,
   SortDescendingIcon,
   Typography,
+  UserIcon,
   useDesignSystemTheme,
   VisibleOffIcon,
 } from '@databricks/design-system';
@@ -46,7 +48,8 @@ export const TraceColumnHeaderMenu = ({
         <Button
           componentId={`${COMPONENT_ID}.trigger`}
           size="small"
-          icon={<ChevronDownIcon />}
+          type="tertiary"
+          icon={<ChevronDownIcon css={{ color: theme.colors.textSecondary }} />}
           aria-label={triggerLabel}
           onClick={stopPropagation}
         />
@@ -96,6 +99,7 @@ export const TraceColumnHeaderMenu = ({
 };
 
 export interface TraceColumnHeaderProps {
+  columnId: string;
   label: React.ReactNode;
   /** Plain-text column name for the menu trigger's accessible label. */
   labelText?: string;
@@ -111,6 +115,7 @@ export interface TraceColumnHeaderProps {
  * inside its button trigger); sort moved into the menu dropdown.
  */
 export const TraceColumnHeader = ({
+  columnId,
   label,
   labelText,
   sortable,
@@ -137,6 +142,13 @@ export const TraceColumnHeader = ({
 
   const showMenu = sortable || Boolean(onHide);
 
+  const columnIcon =
+    columnId === 'input' ? (
+      <UserIcon />
+    ) : columnId === 'output' ? (
+      <ArrowUpIcon css={{ transform: 'rotate(45deg)' }} />
+    ) : null;
+
   const sortToggleLabel = labelText
     ? intl.formatMessage(
         {
@@ -151,8 +163,29 @@ export const TraceColumnHeader = ({
       });
 
   return (
-    <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, width: '100%', minWidth: 0 }}>
-      <Typography.Text bold ellipsis className="table-header-text" css={{ minWidth: 0, flex: '0 1 auto' }}>
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing.xs,
+        width: '100%',
+        minWidth: 0,
+      }}
+    >
+      {columnIcon && (
+        <span
+          aria-hidden
+          css={{
+            display: 'inline-flex',
+            flexShrink: 0,
+            color: theme.colors.textSecondary,
+            fontSize: theme.typography.fontSizeBase,
+          }}
+        >
+          {columnIcon}
+        </span>
+      )}
+      <Typography.Text bold size="sm" color="secondary" ellipsis css={{ minWidth: 0, flex: '0 1 auto' }}>
         {label}
       </Typography.Text>
       {sortable && sortDirection !== 'none' && (
@@ -175,7 +208,10 @@ export const TraceColumnHeader = ({
         </span>
       )}
       {showMenu && (
-        <span css={{ flexShrink: 0 }}>
+        <span
+          className="traces-table-header-menu-trigger"
+          css={{ display: 'inline-flex', flexShrink: 0, opacity: 0, transition: 'opacity 0.1s ease' }}
+        >
           <TraceColumnHeaderMenu
             sortable={sortable}
             sortDirection={sortDirection}

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.test.tsx
@@ -110,16 +110,12 @@ describe('TracesTable', () => {
     expect(screen.queryByRole('columnheader', { name: /Duration/ })).not.toBeInTheDocument();
   });
 
-  test('renders the requested number of skeleton rows at the default size', async () => {
+  test('renders exactly skeletonRowCount skeleton rows', async () => {
     await renderWithProviders(<TracesTable {...baseProps({ isLoading: true, skeletonRowCount: 25 })} />);
     // Real row content (the input preview text) is absent during the skeleton.
     expect(screen.queryByText('request for tr-000')).not.toBeInTheDocument();
+    // 25 skeleton rows + 1 header row.
     expect(screen.getAllByRole('row')).toHaveLength(26);
-  });
-
-  test('renders enough compact skeleton rows to match the default-size loading height', async () => {
-    await renderWithProviders(<TracesTable {...baseProps({ isLoading: true, skeletonRowCount: 25, size: 'small' })} />);
-    expect(screen.getAllByRole('row')).toHaveLength(34);
   });
 
   test('clicking a row calls onTraceSelected with that trace', async () => {
@@ -281,6 +277,31 @@ describe('TracesTable', () => {
     await userEvent.click(screen.getByRole('checkbox', { name: 'Select session s1' }));
     expect(onToggleBulkRows).toHaveBeenCalledWith(traces);
     expect(onSessionSelected).not.toHaveBeenCalled();
+  });
+
+  test('Shift-clicking a row checkbox requests a range selection in flat mode', async () => {
+    const onToggleBulkRow = jest.fn();
+    const traces = makeTraces(3);
+    await renderWithProviders(<TracesTable {...baseProps({ traces, onToggleBulkRow })} />);
+
+    const checkbox = within(screen.getByRole('row', { name: /Select trace tr-001/ })).getByRole('checkbox');
+    fireEvent.click(checkbox, { shiftKey: true });
+
+    expect(onToggleBulkRow).toHaveBeenCalledWith(traces[1], true);
+  });
+
+  test('Shift-clicking a row checkbox never requests a range in grouped mode', async () => {
+    // Grouped mode reorders and hides rows, so a flat-array range would select unrelated or collapsed
+    // traces; the range request is suppressed and the click toggles only the clicked trace.
+    const onToggleBulkRow = jest.fn();
+    const traces = [makeSessionTrace('s1-turn-1', 's1'), makeSessionTrace('s1-turn-2', 's1')];
+    await renderWithProviders(<TracesTable {...baseProps({ traces, isGroupedBySession: true, onToggleBulkRow })} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Expand session s1' }));
+    const checkbox = within(screen.getByRole('row', { name: /Select trace s1-turn-2/ })).getByRole('checkbox');
+    fireEvent.click(checkbox, { shiftKey: true });
+
+    expect(onToggleBulkRow).toHaveBeenCalledWith(traces[1], false);
   });
 
   test('clicking a grouped session summary selects the overall conversation instead of a trace', async () => {
@@ -470,36 +491,23 @@ describe('TracesTable', () => {
     }
   });
 
-  test('keeps compact expanded previews on the default table typography', async () => {
-    const renderPreviewTypographyClassName = async (size?: 'default' | 'small') => {
-      const { unmount } = await renderWithProviders(
-        <TracesTable
-          {...baseProps({
-            traces: [
-              makeTrace(`expanded-${size ?? 'default'}`, {
-                request_preview: 'a long request preview '.repeat(10),
-              }),
-            ],
-            visibleColumns: ['input'],
-            previewLineClamp: 2,
-            size,
-          })}
-        />,
-      );
+  test('keeps expanded previews on the base table typography', async () => {
+    await renderWithProviders(
+      <TracesTable
+        {...baseProps({
+          traces: [makeTrace('expanded', { request_preview: 'a long request preview '.repeat(10) })],
+          visibleColumns: ['input'],
+          previewLineClamp: 2,
+        })}
+      />,
+    );
 
-      const previewText = screen.getByText(/a long request preview a long request preview/);
-      // See the note above: assert the inline wrapping flag, not the jsdom-dropped clamp count.
-      expect(previewText).toHaveStyle({ whiteSpace: 'normal' });
-      const typography = previewText.closest('[class*="typography"]');
-      expect(typography).not.toBeNull();
-      const className = typography?.className;
-      unmount();
-      return className;
-    };
-
-    const defaultTypographyClassName = await renderPreviewTypographyClassName();
-    const compactTypographyClassName = await renderPreviewTypographyClassName('small');
-
-    expect(compactTypographyClassName).toBe(defaultTypographyClassName);
+    const previewText = screen.getByText(/a long request preview a long request preview/);
+    // See the note above: assert the inline wrapping flag, not the jsdom-dropped clamp count.
+    expect(previewText).toHaveStyle({ whiteSpace: 'normal' });
+    // Density changes row height alone: the cell subtree is pinned to the base typography size (the
+    // component's `[role="cell"] *` font-size rule), so the preview keeps the default typography class.
+    const typography = previewText.closest('[class*="typography"]');
+    expect(typography).not.toBeNull();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.test.tsx
@@ -438,4 +438,68 @@ describe('TracesTable', () => {
     expect(within(taggedRow).getByRole('button', { name: 'Open trace changing-tags — tags' })).toHaveTextContent('+2');
     expect(within(taggedRow).queryByRole('button', { name: 'Filter by tag b: 2' })).not.toBeInTheDocument();
   });
+
+  test.each([2, 6])('wraps input and output previews over %s lines', async (previewLineClamp) => {
+    await renderWithProviders(
+      <TracesTable
+        {...baseProps({
+          traces: [
+            makeTrace('expanded', {
+              request_preview: 'a long request preview '.repeat(10),
+              response_preview: 'a long response preview '.repeat(10),
+            }),
+          ],
+          visibleColumns: ['input', 'output'],
+          previewLineClamp,
+        })}
+      />,
+    );
+
+    for (const previewText of [
+      within(screen.getByRole('button', { name: 'Open trace expanded — input' })).getByText(
+        /a long request preview a long request preview/,
+      ),
+      within(screen.getByRole('button', { name: 'Open trace expanded — output' })).getByText(
+        /a long response preview a long response preview/,
+      ),
+    ]) {
+      // A multi-line preview sets an inline `white-space: normal` (single-line previews set no inline
+      // style and stay `nowrap`). The clamp count lives in `-webkit-line-clamp`, which jsdom's CSSOM
+      // silently drops, so it can't be asserted here — the inline wrapping flag is the observable signal.
+      expect(previewText).toHaveStyle({ whiteSpace: 'normal' });
+    }
+  });
+
+  test('keeps compact expanded previews on the default table typography', async () => {
+    const renderPreviewTypographyClassName = async (size?: 'default' | 'small') => {
+      const { unmount } = await renderWithProviders(
+        <TracesTable
+          {...baseProps({
+            traces: [
+              makeTrace(`expanded-${size ?? 'default'}`, {
+                request_preview: 'a long request preview '.repeat(10),
+              }),
+            ],
+            visibleColumns: ['input'],
+            previewLineClamp: 2,
+            size,
+          })}
+        />,
+      );
+
+      const previewText = screen.getByText(/a long request preview a long request preview/);
+      // See the note above: assert the inline wrapping flag, not the jsdom-dropped clamp count.
+      expect(previewText).toHaveStyle({ whiteSpace: 'normal' });
+      const typography = previewText.closest('[class*="typography"]');
+      expect(typography).not.toBeNull();
+      const className = typography?.className;
+      unmount();
+      return className;
+    };
+
+    const defaultTypographyClassName = await renderPreviewTypographyClassName();
+    const compactTypographyClassName = await renderPreviewTypographyClassName('small');
+
+    expect(compactTypographyClassName).toBe(defaultTypographyClassName);
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
@@ -14,6 +14,7 @@ import {
   useDesignSystemTheme,
 } from '@databricks/design-system';
 import { useIntl } from '@databricks/i18n';
+import type { CSSObject } from '@emotion/react';
 // This react-table package predates `useReactTableWithDeepMemo`. Use the canonical
 // `useReactTable_unverifiedWithReact18` (the same hook `GenAiTracesTableBody` uses for react-query
 // data): `data` comes reference-stable from `useTracesPageQuery`, and `columns`/`meta` are memoized
@@ -79,8 +80,11 @@ const rowWidthStyle = { width: `var(${ROW_WIDTH_VARIABLE})`, minWidth: '100%' } 
 const stopPropagationProps = {
   onClick: (event: React.MouseEvent) => event.stopPropagation(),
 };
-// Center the row-select checkbox vertically against the single-line cell text.
-const selectCellAlign = { '.table-row-select-cell': { alignItems: 'center' } } as const;
+const dataSelectCellAlign = {
+  '.table-row-select-cell': { alignItems: 'flex-start' },
+  '.table-row-select-cell > *': { transform: 'translateY(2px)' },
+} as const;
+const headerSelectCellAlign = { '.table-row-select-cell': { alignItems: 'center' } } as const;
 
 export interface TracesTableProps {
   traces: ModelTraceInfoV3[];
@@ -125,8 +129,10 @@ export interface TracesTableProps {
   onHideColumn: (columnId: string) => void;
   /** Groups traces with a session id into collapsible session rows. Standalone traces remain rows. */
   isGroupedBySession?: boolean;
-  /** Row-height density passed to the DS `Table` (`'small'` = compact rows). Defaults to `'default'`. */
+  /** Row-height density for traces rows (`'small'` = compact padding). Defaults to `'default'`. */
   size?: 'default' | 'small';
+  /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
+  previewLineClamp?: number;
 }
 
 interface GroupedTraceRows {
@@ -182,9 +188,14 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     onHideColumn,
     isGroupedBySession = false,
     size = 'default',
+    previewLineClamp = 1,
   }: TracesTableProps) {
     const { theme } = useDesignSystemTheme();
     const intl = useIntl();
+    // Keep the checkbox centered and leave a full spacing token before the first data column.
+    const selectCellCss = {
+      '.table-row-select-cell': { alignItems: 'center', paddingRight: theme.spacing.sm },
+    } as const;
 
     // Canonical-order visible column defs + any product columns. `extraColumns` is guarded to a stable
     // reference so a stable/undefined value doesn't defeat the deep memo (see `getVisibleColumnDefs`).
@@ -237,8 +248,8 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     );
 
     const meta = useMemo<TracesTableMeta>(
-      () => ({ intl, onTraceSelected, getTraceHref, getSessionHref, onFilterByTag, renderRunName }),
-      [intl, onTraceSelected, getTraceHref, getSessionHref, onFilterByTag, renderRunName],
+      () => ({ intl, onTraceSelected, getTraceHref, getSessionHref, onFilterByTag, renderRunName, previewLineClamp }),
+      [intl, onTraceSelected, getTraceHref, getSessionHref, onFilterByTag, renderRunName, previewLineClamp],
     );
 
     // Clamp the state TanStack is seeded with as well as the column definition. `getSize()` normally
@@ -353,9 +364,9 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     // the row's own width) cuts off at the viewport's right edge. `minWidth: 100%` keeps rows filling the
     // viewport — and lets the input/output fill columns grow — when the columns are narrower than it.
     //
-    // The leading select cell lives outside the TanStack column set: it's content-box with a 16px
-    // (spacing.md) content width + 8px (spacing.sm) left padding, so it contributes a fixed 24px.
-    const selectCellWidth = theme.spacing.md + theme.spacing.sm;
+    // The leading select cell lives outside the TanStack column set: 16px checkbox content plus 8px
+    // padding on each side, including the explicit trailing gap before the first data column.
+    const selectCellWidth = theme.spacing.md + theme.spacing.sm * 2;
     // Grouped mode inserts a leading expand/collapse toggle cell (a small button) before the columns;
     // reserve its width so header, session, and trace rows all stay column-aligned.
     const sessionToggleWidth = isGroupedBySession ? theme.general.heightSm + theme.spacing.xs : 0;
@@ -370,6 +381,20 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
       [ROW_WIDTH_VARIABLE]: `${rowWidth}px`,
       ...Object.fromEntries(leafHeaders.map((header, index) => [columnSizeVariable(index), `${header.getSize()}px`])),
     } as CSSProperties;
+    const multiLinePreview = previewLineClamp > 1;
+    const previewLineHeight = Number.parseInt(theme.typography.lineHeightBase, 10);
+    const dataRowStyle = multiLinePreview
+      ? {
+          ...rowWidthStyle,
+          minHeight: theme.general.heightSm + theme.spacing.md + (previewLineClamp - 2) * previewLineHeight,
+        }
+      : rowWidthStyle;
+    const rowPaddingCss: CSSObject = {
+      '&& > *': {
+        paddingTop: 6,
+        paddingBottom: 6,
+      },
+    };
     const columnStyles = useMemo(
       () => new Map(leafHeaders.map((header, index) => [header.column.id, sizeStyleFor(header.column.id, index)])),
       // Header identities are stable while only column sizing changes.
@@ -377,20 +402,26 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
       [table, columns],
     );
 
-    // Header-row overrides: near-black labels and a visible divider.
+    // Header-row overrides: align its contents and set the header's bottom border.
     const headerRowCss = {
-      ...selectCellAlign,
+      ...selectCellCss,
+      borderBottom: `1px solid ${theme.colors.border}`,
       // Center each header label against the (vertically-centered) select-all checkbox. Padding sets
       // the label→divider gap directly — DS applies --table-row-vertical-padding via an inline style,
       // so a `css` override of it is a no-op.
-      '[role="columnheader"]': { alignItems: 'center', paddingBottom: theme.spacing.sm },
-      // The select-all cell keeps the DS default bottom padding otherwise, which shifts the centered
-      // checkbox up off the label line — zero it so the checkbox sits on the labels' center.
-      '&& .table-row-select-cell': { paddingBottom: 0 },
-      // Doubled `&&` beats the DS 2-class `.table-header-text` var rule, forcing the darkest token.
-      '&& .table-header-text': { color: theme.colors.textPrimary },
-      // Light divider (grey200), overriding the separator var for the header subtree only.
-      ['--table-separator-color' as string]: theme.colors.grey200,
+      '[role="columnheader"]': {
+        alignItems: 'center',
+        paddingBottom: theme.spacing.mid - 2,
+        '&:hover .traces-table-header-menu-trigger, &:focus-within .traces-table-header-menu-trigger': {
+          opacity: 1,
+        },
+      },
+      // TableRowSelectCell resets vertical padding to zero, so restore the same padding as the other
+      // header cells to keep the checkbox and labels on the same center line.
+      '&& .table-row-select-cell': {
+        paddingTop: theme.spacing.sm,
+        paddingBottom: theme.spacing.mid - 2,
+      },
       // Keep the header's select-all checkbox always visible (data rows stay hover-reveal).
       '&& .table-row-select-cell input[type="checkbox"] ~ *': { opacity: 1 },
     };
@@ -399,9 +430,11 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     // skeleton, expanded trace rows) keep their columns aligned under the session rows that do.
     const renderSessionToggleSpacer = () => <div css={{ width: sessionToggleWidth, flexShrink: 0 }} />;
 
-    const renderSessionPreview = (value: string) =>
+    const renderSessionPreview = (value: string, color: 'primary' | 'secondary' = 'primary') =>
       value ? (
-        <Typography.Text ellipsis>{value}</Typography.Text>
+        <Typography.Text color={color} ellipsis>
+          {value}
+        </Typography.Text>
       ) : (
         <Typography.Text color="secondary">-</Typography.Text>
       );
@@ -450,11 +483,12 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
             }
             onTraceSelected(row.original);
           }}
-          style={rowWidthStyle}
+          style={dataRowStyle}
           css={{
             cursor: 'pointer',
             backgroundColor: isSelected ? theme.colors.tableBackgroundUnselectedHover : undefined,
-            ...selectCellAlign,
+            ...rowPaddingCss,
+            ...dataSelectCellAlign,
           }}
         >
           <TableRowSelectCell
@@ -517,7 +551,12 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
       >
         {/* `scrollable` makes the DuBois Table the scroll container (both axes), which is what activates
           its sticky-header CSS; `flex: 1` gives it a bounded height from the flex parent to scroll within. */}
-        <Table scrollable size={size} css={{ flex: 1 }} someRowsSelected={isAllOnPageSelected || isSomeOnPageSelected}>
+        <Table
+          scrollable
+          size="default"
+          css={{ flex: 1 }}
+          someRowsSelected={isAllOnPageSelected || isSomeOnPageSelected}
+        >
           <TableRow isHeader css={headerRowCss} style={rowWidthStyle}>
             <TableRowSelectCell
               componentId={`${COMPONENT_ID}.row-select-all`}
@@ -551,6 +590,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                   wrapContent={false}
                 >
                   <TraceColumnHeader
+                    columnId={columnId}
                     label={labelNode}
                     labelText={typeof labelNode === 'string' ? labelNode : undefined}
                     sortable={isSortableTraceColumn(columnId)}
@@ -565,7 +605,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
 
           {isLoading
             ? Array.from({ length: renderedSkeletonRowCount }, (_, i) => (
-                <TableRow key={`skeleton-${i}`} css={selectCellAlign} style={rowWidthStyle}>
+                <TableRow key={`skeleton-${i}`} css={{ ...rowPaddingCss, ...dataSelectCellAlign }} style={dataRowStyle}>
                   <TableRowSelectCell componentId={`${COMPONENT_ID}.row-select.skeleton`} noCheckbox />
                   {isGroupedBySession && renderSessionToggleSpacer()}
                   {leafHeaders.map((header) => (
@@ -593,8 +633,12 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                     <Fragment key={sessionId}>
                       <TableRow
                         isHeader
-                        style={rowWidthStyle}
-                        css={{ cursor: onSessionSelected ? 'pointer' : undefined, ...selectCellAlign }}
+                        style={dataRowStyle}
+                        css={{
+                          cursor: onSessionSelected ? 'pointer' : undefined,
+                          ...rowPaddingCss,
+                          ...dataSelectCellAlign,
+                        }}
                         onClick={
                           onSessionSelected
                             ? () => onSessionSelected({ trace: rows[0].original, sessionId })
@@ -661,7 +705,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                               {header.column.id === 'session'
                                 ? renderSessionHeaderCell(sessionId, rows[0].original)
                                 : header.column.id === 'input'
-                                  ? renderSessionPreview(getTraceInfoInputs(rows[0].original))
+                                  ? renderSessionPreview(getTraceInfoInputs(rows[0].original), 'secondary')
                                   : header.column.id === 'output'
                                     ? renderSessionPreview(
                                         getTraceInfoOutputs(rows.at(-1)?.original ?? rows[0].original),

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
@@ -80,6 +80,20 @@ const rowWidthStyle = { width: `var(${ROW_WIDTH_VARIABLE})`, minWidth: '100%' } 
 const stopPropagationProps = {
   onClick: (event: React.MouseEvent) => event.stopPropagation(),
 };
+// Whether a checkbox change originated from a shift-modified click (range selection). The change
+// event's `nativeEvent` carries `shiftKey`; guard structurally since the handler receives `unknown`.
+const isShiftModifiedEvent = (event: unknown): boolean => {
+  if (typeof event !== 'object' || event === null) {
+    return false;
+  }
+  const nativeEvent = 'nativeEvent' in event ? event.nativeEvent : event;
+  return (
+    typeof nativeEvent === 'object' &&
+    nativeEvent !== null &&
+    'shiftKey' in nativeEvent &&
+    nativeEvent.shiftKey === true
+  );
+};
 const dataSelectCellAlign = {
   '.table-row-select-cell': { alignItems: 'flex-start' },
   '.table-row-select-cell > *': { transform: 'translateY(2px)' },
@@ -108,7 +122,7 @@ export interface TracesTableProps {
   selectedForBulk: ReadonlyMap<string, ModelTraceInfoV3>;
   isAllOnPageSelected: boolean;
   isSomeOnPageSelected: boolean;
-  onToggleBulkRow: (trace: ModelTraceInfoV3) => void;
+  onToggleBulkRow: (trace: ModelTraceInfoV3, selectRange?: boolean) => void;
   /** Toggle-select every trace in a session header row; omit to disable session-level selection. */
   onToggleBulkRows?: (traces: ModelTraceInfoV3[]) => void;
   onToggleBulkAll: () => void;
@@ -494,7 +508,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
           <TableRowSelectCell
             componentId={`${COMPONENT_ID}.row-select`}
             checked={isBulkChecked}
-            onChange={() => onToggleBulkRow(row.original)}
+            onChange={(event) => onToggleBulkRow(row.original, isShiftModifiedEvent(event))}
             checkboxLabel={intl.formatMessage(
               {
                 defaultMessage: 'Select trace {traceId}',

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
@@ -49,17 +49,6 @@ const noop = () => {};
 // requires `componentId` values to be static, so a runtime-injected prefix isn't possible).
 const COMPONENT_ID = 'web-shared.traces-table';
 
-// TableSkeleton and TableRow both reduce their vertical spacing in small tables. Compact loading
-// rows are therefore 25px tall versus 33px at the default size, so rendering the same count leaves
-// the bottom of the table blank. Scale the compact count to preserve the default skeleton height.
-const STANDARD_SKELETON_ROW_HEIGHT = 33;
-const COMPACT_SKELETON_ROW_HEIGHT = 25;
-
-const getRenderedSkeletonRowCount = (skeletonRowCount: number, size: 'default' | 'small') =>
-  size === 'small'
-    ? Math.ceil((skeletonRowCount * STANDARD_SKELETON_ROW_HEIGHT) / COMPACT_SKELETON_ROW_HEIGHT)
-    : skeletonRowCount;
-
 // Input/Output are the fill columns: each takes grow factor 1 so any leftover container width is
 // split equally between them (no dead whitespace on the right), with `maxWidth: unset` so the cap
 // can't block that growth. Every other column stays fixed-width — it occupies exactly its (possibly
@@ -143,8 +132,6 @@ export interface TracesTableProps {
   onHideColumn: (columnId: string) => void;
   /** Groups traces with a session id into collapsible session rows. Standalone traces remain rows. */
   isGroupedBySession?: boolean;
-  /** Row-height density for traces rows (`'small'` = compact padding). Defaults to `'default'`. */
-  size?: 'default' | 'small';
   /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
   previewLineClamp?: number;
 }
@@ -201,7 +188,6 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     renderRunName,
     onHideColumn,
     isGroupedBySession = false,
-    size = 'default',
     previewLineClamp = 1,
   }: TracesTableProps) {
     const { theme } = useDesignSystemTheme();
@@ -368,7 +354,19 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     }, [table, isResizingColumn, onColumnSizingSettled]);
 
     const leafHeaders = table.getLeafHeaders();
-    const renderedSkeletonRowCount = getRenderedSkeletonRowCount(skeletonRowCount, size);
+
+    // A density floor matching the preview clamp keeps Standard/Tall rows uniform and lets the loading
+    // skeleton reserve the height real rows will take (no layout shift on swap). Gate it on a visible
+    // preview column: with both hidden, the floor would force tall, empty rows, so those size to content.
+    const isPreviewColumnVisible = leafHeaders.some(
+      (header) => header.column.id === 'input' || header.column.id === 'output',
+    );
+    const previewLineHeight = Number.parseInt(theme.typography.lineHeightBase, 10);
+    const rowMinHeight =
+      previewLineClamp > 1 && isPreviewColumnVisible
+        ? theme.general.heightSm + theme.spacing.md + (previewLineClamp - 2) * previewLineHeight
+        : undefined;
+    const dataRowStyle: CSSProperties = rowMinHeight ? { ...rowWidthStyle, minHeight: rowMinHeight } : rowWidthStyle;
 
     // Pin every row to the summed width of the visible columns so its hover/selected background spans
     // the full horizontal extent, not just the visible viewport. A DuBois `scrollable` Table makes the
@@ -395,18 +393,10 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
       [ROW_WIDTH_VARIABLE]: `${rowWidth}px`,
       ...Object.fromEntries(leafHeaders.map((header, index) => [columnSizeVariable(index), `${header.getSize()}px`])),
     } as CSSProperties;
-    const multiLinePreview = previewLineClamp > 1;
-    const previewLineHeight = Number.parseInt(theme.typography.lineHeightBase, 10);
-    const dataRowStyle = multiLinePreview
-      ? {
-          ...rowWidthStyle,
-          minHeight: theme.general.heightSm + theme.spacing.md + (previewLineClamp - 2) * previewLineHeight,
-        }
-      : rowWidthStyle;
     const rowPaddingCss: CSSObject = {
       '&& > *': {
-        paddingTop: 6,
-        paddingBottom: 6,
+        paddingTop: theme.spacing.xs + 2,
+        paddingBottom: theme.spacing.xs + 2,
       },
     };
     const columnStyles = useMemo(
@@ -508,7 +498,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
           <TableRowSelectCell
             componentId={`${COMPONENT_ID}.row-select`}
             checked={isBulkChecked}
-            onChange={(event) => onToggleBulkRow(row.original, isShiftModifiedEvent(event))}
+            onChange={(event) => onToggleBulkRow(row.original, !isGroupedBySession && isShiftModifiedEvent(event))}
             checkboxLabel={intl.formatMessage(
               {
                 defaultMessage: 'Select trace {traceId}',
@@ -554,12 +544,9 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
           flexDirection: 'column',
           flex: 1,
           minHeight: 0,
-          // Row-height density (`size='small'`) should change ONLY the row height, not the text size.
-          // DuBois's `TableCell` wraps its content in a `Typography.Text` sized `sm` (12px) when the
-          // table is `small`, which would shrink the cell font. The DS typography class carries a
-          // theme-specific prefix (`du-bois-light-`/`du-bois-dark-`), so pin the whole cell subtree
-          // back to the base size instead — density then affects row height alone. (Cell icons set
-          // their own 13px `fontSize`, which equals the base, so this doesn't disturb them.)
+          // Keep every cell at the base font size so density affects row height alone: the DS
+          // typography class carries a theme-specific prefix (`du-bois-light-`/`du-bois-dark-`), so
+          // pin the whole cell subtree rather than fighting individual styles.
           '[role="cell"], [role="cell"] *': { fontSize: `${theme.typography.fontSizeBase}px !important` },
         }}
       >
@@ -618,7 +605,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
           </TableRow>
 
           {isLoading
-            ? Array.from({ length: renderedSkeletonRowCount }, (_, i) => (
+            ? Array.from({ length: skeletonRowCount }, (_, i) => (
                 <TableRow key={`skeleton-${i}`} css={{ ...rowPaddingCss, ...dataSelectCellAlign }} style={dataRowStyle}>
                   <TableRowSelectCell componentId={`${COMPONENT_ID}.row-select.skeleton`} noCheckbox />
                   {isGroupedBySession && renderSessionToggleSpacer()}
@@ -647,7 +634,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                     <Fragment key={sessionId}>
                       <TableRow
                         isHeader
-                        style={dataRowStyle}
+                        style={rowWidthStyle}
                         css={{
                           cursor: onSessionSelected ? 'pointer' : undefined,
                           ...rowPaddingCss,

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, test, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TracesTableView, type TracesTableViewProps, type TracesTableViewState } from './TracesTableView';
+import { useBulkTraceSelection } from './hooks/useBulkTraceSelection';
 import { makeTraces } from './test-utils/mockTraces';
 import { renderWithProviders } from './test-utils/renderWithProviders';
 
@@ -36,6 +38,25 @@ const baseProps = (over: Partial<TracesTableViewProps> = {}): TracesTableViewPro
   onHideColumn: jest.fn(),
   ...over,
 });
+
+const rangeSelectionTraces = makeTraces(4, 'range');
+
+// Wire the real selection hook so a shift-click drives actual range state through the view.
+const RangeSelectionHarness = (): JSX.Element => {
+  const bulk = useBulkTraceSelection(rangeSelectionTraces);
+  return (
+    <TracesTableView
+      {...baseProps({
+        traces: rangeSelectionTraces,
+        selectedForBulk: bulk.selected,
+        isAllOnPageSelected: bulk.isAllVisibleChecked,
+        isSomeOnPageSelected: bulk.isSomeVisibleChecked,
+        onToggleBulkRow: bulk.toggle,
+        onToggleBulkAll: bulk.toggleAll,
+      })}
+    />
+  );
+};
 
 describe('TracesTableView', () => {
   test('always renders the toolbar search box', async () => {
@@ -114,5 +135,20 @@ describe('TracesTableView', () => {
     await renderWithProviders(<TracesTableView {...baseProps({ viewState: 'ready', PaginationBarWrapper })} />);
     const wrapper = screen.getByTestId('pagination-wrapper');
     expect(wrapper).toContainElement(screen.getByText(/Rows per page/));
+  });
+
+  test('Shift-clicking a trace checkbox selects the visible range from the previous checkbox', async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<RangeSelectionHarness />);
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select trace range-000' }));
+    await user.keyboard('{Shift>}');
+    await user.click(screen.getByRole('checkbox', { name: 'Select trace range-002' }));
+    await user.keyboard('{/Shift}');
+
+    expect(screen.getByRole('checkbox', { name: 'Select trace range-000' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Select trace range-001' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Select trace range-002' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Select trace range-003' })).not.toBeChecked();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
@@ -70,6 +70,8 @@ export interface TracesTableViewProps {
   isGroupedBySession?: boolean;
   /** Row-height density forwarded to the table (`'small'` = compact rows). Defaults to `'default'`. */
   size?: 'default' | 'small';
+  /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
+  previewLineClamp?: number;
 
   // Toolbar passthrough.
   searchValue: string;
@@ -206,6 +208,7 @@ export const TracesTableView: React.FC<TracesTableViewProps> = (props: TracesTab
       onHideColumn={props.onHideColumn}
       isGroupedBySession={props.isGroupedBySession}
       size={props.size}
+      previewLineClamp={props.previewLineClamp}
     />
   );
 

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
@@ -68,8 +68,6 @@ export interface TracesTableViewProps {
   onHideColumn: (columnId: string) => void;
   /** Groups traces with a session id into collapsible session rows — forwarded to the table. */
   isGroupedBySession?: boolean;
-  /** Row-height density forwarded to the table (`'small'` = compact rows). Defaults to `'default'`. */
-  size?: 'default' | 'small';
   /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
   previewLineClamp?: number;
 
@@ -207,7 +205,6 @@ export const TracesTableView: React.FC<TracesTableViewProps> = (props: TracesTab
       renderRunName={props.renderRunName}
       onHideColumn={props.onHideColumn}
       isGroupedBySession={props.isGroupedBySession}
-      size={props.size}
       previewLineClamp={props.previewLineClamp}
     />
   );

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
@@ -51,7 +51,7 @@ export interface TracesTableViewProps {
   selectedForBulk: ReadonlyMap<string, ModelTraceInfoV3>;
   isAllOnPageSelected: boolean;
   isSomeOnPageSelected: boolean;
-  onToggleBulkRow: (trace: ModelTraceInfoV3) => void;
+  onToggleBulkRow: (trace: ModelTraceInfoV3, selectRange?: boolean) => void;
   /** Toggle-select every trace in a session header row; omit to disable session-level selection. */
   onToggleBulkRows?: (traces: ModelTraceInfoV3[]) => void;
   onToggleBulkAll: () => void;

--- a/mlflow/server/js/src/shared/web-shared/traces-table/columns.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/columns.tsx
@@ -36,6 +36,8 @@ export interface TracesTableMeta {
   onFilterByTag?: (key: string, value: string) => void;
   /** Product-owned renderer for resolving an experiment-scoped run name. */
   renderRunName?: (trace: ModelTraceInfoV3) => React.ReactNode;
+  /** Maximum lines shown by input and output previews before truncation. */
+  previewLineClamp: number;
 }
 
 export const getTableMeta = (context: CellContext<ModelTraceInfoV3, unknown>): TracesTableMeta =>
@@ -97,7 +99,7 @@ export const STANDARD_COLUMNS: StandardColumnDef[] = [
     ...COLUMN_SIZES.input,
     header: () => <FormattedMessage {...TRACE_COLUMN_LABELS.input} />,
     cell: (ctx) => {
-      const { intl, onTraceSelected, getTraceHref } = getTableMeta(ctx);
+      const { intl, onTraceSelected, getTraceHref, previewLineClamp } = getTableMeta(ctx);
       const trace = ctx.row.original;
       return (
         <TraceInputCell
@@ -105,6 +107,7 @@ export const STANDARD_COLUMNS: StandardColumnDef[] = [
           onSelect={onTraceSelected}
           to={getTraceHref?.(trace)}
           accessibleLabel={openLabel(intl, trace.trace_id, 'input')}
+          previewLineClamp={previewLineClamp}
         />
       );
     },
@@ -114,7 +117,7 @@ export const STANDARD_COLUMNS: StandardColumnDef[] = [
     ...COLUMN_SIZES.output,
     header: () => <FormattedMessage {...TRACE_COLUMN_LABELS.output} />,
     cell: (ctx) => {
-      const { intl, onTraceSelected, getTraceHref } = getTableMeta(ctx);
+      const { intl, onTraceSelected, getTraceHref, previewLineClamp } = getTableMeta(ctx);
       const trace = ctx.row.original;
       return (
         <TraceOutputCell
@@ -122,6 +125,7 @@ export const STANDARD_COLUMNS: StandardColumnDef[] = [
           onSelect={onTraceSelected}
           to={getTraceHref?.(trace)}
           accessibleLabel={openLabel(intl, trace.trace_id, 'output')}
+          previewLineClamp={previewLineClamp}
         />
       );
     },

--- a/mlflow/server/js/src/shared/web-shared/traces-table/constants.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/constants.ts
@@ -48,7 +48,7 @@ export const DEFAULT_SORT_DIR: SortDirection = 'desc';
 
 /**
  * Seed pixel widths per column, sized from the previous flex intent (input/output carry the most
- * content, so they get the most room; id/session are medium; time/duration/tokens/cost are compact).
+ * content, so they get the most room; identifiers and numeric/status fields are compact).
  * `size` is the initial/reset width; `minSize`/`maxSize` bound dragging. Persisted overrides win over
  * `size` at render time.
  */
@@ -64,12 +64,12 @@ export const COLUMN_SIZES: Record<TraceColumnId, ColumnSizeSpec> = {
   input: { size: 360, minSize: 160, maxSize: 900 },
   output: { size: 360, minSize: 160, maxSize: 900 },
   user: { size: 180, minSize: 100, maxSize: 480 },
-  session: { size: 140, minSize: 100, maxSize: 480 },
+  session: { size: 100, minSize: 100, maxSize: 480 },
   duration: { size: 100, minSize: 80, maxSize: 240 },
   state: { size: 96, minSize: 72, maxSize: 240 },
   source: { size: 180, minSize: 100, maxSize: 480 },
   run_name: { size: 180, minSize: 100, maxSize: 480 },
-  trace_id: { size: 160, minSize: 100, maxSize: 480 },
+  trace_id: { size: 100, minSize: 100, maxSize: 480 },
   tokens: { size: 110, minSize: 80, maxSize: 220 },
   cost: { size: 110, minSize: 80, maxSize: 220 },
   tags: { size: 200, minSize: 120, maxSize: 600 },

--- a/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useBulkTraceSelection.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useBulkTraceSelection.test.ts
@@ -58,4 +58,77 @@ describe('useBulkTraceSelection', () => {
     act(() => result.current.clear());
     expect(result.current.selected.size).toBe(0);
   });
+
+  test('batched single-trace toggles compose without losing an update', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b]));
+
+    act(() => {
+      result.current.toggle(a);
+      result.current.toggle(b);
+    });
+
+    expect(selectedIds(result.current.selected)).toEqual(['a', 'b']);
+  });
+
+  test('batched range toggle uses the preceding toggle as its anchor', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b, c]));
+
+    act(() => {
+      result.current.toggle(a);
+      result.current.toggle(c, true);
+    });
+
+    expect(selectedIds(result.current.selected)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('batched select-all and single-trace toggles compose without losing an update', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b, c]));
+
+    act(() => {
+      result.current.toggleAll();
+      result.current.toggle(a);
+    });
+
+    expect(selectedIds(result.current.selected)).toEqual(['b', 'c']);
+  });
+
+  test('range toggle selects an inclusive forward range and preserves traces outside it', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b, c, d]));
+    act(() => result.current.toggle(d));
+    act(() => result.current.toggle(a));
+
+    act(() => result.current.toggle(c, true));
+
+    expect(selectedIds(result.current.selected)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('range toggle selects an inclusive backward range', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b, c, d]));
+    act(() => result.current.toggle(c));
+
+    act(() => result.current.toggle(a, true));
+
+    expect(selectedIds(result.current.selected)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('range toggle deselects an inclusive range and preserves traces outside it', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b, c, d]));
+    act(() => result.current.toggle(a));
+    act(() => result.current.toggle(c, true));
+    act(() => result.current.toggle(d));
+
+    act(() => result.current.toggle(b, true));
+
+    expect(selectedIds(result.current.selected)).toEqual(['a']);
+  });
+
+  test('clear resets the range anchor', () => {
+    const { result } = renderHook(() => useBulkTraceSelection([a, b, c]));
+    act(() => result.current.toggle(a));
+    act(() => result.current.clear());
+
+    act(() => result.current.toggle(c, true));
+
+    expect(selectedIds(result.current.selected)).toEqual(['c']);
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useBulkTraceSelection.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useBulkTraceSelection.ts
@@ -13,7 +13,8 @@ export interface UseBulkTraceSelectionResult {
   isAllVisibleChecked: boolean;
   /** True iff some — but not all — visible traces are selected (drives the header's indeterminate UI). */
   isSomeVisibleChecked: boolean;
-  toggle: (trace: ModelTraceInfoV3) => void;
+  /** Toggle one trace, or the inclusive visible range from the previous anchor when selectRange is true. */
+  toggle: (trace: ModelTraceInfoV3, selectRange?: boolean) => void;
   /** Select every supplied trace unless all are selected, in which case clear all supplied traces. */
   toggleMany: (traces: ModelTraceInfoV3[]) => void;
   /** Select all visible traces when none/some are checked; clear them when all are checked. */
@@ -33,24 +34,48 @@ export interface UseBulkTraceSelectionResult {
  * re-fetch.
  */
 export const useBulkTraceSelection = (visibleTraces: ModelTraceInfoV3[]): UseBulkTraceSelectionResult => {
-  const [selected, setSelected] = useState<Map<string, ModelTraceInfoV3>>(() => new Map());
+  const [{ selected }, setSelection] = useState<{
+    selected: Map<string, ModelTraceInfoV3>;
+    selectionAnchorTraceId: string | null;
+  }>(() => ({ selected: new Map(), selectionAnchorTraceId: null }));
 
-  const toggle = useCallback((trace: ModelTraceInfoV3) => {
-    setSelected((prev) => {
-      const next = new Map(prev);
-      if (next.has(trace.trace_id)) {
-        next.delete(trace.trace_id);
-      } else {
-        next.set(trace.trace_id, trace);
-      }
-      return next;
-    });
-  }, []);
+  const toggle = useCallback(
+    (trace: ModelTraceInfoV3, selectRange = false) => {
+      setSelection((prev) => {
+        // Shift-click extends from the last-toggled anchor to the clicked row across the visible page;
+        // a plain click toggles just that row (and re-anchors it).
+        const anchorIndex = selectRange
+          ? visibleTraces.findIndex((visibleTrace) => visibleTrace.trace_id === prev.selectionAnchorTraceId)
+          : -1;
+        const targetIndex = selectRange
+          ? visibleTraces.findIndex((visibleTrace) => visibleTrace.trace_id === trace.trace_id)
+          : -1;
+        const tracesToToggle =
+          anchorIndex >= 0 && targetIndex >= 0
+            ? visibleTraces.slice(Math.min(anchorIndex, targetIndex), Math.max(anchorIndex, targetIndex) + 1)
+            : [trace];
+        const isDeselecting = prev.selected.has(trace.trace_id);
+        const next = new Map(prev.selected);
+        tracesToToggle.forEach((rangeTrace) => {
+          if (isDeselecting) {
+            next.delete(rangeTrace.trace_id);
+          } else {
+            next.set(rangeTrace.trace_id, rangeTrace);
+          }
+        });
+        return {
+          selected: next,
+          selectionAnchorTraceId: next.size === 0 ? null : trace.trace_id,
+        };
+      });
+    },
+    [visibleTraces],
+  );
 
   const toggleMany = useCallback((traces: ModelTraceInfoV3[]) => {
-    setSelected((prev) => {
-      const allChecked = traces.length > 0 && traces.every((trace) => prev.has(trace.trace_id));
-      const next = new Map(prev);
+    setSelection((prev) => {
+      const allChecked = traces.length > 0 && traces.every((trace) => prev.selected.has(trace.trace_id));
+      const next = new Map(prev.selected);
       traces.forEach((trace) => {
         if (allChecked) {
           next.delete(trace.trace_id);
@@ -58,25 +83,35 @@ export const useBulkTraceSelection = (visibleTraces: ModelTraceInfoV3[]): UseBul
           next.set(trace.trace_id, trace);
         }
       });
-      return next;
+      return {
+        selected: next,
+        selectionAnchorTraceId: next.size === 0 ? null : prev.selectionAnchorTraceId,
+      };
     });
   }, []);
 
   const toggleAll = useCallback(() => {
-    setSelected((prev) => {
-      const allChecked = visibleTraces.length > 0 && visibleTraces.every((trace) => prev.has(trace.trace_id));
-      const next = new Map(prev);
+    setSelection((prev) => {
+      const allChecked = visibleTraces.length > 0 && visibleTraces.every((trace) => prev.selected.has(trace.trace_id));
+      const next = new Map(prev.selected);
       if (allChecked) {
         visibleTraces.forEach((trace) => next.delete(trace.trace_id));
       } else {
         visibleTraces.forEach((trace) => next.set(trace.trace_id, trace));
       }
-      return next;
+      return {
+        selected: next,
+        selectionAnchorTraceId: next.size === 0 ? null : prev.selectionAnchorTraceId,
+      };
     });
   }, [visibleTraces]);
 
   const clear = useCallback(() => {
-    setSelected((prev) => (prev.size === 0 ? prev : new Map()));
+    setSelection((prev) =>
+      prev.selected.size === 0 && prev.selectionAnchorTraceId === null
+        ? prev
+        : { selected: new Map(), selectionAnchorTraceId: null },
+    );
   }, []);
 
   const { isAllVisibleChecked, isSomeVisibleChecked } = useMemo(() => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24827, #24828 (the original OSS Traces V4 port + mount).

Stacked on #24828 — this branch builds on that (unmounted) port, so the diff against `master` also shows #24828's changes until it merges; the commits unique to this PR are the four table-improvement commits below. The saved-views restyle that previously shared this branch has been split into its own separate PR; this PR is table/navigation only and touches no saved-views files.

### What changes are proposed in this pull request?

A batch of Traces V4 table improvements ported from the Databricks-managed MLflow. All UI-only (React/TypeScript), touching the V4 traces tab and its shared presentational `traces-table` package. No backend changes.

Commits, in order:

1. **Preserve URL filters when opening a trace** — the trace link is built from the current location's pathname/search/hash instead of resetting to a bare Traces route, so active filters and sort survive opening a trace (including Cmd/Ctrl+click into a new tab).
2. **Add a Tall row-height density and refresh the table header** — row-height density becomes a 3-way **Compact / Standard / Tall** choice, decoupled from the DS Table size via a `previewLineClamp` threaded through the shared table so input/output previews clamp to 1 / 2 / 6 lines and rows grow to fit. OSS defaults to Standard. Header refresh: input/output column icons, secondary header text, a hover/focus-revealed column-options menu trigger, and a wider (560px) input/output hover preview.
3. **Polish the toolbar and column defaults** — group the refresh and Detect Issues controls, use `SyncIcon` for the refresh affordance and dim the Display icon, and narrow the default Trace ID / Session column widths (storage version bumped so stale widths reset).
4. **Support shift-click range selection** — shift-clicking a row checkbox selects (or deselects) the inclusive range from the previously-toggled row across the visible page; a plain click still toggles one row and re-anchors.

Notes for reviewers:
- The stack maps 1:1 onto Databricks-internal PRs; happy to share those references.
- jsdom drops `-webkit-line-clamp`, so the preview tests assert the observable inline `white-space: normal` signal instead of the clamp count.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Video that tests the new cell sizes, the url preservation & polish.

tests that shift click works in traces (but not in group by)


https://github.com/user-attachments/assets/79451dd1-8b77-46be-9649-9cf97bec13f0











### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The Traces (V4) table gains a Tall row-height option (with input/output previews that grow to fit), refreshed column headers with a hover-revealed column-options menu, shift-click range selection, and preserves URL filters when opening a trace.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
