### PR TITLE
Drop the `🤖 Generated with Claude` footer from the review payload

### DIFF
--- a/.claude/skills/pr-review/review-payload.schema.json
+++ b/.claude/skills/pr-review/review-payload.schema.json
@@ -12,10 +12,9 @@
       "enum": ["APPROVE", "COMMENT"]
     },
     "body": {
-      "description": "Concise top-level review summary in 2-3 sentences capturing the overall assessment. Do not restate individual findings (those belong in inline comments). Must end with the '🤖 Generated with Claude' footer on its own line.",
+      "description": "Concise top-level review summary in 2-3 sentences capturing the overall assessment. Do not restate individual findings (those belong in inline comments).",
       "type": "string",
-      "minLength": 1,
-      "pattern": "(^|\\n)🤖 Generated with Claude\\s*$"
+      "minLength": 1
     },
     "commit_id": {
       "description": "Head commit SHA being reviewed. Optional; GitHub defaults to the latest commit when omitted.",

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -76,7 +76,6 @@ def collect_files(directory: Path) -> tuple[list[Path], list[str]]:
 def rewrite_payload(
     payload: dict[str, Any], urls: dict[str, str], unavailable: Iterable[str] = ()
 ) -> dict[str, Any]:
-    # The schema pins body to end with the Claude footer, so only substitute, never append.
     match payload:
         case {"body": str(body)}:
             payload["body"] = substitute(body, urls, unavailable)

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -98,11 +98,11 @@ def test_substitute_strips_markup_for_media_that_never_uploaded(text: str, expec
 def test_rewrite_payload_covers_body_and_inline_comments() -> None:
     payload = {
         "event": "COMMENT",
-        "body": f"Race shown in [the trace]({SHOT})\n\n🤖 Generated with Claude",
+        "body": f"Race shown in [the trace]({SHOT})\n\nNothing else stood out.",
         "comments": [{"path": "a.py", "body": f"🔴 **CRITICAL:** ![x]({SHOT})", "line": 1}],
     }
     result = rewrite_payload(payload, URLS)
-    assert result["body"] == f"Race shown in [the trace]({URL})\n\n🤖 Generated with Claude"
+    assert result["body"] == f"Race shown in [the trace]({URL})\n\nNothing else stood out."
     assert result["comments"][0]["body"] == f"🔴 **CRITICAL:** ![x]({URL})"
 
 
@@ -111,9 +111,9 @@ def test_rewrite_payload_neutralizes_unavailable_media_in_comments() -> None:
     assert rewrite_payload(payload, {}, [SHOT])["comments"][0]["body"] == "the bug"
 
 
-def test_rewrite_payload_preserves_the_trailing_footer() -> None:
-    payload = {"body": f"![x]({SHOT})\n\n🤖 Generated with Claude", "comments": []}
-    assert rewrite_payload(payload, URLS)["body"].endswith("🤖 Generated with Claude")
+def test_rewrite_payload_preserves_trailing_text() -> None:
+    payload = {"body": f"![x]({SHOT})\n\nNothing else stood out.", "comments": []}
+    assert rewrite_payload(payload, URLS)["body"].endswith("Nothing else stood out.")
 
 
 def test_rewrite_payload_tolerates_missing_and_malformed_fields() -> None:

--- a/.claude/skills/tests/test_review_payload_schema.py
+++ b/.claude/skills/tests/test_review_payload_schema.py
@@ -5,7 +5,7 @@ import pytest
 from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
 from skills.commands.validate_review import DEFAULT_SCHEMA
 
-BODY = "Overall the change looks good.\n\n🤖 Generated with Claude"
+BODY = "Overall the change looks good."
 CRITICAL = {"path": "a.py", "body": "🔴 **CRITICAL:** unhandled None", "line": 1, "side": "RIGHT"}
 MODERATE = {"path": "a.py", "body": "🟡 **MODERATE:** unclear name", "line": 1, "side": "RIGHT"}
 NIT = {"path": "a.py", "body": "🟢 **NIT:** stray blank line", "line": 1, "side": "RIGHT"}
@@ -74,17 +74,11 @@ def test_comment_rejects_bodies_without_a_severity_prefix(
     ("body", "valid"),
     [
         (BODY, True),
-        ("🤖 Generated with Claude", True),
-        ("Looks good.\n\n🤖 Generated with Claude\n", True),
-        ("Looks good.", False),
-        ("Looks good.\n\n🤖 Generated with Claude\n\nOne more thing.", False),
-        ("Looks good. 🤖 Generated with Claude", False),
+        ("Looks good.", True),
         ("", False),
     ],
 )
-def test_body_requires_the_footer_on_its_own_trailing_line(
-    validator: Draft202012Validator, body: str, valid: bool
-) -> None:
+def test_body_must_be_non_empty(validator: Draft202012Validator, body: str, valid: bool) -> None:
     assert validator.is_valid(payload(body=body)) is valid
 
 

--- a/.claude/skills/tests/test_validate_review.py
+++ b/.claude/skills/tests/test_validate_review.py
@@ -6,7 +6,7 @@ import pytest
 from skills.cli import build_parser
 from skills.commands.validate_review import format_path
 
-BODY = "Overall the change looks good.\n\n🤖 Generated with Claude"
+BODY = "Overall the change looks good."
 CRITICAL = {"path": "a.py", "body": "🔴 **CRITICAL:** unhandled None", "line": 1, "side": "RIGHT"}
 
 
@@ -30,7 +30,7 @@ def test_cli_exits_nonzero_and_reports_each_error(
 ) -> None:
     payload = {
         "event": "APPROVE",
-        "body": "missing the footer",
+        "body": "",
         "comments": [{"path": "a.py", "body": "missing the prefix", "line": 0, "side": "MIDDLE"}],
     }
     with pytest.raises(SystemExit, match="^1$"):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25334

### What changes are proposed in this pull request?

`review-payload.schema.json` required the review `body` to end with the `🤖 Generated with Claude` footer, and the reviewing model omits it often enough that a run fails validation over one line. The review is posted by mlflow-app[bot], so its provenance is already visible without it.

Drop the `pattern` from `body`, keeping `minLength: 1`, and update the fixtures that carried the footer.

### How is this PR tested?

- [x] Existing unit/integration tests

`uv run --package skills pytest .claude/skills/tests` passes (185).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release