### PR TITLE
Fix: show assistant floating button on remote servers with `MLFLOW_ENABLE_REMOTE_ASSISTANT=true`

### DIFF
--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
@@ -71,7 +71,17 @@ describe('AssistantFloatingButton', () => {
     expect(screen.queryByRole('button', { name: 'MLflow Assistant' })).not.toBeInTheDocument();
   });
 
+  test('does not render when canUseAssistant is false even if isLocalServer is true', () => {
+    // Verifies the render guard uses canUseAssistant, not isLocalServer.
+    mockAssistant = { isLocalServer: true, canUseAssistant: false, isPanelOpen: false, openPanel: mockOpenPanel };
+    renderFab();
+    expect(screen.queryByRole('button', { name: 'MLflow Assistant' })).not.toBeInTheDocument();
+  });
+
   test('renders but does not auto-open on a remote server with remote access enabled', () => {
+    // The button renders because canUseAssistant=true.
+    // Auto-open stays local-only (gated on isLocalServer in the useEffect) — remote users should
+    // not get a surprise panel pop-up on first load; they click the FAB themselves.
     mockAssistant = { isLocalServer: false, canUseAssistant: true, isPanelOpen: false, openPanel: mockOpenPanel };
     renderFab();
     expect(mockOpenPanel).not.toHaveBeenCalled();

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.test.tsx
@@ -6,7 +6,7 @@ import { DesignSystemProvider } from '@databricks/design-system';
 import { AssistantFloatingButton } from './AssistantFloatingButton';
 
 const mockOpenPanel = jest.fn();
-let mockAssistant: { isLocalServer: boolean; isPanelOpen: boolean; openPanel: jest.Mock };
+let mockAssistant: { isLocalServer: boolean; canUseAssistant: boolean; isPanelOpen: boolean; openPanel: jest.Mock };
 let mockObstructionWidth: number;
 let mockObstructionHeight: number;
 
@@ -34,7 +34,7 @@ describe('AssistantFloatingButton', () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockOpenPanel.mockClear();
-    mockAssistant = { isLocalServer: true, isPanelOpen: false, openPanel: mockOpenPanel };
+    mockAssistant = { isLocalServer: true, canUseAssistant: true, isPanelOpen: false, openPanel: mockOpenPanel };
     mockObstructionWidth = 0;
     mockObstructionHeight = 0;
   });
@@ -64,11 +64,18 @@ describe('AssistantFloatingButton', () => {
     expect(mockOpenPanel).not.toHaveBeenCalled();
   });
 
-  test('does not auto-open or render on a remote server', () => {
-    mockAssistant.isLocalServer = false;
+  test('does not auto-open or render on a remote server without remote access', () => {
+    mockAssistant = { isLocalServer: false, canUseAssistant: false, isPanelOpen: false, openPanel: mockOpenPanel };
     renderFab();
     expect(mockOpenPanel).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: 'MLflow Assistant' })).not.toBeInTheDocument();
+  });
+
+  test('renders but does not auto-open on a remote server with remote access enabled', () => {
+    mockAssistant = { isLocalServer: false, canUseAssistant: true, isPanelOpen: false, openPanel: mockOpenPanel };
+    renderFab();
+    expect(mockOpenPanel).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'MLflow Assistant' })).toBeInTheDocument();
   });
 
   test('does not auto-open when the panel is already open', () => {

--- a/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
+++ b/mlflow/server/js/src/assistant/AssistantFloatingButton.tsx
@@ -47,7 +47,7 @@ const useWindowWidth = (): number => {
  */
 export const AssistantFloatingButton = () => {
   const { theme } = useDesignSystemTheme();
-  const { isLocalServer, isPanelOpen, openPanel } = useAssistant();
+  const { isLocalServer, canUseAssistant, isPanelOpen, openPanel } = useAssistant();
   const obstructionWidth = useFloatingObstructionWidth();
   const obstructionHeight = useFloatingObstructionHeight();
   const windowWidth = useWindowWidth();
@@ -77,7 +77,7 @@ export const AssistantFloatingButton = () => {
   // surface is open it doesn't hide the button — it reports the width it reserves (via
   // useRegisterFloatingObstruction) and the button shifts to its left so it stays
   // visible without overlapping. This is generic across any registering surface.
-  if (!isLocalServer || isPanelOpen) {
+  if (!canUseAssistant || isPanelOpen) {
     return null;
   }
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #25306

### What changes are proposed in this pull request?

`AssistantFloatingButton` was gated on `isLocalServer`, so it never rendered for remote deployments even when `MLFLOW_ENABLE_REMOTE_ASSISTANT=true` is set and `canUseAssistant` is `true`.

The fix: replace the `!isLocalServer` render guard with `!canUseAssistant` (which equals `isLocalServer || remoteAccessAllowed`). The button now renders on remote servers whose admin has opted in via `MLFLOW_ENABLE_REMOTE_ASSISTANT`.

The auto-open-on-first-load behaviour is intentionally kept local-only (still gated on `isLocalServer`), since remote users should not receive a surprise panel pop-up.

`ExperimentPageSideNavAssistantButton` already used `canUseAssistant` and needed no change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

New test: `renders but does not auto-open on a remote server with remote access enabled` — verifies the button is in the DOM and `openPanel` is not called automatically when `isLocalServer=false` and `canUseAssistant=true`.

Renamed old test from `does not auto-open or render on a remote server` to `does not auto-open or render on a remote server without remote access` to be precise about when the FAB should be hidden.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When `MLFLOW_ENABLE_REMOTE_ASSISTANT=true` is set on a remote MLflow server, the Assistant floating action button now renders so users can open the assistant panel. Previously, the button was suppressed on all non-localhost deployments regardless of the remote-access flag.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release