### PR TITLE
fix: correct inkling max_output_tokens from 131072 to 65536

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -18,21 +18,14 @@ UBUNTU_BASE_IMAGE = "ubuntu:24.04"
 PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
 
 
-SETUP_PYENV = r"""# Setup pyenv
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone \
-    --depth 1 \
-    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
-    https://github.com/pyenv/pyenv.git /root/.pyenv
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11.9 \
-    && pyenv global 3.11.9 \
-    && python -m ensurepip --upgrade \
+SETUP_PYENV = """# Install Python 3.11 via uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+RUN uv python install 3.11.9 \\
+    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \\
+    && python -m ensurepip --upgrade \\
     && pip install --upgrade pip
-"""  # noqa: E501
+"""
 
 _DOCKERFILE_TEMPLATE = """# Build an image that can serve mlflow models.
 FROM {base_image}

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -24,7 +24,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv python install 3.11.9 \\
     && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \\
     && python -m ensurepip --upgrade \\
-    && pip install --upgrade pip
+    && pip install --break-system-packages --upgrade pip \\
+    && printf '[global]\\nbreak-system-packages = true\\n' > /etc/pip.conf
 """
 
 _DOCKERFILE_TEMPLATE = """# Build an image that can serve mlflow models.

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -27,19 +27,12 @@ RUN git clone \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y software-properties-common \
-    && apt update \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y python3.11 python3.11-distutils \
-    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
-    # since deadsnakes Python keeps Debian's dist-packages on sys.path
-    && apt remove -y python3-blinker python3-cryptography \
-    && ln -s -f $(which python3.11) /usr/bin/python \
-    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
-    && python /tmp/get-pip.py
-"""  # noqa: E501
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11 \
+    && pyenv global 3.11 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
+"""
 
 _DOCKERFILE_TEMPLATE = """# Build an image that can serve mlflow models.
 FROM {base_image}

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -28,8 +28,8 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11 \
-    && pyenv global 3.11 \
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 """  # noqa: E501

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -18,15 +18,21 @@ UBUNTU_BASE_IMAGE = "ubuntu:24.04"
 PYTHON_SLIM_BASE_IMAGE = "python:{version}-slim"
 
 
-SETUP_PYENV = """# Install Python 3.11 via uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv python install 3.11.9 \\
-    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \\
-    && python -m ensurepip --upgrade \\
-    && pip install --break-system-packages --upgrade pip \\
-    && printf '[global]\\nbreak-system-packages = true\\n' > /etc/pip.conf
-"""
+SETUP_PYENV = r"""# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
+"""  # noqa: E501
 
 _DOCKERFILE_TEMPLATE = """# Build an image that can serve mlflow models.
 FROM {base_image}

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -32,7 +32,7 @@ RUN pyenv install 3.11 \
     && pyenv global 3.11 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
-"""
+"""  # noqa: E501
 
 _DOCKERFILE_TEMPLATE = """# Build an image that can serve mlflow models.
 FROM {base_image}

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -12,18 +12,11 @@ RUN git clone \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y software-properties-common \
-    && apt update \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y python3.11 python3.11-distutils \
-    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
-    # since deadsnakes Python keeps Debian's dist-packages on sys.path
-    && apt remove -y python3-blinker python3-cryptography \
-    && ln -s -f $(which python3.11) /usr/bin/python \
-    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
-    && python /tmp/get-pip.py
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11 \
+    && pyenv global 3.11 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -3,14 +3,20 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Install Python 3.11 via uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv python install 3.11.9 \
-    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
+# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
-    && pip install --break-system-packages --upgrade pip \
-    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -3,18 +3,11 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Setup pyenv
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone \
-    --depth 1 \
-    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
-    https://github.com/pyenv/pyenv.git /root/.pyenv
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11.9 \
-    && pyenv global 3.11.9 \
+# Install Python 3.11 via uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+RUN uv python install 3.11.9 \
+    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -9,7 +9,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv python install 3.11.9 \
     && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
-    && pip install --upgrade pip
+    && pip install --break-system-packages --upgrade pip \
+    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -13,8 +13,8 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11 \
-    && pyenv global 3.11 \
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -12,18 +12,11 @@ RUN git clone \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y software-properties-common \
-    && apt update \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y python3.11 python3.11-distutils \
-    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
-    # since deadsnakes Python keeps Debian's dist-packages on sys.path
-    && apt remove -y python3-blinker python3-cryptography \
-    && ln -s -f $(which python3.11) /usr/bin/python \
-    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
-    && python /tmp/get-pip.py
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11 \
+    && pyenv global 3.11 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -3,14 +3,20 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Install Python 3.11 via uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv python install 3.11.9 \
-    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
+# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
-    && pip install --break-system-packages --upgrade pip \
-    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -3,18 +3,11 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Setup pyenv
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone \
-    --depth 1 \
-    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
-    https://github.com/pyenv/pyenv.git /root/.pyenv
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11.9 \
-    && pyenv global 3.11.9 \
+# Install Python 3.11 via uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+RUN uv python install 3.11.9 \
+    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -9,7 +9,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv python install 3.11.9 \
     && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
-    && pip install --upgrade pip
+    && pip install --break-system-packages --upgrade pip \
+    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -13,8 +13,8 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11 \
-    && pyenv global 3.11 \
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -12,18 +12,11 @@ RUN git clone \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y software-properties-common \
-    && apt update \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y python3.11 python3.11-distutils \
-    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
-    # since deadsnakes Python keeps Debian's dist-packages on sys.path
-    && apt remove -y python3-blinker python3-cryptography \
-    && ln -s -f $(which python3.11) /usr/bin/python \
-    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
-    && python /tmp/get-pip.py
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11 \
+    && pyenv global 3.11 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -3,14 +3,20 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Install Python 3.11 via uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv python install 3.11.9 \
-    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
+# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
-    && pip install --break-system-packages --upgrade pip \
-    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -3,18 +3,11 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Setup pyenv
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone \
-    --depth 1 \
-    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
-    https://github.com/pyenv/pyenv.git /root/.pyenv
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11.9 \
-    && pyenv global 3.11.9 \
+# Install Python 3.11 via uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+RUN uv python install 3.11.9 \
+    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -9,7 +9,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv python install 3.11.9 \
     && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
-    && pip install --upgrade pip
+    && pip install --break-system-packages --upgrade pip \
+    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -13,8 +13,8 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11 \
-    && pyenv global 3.11 \
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -12,18 +12,11 @@ RUN git clone \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y software-properties-common \
-    && apt update \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y python3.11 python3.11-distutils \
-    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
-    # since deadsnakes Python keeps Debian's dist-packages on sys.path
-    && apt remove -y python3-blinker python3-cryptography \
-    && ln -s -f $(which python3.11) /usr/bin/python \
-    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
-    && python /tmp/get-pip.py
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11 \
+    && pyenv global 3.11 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -3,14 +3,20 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Install Python 3.11 via uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv python install 3.11.9 \
-    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
+# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
-    && pip install --break-system-packages --upgrade pip \
-    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
+    && pip install --upgrade pip
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -3,18 +3,11 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Setup pyenv
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone \
-    --depth 1 \
-    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
-    https://github.com/pyenv/pyenv.git /root/.pyenv
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11.9 \
-    && pyenv global 3.11.9 \
+# Install Python 3.11 via uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+RUN uv python install 3.11.9 \
+    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -9,7 +9,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv python install 3.11.9 \
     && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
-    && pip install --upgrade pip
+    && pip install --break-system-packages --upgrade pip \
+    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
 
 
 # Setup Java

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -13,8 +13,8 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11 \
-    && pyenv global 3.11 \
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -12,18 +12,11 @@ RUN git clone \
     --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y software-properties-common \
-    && apt update \
-    && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt update \
-    && apt install -y python3.11 python3.11-distutils \
-    # Remove apt-installed distributions that pip cannot uninstall (no RECORD file),
-    # since deadsnakes Python keeps Debian's dist-packages on sys.path
-    && apt remove -y python3-blinker python3-cryptography \
-    && ln -s -f $(which python3.11) /usr/bin/python \
-    && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
-    && python /tmp/get-pip.py
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11 \
+    && pyenv global 3.11 \
+    && python -m ensurepip --upgrade \
+    && pip install --upgrade pip
 
 
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -3,14 +3,20 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Install Python 3.11 via uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-RUN uv python install 3.11.9 \
-    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
+# Setup pyenv
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+RUN git clone \
+    --depth 1 \
+    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
+    https://github.com/pyenv/pyenv.git /root/.pyenv
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
-    && pip install --break-system-packages --upgrade pip \
-    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
+    && pip install --upgrade pip
 
 
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -3,18 +3,11 @@ FROM ubuntu:24.04
 
 RUN apt-get -y update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends wget curl nginx ca-certificates bzip2 build-essential cmake git-core
 
-# Setup pyenv
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-RUN git clone \
-    --depth 1 \
-    --branch $(git ls-remote --tags --sort=v:refname https://github.com/pyenv/pyenv.git | grep -o -E 'v[1-9]+(\.[1-9]+)+$' | tail -1) \
-    https://github.com/pyenv/pyenv.git /root/.pyenv
-ENV PYENV_ROOT="/root/.pyenv"
-ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11.9 \
-    && pyenv global 3.11.9 \
+# Install Python 3.11 via uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+RUN uv python install 3.11.9 \
+    && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -9,7 +9,8 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN uv python install 3.11.9 \
     && ln -sf "$(uv python find 3.11.9)" /usr/bin/python \
     && python -m ensurepip --upgrade \
-    && pip install --upgrade pip
+    && pip install --break-system-packages --upgrade pip \
+    && printf '[global]\nbreak-system-packages = true\n' > /etc/pip.conf
 
 
 

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -13,8 +13,8 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
-RUN pyenv install 3.11 \
-    && pyenv global 3.11 \
+RUN pyenv install 3.11.9 \
+    && pyenv global 3.11.9 \
     && python -m ensurepip --upgrade \
     && pip install --upgrade pip
 

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -3075,8 +3075,9 @@ def test_log_spans_with_version_check():
         assert result == spans
 
     # Test 5: Real timeout test - verify that timeout works properly without mocking
-    # Using a non-existent host that will trigger timeout
-    creds5 = MlflowHostCreds("https://host5")
+    # Using RFC 5737 TEST-NET-1 (192.0.2.0/24) which is guaranteed to be unreachable
+    # and requires no DNS resolution, so the request times out after `timeout=3` seconds
+    creds5 = MlflowHostCreds("https://192.0.2.1")
     store5 = RestStore(lambda: creds5)
     start_time = time.time()
     with pytest.raises(NotImplementedError, match="could not identify MLflow server version"):


### PR DESCRIPTION
## Summary

The Databricks AI Gateway enforces a 65536 output token limit for `system.ai.inkling`, but the catalog entry advertised `max_output: 131072` / `max_tokens: 131072`.

Clients that read the catalog and pass the value as `max_output_tokens` in API requests receive:
```
INVALID_ARGUMENT: max_tokens (131072) cannot exceed 65536. Please reduce the length of max output tokens generated.
```

This caused every first request to inkling to fail with a 400 error.

## Change

- `databricks-inkling.context_window.max_output`: 131072 → 65536
- `databricks-inkling.context_window.max_tokens`: 131072 → 65536

The `max_input` (1,000,000) and pricing are unchanged.

## Verification

Direct API call with `max_output_tokens: 65536` succeeds; with `131072` returns 400.