### PR TITLE
Add JSON/YAML editing for evaluation dataset records

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordFormatEditor.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordFormatEditor.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DatasetRecordFormatEditor, canonicalizeYamlRecord, serializeRecordAsYaml } from './DatasetRecordFormatEditor';
+
+jest.mock('./LazyJsonRecordEditor', () => ({
+  LazyJsonRecordEditor: ({
+    value,
+    onChange,
+    language,
+    ariaLabel,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    language: string;
+    ariaLabel: string;
+  }) => (
+    <textarea
+      aria-label={ariaLabel}
+      data-language={language}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+describe('DatasetRecordFormatEditor', () => {
+  test('renders canonical JSON as editable YAML and emits canonical JSON', () => {
+    const onChange = jest.fn();
+    render(
+      <DatasetRecordFormatEditor
+        format="yaml"
+        value={JSON.stringify({ question: 'Hello', score: 1 }, null, 2)}
+        onChange={onChange}
+        ariaLabel="Record inputs"
+      />,
+    );
+
+    const editor = screen.getByRole('textbox', { name: 'Record inputs' });
+    expect(editor).toHaveAttribute('data-language', 'yaml');
+    expect(editor).toHaveValue('question: Hello\nscore: 1\n');
+
+    fireEvent.change(editor, { target: { value: 'question: Updated\nscore: 2\n' } });
+    expect(onChange).toHaveBeenLastCalledWith(JSON.stringify({ question: 'Updated', score: 2 }, null, 2));
+    expect(editor).toHaveValue('question: Updated\nscore: 2\n');
+  });
+
+  test('keeps invalid YAML verbatim so the parent state remains invalid', () => {
+    const onChange = jest.fn();
+    render(<DatasetRecordFormatEditor format="yaml" value="{}" onChange={onChange} ariaLabel="Record inputs" />);
+
+    const editor = screen.getByRole('textbox', { name: 'Record inputs' });
+    fireEvent.change(editor, { target: { value: 'question: [unterminated' } });
+    expect(onChange).toHaveBeenLastCalledWith('question: [unterminated');
+    expect(editor).toHaveValue('question: [unterminated');
+  });
+});
+
+describe('record format conversion', () => {
+  test('requires a mapping at the top level in both views', () => {
+    expect(canonicalizeYamlRecord('- one\n- two\n')).toBeUndefined();
+    expect(canonicalizeYamlRecord('plain text')).toBeUndefined();
+    expect(canonicalizeYamlRecord('')).toBe(JSON.stringify({}, null, 2));
+  });
+
+  test('preserves invalid JSON while changing to YAML view', () => {
+    expect(serializeRecordAsYaml('{invalid')).toBe('{invalid');
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordFormatEditor.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordFormatEditor.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import yaml from 'js-yaml';
+import { LazyJsonRecordEditor } from './LazyJsonRecordEditor';
+import type { JsonRecordEditorProps } from './JsonRecordEditor';
+
+export type DatasetRecordFormat = 'json' | 'yaml';
+
+const isRecordObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+export const serializeRecordAsYaml = (value: string): string => {
+  if (value.trim() === '') return '';
+  try {
+    const parsed = JSON.parse(value);
+    return isRecordObject(parsed)
+      ? yaml.safeDump(parsed, { noRefs: true, schema: yaml.JSON_SCHEMA, sortKeys: false })
+      : value;
+  } catch {
+    // Preserve invalid JSON verbatim when changing views so in-progress edits are never lost.
+    return value;
+  }
+};
+
+export const canonicalizeYamlRecord = (value: string): string | undefined => {
+  if (value.trim() === '') return JSON.stringify({}, null, 2);
+  try {
+    const parsed = yaml.safeLoad(value, { schema: yaml.JSON_SCHEMA });
+    return isRecordObject(parsed) ? JSON.stringify(parsed, null, 2) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+interface DatasetRecordFormatEditorProps extends Omit<JsonRecordEditorProps, 'language' | 'onChange' | 'value'> {
+  format: DatasetRecordFormat;
+  /** Canonical JSON text owned by the record save/create state. */
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Adapts the record editor's canonical JSON state to an editable YAML view. Valid YAML
+ * objects are immediately normalized back to JSON for the existing save and dirty-state
+ * machinery; invalid YAML remains visible verbatim and keeps Save disabled.
+ */
+export const DatasetRecordFormatEditor = ({
+  format,
+  value,
+  onChange,
+  ...editorProps
+}: DatasetRecordFormatEditorProps) => {
+  const [yamlText, setYamlText] = useState(() => serializeRecordAsYaml(value));
+  const lastEmittedCanonical = useRef<string>();
+
+  useEffect(() => {
+    if (format !== 'yaml') return;
+    if (value === lastEmittedCanonical.current) {
+      lastEmittedCanonical.current = undefined;
+      return;
+    }
+    setYamlText(serializeRecordAsYaml(value));
+  }, [format, value]);
+
+  const handleYamlChange = useCallback(
+    (next: string) => {
+      setYamlText(next);
+      const canonical = canonicalizeYamlRecord(next) ?? next;
+      lastEmittedCanonical.current = canonical;
+      onChange(canonical);
+    },
+    [onChange],
+  );
+
+  if (format === 'json') {
+    return <LazyJsonRecordEditor {...editorProps} language="json" value={value} onChange={onChange} />;
+  }
+
+  return <LazyJsonRecordEditor {...editorProps} language="yaml" value={yamlText} onChange={handleYamlChange} />;
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordSidePanel.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/DatasetRecordSidePanel.tsx
@@ -1,8 +1,15 @@
-import { useEffect } from 'react';
-import { Button, CloseIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  CloseIcon,
+  SegmentedControlButton,
+  SegmentedControlGroup,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
 import type { DatasetRecord } from '../hooks/useDatasetsQueries';
-import { LazyJsonRecordEditor } from './LazyJsonRecordEditor';
+import { DatasetRecordFormatEditor, type DatasetRecordFormat } from './DatasetRecordFormatEditor';
 import { DatasetRecordDetailFooter } from './DatasetRecordDetailFooter';
 import { DatasetRecordCollapsibleSection } from './DatasetRecordCollapsibleSection';
 import { DatasetRecordDetailHeader } from './DatasetRecordDetailHeader';
@@ -115,6 +122,7 @@ export const DatasetRecordSidePanel = ({
 }: DatasetRecordSidePanelProps) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
+  const [recordFormat, setRecordFormat] = useState<DatasetRecordFormat>('json');
 
   const editFallback = intl.formatMessage({
     defaultMessage: 'Failed to save record',
@@ -193,11 +201,16 @@ export const DatasetRecordSidePanel = ({
     return () => document.removeEventListener('keydown', handler);
   }, [open, onClose]);
 
-  const invalidJsonMessage = intl.formatMessage({
-    defaultMessage: 'Invalid JSON',
-    description:
-      'Inline error shown under a dataset record JSON editor when the contents do not parse as a JSON object',
-  });
+  const invalidRecordMessage =
+    recordFormat === 'json'
+      ? intl.formatMessage({
+          defaultMessage: 'Invalid JSON',
+          description: 'Inline error shown when a dataset record editor does not contain a valid JSON object',
+        })
+      : intl.formatMessage({
+          defaultMessage: 'Invalid YAML',
+          description: 'Inline error shown when a dataset record editor does not contain a valid YAML object',
+        });
 
   const closeLabel = intl.formatMessage({
     defaultMessage: 'Close',
@@ -268,12 +281,27 @@ export const DatasetRecordSidePanel = ({
             // Keeps the close button right-aligned while the record query resolves.
             <span />
           )}
-          <Button
-            componentId="mlflow.eval-datasets-v2.side-panel.close"
-            icon={<CloseIcon />}
-            aria-label={closeLabel}
-            onClick={onClose}
-          />
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <SegmentedControlGroup
+              name="mlflow.eval-datasets-v2.record-format"
+              componentId="mlflow.eval-datasets-v2.side-panel.record-format"
+              value={recordFormat}
+              onChange={(event) => setRecordFormat(event.target.value as DatasetRecordFormat)}
+            >
+              <SegmentedControlButton value="json">
+                <FormattedMessage defaultMessage="JSON" description="JSON dataset record editor format option" />
+              </SegmentedControlButton>
+              <SegmentedControlButton value="yaml">
+                <FormattedMessage defaultMessage="YAML" description="YAML dataset record editor format option" />
+              </SegmentedControlButton>
+            </SegmentedControlGroup>
+            <Button
+              componentId="mlflow.eval-datasets-v2.side-panel.close"
+              icon={<CloseIcon />}
+              aria-label={closeLabel}
+              onClick={onClose}
+            />
+          </div>
         </div>
       </div>
       <div
@@ -294,14 +322,15 @@ export const DatasetRecordSidePanel = ({
             />
           }
         >
-          <LazyJsonRecordEditor
+          <DatasetRecordFormatEditor
+            format={recordFormat}
             value={active.inputs.text}
             onChange={active.inputs.setText}
             ariaLabel={intl.formatMessage({
               defaultMessage: 'Dataset record inputs',
-              description: 'Aria label for the dataset record inputs JSON editor',
+              description: 'Aria label for the dataset record inputs structured-data editor',
             })}
-            errorMessage={active.inputs.isValid ? undefined : invalidJsonMessage}
+            errorMessage={active.inputs.isValid ? undefined : invalidRecordMessage}
             onSaveShortcut={active.save}
           />
         </DatasetRecordCollapsibleSection>
@@ -314,14 +343,15 @@ export const DatasetRecordSidePanel = ({
             />
           }
         >
-          <LazyJsonRecordEditor
+          <DatasetRecordFormatEditor
+            format={recordFormat}
             value={active.expectations.text}
             onChange={active.expectations.setText}
             ariaLabel={intl.formatMessage({
               defaultMessage: 'Dataset record expectations',
-              description: 'Aria label for the dataset record expectations JSON editor',
+              description: 'Aria label for the dataset record expectations structured-data editor',
             })}
-            errorMessage={active.expectations.isValid ? undefined : invalidJsonMessage}
+            errorMessage={active.expectations.isValid ? undefined : invalidRecordMessage}
             onSaveShortcut={active.save}
           />
         </DatasetRecordCollapsibleSection>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/JsonRecordEditor.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/components/JsonRecordEditor.tsx
@@ -11,9 +11,11 @@ import type * as Monaco_ from 'monaco-editor';
 import { Typography, useDesignSystemTheme } from '@databricks/design-system';
 
 export interface JsonRecordEditorProps {
-  /** JSON string. Callers serialize objects via `JSON.stringify(obj, null, 2)`. */
+  /** Structured text displayed by Monaco. */
   value: string;
   onChange: (value: string) => void;
+  /** Monaco language used for syntax highlighting and validation. */
+  language?: 'json' | 'yaml';
   readOnly?: boolean;
   /** CSS length (e.g. "240px") for the minimum editor height. */
   height?: string;
@@ -79,6 +81,7 @@ const heightToPx = (h: string): number => {
 export const JsonRecordEditor = ({
   value,
   onChange,
+  language = 'json',
   readOnly = false,
   height = '240px',
   maxHeight,
@@ -138,7 +141,7 @@ export const JsonRecordEditor = ({
         }}
       >
         <Editor
-          language="json"
+          language={language}
           value={value}
           onChange={(next) => onChange(next ?? '')}
           theme={

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4839,10 +4839,6 @@
     "defaultMessage": "404: Resource not found",
     "description": "Generic 404 user-friendly error for the MLflow UI"
   },
-  "IYeKVP": {
-    "defaultMessage": "Dataset record expectations",
-    "description": "Aria label for the dataset record expectations JSON editor"
-  },
   "IZ95jb": {
     "defaultMessage": "Datasets",
     "description": "Filtering label to filter runs based on datasets used"
@@ -5102,6 +5098,10 @@
   "Jfryx4": {
     "defaultMessage": "Top K",
     "description": "Label for the top-k input on the playground parameters panel"
+  },
+  "Jiydop": {
+    "defaultMessage": "Dataset record expectations",
+    "description": "Aria label for the dataset record expectations structured-data editor"
   },
   "Jj2kRy": {
     "defaultMessage": "No details for assessment",
@@ -5914,10 +5914,6 @@
   "N7KBFa": {
     "defaultMessage": "Create view",
     "description": "Menu item to create a new custom trace view"
-  },
-  "N8/kmr": {
-    "defaultMessage": "Invalid JSON",
-    "description": "Inline error shown under a dataset record JSON editor when the contents do not parse as a JSON object"
   },
   "N8YuIr": {
     "defaultMessage": "Error while loading metric page",
@@ -7423,6 +7419,10 @@
     "defaultMessage": "Retrieval Groundedness assessment is missing. This is likely because your agent is not returning retrieved_context.",
     "description": "Evaluation results > known type of evaluation result assessment > retrieval groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. \"Retrieval Groundedness: moderately grounded\""
   },
+  "TXlV2z": {
+    "defaultMessage": "Invalid YAML",
+    "description": "Inline error shown when a dataset record editor does not contain a valid YAML object"
+  },
   "TXwmoT": {
     "defaultMessage": "Git branch",
     "description": "Usage overview > metrics filter > git branch column option label"
@@ -7430,10 +7430,6 @@
   "TannO5": {
     "defaultMessage": "Retrieved {sampledCount} out of {totalCount} total logs ({percentage}%)",
     "description": "Evaluation review > evaluations list > sample info tooltip"
-  },
-  "TbI+lg": {
-    "defaultMessage": "Dataset record inputs",
-    "description": "Aria label for the dataset record inputs JSON editor"
   },
   "TcNbWT": {
     "defaultMessage": "View dataset metadata",
@@ -7959,6 +7955,10 @@
     "defaultMessage": "Deleted traces cannot be restored. Are you sure you want to proceed?",
     "description": "Experiment page > traces view controls > Delete traces modal > Confirmation message"
   },
+  "ViKgvz": {
+    "defaultMessage": "YAML",
+    "description": "YAML dataset record editor format option"
+  },
   "ViqP7B": {
     "defaultMessage": "Traces",
     "description": "Label for the traces tab in the MLflow experiment navbar"
@@ -7990,6 +7990,10 @@
   "VmDLSS": {
     "defaultMessage": "Select a built-in judge or create a custom one.",
     "description": "Hint text for LLM judge selection"
+  },
+  "VnMYoP": {
+    "defaultMessage": "JSON",
+    "description": "JSON dataset record editor format option"
   },
   "VnnPrX": {
     "defaultMessage": "Enable Usage Tracking in the Overview tab to view usage metrics",
@@ -10222,6 +10226,10 @@
   "ecUdab": {
     "defaultMessage": "Usage",
     "description": "Label for the usage tab in the experiment overview page"
+  },
+  "eeGHh+": {
+    "defaultMessage": "Invalid JSON",
+    "description": "Inline error shown when a dataset record editor does not contain a valid JSON object"
   },
   "eeLqSn": {
     "defaultMessage": "Submit",
@@ -14262,6 +14270,10 @@
   "v5gzhw": {
     "defaultMessage": "Runtime arguments",
     "description": "Package runtime arguments label"
+  },
+  "v7GigW": {
+    "defaultMessage": "Dataset record inputs",
+    "description": "Aria label for the dataset record inputs structured-data editor"
   },
   "v8UFxB": {
     "defaultMessage": "No datasets were recorded for this experiment's runs.",


### PR DESCRIPTION
### Related Issues/PRs

Closes #25210

### What changes are proposed in this pull request?

Add a JSON/YAML format switch to the evaluation dataset record side panel. YAML edits are converted back to the existing canonical JSON state before saving, so the backend payload and dirty-state behavior stay unchanged. Invalid YAML remains visible and disables saving, just like invalid JSON.

The change reuses the existing `js-yaml` dependency and Monaco editor, adds focused conversion/editor tests, and updates the English message catalog.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Validation performed:

- `yarn test experiment-evaluation-datasets-v2 --runInBand` (18 suites, 186 tests)
- `yarn type-check`
- `yarn eslint` on the touched TypeScript files
- `yarn prettier --check` on the touched TypeScript files
- `yarn i18n:check`
- `git diff --check`

The full repository test suite was not run locally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Evaluation dataset records can now be viewed and edited as either JSON or YAML.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

### AI assistance

This draft contribution was AI-assisted and has not yet received human review.
