### PR TITLE
docs: document error handling for `mlflow.models.evaluate` function evaluation

### DIFF
--- a/docs/docs/classic-ml/evaluation/index.mdx
+++ b/docs/docs/classic-ml/evaluation/index.mdx
@@ -349,6 +349,58 @@ The function must:
 
 For classification tasks, the function should return class predictions. For regression tasks, it should return continuous values.
 
+### Error Handling
+
+<APILink fn="mlflow.models.evaluate" /> propagates any exception raised by the prediction function, which aborts the whole evaluation. When individual rows can fail (a malformed record, a rate-limited API call, a timeout), evaluate the rows that succeed and keep the failures for a later run.
+
+```python
+import mlflow
+import pandas as pd
+
+# Reuses predict_function and eval_data from the example above
+errors = {}
+succeeded = []
+
+for idx, row in eval_data.drop(columns=["target"]).iterrows():
+    try:
+        predict_function(pd.DataFrame([row]))
+        succeeded.append(idx)
+    except Exception as e:
+        errors[idx] = str(e)
+
+with mlflow.start_run():
+    mlflow.models.evaluate(
+        predict_function,
+        eval_data.loc[succeeded],
+        targets="target",
+        model_type="classifier",
+    )
+
+    # Keep the failures with the run so they can be inspected later
+    if errors:
+        mlflow.log_dict(errors, "evaluation_errors.json")
+```
+
+:::note
+Checking each row separately calls the prediction function twice per row. For expensive functions, return a sentinel value from the prediction function itself and filter those rows out before evaluating.
+:::
+
+Once the underlying cause is fixed, re-run the evaluation over the full dataset so the metrics reflect every row:
+
+```python
+with mlflow.start_run(run_name="retry_after_fix"):
+    mlflow.models.evaluate(
+        predict_function,
+        eval_data,
+        targets="target",
+        model_type="classifier",
+    )
+```
+
+:::note
+Evaluating only the previously failed rows works for regression, but classifier evaluation requires at least two distinct label values in the dataset, so a small subset of recovered rows raises `MlflowException`. Re-evaluate the full dataset, or merge the recovered rows back into it, rather than scoring them on their own.
+:::
+
 ## Custom Metrics & Visualizations
 
 Define custom evaluation metrics and create specialized visualizations.


### PR DESCRIPTION
### Related Issues/PRs

Closes #17108

Supersedes #17142, which targeted `docs/docs/classic-ml/evaluation/function-eval.mdx` (removed in #19013) and the legacy LLM evaluation page. This re-targets the same guidance at the page that documents function evaluation today.

Scope: #17108 cites both the classic ML function evaluation docs and the GenAI LLM evaluation docs. This PR covers the classic ML page only. The GenAI page it referred to is now `legacy-llm-evaluation.mdx`, which documents an API slated for removal, and the current GenAI evaluation docs are structured differently enough to deserve their own change. Happy to open a follow-up for that side if you would rather this issue stay open until both are done.

### What changes are proposed in this pull request?

Adds an `Error Handling` subsection to the Function Evaluation section of the classic ML evaluation docs.

#17108 pointed out that the documented pattern for evaluating a custom function shows no way to deal with rows that raise. The example on the page still passes a bare `predict_function` to `mlflow.models.evaluate`, so a single failing row aborts the entire evaluation, and there is no guidance on finding or re-running the rows that failed.

The new subsection covers:

- why an exception in the prediction function aborts the whole run
- identifying the rows that fail and evaluating only the ones that succeed
- persisting the failures with `mlflow.log_dict` so they can be inspected
- re-running the evaluation once the cause is fixed
- a note that the row-by-row check calls the prediction function twice per row, and what to do instead when that function is expensive
- a note that classifier evaluation needs at least two distinct labels, so a small subset of recovered rows will often fail to evaluate on its own

Docs-only. No source changes.

### How is this PR tested?

- [x] Manual tests

Both code blocks were run end to end against the page's existing scikit-learn example, with one row rigged to raise. The first block evaluates the 299 surviving rows and records the single failure via `mlflow.log_dict`; the second re-evaluates the full dataset once the fault is cleared.

The caveat about label cardinality is also verified rather than assumed: scoring only the recovered rows raises `MlflowException: Evaluation dataset for classification must contain at least two unique labels`. That is why the retry example re-evaluates the whole dataset instead of the failed subset.

`prettier --check` passes on the modified file.

<details>
<summary>Script used for manual testing</summary>

```python
import mlflow
import pandas as pd
from mlflow.exceptions import MlflowException
from sklearn.datasets import make_classification
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import train_test_split

# Setup copied from the page's existing Function Evaluation example
X, y = make_classification(n_samples=1000, n_features=20, n_classes=2, random_state=42)
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)

model = RandomForestClassifier(n_estimators=100, random_state=42)
model.fit(X_train, y_train)

eval_data = pd.DataFrame(X_test)
eval_data["target"] = y_test

# Simulate a record the prediction function cannot handle
BAD_ROW = eval_data.index[5]
broken = True


def predict_function(input_data):
    if broken and BAD_ROW in input_data.index:
        raise ValueError(f"malformed record at row {BAD_ROW}")
    return model.predict(input_data)


# First documented block
errors = {}
succeeded = []

for idx, row in eval_data.drop(columns=["target"]).iterrows():
    try:
        predict_function(pd.DataFrame([row]))
        succeeded.append(idx)
    except Exception as e:
        errors[idx] = str(e)

with mlflow.start_run():
    mlflow.models.evaluate(
        predict_function,
        eval_data.loc[succeeded],
        targets="target",
        model_type="classifier",
    )
    if errors:
        mlflow.log_dict(errors, "evaluation_errors.json")

assert len(errors) == 1 and BAD_ROW in errors
assert len(succeeded) == len(eval_data) - 1

# Second documented block, after the fault is cleared
broken = False

with mlflow.start_run(run_name="retry_after_fix"):
    mlflow.models.evaluate(
        predict_function,
        eval_data,
        targets="target",
        model_type="classifier",
    )

# The caveat in the note: the recovered rows alone carry one label here
try:
    with mlflow.start_run(run_name="failed_rows_only"):
        mlflow.models.evaluate(
            predict_function,
            eval_data.loc[list(errors)],
            targets="target",
            model_type="classifier",
        )
except MlflowException as e:
    assert "two unique labels" in str(e)
else:
    raise SystemExit("expected MlflowException for a single-label subset")
```

Output:

```
OK  first block: evaluated 299 rows, captured 1 failure
OK  second block: re-evaluated all 300 rows after the fix
OK  caveat holds: scoring only the recovered rows raises MlflowException
```

</details>

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
