### PR TITLE
Fix two leftovers in the logged-model filter parser

### DIFF
--- a/mlflow/utils/search_logged_model_utils.py
+++ b/mlflow/utils/search_logged_model_utils.py
@@ -66,7 +66,7 @@ class Entity:
         ops = numeric_ops if self.is_numeric() else string_ops
         if op not in ops:
             raise MlflowException.invalid_parameter_value(
-                f"Invalid comparison operator for {self}: {op!r}. Expected one of {string_ops}."
+                f"Invalid comparison operator for {self}: {op!r}. Expected one of {ops}."
             )
 
 
@@ -104,7 +104,6 @@ def parse_filter_string(filter_string: str | None) -> list[Comparison]:
             identifier, op, value = non_whitespace_tokens
             entity = Entity.from_str(identifier)
             entity.validate_op(op)
-            value = float(value) if entity.is_numeric() else value.strip("'")
             if entity.is_numeric():
                 value = float(value)
             else:

--- a/tests/utils/test_search_logged_model_utils.py
+++ b/tests/utils/test_search_logged_model_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.utils.search_logged_model_utils import parse_filter_string
+
+
+def test_invalid_operator_message_lists_the_applicable_operators():
+    # `LIKE` is rejected for a numeric entity, so it must not appear in the
+    # list of operators the message offers as alternatives.
+    with pytest.raises(MlflowException, match="Invalid comparison operator") as exc:
+        parse_filter_string("metrics.loss LIKE 'x'")
+
+    message = str(exc.value)
+    assert "'<'" in message
+    assert "LIKE" not in message.split("Expected one of")[1]
+
+
+def test_quoted_value_that_looks_like_a_tuple_stays_a_string():
+    (comparison,) = parse_filter_string("params.shape = '(1, 2)'")
+    assert comparison.value == "(1, 2)"
+
+
+def test_in_list_is_still_parsed_as_a_tuple():
+    (comparison,) = parse_filter_string("params.shape IN ('a', 'b')")
+    assert comparison.value == ("a", "b")


### PR DESCRIPTION
### Related Issues/PRs

None — I did not find an existing issue for either of these.

### What changes are proposed in this pull request?

Two small leftovers in `search_logged_model_utils.py`, both from the change that added `IN` / `NOT IN` support.

**1. The rejected operator is offered as an alternative.** `validate_op` selects `ops` for the entity it is validating, but reports `string_ops` regardless:

```python
ops = numeric_ops if self.is_numeric() else string_ops
if op not in ops:
    raise MlflowException.invalid_parameter_value(
        f"Invalid comparison operator for {self}: {op!r}. Expected one of {string_ops}."
    )
```

so a string operator rejected on a numeric entity is listed as valid:

```
>>> parse_filter_string("metrics.loss LIKE 'x'")
MlflowException: Invalid comparison operator for metrics.loss: 'LIKE'.
Expected one of ('=', '!=', 'LIKE', 'ILIKE', 'IN', 'NOT IN').
```

**2. A quoted string that looks like a tuple is parsed as one.** `parse_filter_string` assigns `value` and then immediately recomputes it in the `if/else` directly below. The dead assignment strips the quotes first, so a quoted string whose contents start with `(` reaches the `literal_eval` branch:

```
>>> parse_filter_string("params.shape = '(1, 2)'")[0].value
('1', '2')        # expected the string '(1, 2)'
```

Dropping the assignment lets the `if/else` see the original token, which still carries its quotes, so it takes the `else` branch and is stripped once. `IN` lists arrive unquoted and are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `tests/utils/test_search_logged_model_utils.py` with three cases: the operator message, the quoted-tuple string, and an `IN` list still parsing to a tuple. The third passes both before and after — it pins the behaviour that must not change. `tests/utils/test_search_utils.py` shows the same single pre-existing failure (`test_like_pattern_with_plus_character`) before and after.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `search_logged_models` filter strings now keep a quoted value such as `'(1, 2)'` as a string instead of parsing it into a tuple, and an invalid comparison operator is reported with the operators that actually apply to that entity.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
