### PR TITLE
Handle empty output_to_responses_items_stream input

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -409,7 +409,10 @@ def output_to_responses_items_stream(
     Handles an iterator of ChatCompletion chunks or LangChain BaseMessage objects.
     """
     peeking_iter, chunks = tee(chunks)
-    first_chunk = next(peeking_iter)
+    try:
+        first_chunk = next(peeking_iter)
+    except StopIteration:
+        return
     if _HAS_LANGCHAIN_BASE_MESSAGE and isinstance(first_chunk, BaseMessage):
         yield from _langchain_message_stream_to_responses_stream(chunks, aggregator)
     else:

--- a/tests/pyfunc/test_responses_agent.py
+++ b/tests/pyfunc/test_responses_agent.py
@@ -1212,6 +1212,12 @@ def test_responses_agent_output_to_responses_items_stream(chunks, expected_outpu
     assert aggregator == expected_aggregator
 
 
+def test_output_to_responses_items_stream_empty_input():
+    aggregator = []
+    assert list(output_to_responses_items_stream(iter([]), aggregator)) == []
+    assert aggregator == []
+
+
 def test_create_text_delta():
     result = ResponsesAgent.create_text_delta("Hello", "test-id")
     expected = {


### PR DESCRIPTION
﻿### Related Issues/PRs

Closes #25370

### What changes are proposed in this pull request?

`output_to_responses_items_stream()` now handles an empty input iterator by returning without yielding events. Previously it unconditionally peeked with `next()`, so empty streams raised `RuntimeError: generator raised StopIteration` instead of producing an empty stream.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

```text
pytest tests\pyfunc\test_responses_agent.py::test_output_to_responses_items_stream_empty_input -q -o timeout=1200.0
# before fix: FAILED - RuntimeError: generator raised StopIteration
# after fix: 1 passed in 11.60s

pytest tests\pyfunc\test_responses_agent.py::test_output_to_responses_items_stream_empty_input tests\pyfunc\test_responses_agent.py -q -o timeout=1200.0
# 31 passed in 85.70s

ruff format mlflow\types\responses.py tests\pyfunc\test_responses_agent.py --check
ruff check mlflow\types\responses.py tests\pyfunc\test_responses_agent.py
# passed
```

I also attempted `pre-commit run --files mlflow\types\responses.py tests\pyfunc\test_responses_agent.py`; the repository hooks could not complete in this Windows environment because several hooks require `uv`/bash-managed tooling and failed before checking these files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Empty ResponsesAgent output streams now convert to an empty stream instead of raising `RuntimeError`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
