### PR TITLE
Add saved views to MLflow demo

### DIFF
--- a/mlflow/demo/README.md
+++ b/mlflow/demo/README.md
@@ -19,6 +19,7 @@ mlflow/demo/
     ├── prompts.py           # Prompt versions and aliases
     ├── traces.py            # Sample traces with various patterns
     ├── custom_view.py       # Saved custom view (span I/O cards + accuracy form)
+    ├── saved_views.py       # Saved Traces table views
     ├── evaluation.py        # Evaluation runs and datasets
     ├── judges.py            # Registered LLM judges
     ├── issues.py            # Detected issues linked to failing traces

--- a/mlflow/demo/base.py
+++ b/mlflow/demo/base.py
@@ -21,6 +21,7 @@ class DemoFeature(str, Enum):
     ISSUES = "issues"
     REVIEW_QUEUES = "review_queues"
     CUSTOM_VIEW = "custom_view"
+    SAVED_VIEWS = "saved_views"
 
 
 @dataclass

--- a/mlflow/demo/generators/__init__.py
+++ b/mlflow/demo/generators/__init__.py
@@ -4,18 +4,20 @@ from mlflow.demo.generators.issues import IssuesDemoGenerator
 from mlflow.demo.generators.judges import JudgesDemoGenerator
 from mlflow.demo.generators.prompts import PromptsDemoGenerator
 from mlflow.demo.generators.review_queues import ReviewQueuesDemoGenerator
+from mlflow.demo.generators.saved_views import SavedViewsDemoGenerator
 from mlflow.demo.generators.traces import TracesDemoGenerator
 from mlflow.demo.registry import demo_registry
 
 # NB: Order matters here. Prompts must be created before traces (for linking),
 # and traces must exist before evaluation (which references them).
-# The custom view is an experiment tag and needs the demo experiment (created
-# by traces). Judges are independent and can be registered last.
+# The custom view and saved views are experiment tags and need the demo experiment
+# (created by traces). Judges are independent and can be registered last.
 # Issues should be registered after traces exist (since they reference trace problems).
 # Review queues should be registered after traces exist (since they attach traces).
 demo_registry.register(PromptsDemoGenerator)
 demo_registry.register(TracesDemoGenerator)
 demo_registry.register(CustomViewDemoGenerator)
+demo_registry.register(SavedViewsDemoGenerator)
 demo_registry.register(EvaluationDemoGenerator)
 demo_registry.register(JudgesDemoGenerator)
 demo_registry.register(IssuesDemoGenerator)
@@ -28,5 +30,6 @@ __all__ = [
     "JudgesDemoGenerator",
     "PromptsDemoGenerator",
     "ReviewQueuesDemoGenerator",
+    "SavedViewsDemoGenerator",
     "TracesDemoGenerator",
 ]

--- a/mlflow/demo/generators/saved_views.py
+++ b/mlflow/demo/generators/saved_views.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+import zlib
+from dataclasses import dataclass
+from typing import Any
+
+from mlflow.demo.base import (
+    DEMO_EXPERIMENT_NAME,
+    BaseDemoGenerator,
+    DemoFeature,
+    DemoResult,
+)
+from mlflow.entities import LifecycleStage
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
+from mlflow.tracking._tracking_service.utils import _get_store
+from mlflow.tracking.client import MlflowClient
+from mlflow.utils.validation import MAX_EXPERIMENT_TAG_VAL_LENGTH
+
+_logger = logging.getLogger(__name__)
+
+TRACE_V4_SAVED_VIEW_TAG_PREFIX = "mlflow.tracesV4ViewState."
+_DEFLATE_PREFIX = "deflate;"
+
+DEMO_TRACE_V4_MLFLOW_VIEW_ID = "mlflow-demo-traces-mlflow"
+
+
+@dataclass(frozen=True)
+class DemoTraceSavedViewDef:
+    id: str
+    name: str
+    tag_prefix: str
+    state: dict[str, Any]
+
+    @property
+    def tag_key(self) -> str:
+        return f"{self.tag_prefix}{self.id}"
+
+
+DEMO_TRACE_V4_SAVED_VIEW = DemoTraceSavedViewDef(
+    id=DEMO_TRACE_V4_MLFLOW_VIEW_ID,
+    name="MLflow conversations",
+    tag_prefix=TRACE_V4_SAVED_VIEW_TAG_PREFIX,
+    state={
+        "single": {
+            "q": "MLflow",
+            "pageSize": "50",
+            "startTimeLabel": "ALL",
+            "cols": "start_time,session,input,output,duration,state,tokens",
+        },
+        "multi": {},
+    },
+)
+
+DEMO_TRACE_SAVED_VIEWS = [
+    DEMO_TRACE_V4_SAVED_VIEW,
+]
+
+DEMO_TRACE_SAVED_VIEW_TAG_KEYS = [view.tag_key for view in DEMO_TRACE_SAVED_VIEWS]
+
+
+def _compress_state(state: dict[str, Any]) -> str:
+    serialized = json.dumps(state, separators=(",", ":"))
+    compressed = base64.b64encode(zlib.compress(serialized.encode("utf-8"))).decode("ascii")
+    return f"{_DEFLATE_PREFIX}{compressed}"
+
+
+def _serialize_trace_saved_view(view: DemoTraceSavedViewDef, created_at_ms: int) -> str:
+    payload = json.dumps(
+        {
+            "name": view.name,
+            "createdAt": created_at_ms,
+            "state": _compress_state(view.state),
+        },
+        separators=(",", ":"),
+    )
+    if len(payload) > MAX_EXPERIMENT_TAG_VAL_LENGTH:
+        raise ValueError(
+            f"Demo saved view '{view.id}' exceeds experiment tag limit "
+            f"({len(payload)} > {MAX_EXPERIMENT_TAG_VAL_LENGTH})"
+        )
+    return payload
+
+
+def _is_resource_missing(exc: MlflowException) -> bool:
+    return exc.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+
+class SavedViewsDemoGenerator(BaseDemoGenerator):
+    """Seeds saved V4 Traces views on the demo experiment."""
+
+    name = DemoFeature.SAVED_VIEWS
+    version = 1
+
+    def generate(self) -> DemoResult:
+        store = _get_store()
+        experiment = store.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+        if experiment is None:
+            raise ValueError(f"Demo experiment '{DEMO_EXPERIMENT_NAME}' not found")
+
+        experiment_id = experiment.experiment_id
+        client = MlflowClient()
+
+        created_at_ms = int(time.time() * 1000)
+        for view in DEMO_TRACE_SAVED_VIEWS:
+            client.set_experiment_tag(
+                experiment_id,
+                view.tag_key,
+                _serialize_trace_saved_view(view, created_at_ms),
+            )
+
+        return DemoResult(
+            feature=self.name,
+            entity_ids=DEMO_TRACE_SAVED_VIEW_TAG_KEYS,
+            navigation_url=f"#/experiments/{experiment_id}/traces",
+        )
+
+    def _data_exists(self) -> bool:
+        try:
+            experiment = _get_store().get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+            if experiment is None or experiment.lifecycle_stage != LifecycleStage.ACTIVE:
+                return False
+            return all(tag_key in experiment.tags for tag_key in DEMO_TRACE_SAVED_VIEW_TAG_KEYS)
+        except MlflowException as e:
+            if not _is_resource_missing(e):
+                raise
+            _logger.debug("Failed to check if saved views demo exists", exc_info=True)
+            return False
+
+    def delete_demo(self) -> None:
+        experiment = _get_store().get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+        if experiment is None:
+            return
+        client = MlflowClient()
+        for tag_key in DEMO_TRACE_SAVED_VIEW_TAG_KEYS:
+            try:
+                client.delete_experiment_tag(experiment.experiment_id, tag_key)
+            except MlflowException as e:
+                if not _is_resource_missing(e):
+                    raise

--- a/tests/demo/test_base.py
+++ b/tests/demo/test_base.py
@@ -13,6 +13,7 @@ def test_demo_feature_enum():
     assert DemoFeature.TRACES == "traces"
     assert DemoFeature.EVALUATION == "evaluation"
     assert DemoFeature.CUSTOM_VIEW == "custom_view"
+    assert DemoFeature.SAVED_VIEWS == "saved_views"
     assert isinstance(DemoFeature.TRACES, str)
 
 

--- a/tests/demo/test_demo_integration.py
+++ b/tests/demo/test_demo_integration.py
@@ -1,4 +1,6 @@
+import base64
 import json
+import zlib
 from pathlib import Path
 
 import pytest
@@ -23,6 +25,7 @@ from mlflow.demo.generators.issues import (
 )
 from mlflow.demo.generators.judges import DEMO_JUDGE_PREFIX, JudgesDemoGenerator
 from mlflow.demo.generators.prompts import PromptsDemoGenerator
+from mlflow.demo.generators.saved_views import DEMO_TRACE_SAVED_VIEWS
 from mlflow.demo.generators.traces import (
     DEMO_END_TIME_TAG,
     DEMO_START_TIME_TAG,
@@ -134,6 +137,24 @@ def test_generate_all_demos_seeds_custom_view(client):
     stored = json.loads(experiment.tags[DEMO_CUSTOM_VIEW_TAG_KEY])
     assert stored["id"] == DEMO_CUSTOM_VIEW_ID
     assert stored["template"][0]["version"] == "v0.9"
+
+
+def _inflate_saved_view_state(stored):
+    state = stored["state"]
+    assert state.startswith("deflate;"), f"expected deflate-compressed state, got: {state[:40]!r}"
+    compressed = base64.b64decode(state.removeprefix("deflate;"))
+    return json.loads(zlib.decompress(compressed).decode("utf-8"))
+
+
+def test_generate_all_demos_seeds_trace_saved_views(client):
+    generate_all_demos()
+
+    experiment = client.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    for view in DEMO_TRACE_SAVED_VIEWS:
+        stored = json.loads(experiment.tags[view.tag_key])
+        assert stored["name"] == view.name
+        assert stored["state"].startswith("deflate;")
+        assert _inflate_saved_view_state(stored) == view.state
 
 
 def test_version_mismatch_triggers_cleanup_and_regeneration(client, traces_generator):

--- a/tests/demo/test_saved_views_generator.py
+++ b/tests/demo/test_saved_views_generator.py
@@ -1,0 +1,192 @@
+import base64
+import json
+import time
+import zlib
+from unittest import mock
+
+import pytest
+
+import mlflow
+from mlflow.demo.base import DEMO_EXPERIMENT_NAME, DemoFeature, DemoResult
+from mlflow.demo.generators.saved_views import (
+    DEMO_TRACE_SAVED_VIEW_TAG_KEYS,
+    DEMO_TRACE_SAVED_VIEWS,
+    DEMO_TRACE_V4_MLFLOW_VIEW_ID,
+    DEMO_TRACE_V4_SAVED_VIEW,
+    SavedViewsDemoGenerator,
+    _serialize_trace_saved_view,
+)
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
+from mlflow.utils.validation import MAX_EXPERIMENT_TAG_VAL_LENGTH
+
+
+def _create_demo_experiment():
+    return mlflow.set_experiment(DEMO_EXPERIMENT_NAME)
+
+
+def _inflate_envelope(value: str) -> dict[str, object]:
+    envelope = json.loads(value)
+    assert envelope["state"].startswith("deflate;"), (
+        f"expected deflate-compressed state, got: {envelope['state'][:40]!r}"
+    )
+    compressed = base64.b64decode(envelope["state"].removeprefix("deflate;"))
+    return json.loads(zlib.decompress(compressed).decode("utf-8"))
+
+
+def test_generator_attributes():
+    generator = SavedViewsDemoGenerator()
+    assert generator.name == DemoFeature.SAVED_VIEWS
+    assert generator.version == 1
+    assert {view.id for view in DEMO_TRACE_SAVED_VIEWS} == {DEMO_TRACE_V4_MLFLOW_VIEW_ID}
+    assert DEMO_TRACE_SAVED_VIEW_TAG_KEYS == [DEMO_TRACE_V4_SAVED_VIEW.tag_key]
+    assert DEMO_TRACE_V4_SAVED_VIEW.tag_key.startswith("mlflow.tracesV4ViewState.")
+
+
+@pytest.mark.parametrize("view", DEMO_TRACE_SAVED_VIEWS)
+def test_serialized_view_fits_experiment_tag_limit(view):
+    payload = _serialize_trace_saved_view(view, created_at_ms=123)
+    assert len(payload) <= MAX_EXPERIMENT_TAG_VAL_LENGTH
+
+
+@pytest.mark.parametrize("view", DEMO_TRACE_SAVED_VIEWS)
+def test_serialized_view_shape(view):
+    payload = _serialize_trace_saved_view(view, created_at_ms=123)
+    envelope = json.loads(payload)
+    assert envelope["name"] == view.name
+    assert envelope["createdAt"] == 123
+
+    state = _inflate_envelope(payload)
+    assert state == view.state
+    assert "single" in state
+    assert "multi" in state
+    assert state["single"]["startTimeLabel"] == "ALL"
+
+
+def test_v4_serialized_view_uses_v4_state_keys():
+    view = DEMO_TRACE_V4_SAVED_VIEW
+    state = _inflate_envelope(_serialize_trace_saved_view(view, created_at_ms=123))
+    assert "q" in state["single"]
+    assert "cols" in state["single"]
+
+
+def test_data_exists_false_when_no_experiment():
+    generator = SavedViewsDemoGenerator()
+    assert generator._data_exists() is False
+
+
+def test_data_exists_raises_unexpected_store_failure():
+    generator = SavedViewsDemoGenerator()
+    store = mock.MagicMock()
+    store.get_experiment_by_name.side_effect = RuntimeError("boom")
+
+    with mock.patch("mlflow.demo.generators.saved_views._get_store", return_value=store):
+        with pytest.raises(RuntimeError, match="boom"):
+            generator._data_exists()
+
+
+def test_data_exists_false_when_store_resource_is_missing():
+    generator = SavedViewsDemoGenerator()
+    store = mock.MagicMock()
+    store.get_experiment_by_name.side_effect = MlflowException(
+        "missing", error_code=RESOURCE_DOES_NOT_EXIST
+    )
+
+    with mock.patch("mlflow.demo.generators.saved_views._get_store", return_value=store):
+        assert generator._data_exists() is False
+
+
+def test_data_exists_raises_unexpected_mlflow_exception():
+    generator = SavedViewsDemoGenerator()
+    store = mock.MagicMock()
+    store.get_experiment_by_name.side_effect = MlflowException(
+        "invalid", error_code=INVALID_PARAMETER_VALUE
+    )
+
+    with mock.patch("mlflow.demo.generators.saved_views._get_store", return_value=store):
+        with pytest.raises(MlflowException, match="invalid"):
+            generator._data_exists()
+
+
+def test_generate_requires_demo_experiment():
+    generator = SavedViewsDemoGenerator()
+    with pytest.raises(ValueError, match="not found"):
+        generator.generate()
+
+
+def test_generate_writes_experiment_tags():
+    _create_demo_experiment()
+    generator = SavedViewsDemoGenerator()
+    before_generate_ms = int(time.time() * 1000)
+    result = generator.generate()
+
+    assert isinstance(result, DemoResult)
+    assert result.feature == DemoFeature.SAVED_VIEWS
+    assert result.entity_ids == DEMO_TRACE_SAVED_VIEW_TAG_KEYS
+    assert "/experiments/" in result.navigation_url
+    assert result.navigation_url.endswith("/traces")
+
+    experiment = mlflow.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    for view in DEMO_TRACE_SAVED_VIEWS:
+        assert view.tag_key in experiment.tags
+        envelope = json.loads(experiment.tags[view.tag_key])
+        assert before_generate_ms <= envelope["createdAt"] <= int(time.time() * 1000)
+        assert _inflate_envelope(experiment.tags[view.tag_key]) == view.state
+
+
+def test_data_exists_requires_all_tags():
+    _create_demo_experiment()
+    generator = SavedViewsDemoGenerator()
+    assert generator._data_exists() is False
+
+    generator.generate()
+    assert generator._data_exists() is True
+
+    mlflow.MlflowClient().delete_experiment_tag(
+        mlflow.get_experiment_by_name(DEMO_EXPERIMENT_NAME).experiment_id,
+        DEMO_TRACE_SAVED_VIEW_TAG_KEYS[0],
+    )
+    assert generator._data_exists() is False
+
+
+def test_delete_demo_removes_tags():
+    _create_demo_experiment()
+    generator = SavedViewsDemoGenerator()
+    generator.generate()
+    assert generator._data_exists() is True
+
+    generator.delete_demo()
+
+    assert generator._data_exists() is False
+
+    experiment = mlflow.get_experiment_by_name(DEMO_EXPERIMENT_NAME)
+    assert all(key not in experiment.tags for key in DEMO_TRACE_SAVED_VIEW_TAG_KEYS)
+
+
+def test_delete_demo_raises_unexpected_tag_delete_failure():
+    _create_demo_experiment()
+    generator = SavedViewsDemoGenerator()
+    generator.generate()
+
+    with mock.patch("mlflow.tracking.client.MlflowClient.delete_experiment_tag") as delete_tag:
+        delete_tag.side_effect = MlflowException(
+            "cannot delete", error_code=INVALID_PARAMETER_VALUE
+        )
+
+        with pytest.raises(MlflowException, match="cannot delete"):
+            generator.delete_demo()
+
+
+def test_is_generated_checks_version(monkeypatch):
+    _create_demo_experiment()
+    saved_views_generator = SavedViewsDemoGenerator()
+    saved_views_generator.generate()
+    saved_views_generator.store_version()
+
+    assert saved_views_generator.is_generated() is True
+
+    monkeypatch.setattr(SavedViewsDemoGenerator, "version", 99)
+    fresh_generator = SavedViewsDemoGenerator()
+    assert fresh_generator._data_exists() is True
+    assert fresh_generator.is_generated() is False
+    assert fresh_generator._data_exists() is False


### PR DESCRIPTION
### Related Issues/PRs

Relates to saved views for the MLflow demo experiment.

### What changes are proposed in this pull request?

Seed the MLflow Demo experiment with a V4 trace-table saved view so the demo data exercises saved views out of the box.

This adds a `SavedViewsDemoGenerator` that writes deterministic experiment tags using the same saved-view envelope shape as the UI: `{name, createdAt, state: "deflate;..."}`. The generator is registered with the existing demo registry, so `mlflow demo` and the demo API route both populate the saved view automatically.

Seeded view:
- V4 Traces: `mlflow.tracesV4ViewState.mlflow-demo-traces-mlflow`, named `MLflow conversations`.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Local test runs:

```bash
uv run --frozen pytest tests/demo/test_saved_views_generator.py tests/demo/test_demo_integration.py::test_generate_all_demos_seeds_trace_saved_views -q
# 17 passed
```

Manual/Playwright verification:
- Started refreshed demo backend on `http://127.0.0.1:53430` with a fresh SQLite DB and seeded it via `uv run --frozen mlflow demo --tracking-uri http://127.0.0.1:53430 --no-browser --refresh`.
- Started React dev server on non-clashing `https://localhost:53431`, proxied to the demo backend.
- Verified the experiment tags contain exactly one active saved-view tag: `mlflow.tracesV4ViewState.mlflow-demo-traces-mlflow`.
- Playwright opened the V4 traces saved-view menu, verified there is exactly one saved-view entry named `MLflow conversations`, selected it, and verified the URL updated with `traceViewShareKey=mlflow-demo-traces-mlflow`, `q=MLflow`, `pageSize=50`, and `startTimeLabel=ALL`.
- Screenshot captured at `/tmp/mlflow-demo-v4-saved-view-v4only.png`.

<img width="1273" height="977" alt="Screenshot 2026-09-01 at 10 51 11 AM" src="https://github.com/user-attachments/assets/7fb92b76-a73b-426c-a778-24c247c2a95e" />



### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow demo experiment now includes a pre-seeded V4 trace-table saved view so users can explore saved views immediately.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

