### PR TITLE
Fix Windows CI failures: drive-letter paths and OS error messages

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -8,7 +8,6 @@ on:
       - ".github/workflows/slow-tests.yml"
       - "tests/docker/**"
       - "tests/pyfunc/docker/**"
-      - "mlflow/utils/uri.py"
       - "tests/artifacts/**"
       - "tests/assistant/**"
   workflow_dispatch:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -8,7 +8,6 @@ on:
       - ".github/workflows/slow-tests.yml"
       - "tests/docker/**"
       - "tests/pyfunc/docker/**"
-      - "tests/artifacts/**"
       - "tests/assistant/**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/slow-tests.yml"
       - "tests/docker/**"
       - "tests/pyfunc/docker/**"
+      - "mlflow/utils/uri.py"
+      - "tests/artifacts/**"
+      - "tests/assistant/**"
   workflow_dispatch:
     inputs:
       repository:

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -280,6 +280,10 @@ def get_uri_scheme(uri_or_path):
     scheme = urllib.parse.urlparse(uri_or_path).scheme
     if any(scheme.lower().startswith(db) for db in DATABASE_ENGINES):
         return extract_db_type_from_uri(uri_or_path)
+    # Windows absolute paths (e.g. C:\...) are parsed with a single-letter drive scheme.
+    # Treat them as local paths by returning an empty scheme.
+    if len(scheme) == 1 and scheme.isalpha():
+        return ""
     return scheme
 
 

--- a/tests/assistant/providers/test_codex_provider.py
+++ b/tests/assistant/providers/test_codex_provider.py
@@ -409,7 +409,7 @@ async def test_astream_cleans_up_custom_view_schema_when_fdopen_fails(tmp_path):
         ]
 
     assert schema_fd is not None
-    with pytest.raises(OSError, match="Bad file descriptor"):
+    with pytest.raises(OSError, match="Bad file descriptor|The handle is invalid"):
         os.fstat(schema_fd)
     assert not schema_path.exists()
     assert len(events) == 1
@@ -445,7 +445,7 @@ async def test_astream_cleans_up_custom_view_schema_when_serialization_fails(tmp
         ]
 
     assert schema_fd is not None
-    with pytest.raises(OSError, match="Bad file descriptor"):
+    with pytest.raises(OSError, match="Bad file descriptor|The handle is invalid"):
         os.fstat(schema_fd)
     assert not schema_path.exists()
     assert len(events) == 1


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/dev/actions/runs/32973713669

### What changes are proposed in this pull request?

Fix three Windows CI test failures:

1. **`mlflow/utils/uri.py` — `get_uri_scheme` returns wrong scheme for Windows paths**

   `urllib.parse.urlparse('C:\\Users\\...')` returns `scheme='c'` (the drive letter). When a user passes a bare Windows path as `artifact_location`, MLflow later calls `get_artifact_repository` with that path and tries to look up a repository for scheme `'c'`, which doesn't exist. Fix: if the parsed scheme is a single alphabetic character, treat it as a Windows drive letter and return `""` (local file path).

2. **`tests/assistant/providers/test_codex_provider.py` — OS error message differs on Windows**

   Two tests assert that calling `os.fstat` on a closed file descriptor raises `OSError` matching `"Bad file descriptor"`. On Linux/macOS that's the message; on Windows it is `[WinError 6] The handle is invalid`. Fix: update the `match=` regex to accept either.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`get_uri_scheme` now correctly handles Windows absolute paths (e.g. `C:\Users\...`) passed as `artifact_location`, instead of raising `MlflowException: Could not find a registered artifact repository for scheme 'c'`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release