### PR TITLE
Isolate the PR checkout from the review tooling

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,14 +2,17 @@
 name: pr-review
 description: Review a pull request and emit a validated review payload.
 disable-model-invocation: true
-argument-hint: "<pr_url> <payload_path> <media_dir>"
-arguments: [pr_url, payload_path, media_dir]
+argument-hint: "<pr_url> <payload_path> <media_dir> <repo_dir>"
+arguments: [pr_url, payload_path, media_dir, repo_dir]
 ---
 
 # Review Pull Request
 
 Review $pr_url and write a JSON review payload to $payload_path. Do not post anything: writing
 that payload is the whole job.
+
+The tree under review is $repo_dir, not the directory you are running from. That one holds the
+review tooling and is not what you are reviewing, so read and run git against $repo_dir throughout.
 
 ## Instructions
 
@@ -26,11 +29,11 @@ These reads are independent. Issue them as parallel tool calls in a single turn,
 gh pr view <pr_url> --json title,body
 ```
 
-**PR diff hunks**. The working tree is the merge ref (see step 3), so `HEAD^1 HEAD` is exactly the
+**PR diff hunks**. $repo_dir is the merge ref (see step 3), so `HEAD^1 HEAD` there is exactly the
 PR diff:
 
 ```bash
-git diff HEAD^1 HEAD | uv run --package skills skills annotate-diff
+git -C $repo_dir diff HEAD^1 HEAD | uv run --package skills skills annotate-diff
 ```
 
 Each line comes back as `old_line new_line | <marker> content`, which gives you the `line` and
@@ -68,21 +71,22 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> \
 Load the repository style rules applicable to the changed files:
 
 ```bash
-git diff --name-only HEAD^1 | uv run --package skills skills load-rules
+git -C $repo_dir diff --name-only HEAD^1 | uv run --package skills skills load-rules
 ```
 
 ### 3. Analyze the change
 
-The working tree holds the PR merged into the base (`refs/pull/<pr_number>/merge`), so file contents
+$repo_dir holds the PR merged into the base (`refs/pull/<pr_number>/merge`), so file contents there
 reflect the post-merge state. Explore it for context beyond the diff (existing patterns, call sites
-of changed symbols, file conventions).
+of changed symbols, file conventions), and read paths under $repo_dir rather than the same path
+relative to your working directory, which resolves to the tooling checkout instead.
 
 The merge ref's base parent is reachable as `HEAD^1`. When the diff doesn't show enough (verifying
 a refactor preserved behavior, reading a masked deleted file, or seeing the pre-change version of a
-heavily modified one), use `git show HEAD^1:<path>` rather than re-fetching the file over the API.
-The checkout is shallow, so nothing older than `HEAD^1` exists: `git log` and `git blame` stop at
-the shallow boundary rather than reaching the commit that actually introduced a line. Neither
-errors, so don't trust them for pre-change history.
+heavily modified one), use `git -C $repo_dir show HEAD^1:<path>` rather than re-fetching the file
+over the API. That checkout is shallow, so nothing older than `HEAD^1` exists: `git log` and
+`git blame` stop at the shallow boundary rather than reaching the commit that actually introduced a
+line. Neither errors, so don't trust them for pre-change history.
 
 Verify rather than infer. A `grep` through the installed package, a `uv run python -c '...'`, or a
 quick search and fetch of the upstream docs will settle most questions in seconds, and an unverified

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -93,6 +93,12 @@ jobs:
     env:
       REVIEW_PAYLOAD: /tmp/review-payload.json
       REVIEW_MEDIA: /tmp/review-media
+      # The tree under review. Claude runs from the workspace root so it loads the
+      # skill from the tooling checkout, and reads the PR through this path.
+      REVIEW_REPO_DIR: ${{ github.workspace }}/pr
+      # `uv run` picks its project from the working directory, so a `cd` into the
+      # PR would silently run that PR's copy of the skills package. Pin it.
+      UV_PROJECT: ${{ github.workspace }}
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -127,17 +133,37 @@ jobs:
         run: |
           printf '%s\n\n---\n\n🚀 [Review running...](%s)' "$COMMENT_BODY" "$JOB_RUN_URL" \
             | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Everything that runs while the secrets below are in scope comes from this
+      # checkout: the composite actions, the install scripts, the proxy, and the
+      # skills package. The PR is checked out separately and only ever read.
+      #
+      # The smoke path is gated to same-repo PRs (see the gate's
+      # `head.repo.full_name` check), so it points here at the PR to keep testing
+      # its own tooling. On `issue_comment` GitHub already resolves the workflow
+      # file from the default branch, so taking the tooling from there too makes
+      # the two agree instead of running PR scripts from a base-branch workflow.
+      - name: Check out tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          token: ${{ steps.app-token-read.outputs.token }}
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+
+      - name: Check out the PR under review
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           token: ${{ steps.app-token-read.outputs.token }}
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
-          # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
-          # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
+          # Depth 2 so both parents of the merge ref are reachable: HEAD^1 is the
+          # base, which the skill reads pre-change content from, and HEAD^2 is the
+          # head the pin below takes.
           fetch-depth: 2
+          path: pr
       # HEAD^2 of the merge ref is the PR head. Resolved before the review step,
       # which runs with Bash in this tree.
       - name: Pin reviewed head commit
+        working-directory: pr
         run: |
           PR_HEAD_SHA=$(git rev-parse HEAD^2)
           echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
@@ -240,7 +266,7 @@ jobs:
             --print \
             --verbose \
             --output-format stream-json \
-            "/pr-review $PR_URL $REVIEW_PAYLOAD $REVIEW_MEDIA" \
+            "/pr-review $PR_URL $REVIEW_PAYLOAD $REVIEW_MEDIA $REVIEW_REPO_DIR" \
             | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 30 minutes"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -98,7 +98,7 @@ jobs:
       REVIEW_REPO_DIR: ${{ github.workspace }}/pr
       # `uv run` picks its project from the working directory, so a `cd` into the
       # PR would silently run that PR's copy of the skills package. Pin it.
-      UV_PROJECT: ${{ github.workspace }}
+      UV_PROJECT: ${{ github.workspace }}/tooling
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -142,24 +142,29 @@ jobs:
       # its own tooling. On `issue_comment` GitHub already resolves the workflow
       # file from the default branch, so taking the tooling from there too makes
       # the two agree instead of running PR scripts from a base-branch workflow.
-      - name: Check out tooling
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          token: ${{ steps.app-token-read.outputs.token }}
-          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
-
-      - name: Check out the PR under review
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          token: ${{ steps.app-token-read.outputs.token }}
-          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
-          # Depth 2 so both parents of the merge ref are reachable: HEAD^1 is the
-          # base, which the skill reads pre-change content from, and HEAD^2 is the
-          # head the pin below takes.
-          fetch-depth: 2
-          path: pr
+      # Side by side rather than the PR nested inside the tooling tree. Checkout
+      # runs `git clean -ffdx` and wipes non-matching contents, so a nested `pr/`
+      # is untracked from the tooling repo's view and only survives by running
+      # second. As siblings neither can clobber the other, so both run at once.
+      - parallel:
+          - name: Check out tooling
+            uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            with:
+              persist-credentials: false
+              token: ${{ steps.app-token-read.outputs.token }}
+              ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+              path: tooling
+          - name: Check out the PR under review
+            uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            with:
+              persist-credentials: false
+              token: ${{ steps.app-token-read.outputs.token }}
+              ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+              # Depth 2 so both parents of the merge ref are reachable: HEAD^1 is
+              # the base, which the skill reads pre-change content from, and
+              # HEAD^2 is the head the pin below takes.
+              fetch-depth: 2
+              path: pr
       # HEAD^2 of the merge ref is the PR head. Resolved before the review step,
       # which runs with Bash in this tree.
       - name: Pin reviewed head commit
@@ -167,15 +172,25 @@ jobs:
         run: |
           PR_HEAD_SHA=$(git rev-parse HEAD^2)
           echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
+      # setup-python falls back to `cat .python-version`, which resolves against
+      # the workspace root. Nothing lives there now, so pass the version in.
+      - name: Resolve Python version
+        id: python-version
+        working-directory: tooling
+        run: |
+          echo "version=$(cat .python-version)" >> "$GITHUB_OUTPUT"
       - parallel:
-          - uses: ./.github/actions/setup-python
+          - uses: ./tooling/.github/actions/setup-python
             with:
+              python-version: ${{ steps.python-version.outputs.version }}
               pin-micro-version: false
-          - uses: ./.github/actions/setup-node
+          - uses: ./tooling/.github/actions/setup-node
           - name: Install Claude CLI
+            working-directory: tooling
             run: |
               .claude/scripts/install-claude.sh
           - name: Install agent-browser
+            working-directory: tooling
             run: |
               .claude/scripts/install-agent-browser.sh
       - name: Verify tools
@@ -227,6 +242,7 @@ jobs:
       # from recovering it through a signal-triggered inspector session.
       - name: Start Anthropic proxy
         id: proxy
+        working-directory: tooling
         env:
           ANTHROPIC_API_KEY: ${{ secrets.EXPERIMENTAL_ANTHROPIC_API_KEY }}
         run: |
@@ -241,6 +257,7 @@ jobs:
 
       - name: Review
         id: review
+        working-directory: tooling
         env:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
@@ -263,6 +280,7 @@ jobs:
             --max-budget-usd 8 \
             --permission-mode auto \
             --allowed-tools "Bash(uv run --package skills skills:*)" \
+            --add-dir "$REVIEW_REPO_DIR" \
             --print \
             --verbose \
             --output-format stream-json \
@@ -287,6 +305,7 @@ jobs:
       # smoke path stays non-mutating.
       - name: Upload review media
         if: github.event_name == 'issue_comment'
+        working-directory: tooling
         # Attaching media is a nicety; losing the whole review over it is not. Any
         # fault here must not take the job down before Post review.
         continue-on-error: true
@@ -312,6 +331,7 @@ jobs:
           mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
 
       - name: Validate review payload
+        working-directory: tooling
         run: |
           uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25401

### What changes are proposed in this pull request?

The review job checked out the PR's merge ref and then executed from it: the composite actions, `install-claude.sh`, `anthropic-proxy.mjs` (which takes the Anthropic key on stdin), `stream.sh`, and the skills package that `embed-media` runs with `UPLOAD_MEDIA_TOKEN`. That's contained today only because the gate requires the PR author to be admin/maintain, and it's the thing that blocks opening `/review` to external PRs. Sandboxing the agent wouldn't address it either: Claude Code's Read tool makes in-process calls, so it reads the job's environment variables regardless of what the Bash tool is confined to.

The checkout is now split in two, side by side under the workspace: `tooling/` holds everything that runs while the secrets are in scope, and `pr/` is only ever read. The `pr-review` skill takes the PR directory as a new `repo_dir` argument and reads through `git -C`, and Claude runs from `tooling/` with the PR reached via `--add-dir`, so the tree under review sits outside its working directory.

Siblings rather than nesting because checkout runs `git clean -ffdx` and deletes non-matching contents: a nested `pr/` is untracked from the tooling repo's view and survives only by being checked out second. As siblings neither can clobber the other, so both checkouts now run concurrently. `setup-python` falls back to `cat .python-version` against the workspace root, which nothing occupies under this layout, so the version is read from the tooling checkout and passed in.

The smoke path keeps its coverage for free. It's already gated to same-repo PRs, so it points the tooling checkout at the PR and still tests its own changes. `issue_comment` takes the base repo, which is where GitHub already resolves the workflow file from on that event, so the two now agree instead of a base-branch workflow running PR scripts.

`UV_PROJECT` pins the skills package to the tooling root. `uv run` picks its project from the working directory, so without it a `cd` into the PR silently runs that PR's copy.

This does not stop Claude from executing PR code when it runs tests or builds docs, and isn't meant to. It stops the *workflow* from doing so, which is where the secrets are.

### How is this PR tested?

- [x] Manual tests

Built the two-checkout layout locally against #25400 (base checkout at the root, `--depth=2` merge ref in `./pr`) and ran the skill's commands from the root: `git -C $repo_dir diff HEAD^1 HEAD | ... annotate-diff` produced the correct annotated diff, `git -C $repo_dir diff --name-only HEAD^1` listed the changed files for `load-rules`, `git -C $repo_dir show HEAD^1:<path>` returned pre-change content, and `HEAD^2` still resolved to `head.sha`.

Also verified the footgun `UV_PROJECT` closes: run from inside `./pr`, `uv run --package skills` builds `skills @ .../pr/.claude/skills` and fails with `invalid choice: 'annotate-diff'` because #25400 predates the rename; with `UV_PROJECT` set to the tooling root it resolves the trusted package from the same directory.

This PR touches `.github/workflows/review.yml` and `.claude/skills/pr-review/**`, so the workflow's own `pull_request` smoke path exercises the new layout end to end.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
