### PR TITLE
Pin the `/review` bot's comments to the reviewed commit

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -135,6 +135,12 @@ jobs:
           # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
           # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
           fetch-depth: 2
+      # HEAD^2 of the merge ref is the PR head. Resolved before the review runs so
+      # it stays tied to the tree that was actually reviewed.
+      - name: Pin reviewed head commit
+        run: |
+          PR_HEAD_SHA=$(git rev-parse HEAD^2)
+          echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
       - parallel:
           - uses: ./.github/actions/setup-python
             with:
@@ -267,12 +273,17 @@ jobs:
             --target "$REVIEW_PAYLOAD" \
             --repository-id "$REPO_ID"
 
-      - name: Validate review payload
+      - name: Pin and validate review payload
         run: |
           if [ ! -f "$REVIEW_PAYLOAD" ]; then
             echo "::error::Claude did not produce $REVIEW_PAYLOAD"
             exit 1
           fi
+          # Without commit_id, GitHub resolves each comment's line and side against
+          # whatever head is current when the review is posted, so a push during the
+          # review lands comments on the wrong lines or gets them rejected.
+          jq --arg sha "$PR_HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > /tmp/pinned-payload.json
+          mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
           uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"
           jq . "$REVIEW_PAYLOAD"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -135,8 +135,8 @@ jobs:
           # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
           # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
           fetch-depth: 2
-      # HEAD^2 of the merge ref is the PR head. Resolved before the review runs so
-      # it stays tied to the tree that was actually reviewed.
+      # HEAD^2 of the merge ref is the PR head. Resolved before the review step,
+      # which runs with Bash in this tree.
       - name: Pin reviewed head commit
         run: |
           PR_HEAD_SHA=$(git rev-parse HEAD^2)
@@ -273,10 +273,9 @@ jobs:
             --target "$REVIEW_PAYLOAD" \
             --repository-id "$REPO_ID"
 
-      # Without commit_id, GitHub resolves each comment's line and side against
-      # whatever head is current when the review is posted, so a push during the
-      # review lands comments on the wrong lines or gets them rejected. Injected
-      # before the validation below so the schema's SHA pattern covers it.
+      # Without commit_id, GitHub anchors the comments to whatever head is current
+      # at POST time. Injected before validation so the schema's SHA pattern
+      # covers it.
       - name: Pin review to the reviewed commit
         run: |
           if [ ! -f "$REVIEW_PAYLOAD" ]; then

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -273,17 +273,21 @@ jobs:
             --target "$REVIEW_PAYLOAD" \
             --repository-id "$REPO_ID"
 
-      - name: Pin and validate review payload
+      # Without commit_id, GitHub resolves each comment's line and side against
+      # whatever head is current when the review is posted, so a push during the
+      # review lands comments on the wrong lines or gets them rejected. Injected
+      # before the validation below so the schema's SHA pattern covers it.
+      - name: Pin review to the reviewed commit
         run: |
           if [ ! -f "$REVIEW_PAYLOAD" ]; then
             echo "::error::Claude did not produce $REVIEW_PAYLOAD"
             exit 1
           fi
-          # Without commit_id, GitHub resolves each comment's line and side against
-          # whatever head is current when the review is posted, so a push during the
-          # review lands comments on the wrong lines or gets them rejected.
           jq --arg sha "$PR_HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > /tmp/pinned-payload.json
           mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
+
+      - name: Validate review payload
+        run: |
           uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"
           jq . "$REVIEW_PAYLOAD"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25396

### What changes are proposed in this pull request?

The review workflow posts without `commit_id`, so GitHub resolves each comment's `line`/`side` against whatever the PR head is at POST time. A push during the up-to-30-minute review lands comments on lines the review never saw, or gets them rejected.

The merge ref already carries the head, so no API call or resolve step is needed: at `fetch-depth: 2`, `HEAD^2` is the PR head and `HEAD^1` the base. It's resolved from the checkout before the review step can touch the tree, then stamped into the payload as `commit_id`.

This is the narrow half of #25399. The abort checks from that PR are deliberately left out: they guard a race that only matters once `/review` opens to external PRs, and the pre-post re-check discarded valid reviews in the common case.

### How is this PR tested?

- [x] Manual tests

Workflow-only change. Verified against open PR #25400 that a real `--depth=2` fetch of `refs/pull/N/merge` gives `HEAD^1` == `base.sha` and `HEAD^2` == `head.sha`. Both failure paths fail closed: `git rev-parse HEAD^2` on a non-merge HEAD exits 128 under `bash -eo pipefail` (the status propagates through the assignment), and an empty SHA is caught by the schema's `^[0-9a-f]{40}$` pattern before the POST. This PR touches `.github/workflows/review.yml`, so the workflow's own `pull_request` smoke path exercises the new steps.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)