### PR TITLE
fix: correct max_output_tokens for 10 Databricks-hosted models

### DIFF
--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -1016,8 +1016,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 131072,
-        "max_output": 131072,
-        "max_tokens": 131072
+        "max_output": 25000,
+        "max_tokens": 25000
       },
       "pricing": {
         "input_per_million_tokens": 0.15001,
@@ -1030,14 +1030,14 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-gpt-oss-20b": {
       "mode": "chat",
       "context_window": {
         "max_input": 131072,
-        "max_output": 131072,
-        "max_tokens": 131072
+        "max_output": 25000,
+        "max_tokens": 25000
       },
       "pricing": {
         "input_per_million_tokens": 0.07,
@@ -1050,7 +1050,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-gte-large-en": {
       "mode": "embedding",
@@ -1115,8 +1115,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 128000,
-        "max_tokens": 128000
+        "max_output": 8192,
+        "max_tokens": 8192
       },
       "pricing": {
         "input_per_million_tokens": 0.50001,
@@ -1129,7 +1129,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-meta-llama-3-1-405b-instruct": {
       "mode": "chat",
@@ -1155,8 +1155,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 200000,
-        "max_output": 128000,
-        "max_tokens": 128000
+        "max_output": 8192,
+        "max_tokens": 8192
       },
       "pricing": {
         "input_per_million_tokens": 0.15001,
@@ -1169,14 +1169,14 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-meta-llama-3-3-70b-instruct": {
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 128000,
-        "max_tokens": 128000
+        "max_output": 8192,
+        "max_tokens": 8192
       },
       "pricing": {
         "input_per_million_tokens": 0.50001,
@@ -1189,7 +1189,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-meta-llama-3-70b-instruct": {
       "mode": "chat",

--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -626,8 +626,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 128000,
-        "max_output": 32000,
-        "max_tokens": 32000
+        "max_output": 8192,
+        "max_tokens": 8192
       },
       "pricing": {
         "input_per_million_tokens": 0.15001,
@@ -640,14 +640,14 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-04-24"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-glm-5-2": {
       "mode": "chat",
       "context_window": {
         "max_input": 1000000,
-        "max_output": 131072,
-        "max_tokens": 131072
+        "max_output": 65536,
+        "max_tokens": 65536
       },
       "pricing": {
         "input_per_million_tokens": 1.4,
@@ -660,7 +660,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-08-05"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-gpt-5": {
       "mode": "chat",
@@ -1075,8 +1075,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 1000000,
-        "max_output": 131072,
-        "max_tokens": 131072
+        "max_output": 65536,
+        "max_tokens": 65536
       },
       "pricing": {
         "input_per_million_tokens": 1.87502,
@@ -1089,7 +1089,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-08-05"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-llama-2-70b-chat": {
       "mode": "chat",

--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -1294,8 +1294,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 131072,
-        "max_output": 32768,
-        "max_tokens": 32768
+        "max_output": 10000,
+        "max_tokens": 10000
       },
       "pricing": {
         "input_per_million_tokens": 0.15001,
@@ -1308,7 +1308,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-20"
+      "last_updated_at": "2026-08-26"
     },
     "databricks-qwen35-122b-a10b": {
       "mode": "chat",

--- a/mlflow/utils/model_catalog/databricks.json
+++ b/mlflow/utils/model_catalog/databricks.json
@@ -1314,8 +1314,8 @@
       "mode": "chat",
       "context_window": {
         "max_input": 256000,
-        "max_output": 8000,
-        "max_tokens": 8000
+        "max_output": 25000,
+        "max_tokens": 25000
       },
       "pricing": {
         "input_per_million_tokens": 0.15001,
@@ -1328,7 +1328,7 @@
         "prompt_caching": false,
         "response_schema": false
       },
-      "last_updated_at": "2026-05-20"
+      "last_updated_at": "2026-08-26"
     }
   }
 }


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25359 (superseded)

### What changes are proposed in this pull request?

The Databricks AI Gateway enforces output token limits that differ from what the catalog advertised. Clients that read these values and pass them as `max_output_tokens`/`max_tokens` receive a 400 INVALID_ARGUMENT error.

Corrected limits (all verified via direct API calls — the gateway error body includes the exact allowed value):

| Model | Field | Before | After | Direction |
|---|---|---|---|---|
| `databricks-inkling` | `max_output` / `max_tokens` | 131072 | 65536 | ↓ gateway cap |
| `databricks-glm-5-2` | `max_output` / `max_tokens` | 131072 | 65536 | ↓ gateway cap |
| `databricks-gemma-3-12b` | `max_output` / `max_tokens` | 32000 | 8192 | ↓ gateway cap |
| `databricks-qwen3-next-80b-a3b-instruct` | `max_output` / `max_tokens` | 32768 | 10000 | ↓ gateway cap |
| `databricks-qwen35-122b-a10b` | `max_output` / `max_tokens` | 8000 | 25000 | ↑ catalog was under-reporting |
| `databricks-gpt-oss-120b` | `max_output` / `max_tokens` | 131072 | 25000 | ↓ gateway cap |
| `databricks-gpt-oss-20b` | `max_output` / `max_tokens` | 131072 | 25000 | ↓ gateway cap |
| `databricks-llama-4-maverick` | `max_output` / `max_tokens` | 128000 | 8192 | ↓ gateway cap |
| `databricks-meta-llama-3-1-8b-instruct` | `max_output` / `max_tokens` | 128000 | 8192 | ↓ gateway cap |
| `databricks-meta-llama-3-3-70b-instruct` | `max_output` / `max_tokens` | 128000 | 8192 | ↓ gateway cap |

**Note on `qwen35-122b-a10b` (8000 → 25000):** this is an upward correction — the old value (8000) was an under-reporting error, not a gateway cap. The Databricks docs state ["up to 25K output tokens"](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models#alibaba-cloud-qwen35-122b-a10b) and direct API verification confirms `max_output_tokens=25000` succeeds while `max_output_tokens=32768` returns `cannot exceed 25000`.

All `last_updated_at` fields updated to 2026-08-26.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Each model was tested with the catalog value (→ 400) and the corrected value (→ 200). The gateway error message explicitly states the allowed limit:
```
# Reduction examples
POST /ai-gateway/codex/v1/responses  {"model":"system.ai.inkling","max_output_tokens":131072}  → 400 "cannot exceed 65536"
POST /ai-gateway/codex/v1/responses  {"model":"system.ai.inkling","max_output_tokens":65536}   → 200
POST /ai-gateway/mlflow/v1/chat/completions  {"model":"system.ai.llama-4-maverick","max_tokens":128000}  → 400 "cannot exceed 8192"

# Increase example (qwen35-122b-a10b — catalog was under-reporting)
POST /ai-gateway/codex/v1/responses  {"model":"system.ai.qwen35-122b-a10b","max_output_tokens":25000}  → 200
POST /ai-gateway/codex/v1/responses  {"model":"system.ai.qwen35-122b-a10b","max_output_tokens":32768}  → 400 "cannot exceed 25000"
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Corrects `max_output_tokens` for 10 Databricks-hosted models to match actual AI Gateway limits, preventing spurious 400 errors when clients use the catalog-reported values.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release