### PR TITLE
Make `test_setup_outside_git_falls_back_to_cwd` hermetic

### DIFF
--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -129,6 +129,10 @@ def test_setup_outside_git_falls_back_to_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reason: str
 ):
     monkeypatch.chdir(tmp_path)
+    # This test skips `tmp_git_repo`, so clear the tracking URI the same way the
+    # fixture does: a configured URI removes the backend prompt and misaligns
+    # the scripted input.
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
     with (
         mock.patch(
             "mlflow.agent.agents.shutil.which", return_value="/usr/local/bin/claude"
@@ -136,13 +140,19 @@ def test_setup_outside_git_falls_back_to_cwd(
         mock.patch(
             "mlflow.agent.setup.cli._git_root", return_value=(None, reason)
         ) as mock_git_root,
+        # Stubbed so the test does not depend on the `mlflow/assistant/skills`
+        # submodule being initialized in the checkout.
+        mock.patch(
+            "mlflow.agent.setup.cli.install_skills", return_value=["tracing"]
+        ) as mock_install,
     ):
         result = CliRunner().invoke(
             setup, ["--agent", "claude", "--print"], input="3\nhttp://localhost:5001\nn\n1\n"
         )
     assert result.exit_code == 0, result.stderr
     assert f"{reason} The agent's edits cannot be reviewed or reverted with git." in result.stderr
-    assert (tmp_path / ".claude" / "skills").is_dir()
+    # Without a git root, skills land under the current directory.
+    mock_install.assert_called_once_with(tmp_path / ".claude" / "skills")
     mock_which.assert_called()
     mock_git_root.assert_called_once()
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

`test_setup_outside_git_falls_back_to_cwd` fails locally in two environment-dependent ways: it never clears `MLFLOW_TRACKING_URI` (a configured URI removes the backend prompt, misaligning the scripted input), and it requires a real `install_skills` write, which is a no-op when the `mlflow/assistant/skills` submodule is uninitialized. Clear the env var like `tmp_git_repo` does and stub `install_skills`, asserting the cwd-fallback destination directly. CI was unaffected; this only fixes local determinism.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)