### PR TITLE
Pin the head SHA the `/review` bot reviews

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -161,16 +161,30 @@ jobs:
           # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
           # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
           fetch-depth: 2
-      # The merge ref is recomputed on every push, so it can already point at a
-      # newer head. Bail before installing anything or running a line of the
-      # checkout rather than review a commit nobody asked about.
+      # The merge ref is recomputed on every push, so it can carry a head other
+      # than the one the trigger asked about. Check before installing anything
+      # or running a line of the checkout.
+      #
+      # GitHub recomputes it asynchronously, so a `pull_request` run firing the
+      # instant a push lands can legitimately still see the previous head
+      # (actions/checkout instruments this as STALE_MERGE, and only reports
+      # telemetry for it). That path posts no review and has no comment to
+      # re-run, so warn and review what we got; only `issue_comment`, where the
+      # review is real and the lag has long since settled, fails.
       - name: Verify head SHA
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           ACTUAL=$(git rev-parse HEAD^2)
-          if [ "$ACTUAL" != "$HEAD_SHA" ]; then
+          if [ "$ACTUAL" = "$HEAD_SHA" ]; then
+            exit 0
+          fi
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
             echo "::error::PR head moved after the review was requested ($HEAD_SHA -> $ACTUAL). Re-run /review."
             exit 1
           fi
+          echo "::warning::Merge ref carries $ACTUAL, expected $HEAD_SHA (stale merge ref or a new push). Reviewing $ACTUAL."
+          echo "HEAD_SHA=$ACTUAL" >> "$GITHUB_ENV"
       - parallel:
           - uses: ./.github/actions/setup-python
             with:
@@ -285,6 +299,25 @@ jobs:
       - name: Show proxy log
         if: always()
         run: cat /tmp/anthropic-proxy.log || true
+
+      # `skills fetch-diff` reads the live PR diff rather than the checkout, so a
+      # push during the 30-minute review above gives the agent line numbers from
+      # a diff the pinned commit never had. GitHub accepts such a comment
+      # whenever the line still exists there, silently attaching it to unrelated
+      # code, so drop the review rather than post it against the wrong lines.
+      - name: Verify head SHA is unchanged
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          CURRENT=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha) \
+            || { echo "::error::Failed to re-resolve head SHA for PR #$PR_NUMBER"; exit 1; }
+          if [ "$CURRENT" != "$HEAD_SHA" ]; then
+            echo "::error::PR was pushed to during the review ($HEAD_SHA -> $CURRENT). Re-run /review."
+            exit 1
+          fi
 
       # Kept out of the Claude step, which holds only the read-only app token, so a
       # poisoned diff can't reach this PAT. Gated like Post so the pull_request

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -28,6 +28,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
+    outputs:
+      head-sha: ${{ steps.head-sha.outputs.sha }}
     # Cheap author_association prefilter so random users can't spawn workflow
     # runs. The gate step below does the authoritative admin/maintain role
     # check.
@@ -82,6 +85,28 @@ jobs:
             check_user "$COMMENTER" "User"
           fi
 
+      # Pin the commit the trigger asked about. The PR can be pushed to between
+      # the trigger and the checkout below, so resolve the head here and verify
+      # it after checkout: the run then reviews exactly what was requested, or
+      # fails loudly, instead of silently reviewing something newer.
+      - name: Resolve head SHA
+        id: head-sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # Present on pull_request, empty on issue_comment. Prefer it: it is the
+          # head that triggered this run, where the API could already be newer.
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          SHA=$EVENT_HEAD_SHA
+          if [ -z "$SHA" ]; then
+            SHA=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha) \
+              || { echo "::error::Failed to resolve head SHA for PR #$PR_NUMBER"; exit 1; }
+          fi
+          echo "Reviewing $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
   review:
     needs: gate
     runs-on: ubuntu-latest
@@ -93,6 +118,7 @@ jobs:
     env:
       REVIEW_PAYLOAD: /tmp/review-payload.json
       REVIEW_MEDIA: /tmp/review-media
+      HEAD_SHA: ${{ needs.gate.outputs.head-sha }}
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -135,6 +161,16 @@ jobs:
           # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
           # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
           fetch-depth: 2
+      # The merge ref is recomputed on every push, so it can already point at a
+      # newer head. Bail before installing anything or running a line of the
+      # checkout rather than review a commit nobody asked about.
+      - name: Verify head SHA
+        run: |
+          ACTUAL=$(git rev-parse HEAD^2)
+          if [ "$ACTUAL" != "$HEAD_SHA" ]; then
+            echo "::error::PR head moved after the review was requested ($HEAD_SHA -> $ACTUAL). Re-run /review."
+            exit 1
+          fi
       - parallel:
           - uses: ./.github/actions/setup-python
             with:
@@ -273,6 +309,11 @@ jobs:
             echo "::error::Claude did not produce $REVIEW_PAYLOAD"
             exit 1
           fi
+          # Anchor the review to the commit that was reviewed. Without commit_id,
+          # GitHub attaches the comments to whatever the head is at POST time, so
+          # a push mid-run lands them on lines the review never saw.
+          jq --arg sha "$HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > "$REVIEW_PAYLOAD.tmp"
+          mv "$REVIEW_PAYLOAD.tmp" "$REVIEW_PAYLOAD"
           uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"
           jq . "$REVIEW_PAYLOAD"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25396

### What changes are proposed in this pull request?

`/review` doesn't pin the commit it reviews. It checks out `refs/pull/N/merge`, which GitHub recomputes on every push, so a contributor pushing after the trigger silently gets a different commit reviewed than the maintainer asked about. The posted review also omits `commit_id`, so GitHub anchors the inline comments to whatever the head is at POST time.

Now `gate` resolves `head.sha` once and exposes it as a job output; `review` verifies it against `git rev-parse HEAD^2` right after checkout, before running anything from the PR tree; and the payload carries it as `commit_id` so comments land on the commit that was actually read.

Comparing the PR head rather than `merge_commit_sha` is deliberate: the latter also changes when the base moves, so unrelated merges to master would abort reviews. Base drift is fine, only a push to the PR branch should abort.

### How is this PR tested?

- [x] Manual tests

Workflow-only change. `conftest` policy passes, and this PR touches `.github/workflows/review.yml`, so the workflow's own `pull_request` smoke path runs the new steps against this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
