### PR TITLE
Stop duplicating candidate text in GEPA reflective dataset

### DIFF
--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -326,7 +326,6 @@ class GepaPromptOptimizer(BasePromptOptimizer):
 
                         component_data.append({
                             "component_name": component_name,
-                            "current_text": candidate.get(component_name, ""),
                             "trace": spans,
                             "score": score,
                             "inputs": trajectory.inputs,

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -435,7 +435,7 @@ def test_make_reflective_dataset_with_traces(
     system_data = result["system_prompt"]
     assert len(system_data) == 2
     assert system_data[0]["component_name"] == "system_prompt"
-    assert system_data[0]["current_text"] == "You are helpful"
+    assert "current_text" not in system_data[0]
     assert system_data[0]["score"] == 0.9
     assert system_data[0]["inputs"] == {"question": "What is 2+2?"}
     assert system_data[0]["outputs"] == "4"


### PR DESCRIPTION
### Related Issues/PRs

Closes #25364

### What changes are proposed in this pull request?

`make_reflective_dataset` in `mlflow/genai/optimize/optimizers/gepa_optimizer.py` stamped `candidate.get(component_name, "")` into every per-record row as `current_text`. GEPA's own prompt renderer already includes the candidate text once via `current_instruction_doc`, so the full component text was repeated once per minibatch record — `batch_size + 1` copies total in the reflection prompt, wasting tokens with no benefit.

This PR drops the redundant `current_text` field from each row. The candidate text still reaches the reflection model exactly once, via GEPA's own renderer.

### How is this PR tested?

- [x] Existing unit/integration tests

Updated `tests/genai/optimize/optimizers/test_gepa_optimizer.py::test_make_reflective_dataset_with_traces` to assert `current_text` is no longer present. `uv run pytest tests/genai/optimize/optimizers/test_gepa_optimizer.py -k reflective -q` passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`GepaPromptOptimizer` no longer duplicates the candidate instruction text in the reflection prompt it sends to the reflection model, reducing token usage during prompt optimization.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
