### PR TITLE
Add a `CLAUDE.md` note on keeping PRs to one concern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,13 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 git push origin <your-branch>
 ```
 
+### Keep Pull Requests to One Concern
+
+One PR = one concern. NEVER EVER bundle unrelated changes. They multiply
+review cost rather than adding to it, none of them can be reverted piece by
+piece, and the resulting commit is hard to reason about later. When in doubt,
+split.
+
 ### Creating Pull Requests
 
 - Follow the instructions at the top of [the PR template](./.github/pull_request_template.md) carefully.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,10 +190,10 @@ git push origin <your-branch>
 
 ### Keep Pull Requests to One Concern
 
-One PR = one concern. NEVER EVER bundle unrelated changes. They multiply
-review cost rather than adding to it, none of them can be reverted piece by
-piece, and the resulting commit is hard to reason about later. When in doubt,
-split.
+One PR = one concern. NEVER EVER bundle unrelated changes. They multiply review
+cost rather than adding to it, and since this repo squash-merges, they land as
+one commit that can't be reverted piece by piece and is hard to reason about
+later. When in doubt, split.
 
 ### Creating Pull Requests
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a short note to `CLAUDE.md` telling Claude Code to keep a PR to a single concern.

Bundling unrelated changes into one PR (say, a CI config tweak, a behavior change under `mlflow/`, and a test edit) multiplies review cost, makes individual changes impossible to revert on their own, and leaves a commit that's hard to reason about later. The note nudges agent-authored PRs toward splitting instead.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Docs-only change to agent instructions; no tests apply.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)