### PR TITLE
Set model and usage attributes on OpenAI agent response spans in `_agent_tracer.py` for tracing cost and token calculations

### DIFF
--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -96,7 +96,9 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
         self._span_id_to_mlflow_span: dict[str, SpanWithToken] = {}
 
     def on_trace_start(self, trace: oai.Trace) -> None:
-        if (active_span := get_current_active_span()) and _is_agent_run_root(active_span):
+        if (active_span := get_current_active_span()) and _is_agent_run_root(
+            active_span
+        ):
             # The root span is already started by _patched_agent_run / _patched_agent_run_streamed
             mlflow_span = active_span
             token = None
@@ -131,7 +133,9 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
 
     def on_span_start(self, span: oai.Span[Any]) -> None:
         try:
-            parent_st: SpanWithToken | None = self._span_id_to_mlflow_span.get(span.parent_id, None)
+            parent_st: SpanWithToken | None = self._span_id_to_mlflow_span.get(
+                span.parent_id, None
+            )
 
             # Parent might be a trace
             if not parent_st:
@@ -150,16 +154,22 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
             token = set_span_in_context(mlflow_span)
 
             if span_type == SpanType.CHAT_MODEL:
-                mlflow_span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "openai-agent")
+                mlflow_span.set_attribute(
+                    SpanAttributeKey.MESSAGE_FORMAT, "openai-agent"
+                )
 
-            self._span_id_to_mlflow_span[span.span_id] = SpanWithToken(mlflow_span, token)
+            self._span_id_to_mlflow_span[span.span_id] = SpanWithToken(
+                mlflow_span, token
+            )
         except Exception:
             _logger.debug("Failed to start MLflow span", exc_info=True)
 
     def on_span_end(self, span: oai.Span[Any]) -> None:
         try:
             # parsed_span_data = parse_spandata(span.span_data)
-            st: SpanWithToken | None = self._span_id_to_mlflow_span.pop(span.span_id, None)
+            st: SpanWithToken | None = self._span_id_to_mlflow_span.pop(
+                span.span_id, None
+            )
             detach_span_from_context(st.token)
             mlflow_span = st.span
 
@@ -237,6 +247,7 @@ def _parse_span_data(span_data: oai.SpanData) -> tuple[Any, Any, dict[str, Any]]
         outputs = span_data.output
         attributes = {
             SpanAttributeKey.MODEL: span_data.model,
+            SpanAttributeKey.MODEL_PROVIDER: "openai",
             "model_config": span_data.model_config,
         }
         if usage := _parse_generation_usage(span_data.usage):
@@ -258,19 +269,31 @@ def _parse_span_data(span_data: oai.SpanData) -> tuple[Any, Any, dict[str, Any]]
     return inputs, outputs, attributes
 
 
-def _parse_generation_usage(usage: dict[str, int] | None) -> dict[str, int] | None:
+def _parse_generation_usage(usage: dict[str, Any] | None) -> dict[str, int] | None:
     if not usage:
         return None
     try:
         result = {}
-        for key in [
-            TokenUsageKey.INPUT_TOKENS,
-            TokenUsageKey.OUTPUT_TOKENS,
-            TokenUsageKey.TOTAL_TOKENS,
-        ]:
-            if (v := usage.get(key)) is not None:
-                result[key] = v
-        if details := usage.get("input_tokens_details"):
+        input_tokens = usage.get(TokenUsageKey.INPUT_TOKENS)
+        if input_tokens is None:
+            input_tokens = usage.get("prompt_tokens")
+        if input_tokens is not None:
+            result[TokenUsageKey.INPUT_TOKENS] = input_tokens
+
+        output_tokens = usage.get(TokenUsageKey.OUTPUT_TOKENS)
+        if output_tokens is None:
+            output_tokens = usage.get("completion_tokens")
+        if output_tokens is not None:
+            result[TokenUsageKey.OUTPUT_TOKENS] = output_tokens
+
+        total_tokens = usage.get(TokenUsageKey.TOTAL_TOKENS)
+        if total_tokens is not None:
+            result[TokenUsageKey.TOTAL_TOKENS] = total_tokens
+
+        details = usage.get("input_tokens_details") or usage.get(
+            "prompt_tokens_details"
+        )
+        if details and isinstance(details, dict):
             if (v := details.get("cached_tokens")) is not None:
                 result[TokenUsageKey.CACHE_READ_INPUT_TOKENS] = v
             if (v := details.get("cache_write_tokens")) is not None:
@@ -281,12 +304,21 @@ def _parse_generation_usage(usage: dict[str, int] | None) -> dict[str, int] | No
         return None
 
 
-def _parse_response_span_data(span_data: oai.ResponseSpanData) -> tuple[Any, Any, dict[str, Any]]:
+def _parse_response_span_data(
+    span_data: oai.ResponseSpanData,
+) -> tuple[Any, Any, dict[str, Any]]:
     inputs = span_data.input
     response = span_data.response
     response_dict = response.model_dump() if response else {}
     outputs = response_dict.get("output")
     attributes = {k: v for k, v in response_dict.items() if k != "output"}
+
+    if model := response_dict.get("model"):
+        attributes[SpanAttributeKey.MODEL] = model
+        attributes[SpanAttributeKey.MODEL_PROVIDER] = "openai"
+
+    if usage := _parse_generation_usage(response_dict.get("usage")):
+        attributes[SpanAttributeKey.CHAT_USAGE] = usage
 
     # Extract chat tools
     chat_tools = []
@@ -326,7 +358,9 @@ def _build_agent_run_span_args(original, self_, args, kwargs):
     """
     inputs = construct_full_inputs(original, self_, *args, **kwargs)
     attributes = {
-        k: v for k, v in inputs.items() if k not in ("starting_agent", "input", "run_config")
+        k: v
+        for k, v in inputs.items()
+        if k not in ("starting_agent", "input", "run_config")
     }
     return inputs, attributes
 
@@ -393,12 +427,16 @@ def _patched_agent_run_streamed(original, self, *args, **kwargs):
         live_result = result_ref()
         if not finalizer.alive:
             # Re-iteration after finalize: pass through without touching span.
-            async for event in original_stream_events_func(live_result, *args, **kwargs):
+            async for event in original_stream_events_func(
+                live_result, *args, **kwargs
+            ):
                 yield event
             return
         error: Exception | None = None
         try:
-            async for event in original_stream_events_func(live_result, *args, **kwargs):
+            async for event in original_stream_events_func(
+                live_result, *args, **kwargs
+            ):
                 yield event
         except Exception as e:
             error = e

--- a/tests/openai/test_openai_agent_autolog.py
+++ b/tests/openai/test_openai_agent_autolog.py
@@ -29,6 +29,7 @@ from openai.types.responses.response_text_delta_event import ResponseTextDeltaEv
 import mlflow
 from mlflow.entities import SpanType
 from mlflow.openai._agent_tracer import MlflowOpenAgentTracingProcessor
+from mlflow.tracing.constant import SpanAttributeKey
 
 from tests.tracing.helper import get_traces, purge_traces
 
@@ -141,6 +142,12 @@ async def test_autolog_agent():
     spans = trace.data.spans
     assert len(spans) > 5
 
+    response_spans = [s for s in spans if s.name == "Response"]
+    assert len(response_spans) == 2
+    for r_span in response_spans:
+        assert r_span.attributes.get(SpanAttributeKey.MODEL) == "gpt-4o-mini"
+        assert r_span.attributes.get(SpanAttributeKey.MODEL_PROVIDER) == "openai"
+
 
 @pytest.mark.asyncio
 async def test_autolog_agent_tool_exception():
@@ -178,7 +185,9 @@ async def test_autolog_agent_tool_exception():
         ),
     ]
 
-    @function_tool(failure_error_function=None)  # Set error function None to avoid retry
+    @function_tool(
+        failure_error_function=None
+    )  # Set error function None to avoid retry
     def always_fail():
         raise Exception("This function always fails")
 
@@ -518,7 +527,9 @@ def test_autolog_disable_openai_agent_tracer():
         return get_trace_provider()._multi_processor._processors
 
     # Verify default processor exists before autolog
-    assert any(not isinstance(p, MlflowOpenAgentTracingProcessor) for p in _get_processors())
+    assert any(
+        not isinstance(p, MlflowOpenAgentTracingProcessor) for p in _get_processors()
+    )
 
     # When disable_openai_agent_tracer=False, the default OpenAI tracer should be preserved
     mlflow.openai.autolog(disable_openai_agent_tracer=False)
@@ -607,6 +618,22 @@ def test_generation_span_attributes_stored_under_span_attribute_keys():
                 "cache_read_input_tokens": 3,
             },
         ),
+        # prompt_tokens and completion_tokens aliases
+        (
+            {
+                "prompt_tokens": 20,
+                "completion_tokens": 10,
+                "total_tokens": 30,
+                "prompt_tokens_details": {"cached_tokens": 5, "cache_write_tokens": 3},
+            },
+            {
+                "input_tokens": 20,
+                "output_tokens": 10,
+                "total_tokens": 30,
+                "cache_read_input_tokens": 5,
+                "cache_creation_input_tokens": 3,
+            },
+        ),
         (None, None),
         ({}, None),
     ],
@@ -642,4 +669,140 @@ def test_calculate_span_cost_uses_generation_span_model_attribute():
         result = calculate_span_cost(mock_span)
 
     mock_cost.assert_called_once_with("some-model", usage, None)
+    assert result == expected_cost
+
+
+def test_parse_response_span_data_sets_model_and_usage():
+    import agents.tracing as oai
+    from mlflow.openai._agent_tracer import _parse_response_span_data
+    from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+
+    response = Response(
+        id="resp_123",
+        created_at=12345678.0,
+        error=None,
+        model="gpt-4o-mini",
+        object="response",
+        output=[
+            ResponseOutputMessage(
+                id="msg_123",
+                content=[
+                    ResponseOutputText(
+                        annotations=[],
+                        text="Hello!",
+                        type="output_text",
+                    )
+                ],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        tools=[],
+        tool_choice="auto",
+        temperature=1,
+        parallel_tool_calls=True,
+        usage={
+            "input_tokens": 12,
+            "output_tokens": 8,
+            "total_tokens": 20,
+            "input_tokens_details": {"cached_tokens": 4, "cache_write_tokens": 2},
+        },
+    )
+
+    span_data = oai.ResponseSpanData(
+        input=[{"role": "user", "content": "Hi"}],
+        response=response,
+    )
+
+    inputs, outputs, attributes = _parse_response_span_data(span_data)
+
+    assert inputs == [{"role": "user", "content": "Hi"}]
+    assert outputs == [
+        {
+            "id": "msg_123",
+            "content": [
+                {
+                    "annotations": [],
+                    "text": "Hello!",
+                    "type": "output_text",
+                }
+            ],
+            "role": "assistant",
+            "status": "completed",
+            "type": "message",
+        }
+    ]
+    assert attributes[SpanAttributeKey.MODEL] == "gpt-4o-mini"
+    assert attributes[SpanAttributeKey.MODEL_PROVIDER] == "openai"
+    assert attributes[SpanAttributeKey.CHAT_USAGE] == {
+        TokenUsageKey.INPUT_TOKENS: 12,
+        TokenUsageKey.OUTPUT_TOKENS: 8,
+        TokenUsageKey.TOTAL_TOKENS: 20,
+        TokenUsageKey.CACHE_READ_INPUT_TOKENS: 4,
+        TokenUsageKey.CACHE_CREATION_INPUT_TOKENS: 2,
+    }
+
+
+def test_parse_response_span_data_none_response():
+    import agents.tracing as oai
+    from mlflow.openai._agent_tracer import _parse_response_span_data
+
+    span_data = oai.ResponseSpanData(
+        input="test",
+        response=None,
+    )
+    inputs, outputs, attributes = _parse_response_span_data(span_data)
+    assert inputs == "test"
+    assert outputs is None
+    assert attributes == {}
+
+
+def test_calculate_span_cost_uses_response_span_attributes():
+    from mlflow.openai._agent_tracer import _parse_response_span_data
+    from mlflow.tracing.constant import SpanAttributeKey
+    from mlflow.tracing.utils import calculate_span_cost
+
+    response = Response(
+        id="resp_123",
+        created_at=12345678.0,
+        error=None,
+        model="gpt-4o-mini",
+        object="response",
+        output=[],
+        tools=[],
+        tool_choice="auto",
+        temperature=1,
+        parallel_tool_calls=True,
+        usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+        },
+    )
+    mock_span_data = mock.MagicMock()
+    mock_span_data.input = "Hi"
+    mock_span_data.response = response
+
+    _, _, attributes = _parse_response_span_data(mock_span_data)
+
+    mock_span = mock.MagicMock()
+    mock_span.get_attribute.side_effect = attributes.get
+
+    expected_cost = {
+        "input_cost": 0.00015,
+        "output_cost": 0.0003,
+        "total_cost": 0.00045,
+    }
+    with mock.patch(
+        "mlflow.tracing.utils.calculate_cost_by_model_and_token_usage",
+        return_value=expected_cost,
+    ) as mock_cost:
+        result = calculate_span_cost(mock_span)
+
+    mock_cost.assert_called_once_with(
+        "gpt-4o-mini",
+        attributes[SpanAttributeKey.CHAT_USAGE],
+        "openai",
+    )
     assert result == expected_cost


### PR DESCRIPTION
### Related Issues/PRs

Closes #24393

### What changes are proposed in this pull request?

When using `mlflow.openai.autolog()` with the OpenAI Agents SDK (`agents`), LLM generation produces `ResponseSpanData` spans (mapped to `SpanType.CHAT_MODEL`). Previously, `_parse_response_span_data` in `mlflow/openai/_agent_tracer.py` unpacked the raw dictionary fields from `Response.model_dump()`, but did not set the standardized span attributes:
- `SpanAttributeKey.MODEL` (`mlflow.llm.model`)
- `SpanAttributeKey.MODEL_PROVIDER` (`mlflow.llm.modelProvider`)
- `SpanAttributeKey.CHAT_USAGE` (`mlflow.chat.tokenUsage`)

Because of this:
1. `calculate_span_cost(span)` returned `None` for all agent `Response` spans because `span.get_attribute(SpanAttributeKey.MODEL)` was missing.
2. Trace-level token usage and cost aggregation failed to capture LLM usage from OpenAI agents.
3. The MLflow UI did not display model or token breakdown for agent response spans.

This PR:
1. Updates `_parse_response_span_data` to set `SpanAttributeKey.MODEL`, `SpanAttributeKey.MODEL_PROVIDER`, and `SpanAttributeKey.CHAT_USAGE` on `Response` spans.
2. Updates `_parse_generation_usage` to support `prompt_tokens` / `completion_tokens` and details aliases.
3. Adds unit tests covering `ResponseSpanData` attribute extraction, `calculate_span_cost` computation on `Response` spans, and assertions on live agent response spans.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix missing model, provider, and chat usage attributes on OpenAI Agent SDK `Response` spans, enabling trace cost calculation and token aggregation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release