### PR TITLE
Add a job that files a PR as `mlflow-app[bot]`

### DIFF
--- a/.github/workflows/create-bot-pr.yml
+++ b/.github/workflows/create-bot-pr.yml
@@ -1,0 +1,68 @@
+# Opens a PR authored by mlflow-app[bot] from a branch that already exists in
+# this repository. Mechanical PRs filed this way stay exempt from the checks
+# that assume a human filled in the PR template.
+name: Create bot PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Head branch to open the PR from. Must already exist in this repository."
+        required: true
+      title:
+        description: "PR title"
+        required: true
+      body:
+        description: "PR body"
+        required: false
+        default: ""
+      base:
+        description: "Base branch"
+        required: false
+        default: master
+      labels:
+        description: "Comma-separated labels to apply (e.g. rn/none,area/build)"
+        required: false
+        default: ""
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}
+          TITLE: ${{ inputs.title }}
+          BODY: ${{ inputs.body }}
+          BASE: ${{ inputs.base }}
+          LABELS: ${{ inputs.labels }}
+        run: |
+          PR=$(gh api "repos/$REPO/pulls" \
+            -f "title=$TITLE" \
+            -f "head=$BRANCH" \
+            -f "base=$BASE" \
+            -f "body=$BODY" \
+            --jq '"\(.number) \(.html_url)"')
+          read -r PR_NUMBER PR_URL <<< "$PR"
+          echo "Created $PR_URL"
+          echo "Created $PR_URL" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$LABELS" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABELS"
+          fi


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25361

### What changes are proposed in this pull request?

Mechanical PRs (version bumps, dependency updates) are opened without filling in the PR template, so `release-note`, `advice`, and `patch` skip them by matching the author against a bot login list. Filing them through the bot keeps those exemptions working while a human decides when to file, and it keys on `user.login`, which is already in the `opened` payload.

Add `.github/workflows/create-bot-pr.yml`, a `workflow_dispatch` job that takes a branch, title, and body (plus optional `base` and `labels`), mints an app token, and opens the PR. The branch has to already exist in this repository; the job creates no commits, so DCO is decided by whoever pushed it. Dispatching requires write access, so only maintainers can file one.

An app token rather than `GITHUB_TOKEN` is what makes CI run on the resulting PR.

### How is this PR tested?

- [x] Manual tests

Validated the workflow through `actionlint`, the `policy.rego` conftest hook, and `bash -n` on the run block. `workflow_dispatch` is only invocable from the default branch, so the job itself cannot be exercised until this merges.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release