### PR TITLE
Fix flaky `test_download_artifacts` in FTP artifact repo tests

### DIFF
--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -398,8 +398,11 @@ def test_download_artifacts(ftp_mock):
 
     assert set(cwd_call_args) == set(is_dir_call_args)
     assert ftp_mock.nlst.call_count == 3
-    assert ftp_mock.retrbinary.call_args_list[0][0][0] == "RETR " + model_file_path_full
-    assert ftp_mock.retrbinary.call_args_list[1][0][0] == "RETR " + subfile_path_full
+    # Downloads run in a thread pool, so the call order is non-deterministic.
+    assert {arg_entry[0][0] for arg_entry in ftp_mock.retrbinary.call_args_list} == {
+        "RETR " + model_file_path_full,
+        "RETR " + subfile_path_full,
+    }
 
 
 def test_log_artifact_reuse_ftp_client(ftp_mock, tmp_path):

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -400,8 +400,8 @@ def test_download_artifacts(ftp_mock):
     assert ftp_mock.nlst.call_count == 3
     # Downloads run in a thread pool, so the call order is non-deterministic.
     assert {arg_entry[0][0] for arg_entry in ftp_mock.retrbinary.call_args_list} == {
-        "RETR " + model_file_path_full,
-        "RETR " + subfile_path_full,
+        f"RETR {model_file_path_full}",
+        f"RETR {subfile_path_full}",
     }
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #none

### What changes are proposed in this pull request?

`test_download_artifacts` asserted the exact order of `retrbinary` calls, but `ArtifactRepository.download_artifacts` fans the downloads out over a `ThreadPoolExecutor`, so whichever worker reaches `retrbinary` first wins. The test flaked in CI ([failed job](https://github.com/mlflow/mlflow/actions/runs/32942795799/job/98097108910)) when `variables/test.txt` was fetched before `model.pb`:

```
E       AssertionError: assert 'RETR /some/p...bles/test.txt' == 'RETR /some/p...odel/model.pb'
E         - RETR /some/path/model/model.pb
E         + RETR /some/path/model/variables/test.txt
```

Compare the calls as a set instead, which is what the test actually cares about.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
